### PR TITLE
Bugfix FXIOS-8104 Fix screenshots disappearing

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -345,7 +345,7 @@ class BrowserCoordinator: BaseCoordinator,
         navigationController.onViewDismissed = { [weak self] in
             self?.didFinishSettings(from: settingsCoordinator)
         }
-        router.present(navigationController)
+        present(navigationController)
     }
 
     private func showLibrary(with homepanelSection: Route.HomepanelSection) {
@@ -365,7 +365,7 @@ class BrowserCoordinator: BaseCoordinator,
             add(child: libraryCoordinator)
             libraryCoordinator.start(with: homepanelSection)
 
-            router.present(navigationController)
+            present(navigationController)
         }
     }
 
@@ -636,7 +636,6 @@ class BrowserCoordinator: BaseCoordinator,
         guard !childCoordinators.contains(where: { $0 is TabTrayCoordinator }) else {
             return // flow is already handled
         }
-
         let navigationController = DismissableNavigationViewController()
         let isPad = UIDevice.current.userInterfaceIdiom == .pad
         let modalPresentationStyle: UIModalPresentationStyle = isPad ? .fullScreen: .formSheet
@@ -652,7 +651,7 @@ class BrowserCoordinator: BaseCoordinator,
         add(child: tabTrayCoordinator)
         tabTrayCoordinator.start(with: selectedPanel)
 
-        router.present(navigationController)
+        present(navigationController)
     }
 
     func showBackForwardList() {
@@ -662,7 +661,14 @@ class BrowserCoordinator: BaseCoordinator,
         backForwardListVC.browserFrameInfoProvider = browserViewController
         backForwardListVC.tabManager = tabManager
         backForwardListVC.modalPresentationStyle = .overCurrentContext
-        router.present(backForwardListVC)
+        present(backForwardListVC)
+    }
+
+    private func present(_ viewController: UIViewController, 
+                         animated: Bool = true,
+                         completion: (() -> Void)? = nil) {
+        browserViewController.willNavigateAway()
+        router.present(viewController)
     }
 
     // MARK: - ParentCoordinatorDelegate

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -664,7 +664,7 @@ class BrowserCoordinator: BaseCoordinator,
         present(backForwardListVC)
     }
 
-    private func present(_ viewController: UIViewController, 
+    private func present(_ viewController: UIViewController,
                          animated: Bool = true,
                          completion: (() -> Void)? = nil) {
         browserViewController.willNavigateAway()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -35,10 +35,6 @@ extension BrowserViewController: URLBarDelegate {
         updateFindInPageVisibility(visible: false)
 
         guard !isTabTrayRefactorEnabled else {
-            if let tab = tabManager.selectedTab {
-                screenshotHelper.takeScreenshot(tab)
-            }
-
             navigationHandler?.showTabTray(selectedPanel: focusedSegment ?? .tabs)
             return
         }
@@ -92,9 +88,6 @@ extension BrowserViewController: URLBarDelegate {
 
         self.present(navigationController, animated: true, completion: nil)
 
-        if let tab = tabManager.selectedTab {
-            screenshotHelper.takeScreenshot(tab)
-        }
         TelemetryWrapper.recordEvent(category: .action, method: .open, object: .tabTray)
 
         // App store review in-app prompt

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -29,10 +29,6 @@ extension BrowserViewController: WKUIDelegate {
             return nil
         }
 
-        if let currentTab = tabManager.selectedTab {
-            screenshotHelper.takeScreenshot(currentTab)
-        }
-
         if navigationAction.canOpenExternalApp, let url = navigationAction.request.url {
             UIApplication.shared.open(url)
             return nil

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1763,14 +1763,8 @@ class BrowserViewController: UIViewController,
             TabEvent.post(.didChangeURL(url), for: tab)
         }
 
-        // Represents WebView observation or delegate update that called this function
-
         if webViewStatus == .finishedNavigation {
-            // A delay of 500 milliseconds is added when we take screenshot
-            // as we don't know exactly when wkwebview is rendered
-            let delayedTimeInterval = DispatchTimeInterval.milliseconds(500)
-
-            if tab !== tabManager.selectedTab, let webView = tab.webView {
+            if let webView = tab.webView {
                 // To Screenshot a tab that is hidden we must add the webView,
                 // then wait enough time for the webview to render.
                 webView.frame = contentContainer.frame

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -415,6 +415,9 @@ class BrowserViewController: UIViewController,
         if self.presentedViewController as? PhotonActionSheet != nil {
             self.presentedViewController?.dismiss(animated: true, completion: nil)
         }
+        if let tab = tabManager.selectedTab {
+            screenshotHelper.takeScreenshot(tab)
+        }
         // Formerly these calls were run during AppDelegate.didEnterBackground(), but we have
         // individual TabManager instances for each BVC, so we perform these here instead.
         tabManager.preserveTabs()
@@ -764,8 +767,6 @@ class BrowserViewController: UIViewController,
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        screenshotHelper.viewIsVisible = true
-
         if let toast = self.pendingToast {
             self.pendingToast = nil
             show(toast: toast, afterWaiting: ButtonToast.UX.delay)
@@ -799,9 +800,10 @@ class BrowserViewController: UIViewController,
         UIAccessibility.post(notification: .layoutChanged, argument: toolbarContextHintVC)
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        screenshotHelper.viewIsVisible = false
-        super.viewWillDisappear(animated)
+    func willNavigateAway() {
+        if let tab = tabManager.selectedTab {
+            screenshotHelper.takeScreenshot(tab)
+        }
     }
 
     override func viewDidLayoutSubviews() {
@@ -1631,9 +1633,6 @@ class BrowserViewController: UIViewController,
 
     @discardableResult
     func openURLInNewTab(_ url: URL?, isPrivate: Bool = false) -> Tab {
-        if let selectedTab = tabManager.selectedTab {
-            screenshotHelper.takeScreenshot(selectedTab)
-        }
         let request: URLRequest?
         if let url = url {
             request = URLRequest(url: url)
@@ -1779,21 +1778,6 @@ class BrowserViewController: UIViewController,
                 // This is kind of a hacky fix for Bug 1476637 to prevent webpages from focusing the
                 // touch-screen keyboard from the background even though they shouldn't be able to.
                 webView.resignFirstResponder()
-
-                // We need a better way of identifying when webviews are finished rendering
-                // There are cases in which the page will still show a loading animation or nothing
-                // when the screenshot is being taken, depending on internet connection
-                // Issue created: https://github.com/mozilla-mobile/firefox-ios/issues/7003
-                DispatchQueue.main.asyncAfter(deadline: .now() + delayedTimeInterval) {
-                    self.screenshotHelper.takeScreenshot(tab)
-                    if webView.superview == self.view {
-                        webView.removeFromSuperview()
-                    }
-                }
-            } else if tab.webView != nil {
-                DispatchQueue.main.asyncAfter(deadline: .now() + delayedTimeInterval) {
-                    self.screenshotHelper.takeScreenshot(tab)
-                }
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1764,7 +1764,7 @@ class BrowserViewController: UIViewController,
         }
 
         if webViewStatus == .finishedNavigation {
-            if let webView = tab.webView {
+            if tab !== tabManager.selectedTab, let webView = tab.webView {
                 // To Screenshot a tab that is hidden we must add the webView,
                 // then wait enough time for the webview to render.
                 webView.frame = contentContainer.frame

--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -11,8 +11,6 @@ import Common
  * Handles screenshots for a given tab, including pages with non-webview content.
  */
 class ScreenshotHelper {
-    var viewIsVisible = false
-
     fileprivate weak var controller: BrowserViewController?
     private let logger: Logger
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8104)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18034)

## :bulb: Description
The underlying issue is likely that the app is trying to take a screenshot of a webview that is no longer being rendered due to some webkit optimizations while the app is in the background. This PR simplifies how screenshots of the webview are acquired. The app now only takes new screenshots if the user navigates away from browser view controller and if the user backgrounds the app. This should always result in an updated screenshot anytime the user visits the tab tray. The only exception I can think of is if the app crashes while the user is browsing a tab but I think that's an acceptable trade off for the reduced complexity. 

I cannot verify this fix works as the issue is difficult to reproduce so the fact I'm not seeing it isn't great evidence. 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

