### PR TITLE
Fix MTE-2584 - testPrivateClosedSiteDoesNotAppearOnRecentlyClosed test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -322,9 +322,12 @@ class HistoryTests: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
         mozWaitForElementToExist(app.cells.staticTexts[webpage["label"]!])
-        closeFirstTabByX()
+        app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.tap()
 
         // On private mode, the "Recently Closed Tabs List" is empty
+        // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/19672
+        navigator.nowAt(BrowserTab)
+        navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.goto(HomePanelsScreen)
         closeKeyboard()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-2584

## :bulb: Description
There is this old bug caused by tab tray refactoring, that was fixed, but it seems testPrivateClosedSiteDoesNotAppearOnRecentlyClosed is failing due to it. Opened a new ticket and added an workaround for the automation test.
https://github.com/mozilla-mobile/firefox-ios/issues/19672
