### PR TITLE
Fix MTE-2634 Perf data not shown in perfherder

### DIFF
--- a/taskcluster/kinds/bitrise-performance/kind.yml
+++ b/taskcluster/kinds/bitrise-performance/kind.yml
@@ -15,5 +15,6 @@ tasks:
         run-on-tasks-for: []
         worker-type: bitrise
         bitrise:
+            artifact_prefix: public
             workflows:
                 - Bitrise_Performance_Test

--- a/taskcluster/kinds/firebase-performance/kind.yml
+++ b/taskcluster/kinds/firebase-performance/kind.yml
@@ -15,5 +15,6 @@ tasks:
         run-on-tasks-for: []
         worker-type: bitrise
         bitrise:
+            artifact_prefix: public
             workflows:
                 - Firebase_Performance_Test


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2634)


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Perf tests are running in Bitrise and Firebase, however, data is not logged in Perfherder. The task logs are not reachable, so we are making them public in this PR.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

