### PR TITLE
Refactor FXIOS-8518 - Remove Deferred from CredentialProviderPresenter

### DIFF
--- a/firefox-ios/CredentialProvider/CredentialProviderPresenter.swift
+++ b/firefox-ios/CredentialProvider/CredentialProviderPresenter.swift
@@ -32,7 +32,7 @@ class CredentialProviderPresenter {
         if self.profile.logins.reopenIfClosed() != nil {
             cancel(with: .failed)
         } else if let id = credentialIdentity.recordIdentifier {
-            profile.logins.getLogin(id: id).upon { [weak self] result in
+            profile.logins.getLogin(id: id, completionHandler: { [weak self] result in
                 switch result {
                 case .failure:
                     self?.cancel(with: .failed)
@@ -46,38 +46,36 @@ class CredentialProviderPresenter {
                         self?.cancel(with: .userInteractionRequired)
                     }
                 }
-            }
+            })
         }
     }
 
     func showCredentialList(for serviceIdentifiers: [ASCredentialServiceIdentifier]) {
-    if self.profile.logins.reopenIfClosed() != nil {
+        if self.profile.logins.reopenIfClosed() != nil {
             cancel(with: .failed)
         } else {
-            profile.logins.listLogins().upon {[weak self] result in
+            profile.logins.listLogins(completionHandler: { [weak self] result in
                 switch result {
                 case .failure:
                     self?.cancel(with: .failed)
                 case .success(let loginRecords):
-
                     var sortedLogins = loginRecords.sorted(by: <)
                     for (index, element) in sortedLogins.enumerated() {
                         if let identifier = serviceIdentifiers
                             .first?
                             .identifier.asURL?.domainURL
                             .absoluteString.titleFromHostname,
-                            element.passwordCredentialIdentity.serviceIdentifier.identifier.contains(identifier) {
+                           element.passwordCredentialIdentity.serviceIdentifier.identifier.contains(identifier) {
                             sortedLogins.remove(at: index)
                             sortedLogins.insert(element, at: 0)
                         }
                     }
-
                     let dataSource = sortedLogins.map { ($0.passwordCredentialIdentity, $0.passwordCredential) }
                     DispatchQueue.main.async {
                         self?.view?.show(itemList: dataSource)
                     }
                 }
-            }
+            })
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8518)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18917)

## :bulb: Description
- This pull request aims to refactor the `CredentialProviderPresenter` class to eliminate the usage of Deferred, replacing it with the new completion handlers provided by the LoginsProtocol.

### Changes Made
- Updated `getLogin` method call to use completionHandler parameter
- Updated `listLogins` method call to use completionHandler parameter

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

