### PR TITLE
Fix MTE-2675 Workaround to run github action after automatic PR

### DIFF
--- a/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
+++ b/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
@@ -1,6 +1,8 @@
 name: Build and Run Autofill Automation
 permissions: read-all
 on:
+    workflow_call: {}
+    workflow_dispatch: {}
     pull_request:
       paths:
         - 'firefox-ios/Client/Assets/CC_Script/**'

--- a/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
+++ b/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
@@ -1,7 +1,10 @@
 name: Build and Run Autofill Automation
 permissions: read-all
 on:
-    workflow_call: {}
+    workflow_call:
+      secrets:
+          SLACK_WEBHOOK_URL:
+            required: true
     workflow_dispatch: {}
     pull_request:
       paths:
@@ -21,7 +24,11 @@ jobs:
     steps:
         - name: Checkout repository
           uses: actions/checkout@v4
-
+        - name: Get the current github action name
+          if: always()
+          run: |
+            github_action_name="Update credential provider script"
+            echo "github_action_name=$github_action_name" >> $GITHUB_ENV
         - name: Clone repository
           run: |
             git clone https://github.com/issammani/test-playwright.git
@@ -41,3 +48,23 @@ jobs:
             
             echo "Run tests"
             npm test
+        - name: Send custom JSON data to Slack workflow
+          if: always()
+          id: slack
+          uses: slackapi/slack-github-action@v1.26.0
+          with:
+            payload: |
+              {
+                "text": "GitHub Action Running Tests For ${{ env.github_action_name }} result: ${{ job.status }}",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "GitHub Action Running Tests For result: ${{ job.status }}"
+                    }
+                  }
+                ]
+              }
+          env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
+++ b/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         python-version: [3.9]
         xcode: ["15.2"]
+    continue-on-error: true
     steps:
         - name: Checkout repository
           uses: actions/checkout@v4

--- a/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
+++ b/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
@@ -26,7 +26,6 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v4
         - name: Get the current github action name
-          if: always()
           run: |
             github_action_name="Update credential provider script"
             echo "github_action_name=$github_action_name" >> $GITHUB_ENV
@@ -49,8 +48,8 @@ jobs:
             
             echo "Run tests"
             npm test
-        - name: Send custom JSON data to Slack workflow
-          if: always()
+        - name: Send Slack notification if tests fail
+          if: '!cancelled()'
           id: slack
           uses: slackapi/slack-github-action@v1.26.0
           with:

--- a/.github/workflows/firefox-ios-update_credential_provider_script.yml
+++ b/.github/workflows/firefox-ios-update_credential_provider_script.yml
@@ -41,3 +41,6 @@ jobs:
         title: Refactor [vXXX] auto update credential provider script
         branch: update-cred-provider-script
         token: ${{ secrets.GITHUB_TOKEN }}
+
+  call-firefox-ios-autofill-playwrite-tests:
+    uses: ./.github/workflows/firefox-ios-autofill-playwrite-tests.yml

--- a/.github/workflows/firefox-ios-update_credential_provider_script.yml
+++ b/.github/workflows/firefox-ios-update_credential_provider_script.yml
@@ -20,10 +20,9 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Get the current github action name
-          if: always()
-          run: |
-            github_action_name="Update credential provider script"
-            echo "github_action_name=$github_action_name" >> $GITHUB_ENV
+      run: |
+        github_action_name="Update credential provider script"
+        echo "github_action_name=$github_action_name" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -48,8 +47,8 @@ jobs:
         title: Refactor [vXXX] auto update credential provider script
         branch: update-cred-provider-script
         token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Send custom JSON data to Slack workflow
-      if: always()
+    - name: Send Slack to notifiy if github action fails
+      if: '!cancelled()'
       id: slack
       uses: slackapi/slack-github-action@v1.26.0
       with:

--- a/.github/workflows/firefox-ios-update_credential_provider_script.yml
+++ b/.github/workflows/firefox-ios-update_credential_provider_script.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch: # adding the workflow_dispatch so it can be triggered manually
 
+env:
+    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,8 +18,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        persist-credentials: false
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Get the current github action name
+          if: always()
+          run: |
+            github_action_name="Update credential provider script"
+            echo "github_action_name=$github_action_name" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -41,6 +48,27 @@ jobs:
         title: Refactor [vXXX] auto update credential provider script
         branch: update-cred-provider-script
         token: ${{ secrets.GITHUB_TOKEN }}
-
+    - name: Send custom JSON data to Slack workflow
+      if: always()
+      id: slack
+      uses: slackapi/slack-github-action@v1.26.0
+      with:
+            payload: |
+              {
+                "text": "GitHub Action ${{ env.github_action_name }} build result: ${{ job.status }}",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "GitHub Action build result: ${{ job.status }}"
+                    }
+                  }
+                ]
+              }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   call-firefox-ios-autofill-playwrite-tests:
     uses: ./.github/workflows/firefox-ios-autofill-playwrite-tests.yml
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2675)

This is what we would see when the automatic PR Refactor [vXXX] auto update credential provider script
 runs: 
There are two jobs, one that creates the PR (build) and the second one that runs the github action with the autofill tests (autofill-automation in this example)

![Screenshot 2024-04-29 at 12 47 26](https://github.com/mozilla-mobile/firefox-ios/assets/1897507/47288eee-9b13-4166-85bb-8b0a66f53ba3)

If the tests fail, the PR will not be created. Even though I monitor the github actions to see if there are failures, I will add a notificaiton when that happens so that we are sure that we don't miss that..

I'm adding also the dispatch here so that we could manually trigger the github action to run the tests from any branch

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

