### PR TITLE
Refactor FXIOS-9005 [Multi-window] Wallpaper metadata fetch

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -45,6 +45,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private var widgetManager: TopSitesWidgetManager?
     private var menuBuilderHelper: MenuBuilderHelper?
     private var metricKitWrapper = MetricKitWrapper()
+    private let wallpaperMetadataQueue = DispatchQueue(label: "com.moz.wallpaperVerification.queue")
 
     func application(
         _ application: UIApplication,
@@ -168,6 +169,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             self?.profile.pollCommands(forcePoll: false)
         }
 
+        updateWallpaperMetadata()
         loadBackgroundTabs()
 
         logger.log("applicationDidBecomeActive end",
@@ -231,6 +233,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AppEventQueue.wait(for: requiredEvents) { [weak self] in
             self?.isLoadingBackgroundTabs = false
             self?.backgroundTabLoader.loadBackgroundTabs()
+        }
+    }
+
+    private func updateWallpaperMetadata() {
+        wallpaperMetadataQueue.async {
+            let wallpaperManager = WallpaperManager()
+            wallpaperManager.checkForUpdates()
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -493,7 +493,6 @@ class BrowserViewController: UIViewController,
             urlBar.locationView.tabDidChangeContentBlocking(tab)
         }
 
-        updateWallpaperMetadata()
         dismissModalsIfStartAtHome()
     }
 
@@ -1051,14 +1050,6 @@ class BrowserViewController: UIViewController,
             let alertController = queuedAlertInfo.alertController()
             alertController.delegate = self
             present(alertController, animated: true, completion: nil)
-        }
-    }
-
-    private func updateWallpaperMetadata() {
-        let metadataQueue = DispatchQueue(label: "com.moz.wallpaperVerification.queue")
-        metadataQueue.async {
-            let wallpaperManager = WallpaperManager()
-            wallpaperManager.checkForUpdates()
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9005)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19872)

## :bulb: Description

Minor refactor; moves the wallpaper metadata fetching (which occurs on app activation) out of the BVC and into the more global App Delegate. The reason is that once we enable multi-window we would otherwise be enqueuing an update for each iPad window (since each window has its own BVC instance).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

