### PR TITLE
Refactor FXIOS-8872 - Enabled SwiftLint empty_string

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -66,7 +66,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - contains_over_range_nil_comparison
   # - empty_collection_literal
   # - empty_count
-  # - empty_string
+  - empty_string
   # - empty_xctest_method
   # - explicit_init
   # - first_where

--- a/focus-ios/Blockzilla/Extensions/URLExtensions.swift
+++ b/focus-ios/Blockzilla/Extensions/URLExtensions.swift
@@ -32,7 +32,7 @@ private func loadEntriesFromDisk() -> TLDEntryMap? {
     }
 
     let lines = data.components(separatedBy: "\n")
-    let trimmedLines = lines.filter { !$0.hasPrefix("//") && $0 != "\n" && $0 != "" }
+    let trimmedLines = lines.filter { !$0.hasPrefix("//") && $0 != "\n" && !$0.isEmpty }
 
     var entries = TLDEntryMap()
     for line in trimmedLines {

--- a/focus-ios/Blockzilla/Extensions/URLExtensions.swift
+++ b/focus-ios/Blockzilla/Extensions/URLExtensions.swift
@@ -253,7 +253,7 @@ extension URL {
     public var normalizedHost: String? {
         // Use components.host instead of self.host since the former correctly preserves
         // brackets for IPv6 hosts, whereas the latter strips them.
-        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false), var host = components.host, host != "" else {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false), var host = components.host, !host.isEmpty else {
             return nil
         }
 

--- a/focus-ios/Blockzilla/Extensions/URLExtensions.swift
+++ b/focus-ios/Blockzilla/Extensions/URLExtensions.swift
@@ -431,7 +431,7 @@ private extension URL {
                     .backwards,      // Search from the end.
                     .anchored]         // Stick to the end.
                 let suffixlessHost = host.replacingOccurrences(of: suffix, with: "", options: literalFromEnd, range: nil)
-                let suffixlessTokens = suffixlessHost.components(separatedBy: ".").filter { $0 != "" }
+                let suffixlessTokens = suffixlessHost.components(separatedBy: ".").filter { !$0.isEmpty }
                 let maxAdditionalCount = max(0, suffixlessTokens.count - additionalPartCount)
                 let additionalParts = suffixlessTokens[maxAdditionalCount..<suffixlessTokens.count]
                 let partsString = additionalParts.joined(separator: ".")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8872)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19588)

## :bulb: Description
Enabled SwiftLint empty_string rule. I found 3 violations and it were fixed.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

