### PR TITLE
Refactor FXIOS-8674 - Update Fonts related to CreditCardBottomSheetHeaderView to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetHeaderView.swift
@@ -11,8 +11,6 @@ import Shared
 class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView, ReusableCell, ThemeApplicable {
     // MARK: UX
     struct UX {
-        static let titleLabelFontSize: CGFloat = 17
-        static let headerLabelFontSize: CGFloat = 15
         static let headerElementsSpacing: CGFloat = 7.0
         static let mainContainerElementsSpacing: CGFloat = 7.0
         static let bottomSpacing: CGFloat = 24.0
@@ -42,9 +40,7 @@ class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView, ReusableCell
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.text = .CreditCard.RememberCreditCard.MainTitle
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(
-            withTextStyle: .headline,
-            size: UX.titleLabelFontSize)
+        label.font = FXFontStyles.Bold.headline.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityTraits = .header
     }
@@ -55,10 +51,7 @@ class CreditCardBottomSheetHeaderView: UITableViewHeaderFooterView, ReusableCell
         label.lineBreakMode = .byWordWrapping
         label.setContentHuggingPriority(.defaultHigh, for: .vertical)
         label.text = String(format: String.CreditCard.RememberCreditCard.Header, AppName.shortName.rawValue)
-
-        label.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .body,
-            size: UX.headerLabelFontSize)
+        label.font = FXFontStyles.Regular.subheadline.systemFont()
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityTraits = .staticText
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8674)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19245)

## :bulb: Description
- This PR updates the font styles used in the `CreditCardBottomSheetHeaderView` class to improve consistency and adaptability to dynamic font sizes.

**Light**
| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-16 at 00 52 00](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/c2d8d3f3-3bd6-4d93-ae01-16a1d106c184) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-16 at 00 52 04](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/3cf52287-83b4-4803-b766-781323623d26) |

**Dark**
| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-16 at 00 53 18](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/dc4fc61a-46aa-43d3-89f8-75ab3167e30c) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-16 at 00 53 25](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/908ea7f0-369f-45f3-9eba-727f3e0e3597) |

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

