### PR TITLE
Refactor FXIOS-8697 handleServerTrust runtime warning

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1043,19 +1043,25 @@ private extension BrowserViewController {
     func handleServerTrust(challenge: URLAuthenticationChallenge,
                            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
-        // If this is a certificate challenge, see if the certificate has previously been
-        // accepted by the user.
-        let origin = "\(challenge.protectionSpace.host):\(challenge.protectionSpace.port)"
+        DispatchQueue.global(qos: .userInitiated).async {
+            // If this is a certificate challenge, see if the certificate has previously been
+            // accepted by the user.
+            let origin = "\(challenge.protectionSpace.host):\(challenge.protectionSpace.port)"
 
-        guard let trust = challenge.protectionSpace.serverTrust,
-              let cert = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
-              profile.certStore.containsCertificate(cert[0], forOrigin: origin)
-        else {
-            completionHandler(.performDefaultHandling, nil)
-            return
+            guard let trust = challenge.protectionSpace.serverTrust,
+                  let cert = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
+                  self.profile.certStore.containsCertificate(cert[0], forOrigin: origin)
+            else {
+                DispatchQueue.main.async {
+                    completionHandler(.performDefaultHandling, nil)
+                }
+                return
+            }
+
+            DispatchQueue.main.async {
+                completionHandler(.useCredential, URLCredential(trust: trust))
+            }
         }
-
-        completionHandler(.useCredential, URLCredential(trust: trust))
     }
 
     func updateObservationReferral(metadataManager: LegacyTabMetadataManager, url: String?, isPrivate: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8697)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19285)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I managed to reproduce this issue while investigating the current certificates flow in Firefox and moving `SecTrustCopyCertificateChain` to a background thread fixes this warning.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
<img width="1462" alt="Screenshot 2024-04-19 at 9 38 30 AM" src="https://github.com/mozilla-mobile/firefox-ios/assets/126153378/5b8352d1-4f27-484b-9438-c010fb5f730f">

