### PR TITLE
Bugfix FXIOS-8652 ⁃ Intermittent - 'No internet connection' error is not displayed when trying to load a webpage while in airplane mode

### DIFF
--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -243,10 +243,12 @@ class ErrorPageHelper {
     func loadPage(_ error: NSError, forUrl url: URL, inWebView webView: WKWebView) {
         guard var components = URLComponents(
             string: "\(InternalURL.baseUrl)/\(ErrorPageHandler.path)"
-        ), let webViewUrl = webView.url else { return }
+        ) else { return }
 
         // Page has failed to load again, just return and keep showing the existing error page.
-        if let internalUrl = InternalURL(webViewUrl), internalUrl.originalURLFromErrorPage == url {
+        if let webViewUrl = webView.url,
+           let internalUrl = InternalURL(webViewUrl),
+           internalUrl.originalURLFromErrorPage == url {
             return
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8652)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19192)

## :bulb: Description
Sometimes **webView.url** is **nil**, more exactly when you open FF and you have no internet connection and because of that, **guard** not pass and that means -> no feedback to the user. (like no internet connection error)

**let webViewUrl = webView.url** has been moved a little bit down, to the condition where we want to display the same error that was displayed before based on "// Page has failed to load again, just return and keep showing the existing error page."

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

