### PR TITLE
Bugfix MTE-2524 testPrivateClosedSiteDoesNotAppearOnRecentlyClosed fails

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -325,6 +325,7 @@ class HistoryTests: BaseTestCase {
         closeFirstTabByX()
 
         // On private mode, the "Recently Closed Tabs List" is empty
+        navigator.nowAt(BrowserTab)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.goto(HomePanelsScreen)
         closeKeyboard()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2076)

## :bulb: Description
`HistoryTests.testPrivateClosedSiteDoesNotAppearOnRecentlyClosed` fails because closing a tab does not open the tab tray. Such an action opens the tab instead.

Before opening the new tab, we tell the tests that we have a browser tab opened.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

