### PR TITLE
Add FXIOS-8554 - Content blocking generator package

### DIFF
--- a/BrowserKit/.swiftpm/xcode/xcshareddata/xcschemes/ContentBlockingGenerator.xcscheme
+++ b/BrowserKit/.swiftpm/xcode/xcshareddata/xcschemes/ContentBlockingGenerator.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ContentBlockingGenerator"
+               BuildableName = "ContentBlockingGenerator"
+               BlueprintName = "ContentBlockingGenerator"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ContentBlockingGenerator"
+            BuildableName = "ContentBlockingGenerator"
+            BlueprintName = "ContentBlockingGenerator"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ContentBlockingGeneratorTests"
+               BuildableName = "ContentBlockingGeneratorTests"
+               BlueprintName = "ContentBlockingGeneratorTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ContentBlockingGenerator"
+            BuildableName = "ContentBlockingGenerator"
+            BlueprintName = "ContentBlockingGenerator"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -28,7 +28,10 @@ let package = Package(
             targets: ["WebEngine"]),
         .library(
             name: "ToolbarKit",
-            targets: ["ToolbarKit"])
+            targets: ["ToolbarKit"]),
+        .library(
+            name: "ContentBlockingGenerator",
+            targets: ["ContentBlockingGenerator"])
     ],
     dependencies: [
         .package(
@@ -101,6 +104,12 @@ let package = Package(
             swiftSettings: [.unsafeFlags(["-enable-testing"])]),
         .testTarget(
             name: "ToolbarKitTests",
-            dependencies: ["ToolbarKit"])
+            dependencies: ["ToolbarKit"]),
+        .target(
+            name: "ContentBlockingGenerator",
+            swiftSettings: [.unsafeFlags(["-enable-testing"])]),
+        .testTarget(
+            name: "ContentBlockingGeneratorTests",
+            dependencies: ["ContentBlockingGenerator"])
     ]
 )

--- a/BrowserKit/Sources/ContentBlockingGenerator/Temp.swift
+++ b/BrowserKit/Sources/ContentBlockingGenerator/Temp.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+// Temporary so package is not empty
+struct Temp {
+    var foo = 1
+}

--- a/BrowserKit/Tests/ContentBlockingGeneratorTests/TempTest.swift
+++ b/BrowserKit/Tests/ContentBlockingGeneratorTests/TempTest.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import ContentBlockingGenerator
+
+final class TempTest: XCTestCase {
+    func testFoo() {
+        let subject = Temp()
+        XCTAssertEqual(subject.foo, 1)
+    }
+}

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -471,6 +471,16 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ContentBlockingGeneratorTests"
+               BuildableName = "ContentBlockingGeneratorTests"
+               BlueprintName = "ContentBlockingGeneratorTests"
+               ReferencedContainer = "container:../BrowserKit">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "TabDataStoreTests"
                BuildableName = "TabDataStoreTests"
                BlueprintName = "TabDataStoreTests"

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -198,6 +198,13 @@
         "identifier" : "ToolbarKitTests",
         "name" : "ToolbarKitTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/BrowserKit",
+        "identifier" : "ContentBlockingGeneratorTests",
+        "name" : "ContentBlockingGeneratorTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8554)
No Github issue

## :bulb: Description
Add empty content blocking generator package. Next task will be to move the Content blocking generator from Firefox iOS to here.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

