### PR TITLE
Bugfix FXIOS-8453 Fix private theming on undo close

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -348,8 +348,11 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
                                                  textAlignment: .left)
             let toast = ButtonToast(viewModel: viewModel,
                                     theme: currentTheme()) { [weak self] isButtonTapped in
-                guard let self, let closedTab = tabManager.backupCloseTab else { return }
-                isButtonTapped ? self.tabManager.undoCloseTab(tab: closedTab.tab, position: closedTab.restorePosition) : nil
+                guard let self,
+                        tabManager.backupCloseTab != nil,
+                        isButtonTapped
+                else { return }
+                self.tabManager.undoCloseTab()
             }
             show(toast: toast)
         default:

--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -426,7 +426,7 @@ class LegacyTabDisplayManager: NSObject, FeatureFlaggable {
     }
 
     func undoCloseTab(tab: Tab, index: Int?) {
-        tabManager.undoCloseTab(tab: tab, position: index)
+        tabManager.undoCloseTab()
         _ = profile.recentlyClosedTabs.popFirstTab()
 
         refreshStore { [weak self] in
@@ -549,7 +549,10 @@ extension LegacyTabDisplayManager: UICollectionViewDataSource {
 // MARK: - InactiveTabsDelegate
 extension LegacyTabDisplayManager: LegacyInactiveTabsDelegate {
     func closeInactiveTab(_ tab: Tab, index: Int) {
-        tabManager.backupCloseTab = BackupCloseTab(tab: tab, restorePosition: index)
+        tabManager.backupCloseTab = BackupCloseTab(
+            tab: tab,
+            restorePosition: index,
+            isSelected: false)
         removeSingleInactiveTab(tab)
 
         cfrDelegate?.presentUndoSingleToast { [weak self] undoButtonPressed in
@@ -622,7 +625,7 @@ extension LegacyTabDisplayManager: LegacyInactiveTabsDelegate {
     }
 
     private func undoDeleteInactiveTab(_ tab: Tab, at index: Int) {
-        tabManager.undoCloseTab(tab: tab, position: index)
+        tabManager.undoCloseTab()
         inactiveViewModel?.inactiveTabs.insert(tab, at: index)
 
         if inactiveViewModel?.inactiveTabs.count == 1 {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -398,8 +398,10 @@ class LegacyGridTabViewController: UIViewController,
 
     /// Handles close tab by clicking on close button or swipe gesture
     func closeTabAction(tab: Tab, cell: LegacyTabCell) {
-        tabManager.backupCloseTab = BackupCloseTab(tab: tab,
-                                                   restorePosition: tabManager.tabs.firstIndex(of: tab))
+        tabManager.backupCloseTab = BackupCloseTab(
+            tab: tab,
+            restorePosition: tabManager.tabs.firstIndex(of: tab),
+            isSelected: tabManager.selectedTab?.tabUUID == tab.tabUUID)
         tabDisplayManager.tabDisplayCompletionDelegate = self
         tabDisplayManager.performCloseAction(for: tab)
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -208,7 +208,7 @@ class TabManagerMiddleware {
         let tabManagerTabs = isPrivateMode ? tabManager.privateTabs : tabManager.normalActiveTabs
         tabManagerTabs.forEach { tab in
             let tabModel = TabModel(tabUUID: tab.tabUUID,
-                                    isSelected: tab == selectedTab,
+                                    isSelected: tab.tabUUID == selectedTab?.tabUUID,
                                     isPrivate: tab.isPrivate,
                                     isFxHomeTab: tab.isFxHomeTab,
                                     tabTitle: tab.displayTitle,
@@ -358,10 +358,10 @@ class TabManagerMiddleware {
     private func undoCloseTab(state: AppState, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
         guard let tabsState = state.screenState(TabsPanelState.self, for: .tabsPanel, window: uuid),
-              let backupTab = tabManager.backupCloseTab
+              tabManager.backupCloseTab != nil
         else { return }
 
-        tabManager.undoCloseTab(tab: backupTab.tab, position: backupTab.restorePosition)
+        tabManager.undoCloseTab()
 
         let model = getTabsDisplayModel(for: tabsState.isPrivateMode, shouldScrollToTab: false, uuid: uuid)
         let action = TabPanelMiddlewareAction(tabDisplayModel: model,
@@ -456,7 +456,10 @@ class TabManagerMiddleware {
         Task {
             if let tabToClose = tabManager.getTabForUUID(uuid: tabUUID) {
                 let index = tabsState.inactiveTabs.firstIndex { $0.tabUUID == tabUUID }
-                tabManager.backupCloseTab = BackupCloseTab(tab: tabToClose, restorePosition: index)
+                tabManager.backupCloseTab = BackupCloseTab(
+                    tab: tabToClose,
+                    restorePosition: index,
+                    isSelected: false)
             }
             await tabManager.removeTab(tabUUID)
 
@@ -475,9 +478,9 @@ class TabManagerMiddleware {
 
     private func undoCloseInactiveTab(uuid: WindowUUID) {
         let windowTabManager = self.tabManager(for: uuid)
-        guard let backupTab = windowTabManager.backupCloseTab else { return }
+        guard windowTabManager.backupCloseTab != nil else { return }
 
-        windowTabManager.undoCloseTab(tab: backupTab.tab, position: backupTab.restorePosition)
+        windowTabManager.undoCloseTab()
         let inactiveTabs = self.refreshInactiveTabs(uuid: uuid)
         let refreshAction = TabPanelMiddlewareAction(inactiveTabModels: inactiveTabs,
                                                      windowUUID: uuid,

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -849,21 +849,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         storeChanges()
     }
 
-//    func legacyUndoCloseTab(tab: Tab, position: Int?) {
-//        if let index = position {
-//            tabs.insert(tab, at: index)
-//        } else {
-//            tabs.append(tab)
-//        }
-//
-//        delegates.forEach { $0.get()?.tabManagerUpdateCount() }
-//        storeChanges()
-//
-//        // Select previous selected tab
-//        let tabUUID = selectedTab?.tabUUID
-
-//    }
-
     func undoCloseTab() {
         guard let backupCloseTab = self.backupCloseTab else { return }
 

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -60,6 +60,7 @@ enum SwitchPrivacyModeResult {
 struct BackupCloseTab {
     var tab: Tab
     var restorePosition: Int?
+    var isSelected: Bool
 }
 
 // TabManager must extend NSObjectProtocol in order to implement WKNavigationDelegate
@@ -567,10 +568,16 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         let tab = tabs[index]
         let viableTabsIndex = deletedIndexForViableTabs(tab)
         if TabTrayFlagManager.isRefactorEnabled {
-            backupCloseTab = BackupCloseTab(tab: tab, restorePosition: viableTabsIndex)
+            backupCloseTab = BackupCloseTab(
+                tab: tab,
+                restorePosition: viableTabsIndex,
+                isSelected: selectedTab?.tabUUID == tab.tabUUID)
         }
         self.removeTab(tab, flushToDisk: true)
         self.updateIndexAfterRemovalOf(tab, deletedIndex: index, viableTabsIndex: viableTabsIndex)
+
+        // TODO: FXIOS-9084 This is not ideal, follow up in this ticket to make tab selection reasonably synchronous
+        try? await Task.sleep(nanoseconds: NSEC_PER_SEC/10)
 
         TelemetryWrapper.recordEvent(
             category: .action,
@@ -593,7 +600,9 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
             return
         }
 
-        backupCloseTab = BackupCloseTab(tab: tab, restorePosition: removalIndex)
+        backupCloseTab = BackupCloseTab(tab: tab,
+                                        restorePosition: removalIndex,
+                                        isSelected: selectedTab?.tabUUID == tab.tabUUID)
         let prevCount = count
         tabs.remove(at: removalIndex)
         assert(count == prevCount - 1, "Make sure the tab count was actually removed")
@@ -632,7 +641,8 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         let currentModeTabs = tabs.filter { $0.isPrivate == isPrivateMode }
         if let tab = selectedTab, tab.isPrivate == isPrivateMode {
             backupCloseTab = BackupCloseTab(tab: tab,
-                                            restorePosition: tabs.firstIndex(of: tab))
+                                            restorePosition: tabs.firstIndex(of: tab),
+                                            isSelected: selectedTab?.tabUUID == tab.tabUUID)
         }
         backupCloseTabs = tabs
         for tab in currentModeTabs {
@@ -839,24 +849,36 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         storeChanges()
     }
 
-    func undoCloseTab(tab: Tab, position: Int?) {
-        if let index = position {
-            tabs.insert(tab, at: index)
+//    func legacyUndoCloseTab(tab: Tab, position: Int?) {
+//        if let index = position {
+//            tabs.insert(tab, at: index)
+//        } else {
+//            tabs.append(tab)
+//        }
+//
+//        delegates.forEach { $0.get()?.tabManagerUpdateCount() }
+//        storeChanges()
+//
+//        // Select previous selected tab
+//        let tabUUID = selectedTab?.tabUUID
+
+//    }
+
+    func undoCloseTab() {
+        guard let backupCloseTab = self.backupCloseTab else { return }
+
+        if let index = backupCloseTab.restorePosition {
+            tabs.insert(backupCloseTab.tab, at: index)
         } else {
-            tabs.append(tab)
+            tabs.append(backupCloseTab.tab)
+        }
+
+        if backupCloseTab.isSelected {
+            self.selectTab(backupCloseTab.tab)
         }
 
         delegates.forEach { $0.get()?.tabManagerUpdateCount() }
         storeChanges()
-
-        // Select previous selected tab
-        let tabUUID = selectedTab?.tabUUID
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
-            if let tabUUID = tabUUID,
-               let tabToSelect = self.tabs.first(where: { $0.tabUUID == tabUUID }) {
-                self.selectTab(tabToSelect)
-            }
-        }
     }
 
     // Select the most recently visited tab, IFF it is also the parent tab of the closed tab.

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -39,7 +39,7 @@ protocol TabManager: AnyObject {
     func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool)
     func removeTab(_ tab: Tab, completion: (() -> Void)?)
     func removeTabs(_ tabs: [Tab])
-    func undoCloseTab(tab: Tab, position: Int?)
+    func undoCloseTab()
     func getMostRecentHomepageTab() -> Tab?
     func getTabFor(_ url: URL) -> Tab?
     func clearAllTabsHistory()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -87,7 +87,7 @@ class MockTabManager: TabManager {
 
     func undoCloseAllTabs() {}
 
-    func undoCloseTab(tab: Client.Tab, position: Int?) {}
+    func undoCloseTab() {}
 
     func getTabFor(_ url: URL) -> Tab? {
         return nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8453)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18745)

## :bulb: Description
Store the previously selected tab as part of the BackupCloseTab object so that it is explicit when restoring if it needs to be selected or not.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

