### PR TITLE
Add FXIOS-9064 ⁃ Investigate logic of "Open link in external app""

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -629,7 +629,7 @@ extension BrowserViewController: WKNavigationDelegate {
             }
 
             if navigationAction.navigationType == .linkActivated {
-                if tab.isPrivate || !(self.profile.prefs.boolForKey(PrefsKeys.OpenLinksInApps) ?? true) {
+                if tab.isPrivate || (profile.prefs.boolForKey(PrefsKeys.BlockOpeningExternalApps) ?? false) {
                     decisionHandler(.cancel)
                     webView.load(navigationAction.request)
                     return

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -629,7 +629,7 @@ extension BrowserViewController: WKNavigationDelegate {
             }
 
             if navigationAction.navigationType == .linkActivated {
-                if tab.isPrivate {
+                if tab.isPrivate || !(self.profile.prefs.boolForKey(PrefsKeys.OpenLinksInApps) ?? true) {
                     decisionHandler(.cancel)
                     webView.load(navigationAction.request)
                     return

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -256,19 +256,18 @@ class AppSettingsTableViewController: SettingsTableViewController,
             statusText: .SettingsShowLinkPreviewsStatus
         )
 
-        let openLinksInAppsSettings = BoolSetting(
+        let blockOpeningExternalAppsSettings = BoolSetting(
             prefs: profile.prefs,
             theme: themeManager.currentTheme(for: windowUUID),
-            prefKey: PrefsKeys.OpenLinksInApps,
-            defaultValue: true,
-            titleText: .SettingsOpenLinksInAppsTitle,
-            statusText: .SettingsOpenLinksInAppsStatus
+            prefKey: PrefsKeys.BlockOpeningExternalApps,
+            defaultValue: false,
+            titleText: .SettingsBlockOpeningExternalAppsTitle
         )
 
         generalSettings += [
             offerToOpenCopiedLinksSettings,
             showLinksPreviewSettings,
-            openLinksInAppsSettings
+            blockOpeningExternalAppsSettings
         ]
 
         return [SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle),

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -256,9 +256,19 @@ class AppSettingsTableViewController: SettingsTableViewController,
             statusText: .SettingsShowLinkPreviewsStatus
         )
 
+        let openLinksInAppsSettings = BoolSetting(
+            prefs: profile.prefs,
+            theme: themeManager.currentTheme(for: windowUUID),
+            prefKey: PrefsKeys.OpenLinksInApps,
+            defaultValue: true,
+            titleText: .SettingsOpenLinksInAppsTitle,
+            statusText: .SettingsOpenLinksInAppsStatus
+        )
+
         generalSettings += [
             offerToOpenCopiedLinksSettings,
-            showLinksPreviewSettings
+            showLinksPreviewSettings,
+            openLinksInAppsSettings
         ]
 
         return [SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle),

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -2967,7 +2967,7 @@ extension String {
         value: "Offer to Open Copied Links",
         comment: "Title of setting to enable the Go to Copied URL feature. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
     public static let SettingsOfferClipboardBarStatus = MZLocalizedString(
-        key: "Settings.OfferClipboardBar.Status",
+        key: "Settings.OfferClipboardBar.StatusV2",
         tableName: nil,
         value: "When opening Firefox",
         comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
@@ -2981,7 +2981,7 @@ extension String {
         value: "Show Link Previews",
         comment: "Title of setting to enable link previews when long-pressing links.")
     public static let SettingsShowLinkPreviewsStatus = MZLocalizedString(
-        key: "Settings.ShowLinkPreviews.Status",
+        key: "Settings.ShowLinkPreviews.StatusV2",
         tableName: nil,
         value: "When long-pressing links",
         comment: "Description displayed under the ”Show Link Previews” option")

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -2987,18 +2987,13 @@ extension String {
         comment: "Description displayed under the ”Show Link Previews” option")
 }
 
-// MARK: - Open Links in Apps
+// MARK: - Block opening external apps
 extension String {
-    public static let SettingsOpenLinksInAppsTitle = MZLocalizedString(
-        key: "Settings.OpenLinksInApps.Title",
+    public static let SettingsBlockOpeningExternalAppsTitle = MZLocalizedString(
+        key: "Settings.BlockOpeningExternalApps.Title",
         tableName: nil,
-        value: "Open Links In Apps",
-        comment: "Title of setting to enable open links in apps when pressing links.")
-    public static let SettingsOpenLinksInAppsStatus = MZLocalizedString(
-        key: "Settings.OpenLinksInApps.Status",
-        tableName: nil,
-        value: "When pressing Links",
-        comment: "Description displayed under the ”Open Links In Apps” option")
+        value: "Block opening external apps",
+        comment: "Title of setting to block opening external apps when pressing links.")
 }
 
 // MARK: - Errors

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -2969,7 +2969,7 @@ extension String {
     public static let SettingsOfferClipboardBarStatus = MZLocalizedString(
         key: "Settings.OfferClipboardBar.Status",
         tableName: nil,
-        value: "When Opening Firefox",
+        value: "When opening Firefox",
         comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
 }
 
@@ -2983,16 +2983,16 @@ extension String {
     public static let SettingsShowLinkPreviewsStatus = MZLocalizedString(
         key: "Settings.ShowLinkPreviews.Status",
         tableName: nil,
-        value: "When Long-pressing Links",
+        value: "When long-pressing links",
         comment: "Description displayed under the ”Show Link Previews” option")
 }
 
-// MARK: - Block opening external apps
+// MARK: - Block Opening External Apps
 extension String {
     public static let SettingsBlockOpeningExternalAppsTitle = MZLocalizedString(
         key: "Settings.BlockOpeningExternalApps.Title",
         tableName: nil,
-        value: "Block opening external apps",
+        value: "Block Opening External Apps",
         comment: "Title of setting to block opening external apps when pressing links.")
 }
 

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -2987,6 +2987,20 @@ extension String {
         comment: "Description displayed under the ”Show Link Previews” option")
 }
 
+// MARK: - Open Links in Apps
+extension String {
+    public static let SettingsOpenLinksInAppsTitle = MZLocalizedString(
+        key: "Settings.OpenLinksInApps.Title",
+        tableName: nil,
+        value: "Open Links In Apps",
+        comment: "Title of setting to enable open links in apps when pressing links.")
+    public static let SettingsOpenLinksInAppsStatus = MZLocalizedString(
+        key: "Settings.OpenLinksInApps.Status",
+        tableName: nil,
+        value: "When pressing Links",
+        comment: "Description displayed under the ”Open Links In Apps” option")
+}
+
 // MARK: - Errors
 extension String {
     public static let UnableToAddPassErrorTitle = MZLocalizedString(

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -30,7 +30,7 @@ public struct PrefsKeys {
     public static let DidDismissDefaultBrowserMessage = "DidDismissDefaultBrowserCard"
     public static let KeyDidShowDefaultBrowserOnboarding = "didShowDefaultBrowserOnboarding"
     public static let ContextMenuShowLinkPreviews = "showLinkPreviews"
-    public static let OpenLinksInApps = "openLinksInApps"
+    public static let BlockOpeningExternalApps = "blockOpeningExternalApps"
     public static let NewTabCustomUrlPrefKey = "HomePageURLPref"
     public static let GoogleTopSiteAddedKey = "googleTopSiteAddedKey"
     public static let GoogleTopSiteHideKey = "googleTopSiteHideKey"

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -30,6 +30,7 @@ public struct PrefsKeys {
     public static let DidDismissDefaultBrowserMessage = "DidDismissDefaultBrowserCard"
     public static let KeyDidShowDefaultBrowserOnboarding = "didShowDefaultBrowserOnboarding"
     public static let ContextMenuShowLinkPreviews = "showLinkPreviews"
+    public static let OpenLinksInApps = "openLinksInApps"
     public static let NewTabCustomUrlPrefKey = "HomePageURLPref"
     public static let GoogleTopSiteAddedKey = "googleTopSiteAddedKey"
     public static let GoogleTopSiteHideKey = "googleTopSiteHideKey"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9064)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20076)

## :bulb: Description
Added a new option under General Settings -> Open Links In Apps
For URL schemes like "http", "https", "blob", "file", user will have the option to be automatically redirected to the external apps or not.
"By default", WKWebView redirect the user to the external apps, where is possible.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

