### PR TITLE
Refactor FXIOS-9185 - Use the underline style for LinkButton in PasswordManagerOnboardingViewController from Component Library

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -634,6 +634,7 @@ public struct AccessibilityIdentifiers {
             static let passwordField = "passwordField"
             static let websiteField = "websiteField"
             static let onboardingContinue = "onboardingContinue"
+            static let onboardingLearnMore = "Passwords.onboardingLoadMore"
             static let addCredentialButton = "addCredentialButton"
             static let editButton = "editButton"
         }

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -634,7 +634,7 @@ public struct AccessibilityIdentifiers {
             static let passwordField = "passwordField"
             static let websiteField = "websiteField"
             static let onboardingContinue = "onboardingContinue"
-            static let onboardingLearnMore = "Passwords.onboardingLoadMore"
+            static let onboardingLearnMore = "Passwords.onboardingLearnMore"
             static let addCredentialButton = "addCredentialButton"
             static let editButton = "editButton"
         }

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -25,7 +25,10 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     }
 
     private lazy var learnMoreButton: LinkButton = .build { button in
-        button.setTitle(.LoginsOnboardingLearnMoreButtonTitle, for: .normal)
+        let buttonViewModel = LinkButtonViewModel(
+            title: .LoginsOnboardingLearnMoreButtonTitle,
+            a11yIdentifier: AccessibilityIdentifiers.Settings.Passwords.onboardingLearnMore)
+        button.configure(viewModel: buttonViewModel)
         button.addTarget(self, action: #selector(self.learnMoreButtonTapped), for: .touchUpInside)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9185)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20346)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Updated the Learn More Button in `PasswordManagerOnboardingViewController` to use the `LinkButtonViewModel` from the component library to introduce the underline style.

Before:
<img src="https://github.com/mozilla-mobile/firefox-ios/assets/58835213/03177d48-d517-4e4c-b824-70d802aefa47" width="400">

After:
<img src="https://github.com/mozilla-mobile/firefox-ios/assets/58835213/cd48c402-9dfc-4a29-ab14-50b455eb98da" width="400">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

