### PR TITLE
Refactor FXIOS-9004 [Multi-window] Background tab loading

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -33,6 +33,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     lazy var notificationSurfaceManager = NotificationSurfaceManager()
     lazy var tabDataStore = DefaultTabDataStore()
     lazy var windowManager = WindowManagerImplementation()
+    lazy var backgroundTabLoader: BackgroundTabLoader = {
+        return DefaultBackgroundTabLoader(tabQueue: (AppContainer.shared.resolve() as Profile).queue)
+    }()
+    private var isLoadingBackgroundTabs = false
 
     private var shutdownWebServer: DispatchSourceTimer?
     private var webServerUtil: WebServerUtil?
@@ -164,6 +168,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             self?.profile.pollCommands(forcePoll: false)
         }
 
+        loadBackgroundTabs()
+
         logger.log("applicationDidBecomeActive end",
                    level: .info,
                    category: .lifecycle)
@@ -210,6 +216,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func updateTopSitesWidget() {
         // Since we only need the topSites data in the archiver, let's write it
         widgetManager?.writeWidgetKitTopSites()
+    }
+
+    private func loadBackgroundTabs() {
+        guard !isLoadingBackgroundTabs else { return }
+
+        // We want to ensure that both the startup flow as well as all window tab restorations
+        // are completed before we attempt to load a background tab. Reminder: we currently do
+        // not know which window will actually open the tab, that is determined by iOS because
+        // the tab is opened via `applicationHelper.open()`.
+        var requiredEvents: [AppEvent] = [.startupFlowComplete]
+        requiredEvents += windowManager.allWindowUUIDs(includingReserved: true).map { .tabRestoration($0) }
+        isLoadingBackgroundTabs = true
+        AppEventQueue.wait(for: requiredEvents) { [weak self] in
+            self?.isLoadingBackgroundTabs = false
+            self?.backgroundTabLoader.loadBackgroundTabs()
+        }
     }
 }
 

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -27,6 +27,13 @@ protocol WindowManager {
 
     /// Convenience. Returns all TabManagers for all open windows.
     func allWindowTabManagers() -> [TabManager]
+    
+    /// Returns the UUIDs for all open windows, optionally also including windows that
+    /// are still in the process of being configured but have not yet completed.
+    /// Note: the order of the UUIDs is undefined.
+    /// - Parameter includingReserved: whether to include windows that are still launching.
+    /// - Returns: a list of UUIDs. Order is undefined.
+    func allWindowUUIDs(includingReserved: Bool) -> [WindowUUID]
 
     /// Signals the WindowManager that a window was closed.
     /// - Parameter uuid: the ID of the window.
@@ -115,6 +122,10 @@ final class WindowManagerImplementation: WindowManager {
 
     func allWindowTabManagers() -> [TabManager] {
         return windows.compactMap { uuid, window in window.tabManager }
+    }
+
+    func allWindowUUIDs(includingReserved: Bool) -> [WindowUUID] {
+        return Array(windows.keys) + (includingReserved ? reservedUUIDs : [])
     }
 
     func windowWillClose(uuid: WindowUUID) {

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -27,7 +27,7 @@ protocol WindowManager {
 
     /// Convenience. Returns all TabManagers for all open windows.
     func allWindowTabManagers() -> [TabManager]
-    
+
     /// Returns the UUIDs for all open windows, optionally also including windows that
     /// are still in the process of being configured but have not yet completed.
     /// Note: the order of the UUIDs is undefined.

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -83,7 +83,6 @@ class BrowserViewController: UIViewController,
     var toolbarContextHintVC: ContextualHintViewController
     var dataClearanceContextHintVC: ContextualHintViewController
     let shoppingContextHintVC: ContextualHintViewController
-    private var backgroundTabLoader: DefaultBackgroundTabLoader
     var windowUUID: WindowUUID { return tabManager.windowUUID }
     var currentWindowUUID: UUID? { return windowUUID }
     private var observedWebViews = WeakList<WKWebView>()
@@ -241,7 +240,6 @@ class BrowserViewController: UIViewController,
         )
         self.dataClearanceContextHintVC = ContextualHintViewController(with: dataClearanceViewProvider,
                                                                        windowUUID: windowUUID)
-        self.backgroundTabLoader = DefaultBackgroundTabLoader(tabQueue: profile.queue)
         super.init(nibName: nil, bundle: nil)
         didInit()
     }
@@ -497,12 +495,6 @@ class BrowserViewController: UIViewController,
 
         updateWallpaperMetadata()
         dismissModalsIfStartAtHome()
-
-        // When, for example, you "Load in Background" via the share sheet, the tab is added to `Profile`'s `TabQueue`.
-        // Make sure that our startup flow is completed and other tabs have been restored before we load.
-        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(tabManager.windowUUID)]) { [weak self] in
-            self?.backgroundTabLoader.loadBackgroundTabs()
-        }
     }
 
     private func nightModeUpdates() {

--- a/firefox-ios/Extensions/NotificationService/NotificationService.swift
+++ b/firefox-ios/Extensions/NotificationService/NotificationService.swift
@@ -113,8 +113,6 @@ class NotificationService: UNNotificationServiceExtension {
 class SyncDataDisplay {
     var contentHandler: (UNNotificationContent) -> Void
     var notificationContent: UNMutableNotificationContent
-
-    var tabQueue: TabQueue?
     var messageDelivered = false
 
     init(content: UNMutableNotificationContent,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9004)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19871)

## :bulb: Description

This PR refactors our background tab loading to work in a multi-window environment. Previously a background tab loader was instantiated for each BVC, though all of them pointed to the same TabQueue, and all of them would respond to the app being brought forward. There are a couple problems with that (now that we can potentially have any number of BVCs/windows open).

The changes here move ownership out of the individual browsers and also update the related events to ensure that all windows during launch have completed their tab restoration before we attempt to load the background tabs.

Note: I tested both loading background tabs on a cold launch as well as when the app was backgrounded, both worked fine in all of my tests so far.

## Recording

https://github.com/mozilla-mobile/firefox-ios/assets/145381717/88b680f0-0dc3-4bd8-b393-ec930cd30ead

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

