### PR TITLE
Bugfix FXIOS-6363 ⁃ Toast message is not displayed when user closes a tab from tab tray's context menu

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -276,6 +276,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             if let tab = self.tabManager.selectedTab {
                 self.tabManager.removeTab(tab)
                 self.updateTabCountUsingTabManager(self.tabManager)
+                self.showToast(message: .TabsTray.CloseTabsToast.SingleTabTitle, toastAction: .closeTab)
             }
         }.items
 
@@ -339,6 +340,16 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
                     url: bookmarkURL?.absoluteString ?? currentTab.url?.absoluteString ?? "",
                     title: title ?? currentTab.title
                 ) : nil
+            }
+            show(toast: toast)
+        case .closeTab:
+            let viewModel = ButtonToastViewModel(labelText: message,
+                                                 buttonText: .UndoString,
+                                                 textAlignment: .left)
+            let toast = ButtonToast(viewModel: viewModel,
+                                    theme: currentTheme()) { [weak self] isButtonTapped in
+                guard let self, let closedTab = tabManager.backupCloseTab else { return }
+                isButtonTapped ? self.tabManager.undoCloseTab(tab: closedTab.tab, position: closedTab.restorePosition) : nil
             }
             show(toast: toast)
         default:

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -43,6 +43,7 @@ enum MenuButtonToastAction {
     case copyUrl
     case pinPage
     case removePinPage
+    case closeTab
 }
 
 /// MainMenuActionHelper handles the main menu (hamburger menu) in the toolbar.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6363)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14293)

## :bulb: Description
Added toast message for the close tab action from tab tray's context menu

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

