### PR TITLE
Refactor FXIOS-9145 Move WindowUUID into Common

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -31,9 +31,9 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     // MARK: - Variables
 
-    private var windowThemeState: [UUID: Theme] = [:]
-    private var windows: [UUID: UIWindow] = [:]
-    private var allWindowUUIDs: [UUID] { return Array(windows.keys) }
+    private var windowThemeState: [WindowUUID: Theme] = [:]
+    private var windows: [WindowUUID: UIWindow] = [:]
+    private var allWindowUUIDs: [WindowUUID] { return Array(windows.keys) }
     public var notificationCenter: NotificationProtocol
 
     private var userDefaults: UserDefaultsInterface
@@ -44,7 +44,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         return userDefaults.bool(forKey: ThemeKeys.NightMode.isOn)
     }
 
-    private func privateModeIsOn(for window: UUID) -> Bool {
+    private func privateModeIsOn(for window: WindowUUID) -> Bool {
         return getPrivateThemeIsOn(for: window)
     }
 
@@ -92,18 +92,18 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         }
     }
 
-    public func windowDidClose(uuid: UUID) {
+    public func windowDidClose(uuid: WindowUUID) {
         windows.removeValue(forKey: uuid)
         windowThemeState.removeValue(forKey: uuid)
     }
 
-    public func setWindow(_ window: UIWindow, for uuid: UUID) {
+    public func setWindow(_ window: UIWindow, for uuid: WindowUUID) {
         windows[uuid] = window
         updateSavedTheme(to: getNormalSavedTheme())
         updateCurrentTheme(to: fetchSavedThemeType(for: uuid), for: uuid)
     }
 
-    public func currentTheme(for window: UUID?) -> Theme {
+    public func currentTheme(for window: WindowUUID?) -> Theme {
         guard let window else {
             assertionFailure("Attempt to get the theme for a nil window UUID.")
             return DarkTheme()
@@ -112,14 +112,14 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         return windowThemeState[window] ?? DarkTheme()
     }
 
-    public func changeCurrentTheme(_ newTheme: ThemeType, for window: UUID) {
+    public func changeCurrentTheme(_ newTheme: ThemeType, for window: WindowUUID) {
         guard currentTheme(for: window).type != newTheme else { return }
 
         updateSavedTheme(to: newTheme)
         updateCurrentTheme(to: fetchSavedThemeType(for: window), for: window)
     }
 
-    public func reloadTheme(for window: UUID) {
+    public func reloadTheme(for window: WindowUUID) {
         updateCurrentTheme(to: fetchSavedThemeType(for: window), for: window)
     }
 
@@ -148,7 +148,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         }
     }
 
-    public func setPrivateTheme(isOn: Bool, for window: UUID) {
+    public func setPrivateTheme(isOn: Bool, for window: WindowUUID) {
         let currentSetting = getPrivateThemeIsOn(for: window)
         guard currentSetting != isOn else { return }
 
@@ -161,7 +161,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         updateCurrentTheme(to: fetchSavedThemeType(for: window), for: window)
     }
 
-    public func getPrivateThemeIsOn(for window: UUID) -> Bool {
+    public func getPrivateThemeIsOn(for window: WindowUUID) -> Bool {
         let settings = userDefaults.object(forKey: ThemeKeys.PrivateMode.byWindowUUID) as? KeyedPrivateModeFlags
         if settings == nil {
             migrateSingleWindowPrivateDefaultsToMultiWindow(for: window)
@@ -200,7 +200,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     // MARK: - Private methods
 
-    private func migrateSingleWindowPrivateDefaultsToMultiWindow(for window: UUID) {
+    private func migrateSingleWindowPrivateDefaultsToMultiWindow(for window: WindowUUID) {
         // Migrate old private setting to our window-based settings
         let oldPrivateSetting = userDefaults.bool(forKey: ThemeKeys.PrivateMode.legacy_isOn)
         let newSettings: KeyedPrivateModeFlags = [window.uuidString: NSNumber(value: oldPrivateSetting)]
@@ -215,7 +215,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         userDefaults.set(newTheme.rawValue, forKey: ThemeKeys.themeName)
     }
 
-    private func updateCurrentTheme(to newTheme: ThemeType, for window: UUID) {
+    private func updateCurrentTheme(to newTheme: ThemeType, for window: WindowUUID) {
         windowThemeState[window] = newThemeForType(newTheme)
 
         // Overwrite the user interface style on the window attached to our scene
@@ -225,13 +225,11 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         self.windows[window]?.overrideUserInterfaceStyle = style
 
         mainQueue.ensureMainThread { [weak self] in
-            // Eventually WindowUUID and its extensions will be moved into BrowserKit. [FXIOS-9145]
-            // Once that happens we should replace this string literal with `WindowUUID.userInfoKey`
-            self?.notificationCenter.post(name: .ThemeDidChange, withUserInfo: ["windowUUID": window])
+            self?.notificationCenter.post(name: .ThemeDidChange, withUserInfo: window.userInfo)
         }
     }
 
-    private func fetchSavedThemeType(for window: UUID) -> ThemeType {
+    private func fetchSavedThemeType(for window: WindowUUID) -> ThemeType {
         if privateModeIsOn(for: window) { return .privateMode }
         if nightModeIsOn { return .dark }
 

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -6,7 +6,7 @@ import UIKit
 
 public protocol ThemeManager {
     // Current theme
-    func currentTheme(for window: UUID?) -> Theme
+    func currentTheme(for window: WindowUUID?) -> Theme
 
     // System theme and brightness settings
     var systemThemeIsOn: Bool { get }
@@ -20,12 +20,12 @@ public protocol ThemeManager {
     func getNormalSavedTheme() -> ThemeType
 
     // Window management and window-specific themeing
-    func changeCurrentTheme(_ newTheme: ThemeType, for window: UUID)
-    func setPrivateTheme(isOn: Bool, for window: UUID)
-    func getPrivateThemeIsOn(for window: UUID) -> Bool
-    func reloadTheme(for window: UUID)
-    func setWindow(_ window: UIWindow, for uuid: UUID)
-    func windowDidClose(uuid: UUID)
+    func changeCurrentTheme(_ newTheme: ThemeType, for window: WindowUUID)
+    func setPrivateTheme(isOn: Bool, for window: WindowUUID)
+    func getPrivateThemeIsOn(for window: WindowUUID) -> Bool
+    func reloadTheme(for window: WindowUUID)
+    func setWindow(_ window: UIWindow, for uuid: WindowUUID)
+    func windowDidClose(uuid: WindowUUID)
 
     // Theme functions for app extensions
 

--- a/BrowserKit/Sources/Common/Theming/Themeable.swift
+++ b/BrowserKit/Sources/Common/Theming/Themeable.swift
@@ -14,7 +14,7 @@ public protocol Themeable: ThemeUUIDIdentifiable, AnyObject {
 }
 
 public protocol ThemeUUIDIdentifiable: AnyObject {
-    var currentWindowUUID: UUID? { get }
+    var currentWindowUUID: WindowUUID? { get }
 }
 
 extension Themeable {
@@ -28,7 +28,7 @@ extension Themeable {
         }
     }
 
-    public func updateThemeApplicableSubviews(_ view: UIView, for window: UUID?) {
+    public func updateThemeApplicableSubviews(_ view: UIView, for window: WindowUUID?) {
         guard let window else { return }
         let theme = themeManager.currentTheme(for: window)
         let themeViews = getAllSubviews(for: view, ofType: ThemeApplicable.self)

--- a/BrowserKit/Sources/Common/WindowUUID+Extensions.swift
+++ b/BrowserKit/Sources/Common/WindowUUID+Extensions.swift
@@ -48,4 +48,3 @@ public extension Notification {
         return uuid
     }
 }
-

--- a/BrowserKit/Sources/Common/WindowUUID+Extensions.swift
+++ b/BrowserKit/Sources/Common/WindowUUID+Extensions.swift
@@ -48,3 +48,4 @@ public extension Notification {
         return uuid
     }
 }
+

--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -146,7 +146,7 @@ public class BottomSheetViewController: UIViewController,
         }
     }
 
-    public var currentWindowUUID: UUID? {
+    public var currentWindowUUID: WindowUUID? {
         return (self.view as? ThemeUUIDIdentifiable)?.currentWindowUUID
     }
 

--- a/BrowserKit/Sources/Redux/Action.swift
+++ b/BrowserKit/Sources/Redux/Action.swift
@@ -3,13 +3,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 
 /// Used to describe an action that can be dispatched by the redux store
 open class Action {
-    public var windowUUID: UUID
+    public var windowUUID: WindowUUID
     public var actionType: ActionType
 
-    public init(windowUUID: UUID, actionType: ActionType) {
+    public init(windowUUID: WindowUUID, actionType: ActionType) {
         self.windowUUID = windowUUID
         self.actionType = actionType
     }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -75,10 +75,6 @@
 		1DA6F6512B48B42900BB5AD6 /* WindowEventCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA6F6502B48B42900BB5AD6 /* WindowEventCoordinator.swift */; };
 		1DA710072AE7106B00677F6B /* AppDataUsageReportSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA710062AE7106B00677F6B /* AppDataUsageReportSetting.swift */; };
 		1DC372022B23C80F000F96C8 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC372012B23C80F000F96C8 /* WindowManager.swift */; };
-		1DD066042BBCB95B00B0A2CE /* WindowUUID+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD066032BBCB95B00B0A2CE /* WindowUUID+Extension.swift */; };
-		1DD066102BBCBA1000B0A2CE /* WindowUUID+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD066032BBCB95B00B0A2CE /* WindowUUID+Extension.swift */; };
-		1DD066112BBCBA1200B0A2CE /* WindowUUID+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD066032BBCB95B00B0A2CE /* WindowUUID+Extension.swift */; };
-		1DD066122BBCBE7300B0A2CE /* WindowUUID+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD066032BBCB95B00B0A2CE /* WindowUUID+Extension.swift */; };
 		1DDAD13E24F0651C007623C8 /* TopSitesWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDAD13C24F064F7007623C8 /* TopSitesWidget.swift */; };
 		1DDE3DB32AC34E1E0039363B /* TabCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDE3DB22AC34E1E0039363B /* TabCell.swift */; };
 		1DDE3DB52AC360EC0039363B /* TabCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDE3DB42AC360EC0039363B /* TabCellTests.swift */; };
@@ -2269,7 +2265,6 @@
 		1DA6F6502B48B42900BB5AD6 /* WindowEventCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowEventCoordinator.swift; sourceTree = "<group>"; };
 		1DA710062AE7106B00677F6B /* AppDataUsageReportSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataUsageReportSetting.swift; sourceTree = "<group>"; };
 		1DC372012B23C80F000F96C8 /* WindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManager.swift; sourceTree = "<group>"; };
-		1DD066032BBCB95B00B0A2CE /* WindowUUID+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WindowUUID+Extension.swift"; sourceTree = "<group>"; };
 		1DDAD13C24F064F7007623C8 /* TopSitesWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesWidget.swift; sourceTree = "<group>"; };
 		1DDE3DB22AC34E1E0039363B /* TabCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCell.swift; sourceTree = "<group>"; };
 		1DDE3DB42AC360EC0039363B /* TabCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCellTests.swift; sourceTree = "<group>"; };
@@ -8670,7 +8665,6 @@
 				E1442FC7294782D7003680B0 /* UIViewController+Extension.swift */,
 				C81A8F2426D3ED1900EBA539 /* UIWindow+Extension.swift */,
 				E1442FC9294782D8003680B0 /* URL+Mail.swift */,
-				1DD066032BBCB95B00B0A2CE /* WindowUUID+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -13492,7 +13486,6 @@
 				C8DFFE492294AAB600296DB1 /* NetworkUtils.swift in Sources */,
 				E65075A41E37F7AB006961AC /* NSCharacterSetExtensions.swift in Sources */,
 				EB912B9A22722B5F00DF585A /* Deferred.swift in Sources */,
-				1DD066112BBCBA1200B0A2CE /* WindowUUID+Extension.swift in Sources */,
 				E65075961E37F7AB006961AC /* AsyncReducer.swift in Sources */,
 				E65075AB1E37F7AB006961AC /* SetExtensions.swift in Sources */,
 			);
@@ -13534,7 +13527,6 @@
 				E65075C21E37F956006961AC /* ExtensionUtils.swift in Sources */,
 				D057B2AB220103BC000614E0 /* RustLogins.swift in Sources */,
 				B2999FED2B044A5900F0FEC1 /* UnencryptedCreditCardFields.swift in Sources */,
-				1DD066102BBCBA1000B0A2CE /* WindowUUID+Extension.swift in Sources */,
 				15DE98FD27FCED4F00F1ECDB /* RustRemoteTabs.swift in Sources */,
 				285D3B901B4386520035FD22 /* SQLiteQueue.swift in Sources */,
 				394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */,
@@ -14197,7 +14189,6 @@
 				E1442FD2294782D9003680B0 /* UIViewController+Extension.swift in Sources */,
 				E653422D1C5944F90039DD9E /* BrowserPrompts.swift in Sources */,
 				E127313C28B6AD99006F39D2 /* WallpaperSettingsViewController.swift in Sources */,
-				1DD066042BBCB95B00B0A2CE /* WindowUUID+Extension.swift in Sources */,
 				43D4BCBA2972082400775FB5 /* CreditCardSettingsViewModel.swift in Sources */,
 				21583E422B1A3703009D084D /* LegacyInactiveTabModel.swift in Sources */,
 				DF529EA12AB1B421003C5373 /* FakespotReliabilityScoreView.swift in Sources */,
@@ -14876,7 +14867,6 @@
 				C8699153289177FB007ACC5C /* WallpaperDataServiceTests.swift in Sources */,
 				C23889E32A50319A00429673 /* ShareExtensionCoordinatorTests.swift in Sources */,
 				8AFE4C2127480D0C00B97C65 /* LegacyTabTrayViewControllerTests.swift in Sources */,
-				1DD066122BBCBE7300B0A2CE /* WindowUUID+Extension.swift in Sources */,
 				E1312FD129D237EE008DDA85 /* NotificationSurfaceManagerTests.swift in Sources */,
 				21371FA228A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift in Sources */,
 				5AE371842A4DD6F50092A760 /* PasswordManagerListViewControllerSpy.swift in Sources */,

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -67,7 +67,7 @@ class AppLaunchUtil {
             forName: .FSReadingListAddReadingListItem,
             object: nil,
             queue: nil
-        ) { (notification) -> Void in
+        ) { (notification) in
             if let userInfo = notification.userInfo, let url = userInfo["URL"] as? URL {
                 let title = (userInfo["Title"] as? String) ?? ""
                 self.profile.readingList.createRecordWithURL(

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Storage
+import Common
 
 protocol BookmarksCoordinatorDelegate: AnyObject, LibraryPanelCoordinatorDelegate {
     func start(from folder: FxBookmarkNode)

--- a/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Storage
+import Common
 
 protocol PasswordManagerCoordinatorDelegate: AnyObject, ParentCoordinatorDelegate {
     func settingsOpenURLInNewTab(_ url: URL)

--- a/firefox-ios/Client/Coordinators/TabTray/RemoteTabsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/RemoteTabsCoordinator.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 
 class RemoteTabsCoordinator: BaseCoordinator,
                              RemoteTabsPanelDelegate,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
@@ -75,7 +75,7 @@ class CreditCardBottomSheetViewModel {
 
     var didUpdateCreditCard: (() -> Void)?
     var decryptedCreditCard: UnencryptedCreditCardFields?
-    var storedCreditCards: [CreditCard] = [CreditCard]()
+    var storedCreditCards = [CreditCard]()
     var state: CreditCardBottomSheetState
 
     init(profile: Profile,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
@@ -6,6 +6,7 @@ import Foundation
 import Shared
 import Storage
 import UIKit
+import Common
 
 enum CreditCardSettingsState: String, Equatable, CaseIterable {
     // Default state

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewModel.swift
@@ -11,7 +11,7 @@ import Shared
 class CreditCardTableViewModel {
     var toggleModel: ToggleModel?
 
-    var creditCards: [CreditCard] = [CreditCard]() {
+    var creditCards = [CreditCard]() {
         didSet {
             didUpdateCreditCards?()
         }

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -193,7 +193,7 @@ class Authenticator {
         let action = UIAlertAction(
             title: .AuthenticatorLogin,
             style: .default
-        ) { (action) -> Void in
+        ) { (action) in
             guard let user = alert.textFields?[0].text,
                   let pass = alert.textFields?[1].text
             else {
@@ -212,25 +212,25 @@ class Authenticator {
         alert.addAction(action, accessibilityIdentifier: "authenticationAlert.loginRequired")
 
         // Add a cancel button.
-        let cancel = UIAlertAction(title: .AuthenticatorCancel, style: .cancel) { (action) -> Void in
+        let cancel = UIAlertAction(title: .AuthenticatorCancel, style: .cancel) { (action) in
             completionHandler(.failure(LoginRecordError(description: "Save password cancelled")))
         }
         alert.addAction(cancel, accessibilityIdentifier: "authenticationAlert.cancel")
 
         // Add a username textfield.
-        alert.addTextField { (textfield) -> Void in
+        alert.addTextField { (textfield) in
             textfield.placeholder = .AuthenticatorUsernamePlaceholder
             textfield.text = credentials?.user
         }
 
         // Add a password textfield.
-        alert.addTextField { (textfield) -> Void in
+        alert.addTextField { (textfield) in
             textfield.placeholder = .AuthenticatorPasswordPlaceholder
             textfield.isSecureTextEntry = true
             textfield.text = credentials?.password
         }
 
-        viewController.present(alert, animated: true) { () -> Void in }
+        viewController.present(alert, animated: true) { () in }
     }
 
     // MARK: Telemetry

--- a/firefox-ios/Client/Frontend/Browser/BackForwardListAnimator.swift
+++ b/firefox-ios/Client/Frontend/Browser/BackForwardListAnimator.swift
@@ -81,11 +81,11 @@ extension BackForwardListAnimator {
                 usingSpringWithDamping: 0.8,
                 initialSpringVelocity: 0.3,
                 options: [],
-                animations: { () -> Void in
+                animations: { () in
                     backForward.view.alpha = 1
                     backForward.tableViewHeightAnchor.constant = backForward.tableHeight
                     backForward.view.layoutIfNeeded()
-                }, completion: { (completed) -> Void in
+                }, completion: { (completed) in
                     transitionContext.completeTransition(completed)
                 })
         } else {
@@ -95,11 +95,11 @@ extension BackForwardListAnimator {
                 usingSpringWithDamping: 1.2,
                 initialSpringVelocity: 0.0,
                 options: [],
-                animations: { () -> Void in
+                animations: { () in
                     backForward.view.alpha = 0
                     backForward.tableViewHeightAnchor.constant = 0
                     backForward.view.layoutIfNeeded()
-                }, completion: { (completed) -> Void in
+                }, completion: { (completed) in
                     backForward.view.removeFromSuperview()
                     transitionContext.completeTransition(completed)
                 })

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Redux
+import Common
 
 class GeneralBrowserAction: Action {
     let selectedTabURL: URL?
@@ -17,7 +18,7 @@ class GeneralBrowserAction: Action {
          toastType: ToastType? = nil,
          showOverlay: Bool? = nil,
          navigateToHome: Bool? = nil,
-         windowUUID: UUID,
+         windowUUID: WindowUUID,
          actionType: ActionType) {
         self.selectedTabURL = selectedTabURL
         self.isPrivateBrowsing = isPrivateBrowsing

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Redux
 import Shared
+import Common
 
 struct BrowserViewControllerState: ScreenState, Equatable {
     let windowUUID: WindowUUID

--- a/firefox-ios/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/ClipboardBarDisplayHandler.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import Common
 
 protocol ClipboardBarDisplayHandlerDelegate: AnyObject {
     func shouldDisplay(clipBoardURL url: URL)
@@ -21,7 +22,7 @@ class ClipboardBarDisplayHandler: NSObject {
     private var lastDisplayedURL: String?
     private weak var firstTab: Tab?
     var clipboardToast: ButtonToast?
-    private let windowUUID: UUID
+    private let windowUUID: WindowUUID
 
     init(prefs: Prefs, tabManager: TabManager) {
         self.prefs = prefs

--- a/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
@@ -5,6 +5,7 @@
 import Foundation
 import WebKit
 import Shared
+import Common
 
 protocol DownloadDelegate: AnyObject {
     func download(_ download: Download, didCompleteWithError error: Error?)

--- a/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import Common
 
 /// Base event type protocol. Conforming types must be hashable.
 public protocol AppEventType: Hashable { }

--- a/firefox-ios/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import Common
 
 class OpenWithSettingsViewController: ThemedTableViewController {
     struct MailtoProviderEntry {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
@@ -15,7 +15,7 @@ class RemoteTabsPanelAction: Action {
     init(clientAndTabs: [ClientAndTabs]? = nil,
          reason: RemoteTabsPanelEmptyStateReason? = nil,
          url: URL? = nil,
-         windowUUID: UUID,
+         windowUUID: WindowUUID,
          actionType: ActionType) {
         self.clientAndTabs = clientAndTabs
         self.reason = reason

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -4,6 +4,7 @@
 
 import Redux
 import Storage
+import Common
 
 struct MoveTabData {
     let originIndex: Int
@@ -27,7 +28,7 @@ class TabPanelViewAction: Action {
          moveTabData: MoveTabData? = nil,
          toastType: ToastType? = nil,
          shareSheetURL: URL? = nil,
-         windowUUID: UUID,
+         windowUUID: WindowUUID,
          actionType: ActionType) {
         self.panelType = panelType
         self.isPrivateModeActive = isPrivateModeActive
@@ -70,7 +71,7 @@ class TabPanelMiddlewareAction: Action {
     init(tabDisplayModel: TabDisplayModel? = nil,
          inactiveTabModels: [InactiveTabsModel]? = nil,
          toastType: ToastType? = nil,
-         windowUUID: UUID,
+         windowUUID: WindowUUID,
          actionType: ActionType) {
         self.tabDisplayModel = tabDisplayModel
         self.inactiveTabModels = inactiveTabModels

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Redux
+import Common
 
 class TabPeekAction: Action {
     let tabUUID: TabUUID?
@@ -10,7 +11,7 @@ class TabPeekAction: Action {
 
     init(tabUUID: TabUUID? = nil,
          tabPeekModel: TabPeekModel? = nil,
-         windowUUID: UUID,
+         windowUUID: WindowUUID,
          actionType: ActionType) {
         self.tabUUID = tabUUID
         self.tabPeekModel = tabPeekModel

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Redux
+import Common
 
 class TabTrayAction: Action {
     let panelType: TabTrayPanelType?
@@ -12,7 +13,7 @@ class TabTrayAction: Action {
     init(panelType: TabTrayPanelType? = nil,
          tabTrayModel: TabTrayModel? = nil,
          hasSyncableAccount: Bool? = nil,
-         windowUUID: UUID,
+         windowUUID: WindowUUID,
          actionType: ActionType) {
         self.panelType = panelType
         self.tabTrayModel = tabTrayModel

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Redux
+import Common
 
 struct TabPeekState: ScreenState, Equatable {
     let showAddToBookmarks: Bool

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Redux
 import Storage
+import Common
 
 enum TabTrayLayoutType: Equatable {
     case regular // iPad

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Redux
+import Common
 
 struct TabsPanelState: ScreenState, Equatable {
     var isPrivateMode: Bool

--- a/firefox-ios/Client/Frontend/Browser/ToastType.swift
+++ b/firefox-ios/Client/Frontend/Browser/ToastType.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 
 enum ToastType: Equatable {
     case closedSingleTab

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/NavigationToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/NavigationToolbarContainerModel.swift
@@ -8,13 +8,13 @@ import ToolbarKit
 struct NavigationToolbarContainerModel {
     let actions: [ToolbarElement]
     let displayBorder: Bool
-    let windowUUID: UUID
+    let windowUUID: WindowUUID
 
     var navigationToolbarState: NavigationToolbarState {
         return NavigationToolbarState(actions: actions, shouldDisplayBorder: displayBorder)
     }
 
-    init(state: ToolbarState, windowUUID: UUID) {
+    init(state: ToolbarState, windowUUID: WindowUUID) {
         self.displayBorder = state.navigationToolbar.displayBorder
         self.actions = state.navigationToolbar.actions.map { action in
             ToolbarElement(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -96,7 +96,7 @@ class ToolbarMiddleware: FeatureFlaggable {
         return elements
     }
 
-    private func shouldDisplayNavigationToolbarBorder(state: AppState, windowUUID: UUID) -> Bool {
+    private func shouldDisplayNavigationToolbarBorder(state: AppState, windowUUID: WindowUUID) -> Bool {
         guard let browserState = state.screenState(BrowserViewControllerState.self,
                                                    for: .browserViewController,
                                                    window: windowUUID) else { return false }
@@ -104,7 +104,7 @@ class ToolbarMiddleware: FeatureFlaggable {
         return manager.shouldDisplayNavigationBorder(toolbarPosition: toolbarState.toolbarPosition)
     }
 
-    private func handleToolbarButtonTapActions(actionType: ToolbarState.ActionState.ActionType, windowUUID: UUID) {
+    private func handleToolbarButtonTapActions(actionType: ToolbarState.ActionState.ActionType, windowUUID: WindowUUID) {
         switch actionType {
         case .home:
             let action = GeneralBrowserAction(navigateToHome: true,
@@ -118,7 +118,7 @@ class ToolbarMiddleware: FeatureFlaggable {
     }
 
     private func handleToolbarButtonLongPressActions(actionType: ToolbarState.ActionState.ActionType,
-                                                     windowUUID: UUID) {
+                                                     windowUUID: WindowUUID) {
         switch actionType {
         default:
             break

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotAction.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotAction.swift
@@ -15,7 +15,7 @@ class FakespotAction: Action {
          isExpanded: Bool? = nil,
          tabUUID: TabUUID? = nil,
          productId: String? = nil,
-         windowUUID: UUID,
+         windowUUID: WindowUUID,
          actionType: ActionType) {
         self.isOpen = isOpen
         self.isExpanded = isExpanded

--- a/firefox-ios/Client/Frontend/FeltPrivacy/PrivateModeAction.swift
+++ b/firefox-ios/Client/Frontend/FeltPrivacy/PrivateModeAction.swift
@@ -4,12 +4,13 @@
 
 import Foundation
 import Redux
+import Common
 
 class PrivateModeAction: Action {
     let isPrivate: Bool?
 
     init(isPrivate: Bool? = nil,
-         windowUUID: UUID,
+         windowUUID: WindowUUID,
          actionType: ActionType) {
         self.isPrivate = isPrivate
         super.init(windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -23,7 +23,7 @@ actor JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
     nonisolated let notificationCenter: NotificationProtocol
     private let profile: Profile
     private let tabManager: TabManager
-    private var recentTabs: [Tab] = [Tab]()
+    private var recentTabs = [Tab]()
     private var recentGroups: [ASGroup<Tab>]?
     private var mostRecentSyncedTab: JumpBackInSyncedTab?
     private var hasSyncAccount: Bool?

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -31,7 +31,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     var mostRecentSyncedTab: JumpBackInSyncedTab?
 
     // Raw data to calculate what we can show to the user
-    var recentTabs: [Tab] = [Tab]()
+    var recentTabs = [Tab]()
     var recentSyncedTab: JumpBackInSyncedTab?
 
     private var jumpBackInDataAdaptor: JumpBackInDataAdaptor

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -21,7 +21,7 @@ class DownloadsPanel: UIViewController,
     weak var libraryPanelDelegate: LibraryPanelDelegate?
     weak var navigationHandler: DownloadsNavigationHandler?
     var state: LibraryPanelMainState
-    var bottomToolbarItems: [UIBarButtonItem] = [UIBarButtonItem]()
+    var bottomToolbarItems = [UIBarButtonItem]()
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol

--- a/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Shared
 import Storage
+import Common
 
 protocol LibraryPanelDelegate: AnyObject {
     func libraryPanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)

--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController+LibraryPanelDelegate.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController+LibraryPanelDelegate.swift
@@ -4,6 +4,7 @@
 
 import Storage
 import Shared
+import Common
 
 extension LibraryViewController: LibraryPanelDelegate {
     func libraryPanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool) {

--- a/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
@@ -180,7 +180,7 @@ class ReadingListPanel: UITableViewController,
     weak var navigationHandler: ReadingListNavigationHandler?
     let profile: Profile
     var state: LibraryPanelMainState
-    var bottomToolbarItems: [UIBarButtonItem] = [UIBarButtonItem]()
+    var bottomToolbarItems = [UIBarButtonItem]()
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol

--- a/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -27,7 +27,7 @@ class RecentlyClosedTabsPanel: UIViewController, LibraryPanel, Themeable {
     var state: LibraryPanelMainState = .history(state: .inFolder)
     weak var recentlyClosedTabsDelegate: RecentlyClosedPanelDelegate?
     let profile: Profile
-    var bottomToolbarItems: [UIBarButtonItem] = [UIBarButtonItem]()
+    var bottomToolbarItems = [UIBarButtonItem]()
     private let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { return windowUUID }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Redux
+import Common
 
 class MicrosurveyPromptAction: Action { }
 
@@ -11,7 +12,7 @@ class MicrosurveyPromptMiddlewareAction: Action {
     let microsurveyState: MicrosurveyPromptState?
 
     init(microsurveyState: MicrosurveyPromptState? = nil,
-         windowUUID: UUID,
+         windowUUID: WindowUUID,
          actionType: ActionType) {
         self.microsurveyState = microsurveyState
         super.init(windowUUID: windowUUID, actionType: actionType)

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Redux
 import Shared
+import Common
 
 class MicrosurveyPromptMiddleware {
     lazy var microsurveyProvider: Middleware<AppState> = { state, action in

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Redux
 import Shared
+import Common
 
 struct MicrosurveyPromptState: StateType, Equatable {
     var windowUUID: WindowUUID

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingViewModelProtocol.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingViewModelProtocol.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 
 protocol OnboardingViewModelProtocol {
     var availableCards: [OnboardingCardViewController] { get }

--- a/firefox-ios/Client/Frontend/Onboarding/State/OnboardingViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/State/OnboardingViewControllerState.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Redux
 import Shared
+import Common
 
 struct OnboardingViewControllerState: ScreenState, Equatable {
     let windowUUID: WindowUUID

--- a/firefox-ios/Client/Frontend/Reader/ReadabilityService.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReadabilityService.swift
@@ -44,7 +44,7 @@ class ReadabilityOperation: Operation {
         // Setup a tab, attach a Readability helper. Kick all this off on the main thread since UIKit
         // and WebKit are not safe from other threads.
 
-        DispatchQueue.main.async(execute: { () -> Void in
+        DispatchQueue.main.async(execute: { () in
             let configuration = WKWebViewConfiguration()
             // TODO: To resolve profile from DI container
 

--- a/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewModel.swift
+++ b/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewModel.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 
 // MARK: - ReaderModeStyleViewModelDelegate
 

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 import Shared
 
 class TopSitesRowCountSettingsController: SettingsTableViewController {

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 import Shared
 
 class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlaggable {

--- a/firefox-ios/Client/Frontend/Settings/Main/General/OpenWithSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/OpenWithSetting.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import Common
 
 class OpenWithSetting: Setting {
     private weak var settingsDelegate: GeneralSettingsDelegate?

--- a/firefox-ios/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import Common
 
 class NewTabContentSettingsViewController: SettingsTableViewController {
     /* variables for checkmark settings */

--- a/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchBar/SearchBarSettingsViewController.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import Common
 
 class SearchBarSettingsViewController: SettingsTableViewController {
     private let viewModel: SearchBarSettingsViewModel

--- a/firefox-ios/Client/Frontend/Settings/SearchSettings/SearchSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettings/SearchSettingsState.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Redux
+import Common
 
 struct SearchSettingsState: ScreenState, Equatable {
     let windowUUID: WindowUUID

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Shared
 import ComponentLibrary
+import Common
 
 protocol SearchEnginePickerDelegate: AnyObject {
     func searchEnginePicker(

--- a/firefox-ios/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -6,6 +6,7 @@ import Foundation
 import Shared
 import Intents
 import IntentsUI
+import Common
 
 class SiriSettingsViewController: SettingsTableViewController {
     let prefs: Prefs

--- a/firefox-ios/Client/Frontend/Settings/TabsSettingsViewControler.swift
+++ b/firefox-ios/Client/Frontend/Settings/TabsSettingsViewControler.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import Common
 
 class TabsSettingsViewController: SettingsTableViewController, FeatureFlaggable {
     init(windowUUID: WindowUUID) {

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsAction.swift
@@ -17,7 +17,7 @@ class ThemeSettingsViewAction: Action {
          manualThemeType: ThemeType? = nil,
          userBrightness: Float? = nil,
          systemBrightness: Float? = nil,
-         windowUUID: UUID,
+         windowUUID: WindowUUID,
          actionType: ActionType) {
         self.useSystemAppearance = useSystemAppearance
         self.automaticBrightnessEnabled = automaticBrightnessEnabled
@@ -33,7 +33,7 @@ class ThemeSettingsMiddlewareAction: Action {
     let themeSettingsState: ThemeSettingsState?
 
     init(themeSettingsState: ThemeSettingsState? = nil,
-         windowUUID: UUID,
+         windowUUID: WindowUUID,
          actionType: ActionType) {
         self.themeSettingsState = themeSettingsState
         super.init(windowUUID: windowUUID, actionType: actionType)

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -453,7 +453,7 @@ private extension TabLocationView {
                 }
             }
         }
-        UIView.animate(withDuration: 0.1, animations: { () -> Void in
+        UIView.animate(withDuration: 0.1, animations: { () in
             self.readerModeButton.alpha = newReaderModeState == .unavailable ? 0 : 1
         })
     }

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetAnimator.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetAnimator.swift
@@ -74,11 +74,11 @@ extension PhotonActionSheetAnimator {
                 usingSpringWithDamping: 0.8,
                 initialSpringVelocity: 0.3,
                 options: [],
-                animations: { () -> Void in
+                animations: { () in
                     self.shadow.alpha = 1
                     actionSheet.view.frame = containerView.bounds
                     actionSheet.view.layoutIfNeeded()
-                }, completion: { (completed) -> Void in
+                }, completion: { (completed) in
                     transitionContext.completeTransition(completed)
                 })
         } else {
@@ -89,7 +89,7 @@ extension PhotonActionSheetAnimator {
                 initialSpringVelocity: 0.0,
                 options: [],
                 animations: {
-                    () -> Void in
+                    () in
                     self.shadow.alpha = 0
                     actionSheet.view.frame = CGRect(
                         origin: CGPoint(x: 0, y: containerView.frame.size.height),
@@ -97,7 +97,7 @@ extension PhotonActionSheetAnimator {
                     )
                     actionSheet.view.layoutIfNeeded()
                 },
-                completion: { (completed) -> Void in
+                completion: { (completed) in
                     actionSheet.view.removeFromSuperview()
                     self.shadow.removeFromSuperview()
                     transitionContext.completeTransition(completed)

--- a/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -27,7 +27,7 @@ class SiteTableViewController: UIViewController,
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
 
-    var data: Cursor<Site> = Cursor<Site>(status: .success, msg: "No data set")
+    var data = Cursor<Site>(status: .success, msg: "No data set")
     lazy var tableView: UITableView = .build { [weak self] table in
         guard let self = self else { return }
         table.delegate = self

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
@@ -4,11 +4,12 @@
 
 import Foundation
 import Redux
+import Common
 
 class ScreenAction: Action {
     let screen: AppScreen
 
-    init(windowUUID: UUID,
+    init(windowUUID: WindowUUID,
          actionType: ActionType,
          screen: AppScreen) {
         self.screen = screen

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Redux
+import Common
 
 enum AppScreenState: Equatable {
     case onboardingViewController(OnboardingViewControllerState)

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Redux
+import Common
 
 struct AppState: StateType {
     let activeScreens: ActiveScreensState

--- a/firefox-ios/Client/Redux/GlobalState/ScreenState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ScreenState.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 
 /// Defines the state related to a screen used `AppState` reducer to 
 /// retrieve the state for a specific screen. All ScreenStates should

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -117,12 +117,12 @@ class Tab: NSObject, ThemeApplicable {
         }
     }
 
-    var adsTelemetryUrlList: [String] = [String]() {
+    var adsTelemetryUrlList = [String]() {
         didSet {
             startingSearchUrlWithAds = url
         }
     }
-    var adsTelemetryRedirectUrlList: [URL] = [URL]()
+    var adsTelemetryRedirectUrlList = [URL]()
     var startingSearchUrlWithAds: URL?
     var adsProviderName: String = ""
     var hasHomeScreenshot = false
@@ -727,7 +727,7 @@ class Tab: NSObject, ThemeApplicable {
     func hideContent(_ animated: Bool = false) {
         webView?.isUserInteractionEnabled = false
         if animated {
-            UIView.animate(withDuration: 0.25, animations: { () -> Void in
+            UIView.animate(withDuration: 0.25, animations: { () in
                 self.webView?.alpha = 0.0
             })
         } else {
@@ -738,7 +738,7 @@ class Tab: NSObject, ThemeApplicable {
     func showContent(_ animated: Bool = false) {
         webView?.isUserInteractionEnabled = true
         if animated {
-            UIView.animate(withDuration: 0.25, animations: { () -> Void in
+            UIView.animate(withDuration: 0.25, animations: { () in
                 self.webView?.alpha = 1.0
             })
         } else {

--- a/firefox-ios/Client/TabManagement/TabEventHandler.swift
+++ b/firefox-ios/Client/TabManagement/TabEventHandler.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Storage
+import Common
 
 /// A handler can be a plain old swift object. It does not need to extend any
 /// other object, but can.

--- a/firefox-ios/Client/Utils/SearchTermGroupsUtility.swift
+++ b/firefox-ios/Client/Utils/SearchTermGroupsUtility.swift
@@ -122,7 +122,7 @@ class SearchTermGroupsUtility {
         and searchTermMetadata: [String: [HistoryMetadata]]
     ) -> (itemGroupData: [String: [T]], itemsInGroups: [T]) {
         var itemGroupData: [String: [T]] = [:]
-        var itemsInGroups: [T] = [T]()
+        var itemsInGroups = [T]()
 
         outeritemLoop: for item in items {
             innerMetadataLoop: for (searchTerm, historyMetaList) in searchTermMetadata where historyMetaList

--- a/firefox-ios/Shared/Accessibility.swift
+++ b/firefox-ios/Shared/Accessibility.swift
@@ -31,7 +31,7 @@ extension AccessibleAction { // UIAccessibilityCustomAction
 
 extension AccessibleAction { // UIAlertAction
     private var alertActionHandler: (UIAlertAction?) -> Void {
-        return { (_: UIAlertAction?) -> Void in
+        return { _ in
             _ = self.handler()
         }
     }

--- a/firefox-ios/Storage/SQL/BrowserDB.swift
+++ b/firefox-ios/Storage/SQL/BrowserDB.swift
@@ -83,7 +83,7 @@ open class BrowserDB {
             return succeed()
         }
 
-        return transaction { connection -> Void in
+        return transaction { connection in
             for (sql, args) in commands {
                 try connection.executeChange(sql, withArgs: args)
             }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockLibraryCoordinatorDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockLibraryCoordinatorDelegate.swift
@@ -4,10 +4,11 @@
 
 import Foundation
 import Storage
+import Common
 @testable import Client
 
 class MockLibraryCoordinatorDelegate: LibraryCoordinatorDelegate, LibraryPanelDelegate {
-    var libraryPanelWindowUUID: Client.WindowUUID { return Client.WindowUUID.XCTestDefaultUUID }
+    var libraryPanelWindowUUID: WindowUUID { return WindowUUID.XCTestDefaultUUID }
     var didFinishSettingsCalled = 0
     var didRequestToOpenInNewTabCalled = false
     var didSelectURLCalled = false

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/PasswordManagerCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/PasswordManagerCoordinatorTests.swift
@@ -4,6 +4,7 @@
 
 import XCTest
 import Storage
+import Common
 @testable import Client
 
 final class PasswordManagerCoordinatorTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/RemoteTabsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/RemoteTabsCoordinatorTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 @testable import Client
 
 final class RemoteTabsCoordinatorTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputFieldTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputFieldTests.swift
@@ -7,6 +7,7 @@
 import Foundation
 import XCTest
 import SwiftUI
+import Common
 @testable import Client
 
 class CreditCardInputFieldTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadQueueTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadQueueTests.swift
@@ -4,6 +4,7 @@
 
 @testable import Client
 import XCTest
+import Common
 
 class DownloadQueueTests: XCTestCase {
     let didStartDownload = "downloadQueue(_:didStartDownload:)"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
@@ -6,6 +6,7 @@
 import Storage
 import XCTest
 import WebKit
+import Common
 
 // NOTE:
 // Tab groups not tested at the moment since it depends on RustPlaces concrete object.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/PrivateHomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/PrivateHomepageViewControllerTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
@@ -4,6 +4,7 @@
 
 import XCTest
 import WebKit
+import Common
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/DownloadsPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/DownloadsPanelTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelTests.swift
@@ -4,6 +4,7 @@
 
 import XCTest
 
+import Common
 @testable import Client
 
 class HistoryPanelTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/ReadingListPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/ReadingListPanelTests.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
-
+import Common
 @testable import Client
 
 class ReadingListPanelTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockApplicationHelper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockApplicationHelper.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
+import Common
 @testable import Client
 
 class MockApplicationHelper: ApplicationHelper {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLaunchScreenManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLaunchScreenManager.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 @testable import Client
+import Common
 
 class MockLaunchScreenViewModel: LaunchScreenViewModel {
     var introScreenManager: IntroScreenManager

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import WebKit
+import Common
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import Storage
+import Common
 @testable import Client
 
 final class MockWindowManager: WindowManager {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/IntroViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/IntroViewModelTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingButtonActionTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/UpdateViewModelTests.swift
@@ -6,6 +6,7 @@ import Foundation
 @testable import Client
 import XCTest
 import Shared
+import Common
 
 class UpdateViewModelTests: XCTestCase {
     private var profile: MockProfile!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabEventHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabEventHandlerTests.swift
@@ -8,6 +8,7 @@ import WebKit
 import GCDWebServers
 import XCTest
 import Shared
+import Common
 
 class TabEventHandlerTests: XCTestCase {
     let windowUUID: WindowUUID = .XCTestDefaultUUID

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabMigrationUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabMigrationUtilityTests.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
-
+import Common
 @testable import Client
 
 class TabMigrationUtilityTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -4,7 +4,7 @@
 
 import XCTest
 import WebKit
-
+import Common
 @testable import Client
 
 class TabTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/InactiveTabsManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/InactiveTabsManagerTests.swift
@@ -4,6 +4,7 @@
 
 import WebKit
 import XCTest
+import Common
 
 @testable import Client
 final class InactiveTabsManagerTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TestHistory.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TestHistory.swift
@@ -79,7 +79,7 @@ class TestHistory: ProfileTest {
 
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testHistory() {
-        withTestProfile { profile -> Void in
+        withTestProfile { profile in
             let places = profile.places
             self.addSite(places, url: "http://url1/", title: "title")
             self.addSite(places, url: "http://url1/", title: "title")
@@ -241,7 +241,7 @@ class TestHistory: ProfileTest {
 //    }
 
     func testAboutUrls() {
-        withTestProfile { (profile) -> Void in
+        withTestProfile { (profile) in
             let places = profile.places
             self.addSite(
                 places,
@@ -256,12 +256,12 @@ class TestHistory: ProfileTest {
     let numCmds = 10
 
     func testInsertPerformance() {
-        withTestProfile { profile -> Void in
+        withTestProfile { profile in
             let places = profile.places
             var index = 0
 
             self.measure({
-                () -> Void in
+                () in
                 for _ in 0...self.numCmds {
                     self.addSite(
                         places,
@@ -276,7 +276,7 @@ class TestHistory: ProfileTest {
     }
 
     func testGetPerformance() {
-        withTestProfile { profile -> Void in
+        withTestProfile { profile in
             let places = profile.places
             var index = 0
             var urls = [String: String]()
@@ -292,7 +292,7 @@ class TestHistory: ProfileTest {
                 index += 1
             }
 
-            self.measure({ () -> Void in
+            self.measure({ () in
                 self.checkSites(places, urls: urls)
                 return
             })
@@ -304,7 +304,7 @@ class TestHistory: ProfileTest {
     // Fuzzing tests. These fire random insert/query/clear commands into the history database from threads.
     // The don't check the results. Just look for crashes.
     func testRandomThreading() {
-        withTestProfile { profile -> Void in
+        withTestProfile { profile in
             let queue = DispatchQueue(
                 label: "My Queue",
                 qos: DispatchQoS.default,
@@ -317,7 +317,7 @@ class TestHistory: ProfileTest {
             let expectation = self.expectation(description: "Wait for history")
             for _ in 0..<self.numThreads {
                 var places = profile.places
-                self.runRandom(&places, queue: queue, completion: { () -> Void in
+                self.runRandom(&places, queue: queue, completion: { () in
                     counter += 1
                     if counter == self.numThreads {
                         self.clear(places)
@@ -331,7 +331,7 @@ class TestHistory: ProfileTest {
 
     // Same as testRandomThreading, but uses one history connection for all threads
     func testRandomThreading2() {
-        withTestProfile { profile -> Void in
+        withTestProfile { profile in
             let queue = DispatchQueue(
                 label: "My Queue",
                 qos: DispatchQoS.default,
@@ -344,7 +344,7 @@ class TestHistory: ProfileTest {
 
             let expectation = self.expectation(description: "Wait for history")
             for _ in 0..<self.numThreads {
-                self.runRandom(&places, queue: queue, completion: { () -> Void in
+                self.runRandom(&places, queue: queue, completion: { () in
                     counter += 1
                     if counter == self.numThreads {
                         self.clear(places)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/SponsoredContentFilterUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/SponsoredContentFilterUtilityTests.swift
@@ -6,6 +6,7 @@ import XCTest
 import Shared
 import Storage
 import WebKit
+import Common
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestBrowserDB.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestBrowserDB.swift
@@ -132,7 +132,7 @@ class TestBrowserDB: XCTestCase {
         let db = BrowserDB(filename: "foo.db", schema: BrowserSchema(), files: self.files)
         db.run("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, bar TEXT)").succeeded()
 
-        _ = db.withConnection { connection -> Void in
+        _ = db.withConnection { connection in
             for i in 0..<1000 {
                 let args: Args = ["bar \(i)"]
                 try connection.executeChange(

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSwiftData.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSwiftData.swift
@@ -66,7 +66,7 @@ class TestSwiftData: XCTestCase {
     ) -> MaybeErrorType? {
         // Query the database and hold the cursor.
         var c: Cursor<SDRow>!
-        let result = swiftData!.withConnection(SwiftData.Flags.readOnly) { db -> Void in
+        let result = swiftData!.withConnection(SwiftData.Flags.readOnly) { db in
             if safeQuery {
                 c = db.executeQuery("SELECT * FROM history", factory: { $0 })
             } else {
@@ -96,7 +96,7 @@ class TestSwiftData: XCTestCase {
     }
 
     fileprivate func addSite(_ table: BrowserSchema, url: String, title: String) -> MaybeErrorType? {
-        let result = swiftData!.withConnection(SwiftData.Flags.readWrite) { connection -> Void in
+        let result = swiftData!.withConnection(SwiftData.Flags.readWrite) { connection in
             let args: Args = [Bytes.generateGUID(), url, title]
             try connection.executeChange(
                 "INSERT INTO history (guid, url, title, is_deleted, should_upload) VALUES (?, ?, ?, 0, 0)",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9145)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20259)

## :bulb: Description

Moves WindowUUID out of Client and into Common / BrowserKit.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

