### PR TITLE
Add MTE-2784 - shortcuts rows test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
@@ -84,6 +84,7 @@
         "HomePageSettingsUITests\/testRecentlySaved()",
         "HomePageSettingsUITests\/testSetCustomURLAsHome()",
         "HomePageSettingsUITests\/testSetFirefoxHomeAsHome()",
+        "HomePageSettingsUITests\/testShortcutsRows()",
         "HomePageSettingsUITests\/testTopSitesCustomNumberOfRows()",
         "HomePageSettingsUITests\/testTyping()",
         "IntegrationTests",


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-2784

## :bulb: Description

<img width="660" alt="Screenshot 2024-05-13 at 12 07 50" src="https://github.com/mozilla-mobile/firefox-ios/assets/134391433/458a290a-3fc3-4ed8-9fd9-f8f379139b24">

