### PR TITLE
Bugfix MTE-2828 L10n artifacts public to be shared

### DIFF
--- a/taskcluster/kinds/generate-screenshots/kind.yml
+++ b/taskcluster/kinds/generate-screenshots/kind.yml
@@ -21,6 +21,7 @@ task-defaults:
     description: Generate localized screenshots by delegating the work to bitrise.io
     worker-type: bitrise
     bitrise:
+        artifact_prefix: public
         workflows:
             - L10nScreenshotsTests
     build-derived-data-path: {artifact-reference: '<build/public/L10nBuild/l10n-screenshots-dd.zip>'}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2828)

The  L10n cron job is working correctly but artifacts are not available. We need to change that so that localizers can verify them.

Taskcluster task: https://firefox-ci-tc.services.mozilla.com/tasks/groups/De30aThxRKuGhf2Kw3-qSg

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

