### PR TITLE
Bugfix FXIOS-8607 #19104 Use saved password button should appear when I sign in

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
@@ -45,7 +45,7 @@ struct LoginCellView: View {
                     .foregroundColor(iconPrimary)
                     .alignmentGuide(.midAccountAndName) { $0[VerticalAlignment.center] }
                 VStack(alignment: .leading) {
-                    Text(login.decryptedUsername)
+                    Text(login.decryptedUsername.isEmpty ? login.hostname : login.decryptedUsername)
                         .font(.body)
                         .foregroundColor(textColor)
                         .alignmentGuide(.midAccountAndName) { $0[VerticalAlignment.center] }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8607)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19104)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
There are cases where we allowed saving passwords without username, in this case we show the domain.
![image](https://github.com/mozilla-mobile/firefox-ios/assets/26011662/c050579c-cf77-4052-9fe7-b1795620749f)


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

