### PR TITLE
Refactor FXIOS-8834 - Enabled Swiftlint: no_space_in_method_call

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -28,7 +28,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - legacy_hashing
   # - legacy_nsgeometry_functions
   # - mark
-  # - no_space_in_method_call
+  - no_space_in_method_call
   # - ns_number_init_as_function_reference
   # - operator_whitespace
   # - orphaned_doc_comment


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8834)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19550)

## :bulb: Description
- Enabled Swiftlint rule no_space_in_method_call for Focus.
- No new lint errors found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

