### PR TITLE
Add FXIOS-9045 [Component Library] Underline style to our LinkButton component

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
@@ -26,6 +26,7 @@ open class LinkButton: UIButton, ThemeApplicable {
         updatedConfiguration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming
             outgoing.font = viewModel.font
+            outgoing.underlineStyle = .single
             return outgoing
         }
         updatedConfiguration.contentInsets = viewModel.contentInsets


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9045)

## :bulb: Description
To improve accessibility, we would like to add underline to our LinkButton components. This conversation came about due to the privacy notice link being underlined as part of microsurveys. It seems this was enforced on desktop and would 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
| Light | Dark | 
| --- | --- |
![simulator_screenshot_1828DDE6-0E0A-481E-AFBF-C5B37AA48942](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/0992810d-7d5a-42fa-ab56-606a58a80631) |  ![simulator_screenshot_E0EBF9A1-32B8-478E-B906-27F5A515B619](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/3aa347d1-7006-4304-94f3-c72c6222bf76) |
