### PR TITLE
Bugfix FXIOS-8950 - Fix scenerio where tab would have no screenshot (#19770)

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1798,6 +1798,8 @@ class BrowserViewController: UIViewController,
 
         guard let webView = tab.webView else { return }
 
+        self.screenshotHelper.takeScreenshot(tab)
+
         if let url = webView.url {
             if (!InternalURL.isValid(url: url) || url.isReaderModeURL) && !url.isFileURL {
                 postLocationChangeNotificationForTab(tab, navigation: navigation)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8950)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19770)

## :bulb: Description
### After video
https://github.com/mozilla-mobile/firefox-ios/assets/5545720/9101bb18-d241-4082-83ce-ad338f1b2a7f

When multiple new tabs were opened on iPad or iPhone in landscape (by using the + button on the top left) there would only be the image placeholder image for that tab even if the tab had a full opportunity to load the view - this change makes it so that there's an image in that scenario now.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

