### PR TITLE
Refactor FXIOS-9165 - Updated Fonts On SettingsViewController to FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -149,7 +149,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
             let title: String = .TrackerProtectionLearnMore
 
             let theme = themeManager.currentTheme(for: windowUUID)
-            let font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline, size: 12.0)
+            let font = FXFontStyles.Regular.subheadline.scaledFont()
             var attributes = [NSAttributedString.Key: AnyObject]()
             attributes[NSAttributedString.Key.foregroundColor] = theme.colors.actionPrimary
             attributes[NSAttributedString.Key.font] = font

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -149,7 +149,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController {
             let title: String = .TrackerProtectionLearnMore
 
             let theme = themeManager.currentTheme(for: windowUUID)
-            let font = FXFontStyles.Regular.subheadline.scaledFont()
+            let font = FXFontStyles.Regular.caption1.scaledFont()
             var attributes = [NSAttributedString.Key: AnyObject]()
             attributes[NSAttributedString.Key.foregroundColor] = theme.colors.actionPrimary
             attributes[NSAttributedString.Key.font] = font

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -507,7 +507,6 @@ class StringSetting: Setting, UITextFieldDelegate {
     private struct UX {
         static let padding: CGFloat = 15
         static let textFieldHeight: CGFloat = 44
-        static let fontSize: CGFloat = 17
         static let textFieldIdentifierSuffix = "TextField"
     }
 
@@ -575,11 +574,7 @@ class StringSetting: Setting, UITextFieldDelegate {
         cell.accessibilityTraits = UIAccessibilityTraits.none
         cell.contentView.addSubview(textField)
 
-        textField.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .body,
-            size: UX.fontSize,
-            weight: .regular
-        )
+        textField.font = FXFontStyles.Regular.body.scaledFont()
 
         NSLayoutConstraint.activate(
             [

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -13,7 +13,6 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
     struct UX {
         static var rowHeight: CGFloat = 70
         static var moonSunIconSize: CGFloat = 18
-        static var footerFontSize: CGFloat = 12
         static var sliderLeftRightInset: CGFloat = 16
         static var spaceBetweenTableSections: CGFloat = 20
     }
@@ -202,8 +201,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
         let label: UILabel = .build { label in
             label.text = .DisplayThemeSectionFooter
             label.numberOfLines = 0
-            label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .footnote,
-                                                                size: UX.footerFontSize)
+            label.font = FXFontStyles.Regular.footnote.scaledFont()
             label.textColor = self.themeManager.currentTheme(for: self.windowUUID).colors.textSecondary
         }
         footer.addSubview(label)

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -201,7 +201,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
         let label: UILabel = .build { label in
             label.text = .DisplayThemeSectionFooter
             label.numberOfLines = 0
-            label.font = FXFontStyles.Regular.footnote.scaledFont()
+            label.font = FXFontStyles.Regular.caption1.scaledFont()
             label.textColor = self.themeManager.currentTheme(for: self.windowUUID).colors.textSecondary
         }
         footer.addSubview(label)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9165)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20308)

## :bulb: Description
Updated the settings views to use FXFontsStyle instead of DefaultDynamicFontHelper or UIFont. This eliminates the need to specify font sizes in the view controllers.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)