### PR TITLE
Bugfix FXIOS-9025  Focus doesn't build due to swiftlint force unwrap rule

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -120,6 +120,7 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - firefox-ios/Sync/Generated/Metrics.swift
   - firefox-ios/Storage/Generated/Metrics.swift
   - firefox-ios/ThirdParty
+  - focus-ios-tests/tools/Localizations
   - test-fixtures/tmp
   - firefox-ios/firefox-ios-tests/Tests/UITests/
   - l10n-screenshots-dd/


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9025)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19927)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

