### PR TITLE
Bugfix FXIOS-8932 - The Firefox Suggest results disappear if the device orientation is changed

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -621,9 +621,10 @@ class SearchViewController: SiteTableViewController,
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         // The height of the suggestions row may change, so call reloadData() to recalculate cell heights.
-        coordinator.animate(alongsideTransition: { _ in
-            self.tableView.reloadData()
-            self.layoutSearchEngineScrollViewContent()
+        coordinator.animate(alongsideTransition: { [self] _ in
+            totalRowCount = 0
+            tableView.reloadData()
+            layoutSearchEngineScrollViewContent()
         }, completion: nil)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8932)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19730)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Resets totalRowCount when changing device orientation.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

