### PR TITLE
Refactor FXIOS-8188 [Multi-window] Fakespot Redux refactors

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		1D2F68AD2ACB266300524B92 /* RemoteTabsPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AC2ACB266300524B92 /* RemoteTabsPanelState.swift */; };
 		1D2F68AF2ACB272500524B92 /* RemoteTabsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */; };
 		1D2F68B12ACCA22000524B92 /* RemoteTabsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */; };
+		1D3822E92BAB99250046BC5E /* UIView+Multiwindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3822E82BAB99250046BC5E /* UIView+Multiwindow.swift */; };
 		1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */; };
 		1D5CBF492B17E3CB0001D033 /* NotificationPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */; };
 		1D5CBF4A2B17E3CB0001D033 /* NotificationPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */; };
@@ -2209,6 +2210,7 @@
 		1D2F68AC2ACB266300524B92 /* RemoteTabsPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanelState.swift; sourceTree = "<group>"; };
 		1D2F68AE2ACB272500524B92 /* RemoteTabsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsTableViewController.swift; sourceTree = "<group>"; };
 		1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsEmptyView.swift; sourceTree = "<group>"; };
+		1D3822E82BAB99250046BC5E /* UIView+Multiwindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Multiwindow.swift"; sourceTree = "<group>"; };
 		1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabPanelTests.swift; sourceTree = "<group>"; };
 		1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPayloads.swift; sourceTree = "<group>"; };
 		1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLogoHeaderCell.swift; sourceTree = "<group>"; };
@@ -8506,6 +8508,7 @@
 				E1442FCB294782D8003680B0 /* UIView+Extension.swift */,
 				E1442FC4294782D7003680B0 /* UIView+Screenshot.swift */,
 				E1442FCA294782D8003680B0 /* UIView+SnapKit.swift */,
+				1D3822E82BAB99250046BC5E /* UIView+Multiwindow.swift */,
 				E1442FC7294782D7003680B0 /* UIViewController+Extension.swift */,
 				C81A8F2426D3ED1900EBA539 /* UIWindow+Extension.swift */,
 				E1442FC9294782D8003680B0 /* URL+Mail.swift */,
@@ -14130,6 +14133,7 @@
 				2137785F297F3B1B00D01309 /* DownloadsPanelViewModel.swift in Sources */,
 				EBE26B57220C959D00D1D99A /* BrowserViewController+TabToolbarDelegate.swift in Sources */,
 				8A3EF7F02A2FCF3100796E3A /* HiddenSettings.swift in Sources */,
+				1D3822E92BAB99250046BC5E /* UIView+Multiwindow.swift in Sources */,
 				B2FEA6912B4661BE0058E616 /* AddressAutofillToggle.swift in Sources */,
 				B2FEA68F2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift in Sources */,
 				AB03032B2AB47AF300DCD8EF /* FakespotOptInCardView.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -32,7 +32,6 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         self.sceneContainer = sceneContainer
         self.windowManager = windowManager
 
-
         let navigationController = sceneSetupHelper.createNavigationController()
         let router = DefaultRouter(navigationController: navigationController)
         super.init(router: router)

--- a/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -20,15 +20,18 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
          screenshotService: ScreenshotService = ScreenshotService(),
          sceneContainer: SceneContainer = SceneContainer(),
          windowManager: WindowManager = AppContainer.shared.resolve()) {
-        self.window = sceneSetupHelper.configureWindowFor(scene, screenshotServiceDelegate: screenshotService)
-        self.screenshotService = screenshotService
-        self.sceneContainer = sceneContainer
-        self.windowManager = windowManager
         // Note: this is where we singularly decide the UUID for this specific iOS browser window (UIScene).
         // The logic is handled by `reserveNextAvailableWindowUUID`, but this is the point at which a window's UUID
         // is set; this same UUID will be injected throughout several of the window's related components
         // such as its TabManager instance, which also has the window UUID property as a convenience.
         self.windowUUID = windowManager.reserveNextAvailableWindowUUID()
+        self.window = sceneSetupHelper.configureWindowFor(scene,
+                                                          windowUUID: windowUUID,
+                                                          screenshotServiceDelegate: screenshotService)
+        self.screenshotService = screenshotService
+        self.sceneContainer = sceneContainer
+        self.windowManager = windowManager
+
 
         let navigationController = sceneSetupHelper.createNavigationController()
         let router = DefaultRouter(navigationController: navigationController)

--- a/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
@@ -6,16 +6,37 @@ import Common
 import UIKit
 import Shared
 
+class BrowserWindow: UIWindow {
+    let uuid: WindowUUID
+
+    init(frame: CGRect, uuid: WindowUUID) {
+        self.uuid = uuid
+        super.init(frame: frame)
+    }
+
+    init(windowScene: UIWindowScene, uuid: WindowUUID) {
+        self.uuid = uuid
+        super.init(windowScene: windowScene)
+    }
+
+    required init?(coder: NSCoder) {
+        assertionFailure("init(coder:) currently unsupported for BrowserWindow")
+        self.uuid = .unavailable
+        super.init(coder: coder)
+    }
+}
+
 struct SceneSetupHelper {
     func configureWindowFor(_ scene: UIScene,
+                            windowUUID: WindowUUID,
                             screenshotServiceDelegate: UIScreenshotServiceDelegate) -> UIWindow {
         guard let windowScene = (scene as? UIWindowScene) else {
-            return UIWindow(frame: UIScreen.main.bounds)
+            return BrowserWindow(frame: UIScreen.main.bounds, uuid: windowUUID)
         }
 
         windowScene.screenshotService?.delegate = screenshotServiceDelegate
 
-        let window = UIWindow(windowScene: windowScene)
+        let window = BrowserWindow(windowScene: windowScene, uuid: windowUUID)
 
         // Setting the initial theme correctly as we don't have a window attached yet to let ThemeManager set it
         var themeManager: ThemeManager = AppContainer.shared.resolve()

--- a/firefox-ios/Client/Extensions/UIView+Multiwindow.swift
+++ b/firefox-ios/Client/Extensions/UIView+Multiwindow.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import SnapKit
+
+extension UIView {
+    /// If the view is installed in a view hierarchy that is part of a window,
+    /// returns the window UUID. If not, returns nil.
+    var currentWindowUUID: WindowUUID? {
+        return (self.window as? BrowserWindow)?.uuid
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -154,6 +154,7 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     private func configureShoppingContextVC(at sourceView: UIView) {
+        let windowUUID = windowUUID
         shoppingContextHintVC.configure(
             anchor: sourceView,
             withArrowDirection: isBottomSearchBar ? .down : .up,
@@ -168,7 +169,7 @@ extension BrowserViewController: URLBarDelegate {
                 )
             },
             andActionForButton: {
-                store.dispatch(FakespotAction.show)
+                store.dispatch(FakespotAction.show(windowUUID.context))
             },
             overlayState: overlayManager)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -508,7 +508,7 @@ class BrowserViewController: UIViewController,
 
     private func dismissModalsIfStartAtHome() {
         if tabManager.startAtHomeCheck() {
-            store.dispatch(FakespotAction.setAppearanceTo(false))
+            store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
             guard presentedViewController != nil else { return }
             dismissVC()
         }
@@ -725,7 +725,7 @@ class BrowserViewController: UIViewController,
         view.addSubview(statusBarOverlay)
 
         // Setup the URL bar, wrapped in a view to get transparency effect
-        urlBar = URLBarView(profile: profile)
+        urlBar = URLBarView(profile: profile, windowUUID: windowUUID)
         urlBar.translatesAutoresizingMaskIntoConstraints = false
         urlBar.delegate = self
         urlBar.tabToolbarDelegate = self
@@ -1803,17 +1803,17 @@ class BrowserViewController: UIViewController,
               let url = webView.url
         else {
             // We're on homepage or a blank tab
-            store.dispatch(FakespotAction.setAppearanceTo(false))
+            store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
             return
         }
 
-        store.dispatch(FakespotAction.tabDidChange(tabUIDD: tab.tabUUID))
+        store.dispatch(FakespotAction.tabDidChange(FakespotTabContext(tabUUID: tab.tabUUID, windowUUID: windowUUID)))
         let isFeatureEnabled = featureFlags.isCoreFeatureEnabled(.useStagingFakespotAPI)
         let environment = isFeatureEnabled ? FakespotEnvironment.staging : .prod
         let product = ShoppingProduct(url: url, client: FakespotClient(environment: environment))
 
         guard product.product != nil, !tab.isPrivate else {
-            store.dispatch(FakespotAction.setAppearanceTo(false))
+            store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
 
             // Quick fix: make sure to sidebar is hidden when opened from deep-link
             // Relates to FXIOS-7844
@@ -1822,7 +1822,8 @@ class BrowserViewController: UIViewController,
         }
 
         if isReload, let productId = product.product?.id {
-           store.dispatch(FakespotAction.tabDidReload(tabUIDD: tab.tabUUID, productId: productId))
+            let context = FakespotProductContext(productId: productId, tabUUID: tab.tabUUID, windowUUID: windowUUID)
+           store.dispatch(FakespotAction.tabDidReload(context))
         }
 
         // Do not update Fakespot when we are not on a selected tab
@@ -1842,7 +1843,7 @@ class BrowserViewController: UIViewController,
                   fakespotState.sidebarOpenForiPadLandscape,
                   UIDevice.current.userInterfaceIdiom == .pad {
             // Sidebar should be displayed, display Fakespot
-            store.dispatch(FakespotAction.setAppearanceTo(true))
+            store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: true, windowUUID: windowUUID)))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotAction.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotAction.swift
@@ -5,22 +5,59 @@
 import Common
 import Redux
 
+class FakespotUIContext: ActionContext {
+    let isExpanded: Bool
+    init(isExpanded: Bool, windowUUID: WindowUUID) {
+        self.isExpanded = isExpanded
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class FakespotTabContext: ActionContext {
+    let tabUUID: TabUUID?
+    init(tabUUID: TabUUID?, windowUUID: WindowUUID) {
+        self.tabUUID = tabUUID
+        super.init(windowUUID: windowUUID)
+    }
+}
+
+class FakespotProductContext: FakespotTabContext {
+    let productId: String
+    init(productId: String, tabUUID: TabUUID, windowUUID: WindowUUID) {
+        self.productId = productId
+        super.init(tabUUID: tabUUID, windowUUID: windowUUID)
+    }
+}
+
 enum FakespotAction: Action {
-    case settingsStateDidChange(isExpanded: Bool)
-    case reviewQualityDidChange(isExpanded: Bool)
-    case highlightsDidChange(isExpanded: Bool)
-    case tabDidChange(tabUIDD: String)
-    case tabDidReload(tabUIDD: String, productId: String)
-    case pressedShoppingButton
-    case show
-    case dismiss
-    case setAppearanceTo(Bool)
-    case adsImpressionEventSendFor(productId: String)
-    case adsExposureEventSendFor(productId: String)
-    case surfaceDisplayedEventSend
+    case settingsStateDidChange(FakespotUIContext)
+    case reviewQualityDidChange(FakespotUIContext)
+    case highlightsDidChange(FakespotUIContext)
+    case tabDidChange(FakespotTabContext)
+    case tabDidReload(FakespotProductContext)
+    case pressedShoppingButton(ActionContext)
+    case show(ActionContext)
+    case dismiss(ActionContext)
+    case setAppearanceTo(BoolValueContext)
+    case adsImpressionEventSendFor(FakespotProductContext)
+    case adsExposureEventSendFor(FakespotProductContext)
+    case surfaceDisplayedEventSend(ActionContext)
 
     var windowUUID: UUID {
-        // TODO: [8188] Update to return the windowUUID
-        return .unavailable
+        switch self {
+        case .settingsStateDidChange(let context as ActionContext),
+                .reviewQualityDidChange(let context as ActionContext),
+                .highlightsDidChange(let context as ActionContext),
+                .tabDidChange(let context as ActionContext),
+                .tabDidReload(let context as ActionContext),
+                .pressedShoppingButton(let context),
+                .show(let context),
+                .dismiss(let context),
+                .setAppearanceTo(let context as ActionContext),
+                .adsImpressionEventSendFor(let context as ActionContext),
+                .adsExposureEventSendFor(let context as ActionContext),
+                .surfaceDisplayedEventSend(let context):
+            return context.windowUUID
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotAction.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotAction.swift
@@ -23,7 +23,7 @@ class FakespotTabContext: ActionContext {
 
 class FakespotProductContext: FakespotTabContext {
     let productId: String
-    init(productId: String, tabUUID: TabUUID, windowUUID: WindowUUID) {
+    init(productId: String, tabUUID: TabUUID?, windowUUID: WindowUUID) {
         self.productId = productId
         super.init(tabUUID: tabUUID, windowUUID: windowUUID)
     }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -72,7 +72,9 @@ struct FakespotState: ScreenState, Equatable {
     }
 
     static let reducer: Reducer<Self> = { state, action in
-        // TODO: [8188] Check window UUID before reducing? Need to double-check on handling for this.
+        // Only process actions for the current window
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
+        
         switch action {
         case FakespotAction.settingsStateDidChange(let context):
             let isExpanded = context.isExpanded

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -72,23 +72,28 @@ struct FakespotState: ScreenState, Equatable {
     }
 
     static let reducer: Reducer<Self> = { state, action in
+        // TODO: [8188] Check window UUID before reducing? Need to double-check on handling for this.
         switch action {
-        case FakespotAction.settingsStateDidChange(let isExpanded):
+        case FakespotAction.settingsStateDidChange(let context):
+            let isExpanded = context.isExpanded
             var state = state
             state.expandState[state.currentTabUUID, default: ExpandState()].isSettingsExpanded = isExpanded
             return state
 
-        case FakespotAction.reviewQualityDidChange(let isExpanded):
+        case FakespotAction.reviewQualityDidChange(let context):
+            let isExpanded = context.isExpanded
             var state = state
             state.expandState[state.currentTabUUID, default: ExpandState()].isReviewQualityExpanded = isExpanded
             return state
 
-        case FakespotAction.highlightsDidChange(let isExpanded):
+        case FakespotAction.highlightsDidChange(let context):
+            let isExpanded = context.isExpanded
             var state = state
             state.expandState[state.currentTabUUID, default: ExpandState()].isHighlightsSectionExpanded = isExpanded
             return state
 
-        case FakespotAction.tabDidChange(let tabUUID):
+        case FakespotAction.tabDidChange(let context):
+            guard let tabUUID = context.tabUUID else { return state }
             var state = state
             if state.telemetryState[tabUUID] == nil {
                 state.telemetryState[tabUUID] = TelemetryState()
@@ -97,8 +102,9 @@ struct FakespotState: ScreenState, Equatable {
 
             return state
 
-        case FakespotAction.tabDidReload(let tabUUID, let productId):
-            guard state.currentTabUUID == tabUUID else { return state }
+        case FakespotAction.tabDidReload(let context):
+            guard let tabUUID = context.tabUUID, state.currentTabUUID == tabUUID else { return state }
+            let productId = context.productId
 
             var state = state
             state.telemetryState[tabUUID]?.adEvents[productId] = AdTelemetryState()
@@ -126,7 +132,8 @@ struct FakespotState: ScreenState, Equatable {
             state.sendSurfaceDisplayedTelemetryEvent = true
             return state
 
-        case FakespotAction.setAppearanceTo(let isEnabled):
+        case FakespotAction.setAppearanceTo(let context):
+            let isEnabled = context.boolValue
             var state = state
             state.isOpen = isEnabled
             state.sendSurfaceDisplayedTelemetryEvent = !isEnabled
@@ -137,7 +144,8 @@ struct FakespotState: ScreenState, Equatable {
             state.sendSurfaceDisplayedTelemetryEvent = false
             return state
 
-        case FakespotAction.adsImpressionEventSendFor(let productId):
+        case FakespotAction.adsImpressionEventSendFor(let context):
+            let productId = context.productId
             var state = state
             if state.telemetryState[state.currentTabUUID]?.adEvents[productId] == nil {
                 state.telemetryState[state.currentTabUUID]?.adEvents[productId] = AdTelemetryState()
@@ -145,7 +153,8 @@ struct FakespotState: ScreenState, Equatable {
             state.telemetryState[state.currentTabUUID]?.adEvents[productId]?.sendAdsImpressionEvent = false
             return state
 
-        case FakespotAction.adsExposureEventSendFor(let productId):
+        case FakespotAction.adsExposureEventSendFor(let context):
+            let productId = context.productId
             var state = state
             if state.telemetryState[state.currentTabUUID]?.adEvents[productId] == nil {
                 state.telemetryState[state.currentTabUUID]?.adEvents[productId] = AdTelemetryState()

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -74,7 +74,7 @@ struct FakespotState: ScreenState, Equatable {
     static let reducer: Reducer<Self> = { state, action in
         // Only process actions for the current window
         guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
-        
+
         switch action {
         case FakespotAction.settingsStateDidChange(let context):
             let isExpanded = context.isExpanded

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -186,7 +186,7 @@ class FakespotViewController: UIViewController,
               fakespotState.sendSurfaceDisplayedTelemetryEvent
         else { return }
         viewModel.recordBottomSheetDisplayed(presentationController)
-        store.dispatch(FakespotAction.surfaceDisplayedEventSend)
+        store.dispatch(FakespotAction.surfaceDisplayedEventSend(windowUUID.context))
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -411,6 +411,7 @@ class FakespotViewController: UIViewController,
     }
 
     private func createContentView(viewElement: FakespotViewModel.ViewElement) -> UIView? {
+        let windowUUID = windowUUID
         switch viewElement {
         case .loadingView:
             let view: FakespotLoadingView = .build()
@@ -418,7 +419,7 @@ class FakespotViewController: UIViewController,
         case .onboarding:
             let view: FakespotOptInCardView = .build()
             viewModel.optInCardViewModel.dismissViewController = { [weak self] action in
-                store.dispatch(FakespotAction.setAppearanceTo(false))
+                store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
 
                 guard let self = self, let action else { return }
                 viewModel.recordDismissTelemetry(by: action)
@@ -446,7 +447,8 @@ class FakespotViewController: UIViewController,
             guard var cardViewModel = viewModel.highlightsCardViewModel else { return nil }
             cardViewModel.expandState = fakespotState.isHighlightsSectionExpanded ? .expanded : .collapsed
             cardViewModel.onExpandStateChanged = { state in
-                store.dispatch(FakespotAction.highlightsDidChange(isExpanded: state == .expanded))
+                let context = FakespotUIContext(isExpanded: state == .expanded, windowUUID: windowUUID)
+                store.dispatch(FakespotAction.highlightsDidChange(context))
             }
             let view: FakespotHighlightsCardView = .build()
             view.configure(cardViewModel)
@@ -456,10 +458,11 @@ class FakespotViewController: UIViewController,
             let reviewQualityCardView: FakespotReviewQualityCardView = .build()
             viewModel.reviewQualityCardViewModel.expandState = fakespotState.isReviewQualityExpanded ? .expanded : .collapsed
             viewModel.reviewQualityCardViewModel.dismissViewController = {
-                store.dispatch(FakespotAction.setAppearanceTo(false))
+                store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
             }
             viewModel.reviewQualityCardViewModel.onExpandStateChanged = { state in
-                store.dispatch(FakespotAction.reviewQualityDidChange(isExpanded: state == .expanded))
+                let context = FakespotUIContext(isExpanded: state == .expanded, windowUUID: windowUUID)
+                store.dispatch(FakespotAction.reviewQualityDidChange(context))
             }
             reviewQualityCardView.configure(viewModel.reviewQualityCardViewModel)
 
@@ -471,15 +474,16 @@ class FakespotViewController: UIViewController,
             viewModel.settingsCardViewModel.dismissViewController = { [weak self] action in
                 guard let self = self, let action else { return }
 
-                store.dispatch(FakespotAction.setAppearanceTo(false))
-                store.dispatch(FakespotAction.surfaceDisplayedEventSend)
+                store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
+                store.dispatch(FakespotAction.surfaceDisplayedEventSend(windowUUID.context))
                 viewModel.recordDismissTelemetry(by: action)
             }
             viewModel.settingsCardViewModel.toggleAdsEnabled = { [weak self] in
                 self?.viewModel.toggleAdsEnabled()
             }
             viewModel.settingsCardViewModel.onExpandStateChanged = { state in
-                store.dispatch(FakespotAction.settingsStateDidChange(isExpanded: state == .expanded))
+                let context = FakespotUIContext(isExpanded: state == .expanded, windowUUID: windowUUID)
+                store.dispatch(FakespotAction.settingsStateDidChange(context))
             }
             view.configure(viewModel.settingsCardViewModel)
 
@@ -501,7 +505,7 @@ class FakespotViewController: UIViewController,
                 self?.viewModel.addTab(url: adData.url)
                 self?.viewModel.recordSurfaceAdsClickedTelemetry()
                 self?.viewModel.reportAdEvent(eventName: .trustedDealsLinkClicked, aidvs: [adData.aid])
-                store.dispatch(FakespotAction.setAppearanceTo(false))
+                store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
             }
             view.configure(viewModel)
             adView = view
@@ -579,7 +583,7 @@ class FakespotViewController: UIViewController,
     }
 
     private func triggerDismiss() {
-        store.dispatch(FakespotAction.dismiss)
+        store.dispatch(FakespotAction.dismiss(windowUUID.context))
     }
 
     deinit {

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewModel.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewModel.swift
@@ -373,6 +373,7 @@ class FakespotViewModel {
     }
 
     func fetchProductAnalysis(showLoading: Bool = true) async {
+        let windowUUID = tabManager.windowUUID
         if showLoading { state = .loading }
         do {
             let product = try await shoppingProduct.fetchProductAnalysisData()
@@ -403,7 +404,8 @@ class FakespotViewModel {
                 reportAdEvent(eventName: .trustedDealsPlacement, aidvs: productAds.map(\.aid))
             }
 
-            store.dispatch(FakespotAction.adsExposureEventSendFor(productId: productId))
+            let context = FakespotProductContext(productId: productId, tabUUID: nil, windowUUID: windowUUID)
+            store.dispatch(FakespotAction.adsExposureEventSendFor(context))
         } catch {
             state = .error(error)
         }
@@ -540,7 +542,8 @@ class FakespotViewModel {
         stopTimer()
 
         guard let productId = shoppingProduct.product?.id else { return }
-        store.dispatch(FakespotAction.adsImpressionEventSendFor(productId: productId))
+        let context = FakespotProductContext(productId: productId, tabUUID: nil, windowUUID: tabManager.windowUUID)
+        store.dispatch(FakespotAction.adsImpressionEventSendFor(context))
         isViewVisible = false
     }
 

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -46,6 +46,7 @@ class TabLocationView: UIView, FeatureFlaggable {
 
     var notificationCenter: NotificationProtocol = NotificationCenter.default
     private var themeManager: ThemeManager = AppContainer.shared.resolve()
+    private let windowUUID: WindowUUID
 
     /// Tracking protection button, gets updated from tabDidChangeContentBlocking
     var blockerStatus: BlockerStatus = .noBlockedURLs {
@@ -189,8 +190,9 @@ class TabLocationView: UIView, FeatureFlaggable {
         return reloadButton
     }()
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(windowUUID: WindowUUID) {
+        self.windowUUID = windowUUID
+        super.init(frame: .zero)
         setupNotifications(
             forObserver: self,
             observing: [
@@ -331,7 +333,7 @@ class TabLocationView: UIView, FeatureFlaggable {
     func didPressShoppingButton(_ button: UIButton) {
         button.isSelected = true
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .shoppingButton)
-        store.dispatch(FakespotAction.pressedShoppingButton)
+        store.dispatch(FakespotAction.pressedShoppingButton(windowUUID.context))
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -109,7 +109,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     var inOverlayMode = false
 
     lazy var locationView: TabLocationView = {
-        let locationView = TabLocationView()
+        let locationView = TabLocationView(windowUUID: windowUUID)
         locationView.layer.cornerRadius = URLBarViewUX.TextFieldCornerRadius
         locationView.translatesAutoresizingMaskIntoConstraints = false
         locationView.delegate = self
@@ -222,6 +222,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     }
 
     var profile: Profile
+    let windowUUID: WindowUUID
 
     fileprivate lazy var privateModeBadge = BadgeWithBackdrop(
         imageName: ImageIdentifiers.privateModeBadge,
@@ -233,8 +234,9 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         imageMask: ImageIdentifiers.menuWarningMask
     )
 
-    init(profile: Profile) {
+    init(profile: Profile, windowUUID: WindowUUID) {
         self.profile = profile
+        self.windowUUID = windowUUID
         self.searchEngines = SearchEngines(prefs: profile.prefs, files: profile.files)
         super.init(frame: CGRect())
         commonInit()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -25,7 +25,7 @@ class HomepageViewControllerTests: XCTestCase {
 
     func testHomepageViewController_simpleCreation_hasNoLeaks() {
         let tabManager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
-        let urlBar = URLBarView(profile: profile)
+        let urlBar = URLBarView(profile: profile, windowUUID: .XCTestDefaultUUID)
         let overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/TabLocationViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/TabLocationViewTests.swift
@@ -18,7 +18,7 @@ class TabLocationViewTests: XCTestCase {
     }
 
     func testDelegateMemoryLeak() {
-        let tabLocationView = TabLocationView()
+        let tabLocationView = TabLocationView(windowUUID: .XCTestDefaultUUID)
         let delegate = MockTabLocationViewDelegate()
         tabLocationView.delegate = delegate
         trackForMemoryLeaks(tabLocationView)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8188)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18209)

## :bulb: Description

Additional work to support multi-window. Changes in this PR:

- Updates to Fakespot Redux code to include `windowUUID` in actions; this follows the same pattern we're implementing throughout other Redux code (for now) which is to always include an `ActionContext` or subclass which allows us to differentiate Redux messaging across multiple windows
- A few other semi-related refactors, including some conveniences and extensions on UIView which will likely be needed as part of the upcoming MW work for themeing / Felt Privacy

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

