### PR TITLE
Bugfix FXIOS-8973 [Multi-window] Inject tab data stores

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -86,19 +86,10 @@ public actor DefaultTabDataStore: TabDataStore {
     }
 
     private func parseWindowDataFile(fromURL url: URL) -> WindowData? {
-        return parseWindowDataFiles(fromURLs: [url]).first
-    }
-
-    private func parseWindowDataFiles(fromURLs urlList: [URL]) -> [WindowData] {
-        var windowsData: [WindowData] = []
-        for fileURL in urlList {
-            do {
-                if let windowData = try? fileManager.getWindowDataFromPath(path: fileURL) {
-                    windowsData.append(windowData)
-                }
-            }
+        if let windowData = try? fileManager.getWindowDataFromPath(path: url) {
+            return windowData
         }
-        return windowsData
+        return nil
     }
 
     // MARK: - Saving Data

--- a/firefox-ios/Client/Application/WindowManager+DebugUtilities.swift
+++ b/firefox-ios/Client/Application/WindowManager+DebugUtilities.swift
@@ -15,8 +15,10 @@ extension WindowManagerImplementation {
         var result = "----------- Window Debug Info ------------\n"
         result.append("Open windows (\(windows.count)) & normal tabs (via TabManager):\n")
         for (idx, (uuid, _)) in windows.enumerated() {
-            result.append("    \(idx + 1): \(short(uuid))\n")
             let tabMgr = tabManager(for: uuid)
+            let window = windows[uuid]?.sceneCoordinator?.window
+            let frame = window?.frame ?? .zero
+            result.append("    \(idx + 1): \(short(uuid)) (\(tabMgr.normalTabs.count) tabs) (frame: \(frame.debugDescription))\n")
             for (tabIdx, tab) in tabMgr.normalTabs.enumerated() {
                 let memAddr = Unmanaged.passUnretained(tab).toOpaque()
                 result.append("        \(tabIdx + 1) (\(memAddr)): \(tab.url?.absoluteString ?? "<nil url>")\n")
@@ -35,12 +37,15 @@ extension WindowManagerImplementation {
 
         // Note: this is provided as a convenience for internal debugging. See `DefaultTabDataStore.swift`.
         for (idx, uuid) in tabDataStore.fetchWindowDataUUIDs().enumerated() {
-            result.append("    \(idx + 1): Window \(short(uuid))\n")
             let baseURL = fileManager.windowDataDirectory(isBackup: false)!
             let dataURL = baseURL.appendingPathComponent("window-" + uuid.uuidString)
+            if idx == 0 {
+                result.append("    Data dir: \(baseURL.absoluteString)\n")
+            }
+            result.append("    \(idx + 1): Window \(short(uuid))\n")
             guard let data = try? fileManager.getWindowDataFromPath(path: dataURL) else { continue }
             for (tabIdx, tabData) in data.tabData.enumerated() {
-                result.append("        \(tabIdx + 1): \(tabData.siteUrl)\n")
+                result.append("        \(tabIdx + 1): \(tabData.siteUrl) (Window: \(short(data.id))\n")
             }
         }
         return result

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -99,10 +99,11 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
     // MARK: - Initializer
 
     init(logger: Logger = DefaultLogger.shared,
-         tabDataStore: TabDataStore = AppContainer.shared.resolve(),
+         tabDataStore: TabDataStore? = nil,
          userDefaults: UserDefaultsInterface = UserDefaults.standard) {
+        self.tabDataStore = tabDataStore ?? DefaultTabDataStore(logger: logger,
+                                                                fileManager: DefaultTabFileManager())
         self.logger = logger
-        self.tabDataStore = tabDataStore
         self.defaults = userDefaults
         tabSyncCoordinator.delegate = self
     }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -30,16 +30,18 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
          imageStore: DiskImageStore = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared,
          uuid: WindowUUID,
-         tabDataStore: TabDataStore = AppContainer.shared.resolve(),
+         tabDataStore: TabDataStore? = nil,
          tabSessionStore: TabSessionStore = DefaultTabSessionStore(),
-         tabMigration: TabMigrationUtility = DefaultTabMigrationUtility(),
+         tabMigration: TabMigrationUtility? = nil,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          inactiveTabsManager: InactiveTabsManagerProtocol = InactiveTabsManager(),
          windowManager: WindowManager = AppContainer.shared.resolve()) {
-        self.tabDataStore = tabDataStore
+        let dataStore =  tabDataStore ?? DefaultTabDataStore(logger: logger,
+                                                             fileManager: DefaultTabFileManager())
+        self.tabDataStore = dataStore
         self.tabSessionStore = tabSessionStore
         self.imageStore = imageStore
-        self.tabMigration = tabMigration
+        self.tabMigration = tabMigration ?? DefaultTabMigrationUtility(tabDataStore: dataStore)
         self.notificationCenter = notificationCenter
         self.inactiveTabsManager = inactiveTabsManager
         self.windowManager = windowManager

--- a/firefox-ios/Client/TabManagement/TabMigrationUtility.swift
+++ b/firefox-ios/Client/TabManagement/TabMigrationUtility.swift
@@ -22,7 +22,7 @@ class DefaultTabMigrationUtility: TabMigrationUtility {
     var legacyTabs = [LegacySavedTab]()
 
     init(profile: Profile = AppContainer.shared.resolve(),
-         tabDataStore: TabDataStore = AppContainer.shared.resolve(),
+         tabDataStore: TabDataStore,
          logger: Logger = DefaultLogger.shared,
          legacyTabDataRetriever: LegacyTabDataRetriever = LegacyTabDataRetrieverImplementation()) {
         self.prefs = profile.prefs


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8973)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19810)

## :bulb: Description

This fixes a bug happening with multi-window, which manifested as the wrong URL loading in a window on app launch, but the underlying cause ended up being related to the shared tab data store.

### Details

Our `DefaultTabDataStore` is not fundamentally thread safe when used across multiple windows; specifically, if multiple windows are using the same tab data store and attempt to save their tabs at the same time there is a potential for `WindowData` to be saved with an incorrect UUID (in the wrong path) due to how the store caches its save data in `windowDataToSave`.

I considered refactoring the internals of `DefaultTabDataStore` to fix these threading/MW issues, but I believe because of how several aspects of it work (throttling, as well as the file management), the better solution is to simply get rid of the shared instance and allow each individual tab manager / window to have their own instance.

Because the separate tab stores are only ever reading/writing for the data for their window, there are no conflicts between them.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

