### PR TITLE
Bugfix FXIOS-9031 ⁃ Trigger night mode on pages loaded from back forward cache

### DIFF
--- a/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -25,7 +25,9 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         _ userContentController: WKUserContentController,
         didReceiveScriptMessage message: WKScriptMessage
     ) {
-        // Do nothing.
+        guard let webView = message.frameInfo.webView else { return }
+        let jsCallback = "window.__firefox__.NightMode.setEnabled(\(NightModeHelper.isActivated()))"
+        webView.evaluateJavascriptInDefaultContentWorld(jsCallback)
     }
 
     static func toggle(

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/NightModeHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/NightModeHelper.js
@@ -129,6 +129,6 @@ Object.defineProperty(window.__firefox__.NightMode, "setEnabled", {
   }
 });
 
-window.addEventListener("DOMContentLoaded", function() {
-  window.__firefox__.NightMode.setEnabled(window.__firefox__.NightMode.enabled);
+window.addEventListener("pageshow",  () => {
+  webkit.messageHandlers.NightMode.postMessage({ state: "ready" });
 });


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9031)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19935)

## :bulb: Description
This PR:
- Replaces `DOMContentLoaded` with `pageshow` to also run night mode code when page is retrieved from bfcache.
- Delegates calling `setEnabled` to swift. This is necessary because when a page is retrieved from bfcache the in-memory value of `window.__firefox__.NightMode.enabled` will be outdated if night mode was changed.


### Behaviour before 
Current night mode value not reflected when we use back/forwards navigation

https://github.com/mozilla-mobile/firefox-ios/assets/26678795/a1857296-a885-442e-a95d-5601abb73ce2

### Behaviour after
Current night mode value  reflected when we use back/forwards navigation

https://github.com/mozilla-mobile/firefox-ios/assets/26678795/5cd2c9c7-62bf-4d0a-ba55-cdcf636ac3f1


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

