### PR TITLE
Bugfix FXIOS-8905, 8906 Fix private mode tab state

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2103,9 +2103,8 @@ class BrowserViewController: UIViewController,
             $0.applyTheme(theme: currentTheme)
         }
 
-        let ui: [PrivateModeUI?] = [toolbar, topTabsViewController, urlBar]
         let isPrivate = (currentTheme.type == .privateMode)
-        ui.forEach { $0?.applyUIMode(isPrivate: isPrivate, theme: currentTheme) }
+        urlBar.applyUIMode(isPrivate: isPrivate, theme: currentTheme)
 
         guard let contentScript = tabManager.selectedTab?.getContentScript(name: ReaderMode.name()) else { return }
         applyThemeForPreferences(profile.prefs, contentScript: contentScript)

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -343,7 +343,7 @@ extension TopTabsViewController: TopTabCellDelegate {
 
 extension TopTabsViewController: PrivateModeUI {
     func applyUIMode(isPrivate: Bool, theme: Theme) {
-        // TODO: Ideally we shouldn't be creating new tabs as a side-effect of updating UI theme. Investigate refactor.
+        // TODO: [FXIOS-8907] Ideally we shouldn't create tabs as a side-effect of UI theme updates. Investigate refactor.
         topTabDisplayManager.togglePrivateMode(isOn: isPrivate, createTabOnEmptyPrivateMode: true)
 
         privateModeButton.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -343,6 +343,7 @@ extension TopTabsViewController: TopTabCellDelegate {
 
 extension TopTabsViewController: PrivateModeUI {
     func applyUIMode(isPrivate: Bool, theme: Theme) {
+        // TODO: Ideally we shouldn't be creating new tabs as a side-effect of updating UI theme. Investigate refactor.
         topTabDisplayManager.togglePrivateMode(isOn: isPrivate, createTabOnEmptyPrivateMode: true)
 
         privateModeButton.applyTheme(theme: theme)

--- a/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
+++ b/firefox-ios/nimbus-features/feltPrivacyFeature.yaml
@@ -19,6 +19,6 @@ features:
           felt-deletion-enabled: false
       - channel: developer
         value:
-          simplified-ui-enabled: false
-          felt-deletion-enabled: false
+          simplified-ui-enabled: true
+          felt-deletion-enabled: true
 


### PR DESCRIPTION
## :scroll: Tickets
[8905](https://mozilla-hub.atlassian.net/browse/FXIOS-8905)
[8906](https://mozilla-hub.atlassian.net/browse/FXIOS-8906)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19662)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19661)

## :bulb: Description

During the large refactor for FXIOS-8313 there was code calling into `applyUIMode` that was originally in the tab selection delegate callback. To fix an issue with themeing of the URL bar this code was also copied over into `applyTheme`. The problem was that it was not only calling that function on the urlBar but also the top tabs VC, which was actually adding a new private tab unexpectedly in several flows.

The change here is to only call `applyUIMode` on the url bar.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

