### PR TITLE
Refactor FXIOS-7974 [Multi-window] Tab sync refactors

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		1DDE3DB52AC360EC0039363B /* TabCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDE3DB42AC360EC0039363B /* TabCellTests.swift */; };
 		1DDE3DB72AC3820A0039363B /* TabModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDE3DB62AC3820A0039363B /* TabModel.swift */; };
 		1DEBC55E2AC4ED70006E4801 /* RemoteTabsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEBC55D2AC4ED70006E4801 /* RemoteTabsPanel.swift */; };
+		1DF1167A2BDB0FDA00521158 /* WindowTabsSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF116792BDB0FDA00521158 /* WindowTabsSyncCoordinator.swift */; };
 		1DF2BDC32BD1BCF300E53C57 /* WindowManager+DebugUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF2BDC22BD1BCF300E53C57 /* WindowManager+DebugUtilities.swift */; };
 		1DF426CF251BDF6A0086386A /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
 		1DFE57FB27B2CB870025DE58 /* HighlightItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE57FA27B2CB870025DE58 /* HighlightItem.swift */; };
@@ -2255,6 +2256,7 @@
 		1DDE3DB62AC3820A0039363B /* TabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabModel.swift; sourceTree = "<group>"; };
 		1DE6449A95FE587845F9A459 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		1DEBC55D2AC4ED70006E4801 /* RemoteTabsPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsPanel.swift; sourceTree = "<group>"; };
+		1DF116792BDB0FDA00521158 /* WindowTabsSyncCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowTabsSyncCoordinator.swift; sourceTree = "<group>"; };
 		1DF2BDC22BD1BCF300E53C57 /* WindowManager+DebugUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WindowManager+DebugUtilities.swift"; sourceTree = "<group>"; };
 		1DFE57FA27B2CB870025DE58 /* HighlightItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightItem.swift; sourceTree = "<group>"; };
 		1DFE57FC27BADD7C0025DE58 /* HomepageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageViewModel.swift; sourceTree = "<group>"; };
@@ -9538,6 +9540,7 @@
 				5A8017DF29CE15D90047120D /* TabManagerImplementation.swift */,
 				6ACB550B28633860007A6ABD /* TabManagerNavDelegate.swift */,
 				21BFEEF42A040EF40033048D /* TabMigrationUtility.swift */,
+				1DF116792BDB0FDA00521158 /* WindowTabsSyncCoordinator.swift */,
 			);
 			path = TabManagement;
 			sourceTree = "<group>";
@@ -13979,6 +13982,7 @@
 				219935EC2B07110900E5966F /* TabTrayModel.swift in Sources */,
 				8A3EF7F72A2FCF6D00796E3A /* ExportLogDataSetting.swift in Sources */,
 				43E69EC3254D081D00B591C2 /* SimpleTab.swift in Sources */,
+				1DF1167A2BDB0FDA00521158 /* WindowTabsSyncCoordinator.swift in Sources */,
 				8ADAE4202A33A0FD007BF926 /* SendFeedbackSetting.swift in Sources */,
 				C29B64812AD6959E00F3244B /* QRCodeCoordinator.swift in Sources */,
 				21A7C45028353D0E0071D996 /* OnboardingBasicCardViewController.swift in Sources */,

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -54,6 +54,9 @@ protocol WindowManager {
     /// - Parameter event: the event that occurred and any associated metadata.
     /// - Parameter windowUUID: the UUID of the window triggering the event.
     func postWindowEvent(event: WindowEvent, windowUUID: WindowUUID)
+    
+    /// Signals the WindowManager to store tabs (across all windows) on the default Profile.
+    func storeTabs()
 }
 
 /// Captures state and coordinator references specific to one particular app window.
@@ -77,6 +80,7 @@ final class WindowManagerImplementation: WindowManager {
     private let tabDataStore: TabDataStore
     private let defaults: UserDefaultsInterface
     private var _activeWindowUUID: WindowUUID?
+    private lazy var tabSyncCoordinator = WindowTabsSyncCoordinator()
 
     // Ordered set of UUIDs which determines the order that windows are re-opened on iPad
     // UUIDs at the beginning of the list are prioritized over UUIDs at the end
@@ -186,6 +190,10 @@ final class WindowManagerImplementation: WindowManager {
                 coordinator.coordinatorHandleWindowEvent(event: event, uuid: windowUUID)
             }
         }
+    }
+
+    func storeTabs() {
+        tabSyncCoordinator.syncTabsToProfile()
     }
 
     // MARK: - Internal Utilities

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -54,7 +54,7 @@ protocol WindowManager {
     /// - Parameter event: the event that occurred and any associated metadata.
     /// - Parameter windowUUID: the UUID of the window triggering the event.
     func postWindowEvent(event: WindowEvent, windowUUID: WindowUUID)
-    
+
     /// Signals the WindowManager to store tabs (across all windows) on the default Profile.
     func storeTabs()
 }
@@ -65,7 +65,7 @@ struct AppWindowInfo {
     weak var sceneCoordinator: SceneCoordinator?
 }
 
-final class WindowManagerImplementation: WindowManager {
+final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinatorDelegate {
     enum WindowPrefKeys {
         static let windowOrdering = "windowOrdering"
     }
@@ -80,7 +80,7 @@ final class WindowManagerImplementation: WindowManager {
     private let tabDataStore: TabDataStore
     private let defaults: UserDefaultsInterface
     private var _activeWindowUUID: WindowUUID?
-    private lazy var tabSyncCoordinator = WindowTabsSyncCoordinator()
+    private let tabSyncCoordinator = WindowTabsSyncCoordinator()
 
     // Ordered set of UUIDs which determines the order that windows are re-opened on iPad
     // UUIDs at the beginning of the list are prioritized over UUIDs at the end
@@ -104,6 +104,7 @@ final class WindowManagerImplementation: WindowManager {
         self.logger = logger
         self.tabDataStore = tabDataStore
         self.defaults = userDefaults
+        tabSyncCoordinator.delegate = self
     }
 
     // MARK: - Public API
@@ -194,6 +195,12 @@ final class WindowManagerImplementation: WindowManager {
 
     func storeTabs() {
         tabSyncCoordinator.syncTabsToProfile()
+    }
+
+    // MARK: - WindowTabSyncCoordinatorDelegate
+
+    func tabManagers() -> [TabManager] {
+        return allWindowTabManagers()
     }
 
     // MARK: - Internal Utilities

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -298,21 +298,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         }
     }
 
-    func saveTabs(toProfile profile: Profile, _ tabs: [Tab], _ inactiveTabs: [Tab]) {
-        let inactiveTabs = Set(inactiveTabs)
-        // It is possible that not all tabs have loaded yet, so we filter out tabs with a nil URL.
-        let storedTabs: [RemoteTab] = tabs.compactMap {
-            let inactive = inactiveTabs.contains($0)
-            return Tab.toRemoteTab($0, inactive: inactive)
-        }
-
-        // Don't insert into the DB immediately. We tend to contend with more important
-        // work like querying for top sites.
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
-            profile.storeTabs(storedTabs)
-        }
-    }
-
     // TODO: FXIOS-7596 Remove when moving the TabManager protocol to TabManagerImplementation
     func storeChanges() { fatalError("should never be called") }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -16,6 +16,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     private let imageStore: DiskImageStore?
     private let tabMigration: TabMigrationUtility
     private var tabsTelemetry = TabsTelemetry()
+    private let windowManager: WindowManager
     var notificationCenter: NotificationProtocol
     var inactiveTabsManager: InactiveTabsManagerProtocol
 
@@ -33,18 +34,20 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
          tabSessionStore: TabSessionStore = DefaultTabSessionStore(),
          tabMigration: TabMigrationUtility = DefaultTabMigrationUtility(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
-         inactiveTabsManager: InactiveTabsManagerProtocol = InactiveTabsManager()) {
-            self.tabDataStore = tabDataStore
-            self.tabSessionStore = tabSessionStore
-            self.imageStore = imageStore
-            self.tabMigration = tabMigration
-            self.notificationCenter = notificationCenter
-            self.inactiveTabsManager = inactiveTabsManager
-            super.init(profile: profile, uuid: uuid)
+         inactiveTabsManager: InactiveTabsManagerProtocol = InactiveTabsManager(),
+         windowManager: WindowManager = AppContainer.shared.resolve()) {
+        self.tabDataStore = tabDataStore
+        self.tabSessionStore = tabSessionStore
+        self.imageStore = imageStore
+        self.tabMigration = tabMigration
+        self.notificationCenter = notificationCenter
+        self.inactiveTabsManager = inactiveTabsManager
+        self.windowManager = windowManager
+        super.init(profile: profile, uuid: uuid)
 
-            setupNotifications(forObserver: self,
-                               observing: [UIApplication.willResignActiveNotification,
-                                           .TabMimeTypeDidSet])
+        setupNotifications(forObserver: self,
+                           observing: [UIApplication.willResignActiveNotification,
+                                       .TabMimeTypeDidSet])
     }
 
     // MARK: - Restore tabs
@@ -280,7 +283,8 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
 
     /// storeChanges is called when a web view has finished loading a page
     override func storeChanges() {
-        saveTabs(toProfile: profile, normalTabs, inactiveTabs)
+        let windowManager: WindowManager = AppContainer.shared.resolve()
+        windowManager.storeTabs()
         preserveTabs()
         saveCurrentTabSessionData()
     }

--- a/firefox-ios/Client/TabManagement/WindowTabsSyncCoordinator.swift
+++ b/firefox-ios/Client/TabManagement/WindowTabsSyncCoordinator.swift
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import Common
+import Storage
+
+final class WindowTabsSyncCoordinator {
+    private struct Timing {
+        static let throttleDelay = 0.5
+        static let dbInsertionDelay = 0.1
+    }
+    private let throttler = Throttler(seconds: Timing.throttleDelay)
+    // TODO: This creates a retain cycle. Currently doesn't matter since it's a global ubiquitous instance though.
+    private let windowManager: WindowManager
+    private let profile: Profile
+    private let logger: Logger
+
+    init(profile: Profile = AppContainer.shared.resolve(),
+         logger: Logger = DefaultLogger.shared,
+         windowManager: WindowManager = AppContainer.shared.resolve()) {
+        self.profile = profile
+        self.logger = logger
+        self.windowManager = windowManager
+    }
+
+    func syncTabsToProfile() {
+        throttler.throttle { [weak self] in self?.performSync() }
+    }
+
+    // MARK: - Utility
+
+    private func performSync() {
+        // This work is performed on the main thread to avoid potential threading issues with the tab collections
+        let allTabManagers = windowManager.allWindowTabManagers()
+        let windowCount = allTabManagers.count
+        let normalTabs = allTabManagers.flatMap({ $0.normalTabs })
+        let inactiveTabs = Set(allTabManagers.flatMap({ $0.inactiveTabs }))
+
+        // It is possible that not all tabs have loaded yet, so we filter out tabs with a nil URL.
+        let storedTabs: [RemoteTab] = normalTabs.compactMap { Tab.toRemoteTab($0, inactive: inactiveTabs.contains($0)) }
+
+        // Don't insert into the DB immediately. We tend to contend with more important
+        // work like querying for top sites.
+        DispatchQueue.main.asyncAfter(deadline: .now() + Timing.dbInsertionDelay) { [weak self] in
+            self?.logger.log("Storing \(storedTabs.count) total tabs for \(windowCount) windows", level: .info, category: .sync)
+            self?.profile.storeTabs(storedTabs)
+        }
+    }
+}

--- a/firefox-ios/Client/TabManagement/WindowTabsSyncCoordinator.swift
+++ b/firefox-ios/Client/TabManagement/WindowTabsSyncCoordinator.swift
@@ -29,7 +29,9 @@ final class WindowTabsSyncCoordinator {
     }
 
     func syncTabsToProfile() {
-        throttler.throttle { [weak self] in self?.performSync() }
+        // throttler.throttle { [weak self] in self?.performSync() }
+        // TODO: [FXIOS-9050] Once 9050 issue is addressed, throttle calls to `performSync`
+        performSync()
     }
 
     // MARK: - Utility

--- a/firefox-ios/Client/Utils/Throttler.swift
+++ b/firefox-ios/Client/Utils/Throttler.swift
@@ -22,6 +22,7 @@ class Throttler {
 
     // This debounces; the task will not happen unless a duration of delay passes since the function was called
     func throttle(completion: @escaping () -> Void) {
+        // TODO: [FXIOS-9050] This can potentially infinitely delay the enqueued work which is not ideal.
         task.cancel()
         task = DispatchWorkItem { completion() }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -27,8 +27,11 @@ class DependencyHelperMock {
         AppContainer.shared.register(service: diskImageStore)
 
         let windowUUID = WindowUUID.XCTestDefaultUUID
+        let windowManager: WindowManager = WindowManagerImplementation()
         let tabManager: TabManager =
-        injectedTabManager ?? TabManagerImplementation(profile: profile, uuid: windowUUID)
+        injectedTabManager ?? TabManagerImplementation(profile: profile,
+                                                       uuid: windowUUID,
+                                                       windowManager: windowManager)
 
         let appSessionProvider: AppSessionProvider = AppSessionManager()
         AppContainer.shared.register(service: appSessionProvider)
@@ -42,7 +45,6 @@ class DependencyHelperMock {
         let downloadQueue = DownloadQueue()
         AppContainer.shared.register(service: downloadQueue)
 
-        let windowManager: WindowManager = WindowManagerImplementation()
         AppContainer.shared.register(service: windowManager)
         windowManager.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: windowUUID)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7974)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17769)

## :bulb: Description

Refactors our tab syncing so that it occurs outside of the individual tab managers, and tabs for all windows are sent on iPad where multi-window will soon be supported.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

