### PR TITLE
Bugfix FXIOS-8691 Remove theme telemetry call in background

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -119,6 +119,8 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     }
 
     public func setPrivateTheme(isOn: Bool) {
+        guard userDefaults.bool(forKey: ThemeKeys.PrivateMode.isOn) != isOn else { return }
+
         userDefaults.set(isOn, forKey: ThemeKeys.PrivateMode.isOn)
 
         updateCurrentTheme(to: fetchSavedThemeType())

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -224,10 +224,6 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
             GleanMetrics.TrackingProtection.strength.set("basic")
         }
 
-        // System theme enabled
-        let themeManager = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
-        GleanMetrics.Theme.useSystemTheme.set(themeManager.systemThemeIsOn)
-
         // Installed Mozilla applications
         GleanMetrics.InstalledMozillaProducts.focus.set(UIApplication.shared.canOpenURL(URL(string: "firefox-focus://")!))
         GleanMetrics.InstalledMozillaProducts.klar.set(UIApplication.shared.canOpenURL(URL(string: "firefox-klar://")!))

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -3680,24 +3680,6 @@ tabs:
       - fx-ios-data-stewards@mozilla.com
     expires: never
 
-# Theme metrics
-theme:
-  use_system_theme:
-    type: boolean
-    description: |
-      Measures the state of the "Use System Light/Dark Mode"
-      theme preference.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1644846
-      - https://github.com/mozilla-mobile/firefox-ios/pull/9673
-      - https://github.com/mozilla-mobile/firefox-ios/pull/12334
-      - https://github.com/mozilla-mobile/firefox-ios/pull/14102
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2024-06-01"
-
 # Enhanced Tracking Protection metrics
 tracking_protection:
   enabled:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8691)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19277)

## :bulb: Description
This seems to fix the issue. I'm not experiencing any more massive memory hikes wit hbackgrounding the app. Basically, we're no longer instatiating a theme manager every time we're backgrounding the app. Checked with PM, they're not ever looking at this telemetry, so, it's pointless anyway.

Also added a guard statement for `updateCurrentTheme` which gets called every time a tab is created/switched to, because we need to know whether to apply private mode theme or not. Guard will lower the actual times `updateCurrentTheme` gets called to only meaningful calls.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

