### PR TITLE
Refactor FXIOS-8868 - Enabled SwiftLint contains_over_first_not_nil for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -62,7 +62,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - closure_end_indentation
   # - contains_over_filter_count
   # - contains_over_filter_is_empty
-  # - contains_over_first_not_nil
+  - contains_over_first_not_nil
   # - contains_over_range_nil_comparison
   # - empty_collection_literal
   # - empty_count


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8868)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19584)

## :bulb: Description
Enabled SwiftLint rule contains_over_first_not_nil for Focus.  No new violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

