### PR TITLE
Bugfix MTE-2504 Disable animations for Focus tests

### DIFF
--- a/focus-ios/Blockzilla/AppDelegate.swift
+++ b/focus-ios/Blockzilla/AppDelegate.swift
@@ -111,6 +111,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             if let bundleID = Bundle.main.bundleIdentifier {
                 UserDefaults.standard.removePersistentDomain(forName: bundleID)
             }
+            UIView.setAnimationsEnabled(false)
             UserDefaults.standard.removePersistentDomain(forName: AppInfo.sharedContainerIdentifier)
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2504)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description

Some Focus tests have taken longer on Bitrise and MacStadium randomly because the tests wait for some animations to finish:
```
    t =    75.29s App animations complete notification not received, will attempt to continue.
```
https://app.bitrise.io/build/fb4c5e01-7656-4559-b076-e9464cd6c9ca

Let me disable the animations just for the tests.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

