### PR TITLE
Bugfix FXIOS-8427 - address autofill show accessory view

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1985,7 +1985,7 @@ class BrowserViewController: UIViewController,
     }
 
     private func displayAddressAutofillAccessoryView(tabWebView: TabWebView) {
-        profile.autofill.listCreditCards(completion: { addresses, error in
+        profile.autofill.listAllAddresses(completion: { addresses, error in
             guard let addresses = addresses, !addresses.isEmpty, error == nil else { return }
             DispatchQueue.main.async {
                 tabWebView.accessoryView.reloadViewFor(AccessoryType.address)


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-8427 ](https://mozilla-hub.atlassian.net/browse/FXIOS-8427)
[#18681](https://github.com/mozilla-mobile/firefox-ios/issues/18681)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This bugfix allows the proper accessory view to show

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

