### PR TITLE
Bugfix MTE-2525 testOptInNotificationLayout fails

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
@@ -183,7 +183,7 @@ class FakespotTests: IphoneOnlyTestCase {
             let searchBestBuy = app.webViews["contentView"].textFields["Search"]
             mozWaitForElementToExist(searchBestBuy)
             searchBestBuy.tap()
-            searchBestBuy.typeText("iphone")
+            searchBestBuy.typeText("macbook air")
             mozWaitForElementToExist(app.webViews["contentView"].buttons["submit search"])
             app.webViews["contentView"].buttons["submit search"].tap()
             waitUntilPageLoad()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
@@ -145,7 +145,6 @@ class FakespotTests: IphoneOnlyTestCase {
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2358892
-    // Smoketest
     func testOptInNotificationLayout() {
         if skipPlatform { return }
         // Navigate to a product detail page on amazon.com page


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2524)

## :bulb: Description
`FakespotTests.testOptInNotificationLayout` fails because the search term for BestBuy.com isn't specific enough. There are many iPhones available. 😓 "macbook air" returns more specific results.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

