### PR TITLE
Bugfix FXIOS-8024 ⁃ Crash on closing last tab on Firefox iOS

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -518,6 +518,7 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
     }
 
     func numberOfSections(in collectionView: UICollectionView) -> Int {
+        if viewModel.shouldReloadView { reloadView() }
         return viewModel.shownSections.count
     }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -73,6 +73,12 @@ class HomepageViewModel: FeatureFlaggable {
         }
     }
 
+    // Note: Should reload the view when have inconsistency between childViewModels count
+    // and shownSections count in order to avoid a crash
+    var shouldReloadView: Bool {
+        return childViewModels.filter({ $0.shouldShow }).count != shownSections.count
+    }
+
     var theme: Theme {
         didSet {
             childViewModels.forEach { $0.setTheme(theme: theme) }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8024)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17900)

## :bulb: Description
We should reload the view when we have inconsistency between the childViewModels and number of sections that are shown.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

