### PR TITLE
Bugfix FXIOS-9047 ⁃ Opening new site from QR code shows previous homepage ~1s before loading the new site

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/QRCodeViewController.swift
@@ -330,16 +330,9 @@ extension QRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
                 accessibilityIdentifier: AccessibilityIdentifiers.Settings.FirefoxAccount.qrScanFailedAlertOkButton)
             present(alert, animated: true, completion: nil)
         } else {
-            captureSession.stopRunning()
-            stopScanLineAnimation()
-            dismissController {
-                guard let metaData = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
-                      let qrCodeDelegate = self.qrCodeDelegate,
-                      let text = metaData.stringValue
-                else {
-                    return
-                }
-
+            if let metaData = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+               let qrCodeDelegate = self.qrCodeDelegate,
+               let text = metaData.stringValue {
                 // Open QR codes only when they are recognized as webpages, otherwise open as text
                 if let url = URIFixup.getURL(text), url.isWebPage() {
                     qrCodeDelegate.didScanQRCodeWithURL(url)
@@ -347,6 +340,9 @@ extension QRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
                     qrCodeDelegate.didScanQRCodeWithText(text)
                 }
             }
+            captureSession.stopRunning()
+            stopScanLineAnimation()
+            dismissController()
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9047)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19996)

## :bulb: Description
Improve the UX by starting to load the scanned QR page before dismissing camera controller.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

