### PR TITLE
Update FXIOS-8721 Make experiments UI testable

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1467,6 +1467,8 @@
 		E1AFBAF9292EA0330065E35E /* SendToDeviceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AFBAF8292EA0330065E35E /* SendToDeviceHelper.swift */; };
 		E1B04A9D28E20A8300670E54 /* InstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B04A9C28E20A8300670E54 /* InstructionsView.swift */; };
 		E1B18C782B5FFFA9009CD968 /* UIView+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B18C772B5FFFA9009CD968 /* UIView+extension.swift */; };
+		E1BDAC812B9F5DE40063E6BF /* ReportSiteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BDAC802B9F5DE40063E6BF /* ReportSiteTests.swift */; };
+		E1BDAC832B9F65780063E6BF /* reportSiteIssueOff.json in Resources */ = {isa = PBXBuildFile; fileRef = E1BDAC822B9F65780063E6BF /* reportSiteIssueOff.json */; };
 		E1C437A32A96343A00D188CB /* FakespotFadeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C437A22A96343A00D188CB /* FakespotFadeLabel.swift */; };
 		E1CD81BA290C4ED900124B27 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84266742728462900382274 /* AccessibilityIdentifiers.swift */; };
 		E1CD81BC290C5C3F00124B27 /* DevicePickerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CD81BB290C5C3F00124B27 /* DevicePickerTableViewCell.swift */; };
@@ -7471,6 +7473,8 @@
 		E1B04A9C28E20A8300670E54 /* InstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionsView.swift; sourceTree = "<group>"; };
 		E1B18C772B5FFFA9009CD968 /* UIView+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+extension.swift"; sourceTree = "<group>"; };
 		E1B8412CB5BD748F7D81B41E /* oc */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = oc; path = oc.lproj/ErrorPages.strings; sourceTree = "<group>"; };
+		E1BDAC802B9F5DE40063E6BF /* ReportSiteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportSiteTests.swift; sourceTree = "<group>"; };
+		E1BDAC822B9F65780063E6BF /* reportSiteIssueOff.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = reportSiteIssueOff.json; sourceTree = "<group>"; };
 		E1BE455FA65078F46476F88F /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		E1C437A22A96343A00D188CB /* FakespotFadeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakespotFadeLabel.swift; sourceTree = "<group>"; };
 		E1CD81BB290C5C3F00124B27 /* DevicePickerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicePickerTableViewCell.swift; sourceTree = "<group>"; };
@@ -8800,6 +8804,7 @@
 				2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */,
 				2CA16FDD1E5F089100332277 /* SearchTest.swift */,
 				2C3406C71E719F00000FD889 /* SettingsTests.swift */,
+				E1BDAC802B9F5DE40063E6BF /* ReportSiteTests.swift */,
 				0BC9C9C31F26F54D000E8AB5 /* SiteLoadTest.swift */,
 				2CEDADA120207EC400223A89 /* SyncFAUITests.swift */,
 				4F2A06BD26F8E46E0017DA05 /* TabCounterTests.swift */,
@@ -11168,6 +11173,7 @@
 			isa = PBXGroup;
 			children = (
 				E1AF27432A17BCF700CE5991 /* engagementNotificationWithoutConditions.json */,
+				E1BDAC822B9F65780063E6BF /* reportSiteIssueOff.json */,
 			);
 			path = TestData;
 			sourceTree = "<group>";
@@ -12875,6 +12881,7 @@
 				23BEA767251A99ED00A014BF /* NewYorkMedium-Bold.otf in Resources */,
 				3BC659591E5BA505006D560F /* bundle_sites.json in Resources */,
 				E4CD9F541A71506400318571 /* Reader.html in Resources */,
+				E1BDAC832B9F65780063E6BF /* reportSiteIssueOff.json in Resources */,
 				E1AF3563286DE5F800960045 /* FullFunctionalTestPlan.xctestplan in Resources */,
 				8A3345642BA499B7008C52AB /* disconnect-block-analytics.json in Resources */,
 				E1AF3567286DE5F800960045 /* PerformanceTestPlan.xctestplan in Resources */,
@@ -13438,6 +13445,7 @@
 				2C8C07771E7800EA00DC1237 /* FindInPageTests.swift in Sources */,
 				2CB56E3F1E926BFB00AF7586 /* ToolbarTest.swift in Sources */,
 				B10997432A97251D00CC8860 /* UrlBarTests.swift in Sources */,
+				E1BDAC812B9F5DE40063E6BF /* ReportSiteTests.swift in Sources */,
 				2C3406C81E719F00000FD889 /* SettingsTests.swift in Sources */,
 				2CF21D0920A4A163000D08B7 /* PocketTests.swift in Sources */,
 			);

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -262,18 +262,25 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
 
     // MARK: - Private
     private func loadExperiment() {
-        let argument = ProcessInfo.processInfo.arguments.first { string in
+        let argumentExperimentFile = ProcessInfo.processInfo.arguments.first { string in
             string.starts(with: LaunchArguments.LoadExperiment)
         }
 
-        guard let arg = argument else { return }
+        let argumentFeatureName = ProcessInfo.processInfo.arguments.first { string in
+            string.starts(with: LaunchArguments.ExperimentFeatureName)
+        }
 
-        let experimentName = arg.replacingOccurrences(of: LaunchArguments.LoadExperiment, with: "")
-        let fileURL = Bundle.main.url(forResource: experimentName, withExtension: "json")
+        guard let argumentExperimentFile, let argumentFeatureName else { return }
+
+        let experimentFeatureName = argumentFeatureName.replacingOccurrences(of: LaunchArguments.ExperimentFeatureName,
+                                                                             with: "")
+        let experimentFileName = argumentExperimentFile.replacingOccurrences(of: LaunchArguments.LoadExperiment,
+                                                                             with: "")
+        let fileURL = Bundle.main.url(forResource: experimentFileName, withExtension: "json")
         if let fileURL = fileURL {
             do {
                 let fileContent = try String(contentsOf: fileURL)
-                let features = HardcodedNimbusFeatures(with: ["messaging": fileContent])
+                let features = HardcodedNimbusFeatures(with: [experimentFeatureName: fileContent])
                 features.connect(with: FxNimbus.shared)
             } catch {
             }

--- a/firefox-ios/Client/Nimbus/TestData/reportSiteIssueOff.json
+++ b/firefox-ios/Client/Nimbus/TestData/reportSiteIssueOff.json
@@ -1,0 +1,5 @@
+{
+  "report-site-issue": {
+      "status": false
+    }
+}

--- a/firefox-ios/Shared/LaunchArguments.swift
+++ b/firefox-ios/Shared/LaunchArguments.swift
@@ -20,6 +20,7 @@ public struct LaunchArguments {
     public static let SkipAddingGoogleTopSite = "SKIP_ADDING_GOOGLE_TOP_SITE"
     public static let SkipDefaultBrowserOnboarding = "SKIP_DEFAULT_BROWSER_ONBOARDING"
     public static let LoadExperiment = "LOAD_EXPERIMENT"
+    public static let ExperimentFeatureName = "EXPERIMENT_FEATURE_NAME"
     public static let DisableAnimations = "DISABLE_ANIMATIONS"
 
     // After the colon, put the name of the file to load from test bundle

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -57,6 +57,7 @@
         "PrivateBrowsingTest",
         "PrivateBrowsingTestIpad",
         "ReadingListTests",
+        "ReportSiteTests",
         "ScreenGraphTest",
         "SearchSettingsUITests",
         "SearchTests",

--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -62,6 +62,7 @@
         "PrivateBrowsingTestIpad",
         "PrivateBrowsingTestIphone",
         "ReadingListTests",
+        "ReportSiteTests",
         "ScreenGraphTest",
         "SearchSettingsUITests",
         "SearchTests",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
@@ -173,6 +173,7 @@
         "ReadingListTests\/testRemoveFromReadingList()",
         "ReadingListTests\/testRemoveFromReadingView()",
         "ReadingListTests\/testRemoveSavedForReadingLongPress()",
+        "ReportSiteTests",
         "ScreenGraphTest",
         "SearchSettingsUITests",
         "SearchTests",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
@@ -81,6 +81,7 @@
         "PrivateBrowsingTestIpad\/testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad()",
         "PrivateBrowsingTestIpad\/testiPadDirectAccessPrivateModeBrowserTab()",
         "ReadingListTests",
+        "ReportSiteTests",
         "ScreenGraphTest",
         "SearchSettingsUITests",
         "SearchTests",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
@@ -120,6 +120,7 @@
         "PrivateBrowsingTest",
         "PrivateBrowsingTestIpad",
         "ReadingListTests",
+        "ReportSiteTests",
         "ScreenGraphTest",
         "SearchSettingsUITests",
         "SearchTests",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
@@ -108,6 +108,7 @@
         "PrivateBrowsingTest\/testTabCountShowsOnlyNormalOrPrivateTabCount()",
         "PrivateBrowsingTestIpad",
         "ReadingListTests",
+        "ReportSiteTests",
         "ScreenGraphTest",
         "SearchSettingsUITests",
         "SearchTests\/testCopyPasteComplete()",

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
@@ -82,6 +82,7 @@
         "PrivateBrowsingTestIpad",
         "PrivateBrowsingTestIphone",
         "ReadingListTests",
+        "ReportSiteTests",
         "ScreenGraphTest",
         "SearchSettingsUITests",
         "SearchTests",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -65,12 +65,16 @@ class BaseTestCase: XCTestCase {
     }
 
     func setUpApp() {
+        setUpLaunchArguments()
+        app.launch()
+    }
+
+    func setUpLaunchArguments() {
         if !launchArguments.contains("FIREFOX_PERFORMANCE_TEST") {
             app.launchArguments = [LaunchArguments.Test] + launchArguments
         } else {
             app.launchArguments = [LaunchArguments.PerformanceTest] + launchArguments
         }
-        app.launch()
     }
 
     override func setUp() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReportSiteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReportSiteTests.swift
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+
+class ReportSiteTests: BaseTestCase {
+    override func setUpApp() {
+        setUpLaunchArguments()
+    }
+
+    func testReportSiteIssueOn() {
+        launchAndGoToMenu()
+
+        XCTAssertTrue(app.tables.otherElements[StandardImageIdentifiers.Large.lightbulb].exists)
+    }
+
+    func testReportSiteIssueOff() {
+        var launchArgs = app.launchArguments + ["\(LaunchArguments.LoadExperiment)reportSiteIssueOff"]
+        launchArgs = launchArgs + ["\(LaunchArguments.ExperimentFeatureName)general-app-features"]
+        app.launchArguments = launchArgs
+
+        launchAndGoToMenu()
+
+        XCTAssertFalse(app.tables.otherElements[StandardImageIdentifiers.Large.lightbulb].exists)
+    }
+
+    // MARK: Helper
+    func launchAndGoToMenu() {
+        app.launch()
+
+        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
+        navigator.goto(BrowserTabMenu)
+        mozWaitForElementToExist(app.tables["Context Menu"])
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8721)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19331)

## :bulb: Description
Updates the ability to use experiments in UITests.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

