### PR TITLE
Bugfix MTE-2769 Drag and Drop Test

### DIFF
--- a/focus-ios/focus-ios-tests/XCUITest/DragAndDropTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/DragAndDropTest.swift
@@ -7,6 +7,7 @@ import XCTest
 class DragAndDropTest: BaseTestCase {
     let websiteWithSearchField = ["url": "https://developer.mozilla.org/en-US/", "urlSearchField": "Search MDN"]
 
+    // https://testrail.stage.mozaws.net/index.php?/cases/view/2609718
     func testDragElement() {
         let urlBarTextField = app.textFields["URLBar.urlText"]
         loadWebPage(websiteWithSearchField["url"]!)

--- a/focus-ios/focus-ios-tests/XCUITest/DragAndDropTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/DragAndDropTest.swift
@@ -5,20 +5,18 @@
 import XCTest
 
 class DragAndDropTest: BaseTestCase {
-    let websiteWithSearchField = ["url": "https://developer.mozilla.org/en-US/search", "urlSearchField": "Site search..."]
+    let websiteWithSearchField = ["url": "https://developer.mozilla.org/en-US/", "urlSearchField": "Search MDN"]
 
-    func testDragElement() throws {
-        throw XCTSkip("The drag and dop opens the split view instead")
-        if iPad() {
-            let urlBarTextField = app.textFields["URLBar.urlText"]
-            loadWebPage("developer.mozilla.org/en-US/search")
+    func testDragElement() {
+        let urlBarTextField = app.textFields["URLBar.urlText"]
+        loadWebPage(websiteWithSearchField["url"]!)
+        waitForWebPageLoad()
 
-            // Check the text in the search field before dragging and dropping the url text field
-            XCTAssertEqual(app.webViews.searchFields[websiteWithSearchField["urlSearchField"]!].placeholderValue, "Site search...")
-            // DragAndDrop the url for only one second so that the TP menu is not shown and the search box is not covered
-            urlBarTextField.press(forDuration: 1, thenDragTo: app.webViews.searchFields[websiteWithSearchField["urlSearchField"]!])
-            // Verify that the text in the search field is the same as the text in the url text field
-            XCTAssertEqual(app.webViews.searchFields[websiteWithSearchField["urlSearchField"]!].value as? String, websiteWithSearchField["url"]!)
-        }
+        // Check the text in the search field before dragging and dropping the url text field
+        waitForExistence(app.webViews.textFields[websiteWithSearchField["urlSearchField"]!])
+        // DragAndDrop the url for only one second so that the TP menu is not shown and the search box is not covered
+        urlBarTextField.firstMatch.press(forDuration: 1, thenDragTo: app.webViews.otherElements["search"].firstMatch)
+        // Verify that the text in the search field is the same as the text in the url text field
+        XCTAssertEqual(app.webViews.textFields[websiteWithSearchField["urlSearchField"]!].firstMatch.value as? String, websiteWithSearchField["url"]!)
     }
 }

--- a/focus-ios/focus-ios-tests/XCUITest/PageActionMenuTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/PageActionMenuTest.swift
@@ -5,7 +5,6 @@
 import XCTest
 
 class PageActionMenuTest: BaseTestCase {
-
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2587660
     func testFindInPageURLBarElement() {
         // Navigate to website
@@ -32,7 +31,7 @@ class PageActionMenuTest: BaseTestCase {
         // Ensure find in page bar is dismissed
         waitForNoExistence(app.buttons["FindInPage.close"])
     }
-    
+
     // Smoketest
     // https://testrail.stage.mozaws.net/index.php?/cases/view/395022
     func testActivityMenuFindInPageAction() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2679)

## :bulb: Description
I have re-enabled and fixed `DragAndDropTest`. A TestRail test is created.

Note that this test now works with both iPhone and iPad. I have run this test repeatedly (20 times) to ensure that the test passes consistently.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

