### PR TITLE
Refactor FXIOS-8313 [Multi-window] Themeing for Reader Mode & share extensions

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -85,12 +85,11 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     // MARK: - ThemeManager
 
-    public func legacy_currentTheme() -> Theme {
-        // While we are still only allowing single-window mode on iPad we can
-        // provide the theme for the current default window for older code that
-        // has not yet been updated to use UUID-based theme.
-        guard let uuid = allWindowUUIDs.first else { assertionFailure("Unexpected empty UUID list."); return LightTheme() }
-        return currentTheme(for: uuid)
+    public func windowNonspecificTheme() -> Theme {
+        switch getNormalSavedTheme() {
+        case .dark, .privateMode: return DarkTheme()
+        case .light: return LightTheme()
+        }
     }
 
     // TODO: [8313] Need to add support for cleaning up and releasing window references on iPad when a window is closed.

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -26,6 +26,11 @@ public protocol ThemeManager {
     func reloadTheme(for window: UUID)
     func setWindow(_ window: UIWindow, for uuid: UUID)
 
-    // Temporary. Will be removed as part of [FXIOS-8313]
-    func legacy_currentTheme() -> Theme
+    // Theme functions for app extensions
+
+    /// Returns the general theme setting outside of any specific iOS window.
+    /// This is generally only meant to be used in scenarios where the UI is
+    /// presented outside the context of any particular browser window, such
+    /// as in our app extensions.
+    func windowNonspecificTheme() -> Theme
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
@@ -50,7 +50,8 @@ extension BrowserViewController: ReaderModeStyleViewModelDelegate {
                   readerMode.state == ReaderModeState.active
             else { continue }
 
-            readerMode.style = ReaderModeStyle(theme: newStyle.theme,
+            readerMode.style = ReaderModeStyle(windowUUID: windowUUID,
+                                               theme: newStyle.theme,
                                                fontType: ReaderModeFontType(type: newStyle.fontType.rawValue),
                                                fontSize: newStyle.fontSize)
         }
@@ -160,14 +161,15 @@ extension BrowserViewController {
     }
 
     func applyThemeForPreferences(_ preferences: Prefs, contentScript: TabContentScript) {
-        var readerModeStyle = ReaderModeStyle.default
+        var readerModeStyle = ReaderModeStyle.defaultStyle(for: windowUUID)
         if let dict = preferences.dictionaryForKey(ReaderModeProfileKeyStyle),
-           let style = ReaderModeStyle(dict: dict as [String: AnyObject]) {
+           let style = ReaderModeStyle(windowUUID: windowUUID, dict: dict as [String: AnyObject]) {
             readerModeStyle = style
         }
 
         readerModeStyle.fontSize = ReaderModeFontSize.defaultSize
-        let viewModel = ReaderModeStyleViewModel(isBottomPresented: isBottomSearchBar,
+        let viewModel = ReaderModeStyleViewModel(windowUUID: windowUUID,
+                                                 isBottomPresented: isBottomSearchBar,
                                                  readerModeStyle: readerModeStyle)
         let viewController = ReaderModeStyleViewController(viewModel: viewModel, windowUUID: windowUUID)
         viewController.applyTheme(preferences, contentScript: contentScript)
@@ -182,13 +184,14 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
                   readerMode.state == ReaderModeState.active
             else { break }
 
-            var readerModeStyle = ReaderModeStyle.default
+            var readerModeStyle = ReaderModeStyle.defaultStyle(for: windowUUID)
             if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle),
-               let style = ReaderModeStyle(dict: dict as [String: AnyObject]) {
+               let style = ReaderModeStyle(windowUUID: windowUUID, dict: dict as [String: AnyObject]) {
                 readerModeStyle = style
             }
 
-            let readerModeViewModel = ReaderModeStyleViewModel(isBottomPresented: isBottomSearchBar,
+            let readerModeViewModel = ReaderModeStyleViewModel(windowUUID: windowUUID,
+                                                               isBottomPresented: isBottomSearchBar,
                                                                readerModeStyle: readerModeStyle)
             readerModeViewModel.delegate = self
             let readerModeStyleViewController = ReaderModeStyleViewController(viewModel: readerModeViewModel,

--- a/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -133,10 +133,7 @@ class DevicePickerViewController: UITableViewController {
     }
 
     private func currentTheme() -> Theme {
-        // TODO: [8313] Revisit. Needs to be updated to use UUID-based themeing.
-        // guard let uuid = (self.view as? ThemeUUIDIdentifiable)?.currentWindowUUID else { return DarkTheme() }
-        // return themeManager.currentTheme(for: uuid)
-        return themeManager.legacy_currentTheme()
+        return themeManager.windowNonspecificTheme()
     }
 
     private func loadList() {

--- a/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
@@ -74,8 +74,6 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
 
     @objc
     func learnMoreButtonTapped(_ sender: UIButton) {
-        // TODO: [8313] Regression testing needed here
-        guard let windowUUID = (sender as ThemeUUIDIdentifiable).currentWindowUUID else { return }
         let viewController = SettingsContentViewController(windowUUID: windowUUID)
         viewController.url = SupportUtils.URLForTopic("manage-saved-passwords-firefox-ios")
         navigationController?.pushViewController(viewController, animated: true)

--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -378,7 +378,7 @@ class ReaderMode: TabContentScript {
         }
     }
 
-    lazy var style: ReaderModeStyle = ReaderModeStyle.defaultStyle(for: tab?.windowUUID) {
+    lazy var style = ReaderModeStyle.defaultStyle(for: tab?.windowUUID) {
         didSet {
             if state == ReaderModeState.active {
                 tab?.webView?.evaluateJavascriptInDefaultContentWorld(

--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -30,14 +30,17 @@ enum ReaderModeTheme: String {
     case dark
     case sepia
 
-    static func preferredTheme(for theme: ReaderModeTheme? = nil) -> ReaderModeTheme {
+    static func preferredTheme(for theme: ReaderModeTheme? = nil, window: WindowUUID?) -> ReaderModeTheme {
         let themeManager: ThemeManager = AppContainer.shared.resolve()
 
-        // TODO: [8313] Revisit and update for UUID-based themeing.
-        // guard themeManager.currentTheme(for: ??).type != .dark else { return .dark }
-        guard themeManager.legacy_currentTheme().type != .dark else { return .dark }
+        let appTheme: Theme = {
+            guard let uuid = window else { return themeManager.windowNonspecificTheme() }
+            return themeManager.currentTheme(for: uuid)
+        }()
 
-        return theme ?? .light
+        guard appTheme.type != .dark else { return .dark }
+
+        return theme ?? ReaderModeTheme.light
     }
 }
 
@@ -136,6 +139,7 @@ enum ReaderModeFontSize: Int {
 }
 
 struct ReaderModeStyle {
+    let windowUUID: WindowUUID?
     var theme: ReaderModeTheme
     var fontType: ReaderModeFontType
     var fontSize: ReaderModeFontSize
@@ -150,14 +154,18 @@ struct ReaderModeStyle {
         return ["theme": theme.rawValue, "fontType": fontType.rawValue, "fontSize": fontSize.rawValue]
     }
 
-    init(theme: ReaderModeTheme, fontType: ReaderModeFontType, fontSize: ReaderModeFontSize) {
+    init(windowUUID: WindowUUID?,
+         theme: ReaderModeTheme,
+         fontType: ReaderModeFontType,
+         fontSize: ReaderModeFontSize) {
+        self.windowUUID = windowUUID
         self.theme = theme
         self.fontType = fontType
         self.fontSize = fontSize
     }
 
     /// Initialize the style from a dictionary, taken from the profile. Returns nil if the object cannot be decoded.
-    init?(dict: [String: Any]) {
+    init?(windowUUID: WindowUUID?, dict: [String: Any]) {
         let themeRawValue = dict["theme"] as? String
         let fontTypeRawValue = dict["fontType"] as? String
         let fontSizeRawValue = dict["fontSize"] as? Int
@@ -172,20 +180,24 @@ struct ReaderModeStyle {
             return nil
         }
 
-        self.theme = theme ?? ReaderModeTheme.preferredTheme()
+        self.windowUUID = windowUUID
+        self.theme = theme ?? ReaderModeTheme.preferredTheme(window: windowUUID)
         self.fontType = fontType
         self.fontSize = fontSize!
     }
 
     mutating func ensurePreferredColorThemeIfNeeded() {
-        self.theme = ReaderModeTheme.preferredTheme(for: self.theme)
+        self.theme = ReaderModeTheme.preferredTheme(for: self.theme, window: windowUUID)
     }
 
-    static let `default` = ReaderModeStyle(
-        theme: .light,
-        fontType: .sansSerif,
-        fontSize: ReaderModeFontSize.defaultSize
-    )
+    static func defaultStyle(for window: WindowUUID?) -> ReaderModeStyle {
+        return ReaderModeStyle(
+            windowUUID: window,
+            theme: .light,
+            fontType: .sansSerif,
+            fontSize: ReaderModeFontSize.defaultSize
+        )
+    }
 }
 
 /// This struct captures the response from the Readability.js code.
@@ -366,7 +378,7 @@ class ReaderMode: TabContentScript {
         }
     }
 
-    var style: ReaderModeStyle = .default {
+    lazy var style: ReaderModeStyle = ReaderModeStyle.defaultStyle(for: tab?.windowUUID) {
         didSet {
             if state == ReaderModeState.active {
                 tab?.webView?.evaluateJavascriptInDefaultContentWorld(

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -54,12 +54,12 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
                         let readabilityResult = try readerModeCache.get(url)
                         // We have this page in our cache, so we can display it. Just grab the correct style from the
                         // profile and then generate HTML from the Readability results.
-                        var readerModeStyle = ReaderModeStyle.default
+                        var readerModeStyle = ReaderModeStyle.defaultStyle(for: nil)
                         if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle),
-                           let style = ReaderModeStyle(dict: dict) {
+                           let style = ReaderModeStyle(windowUUID: nil, dict: dict) {
                                 readerModeStyle = style
                         } else {
-                            readerModeStyle.theme = ReaderModeTheme.preferredTheme()
+                            readerModeStyle.theme = ReaderModeTheme.preferredTheme(window: nil)
                         }
                         if let html = ReaderModeUtils.generateReaderContent(
                             readabilityResult,

--- a/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewController.swift
+++ b/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewController.swift
@@ -235,7 +235,7 @@ class ReaderModeStyleViewController: UIViewController, Themeable {
     func applyTheme(_ preferences: Prefs, contentScript: TabContentScript) {
         guard let readerPreferences = preferences.dictionaryForKey(ReaderModeProfileKeyStyle),
               let readerMode = contentScript as? ReaderMode,
-              let style = ReaderModeStyle(dict: readerPreferences) else { return }
+              let style = ReaderModeStyle(windowUUID: windowUUID, dict: readerPreferences) else { return }
 
         readerMode.style = style
     }

--- a/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewModel.swift
+++ b/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewModel.swift
@@ -15,9 +15,13 @@ protocol ReaderModeStyleViewModelDelegate: AnyObject {
 // MARK: - ReaderModeStyleViewModel
 
 class ReaderModeStyleViewModel {
-    public init(isBottomPresented: Bool, readerModeStyle: ReaderModeStyle = .default) {
+    public init(windowUUID: WindowUUID,
+                isBottomPresented: Bool,
+                readerModeStyle: ReaderModeStyle? = nil) {
+        let style: ReaderModeStyle = readerModeStyle ?? ReaderModeStyle.defaultStyle(for: windowUUID)
+        self.readerModeStyle = style
         self.isBottomPresented = isBottomPresented
-        self.readerModeStyle = readerModeStyle
+        self.readerModeStyle = style
     }
 
     struct UX {

--- a/firefox-ios/Client/Frontend/Settings/TPAccessoryInfo.swift
+++ b/firefox-ios/Client/Frontend/Settings/TPAccessoryInfo.swift
@@ -24,9 +24,7 @@ class TPAccessoryInfo: ThemedTableViewController {
     }
 
     func currentTheme() -> Theme {
-        // TODO: [8313] Need to revisit and update to use UUID-based themeing.
-        // return themeManager.currentTheme(for: view.currentWindowUUID)
-        return themeManager.legacy_currentTheme()
+        return themeManager.currentTheme(for: windowUUID)
     }
 
     func headerView() -> UIView {

--- a/firefox-ios/Extensions/ShareTo/SendToDevice.swift
+++ b/firefox-ios/Extensions/ShareTo/SendToDevice.swift
@@ -27,10 +27,7 @@ class SendToDevice: DevicePickerViewControllerDelegate, InstructionsViewDelegate
     }
 
     private func currentTheme() -> Theme {
-        // TODO: [8313] Revisit and update to use UUID based themeing.
-        // guard let uuid = (view as? ThemeUUIDIdentifiable)?.currentWindowUUID else { return DarkTheme() }
-        // return themeManager.currentTheme(for: uuid)
-        return themeManager.legacy_currentTheme()
+        return themeManager.windowNonspecificTheme()
     }
 
     func initialViewController() -> UIViewController {

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -89,10 +89,7 @@ class ShareViewController: UIViewController {
     }
 
     private func currentTheme() -> Theme {
-        // TODO: [8313] Revisit and update to use UUID based themeing.
-        // guard let uuid = (self.view as? ThemeUUIDIdentifiable)?.currentWindowUUID else { return DarkTheme() }
-        // return themeManager.currentTheme(for: uuid)
-        return themeManager.legacy_currentTheme()
+        return themeManager.windowNonspecificTheme()
     }
 
     func setupUI() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
@@ -64,7 +64,5 @@ class MockThemeManager: ThemeManager {
 
     func setWindow(_ window: UIWindow, for uuid: UUID) { }
 
-    func legacy_currentTheme() -> Theme {
-        return currentThemeStorage
-    }
+    func windowNonspecificTheme() -> Theme { return currentThemeStorage }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ReaderModeStyleTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ReaderModeStyleTests.swift
@@ -24,7 +24,8 @@ class ReaderModeStyleTests: XCTestCase {
     }
 
     func test_initWithProperties_succeeds() {
-        let readerModeStyle = ReaderModeStyle(theme: .dark,
+        let readerModeStyle = ReaderModeStyle(windowUUID: windowUUID,
+                                              theme: .dark,
                                               fontType: .sansSerif,
                                               fontSize: .size1)
 
@@ -34,7 +35,8 @@ class ReaderModeStyleTests: XCTestCase {
     }
 
     func test_encodingAsDictionary_succeeds() {
-        let readerModeStyle = ReaderModeStyle(theme: .dark,
+        let readerModeStyle = ReaderModeStyle(windowUUID: windowUUID,
+                                              theme: .dark,
                                               fontType: .sansSerif,
                                               fontSize: .size1)
 
@@ -60,7 +62,8 @@ class ReaderModeStyleTests: XCTestCase {
     }
 
     func test_initWithDictionnary_succeeds() {
-        let readerModeStyle = ReaderModeStyle(dict: ["theme": ReaderModeTheme.dark.rawValue,
+        let readerModeStyle = ReaderModeStyle(windowUUID: windowUUID,
+                                              dict: ["theme": ReaderModeTheme.dark.rawValue,
                                                      "fontType": ReaderModeFontType.sansSerif.rawValue,
                                                      "fontSize": ReaderModeFontSize.size1.rawValue])
 
@@ -70,7 +73,8 @@ class ReaderModeStyleTests: XCTestCase {
     }
 
     func test_initWithWrongDictionnary_fails() {
-        let readerModeStyle = ReaderModeStyle(dict: ["wrong": 1,
+        let readerModeStyle = ReaderModeStyle(windowUUID: windowUUID,
+                                              dict: ["wrong": 1,
                                                      "fontType": ReaderModeFontType.sansSerif,
                                                      "fontSize": ReaderModeFontSize.size1])
 
@@ -78,7 +82,8 @@ class ReaderModeStyleTests: XCTestCase {
     }
 
     func test_initWithEmptyDictionnary_fails() {
-        let readerModeStyle = ReaderModeStyle(dict: [:])
+        let readerModeStyle = ReaderModeStyle(windowUUID: windowUUID,
+                                              dict: [:])
 
         XCTAssertNil(readerModeStyle)
     }
@@ -87,32 +92,33 @@ class ReaderModeStyleTests: XCTestCase {
 
     func test_defaultReaderModeTheme_returnsLight() {
         themeManager.changeCurrentTheme(.light, for: windowUUID)
-        let defaultTheme = ReaderModeTheme.preferredTheme(for: nil)
+        let defaultTheme = ReaderModeTheme.preferredTheme(for: nil, window: windowUUID)
         XCTAssertEqual(defaultTheme, .light, "Expected light theme (default) if not theme is selected")
     }
 
     func test_appWideThemeDark_returnsDark() {
         themeManager.changeCurrentTheme(.dark, for: windowUUID)
-        let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.light)
+        let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.light, window: windowUUID)
 
         XCTAssertEqual(theme, .dark, "Expected dark theme because of the app theme")
     }
 
     func test_readerThemeSepia_returnsSepia() {
         themeManager.changeCurrentTheme(.light, for: windowUUID)
-        let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.sepia)
+        let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.sepia, window: windowUUID)
         XCTAssertEqual(theme, .sepia, "Expected sepia theme if App theme is not dark")
     }
 
     func test_readerThemeSepiaWithAppDark_returnsSepia() {
         themeManager.changeCurrentTheme(.dark, for: windowUUID)
-        let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.sepia)
+        let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.sepia, window: windowUUID)
         XCTAssertEqual(theme, .dark, "Expected dark theme if App theme is dark")
     }
 
     func test_preferredColorTheme_changesFromLightToDark() {
         themeManager.changeCurrentTheme(.dark, for: windowUUID)
-        var readerModeStyle = ReaderModeStyle(theme: .light,
+        var readerModeStyle = ReaderModeStyle(windowUUID: windowUUID,
+                                              theme: .light,
                                               fontType: .sansSerif,
                                               fontSize: .size1)
         XCTAssertEqual(readerModeStyle.theme, .light)
@@ -122,7 +128,7 @@ class ReaderModeStyleTests: XCTestCase {
 
     func test_delegateMemoryLeak() {
         let mockReaderModeStyleViewControllerDelegate = MockDelegate()
-        let readerModeStyleViewModel = ReaderModeStyleViewModel(isBottomPresented: false)
+        let readerModeStyleViewModel = ReaderModeStyleViewModel(windowUUID: windowUUID, isBottomPresented: false)
         readerModeStyleViewModel.delegate = mockReaderModeStyleViewControllerDelegate
         trackForMemoryLeaks(readerModeStyleViewModel)
     }
@@ -130,7 +136,7 @@ class ReaderModeStyleTests: XCTestCase {
     // MARK: - Tests
 
     func testSelectTheme() {
-        let viewModel = ReaderModeStyleViewModel(isBottomPresented: true)
+        let viewModel = ReaderModeStyleViewModel(windowUUID: windowUUID, isBottomPresented: true)
 
         let theme = ReaderModeTheme.dark
         viewModel.selectTheme(theme)
@@ -139,7 +145,7 @@ class ReaderModeStyleTests: XCTestCase {
     }
 
     func testSelectFontType() {
-        let viewModel = ReaderModeStyleViewModel(isBottomPresented: true)
+        let viewModel = ReaderModeStyleViewModel(windowUUID: windowUUID, isBottomPresented: true)
 
         let fontType = ReaderModeFontType.sansSerif
         viewModel.selectFontType(fontType)
@@ -148,7 +154,7 @@ class ReaderModeStyleTests: XCTestCase {
     }
 
     func testReaderModeDidChangeTheme() {
-        let viewModel = ReaderModeStyleViewModel(isBottomPresented: true)
+        let viewModel = ReaderModeStyleViewModel(windowUUID: windowUUID, isBottomPresented: true)
         let mockDelegate = MockDelegate()
         viewModel.delegate = mockDelegate
 
@@ -163,7 +169,7 @@ class ReaderModeStyleTests: XCTestCase {
     }
 
     func testFontSizeDidChangeSizeAction() {
-        let viewModel = ReaderModeStyleViewModel(isBottomPresented: true)
+        let viewModel = ReaderModeStyleViewModel(windowUUID: windowUUID, isBottomPresented: true)
         let mockDelegate = MockDelegate()
         viewModel.delegate = mockDelegate
 
@@ -185,7 +191,7 @@ class ReaderModeStyleTests: XCTestCase {
     }
 
     func testFontTypeDidChange() {
-        let viewModel = ReaderModeStyleViewModel(isBottomPresented: true)
+        let viewModel = ReaderModeStyleViewModel(windowUUID: windowUUID, isBottomPresented: true)
         let mockDelegate = MockDelegate()
         viewModel.delegate = mockDelegate
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8313)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18426)

## :bulb: Description

Additional refactors as part of the work for FXIOS-8313. Removes remaining vestiges of `currentTheme` and updates some code for reader mode and app extension UI.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

