### PR TITLE
Add FXIOS-8898 [Fonts] - Standardize fonts on toasts

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
@@ -21,8 +21,6 @@ class ButtonToast: Toast {
         static let buttonPadding: CGFloat = 10
         static let buttonBorderRadius: CGFloat = 5
         static let buttonBorderWidth: CGFloat = 1
-        static let titleFontSize: CGFloat = 15
-        static let descriptionFontSize: CGFloat = 13
         static let widthOffset: CGFloat = 20
     }
 
@@ -41,22 +39,19 @@ class ButtonToast: Toast {
     }
 
     private var titleLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
-                                                                size: UX.titleFontSize)
+        label.font = FXFontStyles.Bold.subheadline.scaledFont()
         label.numberOfLines = 0
     }
 
     private var descriptionLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
-                                                                size: UX.descriptionFontSize)
+        label.font = FXFontStyles.Bold.footnote.scaledFont()
         label.numberOfLines = 0
     }
 
     private var roundedButton: UIButton = .build { button in
         button.layer.cornerRadius = UX.buttonBorderRadius
         button.layer.borderWidth = UX.buttonBorderWidth
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                                         size: Toast.UX.fontSize)
+        button.titleLabel?.font = FXFontStyles.Regular.subheadline.scaledFont()
         button.titleLabel?.numberOfLines = 1
         button.titleLabel?.lineBreakMode = .byClipping
         button.titleLabel?.adjustsFontSizeToFitWidth = true

--- a/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
@@ -31,14 +31,12 @@ class DownloadToast: Toast {
     }
 
     private var titleLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
-                                                                size: ButtonToast.UX.titleFontSize)
+        label.font = FXFontStyles.Bold.subheadline.scaledFont()
         label.numberOfLines = 0
     }
 
     private var descriptionLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
-                                                                size: ButtonToast.UX.descriptionFontSize)
+        label.font = FXFontStyles.Bold.footnote.scaledFont()
         label.numberOfLines = 0
     }
 

--- a/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
@@ -8,8 +8,7 @@ import Shared
 
 struct SimpleToast: ThemeApplicable {
     private let toastLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
-                                                                size: Toast.UX.fontSize)
+        label.font = FXFontStyles.Bold.subheadline.scaledFont()
         label.numberOfLines = 0
         label.textAlignment = .center
     }

--- a/firefox-ios/Client/Frontend/Browser/Toast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toast.swift
@@ -14,7 +14,6 @@ class Toast: UIView, ThemeApplicable {
         static let toastDelayBefore = DispatchTimeInterval.milliseconds(0) // 0 seconds
         static let toastPrivateModeDelayBefore = DispatchTimeInterval.milliseconds(750)
         static let toastAnimationDuration = 0.5
-        static let fontSize: CGFloat = 15
     }
 
     var animationConstraint: NSLayoutConstraint?


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8898)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19643)

## :bulb: Description
Updated the toast structs/classes so they use the newly implemented FXFontsStyle instead of calling DefaultDynamicFontHelper directly.  This eliminates the need to specify font sizes in the toast structs/classes.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

