### PR TITLE
Bugfix FXIOS-8985 ⁃ Weird display of "Customize Homepage" button after changing the wallpaper

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/ResizableButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/ResizableButton.swift
@@ -68,10 +68,4 @@ open class ResizableButton: UIButton {
     private func updateContentInsets() {
         configuration?.contentInsets = buttonEdgeInsets
     }
-
-    func addCornerRadiusForVisualEffectView(radiusSize: CGFloat) {
-        for subview in self.subviews where subview is UIVisualEffectView {
-            subview.layer.cornerRadius = radiusSize
-        }
-    }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/ResizableButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/ResizableButton.swift
@@ -68,4 +68,10 @@ open class ResizableButton: UIButton {
     private func updateContentInsets() {
         configuration?.contentInsets = buttonEdgeInsets
     }
+
+    func addCornerRadiusForVisualEffectView(radiusSize: CGFloat) {
+        for subview in self.subviews where subview is UIVisualEffectView {
+            subview.layer.cornerRadius = radiusSize
+        }
+    }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -69,8 +69,8 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         // use configuration.background.backgroundColor without any transformation
         updatedConfiguration.background.backgroundColorTransformer = nil
         updatedConfiguration.background.cornerRadius = UX.buttonCornerRadius
-        subviews.first?.layer.cornerRadius = UX.buttonCornerRadius
         updatedConfiguration.cornerStyle = .fixed
+        addCornerRadiusForVisualEffectView(radiusSize: UX.buttonCornerRadius)
 
         accessibilityIdentifier = viewModel.a11yIdentifier
 

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -98,8 +98,6 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         setNeedsUpdateConfiguration()
     }
 
-    // changing the corner radius for the subview, in this case UIVisualEffectView.
-    // maybe there can be another way to change the corner for the subview.
     func addCornerRadiusForVisualEffectView(radiusSize: CGFloat) {
         // Note: changing the corner radius for the subview, in this case UIVisualEffectView
         // is required for certain cases where UIVisualEffectView doesn't update with super view radius change

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -101,6 +101,8 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
     // changing the corner radius for the subview, in this case UIVisualEffectView.
     // maybe there can be another way to change the corner for the subview.
     func addCornerRadiusForVisualEffectView(radiusSize: CGFloat) {
+        // Note: changing the corner radius for the subview, in this case UIVisualEffectView
+        // is required for certain cases where UIVisualEffectView doesn't update with super view radius change
         for subview in self.subviews where subview is UIVisualEffectView {
             subview.layer.cornerRadius = radiusSize
         }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -98,6 +98,8 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         setNeedsUpdateConfiguration()
     }
 
+    // changing the corner radius for the subview, in this case UIVisualEffectView.
+    // maybe there can be another way to change the corner for the subview.
     func addCornerRadiusForVisualEffectView(radiusSize: CGFloat) {
         for subview in self.subviews where subview is UIVisualEffectView {
             subview.layer.cornerRadius = radiusSize

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -98,6 +98,12 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         setNeedsUpdateConfiguration()
     }
 
+    func addCornerRadiusForVisualEffectView(radiusSize: CGFloat) {
+        for subview in self.subviews where subview is UIVisualEffectView {
+            subview.layer.cornerRadius = radiusSize
+        }
+    }
+
     // MARK: ThemeApplicable
 
     public func applyTheme(theme: Theme) {

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -69,6 +69,7 @@ public class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         // use configuration.background.backgroundColor without any transformation
         updatedConfiguration.background.backgroundColorTransformer = nil
         updatedConfiguration.background.cornerRadius = UX.buttonCornerRadius
+        subviews.first?.layer.cornerRadius = UX.buttonCornerRadius
         updatedConfiguration.cornerStyle = .fixed
 
         accessibilityIdentifier = viewModel.a11yIdentifier


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8985)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19833)

## :bulb: Description
Changed cornerRadius for the first subview of the **Customize Homepage** button

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

