### PR TITLE
Bugfix FXIOS-7487 Re-enable UI test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
@@ -49,28 +49,27 @@ final class LegacyTabTrayViewControllerTests: XCTestCase {
     }
 
     func testCountUpdatesAfterTabRemoval() throws {
-        throw XCTSkip("Skipping since fails in Bitrise fix in FXIOS-7487")
-//        let tabToRemove = manager.addTab()
-//        manager.addTab()
-//
-//        XCTAssertEqual(tabTray.viewModel.normalTabsCount, "2")
-//        XCTAssertEqual(tabTray.countLabel.text, "2")
-//
-//        gridTab.tabDisplayManager.performCloseAction(for: tabToRemove)
-//        // Wait for notification of .TabClosed when tab is removed
-//        let expectation = expectation(description: "notificationReceived")
-//        NotificationCenter.default.addObserver(
-//            forName: .UpdateLabelOnTabClosed,
-//            object: nil,
-//            queue: nil
-//        ) { notification in
-//            expectation.fulfill()
-//
-//            XCTAssertEqual(self.tabTray.viewModel.normalTabsCount, "1")
-//            XCTAssertEqual(self.tabTray.countLabel.text, "1")
-//        }
-//
-//        waitForExpectations(timeout: 3.0)
+        let tabToRemove = manager.addTab()
+        manager.addTab()
+
+        XCTAssertEqual(tabTray.viewModel.normalTabsCount, "2")
+        XCTAssertEqual(tabTray.countLabel.text, "2")
+
+        gridTab.tabDisplayManager.performCloseAction(for: tabToRemove)
+        // Wait for notification of .TabClosed when tab is removed
+        let expectation = expectation(description: "notificationReceived")
+        NotificationCenter.default.addObserver(
+            forName: .UpdateLabelOnTabClosed,
+            object: nil,
+            queue: nil
+        ) { notification in
+            expectation.fulfill()
+
+            XCTAssertEqual(self.tabTray.viewModel.normalTabsCount, "1")
+            XCTAssertEqual(self.tabTray.countLabel.text, "1")
+        }
+
+        waitForExpectations(timeout: 3.0)
     }
 
     func testTabTrayRevertToRegular_ForNoPrivateTabSelected() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7487)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16623)

## :bulb: Description
Re-enables a test that was failing due to bugs in the tab tray refactor

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

