### PR TITLE
Refactor FXIOS-9239 - Updated Fonts On TwoLineImageOverlayCell

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
@@ -47,12 +47,12 @@ class TwoLineImageOverlayCell: UITableViewCell,
     }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 16)
+        label.font = FXFontStyles.Regular.callout.scaledFont()
         label.textAlignment = .natural
     }
 
     lazy var descriptionLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 14)
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
         label.textAlignment = .natural
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9239)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20465)

## :bulb: Description
Updated `TwoLineImageOverlayCell` to use `FXFontsStyle` instead of `DefaultDynamicFontHelper` or `UIFont`. This eliminates the need to specify font sizes in the view controllers.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
