### PR TITLE
Refactor FXIOS-8855 - Enabled SwiftLint unused_optional_binding for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -49,7 +49,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - unavailable_condition
   # - unneeded_override
   # - unneeded_synthesized_initializer
-  # - unused_optional_binding
+  - unused_optional_binding
   # - unused_setter_value
   # - vertical_parameter_alignment
   - vertical_whitespace


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8855)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19571)

## :bulb: Description
Enabled SwiftLint rule unused_optional_binding for Focus.  No new lint violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

