### PR TITLE
Refactor FXIOS-9043 [Multi-window] Cleanup: Remove ToDo for UUID in ReadabilityOperation

### DIFF
--- a/firefox-ios/Client/Application/WindowManager+DebugUtilities.swift
+++ b/firefox-ios/Client/Application/WindowManager+DebugUtilities.swift
@@ -18,7 +18,8 @@ extension WindowManagerImplementation {
             result.append("    \(idx + 1): \(short(uuid))\n")
             let tabMgr = tabManager(for: uuid)
             for (tabIdx, tab) in tabMgr.normalTabs.enumerated() {
-                result.append("        \(tabIdx): \(tab.url?.absoluteString ?? "<nil url>")\n")
+                let memAddr = Unmanaged.passUnretained(tab).toOpaque()
+                result.append("        \(tabIdx + 1) (\(memAddr)): \(tab.url?.absoluteString ?? "<nil url>")\n")
             }
         }
         result.append("\n")

--- a/firefox-ios/Client/Frontend/Reader/ReadabilityService.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReadabilityService.swift
@@ -48,10 +48,7 @@ class ReadabilityOperation: Operation {
             let configuration = WKWebViewConfiguration()
             // TODO: To resolve profile from DI container
 
-            // TODO: Revisit window UUID here for multi-window [FXIOS-9043]
-            let windowUUID = (AppContainer.shared.resolve() as WindowManager).activeWindow
-
-            let tab = Tab(profile: self.profile, configuration: configuration, windowUUID: windowUUID)
+            let tab = Tab(profile: self.profile, configuration: configuration, windowUUID: .unavailable)
             self.tab = tab
             tab.createWebview()
             tab.navigationDelegate = self

--- a/firefox-ios/Client/Frontend/Reader/ReadabilityService.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReadabilityService.swift
@@ -48,7 +48,8 @@ class ReadabilityOperation: Operation {
             let configuration = WKWebViewConfiguration()
             // TODO: To resolve profile from DI container
 
-            let tab = Tab(profile: self.profile, configuration: configuration, windowUUID: .unavailable)
+            let windowManager: WindowManager = AppContainer.shared.resolve()
+            let tab = Tab(profile: self.profile, configuration: configuration, windowUUID: windowManager.activeWindow)
             self.tab = tab
             tab.createWebview()
             tab.navigationDelegate = self


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9043)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19982)

## :bulb: Description

No changes in this PR, just removes a ToDo (more info below).

### Details

This required some investigation into how exactly the ReadabilityOperation's `Tab` instance was being used, and whether or not the UUID at this callsite was actually relevant (our `Tab`, currently, requires a UUID since in 99% of cases every Tab should have that injected).

Based on the tests I've run so far, the UUID appears to be unnecessary at this point and so we can simply use the active window UUID (we could also pass `.unavailable`, though using active window is perhaps slightly safer in case this code should ever change in the future). The tab instance is used by the operation to load the content, but the tab instance itself is never actually added to a tab manager and AFAICT the tab window UUID reference is never needed for the purposes of themeing the content etc.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

