### PR TITLE
Bugfix FXIOS-8916 [Onboarding Customization] Add endOnboarding action for clear flow

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
@@ -334,6 +334,8 @@ extension IntroViewController: OnboardingCardDelegate {
                 windowUUID: windowUUID,
                 from: cardName,
                 selector: #selector(dismissPrivacyPolicyViewController))
+        case .endOndboarding:
+            closeOnboarding()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Onboarding/Views/UpdateViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/UpdateViewController.swift
@@ -258,7 +258,8 @@ extension UpdateViewController: OnboardingCardDelegate {
                 windowUUID: windowUUID,
                 from: cardName,
                 completionIfLastCard: { self.closeUpdate() })
-
+        case .endOndboarding:
+            closeUpdate()
         default:
             break
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Mocks/MockOnboardingCardDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Mocks/MockOnboardingCardDelegate.swift
@@ -57,6 +57,8 @@ class MockOnboardinCardDelegateController: UIViewController,
             presentPrivacyPolicy(from: cardName,
                                  selector: nil,
                                  completion: {})
+        case .endOndboarding:
+            self.action = .endOndboarding
         }
     }
 

--- a/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
@@ -389,6 +389,9 @@ enums:
       read-privacy-policy:
         description: >
           Will open a webview where the user can read the privacy policy
+      end-ondboarding:
+        description: >
+          Will end the onboarding on a set card
   OnboardingInstructionsPopupActions:
     description: >
       The identifiers for the different actions available for the


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8916)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19703)

## :bulb: Description
Added a new action to allow PM to end onboarding from primary buttons.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

