### PR TITLE
Refactor FXIOS-8530 - Update Fonts in ContextualHintView to use FXFontStyles

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
@@ -10,14 +10,12 @@ public class ContextualHintView: UIView, ThemeApplicable {
     private var viewModel: ContextualHintViewModel!
 
     struct UX {
-        static let actionButtonTextSize: CGFloat = 17
         static let closeButtonSize = CGSize(width: 35, height: 35)
         static let closeButtonTrailing: CGFloat = 5
         static let closeButtonTop: CGFloat = 23
         static let closeButtonBottom: CGFloat = 12
         static let closeButtonInsets = NSDirectionalEdgeInsets(top: 0, leading: 7.5, bottom: 15, trailing: 7.5)
         static let actionButtonInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
-        static let descriptionTextSize: CGFloat = 17
         static let stackViewLeading: CGFloat = 16
         static let stackViewTopArrowTopConstraint: CGFloat = 16
         static let stackViewBottomArrowTopConstraint: CGFloat = 5

--- a/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
@@ -37,7 +37,7 @@ public class ContextualHintView: UIView, ThemeApplicable {
     }
 
     private lazy var descriptionLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.descriptionTextSize)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.textAlignment = .left
         label.numberOfLines = 0
     }
@@ -156,7 +156,7 @@ public class ContextualHintView: UIView, ThemeApplicable {
 
         if viewModel.isActionType {
             let textAttributes: [NSAttributedString.Key: Any] = [
-                .font: DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.actionButtonTextSize),
+                .font: FXFontStyles.Bold.body.scaledFont(),
                 .foregroundColor: theme.colors.textOnDark,
                 .underlineStyle: NSUnderlineStyle.single.rawValue
             ]

--- a/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
@@ -154,7 +154,7 @@ public class ContextualHintView: UIView, ThemeApplicable {
 
         if viewModel.isActionType {
             let textAttributes: [NSAttributedString.Key: Any] = [
-                .font: FXFontStyles.Bold.body.scaledFont(),
+                .font: FXFontStyles.Regular.body.scaledFont(),
                 .foregroundColor: theme.colors.textOnDark,
                 .underlineStyle: NSUnderlineStyle.single.rawValue
             ]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8530)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18944)

## :bulb: Description
- This PR updates the font styles used in ContextualHintView to use FXFontStyles to standardize the font.
- Unused font which was required for DefaultDynamicFontHelper is removed.

## Screenshots
|  Before  |  After  |
|  ------   |  -----  |
|  ![Before](https://github.com/mozilla-mobile/firefox-ios/assets/89182903/db55ca24-3bd0-4b65-a2bc-b3984d72194d)  |  ![After](https://github.com/mozilla-mobile/firefox-ios/assets/89182903/fb65b2fc-c8f7-4957-950a-26a0fc7c2549)  |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

