### PR TITLE
Refactor FXIOS-9114 Update tab button to display number of tabs

### DIFF
--- a/BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift
+++ b/BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift
@@ -19,8 +19,8 @@ public struct StandardImageIdentifiers {
     // Icon size 20x20
     public struct Medium {
         public static let bookmarkBadgeFillBlue50 = "bookmarkBadgeFillMediumBlue50"
-        public static let crossCircleFill = "crossCircleFillMedium"
         public static let cross = "crossMedium"
+        public static let crossCircleFill = "crossCircleFillMedium"
         public static let lock = "lockMedium"
         public static let nightMode = "nightModeMedium"
         public static let privateModeCircleFillPurple = "privateModeCircleFillMediumPurple"

--- a/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
@@ -54,6 +54,7 @@ final class TabNumberButton: ToolbarButton {
         let count = max(count, 1)
         let countToBe = (count <= UX.maxTabCount) ? count.description : UX.infinitySymbol
         countLabel.text = countToBe
+        accessibilityValue = countToBe
     }
 
     // MARK: - Layout

--- a/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
@@ -43,7 +43,14 @@ final class TabNumberButton: ToolbarButton {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func updateTabCount(_ count: Int) {
+    public override func configure(element: ToolbarElement) {
+        super.configure(element: element)
+
+        guard let numberOfTabs = element.numberOfTabs else { return }
+        updateTabCount(numberOfTabs)
+    }
+
+    private func updateTabCount(_ count: Int) {
         let count = max(count, 1)
         let countToBe = (count <= UX.maxTabCount) ? count.description : UX.infinitySymbol
         countLabel.text = countToBe

--- a/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
@@ -43,7 +43,7 @@ final class TabNumberButton: ToolbarButton {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func configure(element: ToolbarElement) {
+    override public func configure(element: ToolbarElement) {
         super.configure(element: element)
 
         guard let numberOfTabs = element.numberOfTabs else { return }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -236,7 +236,8 @@ struct BrowserViewControllerState: ScreenState, Equatable {
     static func reduceStateForToolbarAction(action: ToolbarAction,
                                             state: BrowserViewControllerState) -> BrowserViewControllerState {
         switch action.actionType {
-        case ToolbarActionType.didLoadToolbars:
+        case ToolbarActionType.didLoadToolbars,
+            ToolbarActionType.numberOfTabsChanged:
             return BrowserViewControllerState(
                 searchScreenState: state.searchScreenState,
                 showDataClearanceFlow: state.showDataClearanceFlow,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -372,6 +372,7 @@ class BrowserViewController: UIViewController,
 
         if isToolbarRefactorEnabled {
             navigationToolbarContainer.applyTheme(theme: currentTheme())
+            updateTabCountUsingTabManager(self.tabManager)
         } else {
             urlBar.topTabsIsShowing = showTopTabs
             urlBar.setShowToolbar(!showToolbar)
@@ -3064,7 +3065,12 @@ extension BrowserViewController: TabManagerDelegate {
     func updateTabCountUsingTabManager(_ tabManager: TabManager, animated: Bool = true) {
         if let selectedTab = tabManager.selectedTab {
             let count = selectedTab.isPrivate ? tabManager.privateTabs.count : tabManager.normalTabs.count
-            if !isToolbarRefactorEnabled {
+            if isToolbarRefactorEnabled {
+                let action = ToolbarAction(numberOfTabs: count,
+                                           windowUUID: windowUUID,
+                                           actionType: ToolbarActionType.numberOfTabsChanged)
+                store.dispatch(action)
+            } else {
                 toolbar.updateTabCount(count, animated: animated)
                 urlBar.updateTabCount(count, animated: !urlBar.inOverlayMode)
             }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/NavigationToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/NavigationToolbarContainerModel.swift
@@ -19,6 +19,7 @@ struct NavigationToolbarContainerModel {
         self.actions = state.navigationToolbar.actions.map { action in
             ToolbarElement(
                 iconName: action.iconName,
+                numberOfTabs: action.numberOfTabs,
                 isEnabled: action.isEnabled,
                 a11yLabel: action.a11yLabel,
                 a11yId: action.a11yId,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -9,19 +9,23 @@ import ToolbarKit
 class ToolbarAction: Action {
     let addressToolbarModel: AddressToolbarModel?
     let navigationToolbarModel: NavigationToolbarModel?
+    let numberOfTabs: Int?
 
     init(addressToolbarModel: AddressToolbarModel? = nil,
          navigationToolbarModel: NavigationToolbarModel? = nil,
+         numberOfTabs: Int? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
         self.addressToolbarModel = addressToolbarModel
         self.navigationToolbarModel = navigationToolbarModel
+        self.numberOfTabs = numberOfTabs
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 
 enum ToolbarActionType: ActionType {
     case didLoadToolbars
+    case numberOfTabsChanged
 }
 
 class ToolbarMiddlewareAction: Action {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -116,7 +116,8 @@ class ToolbarMiddleware: FeatureFlaggable {
                                                  a11yLabel: .TabToolbarHomeAccessibilityLabel,
                                                  a11yId: AccessibilityIdentifiers.Toolbar.homeButton))
         elements.append(ToolbarState.ActionState(actionType: .tabs,
-                                                 iconName: StandardImageIdentifiers.Large.tabTray, // correct image
+                                                 iconName: StandardImageIdentifiers.Large.tab,
+                                                 numberOfTabs: 1,
                                                  isEnabled: true,
                                                  a11yLabel: .TabsButtonShowTabsAccessibilityLabel,
                                                  a11yId: AccessibilityIdentifiers.Toolbar.tabsButton))

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -37,6 +37,7 @@ struct ToolbarState: ScreenState, Equatable {
 
         var actionType: ActionType
         var iconName: String
+        var numberOfTabs: Int?
         var isEnabled: Bool
         var a11yLabel: String
         var a11yId: String
@@ -103,6 +104,20 @@ struct ToolbarState: ScreenState, Equatable {
 
             state.navigationToolbar.actions = navToolbarModel.actions
             state.navigationToolbar.displayBorder = navToolbarModel.displayBorder
+            return state
+
+        case ToolbarActionType.numberOfTabsChanged:
+            guard let numberOfTabs = action.numberOfTabs else { return state }
+            var state = state
+
+            if let index = state.navigationToolbar.actions.firstIndex(where: { $0.actionType == .tabs }) {
+                state.navigationToolbar.actions[index].numberOfTabs = numberOfTabs
+            }
+
+            if let index = state.addressToolbar.browserActions.firstIndex(where: { $0.actionType == .tabs }) {
+                state.addressToolbar.browserActions[index].numberOfTabs = numberOfTabs
+            }
+
             return state
 
         default:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9114)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20217)

## :bulb: Description
Displays the number of tabs in the navigation toolbar and updates it when the number of tabs changes.
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-23 at 13 36 49](https://github.com/mozilla-mobile/firefox-ios/assets/4530/879cfd59-2ebb-404a-842e-f97b76b67d3b)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

