### PR TITLE
Refactor FXIOS-8900 - Update fonts related to DownloadsPanel, HistoryPanel and ReaderPanel

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -249,9 +249,7 @@ class DownloadsPanel: UIViewController,
         let welcomeLabel: UILabel = .build { label in
             label.text = .TabsTray.DownloadsPanel.EmptyStateTitle
             label.textAlignment = .center
-            label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                                size: 17,
-                                                                weight: .light)
+            label.font = FXFontStyles.Regular.body.scaledFont()
             label.textColor = theme.colors.textSecondary
             label.numberOfLines = 0
             label.adjustsFontSizeToFitWidth = true

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -132,9 +132,7 @@ class HistoryPanel: UIViewController,
     lazy var welcomeLabel: UILabel = .build { label in
         label.text = self.viewModel.emptyStateText
         label.textAlignment = .center
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: 17,
-                                                            weight: .light)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.adjustsFontSizeToFitWidth = true
     }

--- a/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
@@ -70,7 +70,7 @@ class ReadingListTableViewCell: UITableViewCell, ThemeApplicable {
     }
     let hostnameLabel: UILabel = .build { label in
         label.numberOfLines = 1
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 16, weight: .light)
+        label.font = FXFontStyles.Regular.body.scaledFont()
     }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {

--- a/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
@@ -346,7 +346,7 @@ class ReadingListPanel: UITableViewController,
         }
         let readerModeLabel: UILabel = .build { label in
             label.text = .ReaderPanelReadingModeDescription
-            label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 16, weight: .light)
+            label.font = FXFontStyles.Regular.body.scaledFont()
             label.numberOfLines = 0
             label.textColor = self.currentTheme().colors.textSecondary
         }

--- a/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
@@ -340,7 +340,7 @@ class ReadingListPanel: UITableViewController,
         let welcomeLabel: UILabel = .build { label in
             label.text = .ReaderPanelWelcome
             label.textAlignment = .center
-            label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 16, weight: .semibold)
+            label.font = FXFontStyles.Bold.body.scaledFont()
             label.adjustsFontSizeToFitWidth = true
             label.textColor = self.currentTheme().colors.textSecondary
         }

--- a/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
@@ -358,7 +358,7 @@ class ReadingListPanel: UITableViewController,
         }
         let readingListLabel: UILabel = .build { label in
             label.text = .ReaderPanelReadingListDescription
-            label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 16, weight: .light)
+            label.font = FXFontStyles.Regular.body.scaledFont()
             label.numberOfLines = 0
             label.textColor = self.currentTheme().colors.textSecondary
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8900)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19645)

## :bulb: Description
This PR replaces the usage of `DefaultDynamicFontHelper` to `FXFontStyles` on `DownloadsPanel`, `HistoryPanel` and `ReaderPanel` files.

On `ReaderPanel` I found a label using the `LegacyDynamicFontHelper`. I didn't change this label, but I believe a refactor is necessary too. Can I apply the same approach used on this PR? It is better to open a new issue to work from there?

Screenshots below:

| DownloadsPanel before  | DownloadsPanel after |
| ------------- | ------------- |
|  <img alt="Downloads before" width="350" src="https://github.com/mozilla-mobile/firefox-ios/assets/519642/bff28504-a723-4030-a7fd-8e51c61bd6fe" />  |  <img alt="Downloads after" width="350" src="https://github.com/mozilla-mobile/firefox-ios/assets/519642/ae0e123b-3b43-446d-b117-a506cc9c4ed1" />  |

| HistoryPanel before  | HistoryPanel after |
| ------------- | ------------- |
|  <img alt="History before" width="350" src="https://github.com/mozilla-mobile/firefox-ios/assets/519642/70e42f5d-94ae-4886-925a-52b05942ae05" />  |  <img alt="History after" width="350" src="https://github.com/mozilla-mobile/firefox-ios/assets/519642/79a89c88-8d16-4380-8b62-dae2b1369191" />  |

| ReaderPanel empty before  | ReaderPanel empty after |
| ------------- | ------------- |
|  <img alt="Reader empty before" width="350" src="https://github.com/mozilla-mobile/firefox-ios/assets/519642/a2f06f13-94e1-4f43-95b3-700ba7e87c53" />  |  <img alt="Reader empty after" width="350" src="https://github.com/mozilla-mobile/firefox-ios/assets/519642/5e9c84ec-5d76-4f70-82ab-6078e2586a07" />  |

| ReaderPanel list before  | ReaderPanel list after |
| ------------- | ------------- |
|  <img alt="Reader list before" width="350" src="https://github.com/mozilla-mobile/firefox-ios/assets/519642/0035f719-a640-4e36-ba41-1e12262d446b" />  |  <img alt="Reader list after" width="350" src="https://github.com/mozilla-mobile/firefox-ios/assets/519642/e1495977-e78c-4e73-a4a4-ac1159f2f877" />  |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

