### PR TITLE
Fix 2634 Follow-up Perf data not shown

### DIFF
--- a/taskcluster/kinds/bitrise-performance/kind.yml
+++ b/taskcluster/kinds/bitrise-performance/kind.yml
@@ -13,6 +13,11 @@ tasks:
     tests:
         description: Run Performance Tests on iOS Simulator in Bitrise
         run-on-tasks-for: []
+        treeherder:
+            symbol: bitrise-perf
+            kind: test
+            platform: ios-simulator-iphone14-16-4/opt
+            tier: 1
         worker-type: bitrise
         bitrise:
             artifact_prefix: public

--- a/taskcluster/kinds/build/kind.yml
+++ b/taskcluster/kinds/build/kind.yml
@@ -15,6 +15,11 @@ tasks:
         attributes:
             chunk_locales: ["en-US"]
         run-on-tasks-for: []
+        treeherder:
+            symbol: B(screenshots)
+            kind: build
+            tier: 1
+            platform: ios/opt
         worker-type: bitrise
         bitrise:
             artifact_prefix: public

--- a/taskcluster/kinds/firebase-performance/kind.yml
+++ b/taskcluster/kinds/firebase-performance/kind.yml
@@ -13,6 +13,11 @@ tasks:
     tests:
         description: Run Performance Tests on Physical Devices in Firebase
         run-on-tasks-for: []
+        treeherder:
+            symbol: firebase-perf
+            kind: test
+            platform: ios-physical-iphone14pro-16-6/opt
+            tier: 1
         worker-type: bitrise
         bitrise:
             artifact_prefix: public


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2634)

The routes to treeherder were missing. Adding them back to each task


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

