### PR TITLE
Refactor FXIOS-8729 Enable Address Autofill on Beta by default

### DIFF
--- a/firefox-ios/nimbus-features/addressAutofillFeature.yaml
+++ b/firefox-ios/nimbus-features/addressAutofillFeature.yaml
@@ -10,7 +10,7 @@ features:
     defaults:
       - channel: beta
         value:
-          status: false
+          status: true
       - channel: developer
         value:
           status: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket - FXIOS-8729](https://mozilla-hub.atlassian.net/browse/FXIOS-8729)
[Github issue - 19353](https://github.com/mozilla-mobile/firefox-ios/issues/19353)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Enables the address autofill feature in beta by deafult 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

