### PR TITLE
Bugfix FXIOS-8892 a11y Address autofill Save and Fill Addresses switch button is incorrectly announced

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -72,6 +72,8 @@ struct AddressAutofillToggle: View {
             }
             .accessibilityElement()
             .accessibilityLabel("\(String.Addresses.Settings.SwitchTitle), \(String.Addresses.Settings.SwitchDescription)")
+            .accessibilityValue("\(model.isEnabled ? 1 : 0)")
+            .accessibilityAddTraits(traits)
             .accessibilityAction {
                 model.isEnabled = !model.isEnabled
             }
@@ -89,6 +91,14 @@ struct AddressAutofillToggle: View {
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        }
+    }
+
+    var traits: AccessibilityTraits {
+        if #available(iOS 17.0, *) {
+            return [.isButton, .isToggle]
+        } else {
+            return [.isButton]
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8892)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19617)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add missing value and trait.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

