### PR TITLE
Bugfix MTE-2626 Use Google Cloud bucket for BrowsingPDFTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -6,10 +6,10 @@ import XCTest
 import Common
 
 let PDF_website = [
-    "url": "www.orimi.com/pdf-test.pdf",
-    "pdfValue": "www.orimi.com/pdf",
+    "url": "https://storage.googleapis.com/mobile_test_assets/public/pdf-test.pdf",
+    "pdfValue": "storage.googleapis.com/mobile_test_assets/public/pdf-test.pdf",
     "urlValue": "yukon.ca/en/educat",
-    "bookmarkLabel": "https://www.orimi.com/pdf-test.pdf",
+    "bookmarkLabel": "https://storage.googleapis.com/mobile_test_assets/public/pdf-test.pdf",
     "longUrlValue": "http://www.education.gov.yk.ca/"
 ]
 class BrowsingPDFTests: BaseTestCase {
@@ -28,7 +28,7 @@ class BrowsingPDFTests: BaseTestCase {
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307117
     // Disabled due to link not loading
     func testOpenLinkFromPDF() throws {
-        throw XCTSkip("Link inside pfd is not loading anymore")
+        // throw XCTSkip("Link inside pdf is not loading anymore")
         /*
         navigator.openURL(PDF_website["url"]!)
         waitUntilPageLoad()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2626)

## :bulb: Description
Some `BrowsingPDFTests` fails intermittently because the downloaded PDF file may not be available.

The PDF asset is moved to Mobile Test Engineering's Google Cloud bucket.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

