### PR TITLE
Add MTE-2795 - OpenNewTabButtonOnToolbar test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -483,6 +483,7 @@ class CreditCardsTests: BaseTestCase {
         cardNumber.tapOnApp()
         cardNumber.typeText(cardNr)
         mozWaitForElementToExist(expiration)
+        dismissSavedCardsPrompt()
         expiration.tapOnApp()
         expiration.typeText(expirationDate)
         cvc.tapOnApp()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -125,4 +125,48 @@ class ToolbarTests: BaseTestCase {
             XCTAssertTrue(topElement.isHittable)
         }
    }
+
+    // https://testrail.stage.mozaws.net/index.php?/cases/view/2306870
+    func testOpenNewTabButtonOnToolbar() throws {
+        if iPad() {
+            throw XCTSkip("iPhone only test")
+        } else {
+            // Launch Firefox iOS
+            // A magnifying glass icon is displayed. A "+" icon is displayed
+            validateAddNewTabButtonOnToolbar(isPrivate: false)
+            // Repeat steps on private mode
+            navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+            navigator.performAction(Action.OpenNewTabFromTabTray)
+            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
+            validateAddNewTabButtonOnToolbar(isPrivate: true)
+        }
+    }
+
+    private func validateAddNewTabButtonOnToolbar(isPrivate: Bool) {
+        if isPrivate {
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.fireButton])
+        } else {
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
+        }
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
+        restartInBackground()
+        if isPrivate {
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.fireButton])
+        } else {
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
+        }
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
+        closeFromAppSwitcherAndRelaunch()
+        if isPrivate {
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.fireButton])
+        } else {
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
+        }
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
+        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tapOnApp()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
+        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value as! String, "2")
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-2795

## :bulb: Description
Added validation test of new tab button on toolbar from landspace.


<img width="720" alt="Screenshot 2024-05-15 at 09 49 33" src="https://github.com/mozilla-mobile/firefox-ios/assets/134391433/5256f6fd-0abb-4654-a9f7-e7f253e4bdd4">
