### PR TITLE
Add FXIOS-9021 New trigger for number of app launches

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbContextProvider.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbContextProvider.swift
@@ -13,6 +13,7 @@ class GleanPlumbContextProvider {
         case isDefaultBrowser = "is_default_browser"
         case isInactiveNewUser = "is_inactive_new_user"
         case allowedTipsNotifications = "allowed_tips_notifications"
+        case numberOfAppLaunches = "number_of_app_launches"
     }
 
     struct Constant {
@@ -21,6 +22,11 @@ class GleanPlumbContextProvider {
     }
 
     var userDefaults: UserDefaultsInterface = UserDefaults.standard
+    private var profile: Profile
+
+    init(profile: Profile = AppContainer.shared.resolve()) {
+        self.profile = profile
+    }
 
     private var todaysDate: String {
         let dateFormatter = DateFormatter()
@@ -30,6 +36,10 @@ class GleanPlumbContextProvider {
 
     private var isDefaultBrowser: Bool {
         return userDefaults.bool(forKey: RatingPromptManager.UserDefaultsKey.keyIsBrowserDefault.rawValue)
+    }
+
+    private var numberOfAppLaunches: Int32 {
+        return profile.prefs.intForKey(PrefsKeys.Session.Count) ?? 0
     }
 
     var isInactiveNewUser: Bool {
@@ -62,6 +72,7 @@ class GleanPlumbContextProvider {
         return [ContextKey.todayDate.rawValue: todaysDate,
                 ContextKey.isDefaultBrowser.rawValue: isDefaultBrowser,
                 ContextKey.isInactiveNewUser.rawValue: isInactiveNewUser,
+                ContextKey.numberOfAppLaunches.rawValue: numberOfAppLaunches,
                 ContextKey.allowedTipsNotifications.rawValue: allowedTipsNotifications]
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/GleanPlumbContextProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/GleanPlumbContextProviderTests.swift
@@ -10,12 +10,14 @@ import XCTest
 class GleanPlumbContextProviderTests: XCTestCase {
     private var userDefaults: UserDefaultsInterface!
     private var contextProvider: GleanPlumbContextProvider!
+    private var profile: MockProfile!
 
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         userDefaults = MockUserDefaults()
-        contextProvider = GleanPlumbContextProvider()
+        profile = MockProfile()
+        contextProvider = GleanPlumbContextProvider(profile: profile)
         contextProvider.userDefaults = userDefaults
     }
 
@@ -23,6 +25,20 @@ class GleanPlumbContextProviderTests: XCTestCase {
         super.tearDown()
         userDefaults = nil
         contextProvider = nil
+    }
+
+    func testNumberOfLaunches_withFirstLaunch() {
+        profile.prefs.setInt(1, forKey: PrefsKeys.Session.Count)
+        let context = contextProvider.createAdditionalDeviceContext()
+        let numberOfAppLaunches = context["number_of_app_launches"] as? Int32
+        XCTAssertEqual(numberOfAppLaunches, 1)
+    }
+
+    func testNumberOfLaunches_withSecondLaunch() {
+        profile.prefs.setInt(2, forKey: PrefsKeys.Session.Count)
+        let context = contextProvider.createAdditionalDeviceContext()
+        let numberOfAppLaunches = context["number_of_app_launches"] as? Int32
+        XCTAssertEqual(numberOfAppLaunches, 2)
     }
 
     func testIsInactiveNewUser_noFirstAppUse() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9021)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19922)

## :bulb: Description
Add `number_of_app_launches` to be used as a trigger for the Viewpoint surveys and maintain consistency with triggers with Android. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

