### PR TITLE
Refactor FXIOS-8812 - Enabled Swiftlint: comment_spacing 

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -6,7 +6,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - closure_parameter_position
   # - colon
   # - comma
-  # - comment_spacing
+  - comment_spacing
   - compiler_protocol_init
   - computed_accessors_order
   # - control_statement


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8812)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19536)

## :bulb: Description
- Enabled Swiftlint rule comment_spacing for Focus.
- No new lint errors found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)