### PR TITLE
Bugfix FXIOS-19360 Fix Inconsistency in Sync Now icon animation

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -234,7 +234,7 @@ class SyncNowSetting: WithAccountSetting {
 
         // Animation that loops continuously until stopped
         continuousRotateAnimation.fromValue = 0.0
-        continuousRotateAnimation.toValue = CGFloat(Double.pi)
+        continuousRotateAnimation.toValue = CGFloat(-Double.pi)
         continuousRotateAnimation.isRemovedOnCompletion = true
         continuousRotateAnimation.duration = 0.5
         continuousRotateAnimation.repeatCount = .infinity


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19360)

## :bulb: Description
Fix Sync Now icon animation direction according issue requirements

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

