### PR TITLE
Refactor FXIOS-8867 - Enabled SwiftLint contains_over_filter_is_empty for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -61,7 +61,7 @@ only_rules: # Only enforce these rules, ignore all others
   - closing_brace
   # - closure_end_indentation
   # - contains_over_filter_count
-  # - contains_over_filter_is_empty
+  - contains_over_filter_is_empty
   - contains_over_first_not_nil
   - contains_over_range_nil_comparison
   - empty_collection_literal

--- a/focus-ios/Blockzilla/Settings/Controller/SettingsViewController.swift
+++ b/focus-ios/Blockzilla/Settings/Controller/SettingsViewController.swift
@@ -525,7 +525,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
     }
 
     @objc private func toggleSwitched(_ sender: UISwitch) {
-        let toggle = toggles.values.filter { $0.values.filter { $0.toggle == sender }.isEmpty == false }[0].values.filter { $0.toggle == sender }[0]
+        let toggle = toggles.values.filter { $0.values.contains(where: { $0.toggle == sender }) }[0].values.filter { $0.toggle == sender }[0]
 
         func updateSetting() {
             Settings.set(sender.isOn, forToggle: toggle.setting)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8867)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19583)

## :bulb: Description
Enabled SwiftLint rule contains_over_filter_is_empty for Focus.  Corrected new lint violation.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

