### PR TITLE
Bugfix FXIOS-8645 - Sponsored/Non-sponsored suggestions remain stuck for an entire session

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -654,11 +654,13 @@ extension SearchSettingsTableViewController {
     @objc
     func didToggleEnableNonSponsoredSuggestions(_ toggle: ThemedSwitch) {
         model.shouldShowFirefoxSuggestions = toggle.isOn
+        notificationCenter.post(name: .SponsoredAndNonSponsoredSuggestionsChanged)
     }
 
     @objc
     func didToggleEnableSponsoredSuggestions(_ toggle: ThemedSwitch) {
         model.shouldShowSponsoredSuggestions = toggle.isOn
+        notificationCenter.post(name: .SponsoredAndNonSponsoredSuggestionsChanged)
     }
 
     func cancel() {

--- a/firefox-ios/Shared/NotificationConstants.swift
+++ b/firefox-ios/Shared/NotificationConstants.swift
@@ -79,6 +79,8 @@ extension Notification.Name {
 
     public static let SearchSettingsChanged = Notification.Name("SearchSettingsChanged")
 
+    public static let SponsoredAndNonSponsoredSuggestionsChanged = Notification.Name("SponsoredAndNonSponsoredSuggestions")
+
     public static let TabDataUpdated = Notification.Name("TabDataUpdated")
 
     public static let PendingBlobDownloadAddedToQueue = Notification.Name("PendingBlobDownloadAddedToQueue")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8645)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19175)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- This PR fixes Sponsored/Non Sponsored suggestions that were showing, even though they had been disabled.

https://github.com/mozilla-mobile/firefox-ios/assets/51127880/19b3b482-2005-4a1c-b3e3-dc196d7d58e8

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

