### PR TITLE
Refactor FXIOS-8725 Update Fonts related to SyncNow to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -49,11 +49,7 @@ class SyncNowSetting: WithAccountSetting {
                 string: .FxANoInternetConnection,
                 attributes: [
                     NSAttributedString.Key.foregroundColor: theme.colors.textWarning,
-                    NSAttributedString.Key.font: DefaultDynamicFontHelper.preferredFont(
-                        withTextStyle: .body,
-                        size: 13,
-                        weight: .regular
-                    )
+                    NSAttributedString.Key.font:FXFontStyles.Regular.footnote.scaledFont()
                 ]
             )
         }
@@ -64,11 +60,7 @@ class SyncNowSetting: WithAccountSetting {
             string: .FxASyncNow,
             attributes: [
                 NSAttributedString.Key.foregroundColor: self.enabled ? syncText : headerLightText,
-                NSAttributedString.Key.font: DefaultDynamicFontHelper.preferredFont(
-                    withTextStyle: .body,
-                    size: 17,
-                    weight: .regular
-                )
+                NSAttributedString.Key.font: FXFontStyles.Regular.body.scaledFont()
             ]
         )
     }
@@ -115,11 +107,8 @@ class SyncNowSetting: WithAccountSetting {
                 string: message,
                 attributes: [
                     NSAttributedString.Key.foregroundColor: theme.colors.textWarning,
-                    NSAttributedString.Key.font: DefaultDynamicFontHelper.preferredFont(
-                        withTextStyle: .body,
-                        size: 17,
-                        weight: .regular
-                    )]
+                    NSAttributedString.Key.font: FXFontStyles.Regular.body.scaledFont()
+                ]
             )
         case .inProgress:
             return NSAttributedString(
@@ -167,9 +156,7 @@ class SyncNowSetting: WithAccountSetting {
         troubleshootButton.setTitle(.FirefoxSyncTroubleshootTitle, for: .normal)
         troubleshootButton.addTarget(self, action: #selector(self.troubleshoot), for: .touchUpInside)
         troubleshootButton.setTitleColor(self.theme.colors.textWarning, for: .normal)
-        troubleshootButton.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                                                     size: 12,
-                                                                                     weight: .regular)
+        troubleshootButton.titleLabel?.font = FXFontStyles.Regular.caption1.scaledFont()
     }
 
     private lazy var accessoryViewContainer: UIStackView = .build { stackView in

--- a/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -49,7 +49,7 @@ class SyncNowSetting: WithAccountSetting {
                 string: .FxANoInternetConnection,
                 attributes: [
                     NSAttributedString.Key.foregroundColor: theme.colors.textWarning,
-                    NSAttributedString.Key.font: FXFontStyles.Regular.footnote.scaledFont()
+                    NSAttributedString.Key.font: FXFontStyles.Regular.body.scaledFont()
                 ]
             )
         }

--- a/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -49,7 +49,7 @@ class SyncNowSetting: WithAccountSetting {
                 string: .FxANoInternetConnection,
                 attributes: [
                     NSAttributedString.Key.foregroundColor: theme.colors.textWarning,
-                    NSAttributedString.Key.font:FXFontStyles.Regular.footnote.scaledFont()
+                    NSAttributedString.Key.font: FXFontStyles.Regular.footnote.scaledFont()
                 ]
             )
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8725)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19337)

## :bulb: Description
Refactor to use `FXFontStyles` instead of `DefaultDynamicFontHelper`	

 ## Screenshots
>Before
<img src="https://github.com/mozilla-mobile/firefox-ios/assets/12571923/d0c0e3ad-e4b1-4b08-ad29-c010255dc19a" width=45% height=45%>

<img src="https://github.com/mozilla-mobile/firefox-ios/assets/12571923/24a0cfd9-0bed-40c6-a480-085e711b69e3" width=45% height=45%>

>After
<img src="https://github.com/mozilla-mobile/firefox-ios/assets/12571923/25d53bc2-611b-4cfa-a750-87de8ba93997" width=45% height=45%>

<img src="https://github.com/mozilla-mobile/firefox-ios/assets/12571923/13eb3ad8-58ab-4e29-9868-47069909e890" width=45% height=45%>



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

