### PR TITLE
Refactor FXIOS-8835 - Enabled SwiftLint ns_number_init_as_function_reference for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -29,7 +29,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - legacy_nsgeometry_functions
   # - mark
   - no_space_in_method_call
-  # - ns_number_init_as_function_reference
+  - ns_number_init_as_function_reference
   # - operator_whitespace
   - orphaned_doc_comment
   # - private_over_fileprivate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8835)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19551)

## :bulb: Description
Enabled SwiftLint rule ns_number_init_as_function_reference for Focus.  No new lint violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)