### PR TITLE
Refactor FXIOS-8936 Sample Component Library to incorporate UUID-based themes

### DIFF
--- a/SampleComponentLibraryApp/SampleComponentLibraryApp.xcodeproj/project.pbxproj
+++ b/SampleComponentLibraryApp/SampleComponentLibraryApp.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		8ABC3CED2A6EED7C00B69244 /* BottomSheetComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABC3CEC2A6EED7C00B69244 /* BottomSheetComponentViewModel.swift */; };
 		8ABE7C5C2AB36E1900C2172C /* ButtonsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABE7C5B2AB36E1900C2172C /* ButtonsViewController.swift */; };
 		8ABE7C5E2AB36E2600C2172C /* ButtonComponentsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABE7C5D2AB36E2600C2172C /* ButtonComponentsViewModel.swift */; };
+		8AFDD9CC2BC6F1E200DF12FA /* Theme+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFDD9CB2BC6F1E200DF12FA /* Theme+Extensions.swift */; };
 		E19891C82A790AB700CD256D /* CollapsibleCardViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19891C62A790AB700CD256D /* CollapsibleCardViewViewController.swift */; };
 		E19891C92A790AB700CD256D /* CollapsibleCardViewComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19891C72A790AB700CD256D /* CollapsibleCardViewComponentViewModel.swift */; };
 		E1E0E8712A850479003D847E /* ShadowCardViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E0E86F2A850479003D847E /* ShadowCardViewViewController.swift */; };
@@ -62,6 +63,7 @@
 		8ABC3CEC2A6EED7C00B69244 /* BottomSheetComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetComponentViewModel.swift; sourceTree = "<group>"; };
 		8ABE7C5B2AB36E1900C2172C /* ButtonsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonsViewController.swift; sourceTree = "<group>"; };
 		8ABE7C5D2AB36E2600C2172C /* ButtonComponentsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentsViewModel.swift; sourceTree = "<group>"; };
+		8AFDD9CB2BC6F1E200DF12FA /* Theme+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+Extensions.swift"; sourceTree = "<group>"; };
 		E19891C62A790AB700CD256D /* CollapsibleCardViewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollapsibleCardViewViewController.swift; sourceTree = "<group>"; };
 		E19891C72A790AB700CD256D /* CollapsibleCardViewComponentViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollapsibleCardViewComponentViewModel.swift; sourceTree = "<group>"; };
 		E1E0E86F2A850479003D847E /* ShadowCardViewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShadowCardViewViewController.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				E1E0E86E2A850479003D847E /* ShadowCardView */,
 				8A2FE6512A55EE3D0036B6AF /* AppDelegate.swift */,
 				8A2FE6532A55EE3D0036B6AF /* SceneDelegate.swift */,
+				8AFDD9CB2BC6F1E200DF12FA /* Theme+Extensions.swift */,
 				8A2FE6552A55EE3D0036B6AF /* RootViewController.swift */,
 				8A2FE65A2A55EE3F0036B6AF /* Assets.xcassets */,
 				8A2FE65C2A55EE3F0036B6AF /* LaunchScreen.storyboard */,
@@ -352,6 +355,7 @@
 				8A6EE09B2A57317200B4D401 /* ComponentCell.swift in Sources */,
 				8ABC3CED2A6EED7C00B69244 /* BottomSheetComponentViewModel.swift in Sources */,
 				E19891C92A790AB700CD256D /* CollapsibleCardViewComponentViewModel.swift in Sources */,
+				8AFDD9CC2BC6F1E200DF12FA /* Theme+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SampleComponentLibraryApp/SampleComponentLibraryApp/SceneDelegate.swift
+++ b/SampleComponentLibraryApp/SampleComponentLibraryApp/SceneDelegate.swift
@@ -16,13 +16,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let rootViewController = RootViewController()
         let navigationController = UINavigationController(rootViewController: rootViewController)
 
-        window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = navigationController
-        window?.makeKeyAndVisible()
+        let newWindow = UIWindow(windowScene: windowScene)
+        window = newWindow
+        newWindow.rootViewController = navigationController
+        newWindow.makeKeyAndVisible()
 
-        guard let window else { return }
         let themeManager: ThemeManager = AppContainer.shared.resolve()
-        themeManager.setWindow(window, for: defaultSampleComponentUUID)
+        themeManager.setWindow(newWindow, for: defaultSampleComponentUUID)
         themeManager.setSystemTheme(isOn: true)
     }
 }

--- a/SampleComponentLibraryApp/SampleComponentLibraryApp/SceneDelegate.swift
+++ b/SampleComponentLibraryApp/SampleComponentLibraryApp/SceneDelegate.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
+import Common
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
@@ -18,5 +19,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
+
+        guard let window else { return }
+        let themeManager: ThemeManager = AppContainer.shared.resolve()
+        themeManager.setWindow(window, for: defaultSampleComponentUUID)
+        themeManager.setSystemTheme(isOn: true)
     }
 }

--- a/SampleComponentLibraryApp/SampleComponentLibraryApp/Theme+Extensions.swift
+++ b/SampleComponentLibraryApp/SampleComponentLibraryApp/Theme+Extensions.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+let defaultSampleComponentUUID = UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!
+
+extension ThemeManager {
+    var currentTheme: Theme {
+        return currentTheme(for: defaultSampleComponentUUID)
+    }
+}
+
+extension Themeable {
+    public var currentWindowUUID: UUID? {
+        defaultSampleComponentUUID
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9836)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19738)

## :bulb: Description
Address build errors in the Sample Component Library due to updates in our theming being based on window UUID. Since this is a sample project and no plans now to support multiwindows, created an extension to minimize this build warnings.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

