### PR TITLE
Refactor FXIOS-9240 - Updated Fonts On SiteTableViewHeader

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/SiteTableViewHeader.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SiteTableViewHeader.swift
@@ -25,8 +25,7 @@ class SiteTableViewHeader: UITableViewHeaderFooterView, ThemeApplicable, Reusabl
 
     private let titleLabel: UILabel = .build { label in
         label.numberOfLines = 0
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
-                                                            size: 16)
+        label.font = FXFontStyles.Bold.callout.scaledFont()
         label.adjustsFontForContentSizeCategory = true
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9240)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20466)

## :bulb: Description
Updated `SiteTableViewHeader` to use `FXFontsStyle` instead of `DefaultDynamicFontHelper` or `UIFont`. This eliminates the need to specify font sizes in the view controllers.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

