### PR TITLE
Add FXIOS-8613 - Add BrowserKit to Focus iOS

### DIFF
--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		840057582735309500E48144 /* SettingsTableViewToggleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840057572735309500E48144 /* SettingsTableViewToggleCell.swift */; };
 		8400575A27353B1800E48144 /* UIPasteBoardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400575927353B1800E48144 /* UIPasteBoardExtensions.swift */; };
 		846A23182668CC4500DB3C37 /* FullScreen.js in Resources */ = {isa = PBXBuildFile; fileRef = 846A23172668CC4500DB3C37 /* FullScreen.js */; };
+		8A0E7F2E2BA0F0EE006BC6B6 /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = 8A0E7F2D2BA0F0EE006BC6B6 /* Fuzi */; };
 		A89766DA1F57DCA9008183C5 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		B101243E2B4EE8C20099F3CA /* URLValidationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B101243D2B4EE8C20099F3CA /* URLValidationTest.swift */; };
 		B3481A551FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3481A541FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift */; };
@@ -238,7 +239,6 @@
 		F8324CE5264EA223007E4BFA /* licenses.html in Resources */ = {isa = PBXBuildFile; fileRef = F8324CE0264EA223007E4BFA /* licenses.html */; };
 		F8324CE6264EA223007E4BFA /* style.css in Resources */ = {isa = PBXBuildFile; fileRef = F8324CE1264EA223007E4BFA /* style.css */; };
 		F85F7A292655AD5800395515 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A282655AD5800395515 /* SnapKit */; };
-		F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */ = {isa = PBXBuildFile; productRef = F85F7A2A2655AD5800395515 /* Fuzi */; };
 		F861799B2795D95E00CFD324 /* InternalExperimentsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F861799A2795D95E00CFD324 /* InternalExperimentsSettingsView.swift */; };
 		F861799D2795EE9800CFD324 /* InternalExperimentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F861799C2795EE9800CFD324 /* InternalExperimentDetailView.swift */; };
 		F861799F27961F4200CFD324 /* InternalSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F861799E27961F4200CFD324 /* InternalSettings.swift */; };
@@ -659,6 +659,7 @@
 		840057572735309500E48144 /* SettingsTableViewToggleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewToggleCell.swift; sourceTree = "<group>"; };
 		8400575927353B1800E48144 /* UIPasteBoardExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPasteBoardExtensions.swift; sourceTree = "<group>"; };
 		846A23172668CC4500DB3C37 /* FullScreen.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = FullScreen.js; sourceTree = "<group>"; };
+		8A0E7F2B2BA0F0C2006BC6B6 /* BrowserKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BrowserKit; path = ../BrowserKit; sourceTree = "<group>"; };
 		A847EEFA289A4F5A002AC855 /* pa-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pa-IN"; path = "pa-IN.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		A847EEFC289A4F5A002AC855 /* pa-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pa-IN"; path = "pa-IN.lproj/Intro.strings"; sourceTree = "<group>"; };
 		A847EEFD289A4F5A002AC855 /* pa-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pa-IN"; path = "pa-IN.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -1252,10 +1253,10 @@
 				CDFA746F27ABD43D0055FE55 /* Glean in Frameworks */,
 				45E8FFE72828DE4A0027A8F5 /* FocusAppServices in Frameworks */,
 				C8FB1E6427F59D9C00C60DC6 /* UIHelpers in Frameworks */,
+				8A0E7F2E2BA0F0EE006BC6B6 /* Fuzi in Frameworks */,
 				F8B92FBE279EC73700183998 /* Sentry in Frameworks */,
 				C8FB1E6627F5A79300C60DC6 /* DesignSystem in Frameworks */,
 				C82F45F728193EE8000D7D84 /* AppShortcuts in Frameworks */,
-				F85F7A2B2655AD5800395515 /* Fuzi in Frameworks */,
 				C871586027FB29AC006224BB /* Onboarding in Frameworks */,
 				C809130E2A08F245000889B0 /* Licenses in Frameworks */,
 			);
@@ -1834,6 +1835,7 @@
 				D4E014302B053972006759D7 /* FocusEnterprise.entitlements */,
 				D4E014312B053973006759D7 /* Klar.entitlements */,
 				D4E0142F2B053972006759D7 /* KlarEnterprise.entitlements */,
+				8A0E7F2B2BA0F0C2006BC6B6 /* BrowserKit */,
 				D446C1802AF3B6EE00A230DF /* focus-ios-tests */,
 				C8FB1E6227F59BC600C60DC6 /* BlockzillaPackage */,
 				C817A35222CE73B4002529FF /* Deferred */,
@@ -2078,7 +2080,6 @@
 			name = Blockzilla;
 			packageProductDependencies = (
 				F85F7A282655AD5800395515 /* SnapKit */,
-				F85F7A2A2655AD5800395515 /* Fuzi */,
 				F8B92FBD279EC73700183998 /* Sentry */,
 				CDFA746E27ABD43D0055FE55 /* Glean */,
 				C8FB1E6327F59D9C00C60DC6 /* UIHelpers */,
@@ -2087,6 +2088,7 @@
 				45E8FFE62828DE4A0027A8F5 /* FocusAppServices */,
 				C82F45F628193EE8000D7D84 /* AppShortcuts */,
 				C809130D2A08F245000889B0 /* Licenses */,
+				8A0E7F2D2BA0F0EE006BC6B6 /* Fuzi */,
 			);
 			productName = Blockzilla;
 			productReference = E4BF2DD31BACE8CA00DA9D68 /* Firefox Klar.app */;
@@ -2272,10 +2274,10 @@
 			mainGroup = E4BF2DCA1BACE8CA00DA9D68;
 			packageReferences = (
 				F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */,
-				F8324CB8264DC8ED007E4BFA /* XCRemoteSwiftPackageReference "Fuzi" */,
 				F8B92FBC279EC73700183998 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				CDFA746D27ABD43D0055FE55 /* XCRemoteSwiftPackageReference "glean-swift" */,
 				45E8FFE52828DE4A0027A8F5 /* XCRemoteSwiftPackageReference "rust-components-swift" */,
+				8A0E7F2C2BA0F0E0006BC6B6 /* XCRemoteSwiftPackageReference "Fuzi" */,
 			);
 			productRefGroup = E4BF2DD41BACE8CA00DA9D68 /* Products */;
 			projectDirPath = "";
@@ -6552,6 +6554,14 @@
 				version = 125.0.20240309050254;
 			};
 		};
+		8A0E7F2C2BA0F0E0006BC6B6 /* XCRemoteSwiftPackageReference "Fuzi" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/nbhasin2/Fuzi.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		CDFA746D27ABD43D0055FE55 /* XCRemoteSwiftPackageReference "glean-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mozilla/glean-swift";
@@ -6566,14 +6576,6 @@
 			requirement = {
 				kind = exactVersion;
 				version = 5.7.0;
-			};
-		};
-		F8324CB8264DC8ED007E4BFA /* XCRemoteSwiftPackageReference "Fuzi" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/cezheng/Fuzi";
-			requirement = {
-				kind = exactVersion;
-				version = 3.1.3;
 			};
 		};
 		F8B92FBC279EC73700183998 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
@@ -6591,6 +6593,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 45E8FFE52828DE4A0027A8F5 /* XCRemoteSwiftPackageReference "rust-components-swift" */;
 			productName = FocusAppServices;
+		};
+		8A0E7F2D2BA0F0EE006BC6B6 /* Fuzi */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8A0E7F2C2BA0F0E0006BC6B6 /* XCRemoteSwiftPackageReference "Fuzi" */;
+			productName = Fuzi;
 		};
 		C809130D2A08F245000889B0 /* Licenses */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -6625,11 +6632,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F8324C2D264C807C007E4BFA /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
-		};
-		F85F7A2A2655AD5800395515 /* Fuzi */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F8324CB8264DC8ED007E4BFA /* XCRemoteSwiftPackageReference "Fuzi" */;
-			productName = Fuzi;
 		};
 		F8B92FBD279EC73700183998 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,30 @@
   "object": {
     "pins": [
       {
-        "package": "Fuzi",
-        "repositoryURL": "https://github.com/cezheng/Fuzi",
+        "package": "Dip",
+        "repositoryURL": "https://github.com/AliSoftware/Dip.git",
         "state": {
           "branch": null,
-          "revision": "f08c8323da21e985f3772610753bcfc652c2103f",
-          "version": "3.1.3"
+          "revision": "c3b601df0ff22b06b6d5ff4943faf05c0bd3f9bb",
+          "version": "7.1.1"
+        }
+      },
+      {
+        "package": "Fuzi",
+        "repositoryURL": "https://github.com/nbhasin2/Fuzi.git",
+        "state": {
+          "branch": "master",
+          "revision": "04170682baf5c013a41270963c689c87ba0d1374",
+          "version": null
+        }
+      },
+      {
+        "package": "GCDWebServer",
+        "repositoryURL": "https://github.com/nbhasin2/GCDWebServer.git",
+        "state": {
+          "branch": "master",
+          "revision": "7674c93e79ee5aac17681acace324761325e7346",
+          "version": null
         }
       },
       {
@@ -17,6 +35,15 @@
           "branch": null,
           "revision": "724814f167bf42e33fafa856f7d19fc752beca2c",
           "version": "58.0.0"
+        }
+      },
+      {
+        "package": "Kingfisher",
+        "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
+        "state": {
+          "branch": null,
+          "revision": "3ec0ab0bca4feb56e8b33e289c9496e89059dd08",
+          "version": "7.10.2"
         }
       },
       {
@@ -44,6 +71,15 @@
           "branch": null,
           "revision": "e74fe2a978d1216c3602b129447c7301573cc2d8",
           "version": "5.7.0"
+        }
+      },
+      {
+        "package": "SwiftyBeaver",
+        "repositoryURL": "https://github.com/SwiftyBeaver/SwiftyBeaver.git",
+        "state": {
+          "branch": null,
+          "revision": "1080914828ef1c9ca9cd2bad50667b3d847dabff",
+          "version": "2.0.0"
         }
       }
     ]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8613)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19114)

## :bulb: Description
Add BrowserKit to Focus iOS. Needed to adjust the Fuzi dependency to be the same as the one in BrowserKit.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

