### PR TITLE
Refactor FXIOS-7856 [Multi-window] Fix telemetry tabManager reference

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -56,10 +56,6 @@ class BrowserCoordinator: BaseCoordinator,
         self.glean = glean
         super.init(router: router)
 
-        // TODO [7856]: Additional telemetry updates forthcoming once iPad multi-window enabled.
-        // For now, we only have a single BVC and TabManager. Plug it into our TelemetryWrapper:
-        TelemetryWrapper.shared.defaultTabManager = tabManager
-
         browserViewController.browserDelegate = self
         browserViewController.navigationHandler = self
         tabManager.addDelegate(self)

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -45,9 +45,6 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
 
     static let shared = TelemetryWrapper()
 
-    // TODO [7856]: Temporary. Additional telemetry updates forthcoming once iPad multi-window enabled.
-    var defaultTabManager: TabManager?
-
     let glean = Glean.shared
     // Boolean flag to temporarily remember if we crashed during the
     // last run of the app. We cannot simply use `Sentry.crashedLastLaunch`
@@ -152,10 +149,9 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         GleanMetrics.Search.defaultEngine.set(defaultEngine?.engineID ?? "custom")
 
         // Record the open tab count
-        // TODO [7856]: Additional telemetry updates forthcoming once iPad multi-window enabled.
-        if let count = defaultTabManager?.count {
-            GleanMetrics.Tabs.cumulativeCount.add(Int32(count))
-        }
+        let windowManager: WindowManager = AppContainer.shared.resolve()
+        let tabCount = windowManager.allWindowTabManagers().map({ $0.count }).reduce(0, +)
+        GleanMetrics.Tabs.cumulativeCount.add(Int32(tabCount))
 
         // Record other preference settings.
         // If the setting exists at the key location, use that value. Otherwise record the default


### PR DESCRIPTION
## :scroll: Tickets
Partial work towards:
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7856)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17537)

## :bulb: Description

This removes the single tab manager reference from the TelemetryWrapper and updates the tab count metric to work for multi-window.

This also fixes an issue where the `defaultTabManager` would be incorrectly retained and prevent it from being freed when its associated iPad window is closed.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

