### PR TITLE
Add FXIOS-9095 [Search] Update early search engine metric

### DIFF
--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -247,6 +247,15 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     }
 
     func searchEnginesDidUpdate() {
+        let engineID = profile.searchEngines.defaultEngine?.engineID ?? "custom"
+        TelemetryWrapper.recordEvent(
+            category: .information,
+            method: .change,
+            object: .defaultSearchEngine,
+            value: nil,
+            extras: [TelemetryWrapper.EventExtraKey.recordSearchEngineID.rawValue: engineID]
+        )
+
         self.searchIconImageView.image = profile.searchEngines.defaultEngine?.image
         self.searchIconImageView.largeContentTitle = profile.searchEngines.defaultEngine?.shortName
         self.searchIconImageView.largeContentImage = nil

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -92,6 +92,13 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
     }
 
     func initGlean(_ profile: Profile, sendUsageData: Bool) {
+        // Record default search engine setting to avoid sending a `null` value.
+        // If there's no default search engine, (there's not, at this point), we will
+        // send "unavailable" in order not to send `null`, but still differentiate
+        // the event in the startup sequence.
+        let defaultEngine = profile.searchEngines.defaultEngine
+        GleanMetrics.Search.defaultEngine.set(defaultEngine?.engineID ?? "unavailable")
+
         // Get the legacy telemetry ID and record it in Glean for the deletion-request ping
         if let uuidString = UserDefaults.standard.string(forKey: "telemetry-key-prefix-clientId"), let uuid = UUID(uuidString: uuidString) {
             GleanMetrics.LegacyIds.clientId.set(uuid)
@@ -317,6 +324,7 @@ extension TelemetryWrapper {
         case downloadLinkButton = "download-link-button"
         case downloadNowButton = "download-now-button"
         case downloadsPanel = "downloads-panel"
+        case defaultSearchEngine = "default-search-engine"
         // MARK: Fakespot
         case shoppingButton = "shopping-button"
         case shoppingBottomSheet = "shopping-bottom-sheet"
@@ -1103,6 +1111,18 @@ extension TelemetryWrapper {
                     extras: extras)
             }
 
+        // MARK: - Search Engine
+        case(.information, .change, .defaultSearchEngine, _, let extras):
+            if let searchEngineID = extras?[EventExtraKey.recordSearchEngineID.rawValue] as? String? ?? "custom" {
+                GleanMetrics.Search.defaultEngine.set(searchEngineID)
+            } else {
+                recordUninstrumentedMetrics(
+                    category: category,
+                    method: method,
+                    object: object,
+                    value: value,
+                    extras: extras)
+            }
         // MARK: Start Search Button
         case (.action, .tap, .startSearchButton, _, _):
             GleanMetrics.Search.startSearchPressed.add()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9095)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20167)

## :bulb: Description
So, what I've done is:
1. Added a call to set the `default_engine` before Glean gets initialized. However, our search engines are not initialized at this point in the app's runtime, so, basically we'd be returning `nil` here which doesn't solve the problem we have. In order to make this useful, the `nil` doesn't get converted to `custom` here; rather, it will be converted to `unavailable`. So, if we get a ton of `unavailable`s now in our telemetry, instead of `null`s, we'll know where that's from and have a better understanding of the problem. But because we want to set the default engine in glean ASAP, I've also,
2. Added a second metrics call that will set the glean `default_engine` metric as soon as our app has updated it's search engine config. This is in addition to the already existing metric (when the app gets backgrounded) which I haven't touched.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

