### PR TITLE
Refactor FXIOS-19318 - Update Fonts in SnackBar to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/SnackBar.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SnackBar.swift
@@ -38,7 +38,7 @@ class SnackBar: UIView, ThemeApplicable {
     }
 
     private lazy var textLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
         label.backgroundColor = UIColor.clear

--- a/firefox-ios/Client/Frontend/Widgets/SnackBar.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SnackBar.swift
@@ -9,7 +9,6 @@ import Shared
 class SnackBar: UIView, ThemeApplicable {
     private struct UX {
         static let borderWidth: CGFloat = 0.5
-        static let fontSize: CGFloat = 17
     }
 
     let snackbarClassIdentifier: String


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-19318)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19318)

## :bulb: Description
- This PR updates the font styles used in SnackBar to use FXFontStyles to standardize the font.

## Screenshots
|  Before  |  After  |
|  ------   |  -----  |
|  ![Before](https://github.com/mozilla-mobile/firefox-ios/assets/89182903/7fafbb12-e0df-4314-93f2-2b7dbd483af6)  |  ![After](https://github.com/mozilla-mobile/firefox-ios/assets/89182903/b376f120-e065-4ed6-8bd2-b9c9474685de)   |
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

