### PR TITLE
Add FXIOS-8895 [Microsurvey] Modal survey view

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -677,6 +677,7 @@
 		8A3EF8152A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF8142A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift */; };
 		8A3EF8172A2FD2B900796E3A /* AdvancedAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF8162A2FD2B900796E3A /* AdvancedAccountSettings.swift */; };
 		8A4190D22A6B0848001E8401 /* StatusBarOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4190D02A6B0843001E8401 /* StatusBarOverlayTests.swift */; };
+		8A4490922BF3BC2700E7E682 /* MicrosurveyPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4490912BF3BC2700E7E682 /* MicrosurveyPrompt.swift */; };
 		8A44F20E2B585E1F0016BC81 /* HomepageTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A44F20D2B585E1F0016BC81 /* HomepageTelemetry.swift */; };
 		8A471183287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */; };
 		8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */; };
@@ -709,7 +710,6 @@
 		8A5D1CC12A30DCA4005AD35C /* SettingDisclosureUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5D1CC02A30DCA4005AD35C /* SettingDisclosureUtility.swift */; };
 		8A635ECD289437A8006378BA /* SyncedTabCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A635ECC289437A8006378BA /* SyncedTabCellTests.swift */; };
 		8A6904802B97BBAE00E30047 /* SplashScreenAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A69047F2B97BBAE00E30047 /* SplashScreenAnimation.swift */; };
-		8A6A3D472BD0390100BFDB64 /* MicrosurveyPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6A3D462BD0390100BFDB64 /* MicrosurveyPrompt.swift */; };
 		8A6A796D27F773550022D6C6 /* HomepageContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6A796C27F773550022D6C6 /* HomepageContextMenuHelper.swift */; };
 		8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B77CB2811C468001110D2 /* URLProtocolStub.swift */; };
 		8A6E13982A71BA4E00A88FA8 /* TabWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */; };
@@ -744,6 +744,9 @@
 		8A83B74A2A265044002FF9AC /* SettingsCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A83B7492A265044002FF9AC /* SettingsCoordinatorTests.swift */; };
 		8A83B74C2A265061002FF9AC /* LibraryCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A83B74B2A265061002FF9AC /* LibraryCoordinatorTests.swift */; };
 		8A8482F02BE1602500F9007B /* MicrosurveyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8482EE2BE15FFE00F9007B /* MicrosurveyStateTests.swift */; };
+		8A8482F22BE1834E00F9007B /* MicrosurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8482F12BE1834D00F9007B /* MicrosurveyViewController.swift */; };
+		8A8482F62BE1847800F9007B /* MicrosurveyTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8482F52BE1847800F9007B /* MicrosurveyTableHeaderView.swift */; };
+		8A8482F82BE184AC00F9007B /* MicrosurveyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8482F72BE184AC00F9007B /* MicrosurveyTableViewCell.swift */; };
 		8A8629E2288096C40096DDB1 /* BookmarksFolderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */; };
 		8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E52880B69C0096DDB1 /* BookmarksPanelTests.swift */; };
 		8A86DAD8277298DE00D7BFFF /* ClosedTabsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */; };
@@ -850,6 +853,7 @@
 		8AE1E1D227B1ADC40024C45E /* TopBottomInterchangeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */; };
 		8AE1E1D927B1BD380024C45E /* UIStackViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D827B1BD380024C45E /* UIStackViewExtensionsTests.swift */; };
 		8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1DA27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift */; };
+		8AE2B4A52BEE90F800E28ABD /* MicrosurveyTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE2B4A42BEE90F800E28ABD /* MicrosurveyTableView.swift */; };
 		8AE80BAD2891957C00BC12EA /* TopSitesDimensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BAC2891957C00BC12EA /* TopSitesDimensionTests.swift */; };
 		8AE80BAF2891960300BC12EA /* MockTraitCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BAE2891960300BC12EA /* MockTraitCollection.swift */; };
 		8AE80BB62891AEA100BC12EA /* MockDispatchGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BB42891AE6700BC12EA /* MockDispatchGroup.swift */; };
@@ -5909,6 +5913,7 @@
 		8A3EF8142A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenFiftyTabsDebugOption.swift; sourceTree = "<group>"; };
 		8A3EF8162A2FD2B900796E3A /* AdvancedAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedAccountSettings.swift; sourceTree = "<group>"; };
 		8A4190D02A6B0843001E8401 /* StatusBarOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarOverlayTests.swift; sourceTree = "<group>"; };
+		8A4490912BF3BC2700E7E682 /* MicrosurveyPrompt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicrosurveyPrompt.swift; sourceTree = "<group>"; };
 		8A44F20D2B585E1F0016BC81 /* HomepageTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageTelemetry.swift; sourceTree = "<group>"; };
 		8A471182287F6D9C00F5A6EA /* BookmarksPanelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPanelViewModel.swift; sourceTree = "<group>"; };
 		8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorTableViewCell.swift; sourceTree = "<group>"; };
@@ -5942,7 +5947,6 @@
 		8A5D1CC02A30DCA4005AD35C /* SettingDisclosureUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingDisclosureUtility.swift; sourceTree = "<group>"; };
 		8A635ECC289437A8006378BA /* SyncedTabCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncedTabCellTests.swift; sourceTree = "<group>"; };
 		8A69047F2B97BBAE00E30047 /* SplashScreenAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreenAnimation.swift; sourceTree = "<group>"; };
-		8A6A3D462BD0390100BFDB64 /* MicrosurveyPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyPrompt.swift; sourceTree = "<group>"; };
 		8A6A796C27F773550022D6C6 /* HomepageContextMenuHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageContextMenuHelper.swift; sourceTree = "<group>"; };
 		8A6B77CB2811C468001110D2 /* URLProtocolStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolStub.swift; sourceTree = "<group>"; };
 		8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabWebViewTests.swift; sourceTree = "<group>"; };
@@ -5987,6 +5991,9 @@
 		8A83B7492A265044002FF9AC /* SettingsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A83B74B2A265061002FF9AC /* LibraryCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A8482EE2BE15FFE00F9007B /* MicrosurveyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyStateTests.swift; sourceTree = "<group>"; };
+		8A8482F12BE1834D00F9007B /* MicrosurveyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyViewController.swift; sourceTree = "<group>"; };
+		8A8482F52BE1847800F9007B /* MicrosurveyTableHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyTableHeaderView.swift; sourceTree = "<group>"; };
+		8A8482F72BE184AC00F9007B /* MicrosurveyTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyTableViewCell.swift; sourceTree = "<group>"; };
 		8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksFolderCell.swift; sourceTree = "<group>"; };
 		8A8629E52880B69C0096DDB1 /* BookmarksPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPanelTests.swift; sourceTree = "<group>"; };
 		8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabsStoreTests.swift; sourceTree = "<group>"; };
@@ -6092,6 +6099,7 @@
 		8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBottomInterchangeable.swift; sourceTree = "<group>"; };
 		8AE1E1D827B1BD380024C45E /* UIStackViewExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensionsTests.swift; sourceTree = "<group>"; };
 		8AE1E1DA27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarSettingsViewModelTests.swift; sourceTree = "<group>"; };
+		8AE2B4A42BEE90F800E28ABD /* MicrosurveyTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyTableView.swift; sourceTree = "<group>"; };
 		8AE80BAC2891957C00BC12EA /* TopSitesDimensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesDimensionTests.swift; sourceTree = "<group>"; };
 		8AE80BAE2891960300BC12EA /* MockTraitCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTraitCollection.swift; sourceTree = "<group>"; };
 		8AE80BB42891AE6700BC12EA /* MockDispatchGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDispatchGroup.swift; sourceTree = "<group>"; };
@@ -9451,10 +9459,10 @@
 		8A1CBB932BE017BE008BE4D4 /* Prompt */ = {
 			isa = PBXGroup;
 			children = (
-				8A6A3D462BD0390100BFDB64 /* MicrosurveyPrompt.swift */,
 				8A1CBB942BE017D3008BE4D4 /* MicrosurveyPromptAction.swift */,
 				8A1CBB962BE0182C008BE4D4 /* MicrosurveyPromptMiddleware.swift */,
 				8A1CBB982BE01839008BE4D4 /* MicrosurveyPromptState.swift */,
+				8A4490912BF3BC2700E7E682 /* MicrosurveyPrompt.swift */,
 			);
 			path = Prompt;
 			sourceTree = "<group>";
@@ -9666,6 +9674,10 @@
 			isa = PBXGroup;
 			children = (
 				8A1CBB932BE017BE008BE4D4 /* Prompt */,
+				8A8482F12BE1834D00F9007B /* MicrosurveyViewController.swift */,
+				8A8482F52BE1847800F9007B /* MicrosurveyTableHeaderView.swift */,
+				8AE2B4A42BEE90F800E28ABD /* MicrosurveyTableView.swift */,
+				8A8482F72BE184AC00F9007B /* MicrosurveyTableViewCell.swift */,
 			);
 			path = Microsurvey;
 			sourceTree = "<group>";
@@ -11407,7 +11419,6 @@
 			children = (
 				E177989B2BD7D48500F6F0EB /* ToolbarAction.swift */,
 				E177989D2BD7D75A00F6F0EB /* ToolbarMiddleware.swift */,
-				E1DE2F822BE394E10054BCDC /* ToolbarModel.swift */,
 				E17798992BD7D44200F6F0EB /* ToolbarState.swift */,
 			);
 			path = Redux;
@@ -13942,6 +13953,7 @@
 				21BFEEF52A040EF40033048D /* TabMigrationUtility.swift in Sources */,
 				A55319BB2B5D5A850051559F /* SearchSettingsAction.swift in Sources */,
 				810CD9C12BB346D800E290C2 /* OnboardingCardViewController.swift in Sources */,
+				8A8482F82BE184AC00F9007B /* MicrosurveyTableViewCell.swift in Sources */,
 				C8A012F126AB07D70096A7A7 /* JumpBackInViewModel.swift in Sources */,
 				8A3EF8172A2FD2B900796E3A /* AdvancedAccountSettings.swift in Sources */,
 				EBB89509219398E500EB91A0 /* TabContentBlocker+ContentScript.swift in Sources */,
@@ -14073,9 +14085,11 @@
 				EBB8950C21939E4100EB91A0 /* FirefoxTabContentBlocker.swift in Sources */,
 				21618A632A422A3900A5189E /* ThemeMiddleware.swift in Sources */,
 				219A0FDB2ACCCFFC009A6D1A /* InactiveTabsSectionManager.swift in Sources */,
+				8AE2B4A52BEE90F800E28ABD /* MicrosurveyTableView.swift in Sources */,
 				B2981F8A2B71AD7A00132C1B /* AutofillAccessoryViewButtonItem.swift in Sources */,
 				211F00AC27F4D918001D9189 /* HistoryPanel+Search.swift in Sources */,
 				96EB6C3827D821B800A9D159 /* HistoryPanelViewModel.swift in Sources */,
+				8A4490922BF3BC2700E7E682 /* MicrosurveyPrompt.swift in Sources */,
 				AB52ED3B2A0E8873001067F5 /* UserConversionMetrics.swift in Sources */,
 				219935EC2B07110900E5966F /* TabTrayModel.swift in Sources */,
 				8A3EF7F72A2FCF6D00796E3A /* ExportLogDataSetting.swift in Sources */,
@@ -14327,6 +14341,7 @@
 				274A36CE239EB9EC00A21587 /* LibraryViewController+LibraryPanelDelegate.swift in Sources */,
 				C869912D28917688007ACC5C /* WallpaperImageLoader.swift in Sources */,
 				96A5F73829928B3700234E5F /* GeneralizedImageFetcher.swift in Sources */,
+				8A8482F62BE1847800F9007B /* MicrosurveyTableHeaderView.swift in Sources */,
 				1D7B78992ADF328E0011E9F2 /* AppEvent.swift in Sources */,
 				43F7952525795F69005AEE40 /* SearchTelemetry.swift in Sources */,
 				E65075541E37F6FC006961AC /* LegacyDynamicFontHelper.swift in Sources */,
@@ -14481,6 +14496,7 @@
 				DFD104682B2341F900938418 /* ProductAdsCache.swift in Sources */,
 				C2D71B992A384F6A003DEC7A /* ThemedLeftAlignedTableViewCell.swift in Sources */,
 				B28BF6602B7A9E4F006357CA /* FillAddressAutofillForm.swift in Sources */,
+				8A8482F22BE1834E00F9007B /* MicrosurveyViewController.swift in Sources */,
 				21A7C44E283539170071D996 /* IntroViewModel.swift in Sources */,
 				E1FF93E228A2E55700E6360E /* WallpaperSelectorViewController.swift in Sources */,
 				D3A9949C1A3686BD008AD1AC /* BrowserViewController.swift in Sources */,
@@ -14504,7 +14520,6 @@
 				E633E2DA1C21EAF8001FFF6C /* PasswordDetailViewController.swift in Sources */,
 				8A9AC46B276D11280047F5B0 /* PocketViewModel.swift in Sources */,
 				8A7653BF28A2C92600924ABF /* PocketStandardCellViewModel.swift in Sources */,
-				8A6A3D472BD0390100BFDB64 /* MicrosurveyPrompt.swift in Sources */,
 				8A5D1CAE2A30D71A005AD35C /* ThemeSetting.swift in Sources */,
 				C82F4C2B29AE2DF1005BD116 /* NotificationsSettingsViewController.swift in Sources */,
 				59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -136,6 +136,14 @@ public struct AccessibilityIdentifiers {
             static let closeButton = "Microsurvey.Prompt.CloseButton"
             static let takeSurveyButton = "Microsurvey.Prompt.TakeSurveyButton"
         }
+
+        struct Survey {
+            static let firefoxLogo = "Microsurvey.Survey.FirefoxLogo"
+            static let closeButton = "Microsurvey.Survey.CloseButton"
+            static let privacyPolicyLink = "Microsurvey.Prompt.PrivacyPolicyLink"
+            static let submitButton = "Microsurvey.Survey.SubmitButton"
+            static let radioButton = "Microsurvey.Survey.RadioButton"
+        }
     }
 
     struct PrivateMode {

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTableHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTableHeaderView.swift
@@ -49,7 +49,10 @@ class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCell, The
 
         NSLayoutConstraint.activate(
             [
-                horizontalStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: UX.padding.top),
+                horizontalStackView.topAnchor.constraint(
+                    equalTo: contentView.topAnchor,
+                    constant: UX.padding.top
+                ),
                 horizontalStackView.leadingAnchor.constraint(
                     equalTo: contentView.leadingAnchor,
                     constant: UX.padding.leading
@@ -58,7 +61,10 @@ class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCell, The
                     equalTo: contentView.trailingAnchor,
                     constant: UX.padding.trailing
                 ),
-                horizontalStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: UX.padding.bottom),
+                horizontalStackView.bottomAnchor.constraint(
+                    equalTo: contentView.bottomAnchor,
+                    constant: UX.padding.bottom
+                ),
 
                 iconView.heightAnchor.constraint(equalToConstant: UX.radioButtonSize.height),
                 iconView.widthAnchor.constraint(equalToConstant: UX.radioButtonSize.width)

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTableHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTableHeaderView.swift
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCell, ThemeApplicable {
+    private struct UX {
+        static let radioButtonSize = CGSize(width: 24, height: 24)
+        static let spacing: CGFloat = 12
+        static let padding = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: 16,
+            bottom: -20,
+            trailing: -16
+        )
+    }
+
+    private lazy var horizontalStackView: UIStackView = .build { stackView in
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = UX.spacing
+    }
+
+    private lazy var iconView: UIImageView = .build { imageView in
+        imageView.contentMode = .scaleAspectFit
+        // TODO: FXIOS-9108: This image should come from the data source, based on the target feature
+        // imageView.image = UIImage(systemName: "printer")
+    }
+
+    private lazy var questionLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        // TODO: FXIOS-9108: This string should come from the experiment when target feature is defined
+        // i.e. "How satisfied are you with printing in Firefox?"
+        label.text = ""
+        label.numberOfLines = 0
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
+    }
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+
+        if iconView.image != nil {
+            horizontalStackView.addArrangedSubview(iconView)
+        }
+        horizontalStackView.addArrangedSubview(questionLabel)
+        contentView.addSubview(horizontalStackView)
+
+        NSLayoutConstraint.activate(
+            [
+                horizontalStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: UX.padding.top),
+                horizontalStackView.leadingAnchor.constraint(
+                    equalTo: contentView.leadingAnchor,
+                    constant: UX.padding.leading
+                ),
+                horizontalStackView.trailingAnchor.constraint(
+                    equalTo: contentView.trailingAnchor,
+                    constant: UX.padding.trailing
+                ),
+                horizontalStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: UX.padding.bottom),
+
+                iconView.heightAnchor.constraint(equalToConstant: UX.radioButtonSize.height),
+                iconView.widthAnchor.constraint(equalToConstant: UX.radioButtonSize.width)
+            ]
+        )
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - ThemeApplicable
+    func applyTheme(theme: Theme) {
+        let colors = theme.colors
+        questionLabel.textColor = colors.textPrimary
+        iconView.tintColor = colors.iconPrimary
+    }
+}

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTableView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTableView.swift
@@ -8,7 +8,6 @@ class MicrosurveyTableView: UITableView {
     override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
         isScrollEnabled = false
-        tableFooterView = UIView()
 
         register(
             MicrosurveyTableHeaderView.self,

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTableView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTableView.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class MicrosurveyTableView: UITableView {
+    override init(frame: CGRect, style: UITableView.Style) {
+        super.init(frame: frame, style: style)
+        isScrollEnabled = false
+        tableFooterView = UIView()
+
+        register(
+            MicrosurveyTableHeaderView.self,
+            forHeaderFooterViewReuseIdentifier: MicrosurveyTableHeaderView.cellIdentifier
+        )
+        register(cellType: MicrosurveyTableViewCell.self)
+        rowHeight = UITableView.automaticDimension
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: CGSize { contentSize }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if !bounds.size.equalTo(intrinsicContentSize) {
+            invalidateIntrinsicContentSize()
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTableViewCell.swift
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
+    private struct UX {
+        static let radioButtonSize = CGSize(width: 24, height: 24)
+        static let spacing: CGFloat = 12
+        static let padding = NSDirectionalEdgeInsets(
+            top: 10,
+            leading: 16,
+            bottom: -10,
+            trailing: -16
+        )
+
+        struct Images {
+            // TODO: FXIOS-9028 Fix radio button for accessibility
+            static let selected = ImageIdentifiers.Onboarding.MultipleChoiceButtonImages.checkmarkFilled
+            static let notSelected = ImageIdentifiers.Onboarding.MultipleChoiceButtonImages.checkmarkEmpty
+        }
+    }
+
+    private lazy var horizontalStackView: UIStackView = .build { stackView in
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = UX.spacing
+    }
+
+    private lazy var radioButton: UIImageView = .build { imageView in
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage(named: UX.Images.notSelected)
+        imageView.accessibilityIdentifier = AccessibilityIdentifiers.Microsurvey.Survey.radioButton
+    }
+
+    private lazy var optionLabel: UILabel = .build { label in
+        label.adjustsFontForContentSizeCategory = true
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+    }
+
+    var checked = false {
+        didSet {
+            let checkedButton = UIImage(named: UX.Images.selected)
+            let uncheckedButton = UIImage(named: UX.Images.notSelected)
+            self.radioButton.image = checked ? checkedButton : uncheckedButton
+        }
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupLayout()
+        self.selectionStyle = .none
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        horizontalStackView.addArrangedSubview(radioButton)
+        horizontalStackView.addArrangedSubview(optionLabel)
+        horizontalStackView.accessibilityElements = [radioButton, optionLabel]
+        contentView.addSubview(horizontalStackView)
+
+        NSLayoutConstraint.activate(
+            [
+                radioButton.widthAnchor.constraint(equalToConstant: UX.radioButtonSize.width),
+                radioButton.heightAnchor.constraint(equalToConstant: UX.radioButtonSize.height),
+
+                horizontalStackView.topAnchor.constraint(
+                    equalTo: contentView.topAnchor,
+                    constant: UX.padding.top
+                ),
+                horizontalStackView.leadingAnchor.constraint(
+                    equalTo: contentView.leadingAnchor,
+                    constant: UX.padding.leading
+                ),
+                horizontalStackView.trailingAnchor.constraint(
+                    equalTo: contentView.trailingAnchor,
+                    constant: UX.padding.trailing
+                ),
+                horizontalStackView.bottomAnchor.constraint(
+                    equalTo: contentView.bottomAnchor,
+                    constant: UX.padding.bottom
+                ),
+            ]
+        )
+    }
+
+    func configureCell(_ text: String) {
+        optionLabel.text = text
+    }
+
+    // MARK: - ThemeApplicable
+    func applyTheme(theme: Theme) {
+        let colors = theme.colors
+        optionLabel.textColor = colors.textPrimary
+        backgroundColor = theme.colors.layer5
+    }
+}

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyViewController.swift
@@ -1,0 +1,270 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+import ComponentLibrary
+
+class MicrosurveyViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, Themeable {
+    // MARK: Themable Variables
+    var themeManager: Common.ThemeManager
+    var themeObserver: NSObjectProtocol?
+    var notificationCenter: Common.NotificationProtocol
+    var currentWindowUUID: UUID? { windowUUID }
+
+    private let windowUUID: WindowUUID
+
+    // TODO: FXIOS-9059 / FXIOS-8990 - Replace after Redux implementation + microsurvey surface manager is implemented
+    private let surveyOptions: [String] = [
+        .Microsurvey.Survey.Options.LikertScaleOption1,
+        .Microsurvey.Survey.Options.LikertScaleOption2,
+        .Microsurvey.Survey.Options.LikertScaleOption3,
+        .Microsurvey.Survey.Options.LikertScaleOption4,
+        .Microsurvey.Survey.Options.LikertScaleOption5
+    ]
+
+    // MARK: UI Elements
+    private struct UX {
+        static let headerStackSpacing: CGFloat = 8
+        static let scrollStackSpacing: CGFloat = 22
+        static let logoSize = CGSize(width: 24, height: 24)
+        static let borderWidth: CGFloat = 1
+        static let cornerRadius: CGFloat = 8
+        static let estimatedRowHeight: CGFloat = 44
+        static let padding = NSDirectionalEdgeInsets(
+            top: 22,
+            leading: 16,
+            bottom: -16,
+            trailing: -16
+        )
+    }
+
+    private lazy var headerView: UIStackView = .build { stack in
+        stack.distribution = .fillProportionally
+        stack.axis = .horizontal
+        stack.alignment = self.headerLabel.numberOfLines > 1 ? .top : .center
+        stack.spacing = UX.headerStackSpacing
+    }
+
+    private lazy var logoImage: UIImageView = .build { imageView in
+        imageView.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoBall)
+        imageView.contentMode = .scaleAspectFit
+        // TODO: FXIOS-9028: Add A11y strings
+        imageView.accessibilityIdentifier = AccessibilityIdentifiers.Microsurvey.Survey.firefoxLogo
+    }
+
+    private var headerLabel: UILabel = .build { label in
+        label.adjustsFontForContentSizeCategory = true
+        label.font = FXFontStyles.Bold.title3.scaledFont()
+        label.numberOfLines = 0
+        label.text = .Microsurvey.Survey.HeaderLabel
+        label.accessibilityTraits.insert(.header)
+    }
+
+    private lazy var closeButton: CloseButton = .build { button in
+        button.accessibilityLabel = .Microsurvey.Survey.CloseButtonAccessibilityLabel
+        button.accessibilityIdentifier = AccessibilityIdentifiers.Microsurvey.Survey.closeButton
+        button.addTarget(self, action: #selector(self.didTapClose), for: .touchUpInside)
+    }
+
+    private lazy var scrollView: UIScrollView = .build()
+
+    private lazy var scrollContainer: UIStackView = .build { stackView in
+        stackView.axis = .vertical
+        stackView.spacing = UX.scrollStackSpacing
+    }
+
+    private lazy var containerView: UIView = .build { view in
+        view.layer.cornerRadius = UX.cornerRadius
+    }
+
+    private lazy var tableView: MicrosurveyTableView = .build { [weak self] tableView in
+        guard let self = self else { return }
+        tableView.delegate = self
+        tableView.dataSource = self
+
+        tableView.estimatedRowHeight = UX.estimatedRowHeight
+        tableView.layer.cornerRadius = UX.cornerRadius
+    }
+
+    private lazy var submitButton: PrimaryRoundedButton = .build { button in
+        button.addTarget(self, action: #selector(self.didTapSubmit), for: .touchUpInside)
+    }
+
+    private lazy var privacyPolicyButton: LinkButton = .build { button in
+        button.addTarget(self, action: #selector(self.didTapPrivacyPolicy), for: .touchUpInside)
+        button.setContentCompressionResistancePriority(.required, for: .vertical)
+        button.accessibilityTraits.insert(.link)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    init(windowUUID: WindowUUID,
+         themeManager: ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: NotificationProtocol = NotificationCenter.default
+    ) {
+        self.windowUUID = windowUUID
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        super.init(nibName: nil, bundle: nil)
+
+        self.sheetPresentationController?.prefersGrabberVisible = true
+        configureUI()
+        setupLayout()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        listenForThemeChange(view)
+        applyTheme()
+    }
+
+    private func configureUI() {
+        let viewModel = PrimaryRoundedButtonViewModel(
+            title: .Microsurvey.Survey.SubmitSurveyButton,
+            a11yIdentifier: AccessibilityIdentifiers.Microsurvey.Survey.submitButton
+        )
+        submitButton.configure(viewModel: viewModel)
+
+        let privacyPolicyButtonViewModel = LinkButtonViewModel(
+            title: .Microsurvey.Survey.PrivacyPolicyLinkButtonTitle,
+            a11yIdentifier: AccessibilityIdentifiers.Microsurvey.Survey.privacyPolicyLink,
+            font: FXFontStyles.Regular.caption2.scaledFont(),
+            contentInsets: NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
+            contentHorizontalAlignment: .center
+        )
+        privacyPolicyButton.configure(viewModel: privacyPolicyButtonViewModel)
+    }
+
+    private func setupLayout() {
+        headerView.addArrangedSubview(logoImage)
+        headerView.addArrangedSubview(headerLabel)
+        headerView.addArrangedSubview(closeButton)
+
+        containerView.addSubviews(tableView)
+
+        scrollContainer.addArrangedSubview(containerView)
+        scrollContainer.addArrangedSubview(submitButton)
+        scrollContainer.addArrangedSubview(privacyPolicyButton)
+
+        scrollView.addSubview(scrollContainer)
+
+        view.addSubviews(headerView, scrollView)
+
+        NSLayoutConstraint.activate(
+            [
+                logoImage.widthAnchor.constraint(equalToConstant: UX.logoSize.width),
+                logoImage.heightAnchor.constraint(equalToConstant: UX.logoSize.height),
+
+                headerView.topAnchor.constraint(
+                    equalTo: view.safeAreaLayoutGuide.topAnchor,
+                    constant: UX.padding.top
+                ),
+                headerView.leadingAnchor.constraint(
+                    equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+                    constant: UX.padding.leading
+                ),
+                headerView.trailingAnchor.constraint(
+                    equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                    constant: UX.padding.trailing
+                ),
+
+                scrollView.topAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -UX.padding.bottom),
+
+                scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+                scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+                scrollContainer.topAnchor.constraint(
+                    equalTo: scrollView.topAnchor),
+                scrollContainer.leadingAnchor.constraint(
+                    equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+                    constant: UX.padding.leading
+                ),
+                scrollContainer.trailingAnchor.constraint(
+                    equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                    constant: UX.padding.trailing
+                ),
+                scrollContainer.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+
+                tableView.topAnchor.constraint(equalTo: containerView.topAnchor),
+                tableView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+                tableView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+                tableView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            ]
+        )
+    }
+
+    func applyTheme() {
+        let theme = themeManager.currentTheme(for: windowUUID)
+        view.backgroundColor = theme.colors.layer1
+
+        headerLabel.textColor = theme.colors.textPrimary
+        closeButton.tintColor = theme.colors.textSecondary
+        tableView.backgroundColor = theme.colors.layer2
+
+        containerView.backgroundColor = theme.colors.layer2
+        containerView.layer.borderColor = theme.colors.borderPrimary.cgColor
+        containerView.layer.borderWidth = UX.borderWidth
+
+        submitButton.applyTheme(theme: theme)
+        privacyPolicyButton.applyTheme(theme: theme)
+    }
+
+    @objc
+    private func didTapSubmit() {
+        // TODO: FXIOS-9072: Add confirmation page
+    }
+
+    @objc
+    private func didTapClose() {
+        // TODO: FXIOS-9059: Redux for Survey close action
+    }
+
+    @objc
+    private func didTapPrivacyPolicy() {
+        // TODO: FXIOS-8976: Privacy policy should open a new tab
+    }
+
+    // MARK: UITableViewDataSource
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return surveyOptions.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: MicrosurveyTableViewCell.cellIdentifier,
+            for: indexPath
+        ) as? MicrosurveyTableViewCell else {
+            return UITableViewCell()
+        }
+        cell.configureCell(surveyOptions[indexPath.row])
+        cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        return cell
+    }
+
+    // MARK: UITableViewDelegate
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(
+            withIdentifier: MicrosurveyTableHeaderView.cellIdentifier
+        ) as? MicrosurveyTableHeaderView else {
+            return nil
+        }
+
+        headerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        return headerView
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        submitButton.isEnabled = true
+        (tableView.cellForRow(at: indexPath) as? MicrosurveyTableViewCell)?.checked.toggle()
+    }
+
+    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        (tableView.cellForRow(at: indexPath) as? MicrosurveyTableViewCell)?.checked = false
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8895)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19638)

## :bulb: Description
Add initial survey modal view for microsurveys
Add TODOs to further refine and handle logic for the view via Redux + Microsurvey Surface Manager

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screeenshots 
| iPad | iPhone|
| --- | --- |
|![Simulator Screenshot - iPhone 15 - 2024-05-13 at 09 19 55](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/b52d5d4c-f903-43ea-acb0-3f0601ed9a90) | ![Simulator Screenshot - iPad (10th generation) - 2024-05-13 at 09 18 35](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/ad43699c-0afd-4bdb-90a9-06b84eb9df20) |
