### PR TITLE
Remove FXIOS-9059 [Microsurvey] unused Redux code

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
@@ -7,17 +7,7 @@ import Redux
 import Common
 
 class MicrosurveyPromptAction: Action { }
-
-class MicrosurveyPromptMiddlewareAction: Action {
-    let microsurveyState: MicrosurveyPromptState?
-
-    init(microsurveyState: MicrosurveyPromptState? = nil,
-         windowUUID: WindowUUID,
-         actionType: ActionType) {
-        self.microsurveyState = microsurveyState
-        super.init(windowUUID: windowUUID, actionType: actionType)
-    }
-}
+class MicrosurveyPromptMiddlewareAction: Action { }
 
 enum MicrosurveyPromptActionType: ActionType {
     case showPrompt

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
@@ -6,17 +6,7 @@ import Foundation
 import Redux
 
 class MicrosurveyAction: Action { }
-
-class MicrosurveyMiddlewareAction: Action {
-    let microsurveyState: MicrosurveyPromptState?
-
-    init(microsurveyState: MicrosurveyPromptState? = nil,
-         windowUUID: UUID,
-         actionType: ActionType) {
-        self.microsurveyState = microsurveyState
-        super.init(windowUUID: windowUUID, actionType: actionType)
-    }
-}
+class MicrosurveyMiddlewareAction: Action { }
 
 enum MicrosurveyActionType: ActionType {
     case closeSurvey


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9059)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20054)

## :bulb: Description
Remove unused / old code. This was code was there prior in case we needed to add additional properties to the action, but it turns out that we can use the super class init instead. I missed this in the previous PRs, so removing here.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

