### PR TITLE
Bugfix MTE-2449 testLaunchExternalApp for iPad

### DIFF
--- a/focus-ios/focus-ios-tests/XCUITest/BasicBrowsing.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/BasicBrowsing.swift
@@ -29,7 +29,12 @@ class BasicBrowsing: BaseTestCase {
         shareButton.tap()
 
         // Launch external app
-        let RemindersApp = app.collectionViews.scrollViews.cells.element(boundBy: 1)
+        let RemindersApp: XCUIElement
+        if iPad() {
+            RemindersApp = app.collectionViews.scrollViews.cells.element(boundBy: 0)
+        } else {
+            RemindersApp = app.collectionViews.scrollViews.cells.element(boundBy: 1)
+        }
         waitForExistence(RemindersApp, timeout: 5)
         RemindersApp.tap()
         waitForExistence(app.buttons["Add"], timeout: 10)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2449)

## :bulb: Description
Here's a patch for the PR (https://github.com/mozilla-mobile/firefox-ios/pull/19345) that the test `testLaunchExternalApp()` missed a case for iPad. The reminder app appears in a different index on iPad. 

Now the test passes on both iPhone and iPad.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

