### PR TITLE
Refactor FXIOS-8829 - Enabled SwiftLint legacy_constant for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -23,7 +23,7 @@ only_rules: # Only enforce these rules, ignore all others
   - large_tuple
   # - leading_whitespace
   # - legacy_cggeometry_functions
-  # - legacy_constant
+  - legacy_constant
   - legacy_constructor
   # - legacy_hashing
   - legacy_nsgeometry_functions


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8829)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19545)

## :bulb: Description
Enabled SwiftLint rule legacy_constant for Focus.  No new lint violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)