### PR TITLE
Bugfix FXIOS-8680 - Clicking links that open a new tab instead open about:blank

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -43,7 +43,9 @@ extension BrowserViewController: WKUIDelegate {
             configuration: configuration
         )
 
-        newTab.url = URL(string: "about:blank")
+        if navigationAction.request.url == nil {
+            newTab.url = URL(string: "about:blank")
+        }
 
         return newTab.webView
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8680)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19262)

## :bulb: Description
Set the URL as about:blank only if the URL from navigationAction is nil.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

