### PR TITLE
Refactor FXIOS-8723 - Update Fonts related to FakeSpot to use FXFontStyles (Part II)

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
@@ -11,7 +11,6 @@ import ComponentLibrary
 struct FakespotOptInCardViewModel {
     private struct UX {
         static let contentStackViewPadding: CGFloat = 16
-        static let bodyLabelFontSize: CGFloat = 15
     }
 
     private let tabManager: TabManager
@@ -117,10 +116,9 @@ struct FakespotOptInCardViewModel {
     // MARK: Text methods
     var bodyText: NSAttributedString {
         let websites = orderWebsites
-        let font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                          size: UX.bodyLabelFontSize)
-        let boldFont = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
-                                                                  size: UX.bodyLabelFontSize)
+
+        let font = FXFontStyles.Regular.subheadline.scaledFont()
+        let boldFont = FXFontStyles.Bold.subheadline.scaledFont()
 
         let firstParagraph = if supportedTLDWebsites?.count == websites.count {
             bodyFirstParagraph

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -21,9 +21,7 @@ class FakespotViewController: UIViewController,
         static let headerTopSpacing: CGFloat = 22
         static let headerHorizontalSpacing: CGFloat = 18
         static let titleCloseSpacing: CGFloat = 16
-        static let titleLabelFontSize: CGFloat = 17
         static let titleStackSpacing: CGFloat = 8
-        static let betaLabelFontSize: CGFloat = 15
         static let betaBorderWidth: CGFloat = 2
         static let betaBorderWidthA11ySize: CGFloat = 4
         static let betaCornerRadius: CGFloat = 8
@@ -67,9 +65,7 @@ class FakespotViewController: UIViewController,
         label.text = .Shopping.SheetHeaderTitle
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
-                                                            size: UX.titleLabelFontSize,
-                                                            weight: .semibold)
+        label.font = FXFontStyles.Regular.headline.scaledFont()
         label.accessibilityIdentifier = AccessibilityIdentifiers.Shopping.sheetHeaderTitle
         label.accessibilityTraits.insert(.header)
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -90,8 +86,7 @@ class FakespotViewController: UIViewController,
         label.text = .Shopping.SheetHeaderBetaTitle
         label.numberOfLines = 1
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
-                                                            size: UX.betaLabelFontSize)
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
         label.textAlignment = .center
         label.accessibilityIdentifier = AccessibilityIdentifiers.Shopping.sheetHeaderBetaLabel
     }

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotOptInCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotOptInCardView.swift
@@ -10,10 +10,6 @@ import ComponentLibrary
 // MARK: View
 final class FakespotOptInCardView: UIView, ThemeApplicable {
     private struct UX {
-        static let headerLabelFontSize: CGFloat = 28
-        static let bodyLabelFontSize: CGFloat = 15
-        static let disclaimerTextLabelFontSize: CGFloat = 13
-
         static let privacyButtonInsets = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 8, trailing: 16)
         static let termsOfUseButtonInsets = NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 16, trailing: 16)
         static let learnMoreInsets = NSDirectionalEdgeInsets(top: 16, leading: 0, bottom: 8, trailing: 0)
@@ -53,24 +49,20 @@ final class FakespotOptInCardView: UIView, ThemeApplicable {
     private lazy var headerLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
-                                                            size: UX.headerLabelFontSize,
-                                                            weight: .medium)
+        label.font = FXFontStyles.Regular.title1.scaledFont()
         label.accessibilityTraits.insert(.header)
     }
 
     private lazy var bodyLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: UX.bodyLabelFontSize)
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
     }
 
     private lazy var disclaimerTextLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: UX.disclaimerTextLabelFontSize)
+        label.font = FXFontStyles.Regular.footnote.scaledFont()
     }
 
     // MARK: Buttons

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotOptInCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotOptInCardView.swift
@@ -49,7 +49,7 @@ final class FakespotOptInCardView: UIView, ThemeApplicable {
     private lazy var headerLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
-        label.font = FXFontStyles.Regular.title1.scaledFont()
+        label.font = FXFontStyles.Bold.title1.scaledFont()
         label.accessibilityTraits.insert(.header)
     }
 

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotReliabilityCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotReliabilityCardView.swift
@@ -24,22 +24,17 @@ class FakespotReliabilityCardView: UIView, ThemeApplicable {
         static let letterHorizontalPadding: CGFloat = 7
         static let descriptionVerticalPadding: CGFloat = 6
         static let descriptionHorizontalPadding: CGFloat = 8
-        static let titleFontSize: CGFloat = 15
-        static let letterFontSize: CGFloat = 13
-        static let descriptionFontSize: CGFloat = 13
         static let descriptionBackgroundAlpha: CGFloat = 0.15
     }
 
     private lazy var cardContainer: ShadowCardView = .build()
     private lazy var contentView: UIView = .build()
 
-    private lazy var titleLabel: UILabel = .build { view in
-        view.adjustsFontForContentSizeCategory = true
-        view.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
-                                                           size: UX.titleFontSize,
-                                                           weight: .semibold)
-        view.numberOfLines = 0
-        view.accessibilityTraits.insert(.header)
+    private lazy var titleLabel: UILabel = .build { label in
+        label.adjustsFontForContentSizeCategory = true
+        label.font = FXFontStyles.Bold.subheadline.scaledFont()
+        label.numberOfLines = 0
+        label.accessibilityTraits.insert(.header)
     }
 
     private lazy var reliabilityScoreView: UIView = .build { view in
@@ -51,17 +46,15 @@ class FakespotReliabilityCardView: UIView, ThemeApplicable {
     private lazy var reliabilityLetterView: UIView = .build()
     private lazy var reliabilityDescriptionView: UIView = .build()
 
-    private lazy var reliabilityLetterLabel: UILabel = .build { view in
-        view.adjustsFontForContentSizeCategory = true
-        view.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .footnote,
-                                                           size: UX.letterFontSize,
-                                                           weight: .semibold)
+    private lazy var reliabilityLetterLabel: UILabel = .build { label in
+        label.adjustsFontForContentSizeCategory = true
+        label.font = FXFontStyles.Bold.footnote.scaledFont()
     }
 
-    private lazy var reliabilityDescriptionLabel: UILabel = .build { view in
-        view.adjustsFontForContentSizeCategory = true
-        view.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .footnote, size: UX.descriptionFontSize)
-        view.numberOfLines = 0
+    private lazy var reliabilityDescriptionLabel: UILabel = .build { label in
+        label.adjustsFontForContentSizeCategory = true
+        label.font = FXFontStyles.Regular.footnote.scaledFont()
+        label.numberOfLines = 0
     }
 
     private var viewModel: FakespotReliabilityCardViewModel?

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotReliabilityScoreView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotReliabilityScoreView.swift
@@ -10,7 +10,6 @@ import ComponentLibrary
 final class FakespotReliabilityScoreView: UIView, Notifiable, ThemeApplicable {
     private struct UX {
         static let cornerRadius: CGFloat = 4
-        static let ratingLetterFontSize: CGFloat = 13
         static let ratingSize: CGFloat = 24
         static let maxRatingSize: CGFloat = 58
     }
@@ -23,9 +22,7 @@ final class FakespotReliabilityScoreView: UIView, Notifiable, ThemeApplicable {
 
     private lazy var reliabilityLetterLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: UX.ratingLetterFontSize,
-                                                            weight: .semibold)
+        label.font = FXFontStyles.Bold.footnote.scaledFont()
     }
 
     private var ratingHeightConstraint: NSLayoutConstraint?

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotReviewQualityCardView.swift
@@ -10,9 +10,7 @@ import ComponentLibrary
 // MARK: View Model
 final class FakespotReviewQualityCardViewModel {
     private struct UX {
-        static let labelFontSize: CGFloat = 15
-        static let baseFont = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
-                                                                     size: UX.labelFontSize)
+        static let baseFont = FXFontStyles.Regular.subheadline.scaledFont()
     }
 
     let markupUtility = MarkupAttributeUtility(baseFont: UX.baseFont)

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
@@ -80,7 +80,6 @@ class FakespotSettingsCardViewModel {
 
 final class FakespotSettingsCardView: UIView, ThemeApplicable {
     private struct UX {
-        static let headerLabelFontSize: CGFloat = 15
         static let buttonLeadingTrailingPadding: CGFloat = 8
         static let buttonTopPadding: CGFloat = 16
         static let contentStackViewSpacing: CGFloat = 16
@@ -113,8 +112,7 @@ final class FakespotSettingsCardView: UIView, ThemeApplicable {
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
         label.clipsToBounds = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
-                                                            size: UX.headerLabelFontSize)
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
     }
 
     private lazy var recommendedProductsSwitch: UISwitch = .build { uiSwitch in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8723)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19335)

## :bulb: Description
- I've addressed the issue by replacing the usage of DefaultDynamicFontHelper with FXFontStyles for the FakeSpot feature.
- This change allows us to standardize our fonts across various components, ensuring better alignment with our design system.

**FakespotOptInCardView**
| Before | After |
| ------  | ----- |
| ![Simulator Screenshot - iPhone 15 Plus - 2024-03-29 at 14 30 36](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/19b29399-4d93-4745-98bd-3d5a963902fd) | ![Simulator Screenshot - iPhone 15 Plus - 2024-03-29 at 14 29 33](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/a9ed4695-b05f-41a1-a10b-578e66e80ebf) |


**FakespotReliabilityCardView**
| Before | After |
| ------  | ----- |
| <img width="315" alt="Screenshot 2024-03-29 at 2 52 27 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/1cbdee8a-b01b-44c7-9766-e3a7eb6318e6"> | <img width="310" alt="Screenshot 2024-03-29 at 2 53 16 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/b7f42136-0e24-400d-8043-7e4d9f73c2f3"> |


**FakespotReliabilityScoreView**
| Before | After |
| ------  | ----- |
| <img width="312" alt="Screenshot 2024-03-29 at 2 58 34 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/3363b63d-1f74-4f1e-b56d-b1e2ef0f1f73"> | <img width="313" alt="Screenshot 2024-03-29 at 3 02 11 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/ed349d9a-b7e7-4cb7-9959-26ed43f66218"> |


**FakespotReviewQualityCardView**
| Before | After |
| ------  | ----- |
| <img width="311" alt="Screenshot 2024-03-29 at 3 06 42 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/8a135525-6eba-4640-8462-605fdc467fa4"> | <img width="312" alt="Screenshot 2024-03-29 at 3 08 06 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/16ad1905-772c-405d-8a7e-dcdf5c5ddd67"> |


**FakespotSettingsCardView**
| Before | After |
| ------  | ----- |
| <img width="316" alt="Screenshot 2024-03-29 at 3 18 19 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/ecd4ad56-103c-4fd8-bdb1-15b8e4312dd4"> | <img width="317" alt="Screenshot 2024-03-29 at 3 19 29 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/82c48a89-07f0-4361-b5ff-2c5f049cbc30"> |


**FakespotOptInCardViewModel**
| Before | After |
| ------  | ----- |
| ![Simulator Screenshot - iPhone 15 Plus - 2024-03-29 at 15 27 59](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/6ff4bb29-d4c4-49f5-85dc-1067fff09eb9) | ![Simulator Screenshot - iPhone 15 Plus - 2024-03-29 at 15 29 41](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/e0d0b2fc-197a-4708-a869-a240ebcb3c9e) |


**FakespotViewController**
| Before | After |
| ------  | ----- |
| <img width="314" alt="Screenshot 2024-03-29 at 3 33 57 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/3186f3bd-66b6-4802-8311-fe7193feee5d"> | <img width="315" alt="Screenshot 2024-03-29 at 3 35 36 PM" src="https://github.com/mozilla-mobile/firefox-ios/assets/74779930/cd7a6b2e-8c71-4360-8017-7ca5795aa045"> |




## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

