### PR TITLE
Refactor FXIOS-8612, 8614 WebEngine: renaming & feature flag

### DIFF
--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1D3BEDFB20C5E76B0019B722 /* FindInPageBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3BEDFA20C5E76A0019B722 /* FindInPageBar.swift */; };
 		1D3FEEA120C0A73D00FFAA8C /* RequestDesktopTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3FEEA020C0A73D00FFAA8C /* RequestDesktopTest.swift */; };
 		1D47758820C1E66000C074AE /* CopyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D47758720C1E66000C074AE /* CopyTest.swift */; };
+		1D96A2D92BA2490D00EF7CC7 /* WebEngineRefactorFlagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D96A2D82BA2490D00EF7CC7 /* WebEngineRefactorFlagManager.swift */; };
 		1DD317E120BF1B3000DFA44E /* OnboardingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD317E020BF1B3000DFA44E /* OnboardingTest.swift */; };
 		1DE903CE20C751D7002E53ED /* FindInPageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE903CD20C751D7002E53ED /* FindInPageTest.swift */; };
 		24433101219DA46F00778D02 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24433100219DA46F00778D02 /* Debouncer.swift */; };
@@ -369,6 +370,7 @@
 		1D3BEDFA20C5E76A0019B722 /* FindInPageBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPageBar.swift; sourceTree = "<group>"; };
 		1D3FEEA020C0A73D00FFAA8C /* RequestDesktopTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDesktopTest.swift; sourceTree = "<group>"; };
 		1D47758720C1E66000C074AE /* CopyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyTest.swift; sourceTree = "<group>"; };
+		1D96A2D82BA2490D00EF7CC7 /* WebEngineRefactorFlagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebEngineRefactorFlagManager.swift; sourceTree = "<group>"; };
 		1DD317E020BF1B3000DFA44E /* OnboardingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTest.swift; sourceTree = "<group>"; };
 		1DE903CD20C751D7002E53ED /* FindInPageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindInPageTest.swift; sourceTree = "<group>"; };
 		24433100219DA46F00778D02 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
@@ -1909,6 +1911,7 @@
 				D5D067FA252F945D00C35227 /* metrics.yaml */,
 				C82F45F8281A76EF000D7D84 /* ShortcutsPresenter.swift */,
 				1215EC0828D316B500AECC75 /* NavigationPath.swift */,
+				1D96A2D82BA2490D00EF7CC7 /* WebEngineRefactorFlagManager.swift */,
 			);
 			path = Blockzilla;
 			sourceTree = "<group>";
@@ -2619,6 +2622,7 @@
 				D3E54FE01DF0E221003E1AFF /* SearchSettingsViewController.swift in Sources */,
 				30DFF98021810BF20055707C /* SearchSuggestClient.swift in Sources */,
 				F861799D2795EE9800CFD324 /* InternalExperimentDetailView.swift in Sources */,
+				1D96A2D92BA2490D00EF7CC7 /* WebEngineRefactorFlagManager.swift in Sources */,
 				840057582735309500E48144 /* SettingsTableViewToggleCell.swift in Sources */,
 				16D7169C2114EF76000C8A66 /* BlockerToggle.swift in Sources */,
 				C817A35822CE73B4002529FF /* ReadWriteLock.swift in Sources */,

--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -75,7 +75,7 @@
 		A89766DA1F57DCA9008183C5 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		B101243E2B4EE8C20099F3CA /* URLValidationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B101243D2B4EE8C20099F3CA /* URLValidationTest.swift */; };
 		B3481A551FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3481A541FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift */; };
-		B3AFC2BC1F7C0B9F001AEF38 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AFC2BB1F7C0B9F001AEF38 /* WebViewController.swift */; };
+		B3AFC2BC1F7C0B9F001AEF38 /* LegacyWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AFC2BB1F7C0B9F001AEF38 /* LegacyWebViewController.swift */; };
 		B3CD41C91FD1027000AEBD58 /* InsetTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CD41C81FD1027000AEBD58 /* InsetTextField.swift */; };
 		B3CD41CC1FD1CAF000AEBD58 /* PaddedSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CD41CB1FD1CAF000AEBD58 /* PaddedSwitch.swift */; };
 		B3D23BEF1FA3A9E500D9C50F /* postload.js in Resources */ = {isa = PBXBuildFile; fileRef = B3D23BEE1FA3A9E500D9C50F /* postload.js */; };
@@ -679,7 +679,7 @@
 		AAB8E622E994545108473554 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		B101243D2B4EE8C20099F3CA /* URLValidationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLValidationTest.swift; sourceTree = "<group>"; };
 		B3481A541FCF261900CA2EA6 /* AutocompleteCustomUrlViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteCustomUrlViewController.swift; sourceTree = "<group>"; };
-		B3AFC2BB1F7C0B9F001AEF38 /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
+		B3AFC2BB1F7C0B9F001AEF38 /* LegacyWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyWebViewController.swift; sourceTree = "<group>"; };
 		B3CD41C81FD1027000AEBD58 /* InsetTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetTextField.swift; sourceTree = "<group>"; };
 		B3CD41CB1FD1CAF000AEBD58 /* PaddedSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddedSwitch.swift; sourceTree = "<group>"; };
 		B3D23BEE1FA3A9E500D9C50F /* postload.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = postload.js; sourceTree = "<group>"; };
@@ -1384,7 +1384,7 @@
 		B3AFC2BA1F7C0B92001AEF38 /* WebView */ = {
 			isa = PBXGroup;
 			children = (
-				B3AFC2BB1F7C0B9F001AEF38 /* WebViewController.swift */,
+				B3AFC2BB1F7C0B9F001AEF38 /* LegacyWebViewController.swift */,
 			);
 			path = WebView;
 			sourceTree = "<group>";
@@ -2604,7 +2604,7 @@
 				C8337DFD2710898800093D42 /* ImageCell.swift in Sources */,
 				D34E70351DA874AA00BABDCC /* StringExtensions.swift in Sources */,
 				D30179C31BCC6F65009AD388 /* AboutViewController.swift in Sources */,
-				B3AFC2BC1F7C0B9F001AEF38 /* WebViewController.swift in Sources */,
+				B3AFC2BC1F7C0B9F001AEF38 /* LegacyWebViewController.swift in Sources */,
 				D5ABA3DA1FCC846800D5C060 /* AutocompleteSettingViewController.swift in Sources */,
 				D5ABA3D91FCC846800D5C060 /* AddCustomDomainViewController.swift in Sources */,
 				122D19F728E1B29000B884E7 /* SearchInContentTelemetry.swift in Sources */,

--- a/focus-ios/Blockzilla/BrowserViewController.swift
+++ b/focus-ios/Blockzilla/BrowserViewController.swift
@@ -20,12 +20,12 @@ class BrowserViewController: UIViewController {
         isTrackingEnabled: {
             Settings.getToggle(.trackingProtection)
         })
-    private lazy var webViewController: WebViewController = {
+    private lazy var webViewController: LegacyWebViewController = {
         var menuAction = WebMenuAction.live
         menuAction.openLink = { url in
             self.submit(url: url, source: .action)
         }
-        return WebViewController(trackingProtectionManager: trackingProtectionManager, webMenuAction: menuAction)
+        return LegacyWebViewController(trackingProtectionManager: trackingProtectionManager, webMenuAction: menuAction)
     }()
     private let webViewContainer = UIView()
 
@@ -1637,14 +1637,14 @@ extension BrowserViewController: SearchSuggestionsPromptViewDelegate {
     }
 }
 
-extension BrowserViewController: WebControllerDelegate {
+extension BrowserViewController: LegacyWebControllerDelegate {
 
-    func webControllerDidStartProvisionalNavigation(_ controller: WebController) {
+    func webControllerDidStartProvisionalNavigation(_ controller: LegacyWebController) {
         urlBar.dismiss()
         updateFindInPageVisibility(visible: false)
     }
 
-    func webController(_ controller: WebController, didUpdateFindInPageResults currentResult: Int?, totalResults: Int?) {
+    func webController(_ controller: LegacyWebController, didUpdateFindInPageResults currentResult: Int?, totalResults: Int?) {
         if let total = totalResults {
             findInPageBar?.totalResults = total
         }
@@ -1654,11 +1654,11 @@ extension BrowserViewController: WebControllerDelegate {
         }
     }
 
-    func webControllerDidReload(_ controller: WebController) {
+    func webControllerDidReload(_ controller: LegacyWebController) {
         SearchHistoryUtils.isReload = true
     }
 
-    func webControllerDidStartNavigation(_ controller: WebController) {
+    func webControllerDidStartNavigation(_ controller: LegacyWebController) {
         if !SearchHistoryUtils.isFromURLBar && !SearchHistoryUtils.isNavigating && !SearchHistoryUtils.isReload {
             SearchHistoryUtils.pushSearchToStack(with: (urlBar.url?.absoluteString)!)
         }
@@ -1670,7 +1670,7 @@ extension BrowserViewController: WebControllerDelegate {
         updateURLBar()
     }
 
-    func webControllerDidFinishNavigation(_ controller: WebController) {
+    func webControllerDidFinishNavigation(_ controller: LegacyWebController) {
         updateURLBar()
         urlBarViewModel.isLoading = false
         urlBarViewModel.loadingProgres = 1
@@ -1690,11 +1690,11 @@ extension BrowserViewController: WebControllerDelegate {
         }
     }
 
-    func webControllerURLDidChange(_ controller: WebController, url: URL) {
+    func webControllerURLDidChange(_ controller: LegacyWebController, url: URL) {
         showToolbars()
     }
 
-    func webController(_ controller: WebController, didFailNavigationWithError error: Error) {
+    func webController(_ controller: LegacyWebController, didFailNavigationWithError error: Error) {
         // FXIOS-8637 - #19160 - Integrate onTitleChange, onLocationChange in Focus iOS
         urlBar.url = webViewController.url
         toggleURLBarBackground(isBright: true)
@@ -1702,16 +1702,16 @@ extension BrowserViewController: WebControllerDelegate {
         urlBarViewModel.loadingProgres = 1
     }
 
-    func webController(_ controller: WebController, didUpdateCanGoBack canGoBack: Bool) {
+    func webController(_ controller: LegacyWebController, didUpdateCanGoBack canGoBack: Bool) {
         urlBarViewModel.canGoBack = canGoBack
     }
 
-    func webController(_ controller: WebController, didUpdateCanGoForward canGoForward: Bool) {
+    func webController(_ controller: LegacyWebController, didUpdateCanGoForward canGoForward: Bool) {
         urlBarViewModel.canGoForward = canGoForward
     }
 
     // FXIOS-8636 - #19159 - Integrate onProgress and onNavigationStateChange in Focus iOS
-    func webController(_ controller: WebController, didUpdateEstimatedProgress estimatedProgress: Double) {
+    func webController(_ controller: LegacyWebController, didUpdateEstimatedProgress estimatedProgress: Double) {
         // Don't update progress if the home view is visible. This prevents the centered URL bar
         // from catching the global progress events.
         guard urlBar.inBrowsingMode else { return }
@@ -1721,18 +1721,18 @@ extension BrowserViewController: WebControllerDelegate {
     }
 
     // FXIOS-8642 - #19165 ⁃ Integrate scroll controller delegate with Focus iOS
-    func webController(_ controller: WebController, scrollViewWillBeginDragging scrollView: UIScrollView) {
+    func webController(_ controller: LegacyWebController, scrollViewWillBeginDragging scrollView: UIScrollView) {
         lastScrollOffset = scrollView.contentOffset
         lastScrollTranslation = scrollView.panGestureRecognizer.translation(in: scrollView)
     }
 
     // FXIOS-8642 - #19165 ⁃ Integrate scroll controller delegate with Focus iOS
-    func webController(_ controller: WebController, scrollViewDidEndDragging scrollView: UIScrollView) {
+    func webController(_ controller: LegacyWebController, scrollViewDidEndDragging scrollView: UIScrollView) {
         snapToolbars(scrollView: scrollView)
     }
 
     // FXIOS-8642 - #19165 ⁃ Integrate scroll controller delegate with Focus iOS
-    func webController(_ controller: WebController, scrollViewDidScroll scrollView: UIScrollView) {
+    func webController(_ controller: LegacyWebController, scrollViewDidScroll scrollView: UIScrollView) {
         let translation = scrollView.panGestureRecognizer.translation(in: scrollView)
         let isDragging = scrollView.panGestureRecognizer.state != .possible
 
@@ -1792,7 +1792,7 @@ extension BrowserViewController: WebControllerDelegate {
     }
 
     // FXIOS-8642 - #19165 ⁃ Integrate scroll controller delegate with Focus iOS
-    func webControllerShouldScrollToTop(_ controller: WebController) -> Bool {
+    func webControllerShouldScrollToTop(_ controller: LegacyWebController) -> Bool {
         guard scrollBarOffsetAlpha == 0 else {
             showToolbars()
             return false
@@ -1801,11 +1801,11 @@ extension BrowserViewController: WebControllerDelegate {
         return true
     }
 
-    func webControllerDidNavigateBack(_ controller: WebController) {
+    func webControllerDidNavigateBack(_ controller: LegacyWebController) {
         handleNavigationBack()
     }
 
-    func webControllerDidNavigateForward(_ controller: WebController) {
+    func webControllerDidNavigateForward(_ controller: LegacyWebController) {
         handleNavigationForward()
     }
 
@@ -1836,7 +1836,7 @@ extension BrowserViewController: WebControllerDelegate {
         }
     }
 
-    func webController(_ controller: WebController, didUpdateTrackingProtectionStatus trackingStatus: TrackingProtectionStatus, oldTrackingProtectionStatus: TrackingProtectionStatus) {
+    func webController(_ controller: LegacyWebController, didUpdateTrackingProtectionStatus trackingStatus: TrackingProtectionStatus, oldTrackingProtectionStatus: TrackingProtectionStatus) {
         // Calculate the number of trackers blocked and add that to lifetime total
         if case .on(let info) = trackingStatus,
            case .on(let oldInfo) = oldTrackingProtectionStatus {

--- a/focus-ios/Blockzilla/BrowserViewController.swift
+++ b/focus-ios/Blockzilla/BrowserViewController.swift
@@ -186,7 +186,16 @@ class BrowserViewController: UIViewController {
             make.top.bottom.leading.width.equalToSuperview()
         }
 
-        // FXIOS-8617 - #19118 ⁃ Integrate EngineSession in Focus iOS
+        if WebEngineFlagManager.isWebEngineEnabled {
+            // FXIOS-8617 - #19118 ⁃ Integrate EngineSession in Focus iOS
+        } else {
+            // Legacy UI and related configuration
+            // TODO: [FXIOS-8616] Portions of this configuration will eventually be shared also by WebEngine.
+            configureLegacyUI()
+        }
+    }
+
+    private func configureLegacyUI() {
         webViewController.delegate = self
 
         setupBackgroundImage()

--- a/focus-ios/Blockzilla/BrowserViewController.swift
+++ b/focus-ios/Blockzilla/BrowserViewController.swift
@@ -27,7 +27,7 @@ class BrowserViewController: UIViewController {
         }
         return LegacyWebViewController(trackingProtectionManager: trackingProtectionManager, webMenuAction: menuAction)
     }()
-    private let webViewContainer = UIView()
+    private let legacyWebViewContainer = UIView()
 
     var modalDelegate: ModalDelegate?
     private var keyboardState: KeyboardState?
@@ -204,8 +204,8 @@ class BrowserViewController: UIViewController {
 
         mainContainerView.addSubview(homeViewContainer)
 
-        webViewContainer.isHidden = true
-        mainContainerView.addSubview(webViewContainer)
+        legacyWebViewContainer.isHidden = true
+        mainContainerView.addSubview(legacyWebViewContainer)
 
         urlBarContainer.alpha = 0
         mainContainerView.addSubview(urlBarContainer)
@@ -246,7 +246,7 @@ class BrowserViewController: UIViewController {
 
         addWebViewConstraints()
 
-        webViewContainer.snp.makeConstraints { make in
+        legacyWebViewContainer.snp.makeConstraints { make in
             browserBottomConstraint = make.bottom.equalTo(browserToolbar.snp.top).priority(1000).constraint
             if !showsToolsetInURLBar {
                 browserBottomConstraint.activate()
@@ -629,11 +629,11 @@ class BrowserViewController: UIViewController {
     // FXIOS-8617 - #19118 ⁃ Integrate EngineSession in Focus iOS
     private func containWebView() {
         addChild(webViewController)
-        webViewContainer.addSubview(webViewController.view)
+        legacyWebViewContainer.addSubview(webViewController.view)
         webViewController.didMove(toParent: self)
 
         webViewController.view.snp.makeConstraints { make in
-            make.edges.equalTo(webViewContainer.snp.edges)
+            make.edges.equalTo(legacyWebViewContainer.snp.edges)
         }
     }
 
@@ -714,12 +714,12 @@ class BrowserViewController: UIViewController {
     }
 
     private func addWebViewConstraints() {
-        let topConstraint = webViewContainer.topAnchor.constraint(equalTo: urlBarContainer.bottomAnchor)
+        let topConstraint = legacyWebViewContainer.topAnchor.constraint(equalTo: urlBarContainer.bottomAnchor)
         topConstraint.priority = .defaultLow
-        let bottomConstraint = webViewContainer.bottomAnchor.constraint(equalTo: mainContainerView.bottomAnchor)
+        let bottomConstraint = legacyWebViewContainer.bottomAnchor.constraint(equalTo: mainContainerView.bottomAnchor)
         bottomConstraint.priority = .defaultLow
-        let leadingConstraint = webViewContainer.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor)
-        let trailingConstraint = webViewContainer.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        let leadingConstraint = legacyWebViewContainer.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor)
+        let trailingConstraint = legacyWebViewContainer.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         NSLayoutConstraint.activate([topConstraint, bottomConstraint, leadingConstraint, trailingConstraint])
     }
 
@@ -837,7 +837,7 @@ class BrowserViewController: UIViewController {
         overlayView.currentURL = ""
         // FXIOS-8639 - #19162 - Handle reset webview in Focus iOS
         webViewController.reset()
-        webViewContainer.isHidden = true
+        legacyWebViewContainer.isHidden = true
         browserToolbar.isHidden = true
         urlBarViewModel.canGoBack = false
         urlBarViewModel.canGoForward = false
@@ -950,8 +950,8 @@ class BrowserViewController: UIViewController {
             }
         }
 
-        if webViewContainer.isHidden {
-            webViewContainer.isHidden = false
+        if legacyWebViewContainer.isHidden {
+            legacyWebViewContainer.isHidden = false
             homeViewController.view.isHidden = true
             urlBar.inBrowsingMode = true
 

--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -8,7 +8,7 @@ import PassKit
 import Combine
 import Glean
 
-protocol BrowserState {
+protocol LegacyBrowserState {
     var url: URL? { get }
     var isLoading: Bool { get }
     var canGoBack: Bool { get }
@@ -519,7 +519,7 @@ extension LegacyWebViewController: WKNavigationDelegate {
     }
 }
 
-extension LegacyWebViewController: BrowserState {
+extension LegacyWebViewController: LegacyBrowserState {
     var canGoBack: Bool { return browserView.canGoBack }
     var canGoForward: Bool { return browserView.canGoForward }
     var estimatedProgress: Double { return browserView.estimatedProgress }

--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -16,35 +16,35 @@ protocol BrowserState {
     var estimatedProgress: Double { get }
 }
 
-protocol WebController {
-    var delegate: WebControllerDelegate? { get set }
+protocol LegacyWebController {
+    var delegate: LegacyWebControllerDelegate? { get set }
     var canGoBack: Bool { get }
     var canGoForward: Bool { get }
 
     func load(_ request: URLRequest)
 }
 
-protocol WebControllerDelegate: AnyObject {
-    func webControllerDidStartProvisionalNavigation(_ controller: WebController)
-    func webControllerDidStartNavigation(_ controller: WebController)
-    func webControllerDidFinishNavigation(_ controller: WebController)
-    func webControllerDidNavigateBack(_ controller: WebController)
-    func webControllerDidNavigateForward(_ controller: WebController)
-    func webControllerDidReload(_ controller: WebController)
-    func webControllerURLDidChange(_ controller: WebController, url: URL)
-    func webController(_ controller: WebController, didFailNavigationWithError error: Error)
-    func webController(_ controller: WebController, didUpdateCanGoBack canGoBack: Bool)
-    func webController(_ controller: WebController, didUpdateCanGoForward canGoForward: Bool)
-    func webController(_ controller: WebController, didUpdateEstimatedProgress estimatedProgress: Double)
-    func webController(_ controller: WebController, scrollViewWillBeginDragging scrollView: UIScrollView)
-    func webController(_ controller: WebController, scrollViewDidEndDragging scrollView: UIScrollView)
-    func webController(_ controller: WebController, scrollViewDidScroll scrollView: UIScrollView)
-    func webControllerShouldScrollToTop(_ controller: WebController) -> Bool
-    func webController(_ controller: WebController, didUpdateTrackingProtectionStatus trackingStatus: TrackingProtectionStatus, oldTrackingProtectionStatus: TrackingProtectionStatus)
-    func webController(_ controller: WebController, didUpdateFindInPageResults currentResult: Int?, totalResults: Int?)
+protocol LegacyWebControllerDelegate: AnyObject {
+    func webControllerDidStartProvisionalNavigation(_ controller: LegacyWebController)
+    func webControllerDidStartNavigation(_ controller: LegacyWebController)
+    func webControllerDidFinishNavigation(_ controller: LegacyWebController)
+    func webControllerDidNavigateBack(_ controller: LegacyWebController)
+    func webControllerDidNavigateForward(_ controller: LegacyWebController)
+    func webControllerDidReload(_ controller: LegacyWebController)
+    func webControllerURLDidChange(_ controller: LegacyWebController, url: URL)
+    func webController(_ controller: LegacyWebController, didFailNavigationWithError error: Error)
+    func webController(_ controller: LegacyWebController, didUpdateCanGoBack canGoBack: Bool)
+    func webController(_ controller: LegacyWebController, didUpdateCanGoForward canGoForward: Bool)
+    func webController(_ controller: LegacyWebController, didUpdateEstimatedProgress estimatedProgress: Double)
+    func webController(_ controller: LegacyWebController, scrollViewWillBeginDragging scrollView: UIScrollView)
+    func webController(_ controller: LegacyWebController, scrollViewDidEndDragging scrollView: UIScrollView)
+    func webController(_ controller: LegacyWebController, scrollViewDidScroll scrollView: UIScrollView)
+    func webControllerShouldScrollToTop(_ controller: LegacyWebController) -> Bool
+    func webController(_ controller: LegacyWebController, didUpdateTrackingProtectionStatus trackingStatus: TrackingProtectionStatus, oldTrackingProtectionStatus: TrackingProtectionStatus)
+    func webController(_ controller: LegacyWebController, didUpdateFindInPageResults currentResult: Int?, totalResults: Int?)
 }
 
-class WebViewController: UIViewController, WebController {
+class LegacyWebViewController: UIViewController, LegacyWebController {
     private enum ScriptHandlers: String, CaseIterable {
         case focusTrackingProtection
         case focusTrackingProtectionPostLoad
@@ -60,10 +60,12 @@ class WebViewController: UIViewController, WebController {
         case canGoForward = "canGoForward"
     }
 
-    weak var delegate: WebControllerDelegate?
+    weak var delegate: LegacyWebControllerDelegate?
 
     var browserView: WKWebView! {
-        didSet { configureRefreshControl() }
+        didSet {
+            configureRefreshControl()
+        }
     }
 
     private var progressObserver: NSKeyValueObservation?
@@ -359,7 +361,7 @@ class WebViewController: UIViewController, WebController {
     }
 }
 
-extension WebViewController: UIScrollViewDelegate {
+extension LegacyWebViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         delegate?.webController(self, scrollViewDidScroll: scrollView)
     }
@@ -377,7 +379,7 @@ extension WebViewController: UIScrollViewDelegate {
     }
 }
 
-extension WebViewController: WKNavigationDelegate {
+extension LegacyWebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
         // validate the URL using URIFixup
         guard let urlString = webView.url?.absoluteString,
@@ -517,7 +519,7 @@ extension WebViewController: WKNavigationDelegate {
     }
 }
 
-extension WebViewController: BrowserState {
+extension LegacyWebViewController: BrowserState {
     var canGoBack: Bool { return browserView.canGoBack }
     var canGoForward: Bool { return browserView.canGoForward }
     var estimatedProgress: Double { return browserView.estimatedProgress }
@@ -525,7 +527,7 @@ extension WebViewController: BrowserState {
     var url: URL? { return browserView.url }
 }
 
-extension WebViewController: WKUIDelegate {
+extension LegacyWebViewController: WKUIDelegate {
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         // check if this is a new frame / window
         guard navigationAction.targetFrame == nil else { return nil }
@@ -545,7 +547,7 @@ extension WebViewController: WKUIDelegate {
     }
 }
 
-extension WebViewController: WKScriptMessageHandler {
+extension LegacyWebViewController: WKScriptMessageHandler {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         // FXIOS-8090 - #19152 ⁃ Integrate EngineSession ads handler in Focus iOS
         if message.name == "adsMessageHandler" {
@@ -586,7 +588,7 @@ extension WebViewController: WKScriptMessageHandler {
     }
 }
 
-extension WebViewController {
+extension LegacyWebViewController {
     func webView(_ webView: WKWebView, contextMenuConfigurationFor elementInfo: WKContextMenuElementInfo) async -> UIContextMenuConfiguration? {
         guard let url = elementInfo.linkURL else { return nil }
 

--- a/focus-ios/Blockzilla/Utilities/OpenUtils.swift
+++ b/focus-ios/Blockzilla/Utilities/OpenUtils.swift
@@ -6,9 +6,9 @@ import UIKit
 
 class OpenUtils: NSObject {
     private let selectedURL: URL
-    private let webViewController: WebViewController
+    private let webViewController: LegacyWebViewController
 
-    init(url: URL, webViewController: WebViewController) {
+    init(url: URL, webViewController: LegacyWebViewController) {
         self.selectedURL = url
         self.webViewController = webViewController
     }

--- a/focus-ios/Blockzilla/WebEngineRefactorFlagManager.swift
+++ b/focus-ios/Blockzilla/WebEngineRefactorFlagManager.swift
@@ -8,6 +8,6 @@ struct WebEngineFlagManager {
     /// Whether the refactor for using the new WebEngine as the active browser engine for the client
     /// is enabled. If `true` the WebEngine will be used rather than the legacy browser code.
     ///
-    /// TODO: currently this is hardcoded; eventually this will be updated to a Nimbus feature flag.
+    /// TODO [FXIOS-8655]: currently this is hardcoded; eventually this will be updated to a Nimbus feature flag.
     static let isWebEngineEnabled = false
 }

--- a/focus-ios/Blockzilla/WebEngineRefactorFlagManager.swift
+++ b/focus-ios/Blockzilla/WebEngineRefactorFlagManager.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct WebEngineFlagManager {
+    /// Whether the refactor for using the new WebEngine as the active browser engine for the client
+    /// is enabled. If `true` the WebEngine will be used rather than the legacy browser code.
+    ///
+    /// TODO: currently this is hardcoded; eventually this will be updated to a Nimbus feature flag.
+    static let isWebEngineEnabled = false
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8612)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8614)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19113)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19115)

## :bulb: Description

Some early renaming, plus a temporary hardcoded feature flag that can be used for local testing of early WebEngine work (until the Nimbus feature flag is added).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

