### PR TITLE
Refactor FXIOS-8875 - Enabled SwiftLint first_where for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -69,7 +69,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - empty_string
   # - empty_xctest_method
   # - explicit_init
-  # - first_where
+  - first_where
   # - discouraged_assert
   # - duplicate_imports
   - duplicate_enum_cases

--- a/focus-ios/Blockzilla/Siri/SiriShortcuts.swift
+++ b/focus-ios/Blockzilla/Siri/SiriShortcuts.swift
@@ -62,14 +62,14 @@ class SiriShortcuts {
             DispatchQueue.main.async {
                 guard let voiceShortcuts = voiceShortcuts else { return }
                 // First, check for userActivity, which is for shortcuts that work in the foreground
-                var foundShortcut = voiceShortcuts.filter { (attempt) in
+                var foundShortcut = voiceShortcuts.first(where: { (attempt) in
                     attempt.shortcut.userActivity?.activityType == type.rawValue
-                }.first
+                })
                 // Next, check for intent, which is used for shortcuts that work in the background
                 if type == SiriShortcuts.activityType.erase && foundShortcut == nil {
-                    foundShortcut = voiceShortcuts.filter { (attempt) in
+                    foundShortcut = voiceShortcuts.first(where: { (attempt) in
                         attempt.shortcut.intent as? EraseIntent != nil
-                    }.first
+                    })
                 }
                 completion(foundShortcut != nil)
             }
@@ -102,13 +102,13 @@ class SiriShortcuts {
         INVoiceShortcutCenter.shared.getAllVoiceShortcuts { (voiceShortcuts, error) in
             DispatchQueue.main.async {
                 guard let voiceShortcuts = voiceShortcuts else { return }
-                var foundShortcut = voiceShortcuts.filter { (attempt) in
+                var foundShortcut = voiceShortcuts.first(where: { (attempt) in
                     attempt.shortcut.userActivity?.activityType == activityType.rawValue
-                }.first
+                })
                 if activityType == SiriShortcuts.activityType.erase && foundShortcut == nil {
-                    foundShortcut = voiceShortcuts.filter { (attempt) in
+                    foundShortcut = voiceShortcuts.first(where: { (attempt) in
                         attempt.shortcut.intent as? EraseIntent != nil
-                    }.first
+                    })
                 }
                 if let foundShortcut = foundShortcut {
                     self.displayEditSiri(for: foundShortcut, in: viewController)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8875)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19591)

## :bulb: Description
Enabled SwiftLint rule first_where for Focus.  Corrected new lint errors.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)