### PR TITLE
Add FXIOS-9109 [Component Library] Disabled state for primary button

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/DarkTheme.swift
@@ -57,6 +57,7 @@ private struct DarkColourPalette: ThemeColourPalette {
     // MARK: - Actions
     var actionPrimary: UIColor = FXColors.Blue30
     var actionPrimaryHover: UIColor = FXColors.Blue20
+    var actionPrimaryDisabled: UIColor = FXColors.Blue30.withAlphaComponent(0.5)
     var actionSecondary: UIColor = FXColors.DarkGrey05
     var actionSecondaryHover: UIColor = FXColors.LightGrey90
     var formSurfaceOff: UIColor = FXColors.DarkGrey05
@@ -79,6 +80,7 @@ private struct DarkColourPalette: ThemeColourPalette {
     var textOnDark: UIColor = FXColors.LightGrey05
     var textOnLight: UIColor = FXColors.DarkGrey90
     var textInverted: UIColor = FXColors.DarkGrey90
+    var textInvertedDisabled: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.7)
 
     // MARK: - Icons
     var iconPrimary: UIColor = FXColors.LightGrey05

--- a/BrowserKit/Sources/Common/Theming/LightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/LightTheme.swift
@@ -57,6 +57,7 @@ private struct LightColourPalette: ThemeColourPalette {
     // MARK: - Actions
     var actionPrimary: UIColor = FXColors.Blue50
     var actionPrimaryHover: UIColor = FXColors.Blue60
+    var actionPrimaryDisabled: UIColor = FXColors.Blue50.withAlphaComponent(0.5)
     var actionSecondary: UIColor = FXColors.LightGrey30
     var actionSecondaryHover: UIColor = FXColors.LightGrey40
     var formSurfaceOff: UIColor = FXColors.LightGrey30
@@ -79,6 +80,7 @@ private struct LightColourPalette: ThemeColourPalette {
     var textOnDark: UIColor = FXColors.LightGrey05
     var textOnLight: UIColor = FXColors.DarkGrey90
     var textInverted: UIColor = FXColors.LightGrey05
+    var textInvertedDisabled: UIColor = FXColors.LightGrey05.withAlphaComponent(0.8)
 
     // MARK: - Icons
     var iconPrimary: UIColor = FXColors.DarkGrey90

--- a/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
@@ -59,6 +59,7 @@ private struct PrivateModeColorPalette: ThemeColourPalette {
     // MARK: - Actions
     var actionPrimary: UIColor = FXColors.Blue30
     var actionPrimaryHover: UIColor = FXColors.Blue20
+    var actionPrimaryDisabled: UIColor = FXColors.Blue30.withAlphaComponent(0.5)
     var actionSecondary: UIColor = FXColors.DarkGrey05
     var actionSecondaryHover: UIColor = FXColors.LightGrey90
     var formSurfaceOff: UIColor = FXColors.DarkGrey05
@@ -81,6 +82,7 @@ private struct PrivateModeColorPalette: ThemeColourPalette {
     var textOnDark: UIColor = FXColors.LightGrey05
     var textOnLight: UIColor = FXColors.DarkGrey90
     var textInverted: UIColor = FXColors.DarkGrey90
+    var textInvertedDisabled: UIColor = FXColors.DarkGrey90.withAlphaComponent(0.7)
 
     // MARK: - Icons
     var iconPrimary: UIColor = FXColors.LightGrey05

--- a/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
@@ -45,6 +45,7 @@ public protocol ThemeColourPalette {
     // MARK: - Actions
     var actionPrimary: UIColor { get }
     var actionPrimaryHover: UIColor { get }
+    var actionPrimaryDisabled: UIColor { get }
     var actionSecondary: UIColor { get }
     var actionSecondaryHover: UIColor { get }
     var formSurfaceOff: UIColor { get }
@@ -67,6 +68,7 @@ public protocol ThemeColourPalette {
     var textOnDark: UIColor { get }
     var textOnLight: UIColor { get }
     var textInverted: UIColor { get }
+    var textInvertedDisabled: UIColor { get }
 
     // MARK: - Icons
     var iconPrimary: UIColor { get }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/PrimaryRoundedButton.swift
@@ -21,7 +21,9 @@ public class PrimaryRoundedButton: ResizableButton, ThemeApplicable {
 
     private var backgroundColorNormal: UIColor = .clear
     private var backgroundColorHighlighted: UIColor = .clear
+    private var backgroundColorDisabled: UIColor = .clear
     private var foregroundColor: UIColor = .black
+    private var foregroundColorDisabled: UIColor = .clear
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -40,6 +42,8 @@ public class PrimaryRoundedButton: ResizableButton, ThemeApplicable {
         }
 
         switch state {
+        case [.disabled]:
+            updatedConfiguration.background.backgroundColor = backgroundColorDisabled
         case [.highlighted]:
             updatedConfiguration.background.backgroundColor = backgroundColorHighlighted
         default:
@@ -50,13 +54,21 @@ public class PrimaryRoundedButton: ResizableButton, ThemeApplicable {
         updatedConfiguration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { [weak self] incoming in
         // swiftlint:enable line_length
             var container = incoming
-            container.foregroundColor = self?.foregroundColor
+            if self?.state == .disabled {
+                container.foregroundColor = self?.foregroundColorDisabled
+            } else {
+                container.foregroundColor = self?.foregroundColor
+            }
             container.font = FXFontStyles.Bold.callout.scaledFont()
             return container
         }
 
         updatedConfiguration.imageColorTransformer = UIConfigurationColorTransformer { [weak self] color in
-            return self?.foregroundColor ?? .white
+            if self?.state == .disabled {
+                return self?.foregroundColorDisabled ?? .white
+            } else {
+                return self?.foregroundColor ?? .white
+            }
         }
 
         configuration = updatedConfiguration
@@ -92,7 +104,9 @@ public class PrimaryRoundedButton: ResizableButton, ThemeApplicable {
     public func applyTheme(theme: Theme) {
         backgroundColorNormal = theme.colors.actionPrimary
         backgroundColorHighlighted = theme.colors.actionPrimaryHover
+        backgroundColorDisabled = theme.colors.actionPrimaryDisabled
         foregroundColor = theme.colors.textInverted
+        foregroundColorDisabled = theme.colors.textInvertedDisabled
         setNeedsUpdateConfiguration()
     }
 }

--- a/SampleComponentLibraryApp/SampleComponentLibraryApp/Buttons/ButtonsViewController.swift
+++ b/SampleComponentLibraryApp/SampleComponentLibraryApp/Buttons/ButtonsViewController.swift
@@ -13,6 +13,7 @@ class ButtonsViewController: UIViewController, Themeable {
     var notificationCenter: NotificationProtocol = NotificationCenter.default
 
     private lazy var primaryButton: PrimaryRoundedButton = .build { _ in }
+    private lazy var primaryButtonDisabled: PrimaryRoundedButton = .build { _ in }
     private lazy var secondaryButton: SecondaryRoundedButton = .build { _ in }
     private lazy var linkButton: LinkButton = .build { _ in }
     private lazy var closeButton: CloseButton = .build { _ in }
@@ -51,6 +52,13 @@ class ButtonsViewController: UIViewController, Themeable {
         let primaryViewModel = PrimaryRoundedButtonViewModel(title: "Primary",
                                                              a11yIdentifier: "a11yPrimary")
         primaryButton.configure(viewModel: primaryViewModel)
+
+        let primaryViewModelDisabled = PrimaryRoundedButtonViewModel(
+            title: "Primary Disabled",
+            a11yIdentifier: "a11yPrimaryDisabled"
+        )
+        primaryButtonDisabled.configure(viewModel: primaryViewModelDisabled)
+        primaryButtonDisabled.isEnabled = false
 
         let secondaryViewModel = SecondaryRoundedButtonViewModel(title: "Secondary",
                                                                  a11yIdentifier: "a11ySecondary")
@@ -94,6 +102,7 @@ class ButtonsViewController: UIViewController, Themeable {
         disabledOffSwitch.configure(with: paddedSwitchViewModelOffDisabled)
 
         primaryButton.applyTheme(theme: themeManager.currentTheme)
+        primaryButtonDisabled.applyTheme(theme: themeManager.currentTheme)
         secondaryButton.applyTheme(theme: themeManager.currentTheme)
         linkButton.applyTheme(theme: themeManager.currentTheme)
     }
@@ -101,6 +110,7 @@ class ButtonsViewController: UIViewController, Themeable {
     private func setupView() {
         view.addSubview(buttonStackView)
         buttonStackView.addArrangedSubview(primaryButton)
+        buttonStackView.addArrangedSubview(primaryButtonDisabled)
         buttonStackView.addArrangedSubview(secondaryButton)
         buttonStackView.addArrangedSubview(linkButton)
         buttonStackView.addArrangedSubview(closeButton)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9109)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20202)

## :bulb: Description
Update our component `PrimaryRoundedButton` to update its color based on its disabled state.
Added two new tokens `actionPrimaryDisabled` and `textInvertedDisabled`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots 
| Dark | Light | 
| --- | --- |
|![Simulator Screenshot - iPhone 15 Plus - 2024-05-10 at 15 09 03](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/851c5025-4213-4918-b522-8f467372386a) | ![Simulator Screenshot - iPhone 15 Plus - 2024-05-10 at 15 09 12](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/352afb17-8d64-49c4-9c22-badc99791bfd)|