### PR TITLE
Refactor FXIOS-8827 - Enabled SwiftLint leading_whitespace for Focus

### DIFF
--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -21,7 +21,7 @@ only_rules: # Only enforce these rules, ignore all others
   - inclusive_language
   - invalid_swiftlint_command
   - large_tuple
-  # - leading_whitespace
+  - leading_whitespace
   # - legacy_cggeometry_functions
   # - legacy_constant
   - legacy_constructor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8827)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19543)

## :bulb: Description
Enabled SwiftLint rule leading_whitespace for Focus.  No new lint violations found.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

