### PR TITLE
Refactor FXIOS-8780 Use SecondaryRoundedButton styling for "Customize Homepage" button

### DIFF
--- a/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
+++ b/firefox-ios/Client/Frontend/Home/CustomizeHome/CustomizeHomepageSectionCell.swift
@@ -10,15 +10,12 @@ import Shared
 class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
     typealias a11y = AccessibilityIdentifiers.FirefoxHomepage.OtherButtons
 
-    private struct UX {
-        static let buttonVerticalInset: CGFloat = 11
-        static let buttonCornerRadius: CGFloat = 4
+    // MARK: - UI Elements
+    private lazy var goToSettingsButton: SecondaryRoundedButton = .build { button in
+        button.addTarget(self, action: #selector(self.touchUpInside), for: .touchUpInside)
     }
 
-    // MARK: - UI Elements
-    private let goToSettingsButton: ActionButton = .build { button in
-        button.layer.cornerRadius = UX.buttonCornerRadius
-    }
+    private var touchUpAction: ((UIButton) -> Void)?
 
     // MARK: - Initializers
     override init(frame: CGRect) {
@@ -53,12 +50,17 @@ class CustomizeHomepageSectionCell: UICollectionViewCell, ReusableCell {
     }
 
     func configure(onTapAction: ((UIButton) -> Void)?, theme: Theme) {
-        let goToSettingsButtonViewModel = ActionButtonViewModel(title: .FirefoxHomepage.CustomizeHomepage.ButtonTitle,
-                                                                a11yIdentifier: a11y.customizeHome,
-                                                                verticalInset: UX.buttonVerticalInset,
-                                                                touchUpAction: onTapAction)
+        touchUpAction = onTapAction
+        let goToSettingsButtonViewModel = SecondaryRoundedButtonViewModel(
+            title: .FirefoxHomepage.CustomizeHomepage.ButtonTitle,
+            a11yIdentifier: a11y.customizeHome)
         goToSettingsButton.configure(viewModel: goToSettingsButtonViewModel)
         applyTheme(theme: theme)
+    }
+
+    @objc
+    func touchUpInside(sender: UIButton) {
+        touchUpAction?(sender)
     }
 }
 
@@ -76,9 +78,7 @@ extension CustomizeHomepageSectionCell: Blurrable {
 // MARK: - ThemeApplicable
 extension CustomizeHomepageSectionCell: ThemeApplicable {
     func applyTheme(theme: Theme) {
-        goToSettingsButton.backgroundColorNormal = theme.colors.layer4
-        goToSettingsButton.foregroundColorNormal = theme.colors.textPrimary
-
+        goToSettingsButton.applyTheme(theme: theme)
         adjustBlur(theme: theme)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8780)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19451)

## :bulb: Description
- Utilize `SecondaryRoundedButton` (instead of `ActionButton`) for the "Customize Homepage" button on the homepage. 

| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-28 at 14 03 38](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/9dea192b-ffc6-453b-9f4e-14621a7da480) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-28 at 14 03 10](https://github.com/mozilla-mobile/firefox-ios/assets/15353801/6a5710e7-582e-4f8e-b73b-53df2ac3458d) |

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

