### PR TITLE
Bugfix MTE-2629 Use Walmart for Fakespot screenshots

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -178,6 +178,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         mozWaitForElementToExist(website.otherElements.buttons.firstMatch, timeout: 30)
         website.otherElements.buttons.element(boundBy: 1).tap()
         waitUntilPageLoad()
+        app.swipeUp()
         mozWaitForElementToExist(website.staticTexts["Sponsored"].firstMatch)
         mozWaitForElementToExist(website.staticTexts["Options"].firstMatch)
         website.staticTexts["Options"].firstMatch.tap()

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -167,18 +167,20 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func testFakespotAvailable() throws {
-        navigator.openURL("https://www.amazon.com")
+        navigator.openURL("https://www.walmart.com")
         waitUntilPageLoad()
 
         // Search for and open a shoe listing
         let website = app.webViews["contentView"].firstMatch
-        mozWaitForElementToExist(website.textFields.firstMatch)
-        website.textFields.firstMatch.tap()
-        website.textFields.firstMatch.typeText("Shoe")
+        mozWaitForElementToExist(website.searchFields["Search"])
+        website.searchFields["Search"].tap()
+        website.searchFields["Search"].typeText("end table")
         mozWaitForElementToExist(website.otherElements.buttons.firstMatch, timeout: 30)
         website.otherElements.buttons.element(boundBy: 1).tap()
         waitUntilPageLoad()
-        website.images.firstMatch.tap()
+        mozWaitForElementToExist(website.staticTexts["Sponsored"].firstMatch)
+        mozWaitForElementToExist(website.staticTexts["Options"].firstMatch)
+        website.staticTexts["Options"].firstMatch.tap()
 
         // Tap the shopping cart icon
         waitUntilPageLoad()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2629)

## :bulb: Description
Sometimes, Amazon.com blocks our attempt to access the site via automation means. We need a site that has been supported by Fakespot currently. Fakespot currently supports walmart.com. 

Let's use walmart.com to invoke the Fakespot-related screens.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

