### PR TITLE
Bugfix FXIOS-8690 Focus login inputs after autofilling

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
@@ -547,6 +547,9 @@ window.__firefox__.includeOnce("LoginsHelper", function() {
               // Fire 'change' event to notify client-side validation on this field.
               usernameField.dispatchEvent(new Event("change"));
             }
+            // When the keyboard steals focus and gives it back,
+            // focusin is not triggered on the input it yields focus back to.
+            usernameField.focus();
           }
         }
         if (passwordField.value != selectedLogin.password) {
@@ -557,6 +560,9 @@ window.__firefox__.includeOnce("LoginsHelper", function() {
             // Fire 'change' event to notify client-side validation on this field.
             passwordField.dispatchEvent(new Event("change"));
           }
+          // When the keyboard steals focus and gives it back,
+          // focusin is not triggered on the input it yields focus back to.
+          passwordField.focus();
         }
         didFillForm = true;
       } else if (selectedLogin && !autofillForm) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8690)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19276)

## :bulb: Description
This PR adds explicit `focus` to username and password fields after autofilling. This is necessary because when the keyboard steals focus and gives it back the inputs are in a weird state; they appear focused but they are not. This is a weird webkit behaviour. To fix this we just focus the inputs after we autofill this ensures we are always in a correct state.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

