### PR TITLE
Bugfix FXIOS-8931 ⁃ Missing accessibility identifiers for settings elements

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -532,8 +532,32 @@ public struct AccessibilityIdentifiers {
             static let title = "SendAnonymousUsageData"
         }
 
+        struct PrivacyPolicy {
+            static let title = "PrivacyPolicy"
+        }
+
         struct ShowIntroduction {
             static let title = "ShowTour"
+        }
+
+        struct SendFeedback {
+            static let title = "SendFeedback"
+        }
+
+        struct Help {
+            static let title = "Help"
+        }
+
+        struct RateOnAppStore {
+            static let title = "RateOnAppStore"
+        }
+
+        struct Licenses {
+            static let title = "Licenses"
+        }
+
+        struct YourRights {
+            static let title = "YourRights"
         }
 
         struct Siri {

--- a/firefox-ios/Client/Frontend/Settings/Main/About/AppStoreReviewSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/About/AppStoreReviewSetting.swift
@@ -11,6 +11,10 @@ class AppStoreReviewSetting: Setting {
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.RateOnAppStore.title
+    }
+
     weak var settingsDelegate: AboutSettingsDelegate?
 
     init(settingsDelegate: AboutSettingsDelegate?) {

--- a/firefox-ios/Client/Frontend/Settings/Main/About/LicenseAndAcknowledgementsSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/About/LicenseAndAcknowledgementsSetting.swift
@@ -16,6 +16,10 @@ class LicenseAndAcknowledgementsSetting: Setting {
         return URL(string: "\(InternalURL.baseUrl)/\(AboutLicenseHandler.path)")
     }
 
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.Licenses.title
+    }
+
     weak var settingsDelegate: AboutSettingsDelegate?
 
     init(settingsDelegate: AboutSettingsDelegate?) {

--- a/firefox-ios/Client/Frontend/Settings/Main/About/YourRightsSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/About/YourRightsSetting.swift
@@ -15,6 +15,10 @@ class YourRightsSetting: Setting {
         return URL(string: "https://www.mozilla.org/about/legal/terms/firefox/")
     }
 
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.YourRights.title
+    }
+
     weak var settingsDelegate: AboutSettingsDelegate?
 
     init(settingsDelegate: AboutSettingsDelegate?) {

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/PrivacyPolicySetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/PrivacyPolicySetting.swift
@@ -13,6 +13,10 @@ class PrivacyPolicySetting: Setting {
         return URL(string: "https://www.mozilla.org/privacy/firefox/")
     }
 
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.PrivacyPolicy.title
+    }
+
     init(theme: Theme,
          settingsDelegate: PrivacySettingsDelegate?) {
         self.settingsDelegate = settingsDelegate

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/OpenSupportPageSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/OpenSupportPageSetting.swift
@@ -10,6 +10,10 @@ import Shared
 class OpenSupportPageSetting: Setting {
     private weak var settingsDelegate: SupportSettingsDelegate?
 
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.Help.title
+    }
+
     init(delegate: SettingsDelegate?,
          theme: Theme,
          settingsDelegate: SupportSettingsDelegate?) {

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SendFeedbackSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SendFeedbackSetting.swift
@@ -17,6 +17,10 @@ class SendFeedbackSetting: Setting {
         return URL(string: "https://connect.mozilla.org/")
     }
 
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.SendFeedback.title
+    }
+
     init(settingsDelegate: SupportSettingsDelegate?) {
         self.settingsDelegate = settingsDelegate
         super.init()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8931)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19729)

## :bulb: Description
Added **accessibilityIdentifiers** for few buttons from the Settings menu:
* Privacy Policy 
* Send Feedback 
* Help 
* Rate on App Store 
* Licenses 
* Your Rights 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

