### PR TITLE
Refactor FXIOS-8874 - Enabled SwiftLint explicit_init for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -68,7 +68,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - empty_count
   # - empty_string
   # - empty_xctest_method
-  # - explicit_init
+  - explicit_init
   # - first_where
   # - discouraged_assert
   # - duplicate_imports


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8874)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19590)

## :bulb: Description
Enabled SwiftLint rule explicit_init for Focus.  No new lint errors found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

