### PR TITLE
Bugfix FXIOS-9049 [Multi-window] Fix Widget Close Private Tabs

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		1D2F68B12ACCA22000524B92 /* RemoteTabsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */; };
 		1D3822E92BAB99250046BC5E /* UIView+Multiwindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3822E82BAB99250046BC5E /* UIView+Multiwindow.swift */; };
 		1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */; };
+		1D558A572BED7ECB001EF527 /* MockWindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D558A562BED7ECB001EF527 /* MockWindowManager.swift */; };
+		1D558A582BED7ECB001EF527 /* MockWindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D558A562BED7ECB001EF527 /* MockWindowManager.swift */; };
 		1D5CBF492B17E3CB0001D033 /* NotificationPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */; };
 		1D5CBF4A2B17E3CB0001D033 /* NotificationPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */; };
 		1D69FF8D27B17286001F660E /* HomeLogoHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */; };
@@ -2233,6 +2235,7 @@
 		1D2F68B02ACCA22000524B92 /* RemoteTabsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsEmptyView.swift; sourceTree = "<group>"; };
 		1D3822E82BAB99250046BC5E /* UIView+Multiwindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Multiwindow.swift"; sourceTree = "<group>"; };
 		1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabPanelTests.swift; sourceTree = "<group>"; };
+		1D558A562BED7ECB001EF527 /* MockWindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWindowManager.swift; sourceTree = "<group>"; };
 		1D5CBF482B17E3CB0001D033 /* NotificationPayloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPayloads.swift; sourceTree = "<group>"; };
 		1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLogoHeaderCell.swift; sourceTree = "<group>"; };
 		1D74FF4D2B27962200FF01D0 /* WindowManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManagerTests.swift; sourceTree = "<group>"; };
@@ -10573,6 +10576,7 @@
 				E1463D0529830E4F0074E16E /* MockUserNotificationCenter.swift */,
 				2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */,
 				BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */,
+				1D558A562BED7ECB001EF527 /* MockWindowManager.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -13819,6 +13823,7 @@
 				8A93F86229D36F0F004159D9 /* NavigationController.swift in Sources */,
 				E13F8C342928194800BDC8B4 /* PhotonActionSheetSiteHeaderView.swift in Sources */,
 				C2D71B9B2A3850B4003DEC7A /* ThemedTableViewCellViewModel.swift in Sources */,
+				1D558A572BED7ECB001EF527 /* MockWindowManager.swift in Sources */,
 				C869912F28917688007ACC5C /* WallpaperMetadataLoader.swift in Sources */,
 				8A6904802B97BBAE00E30047 /* SplashScreenAnimation.swift in Sources */,
 				2137785D297F1F2800D01309 /* DownloadedFile.swift in Sources */,
@@ -14576,6 +14581,7 @@
 				E19B38B128A3E69300D8C541 /* WallpaperCollectionAvailabilityTests.swift in Sources */,
 				8A359EF62A1FE840004A5BB7 /* MockAdjustWrapper.swift in Sources */,
 				8AC225662B6D403200CDA7FD /* HomepageTelemetryTests.swift in Sources */,
+				1D558A582BED7ECB001EF527 /* MockWindowManager.swift in Sources */,
 				C8DC90D22A067C6D0008832B /* MarkupAttributionUtilityTests.swift in Sources */,
 				BA1C68BC2B7ED153000D9397 /* MockWebKit.swift in Sources */,
 				21737FB72878A4BD000A9A92 /* HistoryPanelViewModelTests.swift in Sources */,

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -210,7 +210,6 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
             windows.forEach {
                 guard let browserCoordinator = $0.value.sceneCoordinator?
                     .childCoordinators.first(where: { $0 is BrowserCoordinator }) as? BrowserCoordinator else { return }
-                print("DBG: closing all private tabs \(browserCoordinator)")
                 browserCoordinator.browserViewController.closeAllPrivateTabs()
             }
             break

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -212,7 +212,6 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
                     .childCoordinators.first(where: { $0 is BrowserCoordinator }) as? BrowserCoordinator else { return }
                 browserCoordinator.browserViewController.closeAllPrivateTabs()
             }
-            break
         case .storeTabs:
             storeTabs()
         }

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -7,6 +7,16 @@ import Common
 import Shared
 import TabDataStore
 
+/// Defines various actions in the app which are performed for all open iPad
+/// windows. These can be routed through the WindowManager 
+enum MultiWindowAction {
+    /// Signals that we should store tabs (for all windows) on the default Profile.
+    case storeTabs
+
+    /// Closes private tabs across all windows.
+    case closeAllPrivateTabs
+}
+
 /// General window management class that provides some basic coordination and
 /// state management for multiple windows shared across a single running app.
 protocol WindowManager {
@@ -55,8 +65,9 @@ protocol WindowManager {
     /// - Parameter windowUUID: the UUID of the window triggering the event.
     func postWindowEvent(event: WindowEvent, windowUUID: WindowUUID)
 
-    /// Signals the WindowManager to store tabs (across all windows) on the default Profile.
-    func storeTabs()
+    /// Performs a MultiWindowAction.
+    /// - Parameter action: the action to perform.
+    func performMultiWindowAction(_ action: MultiWindowAction)
 }
 
 /// Captures state and coordinator references specific to one particular app window.
@@ -193,11 +204,26 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         }
     }
 
-    func storeTabs() {
-        tabSyncCoordinator.syncTabsToProfile()
+    func performMultiWindowAction(_ action: MultiWindowAction) {
+        switch action {
+        case .closeAllPrivateTabs:
+            windows.forEach {
+                guard let browserCoordinator = $0.value.sceneCoordinator?
+                    .childCoordinators.first(where: { $0 is BrowserCoordinator }) as? BrowserCoordinator else { return }
+                print("DBG: closing all private tabs \(browserCoordinator)")
+                browserCoordinator.browserViewController.closeAllPrivateTabs()
+            }
+            break
+        case .storeTabs:
+            storeTabs()
+        }
     }
 
     // MARK: - WindowTabSyncCoordinatorDelegate
+
+    private func storeTabs() {
+        tabSyncCoordinator.syncTabsToProfile()
+    }
 
     func tabManagers() -> [TabManager] {
         return allWindowTabManagers()

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -278,7 +278,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     private func handleClosePrivateTabsWidgetAction() {
         // Our widget actions will arrive as a URL passed into the client iOS app.
-        // If multiple iPad iwndows are open the resulting action + route will be
+        // If multiple iPad windows are open the resulting action + route will be
         // sent to one particular window, but for this action we want to close tabs
         // for all open windows, so we route this message to the WindowManager.
         windowManager.performMultiWindowAction(.closeAllPrivateTabs)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -246,7 +246,7 @@ class BrowserCoordinator: BaseCoordinator,
         case let .action(routeAction):
             switch routeAction {
             case .closePrivateTabs:
-                handleClosePrivateTabs()
+                handleClosePrivateTabsWidgetAction()
             case .showQRCode:
                 handleQRCode()
             case .showIntroOnboarding:
@@ -276,8 +276,12 @@ class BrowserCoordinator: BaseCoordinator,
         browserViewController.handleQRCode()
     }
 
-    private func handleClosePrivateTabs() {
-        browserViewController.handleClosePrivateTabs()
+    private func handleClosePrivateTabsWidgetAction() {
+        // Our widget actions will arrive as a URL passed into the client iOS app.
+        // If multiple iPad iwndows are open the resulting action + route will be
+        // sent to one particular window, but for this action we want to close tabs
+        // for all open windows, so we route this message to the WindowManager.
+        windowManager.performMultiWindowAction(.closeAllPrivateTabs)
     }
 
     private func handle(homepanelSection section: Route.HomepanelSection) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1650,7 +1650,7 @@ class BrowserViewController: UIViewController,
         navigationHandler?.showQRCode(delegate: self)
     }
 
-    func handleClosePrivateTabs() {
+    func closeAllPrivateTabs() {
         tabManager.removeTabs(tabManager.privateTabs)
         guard let tab = mostRecentTab(inTabs: tabManager.normalTabs) else {
             tabManager.selectTab(tabManager.addTab())

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -284,7 +284,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable {
     /// storeChanges is called when a web view has finished loading a page
     override func storeChanges() {
         let windowManager: WindowManager = AppContainer.shared.resolve()
-        windowManager.storeTabs()
+        windowManager.performMultiWindowAction(.storeTabs)
         preserveTabs()
         saveCurrentTabSessionData()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -728,7 +728,8 @@ final class BrowserCoordinatorTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result)
-        XCTAssertEqual(mbvc.closePrivateTabsCount, 1)
+        let windowManager = (AppContainer.shared.resolve() as WindowManager) as! MockWindowManager
+        XCTAssertEqual(windowManager.closePrivateTabsMultiActionCalled, 1)
     }
 
     func testHandleShowOnboarding_returnsTrueAndShowsOnboarding() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -27,7 +27,7 @@ class DependencyHelperMock {
         AppContainer.shared.register(service: diskImageStore)
 
         let windowUUID = WindowUUID.XCTestDefaultUUID
-        let windowManager: WindowManager = WindowManagerImplementation()
+        let windowManager: WindowManager = MockWindowManager(wrappedManager: WindowManagerImplementation())
         let tabManager: TabManager =
         injectedTabManager ?? TabManagerImplementation(profile: profile,
                                                        uuid: windowUUID,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -99,7 +99,7 @@ class MockBrowserViewController: BrowserViewController {
         qrCodeCount += 1
     }
 
-    override func handleClosePrivateTabs() {
+    override func closeAllPrivateTabs() {
         closePrivateTabsCount += 1
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -40,7 +40,7 @@ class MockBrowserViewController: BrowserViewController {
     var presentSignInCount: Int = 0
 
     var qrCodeCount = 0
-    var closePrivateTabsCount = 0
+    var closePrivateTabsWidgetAction = 0
 
     var embedContentCalled = 0
     var frontEmbeddedContentCalled = 0
@@ -100,7 +100,7 @@ class MockBrowserViewController: BrowserViewController {
     }
 
     override func closeAllPrivateTabs() {
-        closePrivateTabsCount += 1
+        closePrivateTabsWidgetAction += 1
     }
 
     override func presentSignInViewController(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
@@ -31,7 +31,7 @@ final class MockWindowManager: WindowManager {
     }
 
     func tabManager(for windowUUID: WindowUUID) -> TabManager {
-        tabManager(for: windowUUID)
+        wrappedManager.tabManager(for: windowUUID)
     }
 
     func allWindowTabManagers() -> [TabManager] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Storage
+@testable import Client
+
+final class MockWindowManager: WindowManager {
+    private let wrappedManager: WindowManagerImplementation
+
+    var closePrivateTabsMultiActionCalled = 0
+
+    init(wrappedManager: WindowManagerImplementation) {
+        self.wrappedManager = wrappedManager
+    }
+
+    // MARK: - WindowManager Protocol
+
+    var activeWindow: WindowUUID {
+        get { wrappedManager.activeWindow }
+        set { wrappedManager.activeWindow = newValue }
+    }
+
+    var windows: [WindowUUID: AppWindowInfo] {
+        wrappedManager.windows
+    }
+
+    func newBrowserWindowConfigured(_ windowInfo: AppWindowInfo, uuid: WindowUUID) {
+        wrappedManager.newBrowserWindowConfigured(windowInfo, uuid: uuid)
+    }
+
+    func tabManager(for windowUUID: WindowUUID) -> TabManager {
+        tabManager(for: windowUUID)
+    }
+
+    func allWindowTabManagers() -> [TabManager] {
+        wrappedManager.allWindowTabManagers()
+    }
+
+    func allWindowUUIDs(includingReserved: Bool) -> [WindowUUID] {
+        wrappedManager.allWindowUUIDs(includingReserved: includingReserved)
+    }
+
+    func windowWillClose(uuid: WindowUUID) {
+        wrappedManager.windowWillClose(uuid: uuid)
+    }
+
+    func reserveNextAvailableWindowUUID() -> WindowUUID {
+        wrappedManager.reserveNextAvailableWindowUUID()
+    }
+
+    func postWindowEvent(event: WindowEvent, windowUUID: WindowUUID) {
+        wrappedManager.postWindowEvent(event: event, windowUUID: windowUUID)
+    }
+
+    func performMultiWindowAction(_ action: MultiWindowAction) {
+        switch action {
+        case .closeAllPrivateTabs:
+            closePrivateTabsMultiActionCalled += 1
+        default:
+            break
+        }
+        wrappedManager.performMultiWindowAction(action)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9049)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20011)

## :bulb: Description

This introduces some refactors for handling multi-window actions and also fixes the Close Private Tabs widget action so that it closes private tabs across all open windows.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

