### PR TITLE
Add FXIOS-9067 - Add addressFormLayout.js file to be pulled from mozilla-centra

### DIFF
--- a/firefox-ios/Client/Assets/CC_Script/CC_Python_Update.py
+++ b/firefox-ios/Client/Assets/CC_Script/CC_Python_Update.py
@@ -9,6 +9,7 @@ GITHUB_ACTIONS_TMP_PATH = f"{GITHUB_ACTIONS_PATH}tmp/"
 
 
 FILES_TO_DOWNLOAD = [
+    "browser/extensions/formautofill/content/addressFormLayout.js",
     "toolkit/components/formautofill/Constants.ios.mjs",
     "toolkit/modules/CreditCard.sys.mjs",
     "toolkit/components/formautofill/shared/CreditCardRuleset.sys.mjs",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9067)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20079)

## :bulb: Description
This PR: 
- Adds `addressFormLayout.js` to list of pulled scripts from mozilla-central. 

**NOTE**: This is the file responsible for the layout of each country's address format.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

