### PR TITLE
Bugfix FXIOS-8941 ⁃ When accessing a PDF page for the first time it's scrolled instead of showing the top

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -908,7 +908,7 @@ extension BrowserViewController: WKNavigationDelegate {
         tab.contentBlocker?.notifyContentBlockingChanged()
         self.scrollController.resetZoomState()
 
-        self.scrollController.setShouldScrollToTop()
+        scrollController.shouldScrollToTop = true
 
         if tabManager.selectedTab === tab {
             updateUIForReaderHomeStateForTab(tab, focusUrlBar: true)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -908,6 +908,8 @@ extension BrowserViewController: WKNavigationDelegate {
         tab.contentBlocker?.notifyContentBlockingChanged()
         self.scrollController.resetZoomState()
 
+        self.scrollController.setShouldScrollToTop()
+
         if tabManager.selectedTab === tab {
             updateUIForReaderHomeStateForTab(tab, focusUrlBar: true)
             updateFakespot(tab: tab, isReload: true)

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -64,7 +64,7 @@ class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvi
         return tab?.mimeType == MIMEType.PDF && shouldScrollToTop
     }
 
-    private var shouldScrollToTop = false
+    var shouldScrollToTop = false
 
     private var isZoomedOut = false
     private var lastZoomedScale: CGFloat = 0
@@ -216,10 +216,6 @@ class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvi
 
         observedScrollViews.remove(scrollView)
         scrollView.removeObserver(self, forKeyPath: KVOConstants.contentSize.rawValue)
-    }
-
-    func setShouldScrollToTop() {
-        shouldScrollToTop = true
     }
 
     override func observeValue(
@@ -442,6 +438,13 @@ private extension TabScrollingController {
         }
         return 1 - abs(headerTopOffset / topScrollHeight)
     }
+
+    private func setOffset(y: CGFloat, for scrollView: UIScrollView) {
+        scrollView.contentOffset = CGPoint(
+            x: contentOffsetBeforeAnimation.x,
+            y: y
+        )
+    }
 }
 
 extension TabScrollingController: UIGestureRecognizerDelegate {
@@ -514,12 +517,5 @@ extension TabScrollingController: UIScrollViewDelegate {
             return false
         }
         return true
-    }
-
-    func setOffset(y: CGFloat, for scrollView: UIScrollView) {
-        scrollView.contentOffset = CGPoint(
-            x: contentOffsetBeforeAnimation.x,
-            y: y
-        )
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -60,6 +60,12 @@ class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvi
         return isBottomSearchBar ? bottomShowing : headerTopOffset == 0
     }
 
+    private var shouldSetInitialScrollToTop: Bool {
+        return tab?.mimeType == MIMEType.PDF && shouldScrollToTop
+    }
+
+    private var shouldScrollToTop = false
+
     private var isZoomedOut = false
     private var lastZoomedScale: CGFloat = 0
     private var isUserZoom = false
@@ -210,6 +216,10 @@ class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvi
 
         observedScrollViews.remove(scrollView)
         scrollView.removeObserver(self, forKeyPath: KVOConstants.contentSize.rawValue)
+    }
+
+    func setShouldScrollToTop() {
+        shouldScrollToTop = true
     }
 
     override func observeValue(
@@ -445,6 +455,8 @@ extension TabScrollingController: UIScrollViewDelegate {
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         guard !tabIsLoading(), !isBouncingAtBottom(), isAbleToScroll else { return }
 
+        shouldScrollToTop = false
+
         if decelerate || (toolbarState == .animating && !decelerate) {
             if scrollDirection == .up {
                 showToolbars(animated: true)
@@ -457,12 +469,14 @@ extension TabScrollingController: UIScrollViewDelegate {
     // checking if an abrupt scroll event was triggered and adjusting the offset to the one
     // before the WKWebView's contentOffset is reset as a result of the contentView's frame becoming smaller
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        // for PDFs, we should set the initial offset to 0 (ZERO)
+        if shouldSetInitialScrollToTop {
+            setOffset(y: 0, for: scrollView)
+        }
+
         guard isAnimatingToolbar else { return }
         if contentOffsetBeforeAnimation.y - scrollView.contentOffset.y > UX.abruptScrollEventOffset {
-            scrollView.contentOffset = CGPoint(
-                x: contentOffsetBeforeAnimation.x,
-                y: contentOffsetBeforeAnimation.y + self.topScrollHeight
-            )
+            setOffset(y: contentOffsetBeforeAnimation.y + self.topScrollHeight, for: scrollView)
             contentOffsetBeforeAnimation.y = 0
         }
     }
@@ -500,5 +514,12 @@ extension TabScrollingController: UIScrollViewDelegate {
             return false
         }
         return true
+    }
+
+    func setOffset(y: CGFloat, for scrollView: UIScrollView) {
+        scrollView.contentOffset = CGPoint(
+            x: contentOffsetBeforeAnimation.x,
+            y: y
+        )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8941)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19750)

## :bulb: Description
For PDFs, we should move the scroll to the top, when the page is loaded.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)