### PR TITLE
Add FXIOS-7929 [Multi-window] iPad window ordering

### DIFF
--- a/BrowserKit/Sources/TabDataStore/WindowData.swift
+++ b/BrowserKit/Sources/TabDataStore/WindowData.swift
@@ -6,7 +6,6 @@ import Foundation
 
 public struct WindowData: Codable {
     public let id: UUID
-    public let isPrimary: Bool
     public let activeTabId: UUID
     public let tabData: [TabData]
 
@@ -18,11 +17,9 @@ public struct WindowData: Codable {
     ///   - activeTabId: the ID of the currently selected tab
     ///   - tabData: a list of all tabs associated with the window
     public init(id: UUID,
-                isPrimary: Bool = true,
                 activeTabId: UUID,
                 tabData: [TabData]) {
         self.id = id
-        self.isPrimary = isPrimary
         self.activeTabId = activeTabId
         self.tabData = tabData
     }

--- a/BrowserKit/Tests/TabDataStoreTests/TabDataStoreTests.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/TabDataStoreTests.swift
@@ -239,7 +239,6 @@ final class TabDataStoreTests: XCTestCase {
     func createMockWindow(uuid: UUID) -> WindowData {
         let tabs = createMockTabs()
         return WindowData(id: uuid,
-                          isPrimary: true,
                           activeTabId: tabs[0].id,
                           tabData: tabs)
     }

--- a/BrowserKit/Tests/TabDataStoreTests/TabFileManagerTests.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/TabFileManagerTests.swift
@@ -64,7 +64,6 @@ final class TabFileManagerTests: XCTestCase {
     func createMockWindow() -> WindowData {
         let tabs = createMockTabs()
         return WindowData(id: defaultTestTabWindowUUID,
-                          isPrimary: true,
                           activeTabId: tabs[0].id,
                           tabData: tabs)
     }

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -177,9 +177,9 @@ final class WindowManagerImplementation: WindowManager {
     }
 
     // MARK: - Internal Utilities
-    
-    /// When provided an unsorted list of UUIDs of available window data files on
-    /// disk, this function determines which of them should be the next to be
+
+    /// When provided a list of UUIDs of available window data files on disk,
+    /// this function determines which of them should be the next to be
     /// opened. This allows multiple windows to be restored in a sensible way.
     /// - Parameter onDiskUUIDs: on-disk UUIDs representing windows that are not
     /// already open or reserved (this is important - these UUIDs should be pre-
@@ -194,7 +194,7 @@ final class WindowManagerImplementation: WindowManager {
             return (uuid: WindowUUID(), isNew: true)
         }
 
-        guard onDiskUUIDs.isEmpty else {
+        guard !onDiskUUIDs.isEmpty else {
             return (uuid: WindowUUID(), isNew: true)
         }
 

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -56,6 +56,10 @@ struct AppWindowInfo {
 }
 
 final class WindowManagerImplementation: WindowManager {
+    enum WindowPrefKeys {
+        static let windowOrdering = "windowOrdering"
+    }
+
     private(set) var windows: [WindowUUID: AppWindowInfo] = [:]
     private var reservedUUIDs: [WindowUUID] = []
     var activeWindow: WindowUUID {
@@ -64,14 +68,30 @@ final class WindowManagerImplementation: WindowManager {
     }
     private let logger: Logger
     private let tabDataStore: TabDataStore
+    private let defaults: UserDefaultsInterface
     private var _activeWindowUUID: WindowUUID?
+
+    // Ordered set of UUIDs which determines the order that windows are re-opened on iPad
+    private var windowOrderingPriority: [WindowUUID] {
+        get {
+            let stored = defaults.object(forKey: WindowPrefKeys.windowOrdering)
+            guard let prefs: [String] = stored as? [String] else { return [] }
+            return prefs.compactMap({ UUID(uuidString: $0) })
+        }
+        set {
+            let mapped: [String] = newValue.compactMap({ $0.uuidString })
+            defaults.set(mapped, forKey: WindowPrefKeys.windowOrdering)
+        }
+    }
 
     // MARK: - Initializer
 
     init(logger: Logger = DefaultLogger.shared,
-         tabDataStore: TabDataStore = AppContainer.shared.resolve()) {
+         tabDataStore: TabDataStore = AppContainer.shared.resolve(),
+         userDefaults: UserDefaultsInterface = UserDefaults.standard) {
         self.logger = logger
         self.tabDataStore = tabDataStore
+        self.defaults = userDefaults
     }
 
     // MARK: - Public API
@@ -99,26 +119,47 @@ final class WindowManagerImplementation: WindowManager {
 
     func windowWillClose(uuid: WindowUUID) {
         postWindowEvent(event: .windowWillClose, windowUUID: uuid)
+
+        // Closed windows are popped off and moved to the end of the ordering priority
+        var prefs = windowOrderingPriority
+        prefs.removeAll(where: { $0 == uuid })
+        prefs.append(uuid)
+        windowOrderingPriority = prefs
+
         updateWindow(nil, for: uuid)
     }
 
     func reserveNextAvailableWindowUUID() -> WindowUUID {
         // Continue to provide the expected hardcoded UUID for UI tests.
         guard !AppConstants.isRunningUITests else { return WindowUUID.DefaultUITestingUUID }
+        guard !AppConstants.isRunningUnitTest else { return WindowUUID.XCTestDefaultUUID }
 
         // • If no saved windows (tab data), we generate a new UUID.
         // • If user has saved windows (tab data), we return the first available UUID
         //   not already associated with an open window.
         // • If multiple window UUIDs are available, we currently return the first one
-        //   after sorting based on the uuid value.
-        //   TODO: [FXIOS-7929] This ^ is temporary, part of ongoing multi-window work, eventually
-        //   we'll be updating this (to use `isPrimary` on WindowData etc). Forthcoming.
+        //   after sorting based on the order they were last closed (which we track in
+        //   client user defaults).
+        // • If for some reason the user defaults are unavailable we sort open the
+        //   windows by order of their UUID value.
+
+        // Fetch available window data on disk, and remove any already-opened windows
+        // or UUIDs that are already reserved and in the process of opening.
         let openWindowUUIDs = windows.keys
-        let uuids = tabDataStore.fetchWindowDataUUIDs().filter {
+        let filteredUUIDs = tabDataStore.fetchWindowDataUUIDs().filter {
             !openWindowUUIDs.contains($0) && !reservedUUIDs.contains($0)
         }
-        let sortedUUIDs = uuids.sorted(by: { return $0.uuidString > $1.uuidString })
-        let resultUUID = sortedUUIDs.first ?? WindowUUID()
+
+        let result = nextWindowUUIDToOpen(filteredUUIDs)
+        let resultUUID = result.uuid
+        if result.isNew {
+            // Be sure to add any brand-new windows to our ordering preferences
+            var prefs = windowOrderingPriority
+            prefs.append(resultUUID)
+            windowOrderingPriority = prefs
+        }
+
+        // Reserve the UUID until the Client finishes the window configuration process
         reservedUUIDs.append(resultUUID)
         return resultUUID
     }
@@ -136,6 +177,43 @@ final class WindowManagerImplementation: WindowManager {
     }
 
     // MARK: - Internal Utilities
+    
+    /// When provided an unsorted list of UUIDs of available window data files on
+    /// disk, this function determines which of them should be the next to be
+    /// opened. This allows multiple windows to be restored in a sensible way.
+    /// - Parameter onDiskUUIDs: on-disk UUIDs representing windows that are not
+    /// already open or reserved (this is important - these UUIDs should be pre-
+    /// filtered).
+    /// - Returns: the UUID for the next window that will be opened on iPad.
+    private func nextWindowUUIDToOpen(_ onDiskUUIDs: [WindowUUID]) -> (uuid: WindowUUID, isNew: Bool) {
+        func nextUUIDUsingFallbackSorting() -> (uuid: WindowUUID, isNew: Bool) {
+            let sortedUUIDs = onDiskUUIDs.sorted(by: { return $0.uuidString > $1.uuidString })
+            if let resultUUID = sortedUUIDs.first {
+                return (uuid: resultUUID, isNew: false)
+            }
+            return (uuid: WindowUUID(), isNew: true)
+        }
+
+        guard onDiskUUIDs.isEmpty else {
+            return (uuid: WindowUUID(), isNew: true)
+        }
+
+        // Get the ordering preference
+        let priorityPreference = windowOrderingPriority
+        guard !priorityPreference.isEmpty else {
+            // Preferences are empty. Could be initial launch after multi-window release
+            // or preferences have been cleared. Fallback to default sort.
+            return nextUUIDUsingFallbackSorting()
+        }
+
+        // Iterate and return the first UUID that is available within our on-disk UUIDs
+        // (which excludes windows already open or reserved).
+        for uuid in priorityPreference where onDiskUUIDs.contains(uuid) {
+            return (uuid: uuid, isNew: false)
+        }
+
+        return nextUUIDUsingFallbackSorting()
+    }
 
     private func updateWindow(_ info: AppWindowInfo?, for uuid: WindowUUID) {
         windows[uuid] = info

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -132,7 +132,6 @@ final class WindowManagerImplementation: WindowManager {
     func reserveNextAvailableWindowUUID() -> WindowUUID {
         // Continue to provide the expected hardcoded UUID for UI tests.
         guard !AppConstants.isRunningUITests else { return WindowUUID.DefaultUITestingUUID }
-        guard !AppConstants.isRunningUnitTest else { return WindowUUID.XCTestDefaultUUID }
 
         // • If no saved windows (tab data), we generate a new UUID.
         // • If user has saved windows (tab data), we return the first available UUID

--- a/firefox-ios/Client/TabManagement/TabMigrationUtility.swift
+++ b/firefox-ios/Client/TabManagement/TabMigrationUtility.swift
@@ -100,7 +100,6 @@ class DefaultTabMigrationUtility: TabMigrationUtility {
         }
 
         let windowData = WindowData(id: windowUUID,
-                                    isPrimary: true,
                                     activeTabId: selectTabUUID ?? UUID(),
                                     tabData: tabsToMigrate)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7929)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17688)

## :bulb: Description

This PR adds support to the iOS client to allow windows (and their related tabs) to be restored in a sensible order. Previously, if an iPad user had multiple windows open and closed them all, when relaunching the app the first window to be restored would effectively be random from the user's perspective since it was based on the raw UUID value.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

