### PR TITLE
Bugfix FXIOS-8449 - Fix tab positions not updating when in private browsing

### DIFF
--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -471,6 +471,16 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ContentBlockingGeneratorTests"
+               BuildableName = "ContentBlockingGeneratorTests"
+               BlueprintName = "ContentBlockingGeneratorTests"
+               ReferencedContainer = "container:../BrowserKit">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "TabDataStoreTests"
                BuildableName = "TabDataStoreTests"
                BlueprintName = "TabDataStoreTests"

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -471,16 +471,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ContentBlockingGeneratorTests"
-               BuildableName = "ContentBlockingGeneratorTests"
-               BlueprintName = "ContentBlockingGeneratorTests"
-               ReferencedContainer = "container:../BrowserKit">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "TabDataStoreTests"
                BuildableName = "TabDataStoreTests"
                BlueprintName = "TabDataStoreTests"

--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -812,7 +812,7 @@ extension LegacyTabDisplayManager: UICollectionViewDropDelegate {
 
         coordinator.drop(dragItem, toItemAt: destinationIndexPath)
 
-        self.tabManager.moveTab(isPrivate: self.isPrivate, fromIndex: sourceIndex, toIndex: destinationIndexPath.item)
+        self.tabManager.reorderTabsInArray(isPrivate: self.isPrivate, fromIndex: sourceIndex, toIndex: destinationIndexPath.item)
 
         if let indexToRemove = filteredTabs.firstIndex(of: tab) {
             filteredTabs.remove(at: indexToRemove)

--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -812,7 +812,7 @@ extension LegacyTabDisplayManager: UICollectionViewDropDelegate {
 
         coordinator.drop(dragItem, toItemAt: destinationIndexPath)
 
-        self.tabManager.reorderTabsInArray(isPrivate: self.isPrivate, fromIndex: sourceIndex, toIndex: destinationIndexPath.item)
+        self.tabManager.reorderTabs(isPrivate: self.isPrivate, fromIndex: sourceIndex, toIndex: destinationIndexPath.item)
 
         if let indexToRemove = filteredTabs.firstIndex(of: tab) {
             filteredTabs.remove(at: indexToRemove)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -58,9 +58,11 @@ class TabUUIDContext: ActionContext {
 class MoveTabContext: ActionContext {
     let originIndex: Int
     let destinationIndex: Int
-    init(originIndex: Int, destinationIndex: Int, windowUUID: WindowUUID) {
+    let isPrivate: Bool
+    init(originIndex: Int, destinationIndex: Int, isPrivate: Bool, windowUUID: WindowUUID) {
         self.originIndex = originIndex
         self.destinationIndex = destinationIndex
+        self.isPrivate = isPrivate
         super.init(windowUUID: windowUUID)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -45,7 +45,8 @@ class TabManagerMiddleware {
         case TabPanelAction.moveTab(let context):
             let originIndex = context.originIndex
             let destinationIndex = context.destinationIndex
-            self.moveTab(state: state, from: originIndex, to: destinationIndex, uuid: uuid)
+            let isPrivate = context.isPrivate
+            self.moveTab(state: state, from: originIndex, to: destinationIndex, isPrivate: isPrivate, uuid: uuid)
 
         case TabPanelAction.closeTab(let context):
             guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil) else { return }
@@ -223,6 +224,7 @@ class TabManagerMiddleware {
     private func moveTab(state: AppState,
                          from originIndex: Int,
                          to destinationIndex: Int,
+                         isPrivate: Bool,
                          uuid: WindowUUID) {
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: nil) else { return }
 
@@ -231,7 +233,7 @@ class TabManagerMiddleware {
                                      method: .drop,
                                      object: .tab,
                                      value: .tabTray)
-        tabManager.moveTab(isPrivate: false, fromIndex: originIndex, toIndex: destinationIndex)
+        tabManager.reorderTabsInArray(isPrivate: isPrivate, fromIndex: originIndex, toIndex: destinationIndex)
 
         let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false, uuid: uuid)
         let context = RefreshTabContext(tabDisplayModel: model, windowUUID: uuid)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -233,7 +233,7 @@ class TabManagerMiddleware {
                                      method: .drop,
                                      object: .tab,
                                      value: .tabTray)
-        tabManager.reorderTabsInArray(isPrivate: isPrivate, fromIndex: originIndex, toIndex: destinationIndex)
+        tabManager.reorderTabs(isPrivate: isPrivate, fromIndex: originIndex, toIndex: destinationIndex)
 
         let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false, uuid: uuid)
         let context = RefreshTabContext(tabDisplayModel: model, windowUUID: uuid)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -358,6 +358,7 @@ extension TabDisplayView: UICollectionViewDragDelegate, UICollectionViewDropDele
         let end = IndexPath(row: destinationIndexPath.item, section: section)
         store.dispatch(TabPanelAction.moveTab(MoveTabContext(originIndex: start.row,
                                                              destinationIndex: end.row,
+                                                             isPrivate: tabsState.isPrivateMode,
                                                              windowUUID: windowUUID)))
         coordinator.drop(dragItem, toItemAt: destinationIndexPath)
 

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -507,7 +507,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     // MARK: - Move tabs
-    func moveTab(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {
+    func reorderTabsInArray(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {
         let currentTabs = privateMode ? privateTabs : normalTabs
 
         guard visibleFromIndex < currentTabs.count, visibleToIndex < currentTabs.count else { return }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -507,7 +507,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     // MARK: - Move tabs
-    func reorderTabsInArray(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {
+    func reorderTabs(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {
         let currentTabs = privateMode ? privateTabs : normalTabs
 
         guard visibleFromIndex < currentTabs.count, visibleToIndex < currentTabs.count else { return }

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -45,7 +45,7 @@ protocol TabManager: AnyObject {
     func clearAllTabsHistory()
     func willSwitchTabMode(leavingPBM: Bool)
     func cleanupClosedTabs(_ closedTabs: [Tab], previous: Tab?, isPrivate: Bool)
-    func moveTab(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int)
+    func reorderTabsInArray(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int)
     func preserveTabs()
     func restoreTabs(_ forced: Bool)
     func startAtHomeCheck() -> Bool

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -45,7 +45,7 @@ protocol TabManager: AnyObject {
     func clearAllTabsHistory()
     func willSwitchTabMode(leavingPBM: Bool)
     func cleanupClosedTabs(_ closedTabs: [Tab], previous: Tab?, isPrivate: Bool)
-    func reorderTabsInArray(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int)
+    func reorderTabs(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int)
     func preserveTabs()
     func restoreTabs(_ forced: Bool)
     func startAtHomeCheck() -> Bool

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -99,7 +99,7 @@ class MockTabManager: TabManager {
 
     func cleanupClosedTabs(_ closedTabs: [Tab], previous: Tab?, isPrivate: Bool) {}
 
-    func reorderTabsInArray(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {}
+    func reorderTabs(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {}
 
     func preserveTabs() {}
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -99,7 +99,7 @@ class MockTabManager: TabManager {
 
     func cleanupClosedTabs(_ closedTabs: [Tab], previous: Tab?, isPrivate: Bool) {}
 
-    func moveTab(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {}
+    func reorderTabsInArray(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {}
 
     func preserveTabs() {}
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8449)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18739)

## :bulb: Description
Previously the moveTabs method in the TabPanelActions did not check whether the panel was in private browsing mode or not. It now passes a bool `isPrivate` to check. Also I renamed the method `moveTabs` which is different from the redux method, to `reorderTabs` to make the two of them more easily distinguishable, and to clarify what is happening in the second method.

## Future Work
Currently I observe that there's a quick flash of the old layout if the tab is tapped quickly after being moved.
I've created a follow up bug to work on [here](https://mozilla-hub.atlassian.net/browse/FXIOS-8650).

## Video 
https://github.com/mozilla-mobile/firefox-ios/assets/5545720/95a8f3dd-54fc-4a89-b640-837bf932f459

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

