### PR TITLE
Refactor FXIOS-8862 - Enabled SwiftLint redundant_type_annotation for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -56,7 +56,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - void_function_in_ternary
   # - void_return
   # - file_header
-  # - redundant_type_annotation
+  - redundant_type_annotation
   # - attributes
   - closing_brace
   # - closure_end_indentation


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8862)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19578)

## :bulb: Description
Enabled SwiftLint rule redundant_type_annotation for Focus.  No new lint violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

