### PR TITLE
Add FXIOS-8131 - URL Toolbar Dynamic Height & Overlapping Keyboard

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -827,7 +827,7 @@ class BrowserViewController: UIViewController,
         view.layoutIfNeeded()
 
         showQueuedAlertIfAvailable()
-//        adjustURLBarHeightBasedOnLocationViewHeight()
+        adjustURLBarHeightBasedOnLocationViewHeight()
     }
 
     private func adjustURLBarHeightBasedOnLocationViewHeight() {
@@ -2997,18 +2997,18 @@ extension BrowserViewController: KeyboardHelperDelegate {
         updateViewConstraints()
     }
 
-//    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
-//        keyboardState = state
-//        updateViewConstraints()
-//
-//        UIView.animate(
-//            withDuration: state.animationDuration,
-//            delay: 0,
-//            options: [UIView.AnimationOptions(rawValue: UInt(state.animationCurve.rawValue << 16))],
-//            animations: {
-//                self.bottomContentStackView.layoutIfNeeded()
-//            })
-//    }
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
+        keyboardState = state
+        updateViewConstraints()
+
+        UIView.animate(
+            withDuration: state.animationDuration,
+            delay: 0,
+            options: [UIView.AnimationOptions(rawValue: UInt(state.animationCurve.rawValue << 16))],
+            animations: {
+                self.bottomContentStackView.layoutIfNeeded()
+            })
+    }
 
     private func finishEditionMode() {
         // If keyboard is dismiss leave edition mode Homepage case is handled in HomepageVC

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -827,6 +827,33 @@ class BrowserViewController: UIViewController,
         view.layoutIfNeeded()
 
         showQueuedAlertIfAvailable()
+//        adjustURLBarHeightBasedOnLocationViewHeight()
+    }
+
+    private func adjustURLBarHeightBasedOnLocationViewHeight() {
+        // Make sure that we have a height to actually base our calculations on
+        guard urlBar.locationContainer.bounds.height != 0 else { return }
+        let locationViewHeight = urlBar.locationView.bounds.height
+        let heightWithPadding = locationViewHeight + UIConstants.ToolbarPadding
+
+        // Adjustment for landscape on the urlbar
+        // need to account for inset and remove it when keyboard is showing
+        let showToolBar = shouldShowToolbarForTraitCollection(traitCollection)
+        let isKeyboardShowing = keyboardState != nil
+
+        if !showToolBar && isBottomSearchBar &&
+        !isKeyboardShowing && UIDevice.current.orientation.isLandscape {
+            overKeyboardContainer.addBottomInsetSpacer(spacerHeight: UIConstants.BottomInset)
+        } else {
+            overKeyboardContainer.removeBottomInsetSpacer()
+        }
+
+        // We have to deactivate the original constraint, and remake the constraint
+        // or else funky conflicts happen
+        urlBarHeightConstraint.deactivate()
+        urlBar.snp.makeConstraints { make in
+            self.urlBarHeightConstraint = make.height.equalTo(heightWithPadding).constraint
+        }
     }
 
     override func willTransition(
@@ -2969,6 +2996,19 @@ extension BrowserViewController: KeyboardHelperDelegate {
         keyboardState = state
         updateViewConstraints()
     }
+
+//    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
+//        keyboardState = state
+//        updateViewConstraints()
+//
+//        UIView.animate(
+//            withDuration: state.animationDuration,
+//            delay: 0,
+//            options: [UIView.AnimationOptions(rawValue: UInt(state.animationCurve.rawValue << 16))],
+//            animations: {
+//                self.bottomContentStackView.layoutIfNeeded()
+//            })
+//    }
 
     private func finishEditionMode() {
         // If keyboard is dismiss leave edition mode Homepage case is handled in HomepageVC

--- a/firefox-ios/Client/Frontend/Components/BaseContentStackView.swift
+++ b/firefox-ios/Client/Frontend/Components/BaseContentStackView.swift
@@ -78,9 +78,32 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
         keyboardSpacerHeight = heightConstraint
     }
 
+    // MARK: - Spacer view
+
+     private var insetSpacer: UIView?
+
+     func addBottomInsetSpacer(spacerHeight: CGFloat) {
+         guard insetSpacer == nil else { return }
+
+         insetSpacer = UIView()
+         insetSpacer!.snp.makeConstraints { make in
+             make.height.equalTo(spacerHeight)
+         }
+         addArrangedViewToBottom(insetSpacer!)
+     }
+
+     func removeBottomInsetSpacer() {
+         guard let insetSpacer = self.insetSpacer else { return }
+
+         removeArrangedView(insetSpacer)
+         self.insetSpacer = nil
+         self.layoutIfNeeded()
+     }
+
     func applyTheme(theme: Theme) {
         let color = isClearBackground ? .clear : theme.colors.layer1
         backgroundColor = color
         keyboardSpacer?.backgroundColor = color
+        insetSpacer?.backgroundColor = color
     }
 }

--- a/firefox-ios/Client/Frontend/UIConstants.swift
+++ b/firefox-ios/Client/Frontend/UIConstants.swift
@@ -19,6 +19,7 @@ public struct UIConstants {
     static let TopToolbarHeight: CGFloat = 56
     static let TopToolbarHeightMax: CGFloat = 75
     static var ToolbarHeight: CGFloat = 46
+    static var ToolbarPadding: CGFloat = 17
     static let ZoomPageBarHeight: CGFloat = 54
 
     // Static fonts


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8131)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18097)

## :bulb: Description
* Added `browserviewcontroller.adjustURLBarHeightBasedOnLocationViewHeight()` function to dynamically adjust `urlBar` height to the text size selected by user in iOS accessbility settings.

* Function will also add a spacer to the bottom of `overKeyboardContainer` to keep the app switcher bar from overlapping or touching the url text field when toolbar is set to bottom of the screen and when in landscape mode and when keyboard is not showing.

* Added `BaseContentStackView.addBottomInsetSpacer()` and `BaseContentStackView.removeBottomInsetSpacer()` methods so a spacer can be added and removed from `overKeyboardContainer`.

* Added `browserviewcontroller.keyboardHelper(keyboardDidShowWithState)` delegate to move `overKeyboardContainer` into the correct position when `browserviewcontroller.keyboardHelper(keyboardWillShowWithState)` gets the incorrect view position from iOS.  The bug causes `browswerviewcontroller.keyboardState.intersectionHeightForView()` to return a keyboard height that is incorrect which in turn causes `overKeyboardContainer` to be placed in the wrong position.  This results in the keyboard overlapping the url text field.  Bug happens randomly and infrequently when adding a new tab.  `browserviewcontroller.keyboardHelper(keyboardDidShowWithState)` acts as a backstop in case this bug happens.

* Added `UIConstants.ToolbarPadding` to keep the highlighted URL text field from touching the bottom of `urlBar`.

Before and after screenshots in PR comment.

## Background / History
This PR is restoring the `browserviewcontroller.adjustURLBarHeightBasedOnLocationViewHeight()` function that was originally implemented in [PR 8145](https://github.com/mozilla-mobile/firefox-ios/pull/8145) / [Issue 7956](https://github.com/mozilla-mobile/firefox-ios/issues/7956).

This PR is also restoring the `BaseContentStackView.addBottomInsetSpacer()` and `BaseContentStackView.removeBottomInsetSpacer()` methods that were orginally implemented in [PR 10019](https://github.com/mozilla-mobile/firefox-ios/pull/10019) / [Issue 9422](https://github.com/mozilla-mobile/firefox-ios/issues/9422)

The now restored function and methods were removed by [PR 16660](https://github.com/mozilla-mobile/firefox-ios/pull/16660) / [Issue 16340](https://github.com/mozilla-mobile/firefox-ios/pull/16660) to address the overlapping keyboard issue.  Removal of the code then caused `urlBar` to be too tall again and the issue was re-reported in the issue that this PR is addressing.  Removal of the code also caused the app switcher bar to touch the url text field again.

Restoring the code addresses `urlBar` being too tall and keeps the app switcher bar from touching the url text field.  Adding `browserviewcontroller.keyboardHelper(keyboardDidShowWithState)` delegate re-solves [Issue 16340](https://github.com/mozilla-mobile/firefox-ios/pull/16660) and prevents the keyboard from overlapping with the url text field.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

