### PR TITLE
Refactor FXIOS-8926 [Multi-window] DownloadQueue refactors

### DIFF
--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -70,7 +70,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard !AppConstants.isRunningUnitTest else { return }
 
         // Resume previously stopped downloads for, and on, THIS scene only.
-        downloadQueue.resumeAll()
+        if let uuid = sceneCoordinator?.windowUUID {
+            downloadQueue.resumeAll(for: uuid)
+        }
     }
 
     // MARK: - Transitioning to Background
@@ -80,7 +82,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     /// Use this method to reduce the scene's memory usage, clear claims to resources & dependencies / services.
     /// UIKit takes a snapshot of the scene for the app switcher after this method returns.
     func sceneDidEnterBackground(_ scene: UIScene) {
-        downloadQueue.pauseAll()
+        if let uuid = sceneCoordinator?.windowUUID {
+            downloadQueue.pauseAll(for: uuid)
+        }
     }
 
     // MARK: - Opening URLs

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -55,7 +55,6 @@ extension BrowserViewController: DownloadQueueDelegate {
               download.originWindow == windowUUID
         else { return }
 
-        let uuid = windowUUID
         DispatchQueue.main.async {
             downloadToast.dismiss(false)
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -44,9 +44,6 @@ extension BrowserViewController: DownloadQueueDelegate {
         didDownloadCombinedBytes combinedBytesDownloaded: Int64,
         combinedTotalBytesExpected: Int64?
     ) {
-        // For now, each window handles its downloads independently. For 'combined bytes' this is a bit messy
-        // since it will be combining downloads across multiple different windows. For now we update the toasts
-        // across all windows using this combined bytes total. This will likely be revisited soon. [FXIOS-8926]
         downloadToast?.combinedBytesDownloaded = combinedBytesDownloaded
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -52,7 +52,7 @@ extension BrowserViewController: DownloadQueueDelegate {
 
     func downloadQueue(_ downloadQueue: DownloadQueue, download: Download, didFinishDownloadingTo location: URL) {}
 
-    func downloadQueue(_ downloadQueue: DownloadQueue, didCompleteWithError error: DownloadError?) {
+    func downloadQueue(_ downloadQueue: DownloadQueue, didCompleteWithError error: Error?) {
         guard let downloadToast = self.downloadToast,
               let download = downloadToast.downloads.first,
               download.originWindow == windowUUID
@@ -63,7 +63,7 @@ extension BrowserViewController: DownloadQueueDelegate {
             downloadToast.dismiss(false)
 
             // We only care about download errors specific to our window's downloads
-            if error == nil || error?.windowUUID != uuid {
+            if error == nil {
                 let viewModel = ButtonToastViewModel(labelText: download.filename,
                                                      imageName: StandardImageIdentifiers.Large.checkmark,
                                                      buttonText: .DownloadsButtonTitle)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -132,7 +132,6 @@ extension BrowserViewController: WKUIDelegate {
         contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
         completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
     ) {
-        let thisWindowUUID = windowUUID
         completionHandler(
             UIContextMenuConfiguration(
                 identifier: nil,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -132,6 +132,7 @@ extension BrowserViewController: WKUIDelegate {
         contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
         completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
     ) {
+        let thisWindowUUID = windowUUID
         completionHandler(
             UIContextMenuConfiguration(
                 identifier: nil,
@@ -743,7 +744,8 @@ extension BrowserViewController: WKNavigationDelegate {
             }
 
             // Open our helper and cancel this response from the webview.
-            if let downloadViewModel = downloadHelper.downloadViewModel(okAction: downloadAction) {
+            if let downloadViewModel = downloadHelper.downloadViewModel(windowUUID: windowUUID,
+                                                                        okAction: downloadAction) {
                 presentSheetWith(viewModel: downloadViewModel, on: self, from: urlBar)
             }
             decisionHandler(.cancel)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -271,7 +271,7 @@ class BrowserViewController: UIViewController,
         screenshotHelper = ScreenshotHelper(controller: self)
         tabManager.addDelegate(self)
         tabManager.addNavigationDelegate(self)
-        downloadQueue.delegate = self
+        downloadQueue.addDelegate(self)
         let tabWindowUUID = tabManager.windowUUID
         AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(tabWindowUUID)]) { [weak self] in
             // Ensure we call into didBecomeActive at least once during startup flow (if needed)

--- a/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
@@ -333,13 +333,16 @@ extension DownloadQueue: DownloadDelegate {
     }
 
     func download(_ download: Download, didDownloadBytes bytesDownloaded: Int64) {
-        var progress = downloadProgress[download.originWindow] ?? DownloadProgress(bytesDownloaded: 0, totalExpected: 0)
+        let uuid = download.originWindow
+        var progress = downloadProgress[uuid] ?? DownloadProgress(bytesDownloaded: 0, totalExpected: 0)
         progress.bytesDownloaded += bytesDownloaded
-        downloadProgress[download.originWindow] = progress
+        downloadProgress[uuid] = progress
 
-        delegates.forEach { $0.delegate?.downloadQueue(self,
-                                                       didDownloadCombinedBytes: progress.bytesDownloaded,
-                                                       combinedTotalBytesExpected: progress.totalExpected)
+        delegates.forEach {
+            guard $0.delegate?.windowUUID == uuid else { return }
+            $0.delegate?.downloadQueue(self,
+                                       didDownloadCombinedBytes: progress.bytesDownloaded,
+                                       combinedTotalBytesExpected: progress.totalExpected)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
@@ -256,7 +256,7 @@ class DownloadQueue {
     }
 
     func removeDelegate(_ delegate: DownloadQueueDelegate) {
-        delegates.removeAll(where: { $0.delegate === delegate || $0.delegate == nil }) 
+        delegates.removeAll(where: { $0.delegate === delegate || $0.delegate == nil })
     }
 
     func enqueue(_ download: Download) {

--- a/firefox-ios/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
@@ -96,7 +96,8 @@ class DownloadHelper: NSObject {
         self.preflightResponse = response
     }
 
-    func downloadViewModel(okAction: @escaping (HTTPDownload) -> Void) -> PhotonActionSheetViewModel? {
+    func downloadViewModel(windowUUID: WindowUUID,
+                           okAction: @escaping (HTTPDownload) -> Void) -> PhotonActionSheetViewModel? {
         var requestUrl = request.url
         if let url = requestUrl, url.scheme == "blob" {
             requestUrl = url.removeBlobFromUrl()
@@ -104,7 +105,8 @@ class DownloadHelper: NSObject {
 
         guard let host = requestUrl?.host else { return nil }
 
-        guard let download = HTTPDownload(cookieStore: cookieStore,
+        guard let download = HTTPDownload(originWindow: windowUUID,
+                                          cookieStore: cookieStore,
                                           preflightResponse: preflightResponse,
                                           request: request)
         else { return nil }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
@@ -64,6 +64,7 @@ class DownloadContentScript: TabContentScript {
               let data = Bytes.decodeBase64(base64String)
         else { return }
 
+        let windowUUID = tab?.windowUUID ?? (AppContainer.shared.resolve() as WindowManager).activeWindow
         defer {
             notificationCenter.post(name: .PendingBlobDownloadAddedToQueue, withObject: nil)
             DownloadContentScript.blobUrlForDownload = nil
@@ -89,7 +90,7 @@ class DownloadContentScript: TabContentScript {
             }
         }
 
-        let download = BlobDownload(filename: filename, mimeType: mimeType, size: size, data: data)
+        let download = BlobDownload(originWindow: windowUUID, filename: filename, mimeType: mimeType, size: size, data: data)
         downloadQueue.enqueue(download)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadHelperTests.swift
@@ -142,7 +142,7 @@ class DownloadHelperTests: XCTestCase {
             forceDownload: false
         )
 
-        let downloadViewModel = subject?.downloadViewModel(okAction: { _ in })
+        let downloadViewModel = subject?.downloadViewModel(windowUUID: .XCTestDefaultUUID, okAction: { _ in })
 
         XCTAssertNil(downloadViewModel)
     }
@@ -157,7 +157,7 @@ class DownloadHelperTests: XCTestCase {
             forceDownload: false
         )
 
-        let downloadViewModel = subject?.downloadViewModel(okAction: { _ in })
+        let downloadViewModel = subject?.downloadViewModel(windowUUID: .XCTestDefaultUUID, okAction: { _ in })
 
         XCTAssertEqual(downloadViewModel!.title!, "some-image.jpg")
     }
@@ -171,7 +171,7 @@ class DownloadHelperTests: XCTestCase {
             forceDownload: false
         )
 
-        let downloadViewModel = subject?.downloadViewModel(okAction: { _ in })
+        let downloadViewModel = subject?.downloadViewModel(windowUUID: .XCTestDefaultUUID, okAction: { _ in })
 
         XCTAssertEqual(downloadViewModel!.closeButtonTitle, .CancelString)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadTests.swift
@@ -10,7 +10,7 @@ class DownloadTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        download = Download()
+        download = Download(originWindow: .XCTestDefaultUUID)
     }
 
     override func tearDown() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8926)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19720)

## :bulb: Description

Our original `DownloadQueue` (and related code) was written for a single-window environment. There are a few fundamental issues when using it with multi-window on iPadOS. This PR implements several refactors to allow downloads to work more gracefully across multiple windows.

Known issue: if a window is closed, currently there is no UI to allow users to interact with any downloads that had been started in that window (since the related toast will be closed along with its parent window). This has been brought up with the UX/Product teams and will likely be revisited soon. 



## Video

**Notes**
- The total bytes downloaded is currently showing incorrect values on `main`. I confirmed this is a [pre-existing bug](https://mozilla-hub.atlassian.net/browse/FXIOS-9039) and is not related to these refactors.
- The video shows delays in a few spots due to breakpoints, this is not a bug/issue in the app.

https://github.com/mozilla-mobile/firefox-ios/assets/145381717/bce693f6-9c73-4a18-b848-46f4d97ebb35



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

