### PR TITLE
Bugfix MTE-2785 Follow up: Do not send slack notification to github a…

### DIFF
--- a/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
+++ b/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
@@ -52,7 +52,7 @@ jobs:
           if: always()
           run: echo "JOB_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
         - name: Send Slack notification if tests fail
-          if: '!cancelled()'
+          if: '${{ !cancelled() && !github.event.pull_request.head.repo.fork }}'
           id: slack
           uses: slackapi/slack-github-action@v1.26.0
           with:


### PR DESCRIPTION
…ction launch from a PR from fork

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2785)

We have realized that when a PR changing the files affecting the autofill automated tests running in github action, has no access to repo secrets if it comes from a forked repo. In that case, the slack notification with the test results fails since it does not know the slack webhook url.
We are going to skip sending the notification if a PR comes from a fork. The github action will still run, and report status to github but not to slack.

When the github action runs in main or from branches created from main, the action works sending the notification successfully.


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

