### PR TITLE
Refactor FXIOS-8866 - Enabled SwiftLint contains_over_filter_count for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -60,7 +60,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - attributes
   - closing_brace
   # - closure_end_indentation
-  # - contains_over_filter_count
+  - contains_over_filter_count
   # - contains_over_filter_is_empty
   - contains_over_first_not_nil
   - contains_over_range_nil_comparison

--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -440,7 +440,7 @@ extension LegacyWebViewController: WKNavigationDelegate {
 
         switch navigationAction.navigationType {
             case .backForward:
-                let navigatingBack = webView.backForwardList.backList.filter { $0 == currentBackForwardItem }.count == 0
+                let navigatingBack = !webView.backForwardList.backList.contains(where: { $0 == currentBackForwardItem })
                 if navigatingBack {
                     delegate?.webControllerDidNavigateBack(self)
                 } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8866)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19582)

## :bulb: Description
Enabled SwiftLint rule contains_over_filter_count for Focus.  Corrected new lint violation.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

