### PR TITLE
Refactor FXIOS-8879 - Enabled SwiftLint last_where

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -73,7 +73,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - discouraged_assert
   - duplicate_imports
   - duplicate_enum_cases
-  # - last_where
+  - last_where
   - modifier_order
   - multiline_arguments
   - opening_brace


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8879)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19595)

## :bulb: Description
Enabled SwiftLint last_where rule. No violations were found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

