### PR TITLE
Refactor FXIOS-9241 - Updated Fonts On OneLineTableViewCell

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -26,7 +26,6 @@ class OneLineTableViewCell: UITableViewCell,
     struct UX {
         static let imageSize: CGFloat = 29
         static let borderViewMargin: CGFloat = 16
-        static let labelFontSize: CGFloat = 17
         static let verticalMargin: CGFloat = 8
         static let leftImageViewSize: CGFloat = 28
         static let separatorViewHeight: CGFloat = 0.7
@@ -45,8 +44,7 @@ class OneLineTableViewCell: UITableViewCell,
     lazy var leftImageView: FaviconImageView = .build { _ in }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: UX.labelFontSize)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.textAlignment = .natural
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9241)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20467)

## :bulb: Description
Updated `OneLineTableViewCell` to use `FXFontsStyle` instead of `DefaultDynamicFontHelper` or `UIFont`. This eliminates the need to specify font sizes in the view controllers.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
