### PR TITLE
Bugfix FXIOS-9159 - Fix Firefox Suggest operations to avoid blocking.

### DIFF
--- a/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
@@ -72,6 +72,12 @@ class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol, FeatureF
     private func setUp() {
         guard featureFlags.isFeatureEnabled(.firefoxSuggestFeature, checking: .buildAndUser) else { return }
         BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.taskIdentifier, using: nil) { task in
+            task.expirationHandler = {
+                // Interrupt all ongoing storage operations if our
+                // background time is about to expire.
+                self.firefoxSuggest.interruptEverything()
+                task.setTaskCompleted(success: false)
+            }
             Task {
                 let success = await self.ingest()
                 if !success {

--- a/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
@@ -13,11 +13,11 @@ import Storage
 class BackgroundFirefoxSuggestIngestUtility: BackgroundUtilityProtocol, FeatureFlaggable {
     static let taskIdentifier = "org.mozilla.ios.firefox.suggest.ingest"
 
-    let firefoxSuggest: RustFirefoxSuggestActor
+    let firefoxSuggest: RustFirefoxSuggestProtocol
     let logger: Logger
     private var didRegisterTaskHandler = false
 
-    init(firefoxSuggest: RustFirefoxSuggestActor, logger: Logger = DefaultLogger.shared) {
+    init(firefoxSuggest: RustFirefoxSuggestProtocol, logger: Logger = DefaultLogger.shared) {
         self.firefoxSuggest = firefoxSuggest
         self.logger = logger
 

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -82,7 +82,7 @@ protocol Profile: AnyObject {
     var files: FileAccessor { get }
     var pinnedSites: PinnedSites { get }
     var logins: RustLogins { get }
-    var firefoxSuggest: RustFirefoxSuggestActor? { get }
+    var firefoxSuggest: RustFirefoxSuggestProtocol? { get }
     var certStore: CertStore { get }
     var recentlyClosedTabs: ClosedTabsStore { get }
 
@@ -615,7 +615,7 @@ open class BrowserProfile: Profile {
         return RustLogins(databasePath: databasePath)
     }()
 
-    lazy var firefoxSuggest: RustFirefoxSuggestActor? = {
+    lazy var firefoxSuggest: RustFirefoxSuggestProtocol? = {
         do {
             let cacheFileURL = try FileManager.default.url(
                 for: .cachesDirectory,

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -5,7 +5,7 @@
 import Foundation
 import MozillaAppServices
 
-public protocol RustFirefoxSuggestActor: Actor {
+public protocol RustFirefoxSuggestProtocol {
     /// Downloads and stores new Firefox Suggest suggestions.
     func ingest() async throws
 
@@ -17,15 +17,15 @@ public protocol RustFirefoxSuggestActor: Actor {
     ) async throws -> [RustFirefoxSuggestion]
 
     /// Interrupts any ongoing queries for suggestions.
-    nonisolated func interruptReader()
+    func interruptReader()
 
     /// Interrupts all ongoing operations.
-    nonisolated func interruptEverything()
+    func interruptEverything()
 }
 
-/// An actor that wraps the synchronous Rust `SuggestStore` binding to execute
+/// Wraps the synchronous Rust `SuggestStore` binding to execute
 /// blocking operations on a dispatch queue.
-public actor RustFirefoxSuggest: RustFirefoxSuggestActor {
+public class RustFirefoxSuggest: RustFirefoxSuggestProtocol {
     private let store: SuggestStore
 
     // Using a pair of serial queues lets read and write operations run
@@ -83,11 +83,11 @@ public actor RustFirefoxSuggest: RustFirefoxSuggestActor {
         }
     }
 
-    public nonisolated func interruptReader() {
+    public func interruptReader() {
         store.interrupt()
     }
 
-    public nonisolated func interruptEverything() {
+    public func interruptEverything() {
         store.interrupt(kind: .readWrite)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
@@ -108,14 +108,14 @@ open class MockProfile: Client.Profile {
 
     public var files: FileAccessor
     public var syncManager: ClientSyncManager!
-    public var firefoxSuggest: RustFirefoxSuggestActor?
+    public var firefoxSuggest: RustFirefoxSuggestProtocol?
 
     fileprivate let name: String = "mockaccount"
 
     private let directory: String
     private let databasePrefix: String
 
-    init(databasePrefix: String = "mock", firefoxSuggest: RustFirefoxSuggestActor? = nil) {
+    init(databasePrefix: String = "mock", firefoxSuggest: RustFirefoxSuggestProtocol? = nil) {
         files = MockFiles()
         syncManager = ClientSyncManagerSpy()
         self.databasePrefix = databasePrefix

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
@@ -9,7 +9,7 @@ import Shared
 
 @testable import Client
 
-actor MockRustFirefoxSuggest: RustFirefoxSuggestActor {
+class MockRustFirefoxSuggest: RustFirefoxSuggestProtocol {
     func ingest() async throws {
     }
     func query(
@@ -36,9 +36,9 @@ actor MockRustFirefoxSuggest: RustFirefoxSuggestActor {
         }
         return suggestions
     }
-    nonisolated func interruptReader() {
+    func interruptReader() {
     }
-    nonisolated func interruptEverything() {
+    func interruptEverything() {
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
@@ -38,6 +38,8 @@ actor MockRustFirefoxSuggest: RustFirefoxSuggestActor {
     }
     nonisolated func interruptReader() {
     }
+    nonisolated func interruptEverything() {
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9159)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20289)

## :bulb: Description

This commit:

* Refactors `RustFirefoxSuggest` to use a pair of serial dispatch queues to execute blocking read and write operations on the underlying `SuggestStore`. Previously, these operations would block, because calling a blocking function from an actor method (whether isolated or not) does _not_ automatically execute that function on a "global concurrent executor"; it can starve the calling thread.
* Adopts the new `SuggestStore.interrupt(kind:)` API to implement `RustFirefoxSuggest.interruptEverything()`, which interrupts all ongoing operations.
* Adds an expiration handler for the background ingestion task that calls `interruptEverything()`.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

