### PR TITLE
 Update - Add `npm run dev` command to README.md

### DIFF
--- a/firefox-ios/README.md
+++ b/firefox-ios/README.md
@@ -64,7 +64,17 @@ This reduces the total possible number of User Scripts down to four. The compile
 * `MainFrameAtDocumentEnd.js`
 * `MainFrameAtDocumentStart.js`
 
-To simplify the build process, these compiled files are checked-in to this repository. When adding or editing User Scripts, these files can be re-compiled with `webpack` manually. This requires Node.js to be installed, and all required `npm` packages can be installed by running `npm install` in the project's root directory. User Scripts can be compiled by running the following `npm` command in the root directory of the project:
+To simplify the build process, these compiled files are checked-in to this repository.
+
+To start a watcher that will compile the User Scripts on save, run the following `npm` command in the root directory of the project:
+
+```shell
+npm run dev
+```
+
+⚠️ Note: `npm run dev` will build the JS bundles in development mode with source maps, which allows tracking down lines in the source code for debugging.
+
+To create a production build of the User Scripts run the following `npm` command in the root directory of the project:
 
 ```shell
 npm run build


### PR DESCRIPTION
## :scroll: Tickets
~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~
~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~

## :bulb: Description
`npm run dev` starts a dev server that build a development build with source maps for debugging that will compile on save. This is ideal for debugging / working with js stuff instead of running `npm run build` each time a js change was made.


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

