### PR TITLE
Bugfix FXIOS-8751 Fix default nnboarding "Go to Settings" button height

### DIFF
--- a/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -213,12 +213,6 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
                                                            constant: -UX.ctaButtonBottomSpaceSmall),
                 goToSettingsButton.widthAnchor.constraint(equalToConstant: UX.ctaButtonWidth)
             ])
-            goToSettingsButton.configuration?.contentInsets = NSDirectionalEdgeInsets(
-                top: 20.0,
-                leading: 20.0,
-                bottom: 20.0,
-                trailing: 20.0
-            )
         } else {
             NSLayoutConstraint.activate([
                 goToSettingsButton.bottomAnchor.constraint(equalTo: containerView.bottomAnchor,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8751)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19402)

## :bulb: Description
- Utilize default insets from `PrimaryRoundedButton` to fix "Go to Settings" button height on initial default onboarding view

| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-27 at 13 01 34](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/448605cf-8e92-4924-b79d-d6b3e01aa8f8) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-27 at 13 00 04](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/b4fedeae-98b2-4039-8320-3377e6c93539) |


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

