### PR TITLE
Refactor FXIOS-7929 [Multi-window] Window order & debug utility

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		1DDE3DB52AC360EC0039363B /* TabCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDE3DB42AC360EC0039363B /* TabCellTests.swift */; };
 		1DDE3DB72AC3820A0039363B /* TabModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDE3DB62AC3820A0039363B /* TabModel.swift */; };
 		1DEBC55E2AC4ED70006E4801 /* RemoteTabsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEBC55D2AC4ED70006E4801 /* RemoteTabsPanel.swift */; };
+		1DF2BDC32BD1BCF300E53C57 /* WindowManager+DebugUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF2BDC22BD1BCF300E53C57 /* WindowManager+DebugUtilities.swift */; };
 		1DF426CF251BDF6A0086386A /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
 		1DFE57FB27B2CB870025DE58 /* HighlightItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE57FA27B2CB870025DE58 /* HighlightItem.swift */; };
 		1DFE57FD27BADD7D0025DE58 /* HomepageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE57FC27BADD7C0025DE58 /* HomepageViewModel.swift */; };
@@ -2250,6 +2251,7 @@
 		1DDE3DB62AC3820A0039363B /* TabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabModel.swift; sourceTree = "<group>"; };
 		1DE6449A95FE587845F9A459 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		1DEBC55D2AC4ED70006E4801 /* RemoteTabsPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanel.swift; sourceTree = "<group>"; };
+		1DF2BDC22BD1BCF300E53C57 /* WindowManager+DebugUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WindowManager+DebugUtilities.swift"; sourceTree = "<group>"; };
 		1DFE57FA27B2CB870025DE58 /* HighlightItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightItem.swift; sourceTree = "<group>"; };
 		1DFE57FC27BADD7C0025DE58 /* HomepageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageViewModel.swift; sourceTree = "<group>"; };
 		1DFE57FE27BAE3150025DE58 /* HomepageSectionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageSectionType.swift; sourceTree = "<group>"; };
@@ -11882,6 +11884,7 @@
 				5A271ABB2860B0BD00471CE4 /* WebServer */,
 				1DA6F6502B48B42900BB5AD6 /* WindowEventCoordinator.swift */,
 				1DC372012B23C80F000F96C8 /* WindowManager.swift */,
+				1DF2BDC22BD1BCF300E53C57 /* WindowManager+DebugUtilities.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -13926,6 +13929,7 @@
 				CA90753824929B22005B794D /* NoLoginsView.swift in Sources */,
 				E4B423BE1AB9FE6A007E66C8 /* ReaderModeCache.swift in Sources */,
 				396CDB55203C5B870034A3A3 /* TabTrayController+KeyCommands.swift in Sources */,
+				1DF2BDC32BD1BCF300E53C57 /* WindowManager+DebugUtilities.swift in Sources */,
 				C855728629AEA3FB00AF32B0 /* SurveySurfaceViewController.swift in Sources */,
 				74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */,
 				EBB8950C21939E4100EB91A0 /* FirefoxTabContentBlocker.swift in Sources */,

--- a/firefox-ios/Client/Application/WindowManager+DebugUtilities.swift
+++ b/firefox-ios/Client/Application/WindowManager+DebugUtilities.swift
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+import Shared
+import TabDataStore
+
+extension WindowManagerImplementation {
+    /// For developer and internal debugging of Multi-window on iPad
+    func _debugDiagnostics() -> String {
+        func short(_ uuid: UUID) -> String { return String(uuid.uuidString.prefix(4)) }
+        guard let del = (UIApplication.shared.delegate as? AppDelegate) else { return "<err>"}
+        var result = "----------- Window Debug Info ------------\n"
+        result.append("Open windows (\(windows.count)) & normal tabs (via TabManager):\n")
+        for (idx, (uuid, _)) in windows.enumerated() {
+            result.append("    \(idx + 1): \(short(uuid))\n")
+            let tabMgr = tabManager(for: uuid)
+            for (tabIdx, tab) in tabMgr.normalTabs.enumerated() {
+                result.append("        \(tabIdx): \(tab.url?.absoluteString ?? "<nil url>")\n")
+            }
+        }
+        result.append("\n")
+        result.append("Ordering prefs:\n")
+        for (idx, pref) in windowOrderingPriority.enumerated() {
+            result.append("    \(idx + 1): \(short(pref))\n")
+        }
+
+        let tabDataStore = del.tabDataStore
+        result.append("\n")
+        result.append("Persisted tabs:\n")
+        let fileManager: TabFileManager = DefaultTabFileManager()
+
+        // Note: this is provided as a convenience for internal debugging. See `DefaultTabDataStore.swift`.
+        for (idx, uuid) in tabDataStore.fetchWindowDataUUIDs().enumerated() {
+            result.append("    \(idx + 1): Window \(short(uuid))\n")
+            let baseURL = fileManager.windowDataDirectory(isBackup: false)!
+            let dataURL = baseURL.appendingPathComponent("window-" + uuid.uuidString)
+            guard let data = try? fileManager.getWindowDataFromPath(path: dataURL) else { continue }
+            for (tabIdx, tabData) in data.tabData.enumerated() {
+                result.append("        \(tabIdx + 1): \(tabData.siteUrl)\n")
+            }
+        }
+        return result
+    }
+}
+
+/// Convenience. For developer and internal debugging
+func _wndMgrDebug() -> String {
+    let windowMgr: WindowManager = AppContainer.shared.resolve()
+    return (windowMgr as? WindowManagerImplementation)?._debugDiagnostics() ?? "<err>"
+}

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -156,7 +156,7 @@ final class WindowManagerImplementation: WindowManager {
         if result.isNew {
             // Be sure to add any brand-new windows to our ordering preferences
             var prefs = windowOrderingPriority
-            prefs.append(resultUUID)
+            prefs.insert(resultUUID, at: 0)
             windowOrderingPriority = prefs
         }
 

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -72,7 +72,8 @@ final class WindowManagerImplementation: WindowManager {
     private var _activeWindowUUID: WindowUUID?
 
     // Ordered set of UUIDs which determines the order that windows are re-opened on iPad
-    private var windowOrderingPriority: [WindowUUID] {
+    // UUIDs at the beginning of the list are prioritized over UUIDs at the end
+    private(set) var windowOrderingPriority: [WindowUUID] {
         get {
             let stored = defaults.object(forKey: WindowPrefKeys.windowOrdering)
             guard let prefs: [String] = stored as? [String] else { return [] }
@@ -119,14 +120,15 @@ final class WindowManagerImplementation: WindowManager {
 
     func windowWillClose(uuid: WindowUUID) {
         postWindowEvent(event: .windowWillClose, windowUUID: uuid)
+        updateWindow(nil, for: uuid)
 
-        // Closed windows are popped off and moved to the end of the ordering priority
+        // Closed windows are popped off and moved behind any already-open windows in the list
         var prefs = windowOrderingPriority
         prefs.removeAll(where: { $0 == uuid })
-        prefs.append(uuid)
+        let openWindows = Array(windows.keys)
+        let idx = prefs.firstIndex(where: { !openWindows.contains($0) })
+        prefs.insert(uuid, at: idx ?? prefs.count)
         windowOrderingPriority = prefs
-
-        updateWindow(nil, for: uuid)
     }
 
     func reserveNextAvailableWindowUUID() -> WindowUUID {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -208,7 +208,7 @@ class WindowManagerTests: XCTestCase {
         XCTAssertNotEqual(requestedUUID2, savedUUID)
     }
 
-    func testOpeningAndClosingWindowsResultsInSensibleExpectedOrder() {
+    func testClosingTwoWindowsInDifferentOrdersResultsInSensibleExpectedOrderWhenOpening() {
         let subject = createSubject()
         let tabDataStore: TabDataStore = AppContainer.shared.resolve()
         let mockTabDataStore = tabDataStore as! MockTabDataStore
@@ -219,11 +219,9 @@ class WindowManagerTests: XCTestCase {
         let uuid2 = UUID()
         mockTabDataStore.injectMockTabWindowUUID(uuid2)
 
-        // Check that asking for first UUID returns the expected UUID
-        // Open a window using this UUID
+        // Open a window using UUID 1
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: uuid1)
-        // Check that asking for another UUID returns the second UUID
-        // Open a window using this UUID
+        // Open a window using UUID 2
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: uuid2)
 
         // Close window 2, then window 1

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -227,8 +227,8 @@ class WindowManagerTests: XCTestCase {
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: uuid2)
 
         // Close window 2, then window 1
-        subject.windowWillClose(uuid: uuid1)
         subject.windowWillClose(uuid: uuid2)
+        subject.windowWillClose(uuid: uuid1)
 
         // Now attempt to re-open two windows in order. We expect window
         // 1 to open, then window 2
@@ -240,9 +240,9 @@ class WindowManagerTests: XCTestCase {
         // Now re-open both windows in order...
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: uuid1)
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: uuid2)
-        // ...but close them in the opposite order as before
-        subject.windowWillClose(uuid: uuid2)
+        // ...but close them in the opposite order as before (close window 1, then 2)
         subject.windowWillClose(uuid: uuid1)
+        subject.windowWillClose(uuid: uuid2)
 
         // Check that the next time we open the windows the order is now reversed
         let result2_1 = subject.reserveNextAvailableWindowUUID()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7929)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17688)

## :bulb: Description

Minor updates & fixes for multi-window. This PR has no changes for normal (single window) use on `main`. 
- Fixes a bug with the order of window restoration on iPad
- Fixes related unit test (was previously testing for the wrong result)
- Adds internal utility for debugging iPad windows. Ex:
```
(lldb) po _wndMgrDebug() as NSString
----------- Window Debug Info ------------
Open windows (1) & normal tabs (via TabManager):
    1: CC53
        0: https://www.google.com/
Ordering prefs:
    1: CC53
    2: 7CE3
    3: 5E2F
Persisted tabs:
    1: Window 5E2F
        1: https://www.wikipedia.org/
    2: Window CC53
        1: https://www.google.com/
    3: Window 7CE3
        1: https://paizo.com/
        2: https://company.wizards.com/en
```

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

