### PR TITLE
Bugfix MTE-2626 Enable testOpenLinkFromPDF

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -28,8 +28,6 @@ class BrowsingPDFTests: BaseTestCase {
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307117
     // Disabled due to link not loading
     func testOpenLinkFromPDF() throws {
-        // throw XCTSkip("Link inside pdf is not loading anymore")
-        /*
         navigator.openURL(PDF_website["url"]!)
         waitUntilPageLoad()
 
@@ -42,7 +40,6 @@ class BrowsingPDFTests: BaseTestCase {
         // Go back to pdf view
         app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
         mozWaitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
-         */
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307118


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2626)

## :bulb: Description
Enable an existing test after we fix the hosting of the PDF files. The test in question `testOpenLinkFromPDF` passes now.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

