### PR TITLE
Refactor FXIOS-8724 - Update Fonts related to HistoryHighlights to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
+++ b/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsCell.swift
@@ -19,14 +19,12 @@ class HistoryHighlightsCell: UICollectionViewCell, ReusableCell {
     let imageView: FaviconImageView = .build { imageView in }
 
     let itemTitle: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: 15)
+        label.font =  FXFontStyles.Regular.body.scaledFont()
         label.adjustsFontForContentSizeCategory = true
     }
 
     let itemDescription: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1,
-                                                            size: 12)
+        label.font =  FXFontStyles.Regular.caption1.scaledFont()
         label.adjustsFontForContentSizeCategory = true
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR replaces the usage of DefaultDynamicFontHelper with FXFontStyles for HistoryHighlights.

Before:
<img width="355" alt="Before" src="https://github.com/mozilla-mobile/firefox-ios/assets/54324355/8b3ca291-f5b3-4b5f-a0a6-15cccc5e0e64">

After:
<img width="353" alt="After" src="https://github.com/mozilla-mobile/firefox-ios/assets/54324355/f1910353-bf3b-4c06-b43c-ef0458fa34e3">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

