### PR TITLE
Refactor FXIOS-8841 - Enabled SwiftLint redundant_objc_attribute for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -35,7 +35,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - private_over_fileprivate
   # - protocol_property_accessors_order
   # - redundant_discardable_let
-  # - redundant_objc_attribute
+  - redundant_objc_attribute
   - redundant_optional_initialization
   # - redundant_string_enum_value
   # - redundant_void_return


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8841)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19557)

## :bulb: Description
Enabled SwiftLint rule redundant_objc_attribute for Focus.  No new lint violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)