### PR TITLE
Bugfix FXIOS-9174 [Multi-window] Additional theming fixes

### DIFF
--- a/BrowserKit/Sources/Common/Theming/Themeable.swift
+++ b/BrowserKit/Sources/Common/Theming/Themeable.swift
@@ -32,14 +32,14 @@ extension Themeable {
         themeObserver = notificationCenter.addObserver(name: .ThemeDidChange,
                                                        queue: mainQueue) { [weak self] _ in
             self?.applyTheme()
-            self?.updateThemeApplicableSubviews(subview)
+            self?.updateThemeApplicableSubviews(subview, for: self?.currentWindowUUID)
         }
     }
 
-    public func updateThemeApplicableSubviews(_ view: UIView) {
-        guard let window = (view as? ThemeUUIDIdentifiable)?.currentWindowUUID else { return }
-        assert(window != .unavailable, "Theme applicable view has `unavailable` window UUID. Unexpected.")
-        let theme = themeManager.currentTheme(for: window)
+    public func updateThemeApplicableSubviews(_ view: UIView, for window: WindowUUID?) {
+        guard let uuid = (view as? ThemeUUIDIdentifiable)?.currentWindowUUID ?? window else { return }
+        assert(uuid != .unavailable, "Theme applicable view has `unavailable` window UUID. Unexpected.")
+        let theme = themeManager.currentTheme(for: uuid)
         let themeViews = getAllSubviews(for: view, ofType: ThemeApplicable.self)
         themeViews.forEach { $0.applyTheme(theme: theme) }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9174)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20332)

## :bulb: Description

Fixes some additional potential bugs with automatic theme updates for some views that do not have a `currentWindowUUID` at the time of theme change. This simply allows us to default to the parent `Themeable`, typically a view controller, almost all of which have the window UUID injected.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

