### PR TITLE
Refactor FXIOS-8926 [Multi-window] Cancel downloads for closed windows

### DIFF
--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -56,6 +56,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Handle clean-up here for closing windows on iPad
         guard let sceneCoordinator = (scene.delegate as? SceneDelegate)?.sceneCoordinator else { return }
 
+        // For now, we explicitly cancel downloads for windows that are closed.
+        // On iPhone this will happen during app termination, for iPad it will
+        // occur on termination or when a window is disconnected/closed by iPadOS
+        downloadQueue.cancelAll(for: sceneCoordinator.windowUUID)
+
         // Notify WindowManager that window is closing
         (AppContainer.shared.resolve() as WindowManager).windowWillClose(uuid: sceneCoordinator.windowUUID)
     }


### PR DESCRIPTION
## :scroll: Tickets

Additional minor change for FXIOS-8926 based on updated feedback from product: 
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8926)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19720)

## :bulb: Description

For now the decision is that we will explicitly cancel downloads for iPad windows that are closed. This should have no 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

