### PR TITLE
Bugfix FXIOS-9089 Update TabCell title after pushing Home in toolbar

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -183,10 +183,8 @@ class Tab: NSObject, ThemeApplicable {
     }
 
     var title: String? {
-        if let title = webView?.title, !title.isEmpty, !self.isFxHomeTab {
+        if let title = webView?.title, !title.isEmpty {
             return webView?.title
-        } else if self.isFxHomeTab {
-            return .AppMenu.AppMenuOpenHomePageTitleString
         }
 
         return nil
@@ -198,6 +196,7 @@ class Tab: NSObject, ThemeApplicable {
         if self.isFxHomeTab {
             return .AppMenu.AppMenuOpenHomePageTitleString
         }
+
         if let lastTitle = lastTitle, !lastTitle.isEmpty {
             return lastTitle
         }
@@ -205,14 +204,6 @@ class Tab: NSObject, ThemeApplicable {
         // First, check if the webView can give us a title.
         if let title = webView?.title, !title.isEmpty {
             return title
-        }
-
-        // If the webView doesn't give a title. check the URL to see if it's our Home URL, with no sessionData
-        // on this tab. When picking a display title. Tabs with sessionData are pending a restore so show their
-        // old title. To prevent flickering of the display title. If a tab is restoring make sure to use
-        // its lastTitle.
-        if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false {
-            return .AppMenu.AppMenuOpenHomePageTitleString
         }
 
         // Then, if it's not Home, and it's also not a complete and valid URL, display what was "entered" as the title.

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -183,8 +183,10 @@ class Tab: NSObject, ThemeApplicable {
     }
 
     var title: String? {
-        if let title = webView?.title, !title.isEmpty {
+        if let title = webView?.title, !title.isEmpty, !self.isFxHomeTab {
             return webView?.title
+        } else if self.isFxHomeTab {
+            return .AppMenu.AppMenuOpenHomePageTitleString
         }
 
         return nil
@@ -193,6 +195,9 @@ class Tab: NSObject, ThemeApplicable {
     /// This property returns, ideally, the web page's title. Otherwise, based on the page being internal
     /// or not, it will resort to other displayable titles.
     var displayTitle: String {
+        if self.isFxHomeTab {
+            return .AppMenu.AppMenuOpenHomePageTitleString
+        }
         if let lastTitle = lastTitle, !lastTitle.isEmpty {
             return lastTitle
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyViewControllerTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 
 @testable import Client
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9089)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20148)

## :bulb: Description
Replaced logic for displayTitle so that if we are on a Homepage we immediately return the Homepage title and skip the rest of the logic.

### Video After Changes
https://github.com/mozilla-mobile/firefox-ios/assets/5545720/4dc9dbdb-458f-468e-b16b-86c57f6f0170


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

