### PR TITLE
Focus strings export: only export `en-US` strings

### DIFF
--- a/focus-ios/focus-ios-tests/tools/export-strings.sh
+++ b/focus-ios/focus-ios-tests/tools/export-strings.sh
@@ -9,8 +9,8 @@ if [ ! -d Blockzilla.xcodeproj ]; then
 fi
 
 if [ -d "focusios-l10n" ]; then
-echo "Focus iOS L10 directory found. Removing to re-clone for fresh start."
-rm -Rf focusios-l10n;
+  echo "Focus iOS L10 directory found. Removing to re-clone for fresh start."
+  rm -Rf focusios-l10n;
 fi
 
 echo "[*] Cloning mozilla-l10n/focusios-l10n"
@@ -33,7 +33,8 @@ echo "[*] Exporting Strings (output in export-strings.log)"
 (cd focus-ios-tests/tools/Localizations && swift run LocalizationTools \
   --export \
   --project-path "$PWD/../../../Blockzilla.xcodeproj" \
-  --l10n-project-path "$PWD/../../../focusios-l10n") > export-strings.log 2>&1
+  --l10n-project-path "$PWD/../../../focusios-l10n" \
+  --locale en-US) > export-strings.log 2>&1
 
 echo "[!] Hooray strings have been succesfully exported."
 echo "[!] You can create a PR in the focusios-l10n checkout"


### PR DESCRIPTION
We're still exporting strings for all locales, but that's unnecessary, as automation only cares about the source locale (that's already happening [here](https://github.com/mozilla-l10n/firefoxios-l10n/blob/main/.github/workflows/import_strings.yml#L61) for Firefox for iOS).