### PR TITLE
Bugfix FXIOS-8371 Shortcuts' display updates only after homepage refresh

### DIFF
--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -192,7 +192,7 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
                                             availableWidth: size.width)
         numberOfRows = topSitesDataAdaptor.numberOfRows
         unfilteredTopSites = topSitesDataAdaptor.getTopSitesData()
-        let sectionDimension = dimensionManager.getSectionDimension(for: topSites,
+        let sectionDimension = dimensionManager.getSectionDimension(for: unfilteredTopSites,
                                                                     numberOfRows: numberOfRows,
                                                                     interface: interface)
         numberOfItems = sectionDimension.numberOfRows * sectionDimension.numberOfTilesPerRow


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8371)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20165)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Passed the correct array to the `getSectionDimension ` method, previously it was passing the same array so the bug was still reproducible when going from less elements to more.
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

