### PR TITLE
Bugfix FXIOS-8416 Fix intermittent crash during app force-quit

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -178,9 +178,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
-        logger.log("applicationDidEnterBackground start",
-                   level: .info,
-                   category: .lifecycle)
+        logger.log("applicationDidEnterBackground start", level: .info, category: .lifecycle)
 
         TelemetryWrapper.recordEvent(category: .action, method: .background, object: .app)
 
@@ -198,13 +196,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         shutdownWebServer = singleShotTimer
         backgroundWorkUtility?.scheduleOnAppBackground()
 
-        logger.log("applicationDidEnterBackground end",
-                   level: .info,
-                   category: .lifecycle)
+        logger.log("applicationDidEnterBackground end", level: .info, category: .lifecycle)
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
         // We have only five seconds here, so let's hope this doesn't take too long.
+        logger.log("applicationWillTerminate", level: .info, category: .lifecycle)
         profile.shutdown()
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -246,6 +246,7 @@ class BrowserViewController: UIViewController,
     }
 
     deinit {
+        logger.log("BVC deallocating", level: .info, category: .lifecycle)
         unsubscribeFromRedux()
         observedWebViews.forEach({ stopObserving(webView: $0) })
     }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -121,12 +121,28 @@ class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvi
     }
 
     deinit {
+        logger.log("TabScrollController deallocating", level: .info, category: .lifecycle)
         observedScrollViews.forEach({ stopObserving(scrollView: $0) })
     }
 
     init(logger: Logger = DefaultLogger.shared) {
         self.logger = logger
         super.init()
+        setupNotifications()
+    }
+
+    private func setupNotifications() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(applicationWillTerminate(_:)),
+                                               name: UIApplication.willTerminateNotification,
+                                               object: nil)
+    }
+
+    @objc
+    private func applicationWillTerminate(_ notification: Notification) {
+        // Ensures that we immediately de-register KVO observations for content size changes in
+        // webviews if the app is about to terminate.
+        observedScrollViews.forEach({ stopObserving(scrollView: $0) })
     }
 
     @objc


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8416)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18655)

## :bulb: Description

This is another attempt to fix a crash that happens during app termination, primarily impacting iOS 16.x users; there is some additional context (and a Slack thread link) in this PR: https://github.com/mozilla-mobile/firefox-ios/pull/18735

I believe that the original diagnosis is still sound and there is substantial evidence to implicate the underlying culprit, but I believe the previous PR was inadequate because of how iOS appears to clean up memory and deallocate objects during app termination. This fix ensures that we immediately de-register KVO for webview content size changes as soon as we detect app termination.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

