### PR TITLE
Add FXIOS-8594 Create AddressToolbar protocol

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Protocol representing an address toolbar.
+public protocol AddressToolbar {
+    func configure(_ state: AddressToolbarState)
+}

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar.swift
@@ -6,5 +6,5 @@ import Foundation
 
 /// Protocol representing an address toolbar.
 public protocol AddressToolbar {
-    func configure(_ state: AddressToolbarState)
+    func configure(state: AddressToolbarState)
 }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbarState.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbarState.swift
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Defines the state for the address toolbar.
+public struct AddressToolbarState {
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8594)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19085)

## :bulb: Description
This creates the protocol for the address toolbar and an empty address toolbar state. More methods, variables, etc will be added in the following PRs.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

