### PR TITLE
Bugfix FXIOS-9173 x.com website loading glitch after FF update

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
+++ b/firefox-ios/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
@@ -101,14 +101,22 @@ class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
         setupForTab()
     }
 
-    func setupForTab() {
+    func setupForTab(completion: (() -> Void)? = nil) {
         guard let tab = tab else { return }
         let rules = BlocklistFileName.listsForMode(strict: blockingStrengthPref == .strict)
-        ContentBlocker.shared.setupTrackingProtection(forTab: tab, isEnabled: isEnabled, rules: rules)
+        ContentBlocker.shared.setupTrackingProtection(
+            forTab: tab,
+            isEnabled: isEnabled,
+            rules: rules,
+            completion: completion
+        )
     }
 
     override func notifiedTabSetupRequired() {
-        setupForTab()
+        setupForTab(completion: { [weak self] in
+            guard let tab = self?.tab as? Tab else { return }
+            tab.reloadPage()
+        })
         if let tab = tab as? Tab {
             TabEvent.post(.didChangeContentBlocking, for: tab)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9173)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20319)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
We have racing condition in some situations where the website is loaded before the blocking rules are applied. This fix introduces a completion callback to reload the page the changes are applied.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

