### PR TITLE
Fix Comment Bypass Bitrise Mirror for Swiftlint Upgrades step prevent…

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -491,23 +491,24 @@ workflows:
             export XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig
             envman add --key XCODE_XCCONFIG_FILE --value /tmp/tmp.xcconfig
         title: Workaround carthage lipo
-    - script@1.1:
-        title: Bypass Bitrise Mirror for Swiftlint Upgrade
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -ex
-
-            echo "Swiftlint version before mirror swap"
-            swiftlint version
-            # Workaround to find the homebrew-core folder
-            brew tap homebrew/core --force
-            cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
-            # Bypass Bitrise mirror that lags 1 week to 1 month behind homebrew-core versions
-            git remote set-url origin https://github.com/Homebrew/homebrew-core.git
-            brew upgrade swiftlint
-            echo "Swiftlint version after mirror swap"
-            swiftlint version
+    # Skip for now to fix release branches built different swiftlint and xcode versions
+    #- script@1.1:
+    #    title: Bypass Bitrise Mirror for Swiftlint Upgrade
+    #    inputs:
+    #    - content: |-
+    #        #!/usr/bin/env bash
+    #        set -ex
+    #
+    #        echo "Swiftlint version before mirror swap"
+    #        swiftlint version
+    #        # Workaround to find the homebrew-core folder
+    #        brew tap homebrew/core --force
+    #        cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
+    #        # Bypass Bitrise mirror that lags 1 week to 1 month behind homebrew-core versions
+    #        git remote set-url origin https://github.com/Homebrew/homebrew-core.git
+    #        brew upgrade swiftlint
+    #        echo "Swiftlint version after mirror swap"
+    #        swiftlint version
     - script@1:
         inputs:
         - content: |-


### PR DESCRIPTION
…ing successful builds

We found a workaround that is working on main and release v127, builds are using xcode 15.3 and swiftlint 0.53. However that does not seem to work for release v126, which uses xcode 15.2 and swiftlint 0.52.4.
Let's disable that step for now to unblock releasing v126 build

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

