### PR TITLE
Bugfix FXIOS-8544 Telemetry Probes - Address Autofill Phase 1

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/WKScriptMessageExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/WKScriptMessageExtension.swift
@@ -6,9 +6,12 @@ import WebKit
 
 public extension WKScriptMessage {
     func decodeBody<T: Decodable>(as type: T.Type) -> T? {
-        guard let dict = (body as? [String: Any]),
-              let data = try? JSONSerialization.data(withJSONObject: dict, options: [])
-        else { return nil }
-        return try? JSONDecoder().decode(type, from: data)
+        if let dict = (body as? [String: Any]), let data = try? JSONSerialization.data(withJSONObject: dict, options: []) {
+            return try? JSONDecoder().decode(type, from: data)
+        } else if let bodyString = body as? String, let data = bodyString.data(using: .utf8) {
+            return try? JSONDecoder().decode(type, from: data)
+        } else {
+            return nil
+        }
     }
 }

--- a/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
@@ -50,7 +50,7 @@ final class AppStartupTelemetry {
 
     func queryAddresses() {
         profile.autofill.listAllAddresses(completion: { [weak self] addresses, error in
-            guard let addresses = addresses, !addresses.isEmpty, error == nil else { return }
+            guard let addresses = addresses, error == nil else { return }
             self?.sendAddressAutofillSavedAllTelemetry(numberOfAddresses: addresses.count)
         })
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
@@ -304,6 +304,7 @@ class FormAutofillHelperTests: XCTestCase {
 
         XCTAssertTrue(handlerNames!.contains(FormAutofillHelper.HandlerName.addressFormMessageHandler.rawValue))
         XCTAssertTrue(handlerNames!.contains(FormAutofillHelper.HandlerName.creditCardFormMessageHandler.rawValue))
+        XCTAssertTrue(handlerNames!.contains(FormAutofillHelper.HandlerName.addressFormTelemetryMessageHandler.rawValue))
     }
 
     func testUserContentControllerDidReceiveScriptMessage_withCreditCardHandler() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8544)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18980)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Fix decoding method that was causing some telemetry to be skipped.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

