### PR TITLE
Add FXIOS-8264 Onboarding customization Nimbus layer

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -562,6 +562,7 @@
 		7BEB64441C7345600092C02E /* L10nSuite2SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3632D31C2983F000D12AF9 /* L10nSuite2SnapshotTests.swift */; };
 		7BEB64451C7345600092C02E /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B60B0071BDE3AE10090C984 /* SnapshotHelper.swift */; };
 		7BEFC6801BFF68C30059C952 /* QuickActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BEFC67F1BFF68C30059C952 /* QuickActions.swift */; };
+		81055B562BAB7CE200E166B3 /* OnboardingMultipeChoiceButtonModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81055B552BAB7CE200E166B3 /* OnboardingMultipeChoiceButtonModel.swift */; };
 		810FF3542B178343009F062C /* FeltPrivacyMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810FF3532B178343009F062C /* FeltPrivacyMiddleware.swift */; };
 		810FF3562B1783B0009F062C /* FeltPrivacyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810FF3552B1783B0009F062C /* FeltPrivacyManager.swift */; };
 		810FF3582B1784E7009F062C /* PrivateModeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810FF3572B1784E7009F062C /* PrivateModeAction.swift */; };
@@ -5617,6 +5618,7 @@
 		80B54D93BC553D6E6CDFAA0A /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		80B8473B933671C9605DC837 /* gl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gl; path = gl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		80E24B20A5655593E1D9E85B /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/Search.strings"; sourceTree = "<group>"; };
+		81055B552BAB7CE200E166B3 /* OnboardingMultipeChoiceButtonModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMultipeChoiceButtonModel.swift; sourceTree = "<group>"; };
 		810FF3532B178343009F062C /* FeltPrivacyMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeltPrivacyMiddleware.swift; sourceTree = "<group>"; };
 		810FF3552B1783B0009F062C /* FeltPrivacyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeltPrivacyManager.swift; sourceTree = "<group>"; };
 		810FF3572B1784E7009F062C /* PrivateModeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateModeAction.swift; sourceTree = "<group>"; };
@@ -10478,6 +10480,7 @@
 				21A7C44D283539170071D996 /* IntroViewModel.swift */,
 				C88E7A562A0553360072E638 /* OnboardingButtonInfoModel.swift */,
 				C8BD875F2A0C248000CD803A /* OnboardingButtonsModel.swift */,
+				81055B552BAB7CE200E166B3 /* OnboardingMultipeChoiceButtonModel.swift */,
 				C88E7A582A0553440072E638 /* OnboardingCardInfoModel.swift */,
 				C88E7A5A2A0553510072E638 /* OnboardingLinkInfoModel.swift */,
 				C88E7A542A0553180072E638 /* OnboardingViewModel.swift */,
@@ -13888,6 +13891,7 @@
 				8A44F20E2B585E1F0016BC81 /* HomepageTelemetry.swift in Sources */,
 				B236204D2B8673DE000B1DE7 /* AddressScrollView.swift in Sources */,
 				E1FF93E428A2E74600E6360E /* WallpaperSelectorViewModel.swift in Sources */,
+				81055B562BAB7CE200E166B3 /* OnboardingMultipeChoiceButtonModel.swift in Sources */,
 				D0C95E0E200FD3B200E4E51C /* PrintHelper.swift in Sources */,
 				C8CD80DA2A1E8C1D0097C3AE /* OnboardingTelemetryProtocol.swift in Sources */,
 				8A5D1CB02A30D740005AD35C /* SearchBarSetting.swift in Sources */,

--- a/firefox-ios/Client/Application/ImageIdentifiers.swift
+++ b/firefox-ios/Client/Application/ImageIdentifiers.swift
@@ -27,14 +27,6 @@ public struct ImageIdentifiers {
     public static let menuBadge = "menuBadge"
     public static let menuWarningMask = "warning-mask"
     public static let navTabCounter = "nav-tabcounter"
-    public static let onboardingWelcomev106 = "onboardingWelcome"
-    public static let onboardingSyncv106 = "onboardingSync"
-    public static let onboardingNotification = "onboardingNotification"
-    public static let onboardingNotificationsCTD = "onboardingNotificationsCTD"
-    public static let onboardingWelcomeCTD = "onboardingWelcomeCTD"
-    public static let onboardingSyncCTD = "onboardingSyncCTD"
-    public static let onboardingSearchWidget = "onboardingSearchWidget"
-    public static let onboardingSetToDock = "onboardingDock"
     public static let qrCodeScanBorder = "qrcode-scanBorder"
     public static let qrCodeScanLine = "qrcode-scanLine"
     public static let qrCodeLight = "qrcode-light"
@@ -49,4 +41,28 @@ public struct ImageIdentifiers {
     public static let starHalf = "starHalf"
     public static let subtract = "subtract"
     public static let syncOpenTab = "sync_open_tab"
+
+    public struct Onboarding {
+        public struct HeaderImages {
+            public static let welcomev106 = "onboardingWelcome"
+            public static let syncv106 = "onboardingSync"
+            public static let notification = "onboardingNotification"
+            public static let searchWidget = "onboardingSearchWidget"
+            public static let setToDock = "onboardingDock"
+        }
+
+        public struct MultipleChoiceButtonImages {
+            public static let themeSystem = "onboardingDock"
+            public static let themeDark = "onboardingDock"
+            public static let themeLight = "onboardingDock"
+            public static let toolbarTop = "onboardingDock"
+            public static let toolbarBottom = "onboardingDock"
+        }
+
+        public struct ChallengeTheDefault {
+            public static let notifications = "onboardingNotificationsCTD"
+            public static let welcome = "onboardingWelcomeCTD"
+            public static let sync = "onboardingSyncCTD"
+        }
+    }
 }

--- a/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingCardInfoModel.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingCardInfoModel.swift
@@ -12,6 +12,7 @@ struct OnboardingCardInfoModel: OnboardingCardInfoModelProtocol {
     var instructionsPopup: OnboardingInstructionsPopupInfoModel?
     var link: OnboardingLinkInfoModel?
     var buttons: OnboardingButtons
+    var multipleChoiceButtons: [OnboardingMultipleChoiceButtonModel]
     var type: OnboardingType
     var a11yIdRoot: String
 
@@ -28,6 +29,7 @@ struct OnboardingCardInfoModel: OnboardingCardInfoModelProtocol {
         body: String,
         link: OnboardingLinkInfoModel?,
         buttons: OnboardingButtons,
+        multipleChoiceButtons: [OnboardingMultipleChoiceButtonModel],
         type: OnboardingType,
         a11yIdRoot: String,
         imageID: String,
@@ -40,6 +42,7 @@ struct OnboardingCardInfoModel: OnboardingCardInfoModelProtocol {
         self.imageID = imageID
         self.link = link
         self.buttons = buttons
+        self.multipleChoiceButtons = multipleChoiceButtons
         self.type = type
         self.a11yIdRoot = a11yIdRoot
         self.instructionsPopup = instructionsPopup

--- a/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingMultipeChoiceButtonModel.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingMultipeChoiceButtonModel.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct OnboardingMultipleChoiceButtonModel {
+    let title: String
+    let action: OnboardingMultipleChoiceAction
+    var imageID: String
+}

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
@@ -39,7 +39,11 @@ protocol OnboardingCardDelegate: AnyObject {
         qrCodeNavigationHandler: QRCodeNavigationHandler?
     )
 
-    func showNextPage(from cardNamed: String, completionIfLastCard completion: (() -> Void)?)
+    func advance(
+        numberOfPages: Int,
+        from cardName: String,
+        completionIfLastCard completion: (() -> Void)?
+    )
     func pageChanged(from cardName: String)
 }
 
@@ -88,9 +92,11 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
         let instructionsVC = OnboardingInstructionPopupViewController(
             viewModel: popupViewModel,
             buttonTappedFinishFlow: {
-                self.showNextPage(
+                self.advance(
+                    numberOfPages: 1,
                     from: name,
-                    completionIfLastCard: completionIfLastCard)
+                    completionIfLastCard: completionIfLastCard
+                )
             }
         )
         var bottomSheetViewModel = BottomSheetViewModel(closeButtonA11yLabel: .CloseButtonTitle)
@@ -135,7 +141,8 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
     }
 
     // MARK: - Page helpers
-    func showNextPage(
+    func advance(
+        numberOfPages: Int,
         from cardName: String,
         completionIfLastCard completion: (() -> Void)?
     ) {
@@ -144,7 +151,7 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
             return
         }
 
-        moveToNextPage(from: cardName)
+        moveForward(numberOfPages: numberOfPages, from: cardName)
     }
 
     // Extra step to make sure pageControl.currentPage is the right index card

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardInfoModelProtocol.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardInfoModelProtocol.swift
@@ -12,6 +12,7 @@ protocol OnboardingCardInfoModelProtocol {
     var instructionsPopup: OnboardingInstructionsPopupInfoModel? { get set }
     var link: OnboardingLinkInfoModel? { get set }
     var buttons: OnboardingButtons { get set }
+    var multipleChoiceButtons: [OnboardingMultipleChoiceButtonModel] { get set }
     var type: OnboardingType { get set }
     var a11yIdRoot: String { get set }
     var imageID: String { get set }
@@ -25,6 +26,7 @@ protocol OnboardingCardInfoModelProtocol {
         body: String,
         link: OnboardingLinkInfoModel?,
         buttons: OnboardingButtons,
+        multipleChoiceButtons: [OnboardingMultipleChoiceButtonModel],
         type: OnboardingType,
         a11yIdRoot: String,
         imageID: String,

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingViewModelProtocol.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingViewModelProtocol.swift
@@ -14,13 +14,19 @@ protocol OnboardingViewModelProtocol {
 }
 
 extension OnboardingViewModelProtocol {
-    func getNextIndex(currentIndex: Int, goForward: Bool) -> Int? {
-        if goForward && currentIndex + 1 < availableCards.count {
-            return currentIndex + 1
+    func getNextIndexFrom(
+        currentIndex: Int,
+        numberOfCardsToMove: Int,
+        goForward: Bool
+    ) -> Int? {
+        if goForward && currentIndex + numberOfCardsToMove < availableCards.count {
+            return currentIndex + numberOfCardsToMove
         }
 
-        if !goForward && currentIndex > 0 {
-            return currentIndex - 1
+        if !goForward &&
+            currentIndex > 0 &&
+            currentIndex - numberOfCardsToMove >= 0 {
+            return currentIndex - numberOfCardsToMove
         }
 
         return nil

--- a/firefox-ios/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -175,7 +175,8 @@ class IntroViewController: UIViewController,
                 || currentViewModel.buttons.secondary?.action == .setDefaultBrowser
         else { return }
 
-        showNextPage(
+        advance(
+            numberOfPages: 1,
             from: currentViewModel.name,
             completionIfLastCard: { self.showNextPageCompletionForLastCard() })
     }
@@ -203,7 +204,12 @@ extension IntroViewController: UIPageViewControllerDataSource, UIPageViewControl
         else { return nil }
 
         pageControl.currentPage = index
-        return getNextOnboardingCard(index: index, goForward: false)
+
+        return getNextOnboardingCard(
+            currentIndex: index,
+            numberOfCardsToMove: 1,
+            goForward: false
+        )
     }
 
     func pageViewController(
@@ -215,7 +221,12 @@ extension IntroViewController: UIPageViewControllerDataSource, UIPageViewControl
         else { return nil }
 
         pageControl.currentPage = index
-        return getNextOnboardingCard(index: index, goForward: true)
+
+        return getNextOnboardingCard(
+            currentIndex: index,
+            numberOfCardsToMove: 1,
+            goForward: true
+        )
     }
 }
 
@@ -238,15 +249,15 @@ extension IntroViewController: OnboardingCardDelegate {
             introViewModel.updateOnboardingUserActivationEvent()
             askForNotificationPermission(from: cardName)
         case .forwardOneCard:
-            showNextPage(from: cardName) {
+            advance(numberOfPages: 1, from: cardName) {
                 self.showNextPageCompletionForLastCard()
             }
         case .forwardTwoCard:
-            showNextPage(from: cardName) {
+            advance(numberOfPages: 2, from: cardName) {
                 self.showNextPageCompletionForLastCard()
             }
         case .forwardThreeCard:
-            showNextPage(from: cardName) {
+            advance(numberOfPages: 3, from: cardName) {
                 self.showNextPageCompletionForLastCard()
             }
         case .syncSignIn:
@@ -257,7 +268,7 @@ extension IntroViewController: OnboardingCardDelegate {
                 with: fxaPrams,
                 selector: #selector(dismissSignInViewController),
                 completion: {
-                    self.showNextPage(from: cardName) {
+                    self.advance(numberOfPages: 1, from: cardName) {
                         self.showNextPageCompletionForLastCard()
                     }
                 },
@@ -306,7 +317,7 @@ extension IntroViewController: OnboardingCardDelegate {
 
                     NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
                 }
-                self.showNextPage(from: cardName) {
+                self.advance(numberOfPages: 1, from: cardName) {
                     self.showNextPageCompletionForLastCard()
                 }
             }

--- a/firefox-ios/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/ViewControllers/FirstInstall/IntroViewController.swift
@@ -237,7 +237,15 @@ extension IntroViewController: OnboardingCardDelegate {
             introViewModel.chosenOptions.insert(.askForNotificationPermission)
             introViewModel.updateOnboardingUserActivationEvent()
             askForNotificationPermission(from: cardName)
-        case .nextCard:
+        case .forwardOneCard:
+            showNextPage(from: cardName) {
+                self.showNextPageCompletionForLastCard()
+            }
+        case .forwardTwoCard:
+            showNextPage(from: cardName) {
+                self.showNextPageCompletionForLastCard()
+            }
+        case .forwardThreeCard:
             showNextPage(from: cardName) {
                 self.showNextPageCompletionForLastCard()
             }

--- a/firefox-ios/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
@@ -178,7 +178,12 @@ extension UpdateViewController: UIPageViewControllerDataSource, UIPageViewContro
         else { return nil }
 
         pageControl.currentPage = index
-        return getNextOnboardingCard(index: index, goForward: false)
+
+        return getNextOnboardingCard(
+            currentIndex: index,
+            numberOfCardsToMove: 1,
+            goForward: false
+        )
     }
 
     func pageViewController(
@@ -190,7 +195,12 @@ extension UpdateViewController: UIPageViewControllerDataSource, UIPageViewContro
         else { return nil }
 
         pageControl.currentPage = index
-        return getNextOnboardingCard(index: index, goForward: true)
+
+        return getNextOnboardingCard(
+            currentIndex: index,
+            numberOfCardsToMove: 1,
+            goForward: true
+        )
     }
 }
 
@@ -207,15 +217,15 @@ extension UpdateViewController: OnboardingCardDelegate {
 
         switch action {
         case .forwardOneCard:
-            showNextPage(from: cardName) {
+            advance(numberOfPages: 1, from: cardName) {
                 self.didFinishFlow?()
             }
         case .forwardTwoCard:
-            showNextPage(from: cardName) {
+            advance(numberOfPages: 2, from: cardName) {
                 self.didFinishFlow?()
             }
         case .forwardThreeCard:
-            showNextPage(from: cardName) {
+            advance(numberOfPages: 3, from: cardName) {
                 self.didFinishFlow?()
             }
         case .syncSignIn:

--- a/firefox-ios/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/ViewControllers/Update/UpdateViewController.swift
@@ -206,7 +206,15 @@ extension UpdateViewController: OnboardingCardDelegate {
             and: isPrimaryButton)
 
         switch action {
-        case .nextCard:
+        case .forwardOneCard:
+            showNextPage(from: cardName) {
+                self.didFinishFlow?()
+            }
+        case .forwardTwoCard:
+            showNextPage(from: cardName) {
+                self.didFinishFlow?()
+            }
+        case .forwardThreeCard:
             showNextPage(from: cardName) {
                 self.didFinishFlow?()
             }

--- a/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -57,6 +57,7 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
                 body: card.body,
                 link: card.link,
                 buttons: card.buttons,
+                multipleChoiceButtons: card.multipleChoiceButtons,
                 type: card.type,
                 a11yIdRoot: "\(card.a11yIdRoot)\(index)",
                 imageID: card.imageID,
@@ -90,9 +91,10 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
                         AppName.shortName.rawValue),
                     link: getOnboardingLink(from: cardData.link),
                     buttons: getOnboardingCardButtons(from: cardData.buttons),
+                    multipleChoiceButtons: getOnboardingMultipleChoiceButtons(from: cardData.multipleChoiceButtons),
                     type: cardData.type,
                     a11yIdRoot: cardData.type == .freshInstall ? a11yOnboarding : a11yUpgrade,
-                    imageID: getOnboardingImageID(from: cardData.image),
+                    imageID: getOnboardingHeaderImageID(from: cardData.image),
                     instructionsPopup: getPopupInfoModel(
                         from: cardData.instructionsPopup,
                         withA11yID: "")
@@ -160,6 +162,18 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
             })
     }
 
+    private func getOnboardingMultipleChoiceButtons(
+        from cardButtons: [NimbusOnboardingMultipleChoiceButton]
+    ) -> [OnboardingMultipleChoiceButtonModel] {
+        return cardButtons.map { button in
+            return OnboardingMultipleChoiceButtonModel(
+                title: button.title,
+                action: button.action,
+                imageID: getOnboardingMultipleChoiceButtonImageID(from: button.image)
+            )
+        }
+    }
+
     private func getOnboardingLink(from cardLink: NimbusOnboardingLink?) -> OnboardingLinkInfoModel? {
         guard let cardLink = cardLink,
               let url = URL(string: cardLink.url, invalidCharacters: false)
@@ -168,7 +182,7 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
         return OnboardingLinkInfoModel(title: cardLink.title, url: url)
     }
 
-    private func getOnboardingImageID(from identifier: NimbusOnboardingHeaderImage) -> String {
+    private func getOnboardingHeaderImageID(from identifier: NimbusOnboardingHeaderImage) -> String {
         switch identifier {
         case .welcomeGlobe: return ImageIdentifiers.onboardingWelcomev106
         case .syncDevices: return ImageIdentifiers.onboardingSyncv106
@@ -178,6 +192,14 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
         case .syncDevicesCtd: return ImageIdentifiers.onboardingSyncCTD
         case .setToDock: return ImageIdentifiers.onboardingSetToDock
         case .searchWidget: return ImageIdentifiers.onboardingSearchWidget
+        }
+    }
+
+    private func getOnboardingMultipleChoiceButtonImageID(
+        from identifier: NimbusOnboardingMultipleChoiceButtonImage
+    ) -> String {
+        switch identifier {
+        case .themeSystem: return "test"
         }
     }
 

--- a/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -168,7 +168,7 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
         return OnboardingLinkInfoModel(title: cardLink.title, url: url)
     }
 
-    private func getOnboardingImageID(from identifier: NimbusOnboardingImages) -> String {
+    private func getOnboardingImageID(from identifier: NimbusOnboardingHeaderImage) -> String {
         switch identifier {
         case .welcomeGlobe: return ImageIdentifiers.onboardingWelcomev106
         case .syncDevices: return ImageIdentifiers.onboardingSyncv106
@@ -182,7 +182,7 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
     }
 
     private func getPopupInfoModel(
-        from data: NimbusInstructionPopup?,
+        from data: NimbusOnboardingInstructionPopup?,
         withA11yID a11yID: String
     ) -> OnboardingInstructionsPopupInfoModel? {
         guard let data else { return nil }

--- a/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -152,7 +152,9 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
 
     /// Returns an optional array of ``OnboardingButtonInfoModel`` given the data.
     /// A card is not viable without buttons.
-    private func getOnboardingCardButtons(from cardButtons: NimbusOnboardingButtons) -> OnboardingButtons {
+    private func getOnboardingCardButtons(
+        from cardButtons: NimbusOnboardingButtons
+    ) -> OnboardingButtons {
         return OnboardingButtons(
             primary: OnboardingButtonInfoModel(
                 title: cardButtons.primary.title,
@@ -174,7 +176,9 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
         }
     }
 
-    private func getOnboardingLink(from cardLink: NimbusOnboardingLink?) -> OnboardingLinkInfoModel? {
+    private func getOnboardingLink(
+        from cardLink: NimbusOnboardingLink?
+    ) -> OnboardingLinkInfoModel? {
         guard let cardLink = cardLink,
               let url = URL(string: cardLink.url, invalidCharacters: false)
         else { return nil }
@@ -182,7 +186,9 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
         return OnboardingLinkInfoModel(title: cardLink.title, url: url)
     }
 
-    private func getOnboardingHeaderImageID(from identifier: NimbusOnboardingHeaderImage) -> String {
+    private func getOnboardingHeaderImageID(
+        from identifier: NimbusOnboardingHeaderImage
+    ) -> String {
         switch identifier {
         case .welcomeGlobe: return ImageIdentifiers.onboardingWelcomev106
         case .syncDevices: return ImageIdentifiers.onboardingSyncv106
@@ -199,7 +205,11 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
         from identifier: NimbusOnboardingMultipleChoiceButtonImage
     ) -> String {
         switch identifier {
-        case .themeSystem: return "test"
+        case .themeSystem: return ""
+        case .themeDark: return ""
+        case .themeLight: return ""
+        case .toolbarTop: return ""
+        case .toolbarBottom: return ""
         }
     }
 

--- a/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -190,14 +190,15 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
         from identifier: NimbusOnboardingHeaderImage
     ) -> String {
         switch identifier {
-        case .welcomeGlobe: return ImageIdentifiers.onboardingWelcomev106
-        case .syncDevices: return ImageIdentifiers.onboardingSyncv106
-        case .notifications: return ImageIdentifiers.onboardingNotification
-        case .notificationsCtd: return ImageIdentifiers.onboardingNotificationsCTD
-        case .welcomeCtd: return ImageIdentifiers.onboardingWelcomeCTD
-        case .syncDevicesCtd: return ImageIdentifiers.onboardingSyncCTD
-        case .setToDock: return ImageIdentifiers.onboardingSetToDock
-        case .searchWidget: return ImageIdentifiers.onboardingSearchWidget
+        case .welcomeGlobe: return ImageIdentifiers.Onboarding.HeaderImages.welcomev106
+        case .syncDevices: return ImageIdentifiers.Onboarding.HeaderImages.syncv106
+        case .notifications: return ImageIdentifiers.Onboarding.HeaderImages.notification
+        case .setToDock: return ImageIdentifiers.Onboarding.HeaderImages.setToDock
+        case .searchWidget: return ImageIdentifiers.Onboarding.HeaderImages.searchWidget
+        // Challenge the Default experiment
+        case .notificationsCtd: return ImageIdentifiers.Onboarding.ChallengeTheDefault.notifications
+        case .welcomeCtd: return ImageIdentifiers.Onboarding.ChallengeTheDefault.welcome
+        case .syncDevicesCtd: return ImageIdentifiers.Onboarding.ChallengeTheDefault.sync
         }
     }
 
@@ -205,11 +206,11 @@ class NimbusOnboardingFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
         from identifier: NimbusOnboardingMultipleChoiceButtonImage
     ) -> String {
         switch identifier {
-        case .themeSystem: return ""
-        case .themeDark: return ""
-        case .themeLight: return ""
-        case .toolbarTop: return ""
-        case .toolbarBottom: return ""
+        case .themeSystem: return ImageIdentifiers.Onboarding.MultipleChoiceButtonImages.themeSystem
+        case .themeDark: return ImageIdentifiers.Onboarding.MultipleChoiceButtonImages.themeDark
+        case .themeLight: return ImageIdentifiers.Onboarding.MultipleChoiceButtonImages.themeLight
+        case .toolbarTop: return ImageIdentifiers.Onboarding.MultipleChoiceButtonImages.toolbarTop
+        case .toolbarBottom: return ImageIdentifiers.Onboarding.MultipleChoiceButtonImages.toolbarBottom
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
@@ -130,13 +130,14 @@ final class LaunchScreenViewModelTests: XCTestCase {
 
     func createCard(index: Int) -> OnboardingCardInfoModel {
         let buttons = OnboardingButtons(primary: OnboardingButtonInfoModel(title: "Button title \(index)",
-                                                                           action: .nextCard))
+                                                                           action: .forwardOneCard))
         return OnboardingCardInfoModel(name: "Name \(index)",
                                        order: index,
                                        title: "Title \(index)",
                                        body: "Body \(index)",
                                        link: nil,
                                        buttons: buttons,
+                                       multipleChoiceButtons: [],
                                        type: .upgrade,
                                        a11yIdRoot: "A11y id \(index)",
                                        imageID: "Image id \(index)",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Helpers/NimbusOnboardingTestingConfigUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Helpers/NimbusOnboardingTestingConfigUtility.swift
@@ -60,7 +60,7 @@ struct NimbusOnboardingTestingConfigUtility {
         dismissable: Bool = true,
         shouldAddLink: Bool = false,
         withSecondaryButton: Bool = false,
-        withPrimaryButtonAction primaryAction: [OnboardingActions] = [.nextCard],
+        withPrimaryButtonAction primaryAction: [OnboardingActions] = [.forwardOneCard],
         prerequisites: [String] = ["ALWAYS"],
         disqualifiers: [String] = []
     ) {
@@ -150,7 +150,7 @@ struct NimbusOnboardingTestingConfigUtility {
                     action: primaryAction,
                     title: "\(CardElementNames.primaryButtonTitle)"),
                 secondary: NimbusOnboardingButton(
-                    action: .nextCard,
+                    action: .forwardOneCard,
                     title: "\(CardElementNames.secondaryButtonTitle)")
             )
         }
@@ -168,7 +168,7 @@ struct NimbusOnboardingTestingConfigUtility {
         case .welcome, .updateWelcome:
             return NimbusOnboardingButtons(
                 primary: NimbusOnboardingButton(
-                    action: .nextCard,
+                    action: .forwardOneCard,
                     title: "\(CardElementNames.primaryButtonTitle)"))
         case .notifications:
             return NimbusOnboardingButtons(
@@ -176,7 +176,7 @@ struct NimbusOnboardingTestingConfigUtility {
                     action: .requestNotifications,
                     title: "\(CardElementNames.primaryButtonTitle)"),
                 secondary: NimbusOnboardingButton(
-                    action: .nextCard,
+                    action: .forwardOneCard,
                     title: "\(CardElementNames.secondaryButtonTitle)"))
         case .sync, .updateSync:
             return NimbusOnboardingButtons(
@@ -184,7 +184,7 @@ struct NimbusOnboardingTestingConfigUtility {
                     action: .syncSignIn,
                     title: "\(CardElementNames.primaryButtonTitle)"),
                 secondary: NimbusOnboardingButton(
-                    action: .nextCard,
+                    action: .forwardOneCard,
                     title: "\(CardElementNames.secondaryButtonTitle)"))
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Helpers/NimbusOnboardingTestingConfigUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Helpers/NimbusOnboardingTestingConfigUtility.swift
@@ -55,7 +55,7 @@ struct NimbusOnboardingTestingConfigUtility {
 
     // MARK: - Custom setups
     func setupNimbusWith(
-        image: NimbusOnboardingImages = .welcomeGlobe,
+        image: NimbusOnboardingHeaderImage = .welcomeGlobe,
         type: OnboardingType = .freshInstall,
         dismissable: Bool = true,
         shouldAddLink: Bool = false,
@@ -84,7 +84,7 @@ struct NimbusOnboardingTestingConfigUtility {
     // MARK: - Private helpers
     private func createCards(
         numbering numberOfCards: Int,
-        image: NimbusOnboardingImages,
+        image: NimbusOnboardingHeaderImage,
         type: OnboardingType,
         shouldAddLink: Bool,
         withSecondaryButton: Bool,
@@ -119,7 +119,7 @@ struct NimbusOnboardingTestingConfigUtility {
     ) -> NimbusOnboardingCardData {
         let shouldAddLink: [CardOrder] = [.welcome, .updateWelcome]
         let isUpdate: [CardOrder] = [.updateWelcome, .updateSync]
-        let image: NimbusOnboardingImages = {
+        let image: NimbusOnboardingHeaderImage = {
             switch id {
             case .notifications: return .notifications
             case .welcome, .updateWelcome: return .welcomeGlobe
@@ -195,8 +195,8 @@ struct NimbusOnboardingTestingConfigUtility {
             url: "\(CardElementNames.linkURL)")
     }
 
-    private func buildInfoPopup() -> NimbusInstructionPopup {
-        return NimbusInstructionPopup(
+    private func buildInfoPopup() -> NimbusOnboardingInstructionPopup {
+        return NimbusOnboardingInstructionPopup(
             buttonAction: .dismiss,
             buttonTitle: CardElementNames.popupButtonTitle,
             instructions: [

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/IntroViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/IntroViewControllerTests.swift
@@ -66,7 +66,7 @@ class IntroViewControllerTests: XCTestCase {
         let subject = createSubject(withCustomPrimaryActions: [.syncSignIn, .setDefaultBrowser, .requestNotifications])
 
         XCTAssertEqual(subject.pageControl.currentPage, 0)
-        subject.showNextPage(
+        subject.advance(
             from: subject.viewModel.availableCards[subject.pageControl.currentPage].viewModel.name,
             completionIfLastCard: nil)
         XCTAssertEqual(subject.pageControl.currentPage, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/IntroViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/IntroViewControllerTests.swift
@@ -67,6 +67,7 @@ class IntroViewControllerTests: XCTestCase {
 
         XCTAssertEqual(subject.pageControl.currentPage, 0)
         subject.advance(
+            numberOfPages: 1,
             from: subject.viewModel.availableCards[subject.pageControl.currentPage].viewModel.name,
             completionIfLastCard: nil)
         XCTAssertEqual(subject.pageControl.currentPage, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/IntroViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/IntroViewModelTests.swift
@@ -75,7 +75,7 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndex(currentIndex: 0, goForward: true)
+        let resultIndex = subject.getNextIndexFrom(currentIndex: 0, goForward: true)
         XCTAssertEqual(resultIndex, expectedIndex)
     }
 
@@ -86,7 +86,7 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndex(currentIndex: 1, goForward: true)
+        let resultIndex = subject.getNextIndexFrom(currentIndex: 1, goForward: true)
         XCTAssertEqual(resultIndex, expectedIndex)
     }
 
@@ -96,7 +96,7 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndex(currentIndex: 2, goForward: true)
+        let resultIndex = subject.getNextIndexFrom(currentIndex: 2, goForward: true)
         XCTAssertNil(resultIndex)
     }
 
@@ -108,7 +108,7 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndex(currentIndex: 2, goForward: false)
+        let resultIndex = subject.getNextIndexFrom(currentIndex: 2, goForward: false)
         XCTAssertEqual(resultIndex, expectedIndex)
     }
 
@@ -119,7 +119,7 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndex(currentIndex: 1, goForward: false)
+        let resultIndex = subject.getNextIndexFrom(currentIndex: 1, goForward: false)
         XCTAssertEqual(resultIndex, expectedIndex)
     }
 
@@ -129,7 +129,7 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndex(currentIndex: 0, goForward: false)
+        let resultIndex = subject.getNextIndexFrom(currentIndex: 0, goForward: false)
         XCTAssertNil(resultIndex)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/IntroViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/IntroViewModelTests.swift
@@ -75,7 +75,11 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndexFrom(currentIndex: 0, goForward: true)
+        let resultIndex = subject.getNextIndexFrom(
+            currentIndex: 0,
+            numberOfCardsToMove: 1,
+            goForward: true
+        )
         XCTAssertEqual(resultIndex, expectedIndex)
     }
 
@@ -86,7 +90,11 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndexFrom(currentIndex: 1, goForward: true)
+        let resultIndex = subject.getNextIndexFrom(
+            currentIndex: 1,
+            numberOfCardsToMove: 1,
+            goForward: true
+        )
         XCTAssertEqual(resultIndex, expectedIndex)
     }
 
@@ -96,7 +104,11 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndexFrom(currentIndex: 2, goForward: true)
+        let resultIndex = subject.getNextIndexFrom(
+            currentIndex: 2,
+            numberOfCardsToMove: 1,
+            goForward: true
+        )
         XCTAssertNil(resultIndex)
     }
 
@@ -108,7 +120,11 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndexFrom(currentIndex: 2, goForward: false)
+        let resultIndex = subject.getNextIndexFrom(
+            currentIndex: 2,
+            numberOfCardsToMove: 1,
+            goForward: false
+        )
         XCTAssertEqual(resultIndex, expectedIndex)
     }
 
@@ -119,7 +135,11 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndexFrom(currentIndex: 1, goForward: false)
+        let resultIndex = subject.getNextIndexFrom(
+            currentIndex: 1,
+            numberOfCardsToMove: 1,
+            goForward: false
+        )
         XCTAssertEqual(resultIndex, expectedIndex)
     }
 
@@ -129,7 +149,11 @@ class IntroViewModelTests: XCTestCase {
 
         subject.setupViewControllerDelegates(with: MockOnboardinCardDelegateController())
 
-        let resultIndex = subject.getNextIndexFrom(currentIndex: 0, goForward: false)
+        let resultIndex = subject.getNextIndexFrom(
+            currentIndex: 0,
+            numberOfCardsToMove: 1,
+            goForward: false
+        )
         XCTAssertNil(resultIndex)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Mocks/MockOnboardingCardDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Mocks/MockOnboardingCardDelegate.swift
@@ -39,8 +39,12 @@ class MockOnboardinCardDelegateController: UIViewController,
             self.action = .syncSignIn
         case .requestNotifications:
             self.action = .requestNotifications
-        case .nextCard:
-            showNextPage(from: cardName, completionIfLastCard: {})
+        case .forwardOneCard:
+            showNextPage(numberOfCards: 1, from: cardName, completionIfLastCard: {})
+        case .forwardTwoCard:
+            showNextPage(numberOfCards: 2, from: cardName, completionIfLastCard: {})
+        case .forwardThreeCard:
+            showNextPage(numberOfCards: 3, from: cardName, completionIfLastCard: {})
         case .setDefaultBrowser:
             self.action = .setDefaultBrowser
         case .openInstructionsPopup:
@@ -77,8 +81,15 @@ class MockOnboardinCardDelegateController: UIViewController,
         action = .syncSignIn
     }
 
-    func showNextPage(from cardNamed: String, completionIfLastCard completion: () -> Void) {
-        action = .nextCard
+    func showNextPage(numberOfCards: Int, from cardNamed: String, completionIfLastCard completion: () -> Void) {
+        action = .forwardOneCard
+        if numberOfCards == 1 {
+            action = .forwardOneCard
+        } else if numberOfCards == 2 {
+            action = .forwardTwoCard
+        } else if numberOfCards == 3 {
+            action = .forwardThreeCard
+        }
     }
 
     func pageChanged(from cardName: String) { }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/NimbusOnboardingFeatureLayerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/NimbusOnboardingFeatureLayerTests.swift
@@ -59,7 +59,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
 
     // MARK: - Test A11yRoot
     func testLayer_a11yroot_isOnboarding() {
-        configUtility.setupNimbusWith(withPrimaryButtonAction: [.nextCard, .syncSignIn])
+        configUtility.setupNimbusWith(withPrimaryButtonAction: [.forwardOneCard, .syncSignIn])
         let layer = NimbusOnboardingFeatureLayer(with: MockNimbusMessagingHelperUtility())
 
         let subject = layer.getOnboardingModel(for: .freshInstall).cards
@@ -71,7 +71,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
     func testLayer_a11yroot_isUpgrade() {
         configUtility.setupNimbusWith(
             type: .upgrade,
-            withPrimaryButtonAction: [.nextCard, .syncSignIn])
+            withPrimaryButtonAction: [.forwardOneCard, .syncSignIn])
         let layer = NimbusOnboardingFeatureLayer(with: MockNimbusMessagingHelperUtility())
 
         let subject = layer.getOnboardingModel(for: .upgrade).cards
@@ -103,20 +103,21 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             buttons: OnboardingButtons(
                 primary: OnboardingButtonInfoModel(
                     title: CardElementNames.primaryButtonTitle,
-                    action: .nextCard),
+                    action: .forwardOneCard),
                 secondary: OnboardingButtonInfoModel(
                     title: CardElementNames.secondaryButtonTitle,
-                    action: .nextCard)),
+                    action: .forwardOneCard)),
+            multipleChoiceButtons: [],
             type: .freshInstall,
             a11yIdRoot: CardElementNames.a11yIDOnboarding,
-            imageID: ImageIdentifiers.onboardingWelcomev106,
+            imageID: ImageIdentifiers.Onboarding.HeaderImages.welcomev106,
             instructionsPopup: nil)
 
         XCTAssertEqual(subject.name, expectedCard.name)
         XCTAssertEqual(subject.title, expectedCard.title)
         XCTAssertEqual(subject.body, expectedCard.body)
         XCTAssertEqual(subject.type, expectedCard.type)
-        XCTAssertEqual(subject.image, UIImage(named: ImageIdentifiers.onboardingWelcomev106))
+        XCTAssertEqual(subject.image, UIImage(named: ImageIdentifiers.Onboarding.HeaderImages.welcomev106))
         XCTAssertEqual(subject.link?.title, expectedCard.link?.title)
         XCTAssertEqual(subject.link?.url, expectedCard.link?.url)
         XCTAssertEqual(subject.buttons.primary.title, expectedCard.buttons.primary.title)
@@ -128,7 +129,13 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
 
     func testLayer_cardsAreReturned_ThreeCardsReturned() {
         let expectedNumberOfCards = 3
-        configUtility.setupNimbusWith(withPrimaryButtonAction: [.nextCard, .syncSignIn, .requestNotifications])
+        configUtility.setupNimbusWith(
+            withPrimaryButtonAction: [
+                .forwardOneCard,
+                .syncSignIn,
+                .requestNotifications
+            ]
+        )
         let layer = NimbusOnboardingFeatureLayer(with: MockNimbusMessagingHelperUtility())
 
         let subject = layer.getOnboardingModel(for: .freshInstall).cards
@@ -137,7 +144,13 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
     }
 
     func testLayer_cardsAreReturned_InExpectedOrder() {
-        configUtility.setupNimbusWith(withPrimaryButtonAction: [.nextCard, .syncSignIn, .requestNotifications])
+        configUtility.setupNimbusWith(
+            withPrimaryButtonAction: [
+                .forwardOneCard,
+                .syncSignIn,
+                .requestNotifications
+            ]
+        )
         let layer = NimbusOnboardingFeatureLayer(with: MockNimbusMessagingHelperUtility())
 
         let subject = layer.getOnboardingModel(for: .freshInstall).cards
@@ -275,7 +288,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.imageID, ImageIdentifiers.onboardingWelcomev106)
+        XCTAssertEqual(subject.imageID, ImageIdentifiers.Onboarding.HeaderImages.welcomev106)
     }
 
     func testLayer_cardIsReturned_WithNotificationImageIdenfier() {
@@ -287,7 +300,10 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.image, UIImage(named: ImageIdentifiers.onboardingNotification))
+        XCTAssertEqual(
+            subject.image,
+            UIImage(named: ImageIdentifiers.Onboarding.HeaderImages.notification)
+        )
     }
 
     func testLayer_cardIsReturned_WithSyncImageIdenfier() {
@@ -299,7 +315,10 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.image, UIImage(named: ImageIdentifiers.onboardingSyncv106))
+        XCTAssertEqual(
+            subject.image,
+            UIImage(named: ImageIdentifiers.Onboarding.HeaderImages.syncv106)
+        )
     }
 
     func testLayer_cardIsReturned_WithDockImageIdenfier() {
@@ -311,7 +330,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.imageID, ImageIdentifiers.onboardingSetToDock)
+        XCTAssertEqual(subject.imageID, ImageIdentifiers.Onboarding.HeaderImages.setToDock)
     }
 
     func testLayer_cardIsReturned_WithSearchWidgetImageIdenfier() {
@@ -323,7 +342,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.imageID, ImageIdentifiers.onboardingSearchWidget)
+        XCTAssertEqual(subject.imageID, ImageIdentifiers.Onboarding.HeaderImages.searchWidget)
     }
 
     // MARK: - Test install types
@@ -409,7 +428,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
     func testLayer_cardIsReturned_WithNextCardButton() {
         configUtility.setupNimbusWith(
             withSecondaryButton: false,
-            withPrimaryButtonAction: [.nextCard]
+            withPrimaryButtonAction: [.forwardOneCard]
         )
         let layer = NimbusOnboardingFeatureLayer(with: MockNimbusMessagingHelperUtility())
 
@@ -418,7 +437,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(subject.buttons.primary.action, .nextCard)
+        XCTAssertEqual(subject.buttons.primary.action, .forwardOneCard)
     }
 
     func testLayer_cardIsReturned_WithDefaultBrowserButton() {
@@ -472,7 +491,7 @@ class NimbusOnboardingFeatureLayerTests: XCTestCase {
             body: "\(CardElementNames.noPlaceholderString)",
             buttons: NimbusOnboardingButtons(
                 primary: NimbusOnboardingButton(
-                    action: .nextCard,
+                    action: .forwardOneCard,
                     title: "\(CardElementNames.primaryButtonTitle)")),
             disqualifiers: ["NEVER"],
             image: .notifications,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
@@ -20,13 +20,13 @@ class OnboardingButtonActionTests: XCTestCase {
     }
 
     func testMockDelegate_whenInitialized_actionIsNil() {
-        _ = setSubjectUpWith(firstAction: .nextCard)
+        _ = setSubjectUpWith(firstAction: .forwardOneCard)
 
         XCTAssertNil(mockDelegate.action)
     }
 
     func testsubject_whenOnlyOneButtonExists_secondaryButtonIsHidden() {
-        let subject = setSubjectUpWith(firstAction: .nextCard, twoButtons: false)
+        let subject = setSubjectUpWith(firstAction: .forwardOneCard, twoButtons: false)
 
         subject.secondaryAction()
 
@@ -34,11 +34,27 @@ class OnboardingButtonActionTests: XCTestCase {
     }
 
     func testsubject_primaryAction_returnsNextCardAction() {
-        let subject = setSubjectUpWith(firstAction: .nextCard)
+        let subject = setSubjectUpWith(firstAction: .forwardOneCard)
 
         subject.primaryAction()
 
-        XCTAssertEqual(mockDelegate.action, OnboardingActions.nextCard)
+        XCTAssertEqual(mockDelegate.action, OnboardingActions.forwardOneCard)
+    }
+
+    func testsubject_primaryAction_returnsTwoCardAction() {
+        let subject = setSubjectUpWith(firstAction: .forwardTwoCard)
+
+        subject.primaryAction()
+
+        XCTAssertEqual(mockDelegate.action, OnboardingActions.forwardTwoCard)
+    }
+
+    func testsubject_primaryAction_returnsThirdCardAction() {
+        let subject = setSubjectUpWith(firstAction: .forwardThreeCard)
+
+        subject.primaryAction()
+
+        XCTAssertEqual(mockDelegate.action, OnboardingActions.forwardThreeCard)
     }
 
     func testsubject_buttonAction_returnsPrivacyPolicyAction() {
@@ -95,7 +111,7 @@ class OnboardingButtonActionTests: XCTestCase {
                     action: firstAction),
                 secondary: OnboardingButtonInfoModel(
                     title: .Onboarding.Sync.SkipAction,
-                    action: .nextCard))
+                    action: .forwardOneCard))
         } else {
             buttons = OnboardingButtons(
                 primary: OnboardingButtonInfoModel(
@@ -110,9 +126,10 @@ class OnboardingButtonActionTests: XCTestCase {
             body: String(format: .Onboarding.Sync.Description),
             link: nil,
             buttons: buttons,
+            multipleChoiceButtons: [],
             type: .freshInstall,
             a11yIdRoot: AccessibilityIdentifiers.Onboarding.onboarding,
-            imageID: ImageIdentifiers.onboardingSyncv106,
+            imageID: ImageIdentifiers.Onboarding.HeaderImages.syncv106,
             instructionsPopup: nil)
 
         mockDelegate = MockOnboardinCardDelegateController()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
@@ -49,7 +49,7 @@ class OnboardingTelemetryDelegationTests: XCTestCase {
             XCTFail("expected a view controller, but got nothing")
             return
         }
-        subject.showNextPage(from: firstVC.viewModel.name, completionIfLastCard: { })
+        subject.advance(from: firstVC.viewModel.name, completionIfLastCard: { })
         subject.pageChanged(from: firstVC.viewModel.name)
         guard let result = subject.pageController
             .viewControllers?[subject.pageControl.currentPage] as? OnboardingCardViewController else {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
@@ -49,7 +49,10 @@ class OnboardingTelemetryDelegationTests: XCTestCase {
             XCTFail("expected a view controller, but got nothing")
             return
         }
-        subject.advance(from: firstVC.viewModel.name, completionIfLastCard: { })
+        subject.advance(
+            numberOfPages: 1,
+            from: firstVC.viewModel.name,
+            completionIfLastCard: { })
         subject.pageChanged(from: firstVC.viewModel.name)
         guard let result = subject.pageController
             .viewControllers?[subject.pageControl.currentPage] as? OnboardingCardViewController else {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryUtilityTests.swift
@@ -67,7 +67,7 @@ class OnboardingTelemetryUtilityTests: XCTestCase {
         let subject = createTelemetryUtility(for: .freshInstall)
 
         subject.sendButtonActionTelemetry(from: CardNames.welcome.rawValue,
-                                          with: .nextCard,
+                                          with: .forwardOneCard,
                                           and: isPrimaryButton)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
@@ -90,7 +90,7 @@ class OnboardingTelemetryUtilityTests: XCTestCase {
         let subject = createTelemetryUtility(for: .freshInstall)
 
         subject.sendButtonActionTelemetry(from: CardNames.sync.rawValue,
-                                          with: .nextCard,
+                                          with: .forwardOneCard,
                                           and: isPrimaryButton)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.secondaryButtonTap)
@@ -101,7 +101,7 @@ class OnboardingTelemetryUtilityTests: XCTestCase {
         let subject = createTelemetryUtility(for: .upgrade)
 
         subject.sendButtonActionTelemetry(from: CardNames.updateSync.rawValue,
-                                          with: .nextCard,
+                                          with: .forwardOneCard,
                                           and: isPrimaryButton)
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.secondaryButtonTap)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingViewControllerProtocolTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingViewControllerProtocolTests.swift
@@ -37,7 +37,11 @@ class OnboardingViewControllerProtocolTests: XCTestCase {
     func testProtocol_getsCorrectViewController_notifications() {
         let subject = createSubject()
 
-        guard let result = subject.getNextOnboardingCard(index: 0, goForward: true) else {
+        guard let result = subject.getNextOnboardingCard(
+            currentIndex: 0,
+            numberOfCardsToMove: 1,
+            goForward: true
+        ) else {
             XCTFail("expected a view controller, but got nothing")
             return
         }
@@ -48,7 +52,11 @@ class OnboardingViewControllerProtocolTests: XCTestCase {
     func testProtocol_getsCorrectViewController_sync() {
         let subject = createSubject()
 
-        guard let result = subject.getNextOnboardingCard(index: 1, goForward: true) else {
+        guard let result = subject.getNextOnboardingCard(
+            currentIndex: 1,
+            numberOfCardsToMove: 1,
+            goForward: true
+        ) else {
             XCTFail("expected a view controller, but got nothing")
             return
         }
@@ -59,7 +67,11 @@ class OnboardingViewControllerProtocolTests: XCTestCase {
     func testProtocol_getsNoViewContoller_afterLastCard() {
         let subject = createSubject()
 
-        let result = subject.getNextOnboardingCard(index: 2, goForward: true)
+        let result = subject.getNextOnboardingCard(
+            currentIndex: 2,
+            numberOfCardsToMove: 1,
+            goForward: true
+        )
 
         XCTAssertNil(result)
     }
@@ -68,7 +80,11 @@ class OnboardingViewControllerProtocolTests: XCTestCase {
     func testProtocol_getsNoViewContoller_beforeFirstCard() {
         let subject = createSubject()
 
-        let result = subject.getNextOnboardingCard(index: 2, goForward: true)
+        let result = subject.getNextOnboardingCard(
+            currentIndex: 2,
+            numberOfCardsToMove: 1,
+            goForward: true
+        )
 
         XCTAssertNil(result)
     }
@@ -76,7 +92,11 @@ class OnboardingViewControllerProtocolTests: XCTestCase {
     func testProtocol_getsCorrectViewController_fromSecondCard_isWelcome() {
         let subject = createSubject()
 
-        guard let result = subject.getNextOnboardingCard(index: 1, goForward: false) else {
+        guard let result = subject.getNextOnboardingCard(
+            currentIndex: 1,
+            numberOfCardsToMove: 1,
+            goForward: false
+        ) else {
             XCTFail("expected a view controller, but got nothing")
             return
         }
@@ -87,7 +107,11 @@ class OnboardingViewControllerProtocolTests: XCTestCase {
     func testProtocol_getsCorrectViewController_fromThirdCard_isNotifications() {
         let subject = createSubject()
 
-        guard let result = subject.getNextOnboardingCard(index: 2, goForward: false) else {
+        guard let result = subject.getNextOnboardingCard(
+            currentIndex: 2,
+            numberOfCardsToMove: 1,
+            goForward: false
+        ) else {
             XCTFail("expected a view controller, but got nothing")
             return
         }
@@ -111,7 +135,7 @@ class OnboardingViewControllerProtocolTests: XCTestCase {
     func testProtocol_moveToNextPage_FromFirstCard() {
         let subject = createSubject()
 
-        subject.moveToNextPage(from: cards.welcome.rawValue)
+        subject.moveForward(numberOfPages: 1, from: cards.welcome.rawValue)
         guard let result = subject.pageController.viewControllers?.first as? OnboardingCardViewController else {
             XCTFail("expected a view controller, but got nothing")
             return
@@ -124,7 +148,7 @@ class OnboardingViewControllerProtocolTests: XCTestCase {
     func testProtocol_moveToNextPage_FromSecondCard() {
         let subject = createSubject()
 
-        subject.moveToNextPage(from: cards.notifications.rawValue)
+        subject.moveForward(numberOfPages: 1, from: cards.notifications.rawValue)
         guard let result = subject.pageController.viewControllers?.first as? OnboardingCardViewController else {
             XCTFail("expected a view controller, but got nothing")
             return

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
@@ -192,13 +192,14 @@ class UpdateViewModelTests: XCTestCase {
 
     func createCard(index: Int) -> OnboardingCardInfoModel {
         let buttons = OnboardingButtons(primary: OnboardingButtonInfoModel(title: "Button title \(index)",
-                                                                           action: .nextCard))
+                                                                           action: .forwardOneCard))
         return OnboardingCardInfoModel(name: "Name \(index)",
                                        order: index,
                                        title: "Title \(index)",
                                        body: "Body \(index)",
                                        link: nil,
                                        buttons: buttons,
+                                       multipleChoiceButtons: [],
                                        type: .upgrade,
                                        a11yIdRoot: "A11y id \(index)",
                                        imageID: "Image id \(index)",

--- a/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
@@ -46,7 +46,7 @@ features:
                   action: open-instructions-popup
                 secondary:
                   title: Onboarding/Onboarding.Welcome.Skip.v114
-                  action: next-card
+                  action: forward-one-card
               instructions-popup:
                 title: Onboarding/DefaultBrowserPopup.Title.v114
                 button-title: Onboarding/DefaultBrowserPopup.ButtonTitle.v114
@@ -69,7 +69,7 @@ features:
                   action: request-notifications
                 secondary:
                   title: Onboarding/Onboarding.Notification.Skip.Action.v115
-                  action: next-card
+                  action: forward-one-card
               type: fresh-install
               prerequisites:
                 - ALWAYS
@@ -84,7 +84,7 @@ features:
                   action: sync-sign-in
                 secondary:
                   title: Onboarding/Onboarding.Sync.Skip.Action.v114
-                  action: next-card
+                  action: forward-one-card
               type: fresh-install
               prerequisites:
                 - ALWAYS
@@ -96,7 +96,7 @@ features:
               buttons:
                 primary:
                   title: Upgrade/Upgrade.Welcome.Action.v114
-                  action: next-card
+                  action: forward-one-card
               type: upgrade
               prerequisites:
                 - NEVER
@@ -111,7 +111,7 @@ features:
                   action: sync-sign-in
                 secondary:
                   title: Onboarding/Onboarding.LaterAction.v114
-                  action: next-card
+                  action: forward-one-card
               type: upgrade
               prerequisites:
                 - NEVER
@@ -158,7 +158,7 @@ objects:
         default:
           primary:
             title: Onboarding/Onboarding.Sync.Skip.Action.v114
-            action: next-card
+            action: forward-one-card
           secondary: null
       multiple-choice-buttons:
         type: List<NimbusOnboardingMultipleChoiceButton>
@@ -220,7 +220,7 @@ objects:
           The primary button for the card. This must exist.
         default:
           title: "Primary Button"
-          action: next-card
+          action: forward-one-card
       secondary:
         type: Option<NimbusOnboardingButton>
         description: >
@@ -240,8 +240,8 @@ objects:
         type: OnboardingActions
         description: >
           The action the button should take.
-          The default for this will be "next-card"
-        default: next-card
+          The default for this will be "forward-one-card"
+        default: forward-one-card
   NimbusOnboardingMultipleChoiceButton:
     description: >
       A group of properties describing the attributes of a
@@ -298,7 +298,13 @@ enums:
     description: >
       The identifiers for the different actions available for cards in onboarding
     variants:
-      next-card:
+      forward-one-card:
+        description: >
+          Will take the user to the next card
+      forward-two-card:
+        description: >
+          Will take the user to the next card
+      forward-three-card:
         description: >
           Will take the user to the next card
       sync-sign-in:

--- a/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
@@ -160,6 +160,11 @@ objects:
             title: Onboarding/Onboarding.Sync.Skip.Action.v114
             action: next-card
           secondary: null
+      multiple-choice-buttons:
+        type: List<NimbusOnboardingMultipleChoiceButton>
+        description: >
+          A list of multiple choice buttons that the card will display
+        default: []
       instructions-popup:
         type: Option<NimbusOnboardingInstructionPopup>
         description: >
@@ -237,6 +242,29 @@ objects:
           The action the button should take.
           The default for this will be "next-card"
         default: next-card
+  NimbusOnboardingMultipleChoiceButton:
+    description: >
+      A group of properties describing the attributes of a
+      multiple choice button on a card
+    fields:
+      title:
+        type: Text
+        description: >
+          The text of the button title.
+          This should never be defaulted.
+        default: ""
+      image:
+        type: NimbusOnboardingMultipleChoiceButtonImage
+        description: >
+          The text of the button title.
+          This should never be defaulted.
+        default: theme-system
+      action:
+        type: OnboardingMultipleChoiceAction
+        description: >
+          The action the button should take.
+          The default for this will be "theme-system-default"
+        default: theme-system-default
   NimbusOnboardingInstructionPopup:
     description: >
       The object outlining the content of the instruction card.
@@ -342,3 +370,30 @@ enums:
         description: >
           Corresponding to onboarding cards that are for users
           who have updated
+  OnboardingMultipleChoiceAction:
+    description: >
+      The identifiers for the different actions available for cards in onboarding
+    variants:
+      theme-system-default:
+        description: >
+          Will set the theme to use the system theme
+      theme-dark:
+        description: >
+          Will will set the theme to dark mode
+      theme-light:
+        description: >
+          Will set the theme to light mode
+      toolbar-top:
+        description: >
+          Will set the toolbar on the top
+      toolbar-bottom:
+        description: >
+          Will set the toolbar on the bottom
+  NimbusOnboardingMultipleChoiceButtonImage:
+    description: >
+      The identifiers for the different images available
+      for multiple choice buttons in onboarding
+    variants:
+      theme-system:
+        description: >
+          Corresponding to the system theme

--- a/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
@@ -141,7 +141,7 @@ objects:
           This should never be defaulted.
         default: ""
       image:
-        type: NimbusOnboardingImages
+        type: NimbusOnboardingHeaderImage
         description: >
           The image that should be dispalyed on the card.
         default: welcome-globe
@@ -161,7 +161,7 @@ objects:
             action: next-card
           secondary: null
       instructions-popup:
-        type: Option<NimbusInstructionPopup>
+        type: Option<NimbusOnboardingInstructionPopup>
         description: >
           The object describing the specific instruction popup
           button for a card.
@@ -237,7 +237,7 @@ objects:
           The action the button should take.
           The default for this will be "next-card"
         default: next-card
-  NimbusInstructionPopup:
+  NimbusOnboardingInstructionPopup:
     description: >
       The object outlining the content of the instruction card.
     fields:
@@ -303,7 +303,7 @@ enums:
       dismiss:
         description: >
           Will dismiss the popup
-  NimbusOnboardingImages:
+  NimbusOnboardingHeaderImage:
     description: >
       The identifiers for the different images available for cards in onboarding
     variants:

--- a/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
@@ -403,3 +403,15 @@ enums:
       theme-system:
         description: >
           Corresponding to the system theme
+      theme-dark:
+        description: >
+          Corresponding to the dark theme
+      theme-light:
+        description: >
+          Corresponding to the light theme
+      toolbar-top:
+        description: >
+          Corresponding to the toolbar on top
+      toolbar-bottom:
+        description: >
+          Corresponding to the toolbar on the bottom


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8264)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18352)

## :bulb: Description
This PR:
- adds new actions in the Nimbus layer required for onboarding
- adds image identifiers (but not actual images, as those aren't ready yet)
- updates tests to work with required changes

Tests for multiple choice delegation will be implemented in the next PR where the delegates will get created.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

