### PR TITLE
Bugfix FXIOS-9182 Fix tabs sorted into Inactive Tabs incorrectly

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -414,7 +414,9 @@ class Tab: NSObject, ThemeApplicable {
         self.logger = logger
         super.init()
         self.isPrivate = isPrivate
-        self.firstCreatedTime = Date().toTimestamp()
+        let tabCreatedTime = Date().toTimestamp()
+        self.lastExecutedTime = tabCreatedTime
+        self.firstCreatedTime = tabCreatedTime
         debugTabCount += 1
 
         TelemetryWrapper.recordEvent(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -170,9 +170,14 @@ class TabManagerTests: XCTestCase {
         subject.tabs.forEach { $0.firstCreatedTime = Timestamp(0) }
 
         // Override lastExecutedTime of 1st tab to indicate tab active
+        // and lastExecutedTime of other 2 to be distant past
         let tab1 = subject.tabs[0]
+        let tab2 = subject.tabs[1]
+        let tab3 = subject.tabs[2]
         let lastExecutedDate = Calendar.current.add(numberOfDays: 1, to: Date())
         tab1.lastExecutedTime = lastExecutedDate?.toTimestamp()
+        tab2.lastExecutedTime = 0
+        tab3.lastExecutedTime = 0
 
         let inactiveTabs = subject.getInactiveTabs()
         let expectedInactiveTabs = 2


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9182)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20343)

## :bulb: Description

I am still digging into this to understand exactly what is happening (and why this only seems to repro with the tab tray refactor enabled). What I can see so far is:

1. When our `Tab`s are first created, by default the `lastExecutedTime` is nil
2. Tabs created by the contextual menu are opened but not selected which means their `lastExecutedTime` is not updated from this default nil value (normally the `lastExecutedTime` is set as part of `selectTab()`)
3. When a tab is persisted we check for nil values for the created/executed timestamps and default to a value of 0 in `TabManagerImplementation.generateTabDataForSaving()` 
4. When tabs are restored, the default 0 value results in an effective date of `distantPast` (or more accurately 0 ms since 1970)
5. When we are sorting tabs into Inactive Tabs, we follow the logic of `tab.lastExecutedTime ?? tab.firstCreatedTime ?? 0`, so the last executed time takes priority, but if it is nil we fall back to the `firstCreatedTime`, and finally if that is nil we default to a distant past date

I tested the fix here to ensure it did not impact existing functionality with Inactive Tabs, I couldn't see any issues with the Inactive Tabs being sorted with this change in place. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

