### PR TITLE
Bugfix FXIOS-9033 ⁃ [intermittent] Extra space is added under the shortcuts section when switching from landscape to portrait mode

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -184,6 +184,9 @@ class HomepageViewController:
 
         wallpaperView.updateImageForOrientationChange()
 
+        // Note: Saving the newSize for using it, later, in traitCollectionDidChange
+        // because view.frame.size will provide the current size, not the newest one.
+        viewModel.newSize = size
         if UIDevice.current.userInterfaceIdiom == .pad {
             reloadOnRotation(newSize: size)
         }
@@ -196,7 +199,7 @@ class HomepageViewController:
 
         if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass
             || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {
-            reloadOnRotation(newSize: view.frame.size)
+            reloadOnRotation(newSize: viewModel.newSize ?? view.frame.size)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -88,6 +88,8 @@ class HomepageViewModel: FeatureFlaggable {
     /// Record view appeared is sent multiple times, this avoids recording telemetry multiple times for one appearance
     var viewAppeared = false
 
+    var newSize: CGSize?
+
     var shownSections = [HomepageSectionType]()
     weak var delegate: HomepageViewModelDelegate?
     private var wallpaperManager: WallpaperManager


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9033)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19949)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

