### PR TITLE
Refactor FXIOS-8886 Enable swiftlint condition "vertical_whitespace_opening_braces" 

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -80,7 +80,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - overridden_super_call
   # - vertical_parameter_alignment_on_call
   # - vertical_whitespace_closing_braces
-  # - vertical_whitespace_opening_braces
+  - vertical_whitespace_opening_braces
   - yoda_condition
 
 # These rules were originally opted into. Disabling for now to get

--- a/focus-ios/Blockzilla/BrowserViewController.swift
+++ b/focus-ios/Blockzilla/BrowserViewController.swift
@@ -1637,7 +1637,6 @@ extension BrowserViewController: SearchSuggestionsPromptViewDelegate {
 }
 
 extension BrowserViewController: LegacyWebControllerDelegate {
-
     func webControllerDidStartProvisionalNavigation(_ controller: LegacyWebController) {
         urlBar.dismiss()
         updateFindInPageVisibility(visible: false)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8886)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19602)

## :bulb: Description
- Enables the `vertical_whitespace_opening_braces` swiftlint condition
- Fix 1 violation

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

