### PR TITLE
Bugfix FXIOS-8757 Fix intro onboarding default dismissal actions

### DIFF
--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -73,7 +73,9 @@ class LaunchCoordinator: BaseCoordinator,
             if !introViewModel.isDismissable {
                 introViewController.isModalInPresentation = true
             }
-            router.present(introViewController, animated: true)
+            router.present(introViewController, animated: true) {
+                introViewController.closeOnboarding()
+            }
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8757)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19426)

## :bulb: Description
- Run the same dismissal actions when dismissing onboarding via swipe down gesture or tap outside modal interaction as when the "X" button is clicked, including: 
  - Save `IntroViewControllerSeen` preference so that the intro onboarding view is not shown on subsequent launches
  - Fire "sendDismissOnboardingTelemetry` event

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

