### PR TITLE
Bugfix FXIOS-8451 Fix initial tab tray selection on ipad

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -122,6 +122,7 @@ enum TabPanelAction: Action {
 
     // Middleware actions
     case didLoadTabPanel(TabDisplayModelContext)
+    case didChangeTabPanel(TabDisplayModelContext)
     case refreshTab(RefreshTabContext) // Response to all user actions involving tabs ex: add, close and close all tabs
     case refreshInactiveTabs(RefreshInactiveTabsContext)
 
@@ -147,6 +148,7 @@ enum TabPanelAction: Action {
                 .hideUndoToast(let context),
                 .showShareSheet(let context as ActionContext),
                 .didLoadTabPanel(let context as ActionContext),
+                .didChangeTabPanel(let context as ActionContext),
                 .refreshTab(let context as ActionContext),
                 .refreshInactiveTabs(let context as ActionContext):
             return context.windowUUID

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
@@ -29,7 +29,7 @@ class HasSyncableAccountContext: ActionContext {
 }
 
 enum TabTrayAction: Action {
-    case tabTrayDidLoad(TabTrayPanelContext)
+    case tabTrayDidLoad(ActionContext)
     case changePanel(TabTrayPanelContext)
 
     // Middleware actions
@@ -39,7 +39,7 @@ enum TabTrayAction: Action {
 
     var windowUUID: UUID {
         switch self {
-        case .tabTrayDidLoad(let context as ActionContext),
+        case .tabTrayDidLoad(let context),
                 .changePanel(let context as ActionContext),
                 .didLoadTabTray(let context as ActionContext),
                 .dismissTabTray(let context),

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -22,10 +22,7 @@ class TabManagerMiddleware {
         let uuid = action.windowUUID
         switch action {
         case TabTrayAction.tabTrayDidLoad(let context):
-            let panelType = context.panelType
-            let tabTrayModel = self.getTabTrayModel(for: panelType, window: uuid)
-            let context = TabTrayModelContext(tabTrayModel: tabTrayModel, windowUUID: uuid)
-            store.dispatch(TabTrayAction.didLoadTabTray(context))
+            self.tabTrayDidLoad(for: uuid)
 
         case TabPanelAction.tabPanelDidLoad(let context):
             let isPrivate = context.boolValue
@@ -110,6 +107,14 @@ class TabManagerMiddleware {
         default:
             break
         }
+    }
+
+    private func tabTrayDidLoad(for windowUUID: WindowUUID) {
+        let isPrivate = tabManager(for: windowUUID).selectedTab?.isPrivate ?? false
+        let panelType: TabTrayPanelType = isPrivate ? .privateTabs : .tabs
+        let tabTrayModel = self.getTabTrayModel(for: panelType, window: windowUUID)
+        let context = TabTrayModelContext(tabTrayModel: tabTrayModel, windowUUID: windowUUID)
+        store.dispatch(TabTrayAction.didLoadTabTray(context))
     }
 
     private func normalTabsCountText(for windowUUID: WindowUUID) -> String {
@@ -498,7 +503,7 @@ class TabManagerMiddleware {
         let tabState = self.getTabsDisplayModel(for: isPrivate, shouldScrollToTab: false, uuid: uuid)
         if panel != .syncedTabs {
             let context = TabDisplayModelContext(tabDisplayModel: tabState, windowUUID: uuid)
-            store.dispatch(TabPanelAction.didLoadTabPanel(context))
+            store.dispatch(TabPanelAction.didChangeTabPanel(context))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -101,7 +101,7 @@ struct TabTrayState: ScreenState, Equatable {
                                 selectedPanel: panelType,
                                 normalTabsCount: state.normalTabsCount,
                                 hasSyncableAccount: state.hasSyncableAccount)
-        case TabPanelAction.didLoadTabPanel(let context):
+        case TabPanelAction.didChangeTabPanel(let context):
             let tabState = context.tabDisplayModel
             let panelType = tabState.isPrivateMode ? TabTrayPanelType.privateTabs : TabTrayPanelType.tabs
             return TabTrayState(windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -67,7 +67,8 @@ struct TabsPanelState: ScreenState, Equatable {
         guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
 
         switch action {
-        case TabPanelAction.didLoadTabPanel(let context):
+        case TabPanelAction.didLoadTabPanel(let context),
+            TabPanelAction.didChangeTabPanel(let context):
             let tabsModel = context.tabDisplayModel
             let selectedTabIndex = tabsModel.tabs.firstIndex(where: { $0.isSelected })
             return TabsPanelState(windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -255,7 +255,7 @@ class TabTrayViewController: UIViewController,
         store.dispatch(ActiveScreensStateAction.showScreen(
             ScreenActionContext(screen: .tabsTray, windowUUID: windowUUID)
         ))
-        let context = TabTrayPanelContext(panelType: tabTrayState.selectedPanel, windowUUID: windowUUID)
+        let context = ActionContext(windowUUID: windowUUID)
         store.dispatch(TabTrayAction.tabTrayDidLoad(context))
         let uuid = windowUUID
         store.subscribe(self, transform: {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8451)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18743)

## :bulb: Description
Don't have the view supply the initial state of the segment control, derive it from the selected tab state instead.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

