### PR TITLE
Refactor FXIOS-8676-Update-Fonts-in-WallpaperSettingsHeaderView-to-use-FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsHeaderView.swift
@@ -35,13 +35,13 @@ class WallpaperSettingsHeaderView: UICollectionReusableView, ReusableCell {
     }
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline, size: 12.0, weight: .medium)
+        label.font = FXFontStyles.Regular.headline.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 
     private lazy var descriptionLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12.0)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
@@ -145,7 +145,7 @@ extension WallpaperSettingsHeaderView: ThemeApplicable {
         // in iOS 13 the title color set is not used for the attributed text color so we have to set it via attributes
         guard let buttonTitle = viewModel?.buttonTitle else { return }
         let labelAttributes: [NSAttributedString.Key: Any] = [
-            .font: DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12.0),
+            .font: FXFontStyles.Regular.body.scaledFont(),
             .foregroundColor: color,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8676)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19247)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR updates `WallpaperSettingsHeaderView`' to adapt new FXFontStyles.

Image of screen with title, test value as input for descriptionLabel, Link button is below 
| Screenshots with old code for both theme  | Screenshots with new code for both theme |
| ------------- | ------------- |
| <img width="416" alt="Pasted Graphic 9" src="https://github.com/mozilla-mobile/firefox-ios/assets/59967463/ef5963f2-4655-4423-b379-89d331195764">  | <img width="436" alt="Pasted Graphic 14" src="https://github.com/mozilla-mobile/firefox-ios/assets/59967463/16e5bde8-90bc-4488-9cb7-1d7168bb5707">  |
| <img width="406" alt="Pasted Graphic 8" src="https://github.com/mozilla-mobile/firefox-ios/assets/59967463/0012c6d3-a747-47ab-b566-ca27b1dad56c">  | <img width="420" alt="Pasted Graphic 15" src="https://github.com/mozilla-mobile/firefox-ios/assets/59967463/3bc4998d-78d0-4cf4-8164-84a84619c568">  |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

