### PR TITLE
Bugfix FXIOS-8777 ⁃ pdf page jumps to top upon switching to other app or calling out dock

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -912,8 +912,6 @@ extension BrowserViewController: WKNavigationDelegate {
         tab.contentBlocker?.notifyContentBlockingChanged()
         self.scrollController.resetZoomState()
 
-        scrollController.shouldScrollToTop = true
-
         if tabManager.selectedTab === tab {
             updateUIForReaderHomeStateForTab(tab, focusUrlBar: true)
             updateFakespot(tab: tab, isReload: true)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1800,6 +1800,11 @@ class BrowserViewController: UIViewController,
 
         self.screenshotHelper.takeScreenshot(tab)
 
+        // when navigate in tab, if the tab mime type is pdf, we should scroll to top
+        if tab.mimeType == MIMEType.PDF {
+            tab.shouldScrollToTop = true
+        }
+
         if let url = webView.url {
             if (!InternalURL.isValid(url: url) || url.isReaderModeURL) && !url.isFileURL {
                 postLocationChangeNotificationForTab(tab, navigation: navigation)

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -60,12 +60,6 @@ class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvi
         return isBottomSearchBar ? bottomShowing : headerTopOffset == 0
     }
 
-    private var shouldSetInitialScrollToTop: Bool {
-        return tab?.mimeType == MIMEType.PDF && shouldScrollToTop
-    }
-
-    var shouldScrollToTop = false
-
     private var isZoomedOut = false
     private var lastZoomedScale: CGFloat = 0
     private var isUserZoom = false
@@ -159,6 +153,8 @@ class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvi
         }
 
         guard !tabIsLoading() else { return }
+
+        tab?.shouldScrollToTop = false
 
         if let containerView = scrollView?.superview {
             let translation = gesture.translation(in: containerView)
@@ -458,7 +454,7 @@ extension TabScrollingController: UIScrollViewDelegate {
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         guard !tabIsLoading(), !isBouncingAtBottom(), isAbleToScroll else { return }
 
-        shouldScrollToTop = false
+        tab?.shouldScrollToTop = false
 
         if decelerate || (toolbarState == .animating && !decelerate) {
             if scrollDirection == .up {
@@ -473,7 +469,7 @@ extension TabScrollingController: UIScrollViewDelegate {
     // before the WKWebView's contentOffset is reset as a result of the contentView's frame becoming smaller
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         // for PDFs, we should set the initial offset to 0 (ZERO)
-        if shouldSetInitialScrollToTop {
+        if let tab, tab.shouldScrollToTop {
             setOffset(y: 0, for: scrollView)
         }
 

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -126,6 +126,8 @@ class Tab: NSObject, ThemeApplicable {
     var startingSearchUrlWithAds: URL?
     var adsProviderName: String = ""
     var hasHomeScreenshot = false
+    var shouldScrollToTop = false
+
     private var logger: Logger
 
     // To check if current URL is the starting page i.e. either blank page or internal page like topsites


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8777)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19449)

## :bulb: Description
Changed the logic for PDF, in order to be scrolled to the top only when is first time loaded.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

