### PR TITLE
Refactor FXIOS-8908 - Hide Show in Private for 125 Experiment

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -263,6 +263,7 @@ class SearchViewController: SiteTableViewController,
     /// Determines if a suggestion should be shown based on the view model's privacy mode and
     /// the specific suggestion's status.
     private func shouldShowFirefoxSuggestions(_ suggestion: Bool) -> Bool {
+        model.shouldShowPrivateModeFirefoxSuggestions = true
         return viewModel.isPrivate ?
         (suggestion && model.shouldShowPrivateModeFirefoxSuggestions) :
         suggestion

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -58,7 +58,9 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         case syncedTabs
         case nonSponsored
         case sponsored
-        case privateSuggestions
+        // Disable temporary `privateSuggestions` option for Enhanced Firefox Suggest Experiment v125.
+        // https://mozilla-hub.atlassian.net/browse/FXIOS-8908
+//        case privateSuggestions
         case suggestionLearnMore
     }
 
@@ -287,20 +289,20 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                     selector: #selector(didToggleEnableSponsoredSuggestions)
                 )
 
-            case FirefoxSuggestItem.privateSuggestions.rawValue:
-                buildSettingWith(
-                    prefKey: PrefsKeys.SearchSettings.showPrivateModeFirefoxSuggestions,
-                    defaultValue: model.shouldShowPrivateModeFirefoxSuggestions,
-                    titleText: String.localizedStringWithFormat(
-                        .Settings.Search.PrivateSessionSetting
-                    ),
-                    statusText: String.localizedStringWithFormat(
-                        .Settings.Search.Suggest.PrivateSessionDescription
-                    ),
-                    cell: cell,
-                    selector: #selector(didToggleShowFirefoxSuggestionsInPrivateMode)
-                )
-                cell.isHidden = shouldHidePrivateModeFirefoxSuggestSetting
+//            case FirefoxSuggestItem.privateSuggestions.rawValue:
+//                buildSettingWith(
+//                    prefKey: PrefsKeys.SearchSettings.showPrivateModeFirefoxSuggestions,
+//                    defaultValue: model.shouldShowPrivateModeFirefoxSuggestions,
+//                    titleText: String.localizedStringWithFormat(
+//                        .Settings.Search.PrivateSessionSetting
+//                    ),
+//                    statusText: String.localizedStringWithFormat(
+//                        .Settings.Search.Suggest.PrivateSessionDescription
+//                    ),
+//                    cell: cell,
+//                    selector: #selector(didToggleShowFirefoxSuggestionsInPrivateMode)
+//                )
+//                cell.isHidden = shouldHidePrivateModeFirefoxSuggestSetting
 
             case FirefoxSuggestItem.suggestionLearnMore.rawValue:
                 cell.accessibilityLabel = String.localizedStringWithFormat(
@@ -418,16 +420,16 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return false
     }
 
-    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        switch indexPath {
-        case IndexPath(
-                row: FirefoxSuggestItem.privateSuggestions.rawValue,
-                section: Section.firefoxSuggestSettings.rawValue):
-            if shouldHidePrivateModeFirefoxSuggestSetting { return 0 }
-        default: return UITableView.automaticDimension
-        }
-        return UITableView.automaticDimension
-    }
+//    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+//        switch indexPath {
+//        case IndexPath(
+//                row: FirefoxSuggestItem.privateSuggestions.rawValue,
+//                section: Section.firefoxSuggestSettings.rawValue):
+//            if shouldHidePrivateModeFirefoxSuggestSetting { return 0 }
+//        default: return UITableView.automaticDimension
+//        }
+//        return UITableView.automaticDimension
+//    }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return UITableView.automaticDimension
@@ -559,42 +561,42 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         _ toggle: ThemedSwitch,
         suggestionType: FirefoxSuggestItem
     ) {
-        var shouldShowPrivateSuggestionsSetting = false
+//        var shouldShowPrivateSuggestionsSetting = false
         switch suggestionType {
         case .browsingHistory:
             model.shouldShowBrowsingHistorySuggestions = toggle.isOn
-            shouldShowPrivateSuggestionsSetting = model.shouldShowBrowsingHistorySuggestions &&
-            !model.shouldShowBookmarksSuggestions &&
-            !model.shouldShowSyncedTabsSuggestions
+//            shouldShowPrivateSuggestionsSetting = model.shouldShowBrowsingHistorySuggestions &&
+//            !model.shouldShowBookmarksSuggestions &&
+//            !model.shouldShowSyncedTabsSuggestions
         case .bookmarks:
             model.shouldShowBookmarksSuggestions = toggle.isOn
-            shouldShowPrivateSuggestionsSetting = model.shouldShowBookmarksSuggestions &&
-            !model.shouldShowBrowsingHistorySuggestions &&
-            !model.shouldShowSyncedTabsSuggestions
+//            shouldShowPrivateSuggestionsSetting = model.shouldShowBookmarksSuggestions &&
+//            !model.shouldShowBrowsingHistorySuggestions &&
+//            !model.shouldShowSyncedTabsSuggestions
         case .syncedTabs:
             model.shouldShowSyncedTabsSuggestions = toggle.isOn
-            shouldShowPrivateSuggestionsSetting = model.shouldShowSyncedTabsSuggestions &&
-            !model.shouldShowBrowsingHistorySuggestions &&
-            !model.shouldShowBookmarksSuggestions
+//            shouldShowPrivateSuggestionsSetting = model.shouldShowSyncedTabsSuggestions &&
+//            !model.shouldShowBrowsingHistorySuggestions &&
+//            !model.shouldShowBookmarksSuggestions
         default: break
         }
 
-        if shouldShowPrivateSuggestionsSetting {
-            updateCells(
-                at: [IndexPath(
-                    row: FirefoxSuggestItem.privateSuggestions.rawValue,
-                    section: Section.firefoxSuggestSettings.rawValue
-                )]
-            )
-        } else if shouldHidePrivateModeFirefoxSuggestSetting {
-            model.shouldShowPrivateModeFirefoxSuggestions = false
-            updateCells(
-                at: [IndexPath(
-                    row: FirefoxSuggestItem.privateSuggestions.rawValue,
-                    section: Section.firefoxSuggestSettings.rawValue
-                )]
-            )
-        }
+//        if shouldShowPrivateSuggestionsSetting {
+//            updateCells(
+//                at: [IndexPath(
+//                    row: FirefoxSuggestItem.privateSuggestions.rawValue,
+//                    section: Section.firefoxSuggestSettings.rawValue
+//                )]
+//            )
+//        } else if shouldHidePrivateModeFirefoxSuggestSetting {
+//            model.shouldShowPrivateModeFirefoxSuggestions = false
+//            updateCells(
+//                at: [IndexPath(
+//                    row: FirefoxSuggestItem.privateSuggestions.rawValue,
+//                    section: Section.firefoxSuggestSettings.rawValue
+//                )]
+//            )
+//        }
     }
 
     private func updateCells(at indexPaths: [IndexPath]) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8908)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19667)
- This PR hides the `Show in Private Sessions` settings option by commenting some code.
- The change is done for the v125 Firefox Suggest experiment.
- Now, each suggestion will be available, if enabled in both modes simultaneously.
Example: 
- Before: For the `Show in Private Sessions` option to be available in `Private Browsing`, the `Search Browsing History`, `Search Bookmarks` and `Search Synced Tabs` should have been enabled in `Normal Browsing`.
- With the modifications in this PR: When an option is enabled, such as `Search Browsing History`, it will show the suggestions in both modes, `Normal && Private`.
- The `sponsored` and `non-sponsored` suggestions will remain unchanged, meaning will only be available in `Normal Browsing`.
## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

