### PR TITLE
Bugfix FXIOS-7871 - Navigation Link opens in webview and external application

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -634,9 +634,11 @@ extension BrowserViewController: WKNavigationDelegate {
                 } else if UIApplication.shared.canOpenURL(url) {
                     UIApplication.shared.open(url, options: [.universalLinksOnly: true]) { isAppInstalled in
                         if isAppInstalled {
+                            webView.reload()
                            // TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-7524
                         }
                     }
+                    return
                 }
             }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -638,7 +638,6 @@ extension BrowserViewController: WKNavigationDelegate {
                            // TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-7524
                         }
                     }
-                    return
                 }
             }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7871)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17571)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

- The problem is that the URL opens in both the external app and the WebView due to the asynchronous nature of `UIApplication.shared.open`. This method attempts to open the URL in the background and returns immediately. Meanwhile, the WebView continues to load the URL because `decisionHandler(.allow)` is called. The `decisionHandler(.cancel)` does not seem to work due to the fact that the WebView could have been already opened. The only solution I've found for  stopping the WebView from loading the URL was to reload it after the completion returns true. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

