### PR TITLE
Bugfix FXIOS-8064 [Multi-window] Fix memory leaks when closing iPad windows

### DIFF
--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -63,6 +63,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // Notify WindowManager that window is closing
         (AppContainer.shared.resolve() as WindowManager).windowWillClose(uuid: sceneCoordinator.windowUUID)
+        self.sceneCoordinator?.removeAllChildren()
+        self.sceneCoordinator = nil
     }
 
     // MARK: - Transitioning to Foreground

--- a/firefox-ios/Client/Coordinators/BaseCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/BaseCoordinator.swift
@@ -34,6 +34,10 @@ open class BaseCoordinator: NSObject, Coordinator {
         childCoordinators.remove(at: index)
     }
 
+    func removeAllChildren() {
+        childCoordinators.removeAll()
+    }
+
     func canHandle(route: Route) -> Bool {
         return false
     }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -708,10 +708,14 @@ class BrowserCoordinator: BaseCoordinator,
             // Notify theme manager
             themeManager.windowDidClose(uuid: uuid)
 
-            // TODO: Revisit for [FXIOS-8064]. Disabled temporarily to avoid potential KVO crash in WebKit. (FXIOS-8416)
             // Clean up views and ensure BVC for the window is freed
-            // browserViewController.contentContainer.subviews.forEach { $0.removeFromSuperview() }
-            // browserViewController.removeFromParent()
+            browserViewController.view.endEditing(true)
+            browserViewController.dismissUrlBar()
+            self.homepageViewController?.view.removeFromSuperview()
+            self.homepageViewController?.removeFromParent()
+            self.homepageViewController = nil
+            self.browserViewController.contentContainer.subviews.forEach { $0.removeFromSuperview() }
+            self.browserViewController.removeFromParent()
         case .libraryOpened:
             // Auto-close library panel if it was opened in another iPad window. [FXIOS-8095]
             guard uuid != windowUUID else { return }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -711,11 +711,11 @@ class BrowserCoordinator: BaseCoordinator,
             // Clean up views and ensure BVC for the window is freed
             browserViewController.view.endEditing(true)
             browserViewController.dismissUrlBar()
-            self.homepageViewController?.view.removeFromSuperview()
-            self.homepageViewController?.removeFromParent()
-            self.homepageViewController = nil
-            self.browserViewController.contentContainer.subviews.forEach { $0.removeFromSuperview() }
-            self.browserViewController.removeFromParent()
+            homepageViewController?.view.removeFromSuperview()
+            homepageViewController?.removeFromParent()
+            homepageViewController = nil
+            browserViewController.contentContainer.subviews.forEach { $0.removeFromSuperview() }
+            browserViewController.removeFromParent()
         case .libraryOpened:
             // Auto-close library panel if it was opened in another iPad window. [FXIOS-8095]
             guard uuid != windowUUID else { return }

--- a/firefox-ios/Client/Coordinators/Coordinator.swift
+++ b/firefox-ios/Client/Coordinators/Coordinator.swift
@@ -44,6 +44,7 @@ protocol Coordinator: AnyObject {
 
     func add(child coordinator: Coordinator)
     func remove(child coordinator: Coordinator?)
+    func removeAllChildren()
 }
 
 extension Array where Element == Coordinator {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -24,7 +24,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             anchor: navigationToolbar.multiStateButton,
             withArrowDirection: topTabsVisible ? .up : .down,
             andDelegate: self,
-            presentedUsing: { self.presentDataClearanceContextualHint() },
+            presentedUsing: { [weak self] in self?.presentDataClearanceContextualHint() },
             andActionForButton: { },
             overlayState: overlayManager)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -794,8 +794,8 @@ class BrowserViewController: UIViewController,
             anchor: urlBar,
             withArrowDirection: isBottomSearchBar ? .down : .up,
             andDelegate: self,
-            presentedUsing: { self.presentContextualHint() },
-            andActionForButton: { self.homePanelDidRequestToOpenSettings(at: .toolbar) },
+            presentedUsing: { [weak self] in self?.presentContextualHint() },
+            andActionForButton: { [weak self] in self?.homePanelDidRequestToOpenSettings(at: .toolbar) },
             overlayState: overlayManager)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -790,9 +790,9 @@ extension LegacyGridTabViewController: InactiveTabsCFRProtocol {
             withArrowDirection: .up,
             andDelegate: self,
             presentedUsing: { self.presentCFROnView() },
-            andActionForButton: {
-                self.dismissTabTray()
-                self.delegate?.tabTrayDidRequestTabsSettings()
+            andActionForButton: { [weak self] in
+                self?.dismissTabTray()
+                self?.delegate?.tabTrayDidRequestTabsSettings()
             }, andShouldStartTimerRightAway: false
         )
     }

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewController.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewController.swift
@@ -114,9 +114,9 @@ class ContextualHintViewController: UIViewController,
 
     private func performAction() {
         self.viewProvider.sendTelemetryEvent(for: .performAction)
-        self.dismiss(animated: true) { [weak self] in
-            self?.onActionTapped?()
-            self?.onActionTapped = nil
+        self.dismiss(animated: true) {
+            self.onActionTapped?()
+            self.onActionTapped = nil
         }
     }
 

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewController.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewController.swift
@@ -114,9 +114,9 @@ class ContextualHintViewController: UIViewController,
 
     private func performAction() {
         self.viewProvider.sendTelemetryEvent(for: .performAction)
-        self.dismiss(animated: true) {
-            self.onActionTapped?()
-            self.onActionTapped = nil
+        self.dismiss(animated: true) { [weak self] in
+            self?.onActionTapped?()
+            self?.onActionTapped = nil
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -424,8 +424,8 @@ class HomepageViewController:
             withArrowDirection: .down,
             andDelegate: self,
             presentedUsing: { [weak self] in
-                guard let jumpInVC = self?.jumpBackInContextualHintViewController else { return }
-                self?.presentContextualHint(contextualHintViewController: jumpInVC)
+                guard let self else { return }
+                self.presentContextualHint(contextualHintViewController: self.jumpBackInContextualHintViewController)
             },
             sourceRect: rect,
             andActionForButton: { [weak self] in self?.openTabsSettings() },
@@ -444,8 +444,8 @@ class HomepageViewController:
             withArrowDirection: .down,
             andDelegate: self,
             presentedUsing: { [weak self] in
-                guard let hintVC = self?.syncTabContextualHintViewController else { return }
-                self?.presentContextualHint(contextualHintViewController: hintVC)
+                guard let self else { return }
+                self.presentContextualHint(contextualHintViewController: self.syncTabContextualHintViewController)
             },
             overlayState: overlayManager)
     }

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -423,11 +423,12 @@ class HomepageViewController:
             anchor: view,
             withArrowDirection: .down,
             andDelegate: self,
-            presentedUsing: {
-                self.presentContextualHint(contextualHintViewController: self.jumpBackInContextualHintViewController)
+            presentedUsing: { [weak self] in
+                guard let jumpInVC = self?.jumpBackInContextualHintViewController else { return }
+                self?.presentContextualHint(contextualHintViewController: jumpInVC)
             },
             sourceRect: rect,
-            andActionForButton: { self.openTabsSettings() },
+            andActionForButton: { [weak self] in self?.openTabsSettings() },
             overlayState: overlayManager)
     }
 
@@ -442,8 +443,9 @@ class HomepageViewController:
             anchor: cell.getContextualHintAnchor(),
             withArrowDirection: .down,
             andDelegate: self,
-            presentedUsing: {
-                self.presentContextualHint(contextualHintViewController: self.syncTabContextualHintViewController)
+            presentedUsing: { [weak self] in
+                guard let hintVC = self?.syncTabContextualHintViewController else { return }
+                self?.presentContextualHint(contextualHintViewController: hintVC)
             },
             overlayState: overlayManager)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockCoordinator.swift
@@ -18,6 +18,7 @@ class MockCoordinator: Coordinator {
     var removedChildCalled = 0
     var canHandleRouteCalled = 0
     var findRouteCalled = 0
+    var removeAllChildrenCalled = 0
 
     init(router: MockRouter) {
         self.router = router
@@ -34,6 +35,10 @@ class MockCoordinator: Coordinator {
     func canHandle(route: Route) -> Bool {
         canHandleRouteCalled += 1
         return false
+    }
+
+    func removeAllChildren() {
+        removeAllChildrenCalled += 1
     }
 
     func handle(route: Route) { }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8064)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17971)

## :bulb: Description

Adds some clean-up code and fixes some retain cycles that were causing various classes (like the Tab Manager or homepage VC) to be retained incorrectly even after closing iPad windows.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

