### PR TITLE
Bugfix FXIOS-9069 Fix empty white area on private homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -202,6 +202,7 @@ final class PrivateHomepageViewController:
         let theme = themeManager.currentTheme(for: windowUUID)
         gradient.colors = theme.colors.layerHomepage.cgColors
         homepageHeaderCell.applyTheme(theme: theme)
+        privateMessageCardCell.applyTheme(theme: theme)
     }
 
     private func learnMore() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9069)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20085)

## :bulb: Description

Fix empty white rectangle on private home page.

## Screenshots

Before

![Simulator Screenshot - iPad (10th generation) - 2024-04-29 at 16 17 20](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/47565b30-d762-41e7-9c39-2add2dd1f248)

After

![Simulator Screenshot - iPad (10th generation) - 2024-04-30 at 09 44 26](https://github.com/mozilla-mobile/firefox-ios/assets/145381717/f607bdbf-d3ee-440b-a882-cc359e15911b)


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

