### PR TITLE
Bugfix FXIOS-8619 [v125] Undoing a bookmark removal re-adds incorrect bookmark

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -321,6 +321,8 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
     func showToast(_ bookmarkURL: URL? = nil, _ title: String?, message: String, toastAction: MenuButtonToastAction) {
         switch toastAction {
         case .removeBookmark:
+            guard let bookmarkURLString = bookmarkURL?.absoluteString else { return }
+
             let viewModel = ButtonToastViewModel(labelText: message,
                                                  buttonText: .UndoString,
                                                  textAlignment: .left)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -328,7 +328,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
                                                  textAlignment: .left)
             let toast = ButtonToast(viewModel: viewModel,
                                     theme: themeManager.currentTheme) { [weak self] isButtonTapped in
-                guard let strongSelf = self, let currentTab = strongSelf.tabManager.selectedTab else { return }
+                guard let self, let currentTab = tabManager.selectedTab else { return }
                 isButtonTapped ? strongSelf.addBookmark(
                     url: bookmarkURLString,
                     title: title ?? currentTab.title

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -330,7 +330,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
                                     theme: themeManager.currentTheme) { [weak self] isButtonTapped in
                 guard let strongSelf = self, let currentTab = strongSelf.tabManager.selectedTab else { return }
                 isButtonTapped ? strongSelf.addBookmark(
-                    url: bookmarkURL?.absoluteString ?? currentTab.url?.absoluteString ?? "",
+                    url: bookmarkURLString,
                     title: title ?? currentTab.title
                 ) : nil
             }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -318,7 +318,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
         presentWithModalDismissIfNeeded(viewController, animated: true)
     }
 
-    func showToast(message: String, toastAction: MenuButtonToastAction) {
+    func showToast(_ bookmarkURL: URL? = nil, _ title: String?, message: String, toastAction: MenuButtonToastAction) {
         switch toastAction {
         case .removeBookmark:
             let viewModel = ButtonToastViewModel(labelText: message,
@@ -328,8 +328,8 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
                                     theme: themeManager.currentTheme) { [weak self] isButtonTapped in
                 guard let strongSelf = self, let currentTab = strongSelf.tabManager.selectedTab else { return }
                 isButtonTapped ? strongSelf.addBookmark(
-                    url: currentTab.url?.absoluteString ?? "",
-                    title: currentTab.title
+                    url: bookmarkURL?.absoluteString ?? currentTab.url?.absoluteString ?? "",
+                    title: title ?? currentTab.title
                 ) : nil
             }
             show(toast: toast)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -282,7 +282,7 @@ extension BrowserViewController: WKUIDelegate {
                         image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
                         identifier: UIAction.Identifier("linkContextMenu.removeBookmarkLink")
                     ) { _ in
-                        self.removeBookmark(url: url.absoluteString)
+                        self.removeBookmark(url: url, title: elements.title)
                         TelemetryWrapper.recordEvent(category: .action,
                                                      method: .delete,
                                                      object: .bookmark,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1280,10 +1280,10 @@ class BrowserViewController: UIViewController,
         self.show(toast: toast)
     }
 
-    func removeBookmark(url: String) {
-        profile.places.deleteBookmarksWithURL(url: url).uponQueue(.main) { result in
+    func removeBookmark(url: URL, title: String?) {
+        profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
             guard result.isSuccess else { return }
-            self.showToast(message: .AppMenu.RemoveBookmarkConfirmMessage, toastAction: .removeBookmark)
+            self.showToast(url, title, message: .AppMenu.RemoveBookmarkConfirmMessage, toastAction: .removeBookmark)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -20,12 +20,18 @@ protocol ToolBarActionMenuDelegate: AnyObject {
 
     func showLibrary(panel: LibraryPanelType)
     func showViewController(viewController: UIViewController)
-    func showToast(message: String, toastAction: MenuButtonToastAction)
+    func showToast(_ bookmarkURL: URL?, _ title: String?, message: String, toastAction: MenuButtonToastAction)
     func showFindInPage()
     func showCustomizeHomePage()
     func showZoomPage(tab: Tab)
     func showCreditCardSettings()
     func showSignInView(fxaParameters: FxASignInViewParameters)
+}
+
+extension ToolBarActionMenuDelegate {
+    func showToast(_ bookmarkURL: URL? = nil, _ title: String? = nil, message: String, toastAction: MenuButtonToastAction) {
+        showToast(bookmarkURL, title, message: message, toastAction: toastAction)
+    }
 }
 
 enum MenuButtonToastAction {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8619)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19126)

## :bulb: Description
Changed URL and page title when undoing a bookmark removal

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

