### PR TITLE
Fix MTE-2636 - testOpenInNewTab test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -436,10 +436,10 @@ class NavigationTest: BaseTestCase {
         app.buttons["Open in New Tab"].tap()
         // A new tab loading the article page should open
         navigator.goto(TabTray)
+        mozWaitForElementToExist(app.otherElements["Tabs Tray"].cells.staticTexts["Example Domain"])
         let numTabs = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(numTabs, 2, "Total number of opened tabs should be 2")
         XCTAssertTrue(app.otherElements["Tabs Tray"].cells.elementContainingText("Example Domain.").exists)
-        XCTAssertTrue(app.otherElements["Tabs Tray"].cells.staticTexts["Example Domains"].exists)
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2441773


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-2636

## :bulb: Description

Using mozWaitForElementToExist instead of XCTAssertTrue for waiting and validating the existence of Example Domain tab