### PR TITLE
Refactor FXIOS-9184 - Use the underline style for LinkButton in PocketFooterView from Component Library

### DIFF
--- a/firefox-ios/Client/Frontend/Home/PocketFooterView.swift
+++ b/firefox-ios/Client/Frontend/Home/PocketFooterView.swift
@@ -5,6 +5,7 @@
 import Common
 import UIKit
 import Shared
+import ComponentLibrary
 
 class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable {
     private struct UX {
@@ -29,12 +30,14 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
         label.font = FXFontStyles.Regular.caption1.scaledFont()
     }
 
-    private let learnMoreLabel: UILabel = .build { label in
-        label.text = .FirefoxHomepage.Pocket.Footer.LearnMore
-        label.isUserInteractionEnabled = true
-        label.adjustsFontForContentSizeCategory = true
-        label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.Pocket.footerLearnMoreLabel
-        label.font = FXFontStyles.Regular.caption1.scaledFont()
+    private let learnMoreButton: LinkButton = .build { button in
+        let buttonViewModel = LinkButtonViewModel(
+            title: .FirefoxHomepage.Pocket.Footer.LearnMore,
+            a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.Pocket.footerLearnMoreLabel,
+            font: FXFontStyles.Regular.caption1.scaledFont()
+        )
+        button.configure(viewModel: buttonViewModel)
+        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
     }
 
     private let labelsContainer: UIStackView = .build { stackView in
@@ -62,11 +65,8 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
     }
 
     private func setupViews() {
-        let tapGesture = UITapGestureRecognizer(target: self,
-                                                action: #selector(didTapLearnMore))
-        learnMoreLabel.addGestureRecognizer(tapGesture)
-
-        [titleLabel, learnMoreLabel].forEach(labelsContainer.addArrangedSubview)
+        learnMoreButton.addTarget(self, action: #selector(didTapLearnMore), for: .touchUpInside)
+        [titleLabel, learnMoreButton].forEach(labelsContainer.addArrangedSubview)
         [pocketImageView, labelsContainer].forEach(mainContainer.addArrangedSubview)
 
         addSubview(mainContainer)
@@ -87,8 +87,7 @@ class PocketFooterView: UICollectionReusableView, ReusableCell, ThemeApplicable 
     }
 
     func applyTheme(theme: Theme) {
-        let colors = theme.colors
         titleLabel.textColor = wallpaperManager.currentWallpaper.textColor
-        learnMoreLabel.textColor = colors.textAccent
+        learnMoreButton.applyTheme(theme: theme)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9184)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20345)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
**Before:**
<img width="339" alt="Pocket Learn More Before" src="https://github.com/mozilla-mobile/firefox-ios/assets/58835213/16de37c8-3254-42bf-9aa9-ef39b06f5bf7">

**After:**
<img width="338" alt="Pocket Learn More After" src="https://github.com/mozilla-mobile/firefox-ios/assets/58835213/7804b624-6624-49e6-994b-4d0de0e7b030">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

