### PR TITLE
Refactor FXIOS-8860 - Enabled SwiftLint void_return for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -54,7 +54,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - vertical_parameter_alignment
   - vertical_whitespace
   # - void_function_in_ternary
-  # - void_return
+  - void_return
   # - file_header
   - redundant_type_annotation
   # - attributes


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8860)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19576)

## :bulb: Description
Enabled SwiftLint rule void_return for Focus.  No new lint violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

