### PR TITLE
Add FXIOS-8977 [Microsurvey] Configs for mobile messaging

### DIFF
--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -53,3 +53,22 @@ import:
                 action: OPEN_URL
                 action-params:
                   url: https://www.macrumors.com
+
+              # Serves as an example of how microsurveys may look like
+              microsurvey-message:
+                surface: microsurvey
+                style: MICROSURVEY
+                trigger-if-all:
+                  - ALWAYS
+                title: "Firefox Survey"
+                text: "What is your favorite firefox feature?"
+                button-label: "Continue"
+                microsurveyConfig:
+                  target-feature: printing
+                  options:
+                    - "Very Disatisfied"
+                    - "Disatisfied"
+                    - "Neutral"
+                    - "Satisfied"
+                    - "Very Satisfied"
+

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -60,14 +60,14 @@ import:
                 style: MICROSURVEY
                 trigger-if-all:
                   - NEVER
-                title: "Help make printing in Firefox better. It only takes a sec."
+                title: Microsurvey/Microsurvey.Prompt.TitleLabel.v127
                 text: "How satisfied are you with printing in Firefox?" # Should not show this message if this is nil
-                button-label: "Continue"
+                button-label: Microsurvey/Microsurvey.Prompt.TakeSurveyButton.v127
                 microsurveyConfig:
                   target-feature: printing
                   options:
-                    - "Very Satisfied"
-                    - "Satisfied"
-                    - "Neutral"
-                    - "Dissatisfied"
-                    - "Very Dissatisfied"
+                    - Microsurvey/Microsurvey.Survey.Options.LikertScaleOption1.v127
+                    - Microsurvey/Microsurvey.Survey.Options.LikertScaleOption2.v127
+                    - Microsurvey/Microsurvey.Survey.Options.LikertScaleOption3.v127
+                    - Microsurvey/Microsurvey.Survey.Options.LikertScaleOption4.v127
+                    - Microsurvey/Microsurvey.Survey.Options.LikertScaleOption5.v127

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -59,16 +59,15 @@ import:
                 surface: microsurvey
                 style: MICROSURVEY
                 trigger-if-all:
-                  - ALWAYS
-                title: "Firefox Survey"
-                text: "What is your favorite firefox feature?"
+                  - NEVER
+                title: "Help make printing in Firefox better. It only takes a sec."
+                text: "How satisfied are you with printing in Firefox?" # Should not show this message if this is nil
                 button-label: "Continue"
                 microsurveyConfig:
                   target-feature: printing
                   options:
-                    - "Very Disatisfied"
-                    - "Disatisfied"
-                    - "Neutral"
-                    - "Satisfied"
                     - "Very Satisfied"
-
+                    - "Satisfied"
+                    - "Neutral"
+                    - "Disatisfied"
+                    - "Very Disatisfied"

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -69,5 +69,5 @@ import:
                     - "Very Satisfied"
                     - "Satisfied"
                     - "Neutral"
-                    - "Disatisfied"
-                    - "Very Disatisfied"
+                    - "Dissatisfied"
+                    - "Very Dissatisfied"

--- a/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
@@ -63,7 +63,7 @@ import:
               DEFAULT:
                 priority: 50
                 max-display-count: 5
-              MICRO_SURVEY:
+              MICROSURVEY:
                 priority: 50
                 max-display-count: 5
               NOTIFICATION:

--- a/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
@@ -192,9 +192,9 @@ objects:
         Attributes relating to microsurvey messaging.
     fields:
       target-feature:
-        type: TargetFeature
+        type: MicrosurveyTargetFeature
         description: >
-            The type of the feature the survey is targeted for.
+          The type of feature the microsurvey is targeted.
         default: Unknown # Should not be defaulted
       options:
         description: The list of survey options to present to the user.
@@ -226,12 +226,11 @@ enums:
       show-none:
         description: The surface should show no message.
 
-  TargetFeature:
+  MicrosurveyTargetFeature:
     description: >
-      For microsurveys, we would like to have a message tell us which target feature it is associated with.
-      This is a label that matches across both Android and iOS.
+      The specific feature the microsurvey is for. This is a label that matches across both Android and iOS.
     variants:
       printing:
-        description: The target feature for this message is related to the printing feature.
+        description: The printing feature.
       Unknown:
-        description: The message does not have a target feature.
+        description: No target feature set. Only used in an invalid experiment configuration.

--- a/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
@@ -198,7 +198,7 @@ objects:
         default: Unknown # Should not be defaulted
       options:
         description: The list of survey options to present to the user.
-        type: List<String>
+        type: List<Text>
         default: [] # Should not be defaulted
 
 enums:

--- a/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
@@ -163,6 +163,11 @@ objects:
         type: Option<ExperimentSlug>
         description: The experiment slug that this message is involved in.
         default: null
+        
+      microsurveyConfig:
+        type: Option<MicrosurveyConfig>
+        description: Optional configuration data for a microsurvey.
+        default: null
 
   StyleData:
     description: >
@@ -182,6 +187,20 @@ objects:
           before it is expired.
         default: 5
 
+  MicrosurveyConfig:
+    description: >
+        Attributes relating to microsurvey messaging.
+    fields:
+      target-feature:
+        type: TargetFeature
+        description: >
+            The type of the feature the survey is targeted for.
+        default: Unknown # Should not be defaulted
+      options:
+        description: The list of survey options to present to the user.
+        type: List<String>
+        default: [] # Should not be defaulted
+
 enums:
   MessageSurfaceId:
     description: >
@@ -192,6 +211,8 @@ enums:
         description: This is the card that appears at the top on the Firefox Home Page.
       survey:
         description: This is a full-page that appears providing a survey to the user.
+      microsurvey:
+        description: This is a microsurvey that appears on top of the bottom toolbar to the user.
       notification:
         description: This is a local notification send to the user periodically with tips and updates.
       Unknown:
@@ -204,3 +225,13 @@ enums:
         description: The next eligible message should be shown.
       show-none:
         description: The surface should show no message.
+
+  TargetFeature:
+    description: >
+      For microsurveys, we would like to have a message tell us which target feature it is associated with.
+      This is a label that matches across both Android and iOS.
+    variants:
+      printing:
+        description: The target feature for this message is related to the printing feature.
+      Unknown:
+        description: The message does not have a target feature.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8977)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19820)

## :bulb: Description
This PR is in draft to ensure that Android / iOS are aligned in terms of the schema configurations for mobile messaging.

Add configurations for mobile messaging for microsurveys. Will update the strings once the hard-coded strings PR is merged.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

