### PR TITLE
Bugfix FXIOS-9180 - Remove Duplicate Undo Close Tab Toast

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -600,10 +600,6 @@ class TabManagerMiddleware {
 
     private func tabPeekCloseTab(with tabID: TabUUID, uuid: WindowUUID, isPrivate: Bool) {
         closeTabFromTabPanel(with: tabID, uuid: uuid, isPrivate: isPrivate)
-        let toastAction = TabPanelMiddlewareAction(toastType: .closedSingleTab,
-                                                   windowUUID: uuid,
-                                                   actionType: TabPanelMiddlewareActionType.showToast)
-        store.dispatch(toastAction)
     }
 
     private func changePanel(_ panel: TabTrayPanelType, uuid: WindowUUID) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9180)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20340)

## :bulb: Description
Removed `store.dispatch(toastAction)` from `TabManagerMiddleware.tabPeekCloseTab` since the toast will be dispatched again from `TabDisplayPanel.newState`.  This keeps the toast from displaying twice.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

