### PR TITLE
Add FXIOS-8796 [MicroSurvey] New style to messaging manifest

### DIFF
--- a/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
@@ -63,6 +63,9 @@ import:
               DEFAULT:
                 priority: 50
                 max-display-count: 5
+              MICRO_SURVEY:
+                priority: 50
+                max-display-count: 5
               NOTIFICATION:
                 priority: 50
                 max-display-count: 1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19505)

## :bulb: Description
Add new style for micro survey in our mobile messaging config, aligned with Android on the settings. 

It was decided that adding the style is pretty cheap + having it in our config can improve context for future work related to mobile messaging / microsurveys, so we will add a default one for microsurvey and override it via experiment recipe.

Android Ref: https://phabricator.services.mozilla.com/rMOZILLACENTRAL7e60d85c8c3a4187b0ec81d2f07f6519aec12c7f

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)