### PR TITLE
Refactor FXIOS-8869 - Enabled SwiftLint contains_over_range_nil_comparison for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -63,7 +63,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - contains_over_filter_count
   # - contains_over_filter_is_empty
   # - contains_over_first_not_nil
-  # - contains_over_range_nil_comparison
+  - contains_over_range_nil_comparison
   # - empty_collection_literal
   # - empty_count
   - empty_string

--- a/focus-ios/Blockzilla/Utilities/URIFixup.swift
+++ b/focus-ios/Blockzilla/Utilities/URIFixup.swift
@@ -24,7 +24,7 @@ class URIFixup {
             trimmed.range(of: "\\b:[0-9]{1,5}", options: .regularExpression) == nil {
             // check for top-level domain if scheme is "http://" or "https://"
             if trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://") {
-                if trimmed.range(of: ".") == nil {
+                if trimmed.contains(".") == false {
                     return nil
                 }
             }
@@ -35,11 +35,11 @@ class URIFixup {
         // make sure there's at least one "." in the host. This means
         // we'll allow single-word searches (e.g., "foo") at the expense
         // of breaking single-word hosts without a scheme (e.g., "localhost").
-        if trimmed.range(of: ".") == nil {
+        if trimmed.contains(".") == false {
             return nil
         }
 
-        if trimmed.range(of: " ") != nil {
+        if trimmed.contains(" ") == true {
             return nil
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8869)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19585)

## :bulb: Description
Enabled SwiftLint rule contains_over_range_nil_comparison for Focus.  Corrected new lint violations.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

