### PR TITLE
Add MTE-2607 Github action to run automated autofill tests

### DIFF
--- a/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
+++ b/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
@@ -1,0 +1,41 @@
+name: Build and Run Autofill Automation
+permissions: read-all
+on:
+    pull_request:
+      paths:
+        - 'firefox-ios/Client/Assets/CC_Script/**'
+    push:
+      branches: ['main']
+      paths:
+        - 'firefox-ios/Client/Assets/CC_Script/**'
+jobs:
+  build:
+    runs-on: macos-13
+    timeout-minutes: 40
+    strategy:
+      matrix:
+        python-version: [3.9]
+        xcode: ["15.2"]
+    steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+
+        - name: Clone repository
+          run: |
+            git clone https://github.com/issammani/test-playwright.git
+        - name: Install node
+          uses: actions/setup-node@v4
+          with:
+           node-version: 18
+        - run: |
+            echo "Install dependencies and run tests"
+            npm i
+            npm install --save concurrently
+            npm i -D @playwright/test
+
+            cd test-playwright
+            echo "Install playwright"
+            npx playwright install
+            
+            echo "Run tests"
+            npm test


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2607)

As agreed in previous meeting, we are adding a github action to run the automated autofill tests using playwright. We are setting up the enviroment so that the basics one run and then we will iterate over to add more tests and run them more frequently if needed.
For now, the github action in this PR will run only when files in [CC_Script](https://github.com/mozilla-mobile/firefox-ios/tree/555421274fbb8c99e719dd6491915433984e64ee/firefox-ios/Client/Assets/CC_Script) directory are modified in PRs and pushes to main.

The results of the github action will appear as github checks but are not going to be build blocking for now.

There are some examples of how this works in my fork:
- PR that changes one of the files in the directory: https://github.com/isabelrios/firefox-ios/pull/156
- Commit that does not trigger the github action: https://github.com/isabelrios/firefox-ios/commit/0c15529310ee037eb335b863b033278b9578184a

Github action running: 
https://github.com/isabelrios/firefox-ios/actions/runs/8690281186/job/23829846545

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

