### PR TITLE
Bugfix FXIOS-8891 Audio continues playing after Tab is closed

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2299,23 +2299,23 @@ extension BrowserViewController: LegacyTabDelegate {
                 theme: currentTheme()
             )
             tab.addContentScript(logins, name: LoginsHelper.name())
-            logins.foundFieldValues = { [weak self] field, currentRequestId in
+            logins.foundFieldValues = { [weak self, weak tab, weak webView] field, currentRequestId in
                 Task {
                     guard self?.autofillLoginNimbusFeatureFlag() == true else { return }
-                    guard let tabURL = tab.url else { return }
+                    guard let tabURL = tab?.url else { return }
                     let logins = (try? await self?.profile.logins.listLogins()) ?? []
                     let loginsForCurrentTab = logins.filter { login in
                         guard let recordHostnameURL = URL(string: login.hostname) else { return false }
                         return recordHostnameURL.baseDomain == tabURL.baseDomain
                     }
                     if !loginsForCurrentTab.isEmpty {
-                        tab.webView?.accessoryView.reloadViewFor(.login)
-                        tab.webView?.reloadInputViews()
+                        tab?.webView?.accessoryView.reloadViewFor(.login)
+                        tab?.webView?.reloadInputViews()
                     }
-                    tab.webView?.accessoryView.savedLoginsClosure = {
+                    tab?.webView?.accessoryView.savedLoginsClosure = {
                         Task { @MainActor [weak self] in
                             // Dismiss keyboard
-                            webView.resignFirstResponder()
+                            webView?.resignFirstResponder()
                             self?.authenticateSelectSavedLoginsClosureBottomSheet(
                                 tabURL: tabURL,
                                 currentRequestId: currentRequestId


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8891)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19616)

## :bulb: Description

Fixes incorrect strong refs in a LoginsHelper closure that were incorrectly keeping Tabs and their webviews in memory even after the tab was closed.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

