### PR TITLE
Bugfix MTE-2781 Homebrew-core folder not found

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -500,7 +500,7 @@ workflows:
 
             echo "Swiftlint version before mirror swap"
             swiftlint version
-            # Workaround to find the homebre-core folder
+            # Workaround to find the homebrew-core folder
             brew tap homebrew/core --force
             cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
             # Bypass Bitrise mirror that lags 1 week to 1 month behind homebrew-core versions

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -500,6 +500,8 @@ workflows:
 
             echo "Swiftlint version before mirror swap"
             swiftlint version
+            # Workaround to find the homebre-core folder
+            brew tap homebrew/core --force
             cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
             # Bypass Bitrise mirror that lags 1 week to 1 month behind homebrew-core versions
             git remote set-url origin https://github.com/Homebrew/homebrew-core.git


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2781)

Fix the step `Bypass Bitrise Mirror for Swiftlint Upgrade` since it is failing with this error:

echo 'Swiftlint version before mirror swap'
Swiftlint version before mirror swap
+ swiftlint version
0.53.0
++ brew --repository
+ cd /opt/homebrew/Library/Taps/homebrew/homebrew-core
/var/folders/7l/rszmbrmd6tv4pg52z6ql_5rc0000gn/T/bitrise2572919605/step_src/._script_cont: line 6: cd: /opt/homebrew/Library/Taps/homebrew/homebrew-core: No such file or directory

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

