### PR TITLE
Refactor FXIOS-8677 - Update Fonts in SnackButton to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/SnackButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SnackButton.swift
@@ -38,7 +38,7 @@ class SnackButton: UIButton, ThemeApplicable {
         if bold {
             titleLabel?.font = FXFontStyles.Bold.body.scaledFont()
         } else {
-            titleLabel?.font = FXFontStyles.Regular.body.systemFont()
+            titleLabel?.font = FXFontStyles.Regular.body.scaledFont()
         }
         titleLabel?.adjustsFontForContentSizeCategory = true
         setTitle(title, for: .normal)

--- a/firefox-ios/Client/Frontend/Widgets/SnackButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SnackButton.swift
@@ -14,7 +14,6 @@ typealias SnackBarCallback = (_ bar: SnackBar) -> Void
 class SnackButton: UIButton, ThemeApplicable {
     private struct UX {
         static let borderWidth: CGFloat = 0.5
-        static let fontSize: CGFloat = 17
     }
 
     let callback: SnackBarCallback?
@@ -37,9 +36,9 @@ class SnackButton: UIButton, ThemeApplicable {
         super.init(frame: .zero)
 
         if bold {
-            titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body, size: UX.fontSize)
+            titleLabel?.font = FXFontStyles.Bold.body.scaledFont()
         } else {
-            titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
+            titleLabel?.font = FXFontStyles.Regular.body.systemFont()
         }
         titleLabel?.adjustsFontForContentSizeCategory = true
         setTitle(title, for: .normal)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8677)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19248)

## :bulb: Description
- This PR updates the font styles used in the `SnackButton` class to improve consistency and adaptability to dynamic font sizes.

**Light**
| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-17 at 12 05 56](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/a66eea34-5f7c-4791-bc5f-1c9296552b3e) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-17 at 12 06 07](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/aba63156-8153-4c77-969c-5914175c6fb1) |

**Dark**
| Portrait  | Landscape | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-17 at 12 06 44](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/5c8d4475-e7b5-4dfc-a9ba-d8e6dcae15af) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-17 at 12 06 49](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/6584432d-dde8-48f7-b78b-6d666c6f452f) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

