### PR TITLE
Add FXIOS-8700 Create a component that loads an html page with address fields and is able to get input from users

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -920,6 +920,8 @@
 		8CE1E4382B8C76C80026530B /* LoginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1E4342B8C76C80026530B /* LoginListViewModel.swift */; };
 		8CE1E4392B8C76C80026530B /* LoginCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1E4352B8C76C80026530B /* LoginCellView.swift */; };
 		8CE1E43A2B8C76C80026530B /* LoginListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1E4362B8C76C80026530B /* LoginListView.swift */; };
+		8CEDF07E2BFE04B100D2617B /* AddressListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CEDF07D2BFE04B100D2617B /* AddressListViewModelTests.swift */; };
+		8CEDF0802BFE138B00D2617B /* AddressProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CEDF07F2BFE138B00D2617B /* AddressProvider.swift */; };
 		8CFD56882AAF057D003157A6 /* SwitchFakespotProduction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFD56872AAF057D003157A6 /* SwitchFakespotProduction.swift */; };
 		8CFD56892AAF06D3003157A6 /* ShoppingProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6DA7D02A6FE78F00DE264F /* ShoppingProductTests.swift */; };
 		8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8251721F4DE67E00780643 /* AdvancedAccountSettingViewController.swift */; };
@@ -6196,6 +6198,8 @@
 		8CE1E4342B8C76C80026530B /* LoginListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginListViewModel.swift; sourceTree = "<group>"; };
 		8CE1E4352B8C76C80026530B /* LoginCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginCellView.swift; sourceTree = "<group>"; };
 		8CE1E4362B8C76C80026530B /* LoginListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginListView.swift; sourceTree = "<group>"; };
+		8CEDF07D2BFE04B100D2617B /* AddressListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressListViewModelTests.swift; sourceTree = "<group>"; };
+		8CEDF07F2BFE138B00D2617B /* AddressProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressProvider.swift; sourceTree = "<group>"; };
 		8CFD56872AAF057D003157A6 /* SwitchFakespotProduction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchFakespotProduction.swift; sourceTree = "<group>"; };
 		8D1340A4B7E4ACBF43347178 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		8D194DCF9E244D29DA68FDE5 /* az */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = az; path = az.lproj/Shared.strings; sourceTree = "<group>"; };
@@ -10301,6 +10305,7 @@
 			children = (
 				439B78172A09721600CAAE37 /* FormAutofillHelperTests.swift */,
 				8CCD74722B90A945008F919B /* LoginListViewModelTests.swift */,
+				8CEDF07D2BFE04B100D2617B /* AddressListViewModelTests.swift */,
 			);
 			path = Autofill;
 			sourceTree = "<group>";
@@ -10326,6 +10331,7 @@
 				B2FEA68C2B460D390058E616 /* AddressAutofillSettingsViewController.swift */,
 				B2FEA68E2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift */,
 				B2DFB7DE2B619DB80004CEA5 /* AddressListViewModel.swift */,
+				8CEDF07F2BFE138B00D2617B /* AddressProvider.swift */,
 				B2FEA68A2B460D1D0058E616 /* AddressAutofillSettingsView.swift */,
 				B2FEA6902B4661BE0058E616 /* AddressAutofillToggle.swift */,
 				B2DFB7E02B619DF60004CEA5 /* AddressListView.swift */,
@@ -14507,6 +14513,7 @@
 				8AD40FCD27BADC5C00672675 /* TabLocationContainerView.swift in Sources */,
 				8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */,
 				211046CD2A7D842A00A7309F /* TPAccessoryInfo.swift in Sources */,
+				8CEDF0802BFE138B00D2617B /* AddressProvider.swift in Sources */,
 				21E77E502AA8BAEC00FABA10 /* TabTrayState.swift in Sources */,
 				5AE371872A4E11750092A760 /* AboutSettingsDelegate.swift in Sources */,
 				E18EA57128AD46D3003F97FC /* WallpaperCollectionType.swift in Sources */,
@@ -14788,6 +14795,7 @@
 				434CD57829F6FC4500A0D04B /* MockAppAuthenticator.swift in Sources */,
 				DACDE996225E537900C8F37F /* VersionSettingTests.swift in Sources */,
 				8A83B74C2A265061002FF9AC /* LibraryCoordinatorTests.swift in Sources */,
+				8CEDF07E2BFE04B100D2617B /* AddressListViewModelTests.swift in Sources */,
 				21D884412A79628E00AF144C /* MockSettingsDelegate.swift in Sources */,
 				F1BC457E2A40F6D2005541D5 /* EnhancedTrackingProtectionCoordinatorTests.swift in Sources */,
 				8A13FA8F2AD83F00007527AB /* DefaultBackgroundTabLoaderTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -894,6 +894,12 @@
 		8C19532E2B85E7AE00761B20 /* SelfSizingHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C19532D2B85E7AE00761B20 /* SelfSizingHostingController.swift */; };
 		8C1953302B85E7EC00761B20 /* AutofillFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C19532F2B85E7EC00761B20 /* AutofillFooterView.swift */; };
 		8C1953322B85EAB500761B20 /* AutofillHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C1953312B85EAB500761B20 /* AutofillHeaderView.swift */; };
+		8C29376A2BF79EE000146613 /* AddressFormManager.css in Resources */ = {isa = PBXBuildFile; fileRef = 8C2937662BF79EDF00146613 /* AddressFormManager.css */; };
+		8C29376B2BF79EE000146613 /* AddressFormManager.html in Resources */ = {isa = PBXBuildFile; fileRef = 8C2937672BF79EDF00146613 /* AddressFormManager.html */; };
+		8C29376C2BF79EE000146613 /* AddressFormManager.mjs in Resources */ = {isa = PBXBuildFile; fileRef = 8C2937682BF79EDF00146613 /* AddressFormManager.mjs */; };
+		8C2937702BF79F0300146613 /* EditAddressLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C29376D2BF79F0200146613 /* EditAddressLocalization.swift */; };
+		8C2937712BF79F0300146613 /* EditAddressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C29376E2BF79F0300146613 /* EditAddressViewController.swift */; };
+		8C2937722BF79F0300146613 /* Address+Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C29376F2BF79F0300146613 /* Address+Encodable.swift */; };
 		8C29627C2B1F473800571655 /* AdEventsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C29627B2B1F473800571655 /* AdEventsResponse.swift */; };
 		8C44A9D22A6A99FE009A1AA7 /* ShoppingProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C44A9D12A6A99FE009A1AA7 /* ShoppingProduct.swift */; };
 		8C46E1B72B2209F000F56521 /* FakespotAdsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C46E1B62B2209F000F56521 /* FakespotAdsEvent.swift */; };
@@ -1014,8 +1020,6 @@
 		BA1C68BA2B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1C68B92B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift */; };
 		BA1C68BC2B7ED153000D9397 /* MockWebKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */; };
 		BA8E197F2BF2FB1900590B5F /* AddressFormManager.js in Resources */ = {isa = PBXBuildFile; fileRef = BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */; };
-		BA8E19812BF2FB4100590B5F /* AddressFormManager.html in Resources */ = {isa = PBXBuildFile; fileRef = BA8E19802BF2FB4100590B5F /* AddressFormManager.html */; };
-		BA8E19832BF2FB5B00590B5F /* AddressFormManager.css in Resources */ = {isa = PBXBuildFile; fileRef = BA8E19822BF2FB5B00590B5F /* AddressFormManager.css */; };
 		BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
 		BCFF93F02AABA55A005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93EF2AAB97A8005B5B71 /* BackgroundFirefoxSuggestIngestUtility.swift */; };
@@ -6159,6 +6163,12 @@
 		8C19532F2B85E7EC00761B20 /* AutofillFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillFooterView.swift; sourceTree = "<group>"; };
 		8C1953312B85EAB500761B20 /* AutofillHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillHeaderView.swift; sourceTree = "<group>"; };
 		8C264BF5A1C7B2B6378D4DFF /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/Today.strings; sourceTree = "<group>"; };
+		8C2937662BF79EDF00146613 /* AddressFormManager.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = AddressFormManager.css; sourceTree = "<group>"; };
+		8C2937672BF79EDF00146613 /* AddressFormManager.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = AddressFormManager.html; sourceTree = "<group>"; };
+		8C2937682BF79EDF00146613 /* AddressFormManager.mjs */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AddressFormManager.mjs; sourceTree = "<group>"; };
+		8C29376D2BF79F0200146613 /* EditAddressLocalization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditAddressLocalization.swift; sourceTree = "<group>"; };
+		8C29376E2BF79F0300146613 /* EditAddressViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditAddressViewController.swift; sourceTree = "<group>"; };
+		8C29376F2BF79F0300146613 /* Address+Encodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Address+Encodable.swift"; sourceTree = "<group>"; };
 		8C29627B2B1F473800571655 /* AdEventsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdEventsResponse.swift; sourceTree = "<group>"; };
 		8C44A9D12A6A99FE009A1AA7 /* ShoppingProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingProduct.swift; sourceTree = "<group>"; };
 		8C46E1B62B2209F000F56521 /* FakespotAdsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakespotAdsEvent.swift; sourceTree = "<group>"; };
@@ -6632,9 +6642,7 @@
 		BA1C68B92B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKFrameInfoExtensionsTest.swift; sourceTree = "<group>"; };
 		BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebKit.swift; sourceTree = "<group>"; };
 		BA354251BD3FFF63A161E385 /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
-		BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = AddressFormManager.js; path = Client/Assets/AddressFormManager.js; sourceTree = "<group>"; };
-		BA8E19802BF2FB4100590B5F /* AddressFormManager.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = AddressFormManager.html; path = Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.html; sourceTree = "<group>"; };
-		BA8E19822BF2FB5B00590B5F /* AddressFormManager.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = AddressFormManager.css; path = Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.css; sourceTree = "<group>"; };
+		BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AddressFormManager.js; sourceTree = "<group>"; };
 		BA904A3B89BC820A7A802D55 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/Storage.strings"; sourceTree = "<group>"; };
 		BAA64356B54F1CD258764620 /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		BAF14FEC94CB9DA4E08BA60C /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Storage.strings; sourceTree = "<group>"; };
@@ -10126,6 +10134,26 @@
 			path = LaunchView;
 			sourceTree = "<group>";
 		};
+		8C2937692BF79EDF00146613 /* AddressFormManager */ = {
+			isa = PBXGroup;
+			children = (
+				8C2937662BF79EDF00146613 /* AddressFormManager.css */,
+				8C2937672BF79EDF00146613 /* AddressFormManager.html */,
+				8C2937682BF79EDF00146613 /* AddressFormManager.mjs */,
+			);
+			path = AddressFormManager;
+			sourceTree = "<group>";
+		};
+		8C2937732BF79F0C00146613 /* Edit */ = {
+			isa = PBXGroup;
+			children = (
+				8C29376F2BF79F0300146613 /* Address+Encodable.swift */,
+				8C29376D2BF79F0200146613 /* EditAddressLocalization.swift */,
+				8C29376E2BF79F0300146613 /* EditAddressViewController.swift */,
+			);
+			path = Edit;
+			sourceTree = "<group>";
+		};
 		8C802EE12B078BB30059E78D /* Response */ = {
 			isa = PBXGroup;
 			children = (
@@ -10294,6 +10322,7 @@
 		B2FEA6892B460CEC0058E616 /* Address */ = {
 			isa = PBXGroup;
 			children = (
+				8C2937732BF79F0C00146613 /* Edit */,
 				B2FEA68C2B460D390058E616 /* AddressAutofillSettingsViewController.swift */,
 				B2FEA68E2B460D9E0058E616 /* AddressAutofillSettingsViewModel.swift */,
 				B2DFB7DE2B619DB80004CEA5 /* AddressListViewModel.swift */,
@@ -10913,6 +10942,7 @@
 		D0FCF7E71FE44CA9004A7995 /* UserScripts */ = {
 			isa = PBXGroup;
 			children = (
+				8C2937692BF79EDF00146613 /* AddressFormManager */,
 				D0FCF7E81FE44D8F004A7995 /* AllFrames */,
 				8AEE62C82756BA34003207D1 /* DownloadHelper.js */,
 				8AEE62C62756BA34003207D1 /* LoginsHelper.js */,
@@ -11840,9 +11870,6 @@
 		F84B21B51A090F8100AAB793 = {
 			isa = PBXGroup;
 			children = (
-				BA8E19822BF2FB5B00590B5F /* AddressFormManager.css */,
-				BA8E19802BF2FB4100590B5F /* AddressFormManager.html */,
-				BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */,
 				2FA435FC1ABB83B4008031D1 /* Account */,
 				D4F0C2642B2C90FB008ECEE8 /* BrowserKit */,
 				F84B21C01A090F8100AAB793 /* Client */,
@@ -12065,6 +12092,7 @@
 				D03F8F22200EAC1E003C2224 /* AllFramesAtDocumentStart.js */,
 				43F92B3729E9F52B000C0F17 /* AutofillAllFramesAtDocumentStart.js */,
 				3BC659581E5BA505006D560F /* bundle_sites.json */,
+				BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */,
 				43879AFB287BDFB100B15D10 /* CC_Script */,
 				D308EE551CBF0BF5006843F2 /* CertError.css */,
 				D38A1EDF1CB458EC0080C842 /* CertError.html */,
@@ -13107,12 +13135,12 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BA8E19832BF2FB5B00590B5F /* AddressFormManager.css in Resources */,
-				BA8E19812BF2FB4100590B5F /* AddressFormManager.html in Resources */,
 				BA8E197F2BF2FB1900590B5F /* AddressFormManager.js in Resources */,
 				8A1A935B2B757C7C0069C190 /* wave.json in Resources */,
 				D4AFAB0E2AFA8F9A000BFEAA /* SyncIntegrationTests in Resources */,
 				43F92B3829E9F52B000C0F17 /* AutofillAllFramesAtDocumentStart.js in Resources */,
+				8C29376A2BF79EE000146613 /* AddressFormManager.css in Resources */,
+				8C29376B2BF79EE000146613 /* AddressFormManager.html in Resources */,
 				8A3345662BA499B7008C52AB /* disconnect-block-content.json in Resources */,
 				39D056382665235700FBEE59 /* initial_experiments.json in Resources */,
 				C8B0F5F8283B7D38007AE65D /* pocketsponsoredfeed.json in Resources */,
@@ -13147,6 +13175,7 @@
 				D37524871C6E8B5A00A5F6C2 /* topdomains.txt in Resources */,
 				39F4C0FA2045D87400746155 /* FocusHelper.js in Resources */,
 				E1AF3562286DE5F800960045 /* Smoketest2.xctestplan in Resources */,
+				8C29376C2BF79EE000146613 /* AddressFormManager.mjs in Resources */,
 				43175DB626B8774D00C41C31 /* Ads.js in Resources */,
 				D0FCF8081FE4772D004A7995 /* MainFrameAtDocumentStart.js in Resources */,
 				D30684F11C84F12A002D8D82 /* SearchPlugins in Resources */,
@@ -14033,6 +14062,7 @@
 				B2999FF12B194A5800F0FEC1 /* CreditCardPayload.swift in Sources */,
 				E1877A81286E0EFD00F5BDF2 /* WebViewNavigationHandler.swift in Sources */,
 				274A36CC239EB99400A21587 /* LibraryPanelContextMenu.swift in Sources */,
+				8C2937722BF79F0300146613 /* Address+Encodable.swift in Sources */,
 				D314E7F71A37B98700426A76 /* TabToolbar.swift in Sources */,
 				43D00493296FC48F00CB0F31 /* CreditCardSettingsEmptyView.swift in Sources */,
 				CEFA977E1FAA6B490016F365 /* SyncContentSettingsViewController.swift in Sources */,
@@ -14126,6 +14156,7 @@
 				8ADAE4202A33A0FD007BF926 /* SendFeedbackSetting.swift in Sources */,
 				C29B64812AD6959E00F3244B /* QRCodeCoordinator.swift in Sources */,
 				21A7C45028353D0E0071D996 /* OnboardingBasicCardViewController.swift in Sources */,
+				8C2937702BF79F0300146613 /* EditAddressLocalization.swift in Sources */,
 				742A56391D80B54A00BDB803 /* PhotonActionSheet.swift in Sources */,
 				C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */,
 				E1442FD3294782D9003680B0 /* UIView+Constraints.swift in Sources */,
@@ -14246,6 +14277,7 @@
 				8C29627C2B1F473800571655 /* AdEventsResponse.swift in Sources */,
 				962021E128B8078400BDF3D9 /* ContextualHintCopyProvider.swift in Sources */,
 				8AE1E1D227B1ADC40024C45E /* TopBottomInterchangeable.swift in Sources */,
+				8C2937712BF79F0300146613 /* EditAddressViewController.swift in Sources */,
 				8A7653BD28A2C61D00924ABF /* PocketDataAdaptor.swift in Sources */,
 				8A093D7D2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift in Sources */,
 				96EA9454293655BF00123345 /* AppSession+Enums.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/AddressAutofillCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/AddressAutofillCoordinator.swift
@@ -46,7 +46,7 @@ class AddressAutofillCoordinator: BaseCoordinator {
     func showAddressAutofill(frame: WKFrameInfo?) {
         let bottomSheetViewModel = BottomSheetViewModel(closeButtonA11yLabel: .CloseButtonTitle)
 
-        let viewModel = AddressListViewModel(profile: profile)
+        let viewModel = AddressListViewModel(addressProvider: profile.autofill)
 
         viewModel.addressSelectionCallback = { [weak self] selectedAddress in
             // Perform actions with the selected address, such as injecting it into the form

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -12,6 +12,7 @@ import UIKit
 enum NimbusFeatureFlagID: String, CaseIterable {
     case accountSettingsRedux
     case addressAutofill
+    case addressAutofillEdit
     case bottomSearchBar
     case contextualHintForToolbar
     case creditCardAutofillStatus
@@ -68,6 +69,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
         case .contextualHintForToolbar,
                 .accountSettingsRedux,
                 .addressAutofill,
+                .addressAutofillEdit,
                 .creditCardAutofillStatus,
                 .fakespotBackInStock,
                 .fakespotFeature,

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewModel.swift
@@ -15,7 +15,7 @@ class AddressAutofillSettingsViewModel {
     lazy var toggleModel = ToggleModel(isEnabled: isAutofillEnabled, delegate: self)
 
     /// ViewModel for managing the list of addresses.
-    lazy var addressListViewModel = AddressListViewModel(profile: profile)
+    lazy var addressListViewModel = AddressListViewModel(addressProvider: profile.autofill)
 
     /// RustAutofill instance for handling autofill functionality.
     var autofill: RustAutofill?

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -30,7 +30,9 @@ struct AddressListView: View {
                             windowUUID: windowUUID,
                             address: address,
                             onTap: {
-                                // TODO: PHASE - 2: FXIOS-7653 Handle action when address cell is tapped.
+                                if viewModel.isEditingFeatureEnabled {
+                                    viewModel.onAddressTap(address)
+                                }
                             }
                         )
                     }
@@ -41,6 +43,21 @@ struct AddressListView: View {
         }
         .listStyle(.plain)
         .listRowInsets(EdgeInsets())
+        .sheet(item: $viewModel.selectedAddress) { address in
+            NavigationView {
+                EditAddressViewControllerRepresentable(model: viewModel)
+                    .toolbar {
+                        ToolbarItemGroup(placement: .cancellationAction) {
+                            Button {
+                                viewModel.onCancelButtonTap()
+                            } label: {
+                                // Change the correct string after UX finalize copyright
+                                Text(String.CreditCard.EditCard.CancelNavBarButtonLabel)
+                            }
+                        }
+                    }
+            }
+        }
         .onAppear {
             viewModel.fetchAddresses()
             applyTheme(theme: themeManager.currentTheme(for: windowUUID))

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -51,7 +51,7 @@ struct AddressListView: View {
                             Button {
                                 viewModel.onCancelButtonTap()
                             } label: {
-                                // Change the correct string after UX finalize copyright
+                                // TODO: FXIOS-9100 Change the correct string after UX finalize copyright
                                 Text(String.CreditCard.EditCard.CancelNavBarButtonLabel)
                             }
                         }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -21,13 +21,18 @@ extension Address {
 }
 
 // AddressListViewModel: A view model for managing addresses.
-class AddressListViewModel: ObservableObject {
+class AddressListViewModel: ObservableObject, FeatureFlaggable {
     // MARK: - Properties
 
     @Published var addresses: [Address] = []
     @Published var showSection = false
+    @Published var selectedAddress: Address?
+
     private let profile: Profile?
     private let logger: Logger
+
+    var isEditingFeatureEnabled: Bool { featureFlags.isFeatureEnabled(.addressAutofillEdit, checking: .buildOnly) }
+
     var addressSelectionCallback: ((UnencryptedAddressFields) -> Void)?
 
     // MARK: - Initializer
@@ -78,9 +83,17 @@ class AddressListViewModel: ObservableObject {
 
     // MARK: - Handle Address Selection
 
-        /// Handles the selection of an address.
-        /// - Parameter address: The selected address.
-        func handleAddressSelection(_ address: Address) {
-            addressSelectionCallback?(fromAddress(address))
-        }
+    /// Handles the selection of an address.
+    /// - Parameter address: The selected address.
+    func handleAddressSelection(_ address: Address) {
+        addressSelectionCallback?(fromAddress(address))
+    }
+
+    func onAddressTap(_ address: Address) {
+        selectedAddress = address
+    }
+
+    func onCancelButtonTap() {
+        selectedAddress = nil
+    }
 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressProvider.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressProvider.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Storage
+
+protocol AddressProvider {
+    func listAllAddresses(completion: @escaping ([Address]?, Error?) -> Void)
+}
+
+extension RustAutofill: AddressProvider {}

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/Address+Encodable.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/Address+Encodable.swift
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Storage
+
+extension CodingUserInfoKey {
+    static let formatStyleKey = CodingUserInfoKey(rawValue: "FormatStyleKey")!
+}
+
+enum FormatStyle {
+    case kebabCase
+}
+
+extension Address: Encodable {
+    struct FormatStyleError: Error {}
+    enum KebabCodingKeys: String, CodingKey {
+        case guid
+        case name
+        case organization
+        case streetAddress = "street-address"
+        case addressLevel3 = "address-level3"
+        case addressLevel2 = "address-level2"
+        case addressLevel1 = "address-level1"
+        case postalCode = "postal-code"
+        case country
+        case tel
+        case email
+        case timeCreated = "time-created"
+        case timeLastUsed = "time-last-used"
+        case timeLastModified = "time-last-modified"
+        case timesUsed = "times-used"
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        guard let format = encoder.userInfo[.formatStyleKey] as? FormatStyle else {
+            throw FormatStyleError()
+        }
+        switch format {
+        case .kebabCase:
+            var container = encoder.container(keyedBy: KebabCodingKeys.self)
+            try container.encode(guid, forKey: .guid)
+            try container.encode(name, forKey: .name)
+            try container.encode(organization, forKey: .organization)
+            try container.encode(streetAddress, forKey: .streetAddress)
+            try container.encode(addressLevel3, forKey: .addressLevel3)
+            try container.encode(addressLevel2, forKey: .addressLevel2)
+            try container.encode(addressLevel1, forKey: .addressLevel1)
+            try container.encode(postalCode, forKey: .postalCode)
+            try container.encode(country, forKey: .country)
+            try container.encode(tel, forKey: .tel)
+            try container.encode(email, forKey: .email)
+            try container.encode(timeCreated, forKey: .timeCreated)
+            try container.encodeIfPresent(timeLastUsed, forKey: .timeLastUsed)
+            try container.encode(timeLastModified, forKey: .timeLastModified)
+            try container.encode(timesUsed, forKey: .timesUsed)
+        }
+    }
+}
+
+extension Address: Swift.Identifiable {
+    public var id: String { guid }
+}

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressLocalization.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressLocalization.swift
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct EditAddressLocalization: Encodable {
+    let autofillAddressGivenName: String
+    let autofillAddressAdditionalName: String
+    let autofillAddressFamilyName: String
+    let autofillAddressName: String
+    let autofillAddressOrganization: String
+    let autofillAddressStreet: String
+    let autofillAddressState: String
+    let autofillAddressProvince: String
+    let autofillAddressCity: String
+    let autofillAddressCountry: String
+    let autofillAddressZip: String
+    let autofillAddressPostalCode: String
+    let autofillAddressEmail: String
+    let autofillAddressTel: String
+    let autofillEditAddressTitle: String
+    let autofillAddressNeighborhood: String
+    let autofillAddressVillageTownship: String
+    let autofillAddressIsland: String
+    let autofillAddressTownland: String
+    let autofillAddressDistrict: String
+    let autofillAddressCounty: String
+    let autofillAddressPostTown: String
+    let autofillAddressSuburb: String
+    let autofillAddressParish: String
+    let autofillAddressPrefecture: String
+    let autofillAddressArea: String
+    let autofillAddressDoSi: String
+    let autofillAddressDepartment: String
+    let autofillAddressEmirate: String
+    let autofillAddressOblast: String
+    let autofillAddressPin: String
+    let autofillAddressEircode: String
+    let autofillAddressCountryOnly: String
+    let autofillCancelButton: String
+    let autofillSaveButton: String
+
+    enum CodingKeys: String, CodingKey {
+        case autofillAddressGivenName = "autofill-address-given-name"
+        case autofillAddressAdditionalName = "autofill-address-additional-name"
+        case autofillAddressFamilyName = "autofill-address-family-name"
+        case autofillAddressName = "autofill-address-name"
+        case autofillAddressOrganization = "autofill-address-organization"
+        case autofillAddressStreet = "autofill-address-street"
+        case autofillAddressState = "autofill-address-state"
+        case autofillAddressProvince = "autofill-address-province"
+        case autofillAddressCity = "autofill-address-city"
+        case autofillAddressCountry = "autofill-address-country"
+        case autofillAddressZip = "autofill-address-zip"
+        case autofillAddressPostalCode = "autofill-address-postal-code"
+        case autofillAddressEmail = "autofill-address-email"
+        case autofillAddressTel = "autofill-address-tel"
+        case autofillEditAddressTitle = "autofill-edit-address-title"
+        case autofillAddressNeighborhood = "autofill-address-neighborhood"
+        case autofillAddressVillageTownship = "autofill-address-village-township"
+        case autofillAddressIsland = "autofill-address-island"
+        case autofillAddressTownland = "autofill-address-townland"
+        case autofillAddressDistrict = "autofill-address-district"
+        case autofillAddressCounty = "autofill-address-county"
+        case autofillAddressPostTown = "autofill-address-post-town"
+        case autofillAddressSuburb = "autofill-address-suburb"
+        case autofillAddressParish = "autofill-address-parish"
+        case autofillAddressPrefecture = "autofill-address-prefecture"
+        case autofillAddressArea = "autofill-address-area"
+        case autofillAddressDoSi = "autofill-address-do-si"
+        case autofillAddressDepartment = "autofill-address-department"
+        case autofillAddressEmirate = "autofill-address-emirate"
+        case autofillAddressOblast = "autofill-address-oblast"
+        case autofillAddressPin = "autofill-address-pin"
+        case autofillAddressEircode = "autofill-address-eircode"
+        case autofillAddressCountryOnly = "autofill-address-country-only"
+        case autofillCancelButton = "autofill-cancel-button"
+        case autofillSaveButton = "autofill-save-button"
+    }
+
+    // Change the correct strings after UX finalize copyright
+    static let editAddressLocalizationIDs = EditAddressLocalization(
+        autofillAddressGivenName: "Given Name",
+        autofillAddressAdditionalName: "Additional Name",
+        autofillAddressFamilyName: "Family Name",
+        autofillAddressName: "Full Name",
+        autofillAddressOrganization: "Organization",
+        autofillAddressStreet: "Street Address",
+        autofillAddressState: "State",
+        autofillAddressProvince: "Province",
+        autofillAddressCity: "City",
+        autofillAddressCountry: "Country",
+        autofillAddressZip: "ZIP Code",
+        autofillAddressPostalCode: "Postal Code",
+        autofillAddressEmail: "Email Address",
+        autofillAddressTel: "Telephone Number",
+        autofillEditAddressTitle: "Edit Address",
+        autofillAddressNeighborhood: "Neighborhood",
+        autofillAddressVillageTownship: "Village/Township",
+        autofillAddressIsland: "Island",
+        autofillAddressTownland: "Townland",
+        autofillAddressDistrict: "District",
+        autofillAddressCounty: "County",
+        autofillAddressPostTown: "Post Town",
+        autofillAddressSuburb: "Suburb",
+        autofillAddressParish: "Parish",
+        autofillAddressPrefecture: "Prefecture",
+        autofillAddressArea: "Area",
+        autofillAddressDoSi: "District or Sub-island",
+        autofillAddressDepartment: "Department",
+        autofillAddressEmirate: "Emirate",
+        autofillAddressOblast: "Oblast",
+        autofillAddressPin: "Pincode",
+        autofillAddressEircode: "Eircode",
+        autofillAddressCountryOnly: "Country Only",
+        autofillCancelButton: "Cancel",
+        autofillSaveButton: "Save"
+    )
+}

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressLocalization.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressLocalization.swift
@@ -79,7 +79,7 @@ struct EditAddressLocalization: Encodable {
         case autofillSaveButton = "autofill-save-button"
     }
 
-    // Change the correct strings after UX finalize copyright
+    // TODO: FXIOS-9100 Change the correct strings after UX finalize copyright
     static let editAddressLocalizationIDs = EditAddressLocalization(
         autofillAddressGivenName: "Given Name",
         autofillAddressAdditionalName: "Additional Name",

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -107,8 +107,7 @@ struct EditAddressViewControllerRepresentable: UIViewControllerRepresentable {
     var model: AddressListViewModel
 
     func makeUIViewController(context: Context) -> EditAddressViewController {
-        let webViewController = EditAddressViewController(model: model)
-        return webViewController
+        return EditAddressViewController(model: model)
     }
 
     func updateUIViewController(_ uiViewController: EditAddressViewController, context: Context) {

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import WebKit
+import Storage
+import SwiftUI
+import Common
+
+class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler {
+    private lazy var webView: WKWebView = {
+        let webConfiguration = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: webConfiguration)
+        webView.navigationDelegate = self
+        return webView
+    }()
+
+    var model: AddressListViewModel
+    private let logger: Logger
+
+    init(model: AddressListViewModel, logger: Logger = DefaultLogger.shared) {
+        self.model = model
+        self.logger = logger
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = webView
+        setupWebView()
+    }
+
+    private func setupWebView() {
+        if let url = Bundle.main.url(forResource: "AddressFormManager", withExtension: "html") {
+            let request = URLRequest(url: url)
+            webView.loadFileURL(url, allowingReadAccessTo: url)
+            webView.load(request)
+        }
+    }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {}
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard let address = model.selectedAddress else { return }
+        injectJSONDataInit(address: address, editAddressL10n: .editAddressLocalizationIDs)
+    }
+
+    private func jsonString<T: Encodable>(from object: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.userInfo[.formatStyleKey] = FormatStyle.kebabCase
+        let data = try encoder.encode(object)
+        guard let jsonString = String(data: data, encoding: .utf8) else {
+            throw EncodingError.invalidValue(
+                object,
+                EncodingError.Context(codingPath: [], debugDescription: "Unable to convert data to String")
+            )
+        }
+        return jsonString.replacingOccurrences(of: "\\", with: "\\\\")
+    }
+
+    private func injectJSONDataInit(address: Address, editAddressL10n: EditAddressLocalization) {
+        do {
+            let addressString = try jsonString(from: address)
+            let l10sString = try jsonString(from: editAddressL10n)
+
+            let javascript = "init(\(addressString), \(l10sString));"
+            webView.evaluateJavaScript(javascript) { (result, error) in
+                if let error = error {
+                    self.logger.log("Error evaluating JavaScript",
+                                    level: .warning,
+                                    category: .autofill,
+                                    description: "Error evaluating JavaScript: \(error.localizedDescription)")
+                } else {
+                    self.logger.log("JavaScript evaluated successfully",
+                                    level: .info,
+                                    category: .autofill,
+                                    description: "JavaScript evaluated successfully")
+                }
+            }
+        } catch {
+            self.logger.log("Failed to encode data",
+                            level: .warning,
+                            category: .autofill,
+                            description: "Failed to encode data with error: \(error.localizedDescription)")
+        }
+    }
+
+    private func evaluateJavaScript(_ jsCode: String) {
+        webView.evaluateJavaScript(jsCode) { result, error in
+            if let error = error {
+                self.logger.log("JavaScript execution error",
+                                level: .warning,
+                                category: .autofill,
+                                description: "JavaScript execution error: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+struct EditAddressViewControllerRepresentable: UIViewControllerRepresentable {
+    typealias UIViewControllerType = EditAddressViewController
+
+    var model: AddressListViewModel
+
+    func makeUIViewController(context: Context) -> EditAddressViewController {
+        let webViewController = EditAddressViewController(model: model)
+        return webViewController
+    }
+
+    func updateUIViewController(_ uiViewController: EditAddressViewController, context: Context) {
+        // Here you can update the view controller when your SwiftUI state changes.
+        // Since the WebModel is passed at creation, there might not be much to do here.
+    }
+}

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -17,6 +17,9 @@ final class NimbusFeatureFlagLayer {
         case .addressAutofill:
             return checkAddressAutofill(from: nimbus)
 
+        case .addressAutofillEdit:
+            return checkAddressAutofillEditing(from: nimbus)
+
         case .bottomSearchBar,
                 .searchHighlights,
                 .isToolbarCFREnabled:
@@ -235,6 +238,12 @@ final class NimbusFeatureFlagLayer {
 
     private func checkAddressAutofill(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.addressAutofillFeature.value()
+
+        return config.status
+    }
+
+    private func checkAddressAutofillEditing(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.addressAutofillEdit.value()
 
         return config.status
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
@@ -1,0 +1,161 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+import Storage
+import Combine
+
+class AddressListViewModelTests: XCTestCase {
+    var viewModel: AddressListViewModel!
+    var mockProfile: MockProfile!
+    var mockLogger: MockLogger!
+    var mockAutofill: MockAutofill!
+
+    var cancellables: [AnyCancellable] = []
+
+    let dummyAddresses = [
+        Address(
+            guid: "12345-ABCDE",
+            name: "John Doe",
+            organization: "Acme Corp",
+            streetAddress: "123 Main St",
+            addressLevel3: "Suite 100",
+            addressLevel2: "San Francisco",
+            addressLevel1: "CA",
+            postalCode: "94101",
+            country: "USA",
+            tel: "+1-555-1234",
+            email: "john.doe@example.com",
+            timeCreated: 1622547800,
+            timeLastUsed: 1625149800,
+            timeLastModified: 1625149800,
+            timesUsed: 5
+        ),
+        Address(
+            guid: "67890-FGHIJ",
+            name: "Jane Smith",
+            organization: "Widget Inc",
+            streetAddress: "456 Elm St",
+            addressLevel3: "",
+            addressLevel2: "Los Angeles",
+            addressLevel1: "CA",
+            postalCode: "90001",
+            country: "USA",
+            tel: "+1-555-5678",
+            email: "jane.smith@example.com",
+            timeCreated: 1612134600,
+            timeLastUsed: 1627750200,
+            timeLastModified: 1627750200,
+            timesUsed: 10
+        ),
+        Address(
+            guid: "11223-KLMNO",
+            name: "Alice Johnson",
+            organization: "Tech Solutions",
+            streetAddress: "789 Pine St",
+            addressLevel3: "Apt 2B",
+            addressLevel2: "New York",
+            addressLevel1: "NY",
+            postalCode: "10001",
+            country: "USA",
+            tel: "+1-555-9012",
+            email: "alice.johnson@example.com",
+            timeCreated: 1609459200,
+            timeLastUsed: 1622463000,
+            timeLastModified: 1622463000,
+            timesUsed: 3
+        )
+    ]
+
+    override func setUp() {
+        super.setUp()
+        mockProfile = MockProfile()
+        mockLogger = MockLogger()
+        mockAutofill = MockAutofill()
+        viewModel = AddressListViewModel(logger: mockLogger, addressProvider: mockAutofill)
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        mockProfile = nil
+        mockLogger = nil
+        super.tearDown()
+    }
+
+    func testFetchAddressesSuccess() {
+        let addresses = dummyAddresses
+        mockAutofill.mockListAllAddressesResult = .success(addresses)
+
+        let addressesExpectation = XCTestExpectation(description: "Fetch addresses")
+        let showSectionExpectation = XCTestExpectation(description: "Show section")
+
+        viewModel.fetchAddresses()
+
+        viewModel
+            .$addresses
+        // Drop first to ignore the initial value
+            .dropFirst()
+            .sink { value in
+                XCTAssertEqual(value, addresses)
+                addressesExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        viewModel
+            .$showSection
+            .dropFirst()
+            .sink { value in
+                XCTAssertTrue(value)
+                showSectionExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        wait(for: [addressesExpectation, showSectionExpectation], timeout: 1)
+    }
+
+    func testFetchAddressesFailure() {
+        let error = NSError(domain: "test", code: 1, userInfo: nil)
+        mockAutofill.mockListAllAddressesResult = .failure(error)
+
+        viewModel.fetchAddresses()
+
+        XCTAssertTrue(viewModel.addresses.isEmpty)
+        XCTAssertFalse(viewModel.showSection)
+    }
+
+    func testInjectJSONDataInitSuccess() throws {
+        let address = dummyAddresses[0]
+        viewModel.selectedAddress = address
+
+        let javascript = try viewModel.getInjectJSONDataInit()
+
+        XCTAssertNotNil(javascript)
+    }
+
+    func testInjectJSONDataInitFailure() throws {
+        viewModel.selectedAddress = nil
+        do {
+            _ = try viewModel.getInjectJSONDataInit()
+            XCTFail("Parsing invalid JSON should throw an error")
+        } catch {
+            XCTAssertNotNil(error)
+        }
+    }
+}
+
+class MockAutofill: AddressProvider {
+    var mockListAllAddressesResult: Result<[Address], Error>?
+
+    func listAllAddresses(completion: @escaping ([Address]?, Error?) -> Void) {
+        if let result = mockListAllAddressesResult {
+            switch result {
+            case .success(let addresses):
+                completion(addresses, nil)
+            case .failure(let error):
+                completion(nil, error)
+            }
+        }
+    }
+}

--- a/firefox-ios/nimbus-features/addressAutofillFeature.yaml
+++ b/firefox-ios/nimbus-features/addressAutofillFeature.yaml
@@ -14,3 +14,17 @@ features:
       - channel: developer
         value:
           status: true
+  address-autofill-edit:
+    description: This property defines if the address editing is enabled in Settings
+    variables:
+      status:
+        description: If true, we will allow user to edit the address
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          status: false
+      - channel: developer
+        value:
+          status: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8700)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19290)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This pull request introduces a new view controller, `EditAddressViewController`, which is designed to load and display HTML content. This addition enhances the app's flexibility in presenting address-related information in a web-like format, allowing for more dynamic and customizable content.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

