### PR TITLE
Bugfix FXIOS-8758 Fix screenshots on old tab tray

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -39,6 +39,7 @@ extension BrowserViewController: URLBarDelegate {
             let selectedSegment: TabTrayPanelType = focusedSegment ?? (isPrivateTab ? .privateTabs : .tabs)
             navigationHandler?.showTabTray(selectedPanel: selectedSegment)
         } else {
+            willNavigateAway()
             showLegacyTabTrayViewController(withFocusOnUnselectedTab: tabToFocus,
                                             focusedSegment: focusedSegment)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8758)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19427)

## :bulb: Description
Screenshots weren't being fired on the legacy tab tray

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

