### PR TITLE
Bugfix FXIOS-8672 Skip private tab data on store

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -281,17 +281,6 @@ class AppSettingsTableViewController: SettingsTableViewController,
                                                           settingsDelegate: parentCoordinator))
         }
 
-        privacySettings.append(ClearPrivateDataSetting(settings: self, settingsDelegate: parentCoordinator))
-
-        privacySettings += [
-            BoolSetting(prefs: profile.prefs,
-                        theme: themeManager.currentTheme(for: windowUUID),
-                        prefKey: "settings.closePrivateTabs",
-                        defaultValue: false,
-                        titleText: .AppSettingsClosePrivateTabsTitle,
-                        statusText: .AppSettingsClosePrivateTabsDescription)
-        ]
-
         privacySettings.append(ContentBlockerSetting(settings: self, settingsDelegate: parentCoordinator))
 
         privacySettings.append(NotificationsSetting(theme: themeManager.currentTheme(for: windowUUID),

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -281,6 +281,8 @@ class AppSettingsTableViewController: SettingsTableViewController,
                                                           settingsDelegate: parentCoordinator))
         }
 
+        privacySettings.append(ClearPrivateDataSetting(settings: self, settingsDelegate: parentCoordinator))
+
         privacySettings.append(ContentBlockerSetting(settings: self, settingsDelegate: parentCoordinator))
 
         privacySettings.append(NotificationsSetting(theme: themeManager.currentTheme(for: windowUUID),

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -245,7 +245,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     }
 
     private func generateTabDataForSaving() -> [TabData] {
-        let tabData = tabs.map { tab in
+        let tabData = normalTabs.map { tab in
             let oldTabGroupData = tab.metadataManager?.tabGroupData
             let state = TabGroupTimerState(rawValue: oldTabGroupData?.tabHistoryCurrentState ?? "")
             let groupData = TabGroupData(searchTerm: oldTabGroupData?.tabAssociatedSearchTerm,
@@ -287,6 +287,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     private func saveCurrentTabSessionData() {
         guard let selectedTab = self.selectedTab,
+              !selectedTab.isPrivate,
               let tabSession = selectedTab.webView?.interactionState as? Data,
               let tabID = UUID(uuidString: selectedTab.tabUUID)
         else { return }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -147,7 +147,6 @@ class SettingsTests: BaseTestCase {
             table.cells[settingsQuery.NoImageMode.title], app.switches[settingsQuery.OfferToOpen.title],
             table.cells[settingsQuery.Logins.title], app.switches[settingsQuery.ShowLink.title],
             table.cells[settingsQuery.CreditCards.title], table.cells[settingsQuery.Address.title],
-            table.cells[settingsQuery.ClearData.title], app.switches[settingsQuery.ClosePrivateTabs.title],
             table.cells[settingsQuery.ContentBlocker.title], table.cells[settingsQuery.Notifications.title],
             table.cells[settingsQuery.ShowIntroduction.title], table.cells[settingsQuery.SendAnonymousUsageData.title],
             table.cells[settingsQuery.StudiesToggle.title], table.cells[settingsQuery.Version.title],


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8672)

## :bulb: Description
Skip private tab data on store. Private tabs will no longer be restored when restarting Firefox.
Also removed the setting from settings as that is now the default behaviour. 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

