### PR TITLE
Refactor FXIOS-8899 - JumpBackInCell with FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/JumpBackInCell.swift
@@ -25,8 +25,6 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
         static let interGroupSpacing: CGFloat = 8
         static let generalCornerRadius: CGFloat = 12
         static let cellSpacing: CGFloat = 16
-        static let titleFontSize: CGFloat = 15
-        static let siteFontSize: CGFloat = 12
         static let heroImageSize =  CGSize(width: 108, height: 80)
         static let fallbackFaviconSize = CGSize(width: 36, height: 36)
         static let websiteIconSize = CGSize(width: 24, height: 24)
@@ -62,8 +60,7 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
 
     private let itemTitle: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline,
-                                                            size: UX.titleFontSize)
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
         label.numberOfLines = 2
     }
 
@@ -75,8 +72,7 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
     private var websiteLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 2
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .caption1,
-                                                                size: UX.siteFontSize)
+        label.font = FXFontStyles.Bold.caption1.scaledFont()
         label.textColor = .label
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8899)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19644)

## :bulb: Description
Update JumpBackInCell with FXFontStyles instead of DefaultDynamicFontHelper

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)



![CleanShot 2024-04-11 at 14 21 33@2x](https://github.com/mozilla-mobile/firefox-ios/assets/10091984/d64fb0e0-e71b-48d3-bc44-fb30c7265253)

