### PR TITLE
Update label for address autofill in Settings

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -2275,7 +2275,7 @@ extension String {
     public static let SettingsAddressAutofill = MZLocalizedString(
         key: "Settings.AddressAutofill.Title.v124",
         tableName: "Settings",
-        value: "Autofill Addresses",
+        value: "Addresses",
         comment: "Label used as an item in Settings screen. When touched, it will take user to address autofill settings page to that will allow user to add or modify saved addresses to allow for autofill in a webpage.")
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8890)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19614)

## :bulb: Description
**- Update label for address autofill feature in Settings screen**

| Before | After | 
| ------ | ------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-04-04 at 13 38 39](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/e2df3494-66b7-47c1-926b-be9eefcf1359) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-04 at 13 39 25](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/547c2ee8-e30c-4b30-b88c-9042dc57c8a1) |

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

