### PR TITLE
Bugfix FXIOS-8957 Fix theme in empty history panel

### DIFF
--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -580,7 +580,7 @@ class HistoryPanel: UIViewController,
 
     private func applyEmptyStateViewTheme(_ theme: Theme) {
         welcomeLabel.textColor = theme.colors.textSecondary
-        emptyStateOverlayBackgroundColorView?.backgroundColor = self.currentTheme().colors.layer1
+        emptyStateOverlayBackgroundColorView?.backgroundColor = theme.colors.layer1
     }
 
     private func createEmptyStateOverlayView() -> UIView {

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -129,6 +129,7 @@ class HistoryPanel: UIViewController,
     }()
 
     lazy var emptyStateOverlayView: UIView = createEmptyStateOverlayView()
+    private weak var emptyStateOverlayBackgroundColorView: UIView?
     lazy var welcomeLabel: UILabel = .build { label in
         label.text = self.viewModel.emptyStateText
         label.textAlignment = .center
@@ -568,12 +569,18 @@ class HistoryPanel: UIViewController,
 
     func updateEmptyPanelState() {
         if viewModel.shouldShowEmptyState(searchText: searchbar.text ?? "") {
+            applyEmptyStateViewTheme(currentTheme())
             welcomeLabel.text = viewModel.emptyStateText
             tableView.tableFooterView = emptyStateOverlayView
         } else {
             tableView.alwaysBounceVertical = true
             tableView.tableFooterView = nil
         }
+    }
+
+    private func applyEmptyStateViewTheme(_ theme: Theme) {
+        welcomeLabel.textColor = theme.colors.textSecondary
+        emptyStateOverlayBackgroundColorView?.backgroundColor = self.currentTheme().colors.layer1
     }
 
     private func createEmptyStateOverlayView() -> UIView {
@@ -585,6 +592,7 @@ class HistoryPanel: UIViewController,
             view.backgroundColor = self.currentTheme().colors.layer1
         }
         overlayView.addSubview(bgColor)
+        emptyStateOverlayBackgroundColorView = bgColor
 
         NSLayoutConstraint.activate([
             bgColor.heightAnchor.constraint(equalToConstant: UIScreen.main.bounds.height),
@@ -626,7 +634,7 @@ class HistoryPanel: UIViewController,
         ]
         bottomSearchButton.tintColor = theme.colors.iconPrimary
         bottomDeleteButton.tintColor = theme.colors.iconPrimary
-        welcomeLabel.textColor = theme.colors.textSecondary
+        applyEmptyStateViewTheme(theme)
 
         tableView.reloadData()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8957)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19787)

## :bulb: Description

Fixes bug where the theme of the history panel empty state view could go out of sync (notably when in Private browsing mode).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

