### PR TITLE
Refactor FXIOS-8972 [Multi-window] Update TabEvents

### DIFF
--- a/firefox-ios/Client/AccountSyncHandler.swift
+++ b/firefox-ios/Client/AccountSyncHandler.swift
@@ -11,10 +11,13 @@ import Common
 class AccountSyncHandler: TabEventHandler {
     private let throttler: Throttler
     private let profile: Profile
+    internal let windowUUID: WindowUUID
 
     init(with profile: Profile,
+         windowUUID: WindowUUID,
          throttleTime: Double = 5.0,
          queue: DispatchQueueInterface = DispatchQueue.global()) {
+        self.windowUUID = windowUUID
         self.profile = profile
         self.throttler = Throttler(seconds: throttleTime,
                                    on: queue)

--- a/firefox-ios/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -8,7 +8,10 @@ import Storage
 import WebKit
 
 class MetadataParserHelper: TabEventHandler {
-    init() {
+    let windowUUID: WindowUUID
+
+    init(windowUUID: WindowUUID) {
+        self.windowUUID = windowUUID
         register(self, forTabEvents: .didChangeURL)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -71,6 +71,7 @@ class LegacyTabDisplayManager: NSObject, FeatureFlaggable {
     var operations = [(TabAnimationType, (() -> Void))]()
     var refreshStoreOperation: (() -> Void)?
     var tabDisplayType: TabDisplayType = .TabGrid
+    var windowUUID: WindowUUID { return tabManager.windowUUID }
     private let tabManager: TabManager
     private let collectionView: UICollectionView
 

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -46,7 +46,7 @@ class TabLocationView: UIView, FeatureFlaggable {
 
     var notificationCenter: NotificationProtocol = NotificationCenter.default
     private var themeManager: ThemeManager = AppContainer.shared.resolve()
-    private let windowUUID: WindowUUID
+    internal let windowUUID: WindowUUID
 
     /// Tracking protection button, gets updated from tabDidChangeContentBlocking
     var blockerStatus: BlockerStatus = .noBlockedURLs {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -46,7 +46,7 @@ class TabLocationView: UIView, FeatureFlaggable {
 
     var notificationCenter: NotificationProtocol = NotificationCenter.default
     private var themeManager: ThemeManager = AppContainer.shared.resolve()
-    internal let windowUUID: WindowUUID
+    let windowUUID: WindowUUID
 
     /// Tracking protection button, gets updated from tabDidChangeContentBlocking
     var blockerStatus: BlockerStatus = .noBlockedURLs {

--- a/firefox-ios/Client/Helpers/UserActivityHandler.swift
+++ b/firefox-ios/Client/Helpers/UserActivityHandler.swift
@@ -17,8 +17,11 @@ private let searchableIndex = CSSearchableIndex.default()
 
 class UserActivityHandler {
     private let logger: Logger
+    let windowUUID: WindowUUID
 
-    init(logger: Logger = DefaultLogger.shared) {
+    init(windowUUID: WindowUUID,
+         logger: Logger = DefaultLogger.shared) {
+        self.windowUUID = windowUUID
         self.logger = logger
         register(
             self,

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -162,8 +162,8 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     ) {
         self.windowUUID = uuid
         self.profile = profile
-        self.navDelegate = TabManagerNavDelegate()
-        self.tabEventHandlers = TabEventHandlers.create(with: profile)
+        self.navDelegate = TabManagerNavDelegate(windowUUID: uuid)
+        self.tabEventHandlers = TabEventHandlers.create(with: profile, window: uuid)
         self.logger = logger
 
         super.init()

--- a/firefox-ios/Client/TabManagement/TabEventHandlers.swift
+++ b/firefox-ios/Client/TabManagement/TabEventHandlers.swift
@@ -10,11 +10,11 @@ class TabEventHandlers {
     ///
     /// For anything that needs to react to tab events notifications (see `TabEventLabel`), the
     /// pattern is to implement a handler and specify which events to observe.
-    static func create(with profile: Profile) -> [TabEventHandler] {
+    static func create(with profile: Profile, window: WindowUUID) -> [TabEventHandler] {
         let handlers: [TabEventHandler] = [
-            UserActivityHandler(),
-            MetadataParserHelper(),
-            AccountSyncHandler(with: profile)
+            UserActivityHandler(windowUUID: window),
+            MetadataParserHelper(windowUUID: window),
+            AccountSyncHandler(with: profile, windowUUID: window)
         ]
 
         return handlers

--- a/firefox-ios/Client/TabManagement/TabManagerNavDelegate.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerNavDelegate.swift
@@ -9,12 +9,18 @@ import Shared
 // WKNavigationDelegates must implement NSObjectProtocol
 class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
     fileprivate var delegates = WeakList<WKNavigationDelegate>()
+    let windowUUID: WindowUUID
+
+    init(windowUUID: WindowUUID) {
+        self.windowUUID = windowUUID
+    }
 
     func insert(_ delegate: WKNavigationDelegate) {
         delegates.insert(delegate)
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        
         for delegate in delegates {
             delegate.webView?(webView, didCommit: navigation)
         }

--- a/firefox-ios/Client/TabManagement/TabManagerNavDelegate.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerNavDelegate.swift
@@ -20,7 +20,6 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
-        
         for delegate in delegates {
             delegate.webView?(webView, didCommit: navigation)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -21,7 +21,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         profile = MockProfile()
         tabManager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
         subject = BrowserViewController(profile: profile, tabManager: tabManager)
-        tabManagerDelegate = TabManagerNavDelegate()
+        tabManagerDelegate = TabManagerNavDelegate(windowUUID: .XCTestDefaultUUID)
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
@@ -29,7 +29,7 @@ class AccountSyncHandlerTests: XCTestCase {
 
     func testTabDidGainFocus_doesntSyncWithoutAccount() {
         profile.hasSyncableAccountMock = false
-        let subject = AccountSyncHandler(with: profile, queue: queue)
+        let subject = AccountSyncHandler(with: profile, windowUUID: windowUUID, queue: queue)
         let tab = createTab(profile: profile)
         subject.tabDidGainFocus(tab)
 
@@ -37,7 +37,7 @@ class AccountSyncHandlerTests: XCTestCase {
     }
 
     func testTabDidGainFocus_syncWithAccount() {
-        let subject = AccountSyncHandler(with: profile, queue: queue)
+        let subject = AccountSyncHandler(with: profile, windowUUID: windowUUID, queue: queue)
         let tab = createTab(profile: profile)
         subject.tabDidGainFocus(tab)
 
@@ -45,7 +45,10 @@ class AccountSyncHandlerTests: XCTestCase {
     }
 
     func testTabDidGainFocus_highThrottleTime_doesntSync() {
-        let subject = AccountSyncHandler(with: profile, throttleTime: 1000, queue: DispatchQueue.global())
+        let subject = AccountSyncHandler(with: profile,
+                                         windowUUID: windowUUID,
+                                         throttleTime: 1000,
+                                         queue: DispatchQueue.global())
         let tab = createTab(profile: profile)
         subject.tabDidGainFocus(tab)
 
@@ -53,7 +56,10 @@ class AccountSyncHandlerTests: XCTestCase {
     }
 
     func testTabDidGainFocus_multipleThrottle_withoutWaitdoesntSync() {
-        let subject = AccountSyncHandler(with: profile, throttleTime: 0.2, queue: DispatchQueue.global())
+        let subject = AccountSyncHandler(with: profile,
+                                         windowUUID: windowUUID,
+                                         throttleTime: 0.2,
+                                         queue: DispatchQueue.global())
         let tab = createTab(profile: profile)
         subject.tabDidGainFocus(tab)
         subject.tabDidGainFocus(tab)
@@ -65,7 +71,10 @@ class AccountSyncHandlerTests: XCTestCase {
     }
 
     func testTabDidGainFocus_multipleThrottle_withWaitSyncOnce() {
-        let subject = AccountSyncHandler(with: profile, throttleTime: 0.2, queue: DispatchQueue.global())
+        let subject = AccountSyncHandler(with: profile,
+                                         windowUUID: windowUUID,
+                                         throttleTime: 0.2,
+                                         queue: DispatchQueue.global())
         let tab = createTab(profile: profile)
         subject.tabDidGainFocus(tab)
         subject.tabDidGainFocus(tab)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabEventHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabEventHandlerTests.swift
@@ -82,6 +82,8 @@ class DummyHandler: TabEventHandler {
     // of individual tab state.
     var isFocused: Bool?
 
+    let windowUUID: WindowUUID = .XCTestDefaultUUID
+
     init() {
          register(self, forTabEvents: .didGainFocus, .didLoseFocus)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabManagerNavDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabManagerNavDelegateTests.swift
@@ -166,7 +166,7 @@ private extension TabManagerNavDelegateTests {
     }
 
     func createSubject(file: StaticString = #file, line: UInt = #line) -> Subject {
-        let subject = TabManagerNavDelegate()
+        let subject = TabManagerNavDelegate(windowUUID: .XCTestDefaultUUID)
         let delegate1 = WKNavigationDelegateSpy()
         let delegate2 = WKNavigationDelegateSpy()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8972)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19809)

## :bulb: Description

Refactors to `TabEvent` to work with multiple windows. For current single-window operation on `main` this is a pure refactor and should impart no changes to current behaviors.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

