### PR TITLE
Bugfix FXIOS-8727 Prevent Fakespot modal from automatically displaying

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotOptInCardViewModel.swift
@@ -46,7 +46,7 @@ struct FakespotOptInCardViewModel {
     let secondaryButtonA11yId: String = AccessibilityIdentifiers.Shopping.OptInCard.secondaryButton
 
     // MARK: Button Actions
-    var dismissViewController: ((TelemetryWrapper.EventExtraKey.Shopping?) -> Void)?
+    var dismissViewController: ((Bool, TelemetryWrapper.EventExtraKey.Shopping?) -> Void)?
     var onOptIn: (() -> Void)?
 
     // MARK: Links
@@ -71,7 +71,7 @@ struct FakespotOptInCardViewModel {
                                      object: .shoppingLearnMoreButton)
         guard let fakespotLearnMoreLink else { return }
         tabManager.addTabsForURLs([fakespotLearnMoreLink], zombie: false, shouldSelectTab: true)
-        dismissViewController?(.interactionWithALink)
+        dismissViewController?(false, .interactionWithALink)
     }
 
     func onTapTermsOfUse() {
@@ -80,7 +80,7 @@ struct FakespotOptInCardViewModel {
                                      object: .shoppingTermsOfUseButton)
         guard let fakespotTermsOfUseLink else { return }
         tabManager.addTabsForURLs([fakespotTermsOfUseLink], zombie: false, shouldSelectTab: true)
-        dismissViewController?(.interactionWithALink)
+        dismissViewController?(false, .interactionWithALink)
     }
 
     func onTapPrivacyPolicy() {
@@ -89,7 +89,7 @@ struct FakespotOptInCardViewModel {
                                      object: .shoppingPrivacyPolicyButton)
         guard let fakespotPrivacyPolicyLink else { return }
         tabManager.addTabsForURLs([fakespotPrivacyPolicyLink], zombie: false, shouldSelectTab: true)
-        dismissViewController?(.interactionWithALink)
+        dismissViewController?(false, .interactionWithALink)
     }
 
     func onTapMainButton() {
@@ -105,7 +105,7 @@ struct FakespotOptInCardViewModel {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .tap,
                                      object: .shoppingNotNowButton)
-        dismissViewController?(nil)
+        dismissViewController?(true, nil)
     }
 
     var orderWebsites: [String] {

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -415,8 +415,13 @@ class FakespotViewController: UIViewController,
             return view
         case .onboarding:
             let view: FakespotOptInCardView = .build()
-            viewModel.optInCardViewModel.dismissViewController = { [weak self] action in
-                self?.triggerDismiss()
+            viewModel.optInCardViewModel.dismissViewController = { [weak self] dismissPermanently, action in
+                if dismissPermanently {
+                    self?.triggerDismiss()
+                } else {
+                    store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false,
+                                                                                   windowUUID: windowUUID)))
+                }
                 guard let self = self, let action else { return }
                 viewModel.recordDismissTelemetry(by: action)
             }
@@ -453,8 +458,8 @@ class FakespotViewController: UIViewController,
         case .qualityDeterminationCard:
             let reviewQualityCardView: FakespotReviewQualityCardView = .build()
             viewModel.reviewQualityCardViewModel.expandState = fakespotState.isReviewQualityExpanded ? .expanded : .collapsed
-            viewModel.reviewQualityCardViewModel.dismissViewController = { [weak self] in
-                self?.triggerDismiss()
+            viewModel.reviewQualityCardViewModel.dismissViewController = {
+                store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
             }
             viewModel.reviewQualityCardViewModel.onExpandStateChanged = { state in
                 let context = FakespotUIContext(isExpanded: state == .expanded, windowUUID: windowUUID)
@@ -467,11 +472,14 @@ class FakespotViewController: UIViewController,
         case .settingsCard:
             let view: FakespotSettingsCardView = .build()
             viewModel.settingsCardViewModel.expandState = fakespotState.isSettingsExpanded ? .expanded : .collapsed
-            viewModel.settingsCardViewModel.dismissViewController = { [weak self] action in
+            viewModel.settingsCardViewModel.dismissViewController = { [weak self] dismissPermanently, action in
                 guard let self = self, let action else { return }
-
-                store.dispatch(FakespotAction.surfaceDisplayedEventSend(windowUUID.context))
-                self.triggerDismiss()
+                if dismissPermanently {
+                    self.triggerDismiss()
+                } else {
+                    store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false,
+                                                                                   windowUUID: windowUUID)))
+                }
                 viewModel.recordDismissTelemetry(by: action)
             }
             viewModel.settingsCardViewModel.toggleAdsEnabled = { [weak self] in
@@ -501,7 +509,7 @@ class FakespotViewController: UIViewController,
                 self?.viewModel.addTab(url: adData.url)
                 self?.viewModel.recordSurfaceAdsClickedTelemetry()
                 self?.viewModel.reportAdEvent(eventName: .trustedDealsLinkClicked, aidvs: [adData.aid])
-                self?.triggerDismiss()
+                store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
             }
             view.configure(viewModel)
             adView = view

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -416,8 +416,7 @@ class FakespotViewController: UIViewController,
         case .onboarding:
             let view: FakespotOptInCardView = .build()
             viewModel.optInCardViewModel.dismissViewController = { [weak self] action in
-                store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
-
+                self?.triggerDismiss()
                 guard let self = self, let action else { return }
                 viewModel.recordDismissTelemetry(by: action)
             }
@@ -454,8 +453,8 @@ class FakespotViewController: UIViewController,
         case .qualityDeterminationCard:
             let reviewQualityCardView: FakespotReviewQualityCardView = .build()
             viewModel.reviewQualityCardViewModel.expandState = fakespotState.isReviewQualityExpanded ? .expanded : .collapsed
-            viewModel.reviewQualityCardViewModel.dismissViewController = {
-                store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
+            viewModel.reviewQualityCardViewModel.dismissViewController = { [weak self] in
+                self?.triggerDismiss()
             }
             viewModel.reviewQualityCardViewModel.onExpandStateChanged = { state in
                 let context = FakespotUIContext(isExpanded: state == .expanded, windowUUID: windowUUID)
@@ -471,8 +470,8 @@ class FakespotViewController: UIViewController,
             viewModel.settingsCardViewModel.dismissViewController = { [weak self] action in
                 guard let self = self, let action else { return }
 
-                store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
                 store.dispatch(FakespotAction.surfaceDisplayedEventSend(windowUUID.context))
+                self.triggerDismiss()
                 viewModel.recordDismissTelemetry(by: action)
             }
             viewModel.settingsCardViewModel.toggleAdsEnabled = { [weak self] in
@@ -502,7 +501,7 @@ class FakespotViewController: UIViewController,
                 self?.viewModel.addTab(url: adData.url)
                 self?.viewModel.recordSurfaceAdsClickedTelemetry()
                 self?.viewModel.reportAdEvent(eventName: .trustedDealsLinkClicked, aidvs: [adData.aid])
-                store.dispatch(FakespotAction.setAppearanceTo(BoolValueContext(boolValue: false, windowUUID: windowUUID)))
+                self?.triggerDismiss()
             }
             view.configure(viewModel)
             adView = view

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotSettingsCardView.swift
@@ -26,7 +26,7 @@ class FakespotSettingsCardViewModel {
     let footerA11yTitleIdentifier: String = a11yIds.footerTitle
     let footerA11yActionIdentifier: String = a11yIds.footerAction
     let footerActionUrl = FakespotUtils.fakespotUrl
-    var dismissViewController: ((TelemetryWrapper.EventExtraKey.Shopping?) -> Void)?
+    var dismissViewController: ((Bool, TelemetryWrapper.EventExtraKey.Shopping?) -> Void)?
     var toggleAdsEnabled: (() -> Void)?
     var onExpandStateChanged: ((CollapsibleCardView.ExpandButtonState) -> Void)?
     var expandState: CollapsibleCardView.ExpandButtonState = .collapsed
@@ -74,7 +74,7 @@ class FakespotSettingsCardViewModel {
         guard let footerActionUrl else { return }
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .shoppingPoweredByFakespotLabel)
         tabManager.addTabsForURLs([footerActionUrl], zombie: false, shouldSelectTab: true)
-        dismissViewController?(.interactionWithALink)
+        dismissViewController?(false, .interactionWithALink)
     }
 }
 
@@ -231,7 +231,7 @@ final class FakespotSettingsCardView: UIView, ThemeApplicable {
         // Send settings telemetry for Fakespot
         FakespotUtils().addSettingTelemetry()
 
-        viewModel?.dismissViewController?(.optingOutOfTheFeature)
+        viewModel?.dismissViewController?(true, .optingOutOfTheFeature)
     }
 
     // MARK: - Accessibility

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
@@ -404,7 +404,11 @@ class FakespotTests: BaseTestCase {
             app.buttons["Reload page"].tap()
             waitUntilPageLoad()
         }
-        // Tap the price tag icon
+        // Workaround for iPad issue: https://github.com/mozilla-mobile/firefox-ios/issues/19346
+        if app.staticTexts[AccessibilityIdentifiers.Shopping.sheetHeaderTitle].exists {
+            app.otherElements.buttons[AccessibilityIdentifiers.Shopping.sheetCloseButton].tap()
+        }
+        // Tap the shopping cart icon
         let shoppingButton = app.buttons[AccessibilityIdentifiers.Toolbar.shoppingButton]
         var nrOfRetries = 4
         while !shoppingButton.exists && nrOfRetries > 0 {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
@@ -404,11 +404,7 @@ class FakespotTests: BaseTestCase {
             app.buttons["Reload page"].tap()
             waitUntilPageLoad()
         }
-        // Workaround for iPad issue: https://github.com/mozilla-mobile/firefox-ios/issues/19346
-        if app.staticTexts[AccessibilityIdentifiers.Shopping.sheetHeaderTitle].exists {
-            app.otherElements.buttons[AccessibilityIdentifiers.Shopping.sheetCloseButton].tap()
-        }
-        // Tap the shopping cart icon
+        // Tap the price tag icon
         let shoppingButton = app.buttons[AccessibilityIdentifiers.Toolbar.shoppingButton]
         var nrOfRetries = 4
         while !shoppingButton.exists && nrOfRetries > 0 {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/8727)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19346)

## :bulb: Description
- There are many actions that result in closing the `FakespotViewController` (modal/sidebar), some of which should suppress the viewcontroller the next time it is requested (when a product details page is opened), and some that shouldn't. The following table show which actions do what:

| Action | Allow/Suppress |
| ------------- | ------------- |
| Tap outside modal | Suppress |
| Swipe-gesture to close modal | Suppress |
| "X" button | Suppress |
| "Not now" button on "Opt in" view | Suppress |
| "Turn off review checker" button in the review checker | Suppress |
| Links on the "Opt in" view | Allow |
| Links on the actual review checker view | Allow |
| Product ad links | Allow |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

