### PR TITLE
Bugfix FXIOS-8371 Shortcuts' display updates only after homepage refresh

### DIFF
--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -190,10 +190,11 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
                      device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         let interface = TopSitesUIInterface(trait: traitCollection,
                                             availableWidth: size.width)
+        numberOfRows = topSitesDataAdaptor.numberOfRows
+        unfilteredTopSites = topSitesDataAdaptor.getTopSitesData()
         let sectionDimension = dimensionManager.getSectionDimension(for: topSites,
                                                                     numberOfRows: numberOfRows,
                                                                     interface: interface)
-        self.numberOfRows = self.topSitesDataAdaptor.numberOfRows
         numberOfItems = sectionDimension.numberOfRows * sectionDimension.numberOfTilesPerRow
         topSites = unfilteredTopSites
         if numberOfItems < unfilteredTopSites.count {

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -193,6 +193,7 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
         let sectionDimension = dimensionManager.getSectionDimension(for: topSites,
                                                                     numberOfRows: numberOfRows,
                                                                     interface: interface)
+        self.numberOfRows = self.topSitesDataAdaptor.numberOfRows
         numberOfItems = sectionDimension.numberOfRows * sectionDimension.numberOfTilesPerRow
         topSites = unfilteredTopSites
         if numberOfItems < unfilteredTopSites.count {

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -33,6 +33,7 @@ class TopSitesRowCountSettingsController: SettingsTableViewController {
                 self.numberOfRows = num
                 self.prefs.setInt(Int32(num), forKey: PrefsKeys.NumberOfTopSiteRows)
                 self.tableView.reloadData()
+                NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
             })
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8371)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18540)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Updated the number of rows and content before refreshing the layout. Posted the refresh notification on the row number selection to cover the case when you dismiss the whole settings screen by swiping down without going back
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

