### PR TITLE
Refactor FXIOS-9167 - Change lock icon to be a button

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -57,6 +57,7 @@ public struct AccessibilityIdentifiers {
 
         struct AddressToolbar {
             static let clear = "AddressToolbar.clear"
+            static let lockIcon = "AddressToolbar.lockIcon"
             static let searchTextField = "AddressToolbar.address"
             static let searchEngine = "AddressToolbar.searchEngine"
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -18,13 +18,15 @@ class AddressToolbarContainerModel {
         let locationViewState = LocationViewState(
             clearButtonA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.clear,
             clearButtonA11yLabel: .AddressToolbar.LocationClearButtonA11yLabel,
+            lockIconButtonA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon,
+            lockIconButtonA11yLabel: "",
             searchEngineImageViewA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.searchEngine,
             searchEngineImageViewA11yLabel: .AddressToolbar.SearchEngineA11yLabel,
             urlTextFieldPlaceholder: .AddressToolbar.LocationPlaceholder,
             urlTextFieldA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField,
             urlTextFieldA11yLabel: .AddressToolbar.LocationA11yLabel,
             searchEngineImageName: "",
-            lockIconImageName: "",
+            lockIconImageName: StandardImageIdentifiers.Medium.lock,
             url: nil)
         return AddressToolbarState(
             locationViewState: locationViewState,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -19,7 +19,7 @@ class AddressToolbarContainerModel {
             clearButtonA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.clear,
             clearButtonA11yLabel: .AddressToolbar.LocationClearButtonA11yLabel,
             lockIconButtonA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon,
-            lockIconButtonA11yLabel: "",
+            lockIconButtonA11yLabel: .AddressToolbar.PrivacyAndSecuritySettingsA11yLabel,
             searchEngineImageViewA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.searchEngine,
             searchEngineImageViewA11yLabel: .AddressToolbar.SearchEngineA11yLabel,
             urlTextFieldPlaceholder: .AddressToolbar.LocationPlaceholder,

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -5256,6 +5256,11 @@ extension String {
             tableName: "AddressToolbar",
             value: "Search Engine: %@",
             comment: "Accessibility label for the search engine icon in the address field of the address toolbar. The placeholder is getting replaced with the name of the search engine (e.g. Google).")
+        public static let PrivacyAndSecuritySettingsA11yLabel = MZLocalizedString(
+            key: "AddressToolbar.PrivacyAndSecuriySettings.A11y.Label.v128",
+            tableName: "AddressToolbar",
+            value: "Privacy & Security Settings",
+            comment: "Accessibility label for the lock icon button in the address field of the address toolbar, responsible with Privacy & Security Settings.")
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9167)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20313)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Change lock icon from `UIImageView` to `UIButton` and add action to it.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

