### PR TITLE
Refactor FXIOS-9164 - Updated Fonts On SurveySurfaceViewController to FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -21,7 +21,6 @@ class SurveySurfaceViewController: UIViewController, Themeable {
 
         static let sideMarginMultiplier: CGFloat  = 0.05
 
-        static let titleFontSize: CGFloat = 20
         static let titleDistanceFromImage: CGFloat = 16
         static let titleWidth: CGFloat = 343
 
@@ -63,8 +62,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     }
 
     private lazy var titleLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .title3,
-                                                                size: UX.titleFontSize)
+        label.font = FXFontStyles.Bold.title3.scaledFont()
         label.numberOfLines = 0
         label.textAlignment = .center
         label.adjustsFontForContentSizeCategory = true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9164)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20307)

## :bulb: Description
Updated `SurveySurfaceViewController` to use `FXFontsStyle` instead of `DefaultDynamicFontHelper` or `UIFont`. This eliminates the need to specify font sizes in the view controllers.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

