### PR TITLE
Bugfix FXIOS-7871 [v125] Opening a link in external app leaves a "loading" about:blank page behind

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -33,6 +33,11 @@ extension BrowserViewController: WKUIDelegate {
             screenshotHelper.takeScreenshot(currentTab)
         }
 
+        if navigationAction.canOpenExternalApp, let url = navigationAction.request.url {
+            UIApplication.shared.open(url)
+            return nil
+        }
+
         // If the page uses `window.open()` or `[target="_blank"]`, open the page in a new tab.
         // IMPORTANT!!: WebKit will perform the `URLRequest` automatically!! Attempting to do
         // the request here manually leads to incorrect results!!
@@ -1078,5 +1083,15 @@ extension WKNavigationAction {
         } else {
             return false
         }
+    }
+
+    var canOpenExternalApp: Bool {
+        guard let urlShortDomain = request.url?.shortDomain else { return false }
+
+        if let url = URL(string: "\(urlShortDomain)://"), UIApplication.shared.canOpenURL(url) {
+            return true
+        }
+
+        return false
     }
 }

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -55,6 +55,9 @@
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
+		<string>paypal</string>
+		<string>instagram</string>
+		<string>youtube</string>
 		<string>pocket</string>
 		<string>firefox-focus</string>
 		<string>firefox-klar</string>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7871)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17571)

## :bulb: Description
Verify if an app like Youtube is installed and open it when a link (e.g. Youtube link) is accessed.

Based on the issue description and comments, I added in the apps list (LSApplicationQueriesSchemes), Youtube, Instagram and PayPal.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

