### PR TITLE
Bugfix FXIOS-6521 ⁃ Toolbar option is missing from settings when running automated tests

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewModel.swift
@@ -36,7 +36,7 @@ extension SearchBarLocationProvider {
         let isiPad = UIDevice.current.userInterfaceIdiom == .pad
         let isFeatureEnabled = featureFlags.isFeatureEnabled(.bottomSearchBar, checking: .buildOnly)
 
-        return isFeatureEnabled && !isiPad && !AppConstants.isRunningUITests
+        return isFeatureEnabled && !isiPad
     }
 
     var searchBarPosition: SearchBarPosition {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6521)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14625)

## :bulb: Description
Removing **!AppConstants.isRunningUITests** condition in order to enable Toolbar settings option for UITests

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

