### PR TITLE
Refactor FXIOS-8971 POC for tweaks to redux

### DIFF
--- a/BrowserKit/Sources/Redux/Action.swift
+++ b/BrowserKit/Sources/Redux/Action.swift
@@ -10,14 +10,22 @@ import Foundation
 /// action, including a UUID for a particular window. If an Action is truly global in
 /// nature or can't be associated with a UUID it can send either the UUID for the active
 /// window (see `WindowManager.activeWindow`) or if needed `WindowUUID.unavailable`.
-public protocol Action {
-    var windowUUID: UUID { get }
-}
+open class Action {
+    public var windowUUID: UUID
+    public var viewUUID: UUID?
+    public var actionType: ActionType
 
-extension Action {
+    public init(windowUUID: UUID, viewUUID: UUID? = nil, actionType: ActionType) {
+        self.windowUUID = windowUUID
+        self.viewUUID = viewUUID
+        self.actionType = actionType
+    }
+
     func displayString() -> String {
         let className = String(describing: Self.self)
         let actionName = String(describing: self).prefix(20)
         return "\(className).\(actionName)"
     }
 }
+
+public protocol ActionType {}

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxAction.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxAction.swift
@@ -6,19 +6,32 @@ import XCTest
 
 @testable import Redux
 
-enum FakeReduxAction: Action {
+class FakeReduxAction: Action {
+    let counterValue: Int?
+    let privateMode: Bool?
+
+    init(counterValue: Int? = nil,
+         privateMode: Bool? = nil,
+         windowUUID: UUID,
+         viewUUID: UUID? = nil,
+         actionType: ActionType) {
+        self.counterValue = counterValue
+        self.privateMode = privateMode
+        super.init(windowUUID: windowUUID,
+                   viewUUID: viewUUID,
+                   actionType: actionType)
+    }
+}
+
+enum FakeReduxActionType: ActionType {
     // User action
     case requestInitialValue
     case increaseCounter
     case decreaseCounter
 
     // Middleware actions
-    case initialValueLoaded(Int)
-    case counterIncreased(Int)
-    case counterDecreased(Int)
-    case setPrivateModeTo(Bool)
-
-    var windowUUID: UUID {
-        return UUID(uuidString: "D9D9D9D9-D9D9-D9D9-D9D9-CD68A019860B")!
-    }
+    case initialValueLoaded
+    case counterIncreased
+    case counterDecreased
+    case setPrivateModeTo
 }

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
@@ -5,26 +5,33 @@
 import Foundation
 
 @testable import Redux
+
 class FakeReduxMiddleware {
     lazy var fakeProvider: Middleware<FakeReduxState> = { state, action in
-        switch action {
-        case FakeReduxAction.requestInitialValue:
+        switch action.actionType {
+        case FakeReduxActionType.requestInitialValue:
             let initialValue = self.generateInitialValue()
-            DispatchQueue.main.async {
-                store.dispatch(FakeReduxAction.initialValueLoaded(initialValue))
-            }
-        case FakeReduxAction.increaseCounter:
+            let action = FakeReduxAction(counterValue: initialValue,
+                                         windowUUID: windowUUID,
+                                         actionType: FakeReduxActionType.initialValueLoaded)
+            store.dispatch(action)
+
+        case FakeReduxActionType.increaseCounter:
             let existingValue = state.counter
             let newValue = self.increaseCounter(currentValue: existingValue)
-            DispatchQueue.main.async {
-                store.dispatch(FakeReduxAction.counterIncreased(newValue))
-            }
-        case FakeReduxAction.decreaseCounter:
+            let action = FakeReduxAction(counterValue: newValue,
+                                         windowUUID: windowUUID,
+                                         actionType: FakeReduxActionType.counterIncreased)
+            store.dispatch(action)
+
+        case FakeReduxActionType.decreaseCounter:
             let existingValue = state.counter
             let newValue = self.decreaseCounter(currentValue: existingValue)
-            DispatchQueue.main.async {
-                store.dispatch(FakeReduxAction.counterDecreased(newValue))
-            }
+            let action = FakeReduxAction(counterValue: newValue,
+                                         windowUUID: windowUUID,
+                                         actionType: FakeReduxActionType.counterDecreased)
+            store.dispatch(action)
+
         default:
            break
         }

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxState.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxState.swift
@@ -11,15 +11,17 @@ struct FakeReduxState: StateType, Equatable {
     var isInPrivateMode = false
 
     static let reducer: Reducer<Self> = { state, action in
-        switch action {
-        case FakeReduxAction.initialValueLoaded(let value),
-            FakeReduxAction.counterIncreased(let value),
-            FakeReduxAction.counterDecreased(let value):
-            return FakeReduxState(counter: value,
+        guard let action = action as? FakeReduxAction else { return state }
+
+        switch action.actionType {
+        case FakeReduxActionType.initialValueLoaded,
+            FakeReduxActionType.counterIncreased,
+            FakeReduxActionType.counterDecreased:
+            return FakeReduxState(counter: action.counterValue ?? state.counter,
                                   isInPrivateMode: state.isInPrivateMode)
-        case FakeReduxAction.setPrivateModeTo(let value):
+        case FakeReduxActionType.setPrivateModeTo:
             return FakeReduxState(counter: state.counter,
-                                  isInPrivateMode: value)
+                                  isInPrivateMode: action.privateMode ?? state.isInPrivateMode)
         default:
             return state
         }

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxViewController.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxViewController.swift
@@ -6,6 +6,8 @@ import UIKit
 
 @testable import Redux
 
+let windowUUID = UUID(uuidString: "D9D9D9D9-D9D9-D9D9-D9D9-CD68A019860B")!
+
 class FakeReduxViewController: UIViewController, StoreSubscriber {
     typealias SubscriberStateType = FakeReduxState
 
@@ -27,7 +29,9 @@ class FakeReduxViewController: UIViewController, StoreSubscriber {
 
     func subscribeToRedux() {
         store.subscribe(self)
-        store.dispatch(FakeReduxAction.requestInitialValue)
+
+        let action = FakeReduxAction(windowUUID: windowUUID, actionType: FakeReduxActionType.requestInitialValue)
+        store.dispatch(action)
     }
 
     func unsubscribeFromRedux() {
@@ -42,14 +46,19 @@ class FakeReduxViewController: UIViewController, StoreSubscriber {
     // MARK: - Helper functions
 
     func increaseCounter() {
-        store.dispatch(FakeReduxAction.increaseCounter)
+        let action = FakeReduxAction(windowUUID: windowUUID, actionType: FakeReduxActionType.increaseCounter)
+        store.dispatch(action)
     }
 
     func decreaseCounter() {
-        store.dispatch(FakeReduxAction.decreaseCounter)
+        let action = FakeReduxAction(windowUUID: windowUUID, actionType: FakeReduxActionType.decreaseCounter)
+        store.dispatch(action)
     }
 
     func setPrivateMode(to value: Bool) {
-        store.dispatch(FakeReduxAction.setPrivateModeTo(value))
+        let action = FakeReduxAction(privateMode: value,
+                                     windowUUID: windowUUID,
+                                     actionType: FakeReduxActionType.setPrivateModeTo)
+        store.dispatch(action)
     }
 }

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
@@ -5,11 +5,17 @@
 import Foundation
 import Redux
 
-class ScreenActionContext: ActionContext {
+class ScreenAction: Action {
     let screen: AppScreen
-    init(screen: AppScreen, windowUUID: WindowUUID) {
+
+    init(windowUUID: UUID,
+         viewUUID: UUID? = nil,
+         actionType: ActionType,
+         screen: AppScreen) {
         self.screen = screen
-        super.init(windowUUID: windowUUID)
+        super.init(windowUUID: windowUUID,
+                   viewUUID: viewUUID,
+                   actionType: actionType)
     }
 }
 
@@ -23,15 +29,7 @@ enum AppScreen {
     case tabPeek
 }
 
-enum ActiveScreensStateAction: Action {
-    case showScreen(ScreenActionContext)
-    case closeScreen(ScreenActionContext)
-
-    var windowUUID: UUID {
-        switch self {
-        case .showScreen(let context as ActionContext),
-                .closeScreen(let context as ActionContext):
-            return context.windowUUID
-        }
-    }
+enum ScreenActionType: ActionType {
+    case showScreen
+    case closeScreen
 }

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
@@ -71,41 +71,47 @@ struct ActiveScreensState: Equatable {
     }
 
     static let reducer: Reducer<Self> = { state, action in
-        var screens = state.screens
-
-        if let action = action as? ActiveScreensStateAction {
-            switch action {
-            case .closeScreen(let context):
-                let uuid = context.windowUUID
-                let screenType = context.screen
-                screens = screens.filter({
-                    return $0.associatedAppScreen != screenType || $0.windowUUID != uuid
-                })
-            case .showScreen(let context):
-                let screenType = context.screen
-                let uuid = context.windowUUID
-                switch screenType {
-                case .browserViewController:
-                    screens.append(.browserViewController(BrowserViewControllerState(windowUUID: uuid)))
-                case .onboardingViewController:
-                    screens.append(.onboardingViewController(OnboardingViewControllerState(windowUUID: uuid)))
-                case .remoteTabsPanel:
-                    screens.append(.remoteTabsPanel(RemoteTabsPanelState(windowUUID: uuid)))
-                case .tabsTray:
-                    screens.append(.tabsTray(TabTrayState(windowUUID: uuid)))
-                case .tabsPanel:
-                    screens.append(.tabsPanel(TabsPanelState(windowUUID: uuid)))
-                case .themeSettings:
-                    screens.append(.themeSettings(ThemeSettingsState(windowUUID: uuid)))
-                case .tabPeek:
-                    screens.append(.tabPeek(TabPeekState(windowUUID: uuid)))
-                }
-            }
-        }
+        // Add or remove screens from the active screen list as needed
+        var screens = updateActiveScreens(action: action, screens: state.screens)
 
         // Reduce each screen state
         screens = screens.map { AppScreenState.reducer($0, action) }
 
         return ActiveScreensState(screens: screens)
+    }
+
+    private static func updateActiveScreens(action: Action, screens: [AppScreenState]) -> [AppScreenState] {
+        guard let action = action as? ScreenAction else { return screens }
+
+        var screens = screens
+
+        switch action.actionType {
+        case ScreenActionType.closeScreen:
+            screens = screens.filter({
+                return $0.associatedAppScreen != action.screen || $0.windowUUID != action.windowUUID
+            })
+        case ScreenActionType.showScreen:
+            let uuid = action.windowUUID
+            switch action.screen {
+            case .browserViewController:
+                screens.append(.browserViewController(BrowserViewControllerState(windowUUID: uuid)))
+            case .onboardingViewController:
+                screens.append(.onboardingViewController(OnboardingViewControllerState(windowUUID: uuid)))
+            case .remoteTabsPanel:
+                screens.append(.remoteTabsPanel(RemoteTabsPanelState(windowUUID: uuid)))
+            case .tabsTray:
+                screens.append(.tabsTray(TabTrayState(windowUUID: uuid)))
+            case .tabsPanel:
+                screens.append(.tabsPanel(TabsPanelState(windowUUID: uuid)))
+            case .themeSettings:
+                screens.append(.themeSettings(ThemeSettingsState(windowUUID: uuid)))
+            case .tabPeek:
+                screens.append(.tabPeek(TabPeekState(windowUUID: uuid)))
+            }
+        default:
+            return screens
+        }
+
+        return screens
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8971)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19808)

## :bulb: Description
This is a POC for a tweak to the redux system to try to simplify how we handle actions and associate them with the correct window/view etc.
Previously actions were entirely enum driven, this change shifts it so that actions are classes that contain an action type enum variable within. This allows the action to carry associated data in a simpler way, especially for data that we want to present in all or many cases such as a window ID and a view ID and can easily be expanded to add more if needed in the future. 
This removes the need for ActionContext associated values on each of the action enums cases and removes the need to pull the windowUUID var from ever single enum case and the same for future top level variables that would need to be added like viewUUID to fix bugs arising from actions misfiring in places like the normal and private tab panels. 

For the sake of the POC I have only updated the redux library and it's tests so that they run successfully. I've updated the active screen section of the client app just as an example but the client app does not currently compile.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

