### PR TITLE
Bugfix FXIOS-8483 Ignore inactive tabs if user pref is set

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -459,6 +459,8 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     // MARK: - Inactive tabs
     override func getInactiveTabs() -> [Tab] {
+        let inactiveTabsEnabled = profile.prefs.boolForKey(PrefsKeys.FeatureFlags.InactiveTabs)
+        guard inactiveTabsEnabled ?? true else { return [] }
         return inactiveTabsManager.getInactiveTabs(tabs: tabs)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8483)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18844)

## :bulb: Description
Ignores the inactive tabs filter when the user pref is set to disable the feature

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

