### PR TITLE
Refactor FXIOS-9184 - Learn more button in Home Pocket Section to use LinkButton

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -110,7 +110,7 @@ public struct AccessibilityIdentifiers {
 
         struct Pocket {
             static let itemCell = "PocketCell"
-            static let footerLearnMoreLabel = "Pocket.footerLearnMoreLabel"
+            static let footerLearnMoreButton = "Pocket.footerLearnMoreButton"
         }
 
         struct HistoryHighlights {

--- a/firefox-ios/Client/Frontend/Home/PocketFooterView.swift
+++ b/firefox-ios/Client/Frontend/Home/PocketFooterView.swift
@@ -5,10 +5,12 @@
 import Common
 import UIKit
 import Shared
+import ComponentLibrary
 
 class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable {
     private struct UX {
         static let mainContainerSpacing: CGFloat = 8
+        static let learnMoreInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
     }
 
     private let wallpaperManager: WallpaperManager
@@ -28,13 +30,9 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
         label.adjustsFontForContentSizeCategory = true
         label.font = FXFontStyles.Regular.caption1.scaledFont()
     }
-
-    private let learnMoreLabel: UILabel = .build { label in
-        label.text = .FirefoxHomepage.Pocket.Footer.LearnMore
-        label.isUserInteractionEnabled = true
-        label.adjustsFontForContentSizeCategory = true
-        label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.Pocket.footerLearnMoreLabel
-        label.font = FXFontStyles.Regular.caption1.scaledFont()
+    
+    private lazy var learnMoreButton: LinkButton = .build { button in
+        button.addTarget(self, action: #selector(self.didTapLearnMore), for: .touchUpInside)
     }
 
     private let labelsContainer: UIStackView = .build { stackView in
@@ -62,11 +60,15 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
     }
 
     private func setupViews() {
-        let tapGesture = UITapGestureRecognizer(target: self,
-                                                action: #selector(didTapLearnMore))
-        learnMoreLabel.addGestureRecognizer(tapGesture)
-
-        [titleLabel, learnMoreLabel].forEach(labelsContainer.addArrangedSubview)
+        let learnMoreButtonViewModel = LinkButtonViewModel(
+            title: .FirefoxHomepage.Pocket.Footer.LearnMore,
+            a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.Pocket.footerLearnMoreButton,
+            font: FXFontStyles.Regular.subheadline.scaledFont(),
+            contentInsets: UX.learnMoreInsets
+        )
+        learnMoreButton.configure(viewModel: learnMoreButtonViewModel)
+        
+        [titleLabel, learnMoreButton].forEach(labelsContainer.addArrangedSubview)
         [pocketImageView, labelsContainer].forEach(mainContainer.addArrangedSubview)
 
         addSubview(mainContainer)
@@ -89,6 +91,6 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
     func applyTheme(theme: Theme) {
         let colors = theme.colors
         titleLabel.textColor = wallpaperManager.currentWallpaper.textColor
-        learnMoreLabel.textColor = colors.textAccent
+        learnMoreButton.applyTheme(theme: theme)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9184)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20345)

## :bulb: Description
Replace the Learn more button in our Home Pocket Section to use LinkButton in Component Library

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

