### PR TITLE
Refactor FXIOS-8848 - Enabled SwiftLint syntactic_sugar for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -42,7 +42,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - return_arrow_whitespace
   # - statement_position
   # - switch_case_alignment
-  # - syntactic_sugar
+  - syntactic_sugar
   # - trailing_newline
   # - trailing_semicolon
   - trailing_whitespace


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8848)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19564)

## :bulb: Description
Enabled SwiftLint rule syntactic_sugar for Focus.  No new lint violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

