### PR TITLE
Refactor FXIOS-8838 - Enabled SwiftLint private_over_fileprivate for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -32,7 +32,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - ns_number_init_as_function_reference
   # - operator_whitespace
   # - orphaned_doc_comment
-  # - private_over_fileprivate
+  - private_over_fileprivate
   # - protocol_property_accessors_order
   # - redundant_discardable_let
   # - redundant_objc_attribute


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8838)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19554)

## :bulb: Description
Enabled SwiftLint rule private_over_fileprivate for Focus.  No new lint violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)