### PR TITLE
Add FXIOS-6047 - iOS No Longer Asking For Permission To Paste URL

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2432,6 +2432,7 @@ extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
         show(toast: toast, duration: ClipboardBarDisplayHandler.UX.toastDelay)
     }
 
+    @available(iOS 16.0, *)
     func shouldDisplay() {
         let viewModel = ButtonToastViewModel(
             labelText: .GoToCopiedLink,
@@ -2439,17 +2440,15 @@ extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
             buttonText: .GoButtonTittle
         )
 
-        if #available(iOS 16.0, *) {
-            pasteConfiguration = UIPasteConfiguration(acceptableTypeIdentifiers: [UTType.url.identifier])
-            let toast = PasteControlToast(
-                viewModel: viewModel,
-                theme: currentTheme(),
-                target: self
-            )
+        pasteConfiguration = UIPasteConfiguration(acceptableTypeIdentifiers: [UTType.url.identifier])
+        let toast = PasteControlToast(
+            viewModel: viewModel,
+            theme: currentTheme(),
+            target: self
+        )
 
-            clipboardBarDisplayHandler?.clipboardToast = toast
-            show(toast: toast, duration: ClipboardBarDisplayHandler.UX.toastDelay)
-        }
+        clipboardBarDisplayHandler?.clipboardToast = toast
+        show(toast: toast, duration: ClipboardBarDisplayHandler.UX.toastDelay)
     }
 
     override func paste(itemProviders: [NSItemProvider]) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2441,6 +2441,7 @@ extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
         )
 
         pasteConfiguration = UIPasteConfiguration(acceptableTypeIdentifiers: [UTType.url.identifier])
+
         let toast = PasteControlToast(
             viewModel: viewModel,
             theme: currentTheme(),

--- a/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
@@ -172,3 +172,56 @@ class ButtonToast: Toast {
         dismiss(true)
     }
 }
+
+@available(iOS 16.0, *)
+class PasteControlToast: ButtonToast {
+    private var theme: Theme?
+    private var pasteControlTarget: UIViewController?
+
+    private lazy var pasteControl: UIPasteControl = {
+        let pasteControlConfig = UIPasteControl.Configuration()
+        pasteControlConfig.displayMode = .iconAndLabel
+        pasteControlConfig.baseForegroundColor = theme?.colors.textInverted
+        pasteControlConfig.baseBackgroundColor = theme?.colors.actionPrimary
+
+        let pasteControl = UIPasteControl(configuration: pasteControlConfig)
+        pasteControl.target = pasteControlTarget
+        pasteControl.translatesAutoresizingMaskIntoConstraints = false
+        pasteControl.layer.borderWidth = UX.buttonBorderWidth
+        pasteControl.layer.cornerRadius = UX.buttonBorderRadius
+        pasteControl.widthAnchor.constraint(equalToConstant: 90).isActive = true
+
+        return pasteControl
+    }()
+
+    init(viewModel: ButtonToastViewModel, theme: Theme?, target: UIViewController?) {
+        self.theme = theme
+        self.pasteControlTarget = target
+        super.init(viewModel: viewModel, theme: theme)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func setupPaddedButton(stackView: UIStackView, buttonText: String?) {
+        let paddedView = UIView()
+        paddedView.translatesAutoresizingMaskIntoConstraints = false
+        paddedView.addSubview(pasteControl)
+        stackView.addArrangedSubview(paddedView)
+
+        NSLayoutConstraint.activate([
+            pasteControl.centerYAnchor.constraint(equalTo: paddedView.centerYAnchor),
+            pasteControl.centerXAnchor.constraint(equalTo: paddedView.centerXAnchor),
+
+            paddedView.topAnchor.constraint(equalTo: stackView.topAnchor),
+            paddedView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
+            paddedView.widthAnchor.constraint(equalTo: pasteControl.widthAnchor, constant: UX.widthOffset)
+        ])
+    }
+
+    override func applyTheme(theme: Theme) {
+        super.applyTheme(theme: theme)
+        pasteControl.layer.borderColor = theme.colors.borderInverted.cgColor
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -7,6 +7,7 @@ import Shared
 
 protocol ClipboardBarDisplayHandlerDelegate: AnyObject {
     func shouldDisplay(clipBoardURL url: URL)
+    func shouldDisplay()
 }
 
 class ClipboardBarDisplayHandler: NSObject {
@@ -19,6 +20,7 @@ class ClipboardBarDisplayHandler: NSObject {
     weak var tabManager: TabManager?
     private var prefs: Prefs
     private var lastDisplayedURL: String?
+    private var lastPasteBoardChangeCount: Int?
     private weak var firstTab: Tab?
     var clipboardToast: ButtonToast?
     private let windowUUID: UUID
@@ -81,6 +83,14 @@ class ClipboardBarDisplayHandler: NSObject {
         return true
     }
 
+    private func shouldDisplayBar(_ pasteBoardChangeCount: Int) -> Bool {
+        if pasteBoardChangeCount == lastPasteBoardChangeCount ||
+            IntroScreenManager(prefs: prefs).shouldShowIntroScreen {
+            return false
+        }
+        return true
+    }
+
     // If we already displayed this URL on the previous session, or in an already open
     // tab, we shouldn't display it again
     private func isClipboardURLAlreadyDisplayed(_ clipboardURL: String) -> Bool {
@@ -98,16 +108,31 @@ class ClipboardBarDisplayHandler: NSObject {
 
     func checkIfShouldDisplayBar() {
         // Clipboard bar feature needs to be enabled by users to be activated in the user settings
-        guard prefs.boolForKey("showClipboardBar") ?? false else { return }
+        guard
+            prefs.boolForKey("showClipboardBar") ?? false,
+            UIPasteboard.general.hasURLs
+        else { return }
 
-        guard UIPasteboard.general.hasURLs,
-              let url = UIPasteboard.general.url,
-              shouldDisplayBar(url.absoluteString) else { return }
+        if #available(iOS 16.0, *) {
+            let pasteBoardChangeCount = UIPasteboard.general.changeCount
+            guard shouldDisplayBar(pasteBoardChangeCount) else { return }
 
-        lastDisplayedURL = url.absoluteString
+            lastPasteBoardChangeCount = pasteBoardChangeCount
 
-        AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(windowUUID)]) { [weak self] in
-            self?.delegate?.shouldDisplay(clipBoardURL: url)
+            AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(windowUUID)]) { [weak self] in
+                self?.delegate?.shouldDisplay()
+            }
+        } else {
+            guard
+                let url = UIPasteboard.general.url,
+                shouldDisplayBar(url.absoluteString)
+            else { return }
+
+            lastDisplayedURL = url.absoluteString
+
+            AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(windowUUID)]) { [weak self] in
+                self?.delegate?.shouldDisplay(clipBoardURL: url)
+            }
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -7,6 +7,8 @@ import Shared
 
 protocol ClipboardBarDisplayHandlerDelegate: AnyObject {
     func shouldDisplay(clipBoardURL url: URL)
+
+    @available(iOS 16.0, *)
     func shouldDisplay()
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6047)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13700)

## :bulb: Description
Replaced `UIButton` with `UIPasteControl` in URL toast for iOS 16 and above.  This fixes the attached issue as the app will no longer read the clipboard without user interaction.  Clicking on `UIPasteControl` gives the app permission to read the clipboard.  Issue does not exist prior to iOS 16 as `UIPasteControl` and the clipboard security measures were released in iOS 16.

* Added subclass `PasteControlToast: ButtonToast`.  Subclass replaces `UIButton` with `UIPasteControl`.

* Added method `BrowserController.paste()`.  This method is called after `UIPasteControl` is cliked.  Method gets the URL from the clipboard and opens a new browser tab with the URL.

* Added method `BrowserViewController.shouldDisplay()` as delegate for `ClipboardBarDisplayHandler`.  Method sets `view.pasteConfiguration` and configures URL toast.

* Added branched code to `ClipboardBarDisplayHandler.checkIfShouldDisplayBar()` to call `BrowserViewController.shouldDisplay()` instead of `BrowserViewController.shouldDisplay(clipBoardURL:)` if iOS 16 or greater.  The branched code does not read the clipboard as that would trigger iOS to ask for user permission.  Instead, app waits until `UIPasteControl` is clicked to read the clipboard.

* Added method `ClipboardBarDisplayHandler.shouldDisplayBar(pasteBoardChangeCount:)`.  Since app cannot read the clipboard without iOS asking for user permission, app is now using `UIPasteboard.general.changeCount` to check if the clipboard contents have changed.  Checking `changeCount` does not required user permission.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)