### PR TITLE
Add FXIOS-8598 Create RegularBrowserAddressToolbar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/RegularBrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/RegularBrowserAddressToolbar.swift
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+public class RegularBrowserAddressToolbar: BrowserAddressToolbar {
+}

--- a/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainer.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainer.swift
@@ -12,7 +12,7 @@ protocol AddressToolbarContainerDelegate: AnyObject {
 
 class AddressToolbarContainer: UIView, ThemeApplicable {
     private lazy var compactToolbar: CompactBrowserAddressToolbar =  .build { _ in }
-    private lazy var regularToolbar: BrowserAddressToolbar = .build()
+    private lazy var regularToolbar: RegularBrowserAddressToolbar = .build()
     private weak var delegate: AddressToolbarContainerDelegate?
 
     override init(frame: CGRect) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8598)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19088)

## :bulb: Description
Adds a subclass for the regular sized browser toolbar.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

