### PR TITLE
Add FXIOS-8826 - SwiftLint-large_tuple rule added

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -20,7 +20,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - implicit_getter
   # - inclusive_language
   # - invalid_swiftlint_command
-  # - large_tuple
+  - large_tuple
   # - leading_whitespace
   # - legacy_cggeometry_functions
   # - legacy_constant

--- a/focus-ios/Blockzilla/Settings/Controller/SettingsViewController.swift
+++ b/focus-ios/Blockzilla/Settings/Controller/SettingsViewController.swift
@@ -298,12 +298,13 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             if indexPath.row < 2 {
                 let searchCell = SettingsTableViewAccessoryCell(style: .value1, reuseIdentifier: "accessoryCell")
                 let autocompleteLabel = Settings.getToggle(.enableDomainAutocomplete) || Settings.getToggle(.enableCustomDomainAutocomplete) ? UIConstants.strings.autocompleteCustomEnabled : UIConstants.strings.autocompleteCustomDisabled
-                let labels: (label: String, accessoryLabel: String, identifier: String) = indexPath.row == 0 ?
+                let (label, accessoryLabel, identifier) = indexPath.row == 0 ?
                     (UIConstants.strings.settingsSearchLabel, searchEngineManager.activeEngine.name, "SettingsViewController.searchCell")
-                    :(UIConstants.strings.settingsAutocompleteSection, autocompleteLabel, "SettingsViewController.autocompleteCell")
-                searchCell.accessoryLabelText = labels.accessoryLabel
-                searchCell.labelText = labels.label
-                searchCell.accessibilityIdentifier = labels.identifier
+                    : (UIConstants.strings.settingsAutocompleteSection, autocompleteLabel, "SettingsViewController.autocompleteCell")
+
+                searchCell.accessoryLabelText = accessoryLabel
+                searchCell.labelText = label
+                searchCell.accessibilityIdentifier = identifier
                 cell = searchCell
             } else {
                 cell = setupToggleCell(indexPath: indexPath, navigationController: navigationController)


### PR DESCRIPTION
Added large_tuple rule to swiftlint.yaml and fixed related warnings in code

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8826)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19522)

## :bulb: Description
Added large_tuple rule to swiftlint.yaml and fixed related warnings in code

## :pencil: Checklist
You have to check all boxes before merging
- [ ✔️ ] Filled in the above information (tickets numbers and description of your work)
- [ ✔️ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ✔️ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ✔️ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ✔️ ] If needed, I updated documentation / comments for complex code and public methods
- [ ✔️ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

