### PR TITLE
Refactor FXIOS-8967 [Fonts] Account to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
@@ -48,11 +48,7 @@ class AccountStatusSetting: WithAccountSetting {
         return NSAttributedString(
             string: string,
             attributes: [
-                NSAttributedString.Key.font: DefaultDynamicFontHelper.preferredFont(
-                    withTextStyle: .body,
-                    size: 17,
-                    weight: .semibold
-                ),
+                NSAttributedString.Key.font: FXFontStyles.Bold.body.scaledFont(),
                 NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]
         )
     }

--- a/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
@@ -24,9 +24,6 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         static let buttonCornerRadius: CGFloat = 8
         static let buttonVerticalInset: CGFloat = 12
         static let buttonHorizontalInset: CGFloat = 16
-        static let buttonFontSize: CGFloat = 16
-        static let signInLabelFontSize: CGFloat = 20
-        static let descriptionFontSize: CGFloat = 17
     }
 
     // MARK: - Properties
@@ -66,8 +63,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.text = .FxASignin_Subtitle
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .headline,
-                                                                size: UX.signInLabelFontSize)
+        label.font = FXFontStyles.Bold.headline.scaledFont()
         label.adjustsFontForContentSizeCategory = true
     }
 
@@ -80,8 +76,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         label.textAlignment = .center
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
-                                                            size: UX.signInLabelFontSize)
+        label.font = FXFontStyles.Regular.headline.scaledFont()
         label.adjustsFontForContentSizeCategory = true
 
         let placeholder = "firefox.com/pair"
@@ -89,8 +84,8 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
             manager.getPairingAuthorityURL { result in
                 guard let url = try? result.get(), let host = url.host else { return }
 
-                let font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
-                                                                  size: UX.signInLabelFontSize)
+                let font = FXFontStyles.Regular.headline.scaledFont()
+
                 let shortUrl = host + url.path // "firefox.com" + "/pair"
                 let msg: String = .FxASignin_QRInstructions.replaceFirstOccurrence(of: placeholder, with: shortUrl)
                 label.attributedText = msg.attributedText(boldString: shortUrl, font: font)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8967)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19804)

## :bulb: Description
fonts in following classes updated:
FirefoxAccountSignInViewController
AccountStatusSetting

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

