### PR TITLE
Refactor FXIOS-8843 - Enabled SwiftLint redundant_string_enum_value for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -37,7 +37,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - redundant_discardable_let
   # - redundant_objc_attribute
   # - redundant_optional_initialization
-  # - redundant_string_enum_value
+  - redundant_string_enum_value
   # - redundant_void_return
   # - return_arrow_whitespace
   # - statement_position

--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -55,9 +55,9 @@ class LegacyWebViewController: UIViewController, LegacyWebController {
     }
 
     private enum KVOConstants: String, CaseIterable {
-        case URL = "URL"
-        case canGoBack = "canGoBack"
-        case canGoForward = "canGoForward"
+        case URL
+        case canGoBack
+        case canGoForward
     }
 
     weak var delegate: LegacyWebControllerDelegate?

--- a/focus-ios/Blockzilla/Utilities/InternalURL.swift
+++ b/focus-ios/Blockzilla/Utilities/InternalURL.swift
@@ -9,16 +9,16 @@ public struct InternalURL {
     public static let scheme = "internal"
     public static let baseUrl = "\(scheme)://local"
     public enum Path: String {
-        case errorpage = "errorpage"
-        case sessionrestore = "sessionrestore"
+        case errorpage
+        case sessionrestore
         func matches(_ string: String) -> Bool {
             return string.range(of: "/?\(self.rawValue)", options: .regularExpression, range: nil, locale: nil) != nil
         }
     }
 
     public enum Param: String {
-        case uuidkey = "uuidkey"
-        case url = "url"
+        case uuidkey
+        case url
         func matches(_ string: String) -> Bool { return string == self.rawValue }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8843)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19559)

## :bulb: Description
Enabled SwiftLint rule redundant_string_enum_value for Focus.  Corrected new lint violations.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)