### PR TITLE
Bugfix MTE-2540 Password fields for Mozilla Account sign-in

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -655,15 +655,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             }
         }
         screenState.gesture(forAction: Action.FxATypePasswordNewAccount) { userState in
-            print(app.secureTextFields.element(boundBy: 0).debugDescription)
-            print(app.secureTextFields.element(boundBy: 1).debugDescription)
-            print(app.secureTextFields.element(boundBy: 2).debugDescription)
             app.secureTextFields.element(boundBy: 1).tap()
             app.secureTextFields.element(boundBy: 1).typeText(userState.fxaPassword!)
         }
         screenState.gesture(forAction: Action.FxATypePasswordExistingAccount) { userState in
-            print(app.secureTextFields.element(boundBy: 0).debugDescription)
-            print(app.secureTextFields.element(boundBy: 1).debugDescription)
             app.secureTextFields.element(boundBy: 0).tap()
             app.secureTextFields.element(boundBy: 0).typeText(userState.fxaPassword!)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -179,7 +179,8 @@ class Action {
     static let OpenEmailToQR = "OpenEmailToQR"
 
     static let FxATypeEmail = "FxATypeEmail"
-    static let FxATypePassword = "FxATypePassword"
+    static let FxATypePasswordNewAccount = "FxATypePasswordNewAccount"
+    static let FxATypePasswordExistingAccount = "FxATypePasswordExistingAccount"
     static let FxATapOnSignInButton = "FxATapOnSignInButton"
     static let FxATapOnContinueButton = "FxATapOnContinueButton"
 
@@ -653,9 +654,18 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                     .typeText(userState.fxaUsername!)
             }
         }
-        screenState.gesture(forAction: Action.FxATypePassword) { userState in
+        screenState.gesture(forAction: Action.FxATypePasswordNewAccount) { userState in
+            print(app.secureTextFields.element(boundBy: 0).debugDescription)
+            print(app.secureTextFields.element(boundBy: 1).debugDescription)
+            print(app.secureTextFields.element(boundBy: 2).debugDescription)
             app.secureTextFields.element(boundBy: 1).tap()
             app.secureTextFields.element(boundBy: 1).typeText(userState.fxaPassword!)
+        }
+        screenState.gesture(forAction: Action.FxATypePasswordExistingAccount) { userState in
+            print(app.secureTextFields.element(boundBy: 0).debugDescription)
+            print(app.secureTextFields.element(boundBy: 1).debugDescription)
+            app.secureTextFields.element(boundBy: 0).tap()
+            app.secureTextFields.element(boundBy: 0).typeText(userState.fxaPassword!)
         }
         screenState.gesture(forAction: Action.FxATapOnContinueButton) { userState in
             app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton].tap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -59,11 +59,11 @@ class IntegrationTests: BaseTestCase {
             timeout: TIMEOUT_LONG
         )
         mozWaitForElementToExist(app.staticTexts["Continue to your Mozilla account"], timeout: TIMEOUT_LONG)
-        userState.fxaUsername = ProcessInfo.processInfo.environment["FXA_EMAIL"]!
-        userState.fxaPassword = ProcessInfo.processInfo.environment["FXA_PASSWORD"]!
+        userState.fxaUsername = "pytest-5aa7b0f5be@restmail.net" // ProcessInfo.processInfo.environment["FXA_EMAIL"]!
+        userState.fxaPassword = "d1695b9a5bc31ddf8bdf511ea577e9676a61dd7ed00375195a6b4a0f7b0cf61a" // ProcessInfo.processInfo.environment["FXA_PASSWORD"]!
         navigator.performAction(Action.FxATypeEmail)
         navigator.performAction(Action.FxATapOnContinueButton)
-        navigator.performAction(Action.FxATypePassword)
+        navigator.performAction(Action.FxATypePasswordExistingAccount)
         navigator.performAction(Action.FxATapOnSignInButton)
         sleep(3)
         waitForTabsButton()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -59,8 +59,8 @@ class IntegrationTests: BaseTestCase {
             timeout: TIMEOUT_LONG
         )
         mozWaitForElementToExist(app.staticTexts["Continue to your Mozilla account"], timeout: TIMEOUT_LONG)
-        userState.fxaUsername = "pytest-5aa7b0f5be@restmail.net" // ProcessInfo.processInfo.environment["FXA_EMAIL"]!
-        userState.fxaPassword = "d1695b9a5bc31ddf8bdf511ea577e9676a61dd7ed00375195a6b4a0f7b0cf61a" // ProcessInfo.processInfo.environment["FXA_PASSWORD"]!
+        userState.fxaUsername = ProcessInfo.processInfo.environment["FXA_EMAIL"]!
+        userState.fxaPassword = ProcessInfo.processInfo.environment["FXA_PASSWORD"]!
         navigator.performAction(Action.FxATypeEmail)
         navigator.performAction(Action.FxATapOnContinueButton)
         navigator.performAction(Action.FxATypePasswordExistingAccount)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SyncFAUITests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SyncFAUITests.swift
@@ -78,12 +78,12 @@ class SyncUITests: BaseTestCase {
         // Enter invalid (too short, it should be at least 8 chars) and incorrect password
         userState.fxaPassword = "foo"
         mozWaitForElementToExist(app.secureTextFields.element(boundBy: 0))
-        navigator.performAction(Action.FxATypePassword)
+        navigator.performAction(Action.FxATypePasswordNewAccount)
         mozWaitForElementToExist(app.webViews.staticTexts["At least 8 characters"])
 
         // Enter valid but incorrect, it does not exists, password
         userState.fxaPassword = "atleasteight"
-        navigator.performAction(Action.FxATypePassword)
+        navigator.performAction(Action.FxATypePasswordNewAccount)
         mozWaitForElementToExist(app.webViews.staticTexts["Repeat password"], timeout: 10)
     }
 
@@ -119,8 +119,8 @@ class SyncUITests: BaseTestCase {
         navigator.performAction(Action.FxATapOnContinueButton)
         // Typing on Password should show Show (password) option
         userState.fxaPassword = "f"
-        mozWaitForElementToExist(app.secureTextFields.element(boundBy: 0))
-        navigator.performAction(Action.FxATypePassword)
+        mozWaitForElementToExist(app.secureTextFields.element(boundBy: 1))
+        navigator.performAction(Action.FxATypePasswordNewAccount)
         let passMessage = "Your password is currently hidden."
         mozWaitForElementToExist(app.webViews.otherElements.buttons[passMessage], timeout: 3)
         // Remove the password typed, Show (password) option should not be shown


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2540)

## :bulb: Description
The indexes for the password field for the existing accounts and for the new accounts are now different:
* New accounts: `SecureTextFields` at index `0` is now the "Repeat Password" field.
![Simulator Screenshot - iPhone 15 Pro - 2024-03-19 at 13 26 11](https://github.com/mozilla-mobile/firefox-ios/assets/1740517/b115395a-95a4-4985-b6a0-ac154a76c65f)
* Existing accounts: `SecureTextFields` at index `0` is still the password field.
![Simulator Screenshot - iPhone 15 Pro - 2024-03-19 at 13 35 46](https://github.com/mozilla-mobile/firefox-ios/assets/1740517/0c1dfd5c-4f6e-4a0d-820a-48e1e61b7334)

This PR creates `Action.FxATypePasswordNewAccount` and `Action.FxATypePasswordExistingAccount` for use in sign-up page and in sign-in page.

Known issue: Sync Integration Tests still encounters an error at teardown due to an issue unrelated to this change.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

