### PR TITLE
Bugfix FXIOS-8802 [Password autofill] Use saved password prompt not displayed after two field deletions

### DIFF
--- a/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
@@ -148,6 +148,7 @@ class CredentialAutofillCoordinator: BaseCoordinator {
                     )
                 )
 
+                LoginsHelper.yieldFocusBackToField(with: currentTab)
                 router.dismiss(animated: true)
                 parentCoordinator?.didFinish(from: self)
             },


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8802)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19513)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Regain focus for fields after selection.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

