### PR TITLE
Refactor FXIOS-8873 - Enabled SwiftLint empty_xctest_method for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -67,7 +67,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - empty_collection_literal
   # - empty_count
   - empty_string
-  # - empty_xctest_method
+  - empty_xctest_method
   - explicit_init
   # - first_where
   # - discouraged_assert


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8873)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19589)

## :bulb: Description
Enabled SwiftLint rule empty_xctest_method for Focus.  No new lint errors found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

