### PR TITLE
Add MTE-2572 - price tag validation on landscape fakespot test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
@@ -90,6 +90,7 @@
         "FakespotTests\/testLearnMoreAboutFakespotHyperlink()",
         "FakespotTests\/testLearnMoreLink()",
         "FakespotTests\/testOptInNotificationLayout()",
+        "FakespotTests\/testPriceTagIconAndReviewCheckLandscape()",
         "FakespotTests\/testPriceTagIconAvailableOnlyOnDetailPage()",
         "FakespotTests\/testPriceTagNotDisplayedInPrivateMode()",
         "FakespotTests\/testPriceTagNotDisplayedOnSitesNotIntegratedFakespot()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
@@ -42,6 +42,7 @@
         "FakespotTests\/testLearnMoreAboutFakespotHyperlink()",
         "FakespotTests\/testLearnMoreLink()",
         "FakespotTests\/testOptInNotificationLayout()",
+        "FakespotTests\/testPriceTagIconAndReviewCheckLandscape()",
         "FakespotTests\/testPriceTagNotDisplayedInPrivateMode()",
         "FakespotTests\/testPriceTagNotDisplayedOnSitesNotIntegratedFakespot()",
         "FakespotTests\/testPrivacyPolicyLink()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
@@ -46,6 +46,7 @@
         "FakespotTests\/testLearnMoreAboutFakespotHyperlink()",
         "FakespotTests\/testLearnMoreLink()",
         "FakespotTests\/testOptInNotificationLayout()",
+        "FakespotTests\/testPriceTagIconAndReviewCheckLandscape()",
         "FakespotTests\/testPriceTagIconAvailableOnlyOnDetailPage()",
         "FakespotTests\/testPriceTagNotDisplayedInPrivateMode()",
         "FakespotTests\/testPriceTagNotDisplayedOnSitesNotIntegratedFakespot()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
@@ -38,6 +38,7 @@
         "FakespotTests\/testLearnMoreAboutFakespotHyperlink()",
         "FakespotTests\/testLearnMoreLink()",
         "FakespotTests\/testOptInNotificationLayout()",
+        "FakespotTests\/testPriceTagIconAndReviewCheckLandscape()",
         "FakespotTests\/testPriceTagIconAvailableOnlyOnDetailPage()",
         "FakespotTests\/testPriceTagNotDisplayedOnSitesNotIntegratedFakespot()",
         "FakespotTests\/testPrivacyPolicyLink()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -317,7 +317,7 @@ class BaseTestCase: XCTestCase {
         let app = XCUIApplication()
         let progressIndicator = app.progressIndicators.element(boundBy: 0)
 
-        mozWaitForElementToNotExist(progressIndicator, timeout: 60.0)
+        mozWaitForElementToNotExist(progressIndicator, timeout: 90.0)
     }
 
     func waitForTabsButton() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
@@ -4,6 +4,11 @@
 import XCTest
 
 class FakespotTests: BaseTestCase {
+    override func tearDown() {
+        XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
+        super.tearDown()
+    }
+
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307128
     func testFakespotAvailable() {
         reachReviewChecker()
@@ -232,6 +237,22 @@ class FakespotTests: BaseTestCase {
         validateMozillaSupportWebpage("Privacy Notice", "privacy/firefox")
     }
 
+    // https://testrail.stage.mozaws.net/index.php?/cases/view/2358929
+    func testPriceTagIconAndReviewCheckLandscape() {
+        // Change the device orientation to be landscape
+        XCUIDevice.shared.orientation = UIDeviceOrientation.landscapeLeft
+        // Navigate for the first time to a product detail page on amazon.com
+        loadWebsiteAndPerformSearch()
+        app.webViews["contentView"].firstMatch.images.firstMatch.tap()
+        waitUntilPageLoad()
+        // The Price tag icon is correctly displayed
+        if !app.buttons[AccessibilityIdentifiers.Toolbar.shoppingButton].exists {
+            app.webViews["contentView"].firstMatch.images.firstMatch.tap()
+            waitUntilPageLoad()
+        }
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shoppingButton])
+    }
+
     private func validateMozillaSupportWebpage(_ webpageTitle: String, _ url: String) {
         mozWaitForElementToExist(app.staticTexts[webpageTitle])
         mozWaitForValueContains(app.textFields["url"], value: url)
@@ -370,6 +391,11 @@ class FakespotTests: BaseTestCase {
         loadWebsiteAndPerformSearch()
         app.swipeDown()
         app.webViews["contentView"].firstMatch.images.firstMatch.tap()
+        waitUntilPageLoad()
+        if !app.buttons[AccessibilityIdentifiers.Toolbar.shoppingButton].exists {
+            app.webViews["contentView"].firstMatch.images.firstMatch.tap()
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shoppingButton])
+        }
 
         // Retry loading the page if page is not loading
         while app.webViews.staticTexts["Enter the characters you see below"].exists {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-2572

## :bulb: Description
https://testrail.stage.mozaws.net/index.php?/cases/view/2358929
This test also includes an attempt to fix the flaky fakespot tests on iPad.
Locally the solution works.

