### PR TITLE
Refactor FXIOS-9169 - Updated Fonts On DownloadHelper to FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
@@ -134,7 +134,7 @@ class DownloadHelper: NSObject {
 
         filenameItem.customRender = { label, contentView in
             label.numberOfLines = 2
-            label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 16, weight: .semibold)
+            label.font = FXFontStyles.Bold.body.scaledFont()
             label.lineBreakMode = .byCharWrapping
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9169)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20317)

## :bulb: Description
Updated DownloadHelper to use FXFontsStyle instead of DefaultDynamicFontHelper.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Previous Preview of DownloadHelper
![Previous](https://github.com/mozilla-mobile/firefox-ios/assets/20414478/17d5541f-3729-44b7-9f72-b41d60df73d8)

## Recent Preview of DownloadHelper
![Recent](https://github.com/mozilla-mobile/firefox-ios/assets/20414478/40400f74-fd1e-46f7-b0e0-fc177cd6beae)
