### PR TITLE
Add FXIOS-8990 [Microsurvey] Mobile messaging surface manager

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -690,6 +690,11 @@
 		8A471185287F6E4800F5A6EA /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */; };
 		8A4AC0EB28C929D700439F83 /* URLSessionDataTaskProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4AC0E928C929D700439F83 /* URLSessionDataTaskProtocol.swift */; };
 		8A4AC0EC28C929D700439F83 /* URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4AC0EA28C929D700439F83 /* URLSessionProtocol.swift */; };
+		8A4EA0D12C010BE700E4E4F1 /* MicrosurveySurfaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4EA0D02C010BE700E4E4F1 /* MicrosurveySurfaceManager.swift */; };
+		8A4EA0D42C01100200E4E4F1 /* MicrosurveySurfaceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4EA0D22C010BF800E4E4F1 /* MicrosurveySurfaceManagerTests.swift */; };
+		8A4EA0D92C01127C00E4E4F1 /* MicrosurveyMockModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4EA0D72C01125100E4E4F1 /* MicrosurveyMockModel.swift */; };
+		8A4EA0DB2C0117CD00E4E4F1 /* MobileMessageSurfaceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4EA0DA2C0117CD00E4E4F1 /* MobileMessageSurfaceProtocol.swift */; };
+		8A4EA0DD2C0117F200E4E4F1 /* MicrosurveyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4EA0DC2C0117F200E4E4F1 /* MicrosurveyModel.swift */; };
 		8A5038142A5DFCE000A1B02A /* MockBrowserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5038132A5DFCE000A1B02A /* MockBrowserProfile.swift */; };
 		8A55E8042BFBA9BE006DBD85 /* MicrosurveyCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E5F3D2BFBA49400DE052B /* MicrosurveyCoordinatorTests.swift */; };
 		8A5604F629DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */; };
@@ -5966,6 +5971,11 @@
 		8A471184287F6E4800F5A6EA /* SeparatorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorTableViewCell.swift; sourceTree = "<group>"; };
 		8A4AC0E928C929D700439F83 /* URLSessionDataTaskProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskProtocol.swift; sourceTree = "<group>"; };
 		8A4AC0EA28C929D700439F83 /* URLSessionProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionProtocol.swift; sourceTree = "<group>"; };
+		8A4EA0D02C010BE700E4E4F1 /* MicrosurveySurfaceManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicrosurveySurfaceManager.swift; sourceTree = "<group>"; };
+		8A4EA0D22C010BF800E4E4F1 /* MicrosurveySurfaceManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicrosurveySurfaceManagerTests.swift; sourceTree = "<group>"; };
+		8A4EA0D72C01125100E4E4F1 /* MicrosurveyMockModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyMockModel.swift; sourceTree = "<group>"; };
+		8A4EA0DA2C0117CD00E4E4F1 /* MobileMessageSurfaceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileMessageSurfaceProtocol.swift; sourceTree = "<group>"; };
+		8A4EA0DC2C0117F200E4E4F1 /* MicrosurveyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyModel.swift; sourceTree = "<group>"; };
 		8A5038132A5DFCE000A1B02A /* MockBrowserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBrowserProfile.swift; sourceTree = "<group>"; };
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
 		8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchCoordinatorDelegate.swift; sourceTree = "<group>"; };
@@ -9735,6 +9745,8 @@
 		8A6A3D452BD038EF00BFDB64 /* Microsurvey */ = {
 			isa = PBXGroup;
 			children = (
+				8A4EA0D02C010BE700E4E4F1 /* MicrosurveySurfaceManager.swift */,
+				8A4EA0DC2C0117F200E4E4F1 /* MicrosurveyModel.swift */,
 				8AAEB9FF2BF510E4000C02B5 /* Survey */,
 				8A1CBB932BE017BE008BE4D4 /* Prompt */,
 			);
@@ -9764,10 +9776,12 @@
 		8A8482ED2BE15FEF00F9007B /* Microsurvey */ = {
 			isa = PBXGroup;
 			children = (
+				8A4EA0D22C010BF800E4E4F1 /* MicrosurveySurfaceManagerTests.swift */,
 				8AAEB9FD2BF50718000C02B5 /* MicrosurveyViewControllerTests.swift */,
 				8A8482EE2BE15FFE00F9007B /* MicrosurveyPromptStateTests.swift */,
 				8AAEBA092BF53AB5000C02B5 /* MicrosurveyStateTests.swift */,
 				8A0E5F3D2BFBA49400DE052B /* MicrosurveyCoordinatorTests.swift */,
+				8A4EA0D72C01125100E4E4F1 /* MicrosurveyMockModel.swift */,
 			);
 			path = Microsurvey;
 			sourceTree = "<group>";
@@ -10272,6 +10286,7 @@
 				9636D92D27F9E5D900771F5E /* GleanPlumbMessage.swift */,
 				9636D92727F5D72D00771F5E /* GleanPlumbMessageManager.swift */,
 				9636D92B27F9E50100771F5E /* GleanPlumbMessageStore.swift */,
+				8A4EA0DA2C0117CD00E4E4F1 /* MobileMessageSurfaceProtocol.swift */,
 			);
 			path = Messaging;
 			sourceTree = "<group>";
@@ -13964,6 +13979,7 @@
 				8A19ACB02A329078001C2147 /* AutofillCreditCardSettings.swift in Sources */,
 				E1E5BE252A28F7BE00248F77 /* PasswordDetailViewControllerModel.swift in Sources */,
 				E1FE133129C22726002A65FF /* BackgroundFetchAndProcessingUtility.swift in Sources */,
+				8A4EA0D12C010BE700E4E4F1 /* MicrosurveySurfaceManager.swift in Sources */,
 				8AD40FD527BB1C1000672675 /* LockButton.swift in Sources */,
 				5F130D2E2483508E00B0F7D0 /* FxAWebViewModel.swift in Sources */,
 				2109478928AFD24C00B73D44 /* OnboardingViewControllerProtocol.swift in Sources */,
@@ -14309,6 +14325,7 @@
 				8A19ACAB2A32895E001C2147 /* BrowserNavigationHandler.swift in Sources */,
 				8AE80BB82891BE0700BC12EA /* JumpBackInDataAdaptor.swift in Sources */,
 				8A01891C275E9C2A00923EFE /* ClearHistorySheetProvider.swift in Sources */,
+				8A4EA0DD2C0117F200E4E4F1 /* MicrosurveyModel.swift in Sources */,
 				8C44A9D22A6A99FE009A1AA7 /* ShoppingProduct.swift in Sources */,
 				C88E7A572A0553360072E638 /* OnboardingButtonInfoModel.swift in Sources */,
 				21B548952B1E5F1400DC1DF8 /* InactiveTabsManager.swift in Sources */,
@@ -14451,6 +14468,7 @@
 				DFEA639E279F468A00D489C3 /* DynamicHeightCollectionView.swift in Sources */,
 				F8B7109E2ABE380B0029726E /* RustErrors.swift in Sources */,
 				C8124BB129D6F55400540B79 /* Route.swift in Sources */,
+				8A4EA0DB2C0117CD00E4E4F1 /* MobileMessageSurfaceProtocol.swift in Sources */,
 				63306D3921103EAE00F25400 /* LegacySavedTab.swift in Sources */,
 				2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */,
 				21996BAB2AE95AFC00E0D55F /* TabTrayPanelType.swift in Sources */,
@@ -14819,6 +14837,7 @@
 				1D7B789F2AE088930011E9F2 /* EventQueueTests.swift in Sources */,
 				21A1C3C72996AFF800181B7C /* OverlayModeManagerTests.swift in Sources */,
 				C8DF92F72A14101500AA7B05 /* OnboardingViewControllerProtocolTests.swift in Sources */,
+				8A4EA0D92C01127C00E4E4F1 /* MicrosurveyMockModel.swift in Sources */,
 				1D4D79472BF2F4FD007C6796 /* Throttler.swift in Sources */,
 				6A3E5D8A283831D1001E706E /* DownloadQueueTests.swift in Sources */,
 				8AE80BB62891AEA100BC12EA /* MockDispatchGroup.swift in Sources */,
@@ -15032,6 +15051,7 @@
 				C8699152289177F5007ACC5C /* WallpaperNetworkingTests.swift in Sources */,
 				C818AD452A2100BA007F30BC /* OnboardingNotificationCardHelperTests.swift in Sources */,
 				E1AEC178286E0CF500062E29 /* HomepageViewControllerTests.swift in Sources */,
+				8A4EA0D42C01100200E4E4F1 /* MicrosurveySurfaceManagerTests.swift in Sources */,
 				8ADEC6832A40F208002D2ED8 /* AppSettingsTableViewControllerTests.swift in Sources */,
 				5A475E8E29DB89C7009C13FD /* TabManagerTests.swift in Sources */,
 				C88012232A40E38D00F4D1D6 /* IntroViewControllerTests.swift in Sources */,

--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -12,6 +12,7 @@ protocol MessageDataProtocol {
     var buttonLabel: String? { get }
     var experiment: String? { get }
     var actionParams: [String: String] { get }
+    var microsurveyConfig: MicrosurveyConfig? { get }
 }
 
 extension MessageData: MessageDataProtocol {}
@@ -81,6 +82,13 @@ struct GleanPlumbMessage {
     /// Embedding apps should not read from this directly.
     var surface: MessageSurfaceId {
         data.surface
+    }
+
+    /// The survey options for this message if it has a microsurvey configuration.
+    ///
+    /// Embedding apps should not read from this directly.
+    var options: [String] {
+        data.microsurveyConfig?.options ?? []
     }
 }
 

--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -85,7 +85,6 @@ struct GleanPlumbMessage {
     }
 
     /// The survey options for this message if it has a microsurvey configuration.
-    ///
     /// Embedding apps should not read from this directly.
     var options: [String] {
         return data.microsurveyConfig?.options ?? []

--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -88,7 +88,7 @@ struct GleanPlumbMessage {
     ///
     /// Embedding apps should not read from this directly.
     var options: [String] {
-        data.microsurveyConfig?.options ?? []
+        return data.microsurveyConfig?.options ?? []
     }
 }
 

--- a/firefox-ios/Client/Experiments/Messaging/MobileMessageSurfaceProtocol.swift
+++ b/firefox-ios/Client/Experiments/Messaging/MobileMessageSurfaceProtocol.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+protocol MobileMessageSurfaceProtocol {
+    func handleMessageDisplayed()
+    func handleMessagePressed()
+    func handleMessageDismiss()
+}

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1260,11 +1260,6 @@ class BrowserViewController: UIViewController,
     private func setupMicrosurvey() {
         guard featureFlags.isFeatureEnabled(.microsurvey, checking: .buildOnly) else { return }
 
-        // TODO: FXIOS-8990: Create Microsurvey Surface Manager to handle showing survey prompt
-        if microsurvey != nil {
-            removeMicrosurveyPrompt()
-        }
-
         store.dispatch(
             MicrosurveyPromptAction(windowUUID: windowUUID, actionType: MicrosurveyPromptActionType.showPrompt)
         )

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyModel.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyModel.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct MicrosurveyModel: Equatable {
+    let promptTitle: String
+    let promptButtonLabel: String
+    let surveyQuestion: String
+    let surveyOptions: [String]
+}

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+class MicrosurveySurfaceManager: MobileMessageSurfaceProtocol {
+    private var message: GleanPlumbMessage?
+    private var messagingManager: GleanPlumbMessageManagerProtocol
+
+    private let defaultSurveyOptions: [String] = [
+        .Microsurvey.Survey.Options.LikertScaleOption1,
+        .Microsurvey.Survey.Options.LikertScaleOption2,
+        .Microsurvey.Survey.Options.LikertScaleOption3,
+        .Microsurvey.Survey.Options.LikertScaleOption4,
+        .Microsurvey.Survey.Options.LikertScaleOption5
+    ]
+
+    init(
+        messagingManager: GleanPlumbMessageManagerProtocol = Experiments.messaging
+    ) {
+        self.messagingManager = messagingManager
+    }
+
+    // MARK: - Functionality
+    /// Checks whether a message exists, and is not expired, and attempts to
+    /// build a `MicrosurveyPromptView` to be presented.
+    func showMicrosurveyPrompt() -> MicrosurveyModel? {
+        retrieveMessage()
+        guard let surveyQuestion = message?.text else {
+            return nil
+        }
+
+        let promptTitle = message?.title ?? String(
+            format: .Microsurvey.Prompt.TitleLabel,
+            AppName.shortName.rawValue
+        )
+        let promptButtonLabel = message?.buttonLabel ?? .Microsurvey.Prompt.TakeSurveyButton
+        let options: [String] = message?.options ?? defaultSurveyOptions
+
+        return MicrosurveyModel(
+            promptTitle: promptTitle,
+            promptButtonLabel: promptButtonLabel,
+            surveyQuestion: surveyQuestion,
+            surveyOptions: options
+        )
+    }
+
+    private func retrieveMessage() {
+        message = messagingManager.getNextMessage(for: .microsurvey)
+    }
+
+    // MARK: - MobileMessageSurfaceProtocol
+    func handleMessageDisplayed() {
+        message.map(messagingManager.onMessageDisplayed)
+    }
+
+    func handleMessagePressed() {
+        // TODO: FXIOS-8797: Add telemetry to capture user responses
+        message.map(messagingManager.onMessagePressed)
+    }
+
+    func handleMessageDismiss() {
+        message.map(messagingManager.onMessageDismissed)
+    }
+}

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
@@ -28,12 +28,10 @@ class MicrosurveySurfaceManager: MobileMessageSurfaceProtocol {
     /// build a `MicrosurveyPromptView` to be presented.
     func showMicrosurveyPrompt() -> MicrosurveyModel? {
         retrieveMessage()
-        guard let surveyQuestion = message?.text else {
-            return nil
-        }
+        guard let surveyQuestion = message?.text else { return nil }
 
-        let promptTitle = message?.title ?? String(
-            format: .Microsurvey.Prompt.TitleLabel,
+        let promptTitle = String(
+            format: message?.title ?? .Microsurvey.Prompt.TitleLabel,
             AppName.shortName.rawValue
         )
         let promptButtonLabel = message?.buttonLabel ?? .Microsurvey.Prompt.TakeSurveyButton

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
@@ -27,7 +27,7 @@ class MicrosurveyPromptMiddleware {
 
     private func checkIfMicrosurveyShouldShow(windowUUID: WindowUUID) {
         if let model = self.microsurveySurfaceManager.showMicrosurveyPrompt() {
-            self.initializeMicrosurvey(windowUUID: windowUUID, model: model)
+            initializeMicrosurvey(windowUUID: windowUUID, model: model)
         } else {
             return
         }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
@@ -8,11 +8,14 @@ import Shared
 import Common
 
 class MicrosurveyPromptMiddleware {
+    let microsurveySurfaceManager = MicrosurveySurfaceManager()
+
     lazy var microsurveyProvider: Middleware<AppState> = { state, action in
         let windowUUID = action.windowUUID
+
         switch action.actionType {
         case MicrosurveyPromptActionType.showPrompt:
-            self.initializeMicrosurvey(windowUUID: windowUUID)
+            self.checkIfMicrosurveyShouldShow(windowUUID: windowUUID)
         case MicrosurveyPromptActionType.closePrompt:
             self.dismissPrompt(windowUUID: windowUUID)
         case MicrosurveyPromptActionType.continueToSurvey:
@@ -22,12 +25,21 @@ class MicrosurveyPromptMiddleware {
         }
     }
 
-    private func initializeMicrosurvey(windowUUID: WindowUUID) {
+    private func checkIfMicrosurveyShouldShow(windowUUID: WindowUUID) {
+        if let model = self.microsurveySurfaceManager.showMicrosurveyPrompt() {
+            self.initializeMicrosurvey(windowUUID: windowUUID, model: model)
+        } else {
+            return
+        }
+    }
+
+    private func initializeMicrosurvey(windowUUID: WindowUUID, model: MicrosurveyModel) {
         let newAction = MicrosurveyPromptMiddlewareAction(
             windowUUID: windowUUID,
-            actionType: MicrosurveyPromptMiddlewareActionType.initialize(MicrosurveyModel())
+            actionType: MicrosurveyPromptMiddlewareActionType.initialize(model)
         )
         store.dispatch(newAction)
+        microsurveySurfaceManager.handleMessageDisplayed()
     }
 
     private func dismissPrompt(windowUUID: WindowUUID) {
@@ -36,6 +48,7 @@ class MicrosurveyPromptMiddleware {
             actionType: MicrosurveyPromptMiddlewareActionType.dismissPrompt
         )
         store.dispatch(newAction)
+        microsurveySurfaceManager.handleMessageDismiss()
     }
 
     private func openSurvey(windowUUID: WindowUUID) {
@@ -45,21 +58,4 @@ class MicrosurveyPromptMiddleware {
         )
         store.dispatch(newAction)
     }
-}
-
-struct MicrosurveyModel: Equatable {
-    // TODO: FXIOS-8990 - Mobile Messaging Structure
-    let promptTitle = String(
-        format: .Microsurvey.Prompt.TitleLabel,
-        AppName.shortName.rawValue
-    )
-    let promptButtonLabel: String = .Microsurvey.Prompt.TakeSurveyButton
-    let surveyQuestion = "How satisfied are you with your Firefox homepage?"
-    let surveyOptions: [String] = [
-        .Microsurvey.Survey.Options.LikertScaleOption1,
-        .Microsurvey.Survey.Options.LikertScaleOption2,
-        .Microsurvey.Survey.Options.LikertScaleOption3,
-        .Microsurvey.Survey.Options.LikertScaleOption4,
-        .Microsurvey.Survey.Options.LikertScaleOption5
-    ]
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -991,7 +991,7 @@ final class BrowserCoordinatorTests: XCTestCase {
     func testShowMicrosurvey_addsMicrosurveyCoordinator() {
         let subject = createSubject()
 
-        subject.showMicrosurvey(model: MicrosurveyModel())
+        subject.showMicrosurvey(model: MicrosurveyMock.model)
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertTrue(subject.childCoordinators.first is MicrosurveyCoordinator)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
@@ -171,6 +171,7 @@ class MockMessageDataProtocol: MessageDataProtocol {
     var buttonLabel: String?
     var experiment: String?
     var actionParams: [String: String] = [:]
+    var microsurveyConfig: MicrosurveyConfig?
 }
 
 // MARK: - MockStyleDataProtocol

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageStoreTests.swift
@@ -76,6 +76,7 @@ class MockMessageData: MessageDataProtocol {
     var buttonLabel: String?
     var experiment: String?
     var actionParams: [String: String]
+    var microsurveyConfig: MicrosurveyConfig?
 
     init(
         surface: MessageSurfaceId = .newTabCard,
@@ -83,7 +84,8 @@ class MockMessageData: MessageDataProtocol {
         title: String? = "Title",
         text: String = "text",
         buttonLabel: String? = "Tap",
-        actionParams: [String: String] = [:]
+        actionParams: [String: String] = [:],
+        microsurveyConfig: MicrosurveyConfig? = nil
     ) {
         self.surface = surface
         self.isControl = isControl
@@ -91,6 +93,7 @@ class MockMessageData: MessageDataProtocol {
         self.text = text
         self.buttonLabel = buttonLabel
         self.actionParams = actionParams
+        self.microsurveyConfig = microsurveyConfig
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyCoordinatorTests.swift
@@ -61,7 +61,11 @@ final class MicrosurveyCoordinatorTests: XCTestCase {
 
     private func createSubject(file: StaticString = #file,
                                line: UInt = #line) -> MicrosurveyCoordinator {
-        let subject = MicrosurveyCoordinator(model: MicrosurveyModel(), router: mockRouter, tabManager: mockTabManager)
+        let subject = MicrosurveyCoordinator(
+            model: MicrosurveyMock.model,
+            router: mockRouter,
+            tabManager: mockTabManager
+        )
 
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMockModel.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMockModel.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import Client
+
+class MicrosurveyMock {
+    static var model: MicrosurveyModel {
+        return MicrosurveyModel(
+            promptTitle: "prompt title",
+            promptButtonLabel: "prompt button label",
+            surveyQuestion: "is this a survey question?",
+            surveyOptions: [
+                "yes",
+                "no"
+            ]
+        )
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
@@ -24,7 +24,7 @@ final class MicrosurveyPromptStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.showPrompt, false)
 
-        let action = getAction(for: .initialize(MicrosurveyModel()))
+        let action = getAction(for: .initialize(MicrosurveyMock.model))
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.showPrompt, true)
@@ -36,7 +36,7 @@ final class MicrosurveyPromptStateTests: XCTestCase {
             windowUUID: .XCTestDefaultUUID,
             showPrompt: true,
             showSurvey: false,
-            model: MicrosurveyModel()
+            model: MicrosurveyMock.model
         )
         let reducer = microsurveyReducer()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveySurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveySurfaceManagerTests.swift
@@ -1,0 +1,136 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+
+@testable import Client
+
+final class MicrosurveySurfaceManagerTests: XCTestCase {
+    private var messageManager: MockGleanPlumbMessageManagerProtocol!
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        messageManager = MockGleanPlumbMessageManagerProtocol()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        messageManager = nil
+        AppContainer.shared.reset()
+    }
+
+    func testNilMessage_microsurveyShouldNotShow() {
+        let subject = createSubject()
+        let model = subject.showMicrosurveyPrompt()
+        XCTAssertNil(model)
+    }
+
+    func testValidMessage_microsurveyShouldShow() {
+        let subject = createSubject()
+        messageManager.message = createMessage()
+
+        let model = subject.showMicrosurveyPrompt()
+        XCTAssertNotNil(model)
+        XCTAssertEqual(model?.promptTitle, "title label test")
+        XCTAssertEqual(model?.promptButtonLabel, "button label test")
+        XCTAssertEqual(model?.surveyQuestion, "text label test")
+        XCTAssertEqual(model?.surveyOptions, ["yes", "no"])
+    }
+
+    func testInvalidMessageSurface_microsurveyShouldNotShow() {
+        let subject = createSubject()
+        messageManager.message = createMessage(for: .newTabCard)
+        let model = subject.showMicrosurveyPrompt()
+        XCTAssertNil(model)
+    }
+
+    func testManager_noDelegatesCalled() {
+        let subject = createSubject()
+        messageManager.message = createMessage()
+        _ = subject.showMicrosurveyPrompt()
+
+        XCTAssertEqual(messageManager.onMessageDisplayedCalled, 0)
+        XCTAssertEqual(messageManager.onMessagePressedCalled, 0)
+        XCTAssertEqual(messageManager.onMessageDismissedCalled, 0)
+    }
+
+    func testManager_messageDisplayedCalled() {
+        let subject = createSubject()
+        messageManager.message = createMessage()
+        _ = subject.showMicrosurveyPrompt()
+
+        subject.handleMessageDisplayed()
+
+        XCTAssertEqual(messageManager.onMessageDisplayedCalled, 1)
+        XCTAssertEqual(messageManager.onMessagePressedCalled, 0)
+        XCTAssertEqual(messageManager.onMessageDismissedCalled, 0)
+    }
+
+    func testManager_messagePressedCalled() {
+        let subject = createSubject()
+        messageManager.message = createMessage()
+        _ = subject.showMicrosurveyPrompt()
+
+        subject.handleMessagePressed()
+
+        XCTAssertEqual(messageManager.onMessageDisplayedCalled, 0)
+        XCTAssertEqual(messageManager.onMessagePressedCalled, 1)
+        XCTAssertEqual(messageManager.onMessageDismissedCalled, 0)
+    }
+
+    func testManager_messageDimissCalled() {
+        let subject = createSubject()
+        messageManager.message = createMessage()
+        _ = subject.showMicrosurveyPrompt()
+
+        subject.handleMessageDismiss()
+
+        XCTAssertEqual(messageManager.onMessageDisplayedCalled, 0)
+        XCTAssertEqual(messageManager.onMessagePressedCalled, 0)
+        XCTAssertEqual(messageManager.onMessageDismissedCalled, 1)
+    }
+
+    private func createSubject(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> MicrosurveySurfaceManager {
+        let subject = MicrosurveySurfaceManager(messagingManager: messageManager)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+
+    private func createMessage(
+        for surface: MessageSurfaceId = .microsurvey,
+        isExpired: Bool = false
+    ) -> GleanPlumbMessage {
+        let metadata = GleanPlumbMessageMetaData(id: "",
+                                                 impressions: 0,
+                                                 dismissals: 0,
+                                                 isExpired: isExpired)
+
+        return GleanPlumbMessage(id: "12345",
+                                 data: MockMicrosurveyMessageDataProtocol(surface: surface),
+                                 action: "https://mozilla.com",
+                                 triggerIfAll: [],
+                                 exceptIfAny: [],
+                                 style: MockStyleDataProtocol(),
+                                 metadata: metadata)
+    }
+}
+
+class MockMicrosurveyMessageDataProtocol: MessageDataProtocol {
+    var surface: MessageSurfaceId
+    var isControl = true
+    var title: String? = "title label test"
+    var text: String = "text label test"
+    var buttonLabel: String? = "button label test"
+    var experiment: String?
+    var actionParams: [String: String] = [:]
+    var microsurveyConfig: MicrosurveyConfig? = MicrosurveyConfig(options: ["yes", "no"])
+
+    init(surface: MessageSurfaceId) {
+        self.surface = surface
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyViewControllerTests.swift
@@ -21,7 +21,7 @@ final class MicrosurveyViewControllerTests: XCTestCase {
     }
 
     func testMicrosurveyViewController_simpleCreation_hasNoLeaks() {
-        let microsurveyViewController = MicrosurveyViewController(model: MicrosurveyModel(), windowUUID: windowUUID)
+        let microsurveyViewController = MicrosurveyViewController(model: MicrosurveyMock.model, windowUUID: windowUUID)
         trackForMemoryLeaks(microsurveyViewController)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NotificationSurface/NotificationSurfaceManagerTests.swift
@@ -153,6 +153,7 @@ class MockNotificationMessageDataProtocol: MessageDataProtocol {
     var buttonLabel: String? = "button label test"
     var experiment: String?
     var actionParams: [String: String] = [:]
+    var microsurveyConfig: MicrosurveyConfig?
 
     init(surface: MessageSurfaceId = .notification) {
         self.surface = surface

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SurveySurface/SurveySurfaceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SurveySurface/SurveySurfaceManagerTests.swift
@@ -151,6 +151,7 @@ class MockSurveyMessageDataProtocol: MessageDataProtocol {
     var buttonLabel: String? = "button label test"
     var experiment: String?
     var actionParams: [String: String] = [:]
+    var microsurveyConfig: MicrosurveyConfig?
 
     init(surface: MessageSurfaceId = .survey) {
         self.surface = surface

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -59,12 +59,11 @@ import:
                 surface: microsurvey
                 style: MICROSURVEY
                 trigger-if-all:
-                  - NEVER
+                  - ALWAYS
                 title: Microsurvey/Microsurvey.Prompt.TitleLabel.v127
-                text: "How satisfied are you with printing in Firefox?" # Should not show this message if this is nil
-                button-label: Microsurvey/Microsurvey.Prompt.TakeSurveyButton.v127
+                text: "How satisfied are you with Firefox Homepage?" # Should not show this message if this is nil
+                button-label: Microsurvey/Microsurvey.Prompt.Button.v127
                 microsurveyConfig:
-                  target-feature: printing
                   options:
                     - Microsurvey/Microsurvey.Survey.Options.LikertScaleOption1.v127
                     - Microsurvey/Microsurvey.Survey.Options.LikertScaleOption2.v127

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -61,7 +61,7 @@ import:
                 trigger-if-all:
                   - ALWAYS
                 title: Microsurvey/Microsurvey.Prompt.TitleLabel.v127
-                text: "How satisfied are you with Firefox Homepage?" # Should not show this message if this is nil
+                text: "How satisfied are you with your Firefox homepage?" # Should not show this message if this is nil
                 button-label: Microsurvey/Microsurvey.Prompt.Button.v127
                 microsurveyConfig:
                   options:

--- a/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
@@ -191,11 +191,6 @@ objects:
     description: >
         Attributes relating to microsurvey messaging.
     fields:
-      target-feature:
-        type: MicrosurveyTargetFeature
-        description: >
-          The type of feature the microsurvey is targeted.
-        default: Unknown # Should not be defaulted
       options:
         description: The list of survey options to present to the user.
         type: List<Text>
@@ -225,12 +220,3 @@ enums:
         description: The next eligible message should be shown.
       show-none:
         description: The surface should show no message.
-
-  MicrosurveyTargetFeature:
-    description: >
-      The specific feature the microsurvey is for. This is a label that matches across both Android and iOS.
-    variants:
-      printing:
-        description: The printing feature.
-      Unknown:
-        description: No target feature set. Only used in an invalid experiment configuration.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8990)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19843)

## :bulb: Description
- Add mobile messaging infrastructure for microsurveys
- Create surface manager that determines whether to show the microsurvey based on whether a model can be retrieved
- Modified example configuration for microsurveys 
- Removed target feature enum since we will now be using behavioral targeting (will create a separate PR for this trigger)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

