### PR TITLE
Bugfix FXIOS-8793 #19502 [Password autofill] "Used saved password" prompt missing after a specific scenario

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -326,7 +326,7 @@ class BrowserCoordinator: BaseCoordinator,
         return true
     }
 
-    private func handleSettings(with section: Route.SettingsSection) {
+    private func handleSettings(with section: Route.SettingsSection, onDismiss: (() -> Void)? = nil) {
         guard !childCoordinators.contains(where: { $0 is SettingsCoordinator }) else {
             return // route is handled with existing child coordinator
         }
@@ -344,6 +344,7 @@ class BrowserCoordinator: BaseCoordinator,
 
         navigationController.onViewDismissed = { [weak self] in
             self?.didFinishSettings(from: settingsCoordinator)
+            onDismiss?()
         }
         present(navigationController)
     }
@@ -435,9 +436,9 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - BrowserNavigationHandler
 
-    func show(settings: Route.SettingsSection) {
+    func show(settings: Route.SettingsSection, onDismiss: (() -> Void)? = nil) {
         presentWithModalDismissIfNeeded {
-            self.handleSettings(with: settings)
+            self.handleSettings(with: settings, onDismiss: onDismiss)
         }
     }
 

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -106,7 +106,7 @@ extension BrowserNavigationHandler {
         )
     }
 
-    func show(settings: Route.SettingsSection, onDismiss: (() -> Void)? = nil) {
-        show(settings: settings, onDismiss: onDismiss)
+    func show(settings: Route.SettingsSection) {
+        show(settings: settings, onDismiss: nil)
     }
 }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -9,7 +9,8 @@ import WebKit
 protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     /// Asks to show a settings page, can be a general settings page or a child page
     /// - Parameter settings: The settings route we're trying to get to
-    func show(settings: Route.SettingsSection)
+    /// - Parameter onDismiss: An optional closure that is executed when the settings page is dismissed. This closure takes no parameters and returns no value.
+    func show(settings: Route.SettingsSection, onDismiss: (() -> Void)?)
 
     /// Asks to show a enhancedTrackingProtection page, can be a general 
     /// enhancedTrackingProtection page or a child page
@@ -102,5 +103,9 @@ extension BrowserNavigationHandler {
             toastContainer: toastContainer,
             popoverArrowDirection: popoverArrowDirection
         )
+    }
+
+    func show(settings: Route.SettingsSection, onDismiss: (() -> Void)? = nil) {
+        show(settings: settings, onDismiss: onDismiss)
     }
 }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -9,7 +9,8 @@ import WebKit
 protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     /// Asks to show a settings page, can be a general settings page or a child page
     /// - Parameter settings: The settings route we're trying to get to
-    /// - Parameter onDismiss: An optional closure that is executed when the settings page is dismissed. This closure takes no parameters and returns no value.
+    /// - Parameter onDismiss: An optional closure that is executed when the settings page is dismissed. 
+    /// This closure takes no parameters and returns no value.
     func show(settings: Route.SettingsSection, onDismiss: (() -> Void)?)
 
     /// Asks to show a enhancedTrackingProtection page, can be a general 

--- a/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
@@ -153,7 +153,10 @@ class CredentialAutofillCoordinator: BaseCoordinator {
             },
             manageLoginInfoAction: { [weak self] in
                 guard let self else { return }
-                parentCoordinator?.show(settings: .password)
+                parentCoordinator?.show(settings: .password, onDismiss: {
+                    guard let currentTab = self.tabManager.selectedTab else { return }
+                    LoginsHelper.yieldFocusBackToField(with: currentTab)
+                })
                 parentCoordinator?.didFinish(from: self)
             }
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -27,7 +27,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
     var dismissFakespotSidebarCalled = 0
     var updateFakespotSidebarCalled = 0
 
-    func show(settings: Route.SettingsSection) {
+    func show(settings: Client.Route.SettingsSection, onDismiss: (() -> Void)?) {
         showSettingsCalled += 1
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8793)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19502)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Refocus field after dismissing Settings.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

