### PR TITLE
Refactor FXIOS-9034 Remove redundant private tab code

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -567,10 +567,6 @@ public struct AccessibilityIdentifiers {
             static let title = "showLinkPreviews"
         }
 
-        struct ClosePrivateTabs {
-            static let title = "settings.closePrivateTabs"
-        }
-
         struct SearchBar {
             static let searchBarSetting = "SearchBarSetting"
             static let topSetting = "TopSearchBar"

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -42,8 +42,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             Experiments.shared.initializeTooling(url: url)
         }
 
-        routeBuilder.configure(isPrivate: UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate),
-                               prefs: profile.prefs)
+        routeBuilder.configure(prefs: profile.prefs)
 
         let sceneCoordinator = SceneCoordinator(scene: scene)
         self.sceneCoordinator = sceneCoordinator
@@ -135,12 +134,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func handleOpenURL(_ url: URL) {
-        routeBuilder.configure(
-            isPrivate: UserDefaults.standard.bool(
-                forKey: PrefsKeys.LastSessionWasPrivate
-            ),
-            prefs: profile.prefs
-        )
+        routeBuilder.configure(prefs: profile.prefs)
 
         // Before processing the incoming URL, check if it is a widget that is opening a tab via UUID.
         // If so, we want to be sure that we select the tab in the correct iPad window.

--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -7,12 +7,9 @@ import CoreSpotlight
 import Shared
 
 final class RouteBuilder {
-    private var isPrivate = false
     private var prefs: Prefs?
 
-    func configure(isPrivate: Bool,
-                   prefs: Prefs) {
-        self.isPrivate = isPrivate
+    func configure(prefs: Prefs) {
         self.prefs = prefs
     }
 
@@ -28,7 +25,7 @@ final class RouteBuilder {
             let urlQuery = urlScanner.fullURLQueryItem()?.asURL
             // Unless the `open-url` URL specifies a `private` parameter,
             // use the last browsing mode the user was in.
-            let isPrivate = Bool(urlScanner.value(query: "private") ?? "") ?? isPrivate
+            let isPrivate = Bool(urlScanner.value(query: "private") ?? "") ?? false
 
             recordTelemetry(input: host, isPrivate: isPrivate)
 
@@ -126,7 +123,7 @@ final class RouteBuilder {
             TelemetryWrapper.gleanRecordEvent(category: .action, method: .open, object: .asDefaultBrowser)
             RatingPromptManager.isBrowserDefault = true
             // Use the last browsing mode the user was in
-            return .search(url: url, isPrivate: isPrivate, options: [.focusLocationField])
+            return .search(url: url, isPrivate: false, options: [.focusLocationField])
         } else {
             return nil
         }

--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -290,8 +290,6 @@ class LegacyTabDisplayManager: NSObject, FeatureFlaggable {
 
         isPrivate = isOn
 
-        UserDefaults.standard.set(isPrivate, forKey: PrefsKeys.LastSessionWasPrivate)
-
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .tap,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
@@ -221,7 +221,6 @@ class LegacyTabTrayViewController: UIViewController, Themeable, TabTrayControlle
         viewSetup()
         listenForThemeChange(view)
         applyTheme()
-        updatePrivateUIState()
         changePanel()
     }
 
@@ -268,13 +267,6 @@ class LegacyTabTrayViewController: UIViewController, Themeable, TabTrayControlle
         ])
 
         showPanel(viewModel.tabTrayView)
-    }
-
-    func updatePrivateUIState() {
-        UserDefaults.standard.set(
-            viewModel.tabManager.selectedTab?.isPrivate ?? false,
-            forKey: PrefsKeys.LastSessionWasPrivate
-        )
     }
 
     private func updateTitle() {
@@ -339,7 +331,6 @@ class LegacyTabTrayViewController: UIViewController, Themeable, TabTrayControlle
         }
         updateToolbarItems(forSyncTabs: viewModel.profile.hasSyncableAccount())
         viewModel.tabTrayView.didTogglePrivateMode(privateMode)
-        updatePrivateUIState()
         updateTitle()
     }
 
@@ -589,7 +580,6 @@ extension LegacyTabTrayViewController {
         notificationCenter.post(name: .TabsTrayDidClose, withUserInfo: windowUUID.userInfo)
         // Update Private mode when closing TabTray, if the mode toggle but
         // no tab is pressed with return to previous state
-        updatePrivateUIState()
         viewModel.tabTrayView.didTogglePrivateMode(viewModel.tabManager.selectedTab?.isPrivate ?? false)
         if viewModel.segmentToFocus == .privateTabs {
             TelemetryWrapper.recordEvent(category: .action,

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -185,12 +185,6 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
         topTabDisplayManager.refreshStore()
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        UserDefaults.standard.set(tabManager.selectedTab?.isPrivate ?? false,
-                                  forKey: PrefsKeys.LastSessionWasPrivate)
-    }
-
     func updateTabCount(_ count: Int, animated: Bool = true) {
         tabsButton.updateTabCount(count, animated: animated)
     }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -274,10 +274,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     // TODO: FXIOS-7596 Remove when moving the TabManager protocol to TabManagerImplementation
     func preserveTabs() { fatalError("should never be called") }
 
-    func shouldClearPrivateTabs() -> Bool {
-        return profile.prefs.boolForKey("settings.closePrivateTabs") ?? false
-    }
-
     func cleanupClosedTabs(_ closedTabs: [Tab], previous: Tab?, isPrivate: Bool = false) {
         DispatchQueue.main.async { [unowned self] in
             // select normal tab if there are no private tabs, we need to do this

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -147,11 +147,9 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
     /// Creates the webview so needs to live on the main thread
     @MainActor
     private func generateTabs(from windowData: WindowData) async {
-        let filteredTabs = filterPrivateTabs(from: windowData,
-                                             clearPrivateTabs: shouldClearPrivateTabs())
         var tabToSelect: Tab?
 
-        for tabData in filteredTabs {
+        for tabData in windowData.tabData {
             let newTab = addTab(flushToDisk: false, zombie: true, isPrivate: tabData.isPrivate)
             newTab.url = URL(string: tabData.siteUrl, invalidCharacters: false)
             newTab.lastTitle = tabData.title
@@ -181,7 +179,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
             }
         }
 
-        logger.log("There was \(filteredTabs.count) tabs restored",
+        logger.log("There was \(windowData.tabData.count) tabs restored",
                    level: .debug,
                    category: .tabs)
 
@@ -196,14 +194,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
 
             selectTab(tabToSelect)
         }
-    }
-
-    private func filterPrivateTabs(from windowData: WindowData, clearPrivateTabs: Bool) -> [TabData] {
-        var savedTabs = windowData.tabData
-        if clearPrivateTabs {
-            savedTabs = windowData.tabData.filter { !$0.isPrivate }
-        }
-        return savedTabs
     }
 
     /// Creates the webview so needs to live on the main thread
@@ -357,17 +347,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
         }
     }
 
-    private func removeAllPrivateTabs() {
-        // reset the selectedTabIndex if we are on a private tab because we will be removing it.
-        if selectedTab?.isPrivate ?? false {
-            _selectedIndex = -1
-        }
-        privateTabs.forEach { $0.close() }
-        tabs = normalTabs
-
-        privateConfiguration = LegacyTabManager.makeWebViewConfig(isPrivate: true, prefs: profile.prefs)
-    }
-
     private func willSelectTab(_ url: URL?) {
         tabsTelemetry.startTabSwitchMeasurement()
         guard let url else { return }
@@ -390,11 +369,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
 
         previous?.metadataManager?.updateTimerAndObserving(state: .tabSwitched, isPrivate: previous?.isPrivate ?? false)
         tab.metadataManager?.updateTimerAndObserving(state: .tabSelected, isPrivate: tab.isPrivate)
-
-        // Make sure to wipe the private tabs if the user has the pref turned on
-        if shouldClearPrivateTabs(), !tab.isPrivate {
-            removeAllPrivateTabs()
-        }
 
         _selectedIndex = tabs.firstIndex(of: tab) ?? -1
 
@@ -419,12 +393,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
             TabEvent.post(.didGainFocus, for: tab)
         }
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .tab)
-
-        // Note: we setup last session private case as the session is tied to user's selected
-        // tab but there are times when tab manager isn't available and we need to know
-        // users's last state (Private vs Regular)
-        UserDefaults.standard.set(selectedTab?.isPrivate ?? false,
-                                  forKey: PrefsKeys.LastSessionWasPrivate)
     }
 
     // MARK: - Screenshots

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -206,13 +206,6 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
             GleanMetrics.Preferences.showClipboardBar.set(false)
         }
 
-        // Close private tabs
-        if let closePrivateTabs = prefs.boolForKey("settings.closePrivateTabs") {
-            GleanMetrics.Preferences.closePrivateTabs.set(closePrivateTabs)
-        } else {
-            GleanMetrics.Preferences.closePrivateTabs.set(false)
-        }
-
         // Tracking protection - enabled
         if let tpEnabled = prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) {
             GleanMetrics.TrackingProtection.enabled.set(tpEnabled)

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -161,9 +161,6 @@ public struct PrefsKeys {
     // The last recorded CFR timestamp
     public static let FakespotLastCFRTimestamp = "FakespotLastCFRTimestamp"
 
-    // Representing whether or not the last user session was private
-    public static let LastSessionWasPrivate = "wasLastSessionPrivate"
-
     // Only used to force nimbus features to true with tests
     public static let NimbusFeatureTestsOverride = "NimbusFeatureTestsOverride"
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -362,7 +362,7 @@ class RouteTests: XCTestCase {
 
     func createSubject() -> RouteBuilder {
         let subject = RouteBuilder()
-        subject.configure(isPrivate: false, prefs: MockProfile().prefs)
+        subject.configure(prefs: MockProfile().prefs)
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
@@ -80,7 +80,7 @@ final class ShortcutRouteTests: XCTestCase {
 
     func createSubject() -> RouteBuilder {
         let subject = RouteBuilder()
-        subject.configure(isPrivate: false, prefs: MockProfile().prefs)
+        subject.configure(prefs: MockProfile().prefs)
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/UserActivityRouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/UserActivityRouteTests.swift
@@ -54,7 +54,7 @@ class UserActivityRouteTests: XCTestCase {
 
     func createSubject() -> RouteBuilder {
         let subject = RouteBuilder()
-        subject.configure(isPrivate: false, prefs: MockProfile().prefs)
+        subject.configure(prefs: MockProfile().prefs)
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
@@ -71,15 +71,4 @@ final class LegacyTabTrayViewControllerTests: XCTestCase {
 
         waitForExpectations(timeout: 3.0)
     }
-
-    func testTabTrayRevertToRegular_ForNoPrivateTabSelected() {
-        // If the user selects Private mode but doesn't focus or creates a new tab
-        // we considered that regular is actually active
-        tabTray.viewModel.segmentToFocus = TabTrayPanelType.privateTabs
-        tabTray.viewDidLoad()
-        tabTray.didTapDone()
-
-        let privateState = UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate)
-        XCTAssertFalse(privateState)
-    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -262,17 +262,6 @@ fileprivate extension BaseTestCase {
             "The number of tabs is not correct"
         )
     }
-
-    func enableClosePrivateBrowsingOptionWhenLeaving() {
-        navigator.goto(SettingsScreen)
-        let settingsTableView = app.tables[AccessibilityIdentifiers.Settings.tableViewController]
-
-        while settingsTableView.staticTexts["Close Private Tabs"].isHittable == false {
-            settingsTableView.swipeUp()
-        }
-        let closePrivateTabsSwitch = settingsTableView.switches["settings.closePrivateTabs"]
-        closePrivateTabsSwitch.tap()
-    }
 }
 
 class PrivateBrowsingTestIphone: IphoneOnlyTestCase {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9034)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19952)

## :bulb: Description
Cleans up code related to private tab storage

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

