### PR TITLE
Refactor FXIOS-8722 - Update Fonts related to FakeSpot to use FXFontStyles (Part I)

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotActionFooterView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotActionFooterView.swift
@@ -31,16 +31,13 @@ public struct FakespotActionFooterViewModel {
 
 public final class FakespotActionFooterView: UIView, ThemeApplicable {
     private struct UX {
-        static let labelSize: CGFloat = 13
         static let buttonInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 17, trailing: 0)
     }
 
     private var viewModel: FakespotActionFooterViewModel?
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .footnote,
-            size: UX.labelSize)
+        label.font = FXFontStyles.Regular.footnote.scaledFont()
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
     }

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotAdView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotAdView.swift
@@ -83,9 +83,6 @@ struct FakespotAdViewModel: FeatureFlaggable {
 
 class FakespotAdView: UIView, Notifiable, ThemeApplicable, UITextViewDelegate {
     private enum UX {
-        static let titleFontSize: CGFloat = 15
-        static let priceFontSize: CGFloat = 13
-        static let footerFontSize: CGFloat = 13
         static let margins = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
         static let linkInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
         static let titleBottomSpacing: CGFloat = 14
@@ -124,27 +121,21 @@ class FakespotAdView: UIView, Notifiable, ThemeApplicable, UITextViewDelegate {
 
     private lazy var titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
-                                                            size: UX.titleFontSize,
-                                                            weight: .semibold)
+        label.font = FXFontStyles.Bold.subheadline.scaledFont()
         label.numberOfLines = 0
         label.accessibilityTraits.insert(.header)
     }
 
     private lazy var footerLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .footnote,
-                                                            size: UX.footerFontSize,
-                                                            weight: .regular)
+        label.font = FXFontStyles.Regular.footnote.scaledFont()
         label.numberOfLines = 0
         label.accessibilityTraits.insert(.staticText)
     }
 
     private lazy var priceLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .footnote,
-                                                            size: UX.priceFontSize,
-                                                            weight: .semibold)
+        label.font = FXFontStyles.Bold.footnote.scaledFont()
         label.numberOfLines = 0
     }
 

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotAdjustRatingView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotAdjustRatingView.swift
@@ -17,8 +17,6 @@ struct FakespotAdjustRatingViewModel {
 
 class FakespotAdjustRatingView: UIView, Notifiable, ThemeApplicable {
     private enum UX {
-        static let titleFontSize: CGFloat = 15
-        static let descriptionFontSize: CGFloat = 13
         static let margins = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
         static let hStackSpacing: CGFloat = 4
         static let vStackSpacing: CGFloat = 8
@@ -33,18 +31,14 @@ class FakespotAdjustRatingView: UIView, Notifiable, ThemeApplicable {
 
     private lazy var titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
-                                                            size: UX.titleFontSize,
-                                                            weight: .semibold)
+        label.font = FXFontStyles.Bold.subheadline.scaledFont()
         label.numberOfLines = 0
         label.accessibilityTraits.insert(.header)
     }
 
     private lazy var descriptionLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .footnote,
-                                                            size: UX.descriptionFontSize,
-                                                            weight: .regular)
+        label.font = FXFontStyles.Regular.footnote.scaledFont()
         label.numberOfLines = 0
     }
 

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotHighlightGroupView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotHighlightGroupView.swift
@@ -16,26 +16,19 @@ class FakespotHighlightGroupView: UIView, ThemeApplicable, Notifiable {
         static let verticalSpace: CGFloat = 8
         static let imageSize: CGFloat = 24
         static let imageMaxSize: CGFloat = 58
-        static let titleFontSize: CGFloat = 15
-        static let highlightFontSize: CGFloat = 13
     }
 
     private lazy var itemImageView: UIImageView = .build()
 
     private lazy var titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .subheadline,
-            size: UX.titleFontSize,
-            weight: .semibold)
+        label.font = FXFontStyles.Bold.subheadline.scaledFont()
         label.numberOfLines = 0
     }
 
     private lazy var highlightLabel: FakespotFadeLabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .body,
-            size: UX.highlightFontSize)
+        label.font = FXFontStyles.Regular.footnote.scaledFont()
         label.numberOfLines = 0
         label.lineBreakMode = .byClipping
     }

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotHighlightsCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotHighlightsCardView.swift
@@ -51,8 +51,6 @@ struct FakespotHighlightsCardViewModel {
 
 class FakespotHighlightsCardView: UIView, ThemeApplicable {
     private struct UX {
-        static let titleFontSize: CGFloat = 15
-        static let buttonFontSize: CGFloat = 16
         static let buttonCornerRadius: CGFloat = 12
         static let buttonHorizontalInset: CGFloat = 16
         static let buttonVerticalInset: CGFloat = 12
@@ -70,9 +68,7 @@ class FakespotHighlightsCardView: UIView, ThemeApplicable {
 
     private lazy var titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
-                                                            size: UX.titleFontSize,
-                                                            weight: .semibold)
+        label.font = FXFontStyles.Bold.subheadline.scaledFont()
         label.numberOfLines = 0
         label.accessibilityTraits.insert(.header)
     }
@@ -209,11 +205,7 @@ class FakespotHighlightsCardView: UIView, ThemeApplicable {
 
         let highlightLabelWidth = FakespotUtils.widthOfString(
             longestReview,
-            usingFont: DefaultDynamicFontHelper.preferredFont(
-                withTextStyle: .subheadline,
-                size: UX.titleFontSize,
-                weight: .semibold
-            )
+            usingFont: FXFontStyles.Bold.subheadline.scaledFont()
         )
 
         // Calculates the width available for the highlights group view within the view's current bounds,

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardButton.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardButton.swift
@@ -55,15 +55,10 @@ class FakespotMessageCardButton: ResizableButton, ThemeApplicable {
             return
         }
 
-        updatedConfiguration.background.backgroundColor = backgroundColorNormal
-
         let transformer = UIConfigurationTextAttributesTransformer { [weak self] incoming in
             var container = incoming
             container.foregroundColor = self?.foregroundColor
-            container.font = DefaultDynamicFontHelper.preferredBoldFont(
-                withTextStyle: .callout,
-                size: UX.buttonFontSize
-            )
+            container.font = FXFontStyles.Bold.callout.scaledFont()
             return container
         }
         updatedConfiguration.titleTextAttributesTransformer = transformer

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotMessageCardView.swift
@@ -129,8 +129,6 @@ class FakespotMessageCardViewModel: ObservableObject {
 
 final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
     private enum UX {
-        static let buttonFontSize: CGFloat = 16
-        static let progressViewFontSize: CGFloat = 15
         static let buttonVerticalInset: CGFloat = 12
         static let buttonHorizontalInset: CGFloat = 16
         static let buttonCornerRadius: CGFloat = 13
@@ -173,9 +171,7 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
     private lazy var iconContainerView: UIView = .build()
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(
-            withTextStyle: .callout,
-            size: UX.buttonFontSize)
+        label.font = FXFontStyles.Bold.callout.scaledFont()
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
         label.setContentCompressionResistancePriority(.required, for: .vertical)
@@ -184,9 +180,7 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
 
     private lazy var descriptionLabel: UILabel = .build { label in
         label.textColor = .white
-        label.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .subheadline,
-            size: UX.buttonFontSize)
+        label.font = FXFontStyles.Regular.callout.scaledFont()
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
         label.setContentCompressionResistancePriority(.required, for: .vertical)
@@ -237,10 +231,7 @@ final class FakespotMessageCardView: UIView, ThemeApplicable, Notifiable {
                 viewModel.title,
                 viewModel.formatProgress()
             )
-            titleLabel.font = DefaultDynamicFontHelper.preferredFont(
-                withTextStyle: .subheadline,
-                size: UX.progressViewFontSize
-            )
+            titleLabel.font = FXFontStyles.Regular.subheadline.scaledFont()
 
             viewModel.analysisProgressChanged = { [weak self] progress in
                 let progressLevel = viewModel.formatProgress(progress / 100.0)

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotNoAnalysisCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotNoAnalysisCardView.swift
@@ -29,8 +29,6 @@ struct FakespotNoAnalysisCardViewModel {
 final class FakespotNoAnalysisCardView: UIView, ThemeApplicable {
     private struct UX {
         static let noAnalysisImageViewSize = CGSize(width: 280, height: 108)
-        static let headlineLabelFontSize: CGFloat = 15
-        static let bodyLabelFontSize: CGFloat = 13
         static let contentStackViewSpacing: CGFloat = 8
         static let contentStackViewPadding: CGFloat = 8
         static let titleStackViewSpacing: CGFloat = 8
@@ -54,17 +52,14 @@ final class FakespotNoAnalysisCardView: UIView, ThemeApplicable {
     private lazy var headlineLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
-                                                            size: UX.headlineLabelFontSize,
-                                                            weight: .bold)
+        label.font = FXFontStyles.Bold.subheadline.scaledFont()
         label.accessibilityTraits.insert(.header)
     }
 
     private lazy var bodyLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: UX.bodyLabelFontSize)
+        label.font = FXFontStyles.Regular.footnote.scaledFont()
     }
 
     private lazy var analyzerButton: PrimaryRoundedButton = .build { button in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8722)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19334)

## :bulb: Description
- I've addressed the issue by replacing the usage of DefaultDynamicFontHelper with FXFontStyles for the FakeSpot feature.
- This change allows us to standardize our fonts across various components, ensuring better alignment with our design system.


**FakespotActionFooterView**
| Before | After |
| ------ | ------ |
| <img width="314" alt="Screenshot 2024-03-29 at 2 06 09 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/0fbe3794-f761-4e11-abbd-0e857129192e"> | <img width="314" alt="Screenshot 2024-03-29 at 2 06 09 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/0fbe3794-f761-4e11-abbd-0e857129192e"> |


**FakespotAdjustRatingView**
| Before | After |
| ------ | ------ |
| <img width="315" alt="Screenshot 2024-03-29 at 2 52 27 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/cc2e2a5f-53a6-4596-b93c-7cc7cfd789d0"> | <img width="310" alt="Screenshot 2024-03-29 at 2 53 16 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/ecfea74a-6839-4666-a1b5-cb0995efdc40"> |



**FakespotAdView**
| Before | After |
| ------ | ------ |
| <img width="314" alt="Screenshot 2024-03-29 at 9 33 12 AM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/6a060414-c22f-40f4-a4c5-fba09c6d37e9"> | <img width="314" alt="Screenshot 2024-03-29 at 9 31 13 AM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/ae08df48-6418-4ab7-9763-8f2d3fcf6b16"> |


**FakespotHighlightsCardView**
| Before | After |
| ------ | ------ |
| <img width="316" alt="Screenshot 2024-03-29 at 9 42 18 AM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/92a6fea4-e443-4f3c-a880-165359610899"> | <img width="316" alt="Screenshot 2024-03-29 at 9 40 36 AM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/e6e3c14e-6852-4307-bf1b-409bdee0187b"> |


**FakespotHighlightGroupView**
| Before | After |
| ------ | ------ |
| <img width="316" alt="Screenshot 2024-03-29 at 9 46 23 AM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/88f96c82-afcd-4b28-9df3-568f022b431f"> | <img width="318" alt="Screenshot 2024-03-29 at 9 47 28 AM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/817b0389-1daa-4ce1-9093-179c5d4c21a9"> |


**FakespotMessageCardView**
| Before | After |
| ------ | ------ |
| <img width="300" alt="Screenshot 2024-03-29 at 1 02 36 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/29b74be3-a59b-4cce-8462-176b63fe0e22"> | <img width="302" alt="Screenshot 2024-03-29 at 1 11 54 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/bc78d3e9-8349-4d0c-93aa-81d653aefa50"> |


**FakespotMessageCardButton**
| Before | After |
| ------ | ------ |
| <img width="300" alt="Screenshot 2024-03-29 at 1 08 47 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/12d42ff7-0a7e-481f-941d-a2c6d99701ab"> | <img width="313" alt="Screenshot 2024-03-29 at 1 09 09 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/4f465065-863b-4fde-a0b2-aca029a1e441"> |


**FakespotNoAnalysisCardView**
| Before | After |
| ------ | ------ |
| <img width="314" alt="Screenshot 2024-03-29 at 1 15 34 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/ab059366-2637-4181-be69-31198c6880ff"> | <img width="312" alt="Screenshot 2024-03-29 at 1 17 47 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/ce2d33ef-70c8-42d9-bbd4-b4cfe0faebee"> |



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

