### PR TITLE
Add FXIOS-8709 - Create url text field

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/LocationView.swift
@@ -74,7 +74,7 @@ class LocationView: UIView, UITextFieldDelegate, ThemeApplicable {
     }
 
     func configure(_ text: String?, delegate: LocationViewDelegate) {
-        urlTextField.text = text
+        urlTextField.text = getHost(from: text)
         locationViewDelegate = delegate
     }
 
@@ -119,8 +119,8 @@ class LocationView: UIView, UITextFieldDelegate, ThemeApplicable {
     private func updateGradientLayerFrame() {
         let locationViewWidth = frame.width - (UX.horizontalSpace * 2)
         let urlTextFieldWidth = urlTextField.frame.width
-        gradientLayer.frame = if urlTextFieldWidth >= locationViewWidth &&
-                                  !urlTextField.isFirstResponder { gradientView.bounds } else { CGRect() }
+        let showGradientForLongURL = urlTextFieldWidth >= locationViewWidth && !urlTextField.isFirstResponder
+        gradientLayer.frame = if showGradientForLongURL { gradientView.bounds } else { CGRect() }
     }
 
     // MARK: - `urlTextField` Configuration

--- a/BrowserKit/Sources/ToolbarKit/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/LocationView.swift
@@ -77,7 +77,7 @@ class LocationView: UIView, UITextFieldDelegate, ThemeApplicable {
         urlTextField.text = text
         locationViewDelegate = delegate
     }
- 
+
     // MARK: - Layout
     override func layoutSubviews() {
         super.layoutSubviews()
@@ -86,7 +86,7 @@ class LocationView: UIView, UITextFieldDelegate, ThemeApplicable {
 
     private func setupLayout() {
         addSubviews(urlTextField, gradientView)
-    
+
         NSLayoutConstraint.activate(
             [
                 gradientView.topAnchor.constraint(
@@ -100,7 +100,7 @@ class LocationView: UIView, UITextFieldDelegate, ThemeApplicable {
                 gradientView.leadingAnchor.constraint(equalTo: urlTextField.leadingAnchor),
                 gradientView.widthAnchor.constraint(equalToConstant: UX.gradientViewWidth),
                 gradientView.centerYAnchor.constraint(equalTo: urlTextField.centerYAnchor),
-                
+
                 urlTextField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.horizontalSpace),
                 urlTextField.topAnchor.constraint(equalTo: topAnchor),
                 urlTextField.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -UX.horizontalSpace),
@@ -119,9 +119,8 @@ class LocationView: UIView, UITextFieldDelegate, ThemeApplicable {
     private func updateGradientLayerFrame() {
         let locationViewWidth = frame.width - (UX.horizontalSpace * 2)
         let urlTextFieldWidth = urlTextField.frame.width
-        gradientLayer.frame = if (urlTextFieldWidth >= locationViewWidth &&
-                                  !urlTextField.isFirstResponder)
-                                    { gradientView.bounds } else { CGRect() }
+        gradientLayer.frame = if urlTextFieldWidth >= locationViewWidth &&
+                                  !urlTextField.isFirstResponder { gradientView.bounds } else { CGRect() }
     }
 
     // MARK: - `urlTextField` Configuration

--- a/BrowserKit/Sources/ToolbarKit/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/LocationView.swift
@@ -141,9 +141,7 @@ class LocationView: UIView, UITextFieldDelegate, ThemeApplicable {
     }
 
     private func getHost(from stringURL: String?) -> String {
-        guard let stringURL,
-              let url = URL(string: stringURL) else { return "" }
-
+        guard let stringURL, let url = URL(string: stringURL) else { return "" }
         return url.host ?? ""
     }
 

--- a/BrowserKit/Sources/ToolbarKit/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/LocationView.swift
@@ -74,7 +74,7 @@ class LocationView: UIView, UITextFieldDelegate, ThemeApplicable {
     }
 
     func configure(_ text: String?, delegate: LocationViewDelegate) {
-        urlTextField.text = getHost(from: "https://wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwaccounts.firefox.com")
+        urlTextField.text = text
         locationViewDelegate = delegate
     }
  

--- a/BrowserKit/Sources/ToolbarKit/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/LocationView.swift
@@ -64,24 +64,24 @@ class LocationView: UIView, UITextFieldDelegate, ThemeApplicable {
     }
 
     override func becomeFirstResponder() -> Bool {
+        super.becomeFirstResponder()
         return urlTextField.becomeFirstResponder()
     }
 
     override func resignFirstResponder() -> Bool {
+        super.resignFirstResponder()
         return urlTextField.resignFirstResponder()
     }
 
     func configure(_ text: String?, delegate: LocationViewDelegate) {
-        urlTextField.text = getHost(from: text)
+        urlTextField.text = getHost(from: "https://wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwaccounts.firefox.com")
         locationViewDelegate = delegate
     }
  
     // MARK: - Layout
     override func layoutSubviews() {
         super.layoutSubviews()
-        let locationViewWidth = frame.width - (UX.horizontalSpace * 2)
-        let urlTextFieldWidth = urlTextField.frame.width
-        gradientLayer.frame = if urlTextFieldWidth >= locationViewWidth { gradientView.bounds } else { CGRect() }
+        updateGradientLayerFrame()
     }
 
     private func setupLayout() {
@@ -116,6 +116,31 @@ class LocationView: UIView, UITextFieldDelegate, ThemeApplicable {
         gradientView.layer.addSublayer(gradientLayer)
     }
 
+    private func updateGradientLayerFrame() {
+        let locationViewWidth = frame.width - (UX.horizontalSpace * 2)
+        let urlTextFieldWidth = urlTextField.frame.width
+        gradientLayer.frame = if (urlTextFieldWidth >= locationViewWidth &&
+                                  !urlTextField.isFirstResponder)
+                                    { gradientView.bounds } else { CGRect() }
+    }
+
+    // MARK: - `urlTextField` Configuration
+    private func applyTruncationStyleToURLTextField() {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = .byTruncatingHead
+
+        let attributedString = NSMutableAttributedString(string: urlTextField.text ?? "")
+        attributedString.addAttribute(
+            .paragraphStyle,
+            value: paragraphStyle,
+            range: NSRange(
+                location: 0,
+                length: attributedString.length
+            )
+        )
+        urlTextField.attributedText = attributedString
+    }
+
     private func getHost(from stringURL: String?) -> String {
         guard let stringURL,
               let url = URL(string: stringURL) else { return "" }
@@ -131,7 +156,13 @@ class LocationView: UIView, UITextFieldDelegate, ThemeApplicable {
 
     // MARK: - UITextFieldDelegate
     public func textFieldDidBeginEditing(_ textField: UITextField) {
+        gradientLayer.frame = CGRect()
         locationViewDelegate?.locationViewDidBeginEditing(textField.text?.lowercased() ?? "")
+    }
+
+    public func textFieldDidEndEditing(_ textField: UITextField) {
+        updateGradientLayerFrame()
+        applyTruncationStyleToURLTextField()
     }
 
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8709)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19310)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- This PR introduces a gradient to the left of the URL text field in non-editing mode. The gradient appears when the text exceeds the width of the text field, ensuring the domain remains visible at all times.
- Note: The Figma design does not include the `...` ellipsis. However, I'm not sure if it's possible to remove it in iOS. I will continue to explore potential workarounds.

### Demo

https://github.com/mozilla-mobile/firefox-ios/assets/51127880/09069768-2476-4ab7-b32d-2b7b926e23e7

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

