### PR TITLE
Fixes MTE-2843 - for credit card tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -54,6 +54,7 @@ class BaseTestCase: XCTestCase {
     func closeFromAppSwitcherAndRelaunch() {
         let swipeStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.999))
         let swipeEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.001))
+        sleep(2)
         swipeStart.press(forDuration: 0.1, thenDragTo: swipeEnd)
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         mozWaitForElementToExist(springboard.icons["XCUITests-Runner"], timeout: 10)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -399,8 +399,7 @@ class CreditCardsTests: BaseTestCase {
         app.buttons["Close"].tap()
         mozWaitForElementToNotExist(app.staticTexts["Update card?"])
         // Go to the Settings --> Payment methods
-        swipeDown(nrOfSwipes: 2)
-        swipeUp(nrOfSwipes: 1)
+        swipeDown(nrOfSwipes: 3)
         navigator.goto(CreditCardsSettings)
         unlockLoginsView()
         // Credit cards details did not change
@@ -517,7 +516,8 @@ class CreditCardsTests: BaseTestCase {
     }
 
     private func dismissSavedCardsPrompt() {
-        if app.staticTexts["Tap"].isVisible() {
+        if app.buttons.elementContainingText("Decline").isVisible() &&
+            app.buttons.elementContainingText("Decline").isHittable {
             app.staticTexts["TEST CARDS"].tap()
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-2843

## :bulb: Description
Fixes for:
testOpenNewTabButtonOnToolbar
testUpdatePrompt
testSaveThisCardPrompt
