### PR TITLE
Refactor FXIOS-9079 [Multi-window] Auto-restore tabs on iPad

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -751,7 +751,7 @@ class BrowserViewController: UIViewController,
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        // For now, skip the 'restore tabs' alert on iPad; this avoids some potential UX issues with multi-window. [FXIOS-9079]
+        // Skip the 'restore tabs' alert on iPad; this avoids some potential UX issues with multi-window. [FXIOS-9079]
         let iPadDevice = UIDevice.current.userInterfaceIdiom == .pad
         if !iPadDevice && !displayedRestoreTabsAlert && crashedLastLaunch() {
             logger.log("The application crashed on last session",

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -751,7 +751,9 @@ class BrowserViewController: UIViewController,
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if !displayedRestoreTabsAlert && crashedLastLaunch() {
+        // For now, skip the 'restore tabs' alert on iPad; this avoids some potential UX issues with multi-window. [FXIOS-9079]
+        let iPadDevice = UIDevice.current.userInterfaceIdiom == .pad
+        if !iPadDevice && !displayedRestoreTabsAlert && crashedLastLaunch() {
             logger.log("The application crashed on last session",
                        level: .info,
                        category: .lifecycle)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9079)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20112)

## :bulb: Description

Per team discussion, for now we will skip the 'restore tabs' alert on iPad devices and auto-restore in the case of a crash. This avoids several potential UX issues with the alert and the forthcoming multi-window feature. The team will likely revisit this later once we have additional metrics/data.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

