### PR TITLE
Bugfix FXIOS-8791 [v126]: Prevents Notification Service from crashing

### DIFF
--- a/firefox-ios/Extensions/NotificationService/NotificationService.swift
+++ b/firefox-ios/Extensions/NotificationService/NotificationService.swift
@@ -68,7 +68,7 @@ class NotificationService: UNNotificationServiceExtension {
                 }
                 let decryptResult = try await autopush.decrypt(payload: payload)
                 guard let decryptedString = String(
-                    bytes: decryptResult.result.map { byte in UInt8(byte) },
+                    bytes: decryptResult.result.map { byte in UInt8(bitPattern: byte) },
                     encoding: .utf8
                 ) else {
                     completion(.failure(.notDecrypted))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8791)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19494)

## :bulb: Description
This is a bug in that we didn't properly convert the signed bytes we got back from the push component to unsigned bytes. Lucky (or unlucky in that it was hard to see) for us a high bit of 1 wouldn't happen on non-ascii values so this was hard to trigger in practice.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

