### PR TITLE
Bugfix FXIOS-8672, 8480 - Clean Tab Session Data

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabFileManager.swift
+++ b/BrowserKit/Sources/TabDataStore/TabFileManager.swift
@@ -50,6 +50,10 @@ public protocol TabFileManager {
     ///   - windowData: the window data to be saved
     ///   - url: the directory to save the data to
     func writeWindowData(windowData: WindowData, to url: URL) throws
+    
+    /// Removes the file at the given URL.
+    /// - Parameter path: the file to be removed.
+    func removeFileAt(path: URL)
 }
 
 public struct DefaultTabFileManager: TabFileManager {
@@ -101,7 +105,7 @@ public struct DefaultTabFileManager: TabFileManager {
         try fileManager.copyItem(at: sourceURL, to: destinationURL)
     }
 
-    private func removeFileAt(path: URL) {
+    public func removeFileAt(path: URL) {
         do {
             try fileManager.removeItem(at: path)
             return

--- a/BrowserKit/Sources/TabDataStore/TabFileManager.swift
+++ b/BrowserKit/Sources/TabDataStore/TabFileManager.swift
@@ -35,6 +35,10 @@ public protocol TabFileManager {
     /// - Parameter pathURL: the location of the file to check
     /// - Returns: returns true if a file exists at this location
     func fileExists(atPath pathURL: URL) -> Bool
+    
+    /// Removes a file at the given location (if it exists and can be deleted).
+    /// - Parameter path: location of the file to remove.
+    func removeFile(at path: URL)
 
     /// Creates a directory at the given location
     /// - Parameter path: the location to create the directory
@@ -101,7 +105,7 @@ public struct DefaultTabFileManager: TabFileManager {
         try fileManager.copyItem(at: sourceURL, to: destinationURL)
     }
 
-    private func removeFileAt(path: URL) {
+    public func removeFile(at path: URL) {
         do {
             try fileManager.removeItem(at: path)
             return
@@ -115,7 +119,7 @@ public struct DefaultTabFileManager: TabFileManager {
     public func removeAllFilesAt(directory: URL) {
         let fileURLs = contentsOfDirectory(at: directory)
         for fileURL in fileURLs {
-            removeFileAt(path: fileURL)
+            removeFile(at: fileURL)
         }
     }
 

--- a/BrowserKit/Sources/TabDataStore/TabFileManager.swift
+++ b/BrowserKit/Sources/TabDataStore/TabFileManager.swift
@@ -35,10 +35,6 @@ public protocol TabFileManager {
     /// - Parameter pathURL: the location of the file to check
     /// - Returns: returns true if a file exists at this location
     func fileExists(atPath pathURL: URL) -> Bool
-    
-    /// Removes a file at the given location (if it exists and can be deleted).
-    /// - Parameter path: location of the file to remove.
-    func removeFile(at path: URL)
 
     /// Creates a directory at the given location
     /// - Parameter path: the location to create the directory
@@ -105,7 +101,7 @@ public struct DefaultTabFileManager: TabFileManager {
         try fileManager.copyItem(at: sourceURL, to: destinationURL)
     }
 
-    public func removeFile(at path: URL) {
+    private func removeFileAt(path: URL) {
         do {
             try fileManager.removeItem(at: path)
             return
@@ -119,7 +115,7 @@ public struct DefaultTabFileManager: TabFileManager {
     public func removeAllFilesAt(directory: URL) {
         let fileURLs = contentsOfDirectory(at: directory)
         for fileURL in fileURLs {
-            removeFile(at: fileURL)
+            removeFileAt(path: fileURL)
         }
     }
 

--- a/BrowserKit/Sources/TabDataStore/TabFileManager.swift
+++ b/BrowserKit/Sources/TabDataStore/TabFileManager.swift
@@ -50,7 +50,7 @@ public protocol TabFileManager {
     ///   - windowData: the window data to be saved
     ///   - url: the directory to save the data to
     func writeWindowData(windowData: WindowData, to url: URL) throws
-    
+
     /// Removes the file at the given URL.
     /// - Parameter path: the file to be removed.
     func removeFileAt(path: URL)

--- a/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
@@ -74,6 +74,7 @@ public actor DefaultTabSessionStore: TabSessionStore {
         // since this will be performed off the main thread, and it will only be operating
         // on files for dead tabs that won't be accessed by any other code.
         for fileURL in contents {
+            guard fileURL.lastPathComponent.hasPrefix(filePrefix) else { continue }
             let tabID = String(fileURL.lastPathComponent.dropFirst(filePrefix.count))
             guard !liveTabs.contains(tabID) else { continue }
             fileManager.removeFileAt(path: fileURL)

--- a/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
@@ -16,10 +16,6 @@ public protocol TabSessionStore {
     /// - Parameter tabID: an ID that uniquely identifies the tab
     /// - Returns: the data associated with a session, encoded as a Data object
     func fetchTabSession(tabID: UUID) async -> Data?
-
-    /// Deletes the tab session data for the given tab
-    /// - Parameter tabID: the ID of the tab to delete.
-    func deleteTabSession(tabID: UUID) async
 }
 
 public actor DefaultTabSessionStore: TabSessionStore {
@@ -48,14 +44,6 @@ public actor DefaultTabSessionStore: TabSessionStore {
                        level: .debug,
                        category: .tabs)
         }
-    }
-
-    public func deleteTabSession(tabID: UUID) async {
-        guard let directory = fileManager.tabSessionDataDirectory() else { return }
-        guard fileManager.fileExists(atPath: directory) else { return }
-
-        let path = directory.appendingPathComponent(filePrefix + tabID.uuidString)
-        fileManager.removeFile(at: path)
     }
 
     public func fetchTabSession(tabID: UUID) async -> Data? {

--- a/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
@@ -16,6 +16,9 @@ public protocol TabSessionStore {
     /// - Parameter tabID: an ID that uniquely identifies the tab
     /// - Returns: the data associated with a session, encoded as a Data object
     func fetchTabSession(tabID: UUID) async -> Data?
+    
+    /// Cleans up any tab session data files for tabs that are no longer open.
+    func deleteUnusedTabSessionData(keeping: [UUID]) async
 }
 
 public actor DefaultTabSessionStore: TabSessionStore {
@@ -57,6 +60,23 @@ public actor DefaultTabSessionStore: TabSessionStore {
                        level: .debug,
                        category: .tabs)
             return nil
+        }
+    }
+
+    public func deleteUnusedTabSessionData(keeping: [UUID]) async {
+        guard let directory = fileManager.tabSessionDataDirectory() else { return }
+        let contents = fileManager.contentsOfDirectory(at: directory)
+        guard !contents.isEmpty else { return }
+
+        let liveTabs = keeping.compactMap { $0.uuidString }
+
+        // This is O(m*n) but in general the performance here should not be problematic
+        // since this will be performed off the main thread, and it will only be operating
+        // on files for dead tabs that won't be accessed by any other code.
+        for fileURL in contents {
+            let tabID = String(fileURL.lastPathComponent.dropFirst(filePrefix.count))
+            guard !liveTabs.contains(tabID) else { continue }
+            fileManager.removeFileAt(path: fileURL)
         }
     }
 }

--- a/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
@@ -16,7 +16,7 @@ public protocol TabSessionStore {
     /// - Parameter tabID: an ID that uniquely identifies the tab
     /// - Returns: the data associated with a session, encoded as a Data object
     func fetchTabSession(tabID: UUID) async -> Data?
-    
+
     /// Cleans up any tab session data files for tabs that are no longer open.
     func deleteUnusedTabSessionData(keeping: [UUID]) async
 }

--- a/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
@@ -16,6 +16,10 @@ public protocol TabSessionStore {
     /// - Parameter tabID: an ID that uniquely identifies the tab
     /// - Returns: the data associated with a session, encoded as a Data object
     func fetchTabSession(tabID: UUID) async -> Data?
+
+    /// Deletes the tab session data for the given tab
+    /// - Parameter tabID: the ID of the tab to delete.
+    func deleteTabSession(tabID: UUID) async
 }
 
 public actor DefaultTabSessionStore: TabSessionStore {
@@ -44,6 +48,14 @@ public actor DefaultTabSessionStore: TabSessionStore {
                        level: .debug,
                        category: .tabs)
         }
+    }
+
+    public func deleteTabSession(tabID: UUID) async {
+        guard let directory = fileManager.tabSessionDataDirectory() else { return }
+        guard fileManager.fileExists(atPath: directory) else { return }
+
+        let path = directory.appendingPathComponent(filePrefix + tabID.uuidString)
+        fileManager.removeFile(at: path)
     }
 
     public func fetchTabSession(tabID: UUID) async -> Data? {

--- a/BrowserKit/Tests/TabDataStoreTests/Mocks/TabFileManagerMock.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/Mocks/TabFileManagerMock.swift
@@ -22,6 +22,7 @@ class TabFileManagerMock: TabFileManager {
     var fileExists = false
     var removeFileAtCalledCount = 0
     var removeAllFilesAtCalledCount = 0
+    var removeFileAtPathCalledCount = 0
 
     func tabSessionDataDirectory() -> URL? {
         tabSessionDataDirectoryCalledCount += 1
@@ -47,6 +48,10 @@ class TabFileManagerMock: TabFileManager {
 
     func removeAllFilesAt(directory: URL) {
         removeAllFilesAtCalledCount += 1
+    }
+
+    func removeFileAt(path: URL) {
+        removeFileAtPathCalledCount += 1
     }
 
     func fileExists(atPath pathURL: URL) -> Bool {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -399,7 +399,7 @@ class LegacyGridTabViewController: UIViewController,
             return
         }
 
-        presentUndoToast(toastType: .singleTab) { [weak self] undoButtonPressed in
+        presentUndoToast(toastType: .closedSingleTab) { [weak self] undoButtonPressed in
             guard let self,
                   undoButtonPressed,
                   let closedTab = self.tabManager.backupCloseTab else { return }
@@ -760,12 +760,12 @@ extension LegacyGridTabViewController: InactiveTabsCFRProtocol {
     }
 
     func presentUndoToast(tabsCount: Int, completion: @escaping (Bool) -> Void) {
-        presentUndoToast(toastType: .allInactiveTabs(count: tabsCount),
+        presentUndoToast(toastType: .closedAllInactiveTabs(count: tabsCount),
                          completion: completion)
     }
 
     func presentUndoSingleToast(completion: @escaping (Bool) -> Void) {
-        presentUndoToast(toastType: .singleTab, completion: completion)
+        presentUndoToast(toastType: .closedSingleTab, completion: completion)
     }
 
     private func prepareJumpBackInContextualHint(on title: UILabel) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -312,8 +312,9 @@ class TabManagerMiddleware {
                                                                              windowUUID: uuid)))
                 } else {
                     store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
-                    store.dispatch(GeneralBrowserAction.showToast(ToastTypeContext(toastType: .closedAllTabs(count: normalCount),
-                                                                                   windowUUID: uuid)))
+                    let context = ToastTypeContext(toastType: .closedAllTabs(count: normalCount),
+                                                   windowUUID: uuid)
+                    store.dispatch(GeneralBrowserAction.showToast(context))
                 }
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -262,12 +262,13 @@ class TabManagerMiddleware {
 
             if isPrivate && tabManager(for: uuid).privateTabs.isEmpty {
                 store.dispatch(TabPanelAction.tabPanelDidLoad(BoolValueContext(boolValue: true, windowUUID: uuid)))
-                store.dispatch(TabPanelAction.showToast(ToastTypeContext(toastType: .singleTab, windowUUID: uuid)))
+                store.dispatch(TabPanelAction.showToast(ToastTypeContext(toastType: .closedSingleTab, windowUUID: uuid)))
             } else if shouldDismiss {
                 store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
-                store.dispatch(GeneralBrowserAction.showToast(ToastTypeContext(toastType: .singleTab, windowUUID: uuid)))
+                let toastContext = ToastTypeContext(toastType: .closedSingleTab, windowUUID: uuid)
+                store.dispatch(GeneralBrowserAction.showToast(toastContext))
             } else {
-                store.dispatch(TabPanelAction.showToast(ToastTypeContext(toastType: .singleTab, windowUUID: uuid)))
+                store.dispatch(TabPanelAction.showToast(ToastTypeContext(toastType: .closedSingleTab, windowUUID: uuid)))
             }
         }
     }
@@ -307,11 +308,11 @@ class TabManagerMiddleware {
                 let context = RefreshTabContext(tabDisplayModel: model, windowUUID: uuid)
                 store.dispatch(TabPanelAction.refreshTab(context))
                 if tabsState.isPrivateMode {
-                    store.dispatch(TabPanelAction.showToast(ToastTypeContext(toastType: .allTabs(count: privateCount),
+                    store.dispatch(TabPanelAction.showToast(ToastTypeContext(toastType: .closedAllTabs(count: privateCount),
                                                                              windowUUID: uuid)))
                 } else {
                     store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
-                    store.dispatch(GeneralBrowserAction.showToast(ToastTypeContext(toastType: .allTabs(count: normalCount),
+                    store.dispatch(GeneralBrowserAction.showToast(ToastTypeContext(toastType: .closedAllTabs(count: normalCount),
                                                                                    windowUUID: uuid)))
                 }
             }
@@ -338,7 +339,7 @@ class TabManagerMiddleware {
             await tabManager.removeAllInactiveTabs()
             let context = RefreshInactiveTabsContext(tabModels: [InactiveTabsModel](), windowUUID: uuid)
             store.dispatch(TabPanelAction.refreshInactiveTabs(context))
-            let toastContext = ToastTypeContext(toastType: .allInactiveTabs(count: tabsState.inactiveTabs.count),
+            let toastContext = ToastTypeContext(toastType: .closedAllTabs(count: tabsState.inactiveTabs.count),
                                                 windowUUID: uuid)
             store.dispatch(TabPanelAction.showToast(toastContext))
         }
@@ -368,7 +369,7 @@ class TabManagerMiddleware {
             let inactiveTabs = self.refreshInactiveTabs(uuid: uuid)
             let context = RefreshInactiveTabsContext(tabModels: inactiveTabs, windowUUID: uuid)
             store.dispatch(TabPanelAction.refreshInactiveTabs(context))
-            let toastContext = ToastTypeContext(toastType: .singleInactiveTabs, windowUUID: uuid)
+            let toastContext = ToastTypeContext(toastType: .closedSingleInactiveTab, windowUUID: uuid)
             store.dispatch(TabPanelAction.showToast(toastContext))
         }
     }
@@ -485,7 +486,7 @@ class TabManagerMiddleware {
 
     private func tabPeekCloseTab(with tabID: String, uuid: WindowUUID, isPrivate: Bool) {
         closeTabFromTabPanel(with: tabID, uuid: uuid, isPrivate: isPrivate)
-        let context = ToastTypeContext(toastType: .singleTab, windowUUID: uuid)
+        let context = ToastTypeContext(toastType: .closedSingleTab, windowUUID: uuid)
         store.dispatch(TabPanelAction.showToast(context))
     }
 

--- a/firefox-ios/Client/Frontend/Browser/ToastType.swift
+++ b/firefox-ios/Client/Frontend/Browser/ToastType.swift
@@ -5,19 +5,19 @@
 import Foundation
 
 enum ToastType: Equatable {
-    case singleTab
-    case allTabs(count: Int)
-    case singleInactiveTabs
-    case allInactiveTabs(count: Int)
+    case closedSingleTab
+    case closedSingleInactiveTab
+    case closedAllTabs(count: Int)
+    case closedAllInactiveTabs(count: Int)
     case copyURL
     case addBookmark
 
     var title: String {
         switch self {
-        case .singleTab, .singleInactiveTabs:
+        case .closedSingleTab, .closedSingleInactiveTab:
             return .TabsTray.CloseTabsToast.SingleTabTitle
-        case let .allInactiveTabs(tabsCount),
-            let .allTabs(count: tabsCount):
+        case let .closedAllInactiveTabs(tabsCount),
+            let .closedAllTabs(count: tabsCount):
             return String.localizedStringWithFormat(
                 .TabsTray.CloseTabsToast.Title,
                 tabsCount)
@@ -34,10 +34,10 @@ enum ToastType: Equatable {
 
     func reduxAction(for uuid: WindowUUID) -> TabPanelAction? {
         switch self {
-        case .singleTab: return .undoClose(uuid.context)
-        case .singleInactiveTabs: return .undoCloseInactiveTab(uuid.context)
-        case .allTabs: return .undoCloseAllTabs(uuid.context)
-        case .allInactiveTabs: return .undoCloseAllInactiveTabs(uuid.context)
+        case .closedSingleTab: return .undoClose(uuid.context)
+        case .closedSingleInactiveTab: return .undoCloseInactiveTab(uuid.context)
+        case .closedAllTabs: return .undoCloseAllTabs(uuid.context)
+        case .closedAllInactiveTabs: return .undoCloseAllInactiveTabs(uuid.context)
         case .copyURL, .addBookmark: return nil
         }
     }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -662,7 +662,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         guard !backupCloseTabs.isEmpty else { return }
         tabs = backupCloseTabs
         storeChanges()
-        backupCloseTabs = [Tab]()
+        backupCloseTabs.removeAll(keepingCapacity: true)
         if backupCloseTab != nil {
             selectTab(backupCloseTab?.tab)
             backupCloseTab = nil

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -601,7 +601,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     /// - Parameters:
     ///   - tab: the tab to remove
     ///   - flushToDisk: Will store changes if true, and update selected index
-    private func removeTab(_ tab: Tab, flushToDisk: Bool) {
+    func removeTab(_ tab: Tab, flushToDisk: Bool) {
         guard let removalIndex = tabs.firstIndex(where: { $0 === tab }) else {
             logger.log("Could not find index of tab to remove",
                        level: .warning,

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -662,7 +662,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         guard !backupCloseTabs.isEmpty else { return }
         tabs = backupCloseTabs
         storeChanges()
-        backupCloseTabs.removeAll(keepingCapacity: true)
+        backupCloseTabs = [Tab]()
         if backupCloseTab != nil {
             selectTab(backupCloseTab?.tab)
             backupCloseTab = nil

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -601,7 +601,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     /// - Parameters:
     ///   - tab: the tab to remove
     ///   - flushToDisk: Will store changes if true, and update selected index
-    func removeTab(_ tab: Tab, flushToDisk: Bool) {
+    private func removeTab(_ tab: Tab, flushToDisk: Bool) {
         guard let removalIndex = tabs.firstIndex(where: { $0 === tab }) else {
             logger.log("Could not find index of tab to remove",
                        level: .warning,

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -130,6 +130,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         }
         await generateTabs(from: windowData)
         cleanUpUnusedScreenshots()
+        cleanUpTabSessionData()
 
         await MainActor.run {
             for delegate in delegates {
@@ -447,6 +448,13 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         let savedUUIDsCopy = savedUUIDs
         Task {
             try? await imageStore?.clearAllScreenshotsExcluding(savedUUIDsCopy)
+        }
+    }
+
+    private func cleanUpTabSessionData() {
+        let liveTabs = tabs.compactMap { UUID(uuidString: $0.tabUUID) }
+        Task {
+            await tabSessionStore.deleteUnusedTabSessionData(keeping: liveTabs)
         }
     }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -480,6 +480,13 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         backupCloseTabs = [Tab]()
     }
 
+    override func clearAllTabsHistory() {
+        super.clearAllTabsHistory()
+        Task {
+            await tabSessionStore.deleteUnusedTabSessionData(keeping: [])
+        }
+    }
+
     // MARK: - Notifiable
 
     func handleNotifications(_ notification: Notification) {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -413,20 +413,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
                                   forKey: PrefsKeys.LastSessionWasPrivate)
     }
 
-    // MARK: - Closing Tabs
-
-    override func removeTab(_ tab: Tab, flushToDisk: Bool) {
-        let uuid = tab.tabUUID
-
-        super.removeTab(tab, flushToDisk: flushToDisk)
-
-        if let tabUUID = UUID(uuidString: uuid) {
-            Task {
-                await tabSessionStore.deleteTabSession(tabID: tabUUID)
-            }
-        }
-    }
-
     // MARK: - Screenshots
 
     override func tabDidSetScreenshot(_ tab: Tab, hasHomeScreenshot: Bool) {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -413,6 +413,20 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
                                   forKey: PrefsKeys.LastSessionWasPrivate)
     }
 
+    // MARK: - Closing Tabs
+
+    override func removeTab(_ tab: Tab, flushToDisk: Bool) {
+        let uuid = tab.tabUUID
+
+        super.removeTab(tab, flushToDisk: flushToDisk)
+
+        if let tabUUID = UUID(uuidString: uuid) {
+            Task {
+                await tabSessionStore.deleteTabSession(tabID: tabUUID)
+            }
+        }
+    }
+
     // MARK: - Screenshots
 
     override func tabDidSetScreenshot(_ tab: Tab, hasHomeScreenshot: Bool) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabSessionStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabSessionStore.swift
@@ -21,4 +21,6 @@ class MockTabSessionStore: TabSessionStore {
     }
 
     func clearAllData() async {}
+
+    func deleteUnusedTabSessionData(keeping: [UUID]) async {}
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8672)
And: FXIOS-8480

## :bulb: Description

Ensures tab session data for closed tabs is cleaned. Also clears all tab session data when all history is cleared for FXIOS-8480.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

