### PR TITLE
Bugfix FXIOS-8704 Increase in errors for metrics `tabs.tab_switch` and `webview.page_load`

### DIFF
--- a/firefox-ios/Client/Telemetry/TabsTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabsTelemetry.swift
@@ -17,6 +17,7 @@ final class TabsTelemetry {
     func stopTabSwitchMeasurement() {
         guard let timerId = tabSwitchTimerId else { return }
         GleanMetrics.Tabs.tabSwitch.stopAndAccumulate(timerId)
+        tabSwitchTimerId = nil
     }
 
     static func trackTabsQuantity(tabManager: TabManager) {

--- a/firefox-ios/Client/Telemetry/WebviewTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/WebviewTelemetry.swift
@@ -17,6 +17,7 @@ final class WebViewLoadMeasurementTelemetry {
     func stop() {
         guard let timerId = loadTimerId else { return }
         GleanMetrics.Webview.pageLoad.stopAndAccumulate(timerId)
+        loadTimerId = nil
     }
 
     func cancel() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8704)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19298)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I managed to reproduce this error on [Test1](https://glean-debug-view-dev-237806.firebaseapp.com/pings/StefanVPageLoad) and [Test2](https://glean-debug-view-dev-237806.firebaseapp.com/pings/StefanVP), looked into the Glean documentation to see if I can check the status of a timer but couldn't find anything besides the test methods, so I guess the best fix for this is making the timerId nil so the next time `stopTabSwitchMeasurement()` and `webviewTelemetry.stop()` are called for the same timerId they will fail and won't trigger the "invalid_state" error. I tested this on [Test3](https://glean-debug-view-dev-237806.firebaseapp.com/pings/SVCheck) and couldn't reproduce the error anymore.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

