### PR TITLE
Refactor FXIOS-8845 - Enabled SwiftLint return_arrow_whitespace for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -39,7 +39,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - redundant_optional_initialization
   # - redundant_string_enum_value
   # - redundant_void_return
-  # - return_arrow_whitespace
+  - return_arrow_whitespace
   # - statement_position
   # - switch_case_alignment
   - syntactic_sugar


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8845)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19561)

## :bulb: Description
Enabled SwiftLint rule return_arrow_whitespace for Focus.  No new lint violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)