### PR TITLE
Add FXIOS-6009 - Saving Animated GIFs To Photos Album

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -7,6 +7,7 @@ import Common
 import WebKit
 import Shared
 import UIKit
+import Photos
 
 // MARK: - WKUIDelegate
 extension BrowserViewController: WKUIDelegate {
@@ -350,8 +351,15 @@ extension BrowserViewController: WKUIDelegate {
                             identifier: UIAction.Identifier("linkContextMenu.saveImage")
                         ) { _ in
                             getImageData(url) { data in
-                                guard let image = UIImage(data: data) else { return }
-                                self.writeToPhotoAlbum(image: image)
+                                if url.pathExtension.lowercased() == "gif" {
+                                    PHPhotoLibrary.shared().performChanges {
+                                        let creationRequest = PHAssetCreationRequest.forAsset()
+                                        creationRequest.addResource(with: .photo, data: data, options: nil)
+                                    }
+                                } else {
+                                    guard let image = UIImage(data: data) else { return }
+                                    self.writeToPhotoAlbum(image: image)
+                                }
                             }
                         })
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6009)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/13646)

## :bulb: Description
If image file has extension "gif", image will be saved to photos album with `PHPhotoLibrary` instead of `UIImageWriteToSavedPhotosAlbum`.  `PHPhotoLibrary` preserves the image metadata and GIF animation.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)