### PR TITLE
Add FXIOS-8786 Check for showing splash screen only once

### DIFF
--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
@@ -14,6 +14,11 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
     private lazy var splashScreenAnimation = SplashScreenAnimation()
     private let nimbusSplashScreenFeatureLayer = NimbusSplashScreenFeatureLayer()
 
+    private var shouldTriggerSplashScreenExperiment: Bool {
+        return featureFlags.isFeatureEnabled(.splashScreen, checking: .buildOnly)
+        && !viewModel.getSplashScreenExperimentHasShown()
+    }
+
     init(coordinator: LaunchFinishedLoadingDelegate,
          viewModel: LaunchScreenViewModel = LaunchScreenViewModel(),
          mainQueue: DispatchQueueInterface = DispatchQueue.main) {
@@ -85,14 +90,15 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
     // MARK: - Splash Screen
 
     private func delayStart() async throws {
-        guard featureFlags.isFeatureEnabled(.splashScreen, checking: .buildOnly) else { return }
+        guard shouldTriggerSplashScreenExperiment else { return }
+        viewModel.setSplashScreenExperimentHasShown()
         let position: Int = nimbusSplashScreenFeatureLayer.maximumDurationMs
         try await Task.sleep(nanoseconds: UInt64(position * 1_000_000))
     }
 
     private func setupLaunchScreen() {
         setupLayout()
-        guard featureFlags.isFeatureEnabled(.splashScreen, checking: .buildOnly) else { return }
+        guard shouldTriggerSplashScreenExperiment else { return }
         if !UIAccessibility.isReduceMotionEnabled {
             splashScreenAnimation.configureAnimation(with: launchScreen)
         }

--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewModel.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewModel.swift
@@ -4,6 +4,7 @@
 
 import Common
 import Foundation
+import Shared
 
 protocol LaunchFinishedLoadingDelegate: AnyObject {
     func launchWith(launchType: LaunchType)
@@ -14,18 +15,28 @@ class LaunchScreenViewModel {
     private var introScreenManager: IntroScreenManager
     private var updateViewModel: UpdateViewModel
     private var surveySurfaceManager: SurveySurfaceManager
+    private var profile: Profile
 
     weak var delegate: LaunchFinishedLoadingDelegate?
 
     init(profile: Profile = AppContainer.shared.resolve(),
          messageManager: GleanPlumbMessageManagerProtocol = Experiments.messaging,
          onboardingModel: OnboardingViewModel = NimbusOnboardingFeatureLayer().getOnboardingModel(for: .upgrade)) {
+        self.profile = profile
         self.introScreenManager = IntroScreenManager(prefs: profile.prefs)
         let telemetryUtility = OnboardingTelemetryUtility(with: onboardingModel)
         self.updateViewModel = UpdateViewModel(profile: profile,
                                                model: onboardingModel,
                                                telemetryUtility: telemetryUtility)
         self.surveySurfaceManager = SurveySurfaceManager(and: messageManager)
+    }
+
+    func getSplashScreenExperimentHasShown() -> Bool {
+        profile.prefs.boolForKey(PrefsKeys.splashScreenShownKey) ?? false
+    }
+
+    func setSplashScreenExperimentHasShown() {
+        profile.prefs.setBool(true, forKey: PrefsKeys.splashScreenShownKey)
     }
 
     func startLoading(appVersion: String = AppInfo.appVersion) async {

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -171,6 +171,9 @@ public struct PrefsKeys {
 
     // Only used to force showing the App Store review dialog for debugging purposes
     public static let ForceShowAppReviewPromptOverride = "ForceShowAppReviewPromptOverride"
+
+    // Used to show splash screen only during first time on fresh install
+    public static let splashScreenShownKey = "splashScreenShownKey"
 }
 
 public struct PrefsDefaults {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/LaunchView/LaunchScreenViewModelTests.swift
@@ -88,6 +88,17 @@ final class LaunchScreenViewModelTests: XCTestCase {
         XCTAssertEqual(delegate.launchWithTypeCalled, 1)
     }
 
+    func testSplashScreenExperiment_afterShown_returnsTrue() async {
+        let subject = createSubject()
+        let value = subject.getSplashScreenExperimentHasShown()
+        XCTAssertFalse(subject.getSplashScreenExperimentHasShown())
+
+        subject.setSplashScreenExperimentHasShown()
+
+        let updatedValue = subject.getSplashScreenExperimentHasShown()
+        XCTAssertTrue(updatedValue)
+    }
+
     // MARK: - Helpers
     private func createSubject(file: StaticString = #file,
                                line: UInt = #line) -> LaunchScreenViewModel {

--- a/firefox-ios/nimbus-features/splashScreenFeature.yaml
+++ b/firefox-ios/nimbus-features/splashScreenFeature.yaml
@@ -20,5 +20,5 @@ features:
           maximum_duration_ms: 0
       - channel: developer
         value:
-          enabled: false
+          enabled: true
           maximum_duration_ms: 6000


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8786)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19471)

## :bulb: Description
Created new key in PrefsKeys to determine whether the splash screen experiment has been shown once. Add logic to determine whether we should trigger the splash screen experiment or not based on whether it was shown already.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

