### PR TITLE
Add FXIOS-8660 - Add missing address fields ( `tel` and `addressLevel3`)

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -68,10 +68,12 @@ class AddressListViewModel: ObservableObject {
                                         organization: address.organization,
                                         country: address.country,
                                         addressLevel2: address.addressLevel2,
+                                        addressLevel3: address.addressLevel3,
                                         email: address.email,
                                         streetAddress: address.streetAddress,
                                         name: address.name,
-                                        postalCode: address.postalCode)
+                                        postalCode: address.postalCode,
+                                        tel: address.tel)
     }
 
     // MARK: - Handle Address Selection

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/AddressAutofillPayload.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/AddressAutofillPayload.swift
@@ -9,19 +9,23 @@ struct AddressAutofillPayload: Codable {
     let organization: String
     let country: String
     let addressLevel2: String
+    let addressLevel3: String
     let email: String
     let streetAddress: String
     let name: String
     let postalCode: String
+    let tel: String
 
     enum CodingKeys: String, CodingKey, CaseIterable {
         case addressLevel1 = "address-level1"
         case organization = "organization"
         case country = "country"
         case addressLevel2 = "address-level2"
+        case addressLevel3 = "address-level3"
         case email = "email"
         case streetAddress = "street-address"
         case name = "name"
         case postalCode = "postal-code"
+        case tel = "tel"
     }
 }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FormAutofillHelper/FormAutofillHelper.swift
@@ -165,10 +165,12 @@ class FormAutofillHelper: TabContentScript {
             organization: payload.organization,
             country: payload.country,
             addressLevel2: payload.addressLevel2,
+            addressLevel3: payload.addressLevel3,
             email: payload.email,
             streetAddress: payload.streetAddress,
             name: payload.name,
-            postalCode: payload.postalCode
+            postalCode: payload.postalCode,
+            tel: payload.tel
         )
 
         return AutofillFieldValuePayload(fieldValue: .address, fieldData: addressPlainText)
@@ -257,8 +259,10 @@ class FormAutofillHelper: TabContentScript {
         let sanitizedCountry = address.country.htmlEntityEncodedString
         let sanitizedAddressLevel1 = address.addressLevel1.htmlEntityEncodedString
         let sanitizedAddressLevel2 = address.addressLevel2.htmlEntityEncodedString
+        let sanitizedAddressLevel3 = address.addressLevel3.htmlEntityEncodedString
         let sanitizedEmail = address.email.htmlEntityEncodedString
         let sanitizedPostalCode = address.postalCode.htmlEntityEncodedString
+        let sanitizedTel = address.tel.htmlEntityEncodedString
 
         let injectionJSON: [String: Any] = [
             "organization": sanitizedOrganization,
@@ -267,8 +271,10 @@ class FormAutofillHelper: TabContentScript {
             "country": sanitizedCountry,
             "address-level1": sanitizedAddressLevel1,
             "address-level2": sanitizedAddressLevel2,
+            "address-level3": sanitizedAddressLevel3,
             "email": sanitizedEmail,
-            "postal-code": sanitizedPostalCode
+            "postal-code": sanitizedPostalCode,
+            "tel": sanitizedTel
         ]
         return injectionJSON
     }

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AutofillAtDocumentStart/FormAutofillHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AutofillAtDocumentStart/FormAutofillHelper.js
@@ -45,10 +45,12 @@ const expectedAddressPayloadShape = {
   organization: "",
   country: "",
   "address-level2": "",
+  "address-level3": "",
   email: "",
   "street-address": "",
   name: "",
   postalCode: "",
+  tel: "",
 };
 
 const normalizePayload = (expectedPayloadShape) => (payload) => {

--- a/firefox-ios/Storage/Rust/UnencryptedAddressFields.swift
+++ b/firefox-ios/Storage/Rust/UnencryptedAddressFields.swift
@@ -9,10 +9,12 @@ public struct UnencryptedAddressFields {
     public var organization: String = ""
     public var country: String = ""
     public var addressLevel2: String = ""
+    public var addressLevel3: String = ""
     public var email: String = ""
     public var streetAddress: String = ""
     public var name: String = ""
     public var postalCode: String = ""
+    public var tel: String = ""
 
     public init() { }
 
@@ -20,17 +22,21 @@ public struct UnencryptedAddressFields {
                 organization: String,
                 country: String,
                 addressLevel2: String,
+                addressLevel3: String,
                 email: String,
                 streetAddress: String,
                 name: String,
-                postalCode: String) {
+                postalCode: String,
+                tel: String) {
         self.addressLevel1 = addressLevel1
         self.organization = organization
         self.country = country
         self.addressLevel2 = addressLevel2
+        self.addressLevel3 = addressLevel3
         self.email = email
         self.streetAddress = streetAddress
         self.name = name
         self.postalCode = postalCode
+        self.tel = tel
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
@@ -116,7 +116,7 @@ class FormAutofillHelperTests: XCTestCase {
         XCTAssertEqual(json["address-level3"] as? String, "Suburb")
         XCTAssertEqual(json["email"] as? String, "mozilla@mozilla.com")
         XCTAssertEqual(json["postal-code"] as? String, "12345")
-        XCTAssertEqual(json["postal-code"] as? String, "+16509030800")
+        XCTAssertEqual(json["tel"] as? String, "+16509030800")
     }
 
     func testUserContentControllerDidReceiveScriptMessage_withAddressHandler() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
@@ -96,10 +96,12 @@ class FormAutofillHelperTests: XCTestCase {
                                                organization: "Mozilla",
                                                country: "USA",
                                                addressLevel2: "Apt 101",
+                                               addressLevel3: "Suburb",
                                                email: "mozilla@mozilla.com",
                                                streetAddress: "123 Mozilla",
                                                name: "John",
-                                               postalCode: "12345")
+                                               postalCode: "12345",
+                                               tel: "+16509030800")
 
         // Act
         let json = FormAutofillHelper.injectionJSONBuilder(address: address)
@@ -111,8 +113,10 @@ class FormAutofillHelperTests: XCTestCase {
         XCTAssertEqual(json["country"] as? String, "USA")
         XCTAssertEqual(json["address-level1"] as? String, "123 Main St")
         XCTAssertEqual(json["address-level2"] as? String, "Apt 101")
+        XCTAssertEqual(json["address-level3"] as? String, "Suburb")
         XCTAssertEqual(json["email"] as? String, "mozilla@mozilla.com")
         XCTAssertEqual(json["postal-code"] as? String, "12345")
+        XCTAssertEqual(json["postal-code"] as? String, "+16509030800")
     }
 
     func testUserContentControllerDidReceiveScriptMessage_withAddressHandler() {
@@ -123,11 +127,13 @@ class FormAutofillHelperTests: XCTestCase {
         let mockBody: [String: Any] = ["type": "fill-address-form",
                                        "payload": ["address-level1": "123 Main St",
                                                    "address-level2": "Apt 101",
+                                                   "address-level3": "Suburb",
                                                    "email": "mozilla@mozilla.com",
                                                    "street-address": "123 Mozilla",
                                                    "name": "John",
                                                    "organization": "Mozilla",
                                                    "postal-code": "12345",
+                                                   "tel": "+16509030800",
                                                    "country": "USA"]]
         let mockAddressScriptMessage = WKScriptMessageMock(
             name: FormAutofillHelper.HandlerName.addressFormMessageHandler.rawValue,
@@ -145,12 +151,14 @@ class FormAutofillHelperTests: XCTestCase {
             if let addressPayload = payload.fieldData as? UnencryptedAddressFields {
                 XCTAssertEqual(addressPayload.addressLevel1, "123 Main St")
                 XCTAssertEqual(addressPayload.addressLevel2, "Apt 101")
+                XCTAssertEqual(addressPayload.addressLevel3, "Suburb")
                 XCTAssertEqual(addressPayload.email, "mozilla@mozilla.com")
                 XCTAssertEqual(addressPayload.streetAddress, "123 Mozilla")
                 XCTAssertEqual(addressPayload.name, "John")
                 XCTAssertEqual(addressPayload.organization, "Mozilla")
                 XCTAssertEqual(addressPayload.postalCode, "12345")
                 XCTAssertEqual(addressPayload.country, "USA")
+                XCTAssertEqual(addressPayload.tel, "+16509030800")
             } else {
                 XCTFail("Failed to cast fieldData to expected type")
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8660)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19222)

## :bulb: Description
This PR:
- Adds `tel` and `addressLevel3` fields to address records ( basically all fields [in this file](https://github.com/mozilla/application-services/blob/9054db4bb5031881550ceab3448665ef6499a706/components/autofill/src/autofill.udl#L61-L70) should be part of the internal address representation)
- Updates tests

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

