### PR TITLE
Refactor FXIOS-8939 Send UUID in userInfo for theme changes

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -225,8 +225,9 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         self.windows[window]?.overrideUserInterfaceStyle = style
 
         mainQueue.ensureMainThread { [weak self] in
-            // TODO: [FXIOS-8939] Send UUID in userInfo payload rather than object for consistency with Client.
-            self?.notificationCenter.post(name: .ThemeDidChange, withObject: window)
+            // Eventually WindowUUID and its extensions will be moved into BrowserKit. [FXIOS-9145]
+            // Once that happens we should replace this string literal with `WindowUUID.userInfoKey`
+            self?.notificationCenter.post(name: .ThemeDidChange, withUserInfo: ["windowUUID": window])
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
@@ -46,7 +46,7 @@ struct AddressAutofillSettingsView: View {
                 applyTheme(theme: themeManager.currentTheme(for: windowUUID))
             }
             .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-                guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+                guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
                 applyTheme(theme: themeManager.currentTheme(for: windowUUID))
             }
         }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -89,7 +89,7 @@ struct AddressAutofillToggle: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
@@ -60,7 +60,7 @@ struct AddressCellView: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -46,7 +46,7 @@ struct AddressListView: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressScrollView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressScrollView.swift
@@ -47,7 +47,7 @@ struct AddressScrollView: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/AutofillFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillFooterView.swift
@@ -47,7 +47,7 @@ struct AutofillFooterView: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/AutofillHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillHeaderView.swift
@@ -60,7 +60,7 @@ struct AutofillHeaderView: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -105,7 +105,7 @@ struct CreditCardInputView: View {
                 applyTheme(theme: themeManager.currentTheme(for: windowUUID))
             }
             .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-                guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+                guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
                 applyTheme(theme: themeManager.currentTheme(for: windowUUID))
             }
             .onReceive(NotificationCenter.default.publisher(

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -100,7 +100,7 @@ struct CreditCardItemRow: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSectionHeader.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSectionHeader.swift
@@ -29,7 +29,7 @@ struct CreditCardSectionHeader: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
@@ -68,7 +68,7 @@ struct CreditCardSettingsEmptyView: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
@@ -58,7 +58,7 @@ struct CreditCardAutofillToggle: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
@@ -116,7 +116,7 @@ struct CreditCardInputField: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
@@ -63,7 +63,7 @@ struct RemoveCardButton: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in

--- a/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
@@ -35,7 +35,7 @@ struct LoginAutofillView: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
@@ -64,7 +64,7 @@ struct LoginCellView: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/LoginListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginListView.swift
@@ -38,7 +38,7 @@ struct LoginListView: View {
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         }
     }

--- a/firefox-ios/Client/Frontend/Fakespot/Views/CircularProgressView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/CircularProgressView.swift
@@ -23,7 +23,7 @@ struct CircularProgressView: View, ThemeApplicable {
                 applyTheme(theme: themeManager.currentTheme(for: windowUUID))
             }
             .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-                guard let uuid = notification.object as? UUID, uuid == windowUUID else { return }
+                guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
                 applyTheme(theme: themeManager.currentTheme(for: windowUUID))
             }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8939)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19746)

## :bulb: Description

Minor refactor for consistency with the other code in Client that sends window UUIDs in notification `userInfo` payloads.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

