### PR TITLE
ADD FXIOS-8825 - SwiftLint-invalid_swiftlint_command rule added

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -19,7 +19,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - force_try
   # - implicit_getter
   # - inclusive_language
-  # - invalid_swiftlint_command
+  - invalid_swiftlint_command
   # - large_tuple
   # - leading_whitespace
   # - legacy_cggeometry_functions


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8825)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19523)

## :bulb: Description
Added invalid_swiftlint_command rule to swiftlint.yaml and fixed related warnings in code

## :pencil: Checklist
You have to check all boxes before merging
- [ ✔️ ] Filled in the above information (tickets numbers and description of your work)
- [ ✔️ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ✔️ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ✔️ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ✔️ ] If needed, I updated documentation / comments for complex code and public methods
- [ ✔️ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

