### PR TITLE
Bugfix FXIOS-8784 - Removes Tab Tray coordinator when bottom sheet is dismissed

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -651,6 +651,10 @@ class BrowserCoordinator: BaseCoordinator,
         add(child: tabTrayCoordinator)
         tabTrayCoordinator.start(with: selectedPanel)
 
+        navigationController.onViewDismissed = { [weak self] in
+            self?.didDismissTabTray(from: tabTrayCoordinator)
+        }
+
         present(navigationController)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8784)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19464)

## :bulb: Description

This PR fixes an issue where dismissing the tab tray using gestures was not removing the tab coordinator. To fix this, the didDismissTabTray method is called when the navigation controller calls its onViewDismissed closure.

https://github.com/mozilla-mobile/firefox-ios/assets/33697534/2f87db4d-a365-42d8-92b6-8809565ee320

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

