### PR TITLE
Refactor FXIOS-8897 [Fonts] Updated font on password/passcode view controllers to use FXFontStyles.

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/Cells/PasswordManagerTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/Cells/PasswordManagerTableViewCell.swift
@@ -40,14 +40,14 @@ class PasswordManagerTableViewCell: ThemedTableViewCell {
     }()
 
     lazy var hostnameLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title1, size: 16.0)
+        label.font = FXFontStyles.Regular.callout.scaledFont()
         label.numberOfLines = 1
         label.adjustsFontForContentSizeCategory = true
         label.setContentHuggingPriority(.required, for: .vertical)
     }
 
     lazy var usernameLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .title2, size: 14.0)
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
         label.numberOfLines = 1
         label.adjustsFontForContentSizeCategory = true
     }

--- a/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
@@ -5,6 +5,7 @@
 import Common
 import UIKit
 import Shared
+import ComponentLibrary
 
 enum ParentControllerType {
     case passwords
@@ -12,24 +13,22 @@ enum ParentControllerType {
 }
 
 class DevicePasscodeRequiredViewController: SettingsViewController {
-    private var warningLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = FXFontStyles.Regular.body.scaledFont()
-        label.text = .LoginsDevicePasscodeRequiredMessage
-        label.textAlignment = .center
-        label.numberOfLines = 0
-        return label
-    }()
+    private struct UX {
+        static let maxLabelLines: Int = 0
+        static let standardSpacing: CGFloat = 20
+    }
 
-    private lazy var learnMoreButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.translatesAutoresizingMaskIntoConstraints = false
+    private var warningLabel: UILabel = .build { label in
+        label.text = .LoginsDevicePasscodeRequiredMessage
+        label.font = FXFontStyles.Regular.callout.scaledFont()
+        label.textAlignment = .center
+        label.numberOfLines = UX.maxLabelLines
+    }
+
+    private lazy var learnMoreButton: LinkButton = .build { button in
         button.setTitle(.LoginsDevicePasscodeRequiredLearnMoreButtonTitle, for: .normal)
-        button.addTarget(self, action: #selector(learnMoreButtonTapped), for: .touchUpInside)
-        button.titleLabel?.font = FXFontStyles.Regular.title3.scaledFont()
-        return button
-    }()
+        button.addTarget(self, action: #selector(self.learnMoreButtonTapped), for: .touchUpInside)
+    }
 
     var parentType: ParentControllerType = .passwords
 
@@ -43,11 +42,11 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
             [
                 warningLabel.leadingAnchor.constraint(
                     equalTo: self.view.safeAreaLayoutGuide.leadingAnchor,
-                    constant: 20
+                    constant: UX.standardSpacing
                 ),
                 warningLabel.trailingAnchor.constraint(
                     equalTo: self.view.safeAreaLayoutGuide.trailingAnchor,
-                    constant: -20
+                    constant: -UX.standardSpacing
                 ),
                 warningLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
                 warningLabel.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
@@ -55,7 +54,7 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
                 learnMoreButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
                 learnMoreButton.topAnchor.constraint(
                     equalTo: warningLabel.safeAreaLayoutGuide.bottomAnchor,
-                    constant: 20
+                    constant: UX.standardSpacing
                 )
             ]
         )
@@ -77,5 +76,12 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
         let viewController = SettingsContentViewController(windowUUID: windowUUID)
         viewController.url = SupportUtils.URLForTopic("manage-saved-passwords-firefox-ios")
         navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    override func applyTheme() {
+        super.applyTheme()
+
+        let currentTheme = themeManager.currentTheme(for: windowUUID).colors
+        learnMoreButton.setTitleColor(currentTheme.actionPrimary, for: .normal)
     }
 }

--- a/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
@@ -81,7 +81,7 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
     override func applyTheme() {
         super.applyTheme()
 
-        let currentTheme = themeManager.currentTheme(for: windowUUID).colors
-        learnMoreButton.setTitleColor(currentTheme.actionPrimary, for: .normal)
+        let currentTheme = themeManager.currentTheme(for: windowUUID)
+        learnMoreButton.applyTheme(theme: currentTheme)
     }
 }

--- a/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
@@ -15,7 +15,7 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
     private var warningLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.text = .LoginsDevicePasscodeRequiredMessage
         label.textAlignment = .center
         label.numberOfLines = 0
@@ -27,7 +27,7 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(.LoginsDevicePasscodeRequiredLearnMoreButtonTitle, for: .normal)
         button.addTarget(self, action: #selector(learnMoreButtonTapped), for: .touchUpInside)
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 19)
+        button.titleLabel?.font = FXFontStyles.Regular.title3.scaledFont()
         return button
     }()
 

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -11,8 +11,6 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     private struct UX {
         static let maxLabelLines: Int = 0
         static let buttonCornerRadius: CGFloat = 8
-        static let defaultContentSize: CGFloat = 0
-        static let leadingContentSize: CGFloat = 15
         static let standardSpacing: CGFloat = 20
         static let continueButtonHeight: CGFloat = 44
         static let buttonHorizontalPadding: CGFloat = 35
@@ -21,7 +19,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
 
     private var onboardingMessageLabel: UILabel = . build { label in
         label.text = .Settings.Passwords.OnboardingMessage
-        label.font = FXFontStyles.Regular.title3.scaledFont()
+        label.font = FXFontStyles.Regular.callout.scaledFont()
         label.textAlignment = .center
         label.numberOfLines = UX.maxLabelLines
     }
@@ -35,10 +33,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         button.layer.cornerRadius = UX.buttonCornerRadius
         button.setTitle(.LoginsOnboardingContinueButtonTitle, for: .normal)
         button.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Passwords.onboardingContinue
-        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: UX.defaultContentSize,
-                                                                      leading: UX.leadingContentSize,
-                                                                      bottom: UX.defaultContentSize,
-                                                                      trailing: UX.defaultContentSize)
+        button.configuration?.titleAlignment = .center
         button.addTarget(self, action: #selector(self.proceedButtonTapped), for: .touchUpInside)
     }
 

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -127,9 +127,8 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     override func applyTheme() {
         super.applyTheme()
 
-        let currentTheme = themeManager.currentTheme(for: windowUUID).colors
-        learnMoreButton.setTitleColor(currentTheme.actionPrimary, for: .normal)
-        continueButton.backgroundColor = currentTheme.actionPrimary
-        continueButton.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        let currentTheme = themeManager.currentTheme(for: windowUUID)
+        learnMoreButton.applyTheme(theme: currentTheme)
+        continueButton.applyTheme(theme: currentTheme)
     }
 }

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -9,7 +9,6 @@ import ComponentLibrary
 
 class PasswordManagerOnboardingViewController: SettingsViewController {
     private struct UX {
-        static let fontSize: CGFloat = 19
         static let maxLabelLines: Int = 0
         static let buttonCornerRadius: CGFloat = 8
         static let defaultContentSize: CGFloat = 0
@@ -22,7 +21,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
 
     private var onboardingMessageLabel: UILabel = . build { label in
         label.text = .Settings.Passwords.OnboardingMessage
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
+        label.font = FXFontStyles.Regular.title3.scaledFont()
         label.textAlignment = .center
         label.numberOfLines = UX.maxLabelLines
     }
@@ -30,7 +29,6 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     private lazy var learnMoreButton: LinkButton = .build { button in
         button.setTitle(.LoginsOnboardingLearnMoreButtonTitle, for: .normal)
         button.addTarget(self, action: #selector(self.learnMoreButtonTapped), for: .touchUpInside)
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: UX.fontSize)
     }
 
     private lazy var continueButton: PrimaryRoundedButton = .build { button in

--- a/firefox-ios/CredentialProvider/CredentialPasscodeRequirementViewController.swift
+++ b/firefox-ios/CredentialProvider/CredentialPasscodeRequirementViewController.swift
@@ -12,10 +12,6 @@ protocol CredentialPasscodeRequirementViewControllerDelegate: AnyObject {
 
 class CredentialPasscodeRequirementViewController: UIViewController {
     private struct UX {
-        static let titleFontSize: CGFloat = 32
-        static let taglineFontSize: CGFloat = 20
-        static let warningFontSize: CGFloat = 18
-        static let cancelButtonFontSize: CGFloat = 17
         static let cancelButtonCornerRadius: CGFloat = 8
     }
     var delegate: CredentialPasscodeRequirementViewControllerDelegate?
@@ -30,7 +26,7 @@ class CredentialPasscodeRequirementViewController: UIViewController {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = .LoginsWelcomeViewTitle2
-        label.font = UIFont.systemFont(ofSize: UX.titleFontSize, weight: .bold)
+        label.font = FXFontStyles.Bold.largeTitle.systemFont()
         label.numberOfLines = 0
         label.textAlignment = .center
         return label
@@ -40,7 +36,7 @@ class CredentialPasscodeRequirementViewController: UIViewController {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = .LoginsWelcomeViewTagline
-        label.font = UIFont.systemFont(ofSize: UX.taglineFontSize)
+        label.font = FXFontStyles.Regular.title3.systemFont()
         label.numberOfLines = 0
         label.textAlignment = .center
         return label
@@ -49,7 +45,7 @@ class CredentialPasscodeRequirementViewController: UIViewController {
     private lazy var warningLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: UX.warningFontSize)
+        label.font = FXFontStyles.Regular.body.systemFont()
         label.text = .LoginsPasscodeRequirementWarning
         label.textAlignment = .center
         label.numberOfLines = 0
@@ -61,8 +57,7 @@ class CredentialPasscodeRequirementViewController: UIViewController {
         button.backgroundColor = .systemRed
         button.layer.cornerRadius = UX.cancelButtonCornerRadius
         button.setTitle(.CancelString, for: .normal)
-        button.titleLabel?.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .body,
-                                                                             size: UX.cancelButtonFontSize)
+        button.titleLabel?.font = FXFontStyles.Bold.body.scaledFont()
         button.addTarget(self, action: #selector(self.cancelButtonTapped), for: .touchUpInside)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8897)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19642)

## :bulb: Description
Updated the password/passcode views to use the newly implemented FXFontsStyle instead of DefaultDynamicFontHelper or UIFont.  This eliminates the need to specify font sizes in the password/passcode view controllers.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

