### PR TITLE
Refactor FXIOS-8707 TabUUID typealias

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -59,7 +59,7 @@ enum TabDisplayType {
 // Regular tab order persistence for TabDisplayManager
 struct TabDisplayOrder: Codable {
     static let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
-    var regularTabUUID: [String] = []
+    var regularTabUUID: [TabUUID] = []
 }
 
 class LegacyTabDisplayManager: NSObject, FeatureFlaggable {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -48,8 +48,8 @@ class URLContext: ActionContext {
 }
 
 class TabUUIDContext: ActionContext {
-    let tabUUID: String
-    init(tabUUID: String, windowUUID: WindowUUID) {
+    let tabUUID: TabUUID
+    init(tabUUID: TabUUID, windowUUID: WindowUUID) {
         self.tabUUID = tabUUID
         super.init(windowUUID: windowUUID)
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -341,7 +341,7 @@ class LegacyGridTabViewController: UIViewController,
         }
     }
 
-    private func presentToastForClosingAllTabs(recentlyClosedTabs: [Tab], previousTabUUID: String, isPrivate: Bool) {
+    private func presentToastForClosingAllTabs(recentlyClosedTabs: [Tab], previousTabUUID: TabUUID, isPrivate: Bool) {
         self.presentUndoToast(tabsCount: recentlyClosedTabs.count) { [weak self] undoButtonPressed in
             guard undoButtonPressed else { return }
             self?.tabManager.undoCloseAllTabsLegacy(

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabModel.swift
@@ -18,7 +18,7 @@ struct InactiveTabStates: Codable {
 
 struct LegacyInactiveTabModel: Codable {
     // Contains [TabUUID String : InactiveTabState current or for next launch]
-    var tabWithStatus: [String: InactiveTabStates] = [String: InactiveTabStates]()
+    var tabWithStatus: [TabUUID: InactiveTabStates] = [TabUUID: InactiveTabStates]()
 
     static let userDefaults = UserDefaults()
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -246,7 +246,7 @@ class TabManagerMiddleware {
     /// - Parameters:
     ///   - tabUUID: UUID of the tab to be closed/removed
     /// - Returns: If is the last tab to be closed used to trigger dismissTabTray action
-    private func closeTab(with tabUUID: String, uuid: WindowUUID) async -> Bool {
+    private func closeTab(with tabUUID: TabUUID, uuid: WindowUUID) async -> Bool {
         let tabManager = tabManager(for: uuid)
         let isLastTab = tabManager.normalTabs.count == 1
         await tabManager.removeTab(tabUUID)
@@ -255,7 +255,7 @@ class TabManagerMiddleware {
 
     /// Close tab and trigger refresh
     /// - Parameter tabUUID: UUID of the tab to be closed/removed
-    private func closeTabFromTabPanel(with tabUUID: String, uuid: WindowUUID, isPrivate: Bool) {
+    private func closeTabFromTabPanel(with tabUUID: TabUUID, uuid: WindowUUID, isPrivate: Bool) {
         Task {
             let shouldDismiss = await self.closeTab(with: tabUUID, uuid: uuid)
             await self.triggerRefresh(shouldScrollToTab: false, uuid: uuid, isPrivate: isPrivate)
@@ -393,7 +393,7 @@ class TabManagerMiddleware {
         store.dispatch(TabTrayAction.dismissTabTray(uuid.context))
     }
 
-    private func selectTab(for tabUUID: String, uuid: WindowUUID) {
+    private func selectTab(for tabUUID: TabUUID, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         guard let tab = tabManager.getTabForUUID(uuid: tabUUID) else { return }
 
@@ -415,7 +415,7 @@ class TabManagerMiddleware {
 
     // MARK: - Tab Peek
 
-    private func didLoadTabPeek(tabID: String, uuid: WindowUUID) {
+    private func didLoadTabPeek(tabID: TabUUID, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         let tab = tabManager.getTabForUUID(uuid: tabID)
         profile.places.isBookmarked(url: tab?.url?.absoluteString ?? "") >>== { isBookmarked in
@@ -435,7 +435,7 @@ class TabManagerMiddleware {
         }
     }
 
-    private func addToBookmarks(with tabID: String, uuid: WindowUUID) {
+    private func addToBookmarks(with tabID: TabUUID, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         guard let tab = tabManager.getTabForUUID(uuid: tabID),
               let url = tab.url?.absoluteString, !url.isEmpty
@@ -469,7 +469,7 @@ class TabManagerMiddleware {
                                      value: .tabTray)
     }
 
-    private func sendToDevice(tabID: String, uuid: WindowUUID) {
+    private func sendToDevice(tabID: TabUUID, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         guard let tabToShare = tabManager.getTabForUUID(uuid: tabID),
               let url = tabToShare.url
@@ -478,14 +478,14 @@ class TabManagerMiddleware {
         store.dispatch(TabPanelAction.showShareSheet(URLContext(url: url, windowUUID: uuid)))
     }
 
-    private func copyURL(tabID: String, uuid: WindowUUID) {
+    private func copyURL(tabID: TabUUID, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         UIPasteboard.general.url = tabManager.selectedTab?.canonicalURL
         let context = ToastTypeContext(toastType: .copyURL, windowUUID: uuid)
         store.dispatch(TabPanelAction.showToast(context))
     }
 
-    private func tabPeekCloseTab(with tabID: String, uuid: WindowUUID, isPrivate: Bool) {
+    private func tabPeekCloseTab(with tabID: TabUUID, uuid: WindowUUID, isPrivate: Bool) {
         closeTabFromTabPanel(with: tabID, uuid: uuid, isPrivate: isPrivate)
         let context = ToastTypeContext(toastType: .closedSingleTab, windowUUID: uuid)
         store.dispatch(TabPanelAction.showToast(context))

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/InactiveTabsModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/InactiveTabsModel.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 struct InactiveTabsModel: Equatable {
-    var tabUUID: String
+    var tabUUID: TabUUID
     var title: String
     var url: URL?
     var favIconURL: String?

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 struct TabModel: Equatable {
-    let tabUUID: String
+    let tabUUID: TabUUID
     let isSelected: Bool
     let isPrivate: Bool
     let isFxHomeTab: Bool
@@ -15,7 +15,7 @@ struct TabModel: Equatable {
     let screenshot: UIImage?
     let hasHomeScreenshot: Bool
 
-    static func emptyTabState(tabUUID: String, title: String) -> TabModel {
+    static func emptyTabState(tabUUID: TabUUID, title: String) -> TabModel {
         return TabModel(
             tabUUID: tabUUID,
             isSelected: false,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -9,7 +9,7 @@ import Shared
 import SiteImageView
 
 protocol TabCellDelegate: AnyObject {
-    func tabCellDidClose(for tabUUID: String)
+    func tabCellDidClose(for tabUUID: TabUUID)
 }
 
 class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -306,7 +306,7 @@ class TabDisplayView: UIView,
     }
 
     // MARK: - TabCellDelegate
-    func tabCellDidClose(for tabUUID: String) {
+    func tabCellDidClose(for tabUUID: TabUUID) {
         store.dispatch(TabPanelAction.closeTab(TabUUIDContext(tabUUID: tabUUID, windowUUID: windowUUID)))
     }
 

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -9,8 +9,8 @@ struct FakespotState: ScreenState, Equatable {
     var isOpen: Bool
     var sidebarOpenForiPadLandscape: Bool
     var currentTabUUID: String
-    var expandState: [String: ExpandState] // tabUUID as key
-    var telemetryState: [String: TelemetryState] // tabUUID as key
+    var expandState: [TabUUID: ExpandState]
+    var telemetryState: [TabUUID: TelemetryState]
     var sendSurfaceDisplayedTelemetryEvent = true
     var windowUUID: WindowUUID
 
@@ -59,7 +59,7 @@ struct FakespotState: ScreenState, Equatable {
         windowUUID: WindowUUID,
         isOpen: Bool,
         sidebarOpenForiPadLandscape: Bool,
-        currentTabUUID: String,
+        currentTabUUID: TabUUID,
         expandState: [String: FakespotState.ExpandState] = [:],
         telemetryState: [String: TelemetryState] = [:]
     ) {

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -247,7 +247,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         return tabs.first(where: { $0.webView?.url == url })
     }
 
-    func getTabForUUID(uuid: String) -> Tab? {
+    func getTabForUUID(uuid: TabUUID) -> Tab? {
         let filterdTabs = tabs.filter { tab -> Bool in
             tab.tabUUID == uuid
         }
@@ -571,7 +571,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     @MainActor
-    func removeTab(_ tabUUID: String) async {
+    func removeTab(_ tabUUID: TabUUID) async {
         guard let index = tabs.firstIndex(where: { $0.tabUUID == tabUUID }) else { return }
 
         let tab = tabs[index]
@@ -675,7 +675,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     func backgroundRemoveAllTabs(isPrivate: Bool = false,
                                  didClearTabs: @escaping (_ tabsToRemove: [Tab],
                                                           _ isPrivate: Bool,
-                                                          _ previousTabUUID: String) -> Void) {
+                                                          _ previousTabUUID: TabUUID) -> Void) {
         let previousSelectedTabUUID = selectedTab?.tabUUID ?? ""
         // moved closing of multiple tabs to background thread
         DispatchQueue.global().async { [unowned self] in
@@ -721,7 +721,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     // MARK: - Toasts
     func makeToastFromRecentlyClosedUrls(_ recentlyClosedTabs: [Tab],
                                          isPrivate: Bool,
-                                         previousTabUUID: String) {
+                                         previousTabUUID: TabUUID) {
         guard !recentlyClosedTabs.isEmpty else { return }
 
         // Add last 10 tab(s) to recently closed list
@@ -766,7 +766,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     /// Restore recently closed tabs when tab tray refactor is disabled
-    func undoCloseAllTabsLegacy(recentlyClosedTabs: [Tab], previousTabUUID: String, isPrivate: Bool = false) {
+    func undoCloseAllTabsLegacy(recentlyClosedTabs: [Tab], previousTabUUID: TabUUID, isPrivate: Bool = false) {
         self.reAddTabs(
             tabsToAdd: recentlyClosedTabs,
             previousTabUUID: previousTabUUID,
@@ -831,7 +831,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         }
     }
 
-    private func reAddTabs(tabsToAdd: [Tab], previousTabUUID: String, isPrivate: Bool = false) {
+    private func reAddTabs(tabsToAdd: [Tab], previousTabUUID: TabUUID, isPrivate: Bool = false) {
         tabs.append(contentsOf: tabsToAdd)
         let tabToSelect = tabs.first(where: { $0.tabUUID == previousTabUUID })
         let currentlySelectedTab = selectedTab

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -60,6 +60,8 @@ enum TabUrlType: String {
     case googleTopSiteFollowOn
 }
 
+typealias TabUUID = String
+
 class Tab: NSObject, ThemeApplicable {
     static let privateModeKey = "PrivateModeKey"
     private var _isPrivate = false
@@ -98,7 +100,7 @@ class Tab: NSObject, ThemeApplicable {
 
     // Setting default page as topsites
     var newTabPageType: NewTabPage = .topSites
-    var tabUUID: String = UUID().uuidString
+    var tabUUID: TabUUID = UUID().uuidString
     private var screenshotUUIDString: String?
 
     var screenshotUUID: UUID? {

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -49,7 +49,7 @@ protocol TabManager: AnyObject {
     func preserveTabs()
     func restoreTabs(_ forced: Bool)
     func startAtHomeCheck() -> Bool
-    func getTabForUUID(uuid: String) -> Tab?
+    func getTabForUUID(uuid: TabUUID) -> Tab?
     func getTabForURL(_ url: URL) -> Tab?
     func expireSnackbars()
     @discardableResult
@@ -57,8 +57,8 @@ protocol TabManager: AnyObject {
     func addPopupForParentTab(profile: Profile, parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab
     func makeToastFromRecentlyClosedUrls(_ recentlyClosedTabs: [Tab],
                                          isPrivate: Bool,
-                                         previousTabUUID: String)
-    func undoCloseAllTabsLegacy(recentlyClosedTabs: [Tab], previousTabUUID: String, isPrivate: Bool)
+                                         previousTabUUID: TabUUID)
+    func undoCloseAllTabsLegacy(recentlyClosedTabs: [Tab], previousTabUUID: TabUUID, isPrivate: Bool)
 
     @discardableResult
     func addTab(_ request: URLRequest!,
@@ -74,7 +74,7 @@ protocol TabManager: AnyObject {
 
     /// Async Remove tab option using tabUUID. Replaces direct usage of removeTab where the whole Tab is needed
     /// - Parameter tabUUID: UUID from the tab
-    func removeTab(_ tabUUID: String) async
+    func removeTab(_ tabUUID: TabUUID) async
 
     /// Async Remove all tabs indicating if is on private mode or not
     /// - Parameter isPrivateMode: Is private mode enabled or not
@@ -140,7 +140,7 @@ extension TabManager {
     func backgroundRemoveAllTabs(isPrivate: Bool = false,
                                  didClearTabs: @escaping (_ tabsToRemove: [Tab],
                                                           _ isPrivate: Bool,
-                                                          _ previousTabUUID: String) -> Void) {
+                                                          _ previousTabUUID: TabUUID) -> Void) {
         backgroundRemoveAllTabs(isPrivate: isPrivate,
                                 didClearTabs: didClearTabs)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8707)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19306)

## :bulb: Description

Minor refactor. Adds a `TabUUID` typealias to make function definitions etc. slightly more readable. I undoubtedly missed a lot of places that could be updated but will continue to change these as I find them.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

