### PR TITLE
Refactor FXIOS-9168 - Updated Fonts On PhotonActionSheetView to FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
@@ -56,16 +56,14 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: 19)
+        label.font = FXFontStyles.Regular.title3.scaledFont()
         return label
     }()
 
     private lazy var subtitleLabel: UILabel = {
         let label = createLabel()
         label.numberOfLines = 0
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .caption1,
-                                                            size: 13)
+        label.font = FXFontStyles.Regular.footnote.scaledFont()
         return label
     }()
 
@@ -190,11 +188,9 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
         titleLabel.text = item.currentTitle
 
         if item.bold {
-            titleLabel.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .headline,
-                                                                         size: 19)
+            titleLabel.font = FXFontStyles.Bold.title3.scaledFont()
         } else {
-            titleLabel.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                                     size: 17)
+            titleLabel.font = FXFontStyles.Regular.body.scaledFont()
         }
 
         item.customRender?(titleLabel, self)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9168)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20316)

## :bulb: Description
Updated `PhotonActionSheetView` to use `FXFontsStyle` instead of `DefaultDynamicFontHelper` or `UIFont`. This eliminates the need to specify font sizes in the view controllers.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
