### PR TITLE
Add FXIOS-8703 Share to Top Sites context menu

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -60,7 +60,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     ) -> [PhotonRowActions]? {
         var actions = [PhotonRowActions]()
         if sectionType == .topSites,
-           let topSitesActions = getTopSitesActions(site: site) {
+           let topSitesActions = getTopSitesActions(site: site, with: sourceView) {
             actions = topSitesActions
         } else if sectionType == .pocket,
                   let pocketActions = getPocketActions(site: site, with: sourceView) {
@@ -255,7 +255,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
 
     // MARK: - Top sites
 
-    func getTopSitesActions(site: Site) -> [PhotonRowActions]? {
+    func getTopSitesActions(site: Site, with sourceView: UIView?) -> [PhotonRowActions]? {
         guard let siteURL = site.url.asURL else { return nil }
 
         let topSiteActions: [PhotonRowActions]
@@ -263,17 +263,20 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
             topSiteActions = [getRemovePinTopSiteAction(site: site),
                               getOpenInNewTabAction(siteURL: siteURL, sectionType: .topSites),
                               getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
-                              getRemoveTopSiteAction(site: site)]
+                              getRemoveTopSiteAction(site: site),
+                              getShareAction(site: site, sourceView: sourceView)]
         } else if site as? SponsoredTile != nil {
             topSiteActions = [getOpenInNewTabAction(siteURL: siteURL, sectionType: .topSites),
                               getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
                               getSettingsAction(),
-                              getSponsoredContentAction()]
+                              getSponsoredContentAction(),
+                              getShareAction(site: site, sourceView: sourceView)]
         } else {
             topSiteActions = [getPinTopSiteAction(site: site),
                               getOpenInNewTabAction(siteURL: siteURL, sectionType: .topSites),
                               getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
-                              getRemoveTopSiteAction(site: site)]
+                              getRemoveTopSiteAction(site: site),
+                              getShareAction(site: site, sourceView: sourceView)]
         }
         return topSiteActions
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8703)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19294)

## :bulb: Description
Add share option to Top Sites. 

_Note: A separate PR will contain adding share option for the Library Panels._

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots 
| Pinned | Sponsored | Other | 
| --- | --- | --- |
| ![simulator_screenshot_57A74B05-0851-4CAB-8511-77E607B495AF](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/8bf6cfb1-f02a-4d69-8eef-a4212a874fbc) | ![simulator_screenshot_BD472365-51A6-4927-9195-52F00CCBBEAD](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/999a7771-9f38-4514-aee6-7fdb2bdc4870) | ![simulator_screenshot_AB245BF4-5920-4C8B-83A2-D2BEE8B7CA2D](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/6e0fe4f5-ac8a-4d5b-aa97-0aed9ee27ac8) |