### PR TITLE
Refactor FXIOS-8808 - Enabled Swiftlint: closure_spacing

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -2,7 +2,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - line_length
   # - blanket_disable_command
   # - class_delegate_protocol
-  # - closure_spacing
+  - closure_spacing
   # - closure_parameter_position
   # - colon
   # - comma


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8808)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19540)

## :bulb: Description
- Enabled Swiftlint rule closure_spacing for Focus.
- No new lint errors found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)