### PR TITLE
Bugfix MTE-2281 Increase wait time for L10n screenshot tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -64,6 +64,10 @@ class L10nBaseSnapshotTests: XCTestCase {
             usleep(10000)
         }
     }
+    
+    func waitForTabsButton() {
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: TIMEOUT)
+    }
 
     private func waitFor(
         _ element: XCUIElement,

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -64,7 +64,7 @@ class L10nBaseSnapshotTests: XCTestCase {
             usleep(10000)
         }
     }
-    
+
     func waitForTabsButton() {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: TIMEOUT)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -123,6 +123,6 @@ class L10nBaseSnapshotTests: XCTestCase {
     func waitUntilPageLoad() {
         let app = XCUIApplication()
         let progressIndicator = app.progressIndicators.element(boundBy: 0)
-        mozWaitForElementToNotExist(progressIndicator, timeout: 20.0)
+        mozWaitForElementToNotExist(progressIndicator, timeout: 30.0)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -113,6 +113,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     @MainActor
     func testTopSitesMenu() {
         sleep(3)
+        waitForTabsButton()
         // mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
         navigator.nowAt(NewTabScreen)
         app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell].firstMatch.swipeUp()

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -175,7 +175,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         mozWaitForElementToExist(website.textFields.firstMatch)
         website.textFields.firstMatch.tap()
         website.textFields.firstMatch.typeText("Shoe")
-        mozWaitForElementToExist(website.otherElements.buttons.firstMatch)
+        mozWaitForElementToExist(website.otherElements.buttons.firstMatch, timeout: 30)
         website.otherElements.buttons.element(boundBy: 1).tap()
         waitUntilPageLoad()
         website.images.firstMatch.tap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2281)

## :bulb: Description
L10n screenshot tests may fail occasionally due to the app loads slowly or the webpage is not finished fetching. I have increased the timeout in some places to prevent the tests to fail due to timeout.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

