### PR TITLE
Bugfix FXIOS-8803 ⁃ Amazon Homepage Product are always opening in external app (if Amazon app is installed)

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -633,14 +633,18 @@ extension BrowserViewController: WKNavigationDelegate {
                     decisionHandler(.cancel)
                     webView.load(navigationAction.request)
                     return
-                } else if UIApplication.shared.canOpenURL(url) {
-                    UIApplication.shared.open(url, options: [.universalLinksOnly: true]) { isAppInstalled in
-                        if isAppInstalled {
-                            webView.reload()
-                           // TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-7524
-                        }
-                    }
                 }
+                // Removing this code, maybe temporary, because it is causing other problems
+                // like opening a native app (if is installed) every time when clicking on a link
+                // please see https://mozilla-hub.atlassian.net/browse/FXIOS-8803
+//                else if UIApplication.shared.canOpenURL(url) {
+//                    UIApplication.shared.open(url, options: [.universalLinksOnly: true]) { isAppInstalled in
+//                        if isAppInstalled {
+//                            webView.reload()
+//                           // TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-7524
+//                        }
+//                    }
+//                }
             }
 
             decisionHandler(.allow)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -634,17 +634,6 @@ extension BrowserViewController: WKNavigationDelegate {
                     webView.load(navigationAction.request)
                     return
                 }
-                // Removing this code, maybe temporary, because it is causing other problems
-                // like opening a native app (if is installed) every time when clicking on a link
-                // please see https://mozilla-hub.atlassian.net/browse/FXIOS-8803
-//                else if UIApplication.shared.canOpenURL(url) {
-//                    UIApplication.shared.open(url, options: [.universalLinksOnly: true]) { isAppInstalled in
-//                        if isAppInstalled {
-//                            webView.reload()
-//                           // TODO: https://mozilla-hub.atlassian.net/browse/FXIOS-7524
-//                        }
-//                    }
-//                }
             }
 
             decisionHandler(.allow)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8803)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19514)

## :bulb: Description
Removing temporary this part of the code because: for example when you navigate on the Amazon website and have the native app installed and click on a product link, native app will be open for every time and that is not the expected behaviour. 

User should be able to navigate in browser, for products.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

