### PR TITLE
Bugfix FXIOS-9119 Update redux logging to be more useful

### DIFF
--- a/BrowserKit/Sources/Redux/Action.swift
+++ b/BrowserKit/Sources/Redux/Action.swift
@@ -15,9 +15,8 @@ open class Action {
     }
 
     func displayString() -> String {
-        let className = String(describing: Self.self)
-        let actionName = String(describing: self).prefix(20)
-        return "\(className).\(actionName)"
+        let className = String(describing: actionType.self)
+        return "\(className).\(actionType)"
     }
 }
 

--- a/BrowserKit/Sources/Redux/Action.swift
+++ b/BrowserKit/Sources/Redux/Action.swift
@@ -15,8 +15,8 @@ open class Action {
     }
 
     func displayString() -> String {
-        let className = String(describing: actionType.self)
-        return "\(className).\(actionType)"
+        let className = String(describing: Self.self)
+        return "\(className) \(actionType)"
     }
 }
 

--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -68,11 +68,13 @@ public class Store<State: StateType>: DefaultDispatchStore {
     }
 
     public func dispatch(_ action: Action) {
-        logger.log("Dispatched action: \(action.displayString())", level: .info, category: .redux)
         guard Thread.isMainThread && !actionRunning else {
             DispatchQueue.main.async { [weak self] in self?.dispatch(action) }
             return
         }
+
+        logger.log("Dispatched action: \(action.displayString())", level: .info, category: .redux)
+
         actionRunning = true; defer { actionRunning = false }
 
         // Each active screen state is given an opportunity to be reduced using the dispatched action


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9119)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20224)

## :bulb: Description
The log to track which events are dispatched was fired before the check for main thread. Because this is handled recursively it resulted in duplicate logs for any events dispatched off the main thread.
I also updated the display string to be more useful. Since the update to use action classes instead of enums it was only outputting the class type and not the name of the action.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

