### PR TITLE
Refactor FXIOS-8882 - Enabled SwiftLint opening_brace for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -76,7 +76,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - last_where
   # - modifier_order
   # - multiline_arguments
-  # - opening_brace
+  - opening_brace
   # - overridden_super_call
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_closing_braces


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8882)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19598)

## :bulb: Description
Enabled SwiftLint rule opening_brace for Focus.  No lint errors found after enabling rule.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

