### PR TITLE
Refactor MTE-2785 Add status and logs to the github action notification

### DIFF
--- a/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
+++ b/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
@@ -48,23 +48,17 @@ jobs:
             
             echo "Run tests"
             npm test
+        - name: Set job log URL
+          if: always()
+          run: echo "JOB_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
         - name: Send Slack notification if tests fail
           if: '!cancelled()'
           id: slack
           uses: slackapi/slack-github-action@v1.26.0
           with:
-            payload: |
-              {
-                "text": "GitHub Action Running Tests For ${{ env.github_action_name }} result: ${{ job.status }}",
-                "blocks": [
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "GitHub Action Running Tests For result: ${{ job.status }}"
-                    }
-                  }
-                ]
-              }
+            payload-file-path: "./test-fixtures/ci/slack-notification-payload-autofill-test.json"
           env:
+            JOB_STATUS: ${{ job.status == 'success' && ':white_check_mark:' || job.status == 'failure' && ':x:' }}
+            JOB_STATUS_COLOR: ${{ job.status == 'success' && '#36a64f' || job.status == 'failure' && '#FF0000' }}
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/firefox-ios-update_credential_provider_script.yml
+++ b/.github/workflows/firefox-ios-update_credential_provider_script.yml
@@ -47,26 +47,20 @@ jobs:
         title: Refactor [vXXX] auto update credential provider script
         branch: update-cred-provider-script
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set job log URL
+      if: always()
+      run: echo "JOB_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
     - name: Send Slack to notifiy if github action fails
       if: '!cancelled()'
       id: slack
       uses: slackapi/slack-github-action@v1.26.0
-      with:
-            payload: |
-              {
-                "text": "GitHub Action ${{ env.github_action_name }} build result: ${{ job.status }}",
-                "blocks": [
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "GitHub Action build result: ${{ job.status }}"
-                    }
-                  }
-                ]
-              }
       env:
+        JOB_STATUS: ${{ job.status == 'success' && ':white_check_mark:' || job.status == 'failure' && ':x:' }}
+        JOB_STATUS_COLOR: ${{ job.status == 'success' && '#36a64f' || job.status == 'failure' && '#FF0000' }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      with:
+        payload-file-path: "./test-fixtures/ci/slack-notification-payload-autofill.json"
   call-firefox-ios-autofill-playwrite-tests:
     uses: ./.github/workflows/firefox-ios-autofill-playwrite-tests.yml
     secrets:

--- a/test-fixtures/ci/slack-notification-payload-autofill-test.json
+++ b/test-fixtures/ci/slack-notification-payload-autofill-test.json
@@ -1,0 +1,39 @@
+{
+    "attachments": [
+        {
+            "color": "${{ env.JOB_STATUS_COLOR }}",
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "GitHub Action :github: credential provider playwrite tests",
+                        "emoji": true
+                    }
+                },
+                {
+                    "type": "divider"
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "Status: ${{ env.JOB_STATUS }}\n Logs: <${{ env.JOB_LOG_URL }}|Build Logs>"
+                    }
+                },
+                {
+                    "type": "divider"
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text": ":testops-notify: created by <www.go.com|Mobile Test Engineering>"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/test-fixtures/ci/slack-notification-payload-autofill.json
+++ b/test-fixtures/ci/slack-notification-payload-autofill.json
@@ -1,0 +1,39 @@
+{
+    "attachments": [
+        {
+            "color": "${{ env.JOB_STATUS_COLOR }}",
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "GitHub Action :github: credential provider script",
+                        "emoji": true
+                    }
+                },
+                {
+                    "type": "divider"
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "Status: ${{ env.JOB_STATUS }}\n Logs: <${{ env.JOB_LOG_URL }}|Build Logs>"
+                    }
+                },
+                {
+                    "type": "divider"
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text": ":testops-notify: created by <www.go.com|Mobile Test Engineering>"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2785)

This PR is a refactor to the slack notification so that it uses the MTE templating, having links to track the status and logs.

The new notification would look like this one, with its own title:
https://mozilla.slack.com/archives/G016BC5FUHJ/p1715400472717159
<img width="509" alt="imagen" src="https://github.com/mozilla-mobile/firefox-ios/assets/1897507/82519ce2-4e1c-4b5d-ba24-ddd3134d7f5c">


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

