### PR TITLE
Refactor FXIOS-8876 - Enabled SwiftLint discouraged_assert

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -70,7 +70,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - empty_xctest_method
   - explicit_init
   - first_where
-  # - discouraged_assert
+  - discouraged_assert
   - duplicate_imports
   - duplicate_enum_cases
   # - last_where

--- a/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionPageStats.swift
+++ b/focus-ios/Blockzilla/Tracking Protection/TrackingProtectionPageStats.swift
@@ -154,7 +154,7 @@ private class TPStatsBlocklists {
                 }
 
                 guard let loc = filter.range(of: standardPrefix) else {
-                    assert(false, "url-filter code needs updating for new list format")
+                    assertionFailure("url-filter code needs updating for new list format")
                     return
                 }
                 let baseDomain = filter[loc.upperBound...].replacingOccurrences(of: "\\.", with: ".")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8876)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19592)

## :bulb: Description
Enabled SwiftLint discouraged_assert rule. I found 1 violation and it were fixed.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

