### PR TITLE
Add FXIOS-6238 - ShareTo Extension Changes To Light or Dark Theme When iOS Appearance Is Changed

### DIFF
--- a/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -67,11 +67,6 @@ class DevicePickerViewController: UITableViewController {
         static let tabTitleTextFont = UIFont.boldSystemFont(ofSize: 16)
     }
 
-    private lazy var tabTitleLabel: UILabel = .build { label in
-        label.font = UX.tabTitleTextFont
-        label.textColor = self.currentTheme().colors.textPrimary
-    }
-
     private var devices = [RemoteDevice]()
     var profile: Profile
     weak var pickerDelegate: DevicePickerViewControllerDelegate?
@@ -99,9 +94,8 @@ class DevicePickerViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let tabTitle = tabTitleLabel
-        tabTitle.text = .SendToTitle
-        navigationItem.titleView = tabTitle
+        setNavBarTitle()
+        setNavBarApperanace()
         refreshControl = UIRefreshControl()
         refreshControl?.addTarget(self, action: #selector(refresh), for: .valueChanged)
         navigationItem.leftBarButtonItem = UIBarButtonItem(
@@ -145,7 +139,25 @@ class DevicePickerViewController: UITableViewController {
         }
     }
 
-    private func currentTheme() -> Theme {
+    fileprivate func setNavBarTitle() {
+        let tabTitle: UILabel = .build { label in
+            label.font = UX.tabTitleTextFont
+            label.textColor = self.currentTheme().colors.textPrimary
+        }
+        tabTitle.text = .SendToTitle
+        navigationItem.titleView = tabTitle
+    }
+
+    fileprivate func setNavBarApperanace() {
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = currentTheme().colors.layer2
+        appearance.shadowColor = currentTheme().colors.borderPrimary
+
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+    }
+
+    fileprivate func currentTheme() -> Theme {
         return themeManager.windowNonspecificTheme()
     }
 
@@ -324,5 +336,21 @@ class DevicePickerViewController: UITableViewController {
         loadingIndicator.startAnimating()
         let customBarButton = UIBarButtonItem(customView: loadingIndicator)
         self.navigationItem.rightBarButtonItem = customBarButton
+    }
+}
+
+class SendToDevicePickerViewController: DevicePickerViewController {
+    override fileprivate func currentTheme() -> Theme {
+        return traitCollection.userInterfaceStyle == .dark ? DarkTheme() : LightTheme()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
+            self.tableView.backgroundColor = currentTheme().colors.layer2
+            self.tableView.reloadData()
+
+            setNavBarApperanace()
+            setNavBarTitle()
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/InstructionsView.swift
+++ b/firefox-ios/Client/Frontend/InstructionsView.swift
@@ -5,12 +5,16 @@
 import Shared
 import SwiftUI
 import UIKit
+import Common
 
 protocol InstructionsViewDelegate: AnyObject {
     func dismissInstructionsView()
 }
 
 struct InstructionsView: View {
+    @Environment(\.colorScheme)
+    var colorScheme
+
     private struct UX {
         static let padding: CGFloat = 20
         static let textFont = Font.body
@@ -20,22 +24,33 @@ struct InstructionsView: View {
     var textColor: UIColor
     var imageColor: UIColor
     var dismissAction: (() -> Void)?
+    var useSystemLightDarkMode = false
 
     var body: some View {
+        if #available(iOS 16.0, *) {
+            mainView
+            .toolbarBackground(getBackgroundColor().color, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+        } else {
+            mainView
+        }
+    }
+
+    var mainView: some View {
         ZStack {
-            backgroundColor.color.edgesIgnoringSafeArea(.all)
+            getBackgroundColor().color.edgesIgnoringSafeArea(.all)
             ScrollView {
-                HelpView(textColor: textColor,
-                         imageColor: imageColor,
-                         topMessage: String.SendToNotSignedInText,
-                         bottomMessage: String.SendToNotSignedInMessage)
+                HelpView(
+                    textColor: getTextColor(),
+                    imageColor: getImageColor(),
+                    topMessage: String.SendToNotSignedInText,
+                    bottomMessage: String.SendToNotSignedInMessage
+                )
             }
         }
-        .foregroundColor(Color(textColor))
-        .navigationBarItems(leading:
-            Button(action: {
-                dismissAction?()
-            }) {
+        .foregroundColor(Color(getTextColor()))
+        .navigationBarItems(
+            leading: Button(action: { dismissAction?() }) {
                 Text(String.CloseButtonTitle)
             }
             .accessibility(identifier: AccessibilityIdentifiers.ShareTo.HelpView.doneButton)
@@ -44,6 +59,36 @@ struct InstructionsView: View {
         .onDisappear {
             dismissAction?()
         }
+    }
+}
+
+extension InstructionsView {
+    func currentTheme() -> Theme {
+        return colorScheme == .dark ? DarkTheme() : LightTheme()
+    }
+
+    func getBackgroundColor() -> UIColor {
+        if useSystemLightDarkMode {
+            return currentTheme().colors.layer2
+        }
+
+        return backgroundColor
+    }
+
+    func getTextColor() -> UIColor {
+        if useSystemLightDarkMode {
+            return currentTheme().colors.textPrimary
+        }
+
+        return textColor
+    }
+
+    func getImageColor() -> UIColor {
+        if useSystemLightDarkMode {
+            return currentTheme().colors.iconDisabled
+        }
+
+        return imageColor
     }
 }
 

--- a/firefox-ios/Client/Frontend/Share/SendToDeviceHelper.swift
+++ b/firefox-ios/Client/Frontend/Share/SendToDeviceHelper.swift
@@ -21,10 +21,10 @@ class SendToDeviceHelper {
         case picker
     }
 
-    private var shareItem: ShareItem
-    private var profile: Profile
-    private var colors: Colors
-    private weak var delegate: Delegate?
+    fileprivate var shareItem: ShareItem
+    fileprivate var profile: Profile
+    fileprivate var colors: Colors
+    fileprivate weak var delegate: Delegate?
 
     init(shareItem: ShareItem, profile: Profile, colors: Colors, delegate: Delegate) {
         self.shareItem = shareItem
@@ -36,12 +36,7 @@ class SendToDeviceHelper {
     func initialViewController() -> UIViewController {
         if !hasAccount() {
             // Display instructions to log in if user has no account
-            let instructionsView = InstructionsView(backgroundColor: colors.defaultBackground,
-                                                    textColor: colors.textColor,
-                                                    imageColor: colors.iconColor,
-                                                    dismissAction: {
-                self.delegate?.dismissInstructionsView()
-            })
+            let instructionsView = getInstructionsView()
             let hostingViewController = UIHostingController(rootView: instructionsView)
             #if MOZ_TARGET_SHARETO
                 return hostingViewController
@@ -53,7 +48,7 @@ class SendToDeviceHelper {
         }
 
         // Display device picker if the user has an account
-        let devicePickerViewController = DevicePickerViewController(profile: profile)
+        let devicePickerViewController = getDevicePickerViewController()
         devicePickerViewController.pickerDelegate = delegate
         devicePickerViewController.shareItem = shareItem
         #if MOZ_TARGET_SHARETO
@@ -68,5 +63,51 @@ class SendToDeviceHelper {
     // MARK: - Private
     private func hasAccount() -> Bool {
         return profile.hasAccount()
+    }
+
+    fileprivate func getInstructionsView() -> InstructionsView {
+        return InstructionsView(
+            backgroundColor: colors.defaultBackground,
+            textColor: colors.textColor,
+            imageColor: colors.iconColor,
+            dismissAction: {
+                self.delegate?.dismissInstructionsView()
+            }
+        )
+    }
+
+    fileprivate func getDevicePickerViewController() -> DevicePickerViewController {
+        return DevicePickerViewController(profile: profile)
+    }
+}
+
+class SendToExtensionHelper: SendToDeviceHelper {
+    private var useSystemLightDarkMode: Bool
+
+    init(
+        shareItem: ShareItem,
+        profile: Profile,
+        colors: Colors,
+        delegate: Delegate,
+        useSystemLightDarkMode: Bool
+    ) {
+        self.useSystemLightDarkMode = useSystemLightDarkMode
+        super.init(shareItem: shareItem, profile: profile, colors: colors, delegate: delegate)
+    }
+
+    override fileprivate func getDevicePickerViewController() -> DevicePickerViewController {
+        return SendToDevicePickerViewController(profile: profile)
+    }
+
+    override fileprivate func getInstructionsView() -> InstructionsView {
+        return InstructionsView(
+            backgroundColor: colors.defaultBackground,
+            textColor: colors.textColor,
+            imageColor: colors.iconColor,
+            dismissAction: {
+                self.delegate?.dismissInstructionsView()
+            },
+            useSystemLightDarkMode: useSystemLightDarkMode
+        )
     }
 }

--- a/firefox-ios/Extensions/ShareTo/SendToDevice.swift
+++ b/firefox-ios/Extensions/ShareTo/SendToDevice.swift
@@ -37,15 +37,20 @@ class SendToDevice: DevicePickerViewControllerDelegate, InstructionsViewDelegate
             return UIViewController()
         }
 
-        let colors = SendToDeviceHelper.Colors(
+        let colors = SendToExtensionHelper.Colors(
             defaultBackground: theme.colors.layer2,
             textColor: theme.colors.textPrimary,
             iconColor: theme.colors.iconDisabled
         )
-        let helper = SendToDeviceHelper(shareItem: shareItem,
-                                        profile: profile,
-                                        colors: colors,
-                                        delegate: self)
+
+        let helper = SendToExtensionHelper(
+            shareItem: shareItem,
+            profile: profile,
+            colors: colors,
+            delegate: self,
+            useSystemLightDarkMode: true
+        )
+
         return helper.initialViewController()
     }
 

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -89,7 +89,7 @@ class ShareViewController: UIViewController {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.windowNonspecificTheme()
+        return traitCollection.userInterfaceStyle == .dark ? DarkTheme() : LightTheme()
     }
 
     func setupUI() {
@@ -555,5 +555,11 @@ extension ShareViewController {
         }
 
         finish(afterDelay: 0)
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
+            self.setupUI()
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6238)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14054)

## :bulb: Description
ShareTo extension updated so that it now responds to the light/dark mode appearance setting in iOS.  `LightTheme()` or `DarkTheme()` from Firefox theme is applied to the corresponding appearance settting.

### `InstructionsView`
* Added `import Common` to get access to Firefox themes.
* Added `@Environment(\.colorScheme) var colorScheme` property to track changes to iOS appearance setting.
* Added `useSystemLightDarkMode` property to enable or disable view responding to iOS appearance setting.  Property is set to false by default to allow for backwards compatibility to other parts of the app that also use this view.
* Moved code for the main view into `mainView` property to allow for re-use.
* Added branching to `body` property so toolbar background is modified if iOS16 or greater.
* Added helper functions in `InstructionsView` extension.  Helper functions will apply the appropriate theme colors if `useSystemLightDarkMode` is true, else the view property colors as set when the view was created are applied.

### `DevicePickerViewController`
* Moved `tabTitleLabel` property and code for setting the nav bar title into `setNavBarTitle()` so it is re-usable.
* Added `setNavBarAppearance()` to configure the nav bar backgound colors.
* Added subclass `SendToDevicePickerViewController: DevicePickerViewController`.  Subclass has delegate `traitCollectionDidChange()` that responds to iOS appearance changes.

### `SendToDeviceHelper`
* Moved `InstructionsView()` call into `getInstructionsView()` so subclass can override.
* Moved `DevicePickerViewController()` call into `getDevicePickerViewController()` so subclass can override.
* Added subclass `SendToExtensionHelper: SendToDeviceHelper` to pass `useSystemLightDarkMode` flag to `InstructionsView` and call subclass `SendToDevicePickerViewController` instead of `DevicePickerViewController`

### `SendToDevice`
* Updated code to use subclass `SendToExtensionHelper` instead of `SendToDeviceHelper` and pass `useSystemLightDarkMode: true` flag.

### `ShareViewController`
* Changed `currentTheme()` to use `traitCollection.userInterfaceStyle` to set the appropriate theme in response to changes in appearance setting.
* Added delegate `traitCollectionDidChange()` that responds to iOS appearance changes.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)