### PR TITLE
Bump - Update Sentry to version 8.26.0

### DIFF
--- a/BrowserKit/Package.resolved
+++ b/BrowserKit/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "38f4f70d07117b9f958a76b1bff278c2f29ffe0e",
-        "version" : "8.21.0"
+        "revision" : "7fc7ca43967e2980d8691a8e017c118a84133aac",
+        "version" : "8.26.0"
       }
     },
     {

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
             exact: "2.0.0"),
         .package(
             url: "https://github.com/getsentry/sentry-cocoa.git",
-            exact: "8.21.0"),
+            exact: "8.26.0"),
         .package(url: "https://github.com/nbhasin2/GCDWebServer.git",
                  branch: "master")
     ],

--- a/SampleBrowser/SampleBrowser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleBrowser/SampleBrowser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "38f4f70d07117b9f958a76b1bff278c2f29ffe0e",
-        "version" : "8.21.0"
+        "revision" : "7fc7ca43967e2980d8691a8e017c118a84133aac",
+        "version" : "8.26.0"
       }
     },
     {

--- a/SampleComponentLibraryApp/SampleComponentLibraryApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleComponentLibraryApp/SampleComponentLibraryApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "38f4f70d07117b9f958a76b1bff278c2f29ffe0e",
-        "version" : "8.21.0"
+        "revision" : "7fc7ca43967e2980d8691a8e017c118a84133aac",
+        "version" : "8.26.0"
       }
     },
     {

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -21814,7 +21814,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = exactVersion;
-				version = 8.21.0;
+				version = 8.26.0;
 			};
 		};
 		8AB30EC62B6C038600BD9A9B /* XCRemoteSwiftPackageReference "lottie-ios" */ = {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "38f4f70d07117b9f958a76b1bff278c2f29ffe0e",
-        "version" : "8.21.0"
+        "revision" : "7fc7ca43967e2980d8691a8e017c118a84133aac",
+        "version" : "8.26.0"
       }
     },
     {

--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -7201,7 +7201,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
 			requirement = {
 				kind = exactVersion;
-				version = 8.21.0;
+				version = 8.26.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "38f4f70d07117b9f958a76b1bff278c2f29ffe0e",
-          "version": "8.21.0"
+          "revision": "7fc7ca43967e2980d8691a8e017c118a84133aac",
+          "version": "8.26.0"
         }
       },
       {


### PR DESCRIPTION
Given that the 8.23.0 update was backed out previously, we should do some extra testing around this to make sure that it doesn't re-introduce the problem that update was backed out for (CC @nbhasin2). If we're still seeing issues, we might want to get an issue filed upstream for it.

Changelogs:
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.22.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.22.1
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.22.2
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.22.3
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.22.4
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.23.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.24.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.25.0
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.25.1
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.25.2
* https://github.com/getsentry/sentry-cocoa/releases/tag/8.26.0