### PR TITLE
Bugfix FXIOS-8893 Default to tab tray segment for selected tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -34,13 +34,14 @@ extension BrowserViewController: URLBarDelegate {
                      focusedSegment: TabTrayPanelType? = nil) {
         updateFindInPageVisibility(visible: false)
 
-        guard !isTabTrayRefactorEnabled else {
-            navigationHandler?.showTabTray(selectedPanel: focusedSegment ?? .tabs)
-            return
+        if isTabTrayRefactorEnabled {
+            let isPrivateTab = tabManager.selectedTab?.isPrivate ?? false
+            let selectedSegment: TabTrayPanelType = focusedSegment ?? (isPrivateTab ? .privateTabs : .tabs)
+            navigationHandler?.showTabTray(selectedPanel: selectedSegment)
+        } else {
+            showLegacyTabTrayViewController(withFocusOnUnselectedTab: tabToFocus,
+                                            focusedSegment: focusedSegment)
         }
-
-        showLegacyTabTrayViewController(withFocusOnUnselectedTab: tabToFocus,
-                                        focusedSegment: focusedSegment)
     }
 
     private func showLegacyTabTrayViewController(withFocusOnUnselectedTab tabToFocus: Tab? = nil,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8893)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19621)

## :bulb: Description

Default to the correct selected segment when opening the tab tray.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

