### PR TITLE
Refactor FXIOS-8831 - Enabled SwiftLint legacy_hashing for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -25,7 +25,7 @@ only_rules: # Only enforce these rules, ignore all others
   # - legacy_cggeometry_functions
   # - legacy_constant
   # - legacy_constructor
-  # - legacy_hashing
+  - legacy_hashing
   # - legacy_nsgeometry_functions
   # - mark
   - no_space_in_method_call


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8831)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19547)

## :bulb: Description
Enabled SwiftLint rule legacy_hashing for Focus.  No new lint violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)