### PR TITLE
Fix MTE-2674 saveThisCardPrompt test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -342,6 +342,7 @@ class CreditCardsTests: BaseTestCase {
         app.buttons["Close"].tap()
         mozWaitForElementToNotExist(app.staticTexts["Securely save this card?"])
         // Go to the Settings --> Payment methods
+        swipeDown(nrOfSwipes: 2)
         navigator.goto(CreditCardsSettings)
         unlockLoginsView()
         // The credit card is not saved
@@ -362,6 +363,7 @@ class CreditCardsTests: BaseTestCase {
         mozWaitForElementToExist(app.staticTexts["New Card Saved"])
         mozWaitForElementToNotExist(app.staticTexts["Securely save this card?"])
         // Go to the Settings --> Payment methods
+        swipeDown(nrOfSwipes: 2)
         navigator.goto(CreditCardsSettings)
         unlockLoginsView()
         // The credit card is saved and displayed in the Credit cards section


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-2674

## :bulb: Description

Fix for testSaveThisCardPrompt test. Some swipes are required to make the toolbar menu visible.