### PR TITLE
Refactor FXIOS-8910 - Enable Login Autofill by default on v125

### DIFF
--- a/firefox-ios/nimbus-features/autofillFeature.yaml
+++ b/firefox-ios/nimbus-features/autofillFeature.yaml
@@ -21,7 +21,7 @@ features:
       login-autofill-status:
         description: If true, allows the user to use the login autofill feature for usernames and passwords.
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: developer
         value: {
@@ -29,6 +29,6 @@ features:
         }
       - channel: beta
         value: {
-            "login-autofill-status": false
+            "login-autofill-status": true
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket - 8910](https://mozilla-hub.atlassian.net/browse/FXIOS-8910)
[Github issue - 19679](https://github.com/mozilla-mobile/firefox-ios/issues/19679)

## :bulb: Description
Changed the flag for enabling login autofill by default for future versions 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

