### PR TITLE
Bugfix FXIOS-8747 ⁃ Firefox gets stuck and then crashes when multitasking outside of FF and then back - Edge Case

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -214,11 +214,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         case UIScreen.brightnessDidChangeNotification:
             brightnessChanged()
         case UIApplication.didBecomeActiveNotification:
-            // It seems this notification is fired before the UI is informed of any changes to dark mode
-            // So dispatching to the end of the main queue will ensure it's always got the latest info
-            DispatchQueue.main.async {
-                self.systemThemeChanged()
-            }
+            self.systemThemeChanged()
         default:
             return
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8747)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19395)

## :bulb: Description
Moved _self.systemThemeChanged()_ method call, out from the _ DispatchQueue.main.async { }_ because it caused a severe UI blocking and a crash.

_ DispatchQueue.main.async { }_ was added [here](https://github.com/mozilla-mobile/firefox-ios/pull/11952) in 2022.

After talking to the owner of that PR, I got the confirmation that this fix should be fine if no other issues appear. Also, that fix was related to the _legacy theme system_ which has been removed.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

