### PR TITLE
Add FXIOS-8591 Nimbus loading for splash screen experiment

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -130,6 +130,10 @@ public struct AccessibilityIdentifiers {
         public static let back = "Back"
     }
 
+    struct LaunchScreen {
+        public static let splashScreenAnimation = "SplashScreenAnimation"
+    }
+
     struct PrivateMode {
         static let dimmingView = "PrivateMode.DimmingView"
         struct Homepage {

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -55,8 +55,10 @@ class AppLaunchUtil {
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 
         // Start initializing the Nimbus SDK. This should be done after Glean
-        // has been started.
-        initializeExperiments()
+        // has been started. For splashscreen experiment, the initialization has been moved to launch screen.
+        if !LegacyFeatureFlagsManager.shared.isFeatureEnabled(.splashScreen, checking: .buildOnly) {
+            initializeExperiments()
+        }
 
         // We migrate history from browser db to places if it hasn't already
         DispatchQueue.global().async {

--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
@@ -12,7 +12,6 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
     private var mainQueue: DispatchQueueInterface
 
     private lazy var splashScreenAnimation = SplashScreenAnimation()
-    private let nimbusSplashScreenFeatureLayer = NimbusSplashScreenFeatureLayer()
 
     init(coordinator: LaunchFinishedLoadingDelegate,
          viewModel: LaunchScreenViewModel = LaunchScreenViewModel(),
@@ -39,7 +38,7 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
         view.backgroundColor = .systemBackground
 
         Task {
-            try await delayStart()
+            await startSplashScreenExperiment()
             await startLoading()
         }
     }
@@ -83,11 +82,8 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
     }
 
     // MARK: - Splash Screen
-
-    private func delayStart() async throws {
-        guard featureFlags.isFeatureEnabled(.splashScreen, checking: .buildOnly) else { return }
-        let position: Int = nimbusSplashScreenFeatureLayer.maximumDurationMs
-        try await Task.sleep(nanoseconds: UInt64(position * 1_000_000))
+    func startSplashScreenExperiment() async {
+        await viewModel.startSplashScreenExperiment()
     }
 
     private func setupLaunchScreen() {

--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewModel.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewModel.swift
@@ -10,26 +10,68 @@ protocol LaunchFinishedLoadingDelegate: AnyObject {
     func launchBrowser()
 }
 
-class LaunchScreenViewModel {
+class LaunchScreenViewModel: FeatureFlaggable {
+    private var profile: Profile
     private var introScreenManager: IntroScreenManager
     private var updateViewModel: UpdateViewModel
     private var surveySurfaceManager: SurveySurfaceManager
+
+    private let nimbusSplashScreenFeatureLayer = NimbusSplashScreenFeatureLayer()
+    private var splashScreenTask: Task<Void, Never>?
+    private var hasExperimentsLoaded = false
 
     weak var delegate: LaunchFinishedLoadingDelegate?
 
     init(profile: Profile = AppContainer.shared.resolve(),
          messageManager: GleanPlumbMessageManagerProtocol = Experiments.messaging,
          onboardingModel: OnboardingViewModel = NimbusOnboardingFeatureLayer().getOnboardingModel(for: .upgrade)) {
+        self.profile = profile
         self.introScreenManager = IntroScreenManager(prefs: profile.prefs)
         let telemetryUtility = OnboardingTelemetryUtility(with: onboardingModel)
         self.updateViewModel = UpdateViewModel(profile: profile,
                                                model: onboardingModel,
                                                telemetryUtility: telemetryUtility)
         self.surveySurfaceManager = SurveySurfaceManager(and: messageManager)
+
+        if featureFlags.isFeatureEnabled(.splashScreen, checking: .buildOnly) {
+            Task {
+                await fetchNimbusExperiments()
+            }
+        }
     }
 
     func startLoading(appVersion: String = AppInfo.appVersion) async {
         await loadLaunchType(appVersion: appVersion)
+    }
+
+    /// Delay start up and continue to show splash screen up to a maximum duration to ensure Nimbus 
+    /// experiments are loaded on first launch. Skip the delay start if experiments are already successfully
+    /// loaded at this point.
+    func startSplashScreenExperiment() async {
+        guard featureFlags.isFeatureEnabled(.splashScreen, checking: .buildOnly), !hasExperimentsLoaded else { return }
+        await delayStart()
+    }
+
+    private func delayStart() async {
+        let position: Int = nimbusSplashScreenFeatureLayer.maximumDurationMs
+        splashScreenTask?.cancel()
+        splashScreenTask = Task {
+            try? await Task.sleep(nanoseconds: UInt64(position * 1_000_000))
+        }
+        await splashScreenTask?.value
+    }
+
+    private func fetchNimbusExperiments() async {
+        Experiments.intialize()
+
+        NotificationCenter.default.addObserver(
+            forName: .nimbusExperimentsFetched,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.splashScreenTask?.cancel()
+            self?.hasExperimentsLoaded = true
+        }
     }
 
     private func loadLaunchType(appVersion: String) async {

--- a/firefox-ios/Client/Coordinators/LaunchView/SplashScreenAnimation.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/SplashScreenAnimation.swift
@@ -16,6 +16,7 @@ struct SplashScreenAnimation {
 
     init() {
         animationView = LottieAnimationView(name: "splashScreen.json")
+        animationView.accessibilityIdentifier = AccessibilityIdentifiers.LaunchScreen.splashScreenAnimation
     }
 
     func configureAnimation(with view: UIView) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLaunchScreenManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLaunchScreenManager.swift
@@ -3,19 +3,23 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 @testable import Client
 
 class MockLaunchScreenViewModel: LaunchScreenViewModel {
     var introScreenManager: IntroScreenManager
     var updateViewModel: UpdateViewModel
     var surveySurfaceManager: SurveySurfaceManager
+    var notificationCenter: NotificationProtocol
     var startLoadingCalled = 0
+    var startSplashScreenExperiment = 0
     var mockLaunchType: LaunchType?
 
     override init(
         profile: Profile,
         messageManager: GleanPlumbMessageManagerProtocol = Experiments.messaging,
-        onboardingModel: OnboardingViewModel = NimbusOnboardingFeatureLayer().getOnboardingModel(for: .upgrade)
+        onboardingModel: OnboardingViewModel = NimbusOnboardingFeatureLayer().getOnboardingModel(for: .upgrade),
+        notificationCenter: NotificationProtocol = NotificationCenter.default
     ) {
         self.introScreenManager = IntroScreenManager(prefs: profile.prefs)
         let telemetryUtility = OnboardingTelemetryUtility(with: onboardingModel)
@@ -23,6 +27,7 @@ class MockLaunchScreenViewModel: LaunchScreenViewModel {
                                                model: onboardingModel,
                                                telemetryUtility: telemetryUtility)
         self.surveySurfaceManager = SurveySurfaceManager(and: messageManager)
+        self.notificationCenter = notificationCenter
     }
 
     override func startLoading(appVersion: String) async {
@@ -32,5 +37,9 @@ class MockLaunchScreenViewModel: LaunchScreenViewModel {
         } else {
             delegate?.launchBrowser()
         }
+    }
+
+    override func startSplashScreenExperiment() async {
+        startSplashScreenExperiment += 1
     }
 }

--- a/firefox-ios/nimbus-features/splashScreenFeature.yaml
+++ b/firefox-ios/nimbus-features/splashScreenFeature.yaml
@@ -20,5 +20,5 @@ features:
           maximum_duration_ms: 0
       - channel: developer
         value:
-          enabled: false
+          enabled: true
           maximum_duration_ms: 6000


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8591)

## :bulb: Description
Add nimbus loading to launch screen so that we can wait for experiments to be fetched before starting. As part of the splashscreen experiment, we will use a maximum time in the Nimbus configuration as well as confirm if we received the nimbus data so that we can have first-run nimbus experiments. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)