### PR TITLE
Add FXIOS-19805 [Fonts] Update: Fonts related to Accessory view to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -18,7 +18,6 @@ class AccessoryViewProvider: UIView, Themeable {
         static let fixedSpacerHeight: CGFloat = 30
         static let fixedLeadingSpacerWidth: CGFloat = 2
         static let fixedTrailingSpacerWidth: CGFloat = 3
-        static let doneButtonFontSize: CGFloat = 17
     }
 
     // MARK: - Properties
@@ -65,11 +64,7 @@ class AccessoryViewProvider: UIView, Themeable {
         let button = UIButton(type: .system)
         button.setTitle(.CreditCard.Settings.Done, for: .normal)
         button.addTarget(self, action: #selector(self.tappedDoneButton), for: .touchUpInside)
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .body,
-            size: UX.doneButtonFontSize,
-            weight: .semibold
-        )
+        button.titleLabel?.font = FXFontStyles.Bold.body.scaledFont()
         let barButton = UIBarButtonItem(customView: button)
         barButton.accessibilityIdentifier = AccessibilityIdentifiers.Browser.KeyboardAccessory.doneButton
         return barButton

--- a/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
@@ -28,7 +28,6 @@ class AutofillAccessoryViewButtonItem: UIBarButtonItem {
         static let accessoryImageViewSize: CGFloat = 24
         static let accessoryButtonStackViewSpacing: CGFloat = 2
         static let cornerRadius: CGFloat = 4
-        static let fontSize: CGFloat = 16
         static let padding: CGFloat = 4
     }
 
@@ -73,11 +72,7 @@ class AutofillAccessoryViewButtonItem: UIBarButtonItem {
         }
 
         self.useAccessoryTextLabel = .build { label in
-            label.font = DefaultDynamicFontHelper.preferredFont(
-                withTextStyle: .title3,
-                size: UX.fontSize,
-                weight: .medium
-            )
+            label.font = FXFontStyles.Bold.title3.scaledFont()
             label.text = labelText
             label.numberOfLines = 0
             label.accessibilityTraits = .button

--- a/firefox-ios/Client/Frontend/Settings/TPAccessoryInfo.swift
+++ b/firefox-ios/Client/Frontend/Settings/TPAccessoryInfo.swift
@@ -40,11 +40,7 @@ class TPAccessoryInfo: ThemedTableViewController {
 
         let header = UILabel()
         header.text = .TPAccessoryInfoBlocksTitle
-        header.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .body,
-            size: 13,
-            weight: .semibold
-        )
+        header.font = FXFontStyles.Bold.body.scaledFont()
 
         let theme = currentTheme()
         header.textColor = theme.colors.textSecondary
@@ -140,11 +136,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         }
         cell.imageView?.tintColor = theme.colors.iconPrimary
         if indexPath.row == 1 {
-            cell.textLabel?.font = DefaultDynamicFontHelper.preferredFont(
-                withTextStyle: .body,
-                size: 13,
-                weight: .regular
-            )
+            cell.textLabel?.font = FXFontStyles.Regular.body.scaledFont()
         }
         cell.textLabel?.numberOfLines = 0
         cell.detailTextLabel?.numberOfLines = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19805)

## :bulb: Description
fonts in following classes updated:
AccessoryViewProvider
TPAccessoryInfo
AutofillAccessoryViewButtonItem

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

