### PR TITLE
Add FXIOS-8595 Create BrowserAddressToolbar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/BrowserAddressToolbar.swift
@@ -35,6 +35,7 @@ public class BrowserAddressToolbar: UIView, AddressToolbar, ThemeApplicable {
 
     private var leadingBrowserActionConstraint: NSLayoutConstraint?
     private var leadingLocationContainerConstraint: NSLayoutConstraint?
+    private var dividerWidthConstraint: NSLayoutConstraint?
 
     override init(frame: CGRect) {
         super.init(frame: .zero)
@@ -46,12 +47,12 @@ public class BrowserAddressToolbar: UIView, AddressToolbar, ThemeApplicable {
     }
 
     public func configure(state: AddressToolbarState) {
-        updateBrowserActionSpacing()
-        updateNavigationActionSpacing()
+        updateActionSpacing()
     }
 
     // MARK: - ThemeApplicable
     public func applyTheme(theme: Theme) {
+        backgroundColor = theme.colors.layer1
         locationContainer.backgroundColor = theme.colors.layer3
         locationDividerView.backgroundColor = theme.colors.layer1
     }
@@ -77,14 +78,28 @@ public class BrowserAddressToolbar: UIView, AddressToolbar, ThemeApplicable {
             constant: UX.horizontalSpace)
         leadingBrowserActionConstraint?.isActive = true
 
+        dividerWidthConstraint = locationDividerView.widthAnchor.constraint(equalToConstant: UX.dividerWidth)
+        dividerWidthConstraint?.isActive = true
+
+        let navigationActionWidthAnchor = navigationActionStack.widthAnchor.constraint(equalToConstant: 0)
+        navigationActionWidthAnchor.isActive = true
+        navigationActionWidthAnchor.priority = .defaultHigh
+
+        let pageActionWidthAnchor = pageActionStack.widthAnchor.constraint(equalToConstant: 0)
+        pageActionWidthAnchor.isActive = true
+        pageActionWidthAnchor.priority = .defaultHigh
+
+        let browserActionWidthAnchor = browserActionStack.widthAnchor.constraint(equalToConstant: 0)
+        browserActionWidthAnchor.isActive = true
+        browserActionWidthAnchor.priority = .defaultHigh
+
         NSLayoutConstraint.activate([
-            navigationActionStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            navigationActionStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.horizontalSpace),
             navigationActionStack.topAnchor.constraint(equalTo: topAnchor),
             navigationActionStack.bottomAnchor.constraint(equalTo: bottomAnchor),
 
             locationContainer.topAnchor.constraint(equalTo: topAnchor),
             locationContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
-            locationContainer.heightAnchor.constraint(equalToConstant: 40),
 
             locationView.leadingAnchor.constraint(equalTo: locationContainer.leadingAnchor),
             locationView.topAnchor.constraint(equalTo: locationContainer.topAnchor),
@@ -94,31 +109,31 @@ public class BrowserAddressToolbar: UIView, AddressToolbar, ThemeApplicable {
             locationDividerView.topAnchor.constraint(equalTo: locationContainer.topAnchor),
             locationDividerView.trailingAnchor.constraint(equalTo: pageActionStack.leadingAnchor),
             locationDividerView.bottomAnchor.constraint(equalTo: locationContainer.bottomAnchor),
-            locationDividerView.widthAnchor.constraint(equalToConstant: UX.dividerWidth),
 
             pageActionStack.topAnchor.constraint(equalTo: locationContainer.topAnchor),
             pageActionStack.trailingAnchor.constraint(equalTo: locationContainer.trailingAnchor),
             pageActionStack.bottomAnchor.constraint(equalTo: locationContainer.bottomAnchor),
 
             browserActionStack.topAnchor.constraint(equalTo: topAnchor),
-            browserActionStack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            browserActionStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.horizontalSpace),
             browserActionStack.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
 
-        navigationActionStack.setContentHuggingPriority(.required, for: .horizontal)
-        locationContainer.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        browserActionStack.setContentHuggingPriority(.required, for: .horizontal)
-        updateNavigationActionSpacing()
-        updateBrowserActionSpacing()
+        updateActionSpacing()
     }
 
-    private func updateBrowserActionSpacing() {
-        let hasActions = !browserActionStack.arrangedSubviews.isEmpty
-        leadingBrowserActionConstraint?.constant = hasActions ? UX.horizontalSpace : 0
-    }
+    //MARK: - Private
+    private func updateActionSpacing() {
+        // Browser action spacing
+        let hasBrowserActions = !browserActionStack.arrangedSubviews.isEmpty
+        leadingBrowserActionConstraint?.constant = hasBrowserActions ? UX.horizontalSpace : 0
 
-    private func updateNavigationActionSpacing() {
-        let hasActions = !navigationActionStack.arrangedSubviews.isEmpty
-        leadingLocationContainerConstraint?.constant = hasActions ? -UX.horizontalSpace : 0
+        // Navigation action spacing
+        let hasNavigationActions = !navigationActionStack.arrangedSubviews.isEmpty
+        leadingLocationContainerConstraint?.constant = hasNavigationActions ? -UX.horizontalSpace : 0
+
+        // Page action spacing
+        let hasPageActions = !pageActionStack.arrangedSubviews.isEmpty
+        dividerWidthConstraint?.constant = hasPageActions ? UX.dividerWidth : 0
     }
 }

--- a/BrowserKit/Sources/ToolbarKit/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/BrowserAddressToolbar.swift
@@ -122,7 +122,7 @@ public class BrowserAddressToolbar: UIView, AddressToolbar, ThemeApplicable {
         updateActionSpacing()
     }
 
-    //MARK: - Private
+    // MARK: - Private
     private func updateActionSpacing() {
         // Browser action spacing
         let hasBrowserActions = !browserActionStack.arrangedSubviews.isEmpty

--- a/BrowserKit/Sources/ToolbarKit/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/BrowserAddressToolbar.swift
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+
+/// Simple address toolbar implementation.
+/// +-------------+------------+-----------------------+----------+------+
+/// | navigation  | indicators | url       [ page    ] | browser  | menu |
+/// |   actions   |            |           [ actions ] | actions  |      |
+/// +-------------+------------+-----------------------+----------+------+
+/// +------------------------progress------------------------------------+
+public class BrowserAddressToolbar: UIView, AddressToolbar, ThemeApplicable {
+    private enum UX {
+        static let horizontalSpace: CGFloat = 16
+        static let cornerRadius: CGFloat = 8
+        static let dividerWidth: CGFloat = 4
+        static let actionSpacing: CGFloat = 0
+    }
+
+    private lazy var navigationActionStack: UIStackView = .build()
+
+    private lazy var locationContainer: UIView = .build { view in
+        view.layer.cornerRadius = UX.cornerRadius
+    }
+
+    private lazy var locationView: UIView = .build()
+    private lazy var locationDividerView: UIView = .build()
+
+    private lazy var pageActionStack: UIStackView = .build { view in
+        view.spacing = UX.actionSpacing
+    }
+    private lazy var browserActionStack: UIStackView = .build()
+
+    private var leadingBrowserActionConstraint: NSLayoutConstraint?
+    private var leadingLocationContainerConstraint: NSLayoutConstraint?
+
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public func configure(state: AddressToolbarState) {
+        updateBrowserActionSpacing()
+        updateNavigationActionSpacing()
+    }
+
+    // MARK: - ThemeApplicable
+    public func applyTheme(theme: Theme) {
+    }
+
+    // MARK: - Private
+    private func setupLayout() {
+        addSubview(navigationActionStack)
+
+        locationContainer.addSubview(locationView)
+        locationContainer.addSubview(locationDividerView)
+        locationContainer.addSubview(pageActionStack)
+
+        addSubview(locationContainer)
+        addSubview(browserActionStack)
+
+        leadingLocationContainerConstraint = navigationActionStack.trailingAnchor.constraint(
+            equalTo: locationContainer.leadingAnchor,
+            constant: -UX.horizontalSpace)
+        leadingLocationContainerConstraint?.isActive = true
+
+        leadingBrowserActionConstraint = browserActionStack.leadingAnchor.constraint(
+            equalTo: locationContainer.trailingAnchor,
+            constant: UX.horizontalSpace)
+        leadingBrowserActionConstraint?.isActive = true
+
+        NSLayoutConstraint.activate([
+            navigationActionStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            navigationActionStack.topAnchor.constraint(equalTo: topAnchor),
+            navigationActionStack.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            locationContainer.topAnchor.constraint(equalTo: topAnchor),
+            locationContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
+            locationContainer.heightAnchor.constraint(equalToConstant: 40),
+
+            locationView.leadingAnchor.constraint(equalTo: locationContainer.leadingAnchor),
+            locationView.topAnchor.constraint(equalTo: locationContainer.topAnchor),
+            locationView.trailingAnchor.constraint(equalTo: locationDividerView.leadingAnchor),
+            locationView.bottomAnchor.constraint(equalTo: locationContainer.bottomAnchor),
+
+            locationDividerView.topAnchor.constraint(equalTo: locationContainer.topAnchor),
+            locationDividerView.trailingAnchor.constraint(equalTo: pageActionStack.leadingAnchor),
+            locationDividerView.bottomAnchor.constraint(equalTo: locationContainer.bottomAnchor),
+            locationDividerView.widthAnchor.constraint(equalToConstant: UX.dividerWidth),
+
+            pageActionStack.topAnchor.constraint(equalTo: locationContainer.topAnchor),
+            pageActionStack.trailingAnchor.constraint(equalTo: locationContainer.trailingAnchor),
+            pageActionStack.bottomAnchor.constraint(equalTo: locationContainer.bottomAnchor),
+
+            browserActionStack.topAnchor.constraint(equalTo: topAnchor),
+            browserActionStack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            browserActionStack.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        navigationActionStack.setContentHuggingPriority(.required, for: .horizontal)
+        locationContainer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        browserActionStack.setContentHuggingPriority(.required, for: .horizontal)
+        updateNavigationActionSpacing()
+        updateBrowserActionSpacing()
+    }
+
+    private func updateBrowserActionSpacing() {
+        let hasActions = !browserActionStack.arrangedSubviews.isEmpty
+        leadingBrowserActionConstraint?.constant = hasActions ? UX.horizontalSpace : 0
+    }
+
+    private func updateNavigationActionSpacing() {
+        let hasActions = !navigationActionStack.arrangedSubviews.isEmpty
+        leadingLocationContainerConstraint?.constant = hasActions ? -UX.horizontalSpace : 0
+    }
+}

--- a/BrowserKit/Sources/ToolbarKit/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/BrowserAddressToolbar.swift
@@ -52,6 +52,8 @@ public class BrowserAddressToolbar: UIView, AddressToolbar, ThemeApplicable {
 
     // MARK: - ThemeApplicable
     public func applyTheme(theme: Theme) {
+        locationContainer.backgroundColor = theme.colors.layer3
+        locationDividerView.backgroundColor = theme.colors.layer1
     }
 
     // MARK: - Private


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8595)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19086)

## :bulb: Description
Adds the basic UI for the address toolbar. Please note that `configure(state:)` will be updated with the model in a future PR.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

