### PR TITLE
Refactor FXIOS-7791 [Multi-window] App notifications

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -225,6 +225,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         self.windows[window]?.overrideUserInterfaceStyle = style
 
         mainQueue.ensureMainThread { [weak self] in
+            // TODO: [FXIOS-8939] Send UUID in userInfo payload rather than object for consistency with Client.
             self?.notificationCenter.post(name: .ThemeDidChange, withObject: window)
         }
     }

--- a/BrowserKit/Sources/Common/Utilities/Notifiable.swift
+++ b/BrowserKit/Sources/Common/Utilities/Notifiable.swift
@@ -25,7 +25,7 @@ extension NotificationProtocol {
 
 extension NotificationCenter: NotificationProtocol {
     public func post(name: NSNotification.Name, withObject object: Any?, withUserInfo info: Any?) {
-        let payload = (info as? [AnyHashable: Any]) ?? nil
+        let payload = (info as? [AnyHashable: Any])
         self.post(name: name, object: object, userInfo: payload)
     }
 

--- a/BrowserKit/Sources/Common/Utilities/Notifiable.swift
+++ b/BrowserKit/Sources/Common/Utilities/Notifiable.swift
@@ -6,7 +6,7 @@ import Foundation
 
 @objc
 public protocol NotificationProtocol {
-    func post(name: NSNotification.Name, withObject object: Any?)
+    func post(name: NSNotification.Name, withObject object: Any?, withUserInfo info: Any?)
     func addObserver(_ observer: Any,
                      selector aSelector: Selector,
                      name aName: NSNotification.Name?,
@@ -18,14 +18,15 @@ public protocol NotificationProtocol {
 }
 
 extension NotificationProtocol {
-    public func post(name: NSNotification.Name, withObject object: Any? = nil) {
-        self.post(name: name, withObject: object)
+    public func post(name: NSNotification.Name, withObject object: Any? = nil, withUserInfo info: Any? = nil) {
+        self.post(name: name, withObject: object, withUserInfo: info)
     }
 }
 
 extension NotificationCenter: NotificationProtocol {
-    public func post(name: NSNotification.Name, withObject object: Any?) {
-        self.post(name: name, object: object)
+    public func post(name: NSNotification.Name, withObject object: Any?, withUserInfo info: Any?) {
+        let payload = (info as? [AnyHashable: Any]) ?? nil
+        self.post(name: name, object: object, userInfo: payload)
     }
 
     public func addObserver(name: NSNotification.Name?,

--- a/firefox-ios/Client/Extensions/WindowUUID+Extension.swift
+++ b/firefox-ios/Client/Extensions/WindowUUID+Extension.swift
@@ -27,3 +27,24 @@ public extension WindowUUID {
     /// Default window UUID for UI testing.
     static let DefaultUITestingUUID = WindowUUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!
 }
+
+public extension WindowUUID {
+    /// Key for setting (or obtaining) the windowUUID from notification userInfo payloads
+    static let userInfoKey = "windowUUID"
+    
+    /// Convenience. Returns a Notification user info payload containing the receiving UUID.
+    var userInfo: [AnyHashable: Any] {
+        return [WindowUUID.userInfoKey: self]
+    }
+}
+
+public extension Notification {
+    /// Convenience for obtaining the windowUUID for a posted notification
+    var windowUUID: WindowUUID? {
+        guard let info = userInfo,
+        let uuid = info[WindowUUID.userInfoKey] as? WindowUUID
+        else { return nil }
+
+        return uuid
+    }
+}

--- a/firefox-ios/Client/Extensions/WindowUUID+Extension.swift
+++ b/firefox-ios/Client/Extensions/WindowUUID+Extension.swift
@@ -31,7 +31,7 @@ public extension WindowUUID {
 public extension WindowUUID {
     /// Key for setting (or obtaining) the windowUUID from notification userInfo payloads
     static let userInfoKey = "windowUUID"
-    
+
     /// Convenience. Returns a Notification user info payload containing the receiving UUID.
     var userInfo: [AnyHashable: Any] {
         return [WindowUUID.userInfoKey: self]

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -671,7 +671,7 @@ extension BrowserViewController: WKNavigationDelegate {
         let responseURL = response.url
 
         tabManager[webView]?.mimeType = response.mimeType
-        notificationCenter.post(name: .TabMimeTypeDidSet)
+        notificationCenter.post(name: .TabMimeTypeDidSet, withUserInfo: windowUUID.userInfo)
 
         var request: URLRequest?
         if let url = responseURL {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -290,7 +290,7 @@ class BrowserViewController: UIViewController,
     /// open tab, and because of that we need to leave overlay state
     @objc
     func didTapUndoCloseAllTabToast(notification: Notification) {
-        guard windowUUID == notification.userInfo else { return }
+        guard windowUUID == notification.windowUUID else { return }
         overlayManager.switchTab(shouldCancelLoading: true)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -290,6 +290,7 @@ class BrowserViewController: UIViewController,
     /// open tab, and because of that we need to leave overlay state
     @objc
     func didTapUndoCloseAllTabToast(notification: Notification) {
+        guard windowUUID == notification.userInfo else { return }
         overlayManager.switchTab(shouldCancelLoading: true)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -318,7 +318,9 @@ class LegacyTabDisplayManager: NSObject, FeatureFlaggable {
         refreshStore(evenIfHidden: false, shouldAnimate: true)
 
         let notificationObject = [Tab.privateModeKey: isPrivate]
-        NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: notificationObject)
+        NotificationCenter.default.post(name: .TabsPrivacyModeChanged,
+                                        object: notificationObject,
+                                        userInfo: tabManager.windowUUID.userInfo)
     }
 
     /// Find the previously selected cell, which is still displayed as selected
@@ -1070,6 +1072,7 @@ extension LegacyTabDisplayManager: Notifiable {
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
         case .DidTapUndoCloseAllTabToast:
+            guard tabManager.windowUUID == notification.windowUUID else { return }
             refreshStore()
             collectionView.reloadData()
         default:

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -287,7 +287,9 @@ class LegacyGridTabViewController: UIViewController,
         // Ensure Firefox home page is refreshed if privacy mode was changed
         if tabManager.selectedTab?.isPrivate != isPrivate {
             let notificationObject = [Tab.privateModeKey: isPrivate]
-            NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: notificationObject)
+            NotificationCenter.default.post(name: .TabsPrivacyModeChanged,
+                                            object: notificationObject,
+                                            userInfo: windowUUID.userInfo)
         }
         if isPrivate {
             TelemetryWrapper.recordEvent(category: .action,
@@ -377,7 +379,7 @@ class LegacyGridTabViewController: UIViewController,
                   let tab = tabManager.normalTabs.first {
             tabManager.selectTab(tab)
             dismissTabTray()
-            notificationCenter.post(name: .TabsTrayDidClose)
+            notificationCenter.post(name: .TabsTrayDidClose, withUserInfo: windowUUID.userInfo)
         }
     }
 
@@ -413,7 +415,9 @@ class LegacyGridTabViewController: UIViewController,
                   let closedTab = self.tabManager.backupCloseTab else { return }
 
             self.tabDisplayManager.undoCloseTab(tab: closedTab.tab, index: closedTab.restorePosition)
-            NotificationCenter.default.post(name: .UpdateLabelOnTabClosed, object: nil)
+            NotificationCenter.default.post(name: .UpdateLabelOnTabClosed,
+                                            object: nil,
+                                            userInfo: windowUUID.userInfo)
 
             if self.tabDisplayManager.isPrivate {
                 self.emptyPrivateTabsView.isHidden = !self.privateTabsAreEmpty
@@ -516,7 +520,7 @@ extension LegacyGridTabViewController: TabSelectionDelegate {
     func didSelectTabAtIndex(_ index: Int) {
         if let tab = tabDisplayManager.dataStore.at(index) {
             if tab.isFxHomeTab {
-                notificationCenter.post(name: .TabsTrayDidSelectHomeTab)
+                notificationCenter.post(name: .TabsTrayDidSelectHomeTab, withUserInfo: windowUUID.userInfo)
             }
             tabManager.selectTab(tab)
             dismissTabTray()
@@ -662,7 +666,7 @@ extension LegacyGridTabViewController: TabDisplayCompletionDelegate, RecentlyClo
         case .removedLastTab:
             // when removing the last tab (only in normal mode) we will automatically open a new tab.
             // When that happens focus it by dismissing the tab tray
-            notificationCenter.post(name: .TabsTrayDidClose)
+            notificationCenter.post(name: .TabsTrayDidClose, withUserInfo: windowUUID.userInfo)
             if !tabDisplayManager.isPrivate {
                 self.dismissTabTray()
             }
@@ -681,7 +685,7 @@ extension LegacyGridTabViewController {
         case .deleteTab:
             didTapToolbarDelete(sender)
         }
-        notificationCenter.post(name: .TabDataUpdated)
+        notificationCenter.post(name: .TabDataUpdated, withUserInfo: windowUUID.userInfo)
     }
 
     func didTapToolbarAddTab() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
@@ -524,7 +524,9 @@ extension LegacyTabTrayViewController: Notifiable {
             case .ProfileDidStartSyncing, .ProfileDidFinishSyncing:
                 self?.updateButtonTitle(notification)
             case .UpdateLabelOnTabClosed:
-                guard let label = self?.countLabel else { return }
+                guard let label = self?.countLabel,
+                      notification.windowUUID == self?.windowUUID
+                else { return }
                 self?.countLabel.text = self?.viewModel.normalTabsCount
                 self?.segmentedControlIphone.setImage(
                     UIImage(named: ImageIdentifiers.navTabCounter)!.overlayWith(image: label),
@@ -556,7 +558,7 @@ extension LegacyTabTrayViewController: UIAdaptivePresentationControllerDelegate,
     }
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        notificationCenter.post(name: .TabsTrayDidClose)
+        notificationCenter.post(name: .TabsTrayDidClose, withUserInfo: windowUUID.userInfo)
         TelemetryWrapper.recordEvent(category: .action, method: .close, object: .tabTray)
     }
 }
@@ -565,7 +567,7 @@ extension LegacyTabTrayViewController: UIAdaptivePresentationControllerDelegate,
 extension LegacyTabTrayViewController {
     @objc
     func didTapAddTab(_ sender: UIBarButtonItem) {
-        notificationCenter.post(name: .TabsTrayDidClose)
+        notificationCenter.post(name: .TabsTrayDidClose, withUserInfo: windowUUID.userInfo)
         viewModel.didTapAddTab(sender)
         self.dismiss(animated: true) {
             self.viewModel.didDismiss()
@@ -584,7 +586,7 @@ extension LegacyTabTrayViewController {
 
     @objc
     func didTapDone() {
-        notificationCenter.post(name: .TabsTrayDidClose)
+        notificationCenter.post(name: .TabsTrayDidClose, withUserInfo: windowUUID.userInfo)
         // Update Private mode when closing TabTray, if the mode toggle but
         // no tab is pressed with return to previous state
         updatePrivateUIState()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -492,7 +492,7 @@ class TabTrayViewController: UIViewController,
 
     @objc
     private func doneButtonTapped() {
-        notificationCenter.post(name: .TabsTrayDidClose)
+        notificationCenter.post(name: .TabsTrayDidClose, withUserInfo: windowUUID.userInfo)
         // TODO: FXIOS-6928 Update mode when closing tabTray
         delegate?.didFinish()
     }

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -306,6 +306,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
         case .TabsTrayDidClose:
+            guard windowUUID == notification.windowUUID else { return }
             refreshTabs()
         default:
             break
@@ -337,7 +338,7 @@ extension TopTabsViewController: TabDisplayerDelegate {
 extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(_ cell: UICollectionViewCell) {
         topTabDisplayManager.closeActionPerformed(forCell: cell)
-        NotificationCenter.default.post(name: .TopTabsTabClosed, object: nil)
+        NotificationCenter.default.post(name: .TopTabsTabClosed, object: nil, userInfo: windowUUID.userInfo)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -150,7 +150,7 @@ class HomepageViewController:
         super.viewWillAppear(animated)
         viewModel.recordViewAppeared()
 
-        notificationCenter.post(name: .ShowHomepage)
+        notificationCenter.post(name: .ShowHomepage, withUserInfo: windowUUID.userInfo)
         notificationCenter.post(name: .HistoryUpdated)
 
         applyTheme()
@@ -849,6 +849,7 @@ extension HomepageViewController: Notifiable {
 
             switch notification.name {
             case .TabsPrivacyModeChanged:
+                guard windowUUID == notification.windowUUID else { return }
                 self.adjustPrivacySensitiveSections(notification: notification)
 
             case .HomePanelPrefsChanged,

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -204,6 +204,9 @@ actor JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
                     .TabsTrayDidClose,
                     .TabsTrayDidSelectHomeTab,
                     .TopTabsTabClosed:
+                guard let uuid = notification.windowUUID,
+                      uuid == tabManager.windowUUID
+                else { return }
                 await updateTabsData()
             case .ProfileDidFinishSyncing,
                     .FirefoxAccountChanged:

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -325,7 +325,6 @@ class HistoryPanel: UIViewController,
     }
 
     func handleNotifications(_ notification: Notification) {
-        // TODO: [FXIOS-7953, 7791] Needs updates for multi-window support.
         switch notification.name {
         case .FirefoxAccountChanged, .PrivateDataClearedHistory:
             viewModel.removeAllData()

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -541,7 +541,9 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         selectTab(nextSelectedTab)
 
         let notificationObject = [Tab.privateModeKey: nextSelectedTab?.isPrivate ?? true]
-        NotificationCenter.default.post(name: .TabsPrivacyModeChanged, object: notificationObject)
+        NotificationCenter.default.post(name: .TabsPrivacyModeChanged,
+                                        object: notificationObject,
+                                        userInfo: windowUUID.userInfo)
         return result
     }
 
@@ -775,7 +777,9 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
             previousTabUUID: previousTabUUID,
             isPrivate: isPrivate
         )
-        NotificationCenter.default.post(name: .DidTapUndoCloseAllTabToast, object: nil)
+        NotificationCenter.default.post(name: .DidTapUndoCloseAllTabToast,
+                                        object: nil,
+                                        userInfo: windowUUID.userInfo)
     }
 
     func tabDidSetScreenshot(_ tab: Tab, hasHomeScreenshot: Bool) {}

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -106,8 +106,11 @@ extension TabManager {
     }
 
     func removeTab(_ tab: Tab) {
+        let uuid = windowUUID
         removeTab(tab) {
-            NotificationCenter.default.post(name: .UpdateLabelOnTabClosed, object: nil)
+            NotificationCenter.default.post(name: .UpdateLabelOnTabClosed,
+                                            object: nil,
+                                            userInfo: uuid.userInfo)
         }
     }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -528,6 +528,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
         case UIApplication.willResignActiveNotification:
             saveAllTabData()
         case .TabMimeTypeDidSet:
+            guard windowUUID == notification.windowUUID else { return }
             updateMenuItemsForSelectedTab()
         default:
             break

--- a/firefox-ios/Shared/NotificationConstants.swift
+++ b/firefox-ios/Shared/NotificationConstants.swift
@@ -12,9 +12,7 @@ extension Notification.Name {
 
     public static let FirefoxAccountProfileChanged = Notification.Name("FirefoxAccountProfileChanged")
 
-    // swiftlint:disable line_length
     public static let FirefoxAccountDeviceRegistrationUpdated = Notification.Name("FirefoxAccountDeviceRegistrationUpdated")
-    // swiftlint:enable line_length
 
     public static let PrivateDataClearedHistory = Notification.Name("PrivateDataClearedHistory")
     public static let PrivateDataClearedDownloadedFiles = Notification.Name("PrivateDataClearedDownloadedFiles")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNotificationCenter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNotificationCenter.swift
@@ -13,6 +13,7 @@ class MockNotificationCenter: NotificationProtocol {
 
     var savePostName: NSNotification.Name?
     var savePostObject: Any?
+    var saveUserInfo: Any?
 
     weak var notifiableListener: Notifiable?
 
@@ -22,9 +23,10 @@ class MockNotificationCenter: NotificationProtocol {
         notifiableListener?.handleNotifications(Notification(name: name))
     }
 
-    func post(name aName: NSNotification.Name, withObject anObject: Any?) {
+    func post(name aName: NSNotification.Name, withObject anObject: Any?, withUserInfo info: Any?) {
         savePostName = aName
         savePostObject = anObject
+        saveUserInfo = info
         postCallCount += 1
         notifiableListener?.handleNotifications(Notification(name: aName))
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7791)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17382)

## :bulb: Description

This PR updates some of our notifications to include the window UUID in the `userInfo` payload, and updates related observers to check against that UUID. Many of our notifications should still be handled "app-wide" (by all open windows), but some are window-specific and need to include a UUID check to ensure we're not incorrectly performing work on the wrong window.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

