### PR TITLE
Refactor FXIOS-9246 - Qualify `MozillaAppServices` imports.

### DIFF
--- a/firefox-ios/Account/FxAPushMessageHandler.swift
+++ b/firefox-ios/Account/FxAPushMessageHandler.swift
@@ -4,7 +4,6 @@
 
 import Shared
 import Account
-import MozillaAppServices
 import Common
 
 let PendingAccountDisconnectedKey = "PendingAccountDisconnect"

--- a/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
+++ b/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
@@ -8,7 +8,8 @@ import Storage
 import Sync
 import UserNotifications
 import Account
-import MozillaAppServices
+
+import struct MozillaAppServices.ConstellationState
 
 /**
  * This exists because the Sync code is extension-safe, and thus doesn't get

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -10,6 +10,8 @@ import Common
 import Glean
 import TabDataStore
 
+import class MozillaAppServices.Viaduct
+
 class AppDelegate: UIResponder, UIApplicationDelegate {
     let logger = DefaultLogger.shared
     var notificationCenter: NotificationProtocol = NotificationCenter.default

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -9,7 +9,6 @@ import Shared
 import Sync
 import UserNotifications
 import Account
-import MozillaAppServices
 import Common
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -6,7 +6,8 @@ import Common
 import Foundation
 import Shared
 import Kingfisher
-import MozillaAppServices
+
+import class MozillaAppServices.HardcodedNimbusFeatures
 
 class UITestAppDelegate: AppDelegate, FeatureFlaggable {
     lazy var dirForTestProfile = { return "\(self.appRootDir())/profile.testProfile" }()

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -10,6 +10,9 @@ import Storage
 import Redux
 import TabDataStore
 
+import enum MozillaAppServices.VisitType
+import struct MozillaAppServices.CreditCard
+
 class BrowserCoordinator: BaseCoordinator,
                           LaunchCoordinatorDelegate,
                           BrowserDelegate,
@@ -409,7 +412,7 @@ class BrowserCoordinator: BaseCoordinator,
         router.dismiss()
     }
 
-    func libraryPanel(didSelectURL url: URL, visitType: Storage.VisitType) {
+    func libraryPanel(didSelectURL url: URL, visitType: VisitType) {
         browserViewController.libraryPanel(didSelectURL: url, visitType: visitType)
         router.dismiss()
     }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -6,6 +6,8 @@ import Foundation
 import Storage
 import WebKit
 
+import struct MozillaAppServices.CreditCard
+
 protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     /// Asks to show a settings page, can be a general settings page or a child page
     /// - Parameter settings: The settings route we're trying to get to

--- a/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
@@ -9,6 +9,8 @@ import Shared
 import WebKit
 import ComponentLibrary
 
+import struct MozillaAppServices.CreditCard
+
 class CredentialAutofillCoordinator: BaseCoordinator {
     // MARK: - Properties
 

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -6,6 +6,8 @@ import Foundation
 import Storage
 import Common
 
+import enum MozillaAppServices.BookmarkNodeType
+
 protocol BookmarksCoordinatorDelegate: AnyObject, LibraryPanelCoordinatorDelegate {
     func start(from folder: FxBookmarkNode)
 

--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -7,6 +7,8 @@ import Foundation
 import Shared
 import Storage
 
+import enum MozillaAppServices.VisitType
+
 protocol LibraryCoordinatorDelegate: AnyObject, LibraryPanelDelegate, RecentlyClosedPanelDelegate {
     func didFinishLibrary(from coordinator: LibraryCoordinator)
 }
@@ -160,7 +162,7 @@ class LibraryCoordinator: BaseCoordinator, LibraryPanelDelegate, LibraryNavigati
         parentCoordinator?.libraryPanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate)
     }
 
-    func libraryPanel(didSelectURL url: URL, visitType: Storage.VisitType) {
+    func libraryPanel(didSelectURL url: URL, visitType: VisitType) {
         parentCoordinator?.libraryPanel(didSelectURL: url, visitType: visitType)
     }
 

--- a/firefox-ios/Client/Coordinators/Library/ReadingListCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/ReadingListCoordinator.swift
@@ -5,6 +5,8 @@
 import Foundation
 import Storage
 
+import enum MozillaAppServices.VisitType
+
 protocol ReadingListNavigationHandler: AnyObject, LibraryPanelCoordinatorDelegate {
     func openUrl(_ url: URL, visitType: VisitType)
 }

--- a/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PasswordManagerCoordinator.swift
@@ -6,6 +6,8 @@ import Foundation
 import Storage
 import Common
 
+import struct MozillaAppServices.LoginEntry
+
 protocol PasswordManagerCoordinatorDelegate: AnyObject, ParentCoordinatorDelegate {
     func settingsOpenURLInNewTab(_ url: URL)
     func didFinishPasswordManager(from: PasswordManagerCoordinator)

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -4,8 +4,15 @@
 
 import Common
 import Foundation
-import MozillaAppServices
 import Shared
+
+import class MozillaAppServices.NimbusBuilder
+import class MozillaAppServices.NimbusDisabled
+import protocol MozillaAppServices.NimbusEventStore
+import protocol MozillaAppServices.NimbusInterface
+import protocol MozillaAppServices.NimbusMessagingHelperProtocol
+import struct MozillaAppServices.NimbusAppSettings
+import typealias MozillaAppServices.NimbusErrorReporter
 
 private let nimbusAppName = "firefox_ios"
 private let NIMBUS_URL_KEY = "NimbusURL"

--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -4,8 +4,11 @@
 
 import Foundation
 
-import MozillaAppServices
 import Shared
+
+import class MozillaAppServices.FeatureHolder
+import enum MozillaAppServices.NimbusError
+import protocol MozillaAppServices.NimbusMessagingHelperProtocol
 
 protocol GleanPlumbMessageManagerProtocol {
     /// Performs the bookkeeping and preparation of messages for their respective surfaces.

--- a/firefox-ios/Client/Experiments/Messaging/NimbusMessagingEvaluationUtility.swift
+++ b/firefox-ios/Client/Experiments/Messaging/NimbusMessagingEvaluationUtility.swift
@@ -4,8 +4,9 @@
 
 import Common
 import Foundation
-import MozillaAppServices
 import Shared
+
+import protocol MozillaAppServices.NimbusMessagingHelperProtocol
 
 /// A utility for evaluating a Nimbus feature based on a set of valid JEXLs.
 /// Adaptable to any Nimbus feature by implementing a variable of type

--- a/firefox-ios/Client/Experiments/Messaging/NimbusMessagingHelperUtilityProtocol.swift
+++ b/firefox-ios/Client/Experiments/Messaging/NimbusMessagingHelperUtilityProtocol.swift
@@ -5,7 +5,8 @@
 import Foundation
 import Common
 import Shared
-import MozillaAppServices
+
+import protocol MozillaAppServices.NimbusMessagingHelperProtocol
 
 protocol NimbusMessagingHelperUtilityProtocol {
     func createNimbusMessagingHelper() -> NimbusMessagingHelperProtocol?

--- a/firefox-ios/Client/Experiments/Settings/ExperimentsBranchesViewController.swift
+++ b/firefox-ios/Client/Experiments/Settings/ExperimentsBranchesViewController.swift
@@ -3,7 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import MozillaAppServices
+
+import struct MozillaAppServices.AvailableExperiment
 
 class ExperimentsBranchesViewController: UIViewController {
     private let experiment: AvailableExperiment

--- a/firefox-ios/Client/Experiments/Settings/ExperimentsSettingsViewController.swift
+++ b/firefox-ios/Client/Experiments/Settings/ExperimentsSettingsViewController.swift
@@ -3,7 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import MozillaAppServices
+
+import protocol MozillaAppServices.NimbusApi
 
 class ExperimentsSettingsViewController: UIViewController {
     private let experiments: NimbusApi

--- a/firefox-ios/Client/Experiments/Settings/ExperimentsViewController.swift
+++ b/firefox-ios/Client/Experiments/Settings/ExperimentsViewController.swift
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import MozillaAppServices
+
+import protocol MozillaAppServices.NimbusApi
+import struct MozillaAppServices.AvailableExperiment
 
 class ExperimentsViewController: UIViewController {
     private let experimentsView = ExperimentsTableView()

--- a/firefox-ios/Client/Experiments/UserResearch.swift
+++ b/firefox-ios/Client/Experiments/UserResearch.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import MozillaAppServices
+import protocol MozillaAppServices.NimbusApi
 
 /// This protocol will give access to the `Experiments` singleton and require
 /// the conforming class to set up an experiment.

--- a/firefox-ios/Client/FeatureFlags/CoreFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/CoreFlaggableFeature.swift
@@ -4,7 +4,6 @@
 
 import Common
 import Shared
-import MozillaAppServices
 import UIKit
 
 /// Core features are features that are used for developer purposes and are

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Shared
-import MozillaAppServices
 import UIKit
 
 /// An enum describing the featureID of all features found in Nimbus.

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
@@ -7,6 +7,8 @@ import Common
 import Shared
 import Storage
 
+import struct MozillaAppServices.Address
+
 // MARK: - AddressCellView
 
 /// A view representing a cell displaying address information.

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -7,6 +7,8 @@ import Common
 import Shared
 import Storage
 
+import struct MozillaAppServices.Address
+
 // MARK: - AddressListView
 
 /// A view displaying a list of addresses.

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -7,6 +7,8 @@ import Common
 import Shared
 import Storage
 
+import struct MozillaAppServices.Address
+
 // TODO: PHASE-2 FXIOS-7653
 // AddressListViewModelDelegate: A protocol to notify delegates about address updates.
 // protocol AddressListViewModelDelegate: AnyObject {

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressProvider.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressProvider.swift
@@ -4,6 +4,8 @@
 
 import Storage
 
+import struct MozillaAppServices.Address
+
 protocol AddressProvider {
     func listAllAddresses(completion: @escaping ([Address]?, Error?) -> Void)
 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/Address+Encodable.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/Address+Encodable.swift
@@ -4,6 +4,8 @@
 
 import Storage
 
+import struct MozillaAppServices.Address
+
 extension CodingUserInfoKey {
     static let formatStyleKey = CodingUserInfoKey(rawValue: "FormatStyleKey")!
 }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
@@ -7,6 +7,9 @@ import Common
 import Storage
 import Shared
 
+import enum MozillaAppServices.AutofillApiError
+import struct MozillaAppServices.CreditCard
+
 enum CreditCardBottomSheetState: String, Equatable, CaseIterable {
     case save
     case update

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -8,6 +8,8 @@ import Storage
 import SwiftUI
 import Shared
 
+import struct MozillaAppServices.CreditCard
+
 struct CreditCardInputView: View {
     @ObservedObject var viewModel: CreditCardInputViewModel
     @State private var isBlurred = false

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -7,6 +7,8 @@ import SwiftUI
 import Common
 import Storage
 
+import struct MozillaAppServices.CreditCard
+
 enum CreditCardLeftBarButton: String, Equatable, CaseIterable {
     case close
     case cancel

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -8,6 +8,8 @@ import SwiftUI
 import Storage
 import Shared
 
+import struct MozillaAppServices.CreditCard
+
 struct CreditCardItemRow: View {
     let item: CreditCard
     let isAccessibilityCategory: Bool

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -8,6 +8,8 @@ import Shared
 import Storage
 import SwiftUI
 
+import struct MozillaAppServices.CreditCard
+
 class CreditCardSettingsViewController: SensitiveViewController, Themeable {
     var viewModel: CreditCardSettingsViewModel
     var themeObserver: NSObjectProtocol?

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
@@ -8,6 +8,8 @@ import Storage
 import UIKit
 import Common
 
+import struct MozillaAppServices.CreditCard
+
 enum CreditCardSettingsState: String, Equatable, CaseIterable {
     // Default state
     case empty = "Empty"

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
@@ -8,6 +8,8 @@ import Storage
 import SwiftUI
 import UIKit
 
+import struct MozillaAppServices.CreditCard
+
 class CreditCardTableViewController: UIViewController, Themeable {
     // MARK: UX constants
     struct UX {

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewModel.swift
@@ -8,6 +8,8 @@ import SwiftUI
 import Storage
 import Shared
 
+import struct MozillaAppServices.CreditCard
+
 class CreditCardTableViewModel {
     var toggleModel: ToggleModel?
 

--- a/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
@@ -6,6 +6,8 @@ import SwiftUI
 import Common
 import Storage
 
+import struct MozillaAppServices.EncryptedLogin
+
 // MARK: - LoginCellView
 
 extension VerticalAlignment {

--- a/firefox-ios/Client/Frontend/Autofill/LoginListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginListViewModel.swift
@@ -6,6 +6,8 @@ import Common
 import Storage
 import Foundation
 
+import struct MozillaAppServices.EncryptedLogin
+
 @MainActor
 class LoginListViewModel: ObservableObject {
     @Published var logins: [EncryptedLogin] = []

--- a/firefox-ios/Client/Frontend/Autofill/LoginStorage.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginStorage.swift
@@ -4,6 +4,8 @@
 
 import Storage
 
+import struct MozillaAppServices.EncryptedLogin
+
 protocol LoginStorage {
     func listLogins() async throws -> [EncryptedLogin]
 }

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -7,6 +7,8 @@ import Shared
 import Storage
 import Common
 
+import struct MozillaAppServices.LoginEntry
+
 class Authenticator {
     fileprivate static let MaxAuthenticationAttempts = 3
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+UIDropInteractionDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+UIDropInteractionDelegate.swift
@@ -5,6 +5,8 @@
 import Foundation
 import Storage
 
+import enum MozillaAppServices.VisitType
+
 extension BrowserViewController: UIDropInteractionDelegate {
     func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
         // Prevent tabs from being dragged and dropped into the address bar.

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -8,6 +8,8 @@ import Glean
 import Common
 import ComponentLibrary
 
+import enum MozillaAppServices.VisitType
+
 protocol OnViewDismissable: AnyObject {
     var onViewDismissed: (() -> Void)? { get set }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -16,6 +16,11 @@ import ComponentLibrary
 import Redux
 import ToolbarKit
 
+import class MozillaAppServices.BookmarkFolderData
+import class MozillaAppServices.BookmarkItemData
+import enum MozillaAppServices.BookmarkRoots
+import enum MozillaAppServices.VisitType
+
 class BrowserViewController: UIViewController,
                              SearchBarLocationProvider,
                              Themeable,

--- a/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchViewController.swift
@@ -8,6 +8,8 @@ import Storage
 import Common
 import SiteImageView
 
+import class MozillaAppServices.FeatureHolder
+
 private enum SearchListSection: Int, CaseIterable {
     case searchSuggestions
     case firefoxSuggestions

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
@@ -8,6 +8,8 @@ import Foundation
 import UIKit
 import Common
 
+import enum MozillaAppServices.VisitType
+
 enum TabTrayViewAction {
     case addTab
     case deleteTab

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsPanel.swift
@@ -6,6 +6,8 @@ import UIKit
 import Storage
 import Common
 
+import enum MozillaAppServices.VisitType
+
 protocol RemotePanelDelegateProvider: AnyObject {
     var remotePanelDelegate: RemotePanelDelegate? { get }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -8,6 +8,8 @@ import TabDataStore
 import Shared
 import Storage
 
+import enum MozillaAppServices.BookmarkRoots
+
 class TabManagerMiddleware {
     private let profile: Profile
     private let logger: Logger

--- a/firefox-ios/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/RemoteTabs/RemoteTabsClientAndTabsDataSource.swift
@@ -8,6 +8,8 @@ import Storage
 import Shared
 import SiteImageView
 
+import enum MozillaAppServices.VisitType
+
 protocol RemoteTabsClientAndTabsDataSourceDelegate: AnyObject {
     func remoteTabsClientAndTabsDataSourceDidSelectURL(_ url: URL, visitType: VisitType)
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -8,6 +8,8 @@ import Common
 import Shared
 import Redux
 
+import enum MozillaAppServices.VisitType
+
 protocol RemoteTabsPanelDelegate: AnyObject {
     func presentFirefoxAccountSignIn()
     func presentFxAccountSettings()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -8,6 +8,8 @@ import Shared
 import Redux
 import SiteImageView
 
+import enum MozillaAppServices.VisitType
+
 class RemoteTabsTableViewController: UITableViewController,
                                      Themeable,
                                      CollapsibleTableViewSection,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -8,6 +8,8 @@ import Storage
 import Redux
 import Shared
 
+import enum MozillaAppServices.VisitType
+
 protocol TabTrayController: UIViewController,
                             UIAdaptivePresentationControllerDelegate,
                             UIPopoverPresentationControllerDelegate,
@@ -44,7 +46,7 @@ class TabTrayViewController: UIViewController,
     weak var navigationHandler: TabTrayNavigationHandler?
 
     var openInNewTab: ((URL, Bool) -> Void)?
-    var didSelectUrl: ((URL, Storage.VisitType) -> Void)?
+    var didSelectUrl: ((URL, VisitType) -> Void)?
 
     // MARK: - Redux state
     var tabTrayState: TabTrayState

--- a/firefox-ios/Client/Frontend/Fakespot/ShoppingProduct.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/ShoppingProduct.swift
@@ -3,7 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import MozillaAppServices
+
+import enum MozillaAppServices.OhttpError
 
 /// Represents a parsed product for a URL.
 ///

--- a/firefox-ios/Client/Frontend/Fakespot/Views/FakespotAdView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/FakespotAdView.swift
@@ -6,7 +6,8 @@ import UIKit
 import Common
 import Shared
 import ComponentLibrary
-import MozillaAppServices
+
+import class MozillaAppServices.OhttpManager
 
 // MARK: View Model
 struct FakespotAdViewModel: FeatureFlaggable {

--- a/firefox-ios/Client/Frontend/Home/HistoryHighlights/HighlightItem.swift
+++ b/firefox-ios/Client/Frontend/Home/HistoryHighlights/HighlightItem.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import MozillaAppServices
+import struct MozillaAppServices.HistoryHighlight
 
 enum HighlightItemType {
     case group

--- a/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
+++ b/firefox-ios/Client/Frontend/Home/HistoryHighlights/HistoryHighlightsManager.swift
@@ -5,7 +5,9 @@
 import Foundation
 import Shared
 import Storage
-import MozillaAppServices
+
+import struct MozillaAppServices.HistoryHighlight
+import struct MozillaAppServices.HistoryHighlightWeights
 
 private let defaultHighlightCount = 9
 private let searchLimit = 1000

--- a/firefox-ios/Client/Frontend/Home/HomePanelDelegate.swift
+++ b/firefox-ios/Client/Frontend/Home/HomePanelDelegate.swift
@@ -5,6 +5,8 @@
 import Foundation
 import Storage
 
+import enum MozillaAppServices.VisitType
+
 protocol HomePanelDelegate: AnyObject {
     func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool, selectNewTab: Bool)
     func homePanel(didSelectURL url: URL, visitType: VisitType, isGoogleTopSite: Bool)

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -7,6 +7,8 @@ import Foundation
 import Shared
 import Storage
 
+import enum MozillaAppServices.BookmarkRoots
+
 // swiftlint:disable class_delegate_protocol
 protocol HomepageContextMenuHelperDelegate: UIViewController {
     func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool, selectNewTab: Bool)

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -4,11 +4,12 @@
 
 import Common
 import ComponentLibrary
-import MozillaAppServices
 import Shared
 import Storage
 import Redux
 import UIKit
+
+import enum MozillaAppServices.VisitType
 
 class HomepageViewController:
     UIViewController,

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import MozillaAppServices
 import Shared
 
 protocol HomepageViewModelDelegate: AnyObject {

--- a/firefox-ios/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/RecentlySaved/RecentlySavedViewModel.swift
@@ -7,6 +7,8 @@ import Foundation
 import Storage
 import Shared
 
+import enum MozillaAppServices.VisitType
+
 struct RecentlySavedCellViewModel {
     let site: Site
     var accessibilityLabel: String {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -7,6 +7,12 @@ import UIKit
 import Storage
 import Shared
 
+import class MozillaAppServices.BookmarkFolderData
+import class MozillaAppServices.BookmarkItemData
+import class MozillaAppServices.BookmarkNodeData
+import enum MozillaAppServices.BookmarkNodeType
+import enum MozillaAppServices.BookmarkRoots
+
 private let BookmarkDetailFieldCellIdentifier = "BookmarkDetailFieldCellIdentifier"
 private let BookmarkDetailFolderCellIdentifier = "BookmarkDetailFolderCellIdentifier"
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderCell.swift
@@ -6,6 +6,9 @@ import Foundation
 import Storage
 import Common
 
+import class MozillaAppServices.BookmarkFolderData
+import class MozillaAppServices.BookmarkItemData
+
 /// Used to setup bookmarks and folder cell in Bookmarks panel, getting their viewModel
 protocol BookmarksFolderCell {
     func getViewModel() -> OneLineTableViewCellViewModel

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -8,6 +8,10 @@ import Storage
 import Shared
 import SiteImageView
 
+import class MozillaAppServices.BookmarkItemData
+import class MozillaAppServices.BookmarkSeparatorData
+import enum MozillaAppServices.BookmarkRoots
+
 let LocalizedRootBookmarkFolderStrings = [
     BookmarkRoots.MenuFolderGUID: String.BookmarksFolderTitleMenu,
     BookmarkRoots.ToolbarFolderGUID: String.BookmarksFolderTitleToolbar,

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanelViewModel.swift
@@ -7,6 +7,9 @@ import Common
 import Storage
 import Shared
 
+import class MozillaAppServices.BookmarkFolderData
+import enum MozillaAppServices.BookmarkRoots
+
 class BookmarksPanelViewModel {
     enum BookmarksSection: Int, CaseIterable {
         case bookmarks

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/FxBookmarkNode.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/FxBookmarkNode.swift
@@ -2,8 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import MozillaAppServices
 import Storage
+
+import class MozillaAppServices.BookmarkFolderData
+import class MozillaAppServices.BookmarkItemData
+import class MozillaAppServices.BookmarkSeparatorData
+import enum MozillaAppServices.BookmarkNodeType
 
 // Provides a layer of abstraction so we have more power over BookmarkNodeData provided by App Services.
 // For instance, this enables us to have the LocalDesktopFolder.

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/LocalDesktopFolder.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/LocalDesktopFolder.swift
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import MozillaAppServices
 import Storage
 import Common
+
+import enum MozillaAppServices.BookmarkNodeType
+import struct MozillaAppServices.Guid
 
 /// A folder class that enables us to have local folder presented to the user
 /// We can use this folder class for:

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -8,6 +8,8 @@ import Shared
 import Storage
 import SwiftUI
 
+import struct MozillaAppServices.VisitTransitionSet
+
 private class FetchInProgressError: MaybeErrorType {
     internal var description: String {
         return "Fetch is already in-progress"

--- a/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
@@ -7,6 +7,8 @@ import Shared
 import Storage
 import Common
 
+import enum MozillaAppServices.VisitType
+
 protocol LibraryPanelDelegate: AnyObject {
     func libraryPanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)
     func libraryPanel(didSelectURL url: URL, visitType: VisitType)

--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController+LibraryPanelDelegate.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController+LibraryPanelDelegate.swift
@@ -6,6 +6,8 @@ import Storage
 import Shared
 import Common
 
+import enum MozillaAppServices.VisitType
+
 extension LibraryViewController: LibraryPanelDelegate {
     func libraryPanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool) {
         delegate?.libraryPanelDidRequestToOpenInNewTab(url, isPrivate: isPrivate)

--- a/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
@@ -7,6 +7,8 @@ import Storage
 import Shared
 import Common
 
+import enum MozillaAppServices.VisitType
+
 private struct ReadingListTableViewCellUX {
     static let RowHeight: CGFloat = 86
 

--- a/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -8,6 +8,8 @@ import Storage
 import SiteImageView
 import Common
 
+import enum MozillaAppServices.VisitType
+
 private struct RecentlyClosedPanelUX {
     static let IconSize = CGSize(width: 23, height: 23)
     static let IconBorderWidth: CGFloat = 0.5

--- a/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
@@ -7,6 +7,8 @@ import Shared
 import Storage
 import Common
 
+import struct MozillaAppServices.LoginEntry
+
 enum AddCredentialField: Int {
     case websiteItem
     case usernameItem

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -7,6 +7,8 @@ import Storage
 import Shared
 import Common
 
+import struct MozillaAppServices.LoginEntry
+
 class PasswordManagerListViewController: SensitiveViewController, Themeable {
     static let loginsSettingsSection = 0
 

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerViewModel.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerViewModel.swift
@@ -8,6 +8,9 @@ import Storage
 import Shared
 import AuthenticationServices
 
+import struct MozillaAppServices.EncryptedLogin
+import struct MozillaAppServices.LoginEntry
+
 struct NewSearchInProgressError: MaybeErrorType {
     public let description: String
 }

--- a/firefox-ios/Client/Frontend/Settings/NotificationsSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/NotificationsSettingsViewController.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Shared
 import Common
-import MozillaAppServices
 
 class NotificationsSettingsViewController: SettingsTableViewController, FeatureFlaggable {
     private lazy var syncNotifications: BoolNotificationSetting = {

--- a/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -7,6 +7,8 @@ import Storage
 import Shared
 import Common
 
+import struct MozillaAppServices.LoginEntry
+
 class PasswordDetailViewController: SensitiveViewController, Themeable {
     private struct UX {
         static let horizontalMargin: CGFloat = 14

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -8,6 +8,8 @@ import Shared
 import Storage
 import WebKit
 
+import struct MozillaAppServices.LoginEntry
+
 enum FocusFieldType: String, Codable {
     case username
     case password

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import MozillaAppServices
 
 final class NimbusFeatureFlagLayer {
     // MARK: - Public methods

--- a/firefox-ios/Client/Nimbus/NimbusFirefoxSuggestFeatureLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFirefoxSuggestFeatureLayer.swift
@@ -3,7 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import MozillaAppServices
+
+import enum MozillaAppServices.SuggestionProvider
 
 protocol NimbusFirefoxSuggestFeatureLayerProtocol {
     var config: [SuggestionType: Bool] { get }

--- a/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
+++ b/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayer.swift
@@ -3,7 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Shared
-import MozillaAppServices
+
+import protocol MozillaAppServices.NimbusMessagingHelperProtocol
 
 /// A translation layer for the `onboardingFrameworkFeature.fml`
 ///

--- a/firefox-ios/Client/Protocols/CanRemoveQuickActionBookmark.swift
+++ b/firefox-ios/Client/Protocols/CanRemoveQuickActionBookmark.swift
@@ -5,6 +5,8 @@
 import Foundation
 import Storage
 
+import class MozillaAppServices.BookmarkItemData
+
 protocol CanRemoveQuickActionBookmark {
     var bookmarksHandler: BookmarksHandler { get }
     func removeBookmarkShortcut(quickAction: QuickActions)

--- a/firefox-ios/Client/RatingPromptManager.swift
+++ b/firefox-ios/Client/RatingPromptManager.swift
@@ -8,6 +8,9 @@ import Shared
 import Storage
 import Common
 
+import class MozillaAppServices.BookmarkFolderData
+import enum MozillaAppServices.BookmarkRoots
+
 /// The `RatingPromptManager` handles app store review requests and the internal logic of when
 /// they can be presented to a user.
 final class RatingPromptManager {

--- a/firefox-ios/Client/RecentItemsHelper.swift
+++ b/firefox-ios/Client/RecentItemsHelper.swift
@@ -6,6 +6,8 @@ import Foundation
 import Storage
 import Shared
 
+import class MozillaAppServices.BookmarkItemData
+
 protocol RecentlySavedItem {
     var title: String { get }
     var url: String { get }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabGroupData.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabGroupData.swift
@@ -3,7 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import MozillaAppServices
+
+import struct MozillaAppServices.HistoryMetadataKey
 
 enum LegacyTabGroupTimerState: String, Codable {
     case navSearchLoaded

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabMetadataManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabMetadataManager.swift
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import MozillaAppServices
 import Shared
 import Storage
+
+import struct MozillaAppServices.HistoryMetadataKey
+import struct MozillaAppServices.HistoryMetadataObservation
 
 class LegacyTabMetadataManager {
     let metadataObserver: HistoryMetadataObserver

--- a/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
@@ -7,6 +7,9 @@ import Glean
 import Storage
 import Common
 
+import class MozillaAppServices.BookmarkFolderData
+import enum MozillaAppServices.BookmarkRoots
+
 final class AppStartupTelemetry {
     let profile: Profile
 

--- a/firefox-ios/Client/Utils/HistoryDeletionUtility.swift
+++ b/firefox-ios/Client/Utils/HistoryDeletionUtility.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import MozillaAppServices
 import WebKit
 import Shared
 

--- a/firefox-ios/Client/Utils/SearchTermGroupsUtility.swift
+++ b/firefox-ios/Client/Utils/SearchTermGroupsUtility.swift
@@ -5,7 +5,9 @@
 import Foundation
 import Shared
 import Storage
-import MozillaAppServices
+
+import struct MozillaAppServices.HistoryHighlight
+import struct MozillaAppServices.HistoryMetadata
 
 class SearchTermGroupsUtility {
     public static func getHighlightGroups(

--- a/firefox-ios/Client/Utils/SponsoredContentFilterUtility.swift
+++ b/firefox-ios/Client/Utils/SponsoredContentFilterUtility.swift
@@ -6,6 +6,8 @@ import Foundation
 import Storage
 import Shared
 
+import struct MozillaAppServices.HistoryHighlight
+
 // Utility to filter sponsored content out of certain data type
 struct SponsoredContentFilterUtility {
     /// Hide with search param is defined by adMarketplace, indicates this URL was registered through sponsored clicks

--- a/firefox-ios/Extensions/NotificationService/NotificationService.swift
+++ b/firefox-ios/Extensions/NotificationService/NotificationService.swift
@@ -9,6 +9,8 @@ import Storage
 import Sync
 import UserNotifications
 
+import class MozillaAppServices.Viaduct
+
 class NotificationService: UNNotificationServiceExtension {
     var display: SyncDataDisplay?
     var profile: BrowserProfile?

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -8,6 +8,9 @@ import Storage
 import Account
 import Common
 
+import class MozillaAppServices.Viaduct
+import enum MozillaAppServices.BookmarkRoots
+
 extension UIStackView {
     func addBackground(color: UIColor) {
         let subView = UIView(frame: bounds)

--- a/firefox-ios/Providers/LoginRecordExtension.swift
+++ b/firefox-ios/Providers/LoginRecordExtension.swift
@@ -5,6 +5,8 @@
 import Storage
 import AuthenticationServices
 
+import struct MozillaAppServices.EncryptedLogin
+
 extension LoginRecord {
     public var passwordCredentialIdentity: ASPasswordCredentialIdentity {
         let serviceIdentifier = ASCredentialServiceIdentifier(identifier: self.hostname, type: .URL)

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -14,7 +14,17 @@ import Shared
 import Storage
 import Sync
 import AuthenticationServices
-import MozillaAppServices
+
+import class MozillaAppServices.MZKeychainWrapper
+import enum MozillaAppServices.Level
+import enum MozillaAppServices.SyncReason
+import enum MozillaAppServices.VisitType
+import func MozillaAppServices.setLogger
+import func MozillaAppServices.setMaxLevel
+import struct MozillaAppServices.HistoryMigrationResult
+import struct MozillaAppServices.SyncParams
+import struct MozillaAppServices.SyncResult
+import struct MozillaAppServices.VisitObservation
 
 public protocol SyncManager {
     var isSyncing: Bool { get }

--- a/firefox-ios/Providers/RustErrors.swift
+++ b/firefox-ios/Providers/RustErrors.swift
@@ -4,7 +4,12 @@
 
 import Common
 import Foundation
-import MozillaAppServices
+
+import enum MozillaAppServices.Level
+import func MozillaAppServices.setApplicationErrorReporter
+import protocol MozillaAppServices.ApplicationErrorReporter
+import protocol MozillaAppServices.AppServicesLogger
+import struct MozillaAppServices.Record
 
 public func initializeRustErrors(logger: Logger) {
     setApplicationErrorReporter(errorReporter: FirefoxIOSErrorReporter(logger: logger))

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -9,6 +9,15 @@ import Sync
 import AuthenticationServices
 import Common
 
+import class MozillaAppServices.MZKeychainWrapper
+import enum MozillaAppServices.OAuthScope
+import enum MozillaAppServices.SyncEngineSelection
+import enum MozillaAppServices.SyncReason
+import struct MozillaAppServices.DeviceSettings
+import struct MozillaAppServices.SyncAuthInfo
+import struct MozillaAppServices.SyncParams
+import struct MozillaAppServices.SyncResult
+
 // Extends NSObject so we can use timers.
 public class RustSyncManager: NSObject, SyncManager {
     // We shouldn't live beyond our containing BrowserProfile, either in the main app

--- a/firefox-ios/Providers/TopSitesProvider.swift
+++ b/firefox-ios/Providers/TopSitesProvider.swift
@@ -7,6 +7,8 @@ import Shared
 import UIKit
 import Storage
 
+import enum MozillaAppServices.FrecencyThresholdOption
+
 /// A provider for frecency and pinned top sites, used for the home page and widgets
 protocol TopSitesProvider {
     /// Get top sites from frecency and pinned tiles

--- a/firefox-ios/Push/Autopush.swift
+++ b/firefox-ios/Push/Autopush.swift
@@ -5,7 +5,11 @@
 import Common
 import Shared
 import Storage
-import MozillaAppServices
+
+import class MozillaAppServices.PushManager
+import protocol MozillaAppServices.PushManagerProtocol
+import struct MozillaAppServices.DecryptResponse
+import struct MozillaAppServices.SubscriptionResponse
 
 public protocol AutopushProtocol {
     /// Updates the APNS token `Autopush` is using to send notifications to the device

--- a/firefox-ios/Push/PushConfiguration.swift
+++ b/firefox-ios/Push/PushConfiguration.swift
@@ -3,7 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import MozillaAppServices
+
+import enum MozillaAppServices.BridgeType
+import enum MozillaAppServices.PushHttpProtocol
+import struct MozillaAppServices.PushConfiguration
 
 public struct KnownPushHost {
     public static let prod = "updates.push.services.mozilla.com"

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -5,10 +5,13 @@
 import WebKit
 import Foundation
 import Account
-import MozillaAppServices
 import Shared
 import Common
 import PDFKit
+
+import enum MozillaAppServices.OAuthScope
+import struct MozillaAppServices.FxaAuthData
+import struct MozillaAppServices.UserData
 
 enum FxAPageType: Equatable {
     case emailLoginFlow

--- a/firefox-ios/RustFxA/PushNotificationSetup.swift
+++ b/firefox-ios/RustFxA/PushNotificationSetup.swift
@@ -4,7 +4,9 @@
 
 import Common
 import Shared
-import MozillaAppServices
+
+import struct MozillaAppServices.DevicePushSubscription
+import struct MozillaAppServices.SubscriptionResponse
 
 open class PushNotificationSetup {
     /// Disables FxA push notifications for the user

--- a/firefox-ios/RustFxA/RustFirefoxAccounts.swift
+++ b/firefox-ios/RustFxA/RustFirefoxAccounts.swift
@@ -5,7 +5,13 @@
 import Common
 import UIKit
 import Shared
-import MozillaAppServices
+
+import class MozillaAppServices.FxAccountManager
+import class MozillaAppServices.FxAConfig
+import enum MozillaAppServices.DeviceType
+import enum MozillaAppServices.OAuthScope
+import struct MozillaAppServices.DeviceConfig
+import struct MozillaAppServices.Profile
 
 let PendingAccountDisconnectedKey = "PendingAccountDisconnect"
 

--- a/firefox-ios/Shared/Extensions/KeychainWrapperExtensions.swift
+++ b/firefox-ios/Shared/Extensions/KeychainWrapperExtensions.swift
@@ -4,7 +4,9 @@
 
 import Common
 import Foundation
-import MozillaAppServices
+
+import class MozillaAppServices.MZKeychainWrapper
+import enum MozillaAppServices.MZKeychainItemAccessibility
 
 public extension MZKeychainWrapper {
     static var sharedClientAppContainerKeychain: MZKeychainWrapper {

--- a/firefox-ios/Shared/KeychainCache.swift
+++ b/firefox-ios/Shared/KeychainCache.swift
@@ -4,7 +4,8 @@
 
 import Common
 import Foundation
-import MozillaAppServices
+
+import class MozillaAppServices.MZKeychainWrapper
 
 public protocol JSONLiteralConvertible {
     func asJSON() -> [String: Any]

--- a/firefox-ios/Storage/RemoteTabs.swift
+++ b/firefox-ios/Storage/RemoteTabs.swift
@@ -5,6 +5,8 @@
 import Foundation
 import Shared
 
+import struct MozillaAppServices.RemoteTabRecord
+
 public struct ClientAndTabs: Equatable, CustomStringConvertible {
     public let client: RemoteClient
     public let tabs: [RemoteTab]

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -4,8 +4,15 @@
 
 import Foundation
 import Shared
-@_exported import MozillaAppServices
 import Common
+
+import class MozillaAppServices.Store
+import enum MozillaAppServices.AutofillApiError
+import func MozillaAppServices.encryptString
+import struct MozillaAppServices.Address
+import struct MozillaAppServices.CreditCard
+import struct MozillaAppServices.UpdatableAddressFields
+import struct MozillaAppServices.UpdatableCreditCardFields
 
 /// Typealias for AutofillStore.
 typealias AutofillStore = Store

--- a/firefox-ios/Storage/Rust/RustAutofillEncryptionKeys.swift
+++ b/firefox-ios/Storage/Rust/RustAutofillEncryptionKeys.swift
@@ -5,6 +5,13 @@
 import Foundation
 import Common
 
+import class MozillaAppServices.MZKeychainWrapper
+import enum MozillaAppServices.AutofillApiError
+import enum MozillaAppServices.MZKeychainItemAccessibility
+import func MozillaAppServices.createAutofillKey
+import func MozillaAppServices.decryptString
+import func MozillaAppServices.encryptString
+
 public extension AutofillApiError {
     var descriptionValue: String {
         switch self {

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -3,7 +3,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import MozillaAppServices
+
+import class MozillaAppServices.SuggestStore
+import class MozillaAppServices.SuggestStoreBuilder
+import class MozillaAppServices.Viaduct
+import enum MozillaAppServices.SuggestionProvider
+import struct MozillaAppServices.RemoteSettingsConfig
+import struct MozillaAppServices.SuggestIngestionConstraints
+import struct MozillaAppServices.SuggestionQuery
 
 public protocol RustFirefoxSuggestProtocol {
     /// Downloads and stores new Firefox Suggest suggestions.

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggestion.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggestion.swift
@@ -3,8 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import MozillaAppServices
 import UIKit
+
+import enum MozillaAppServices.Suggestion
 
 /// Additional information about a Firefox Suggestion to record
 /// in telemetry when the user interacts with the suggestion

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -5,8 +5,23 @@
 import Foundation
 import Glean
 import Shared
-@_exported import MozillaAppServices
 import Common
+
+import class MozillaAppServices.LoginsStorage
+import class MozillaAppServices.MZKeychainWrapper
+import enum MozillaAppServices.LoginsApiError
+import enum MozillaAppServices.MZKeychainItemAccessibility
+import func MozillaAppServices.checkCanary
+import func MozillaAppServices.createCanary
+import func MozillaAppServices.createKey
+import func MozillaAppServices.decryptLogin
+import func MozillaAppServices.encryptLogin
+import struct MozillaAppServices.EncryptedLogin
+import struct MozillaAppServices.Login
+import struct MozillaAppServices.LoginEntry
+import struct MozillaAppServices.LoginFields
+import struct MozillaAppServices.RecordFields
+import struct MozillaAppServices.SecureLoginFields
 
 typealias LoginsStoreError = LoginsApiError
 public typealias LoginRecord = EncryptedLogin

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -5,7 +5,29 @@
 import Foundation
 import Common
 import Shared
-@_exported import MozillaAppServices
+
+import class MozillaAppServices.BookmarkItemData
+import class MozillaAppServices.BookmarkNodeData
+import class MozillaAppServices.PlacesAPI
+import class MozillaAppServices.PlacesReadConnection
+import class MozillaAppServices.PlacesWriteConnection
+import enum MozillaAppServices.FrecencyThresholdOption
+import enum MozillaAppServices.PlacesApiError
+import enum MozillaAppServices.PlacesConnectionError
+import enum MozillaAppServices.VisitType
+import struct MozillaAppServices.HistoryHighlight
+import struct MozillaAppServices.HistoryHighlightWeights
+import struct MozillaAppServices.HistoryMetadata
+import struct MozillaAppServices.HistoryMetadataKey
+import struct MozillaAppServices.HistoryMetadataObservation
+import struct MozillaAppServices.HistoryMigrationResult
+import struct MozillaAppServices.HistoryVisitInfosWithBound
+import struct MozillaAppServices.PlacesTimestamp
+import struct MozillaAppServices.SearchResult
+import struct MozillaAppServices.TopFrecentSiteInfo
+import struct MozillaAppServices.Url
+import struct MozillaAppServices.VisitObservation
+import struct MozillaAppServices.VisitTransitionSet
 
 public protocol BookmarksHandler {
     func getRecentBookmarks(limit: UInt, completion: @escaping ([BookmarkItemData]) -> Void)

--- a/firefox-ios/Storage/Rust/RustRemoteTabs.swift
+++ b/firefox-ios/Storage/Rust/RustRemoteTabs.swift
@@ -4,8 +4,12 @@
 
 import Foundation
 import Shared
-@_exported import MozillaAppServices
 import Common
+
+import class MozillaAppServices.TabsStorage
+import enum MozillaAppServices.TabsApiError
+import struct MozillaAppServices.ClientRemoteTabs
+import struct MozillaAppServices.RemoteTabRecord
 
 public class RustRemoteTabs {
     let databasePath: String

--- a/firefox-ios/Storage/Rust/UnencryptedCreditCardFields.swift
+++ b/firefox-ios/Storage/Rust/UnencryptedCreditCardFields.swift
@@ -4,6 +4,8 @@
 
 import Foundation
 
+import struct MozillaAppServices.CreditCard
+
 // Note: This was created in lieu of a view model
 public struct UnencryptedCreditCardFields {
     public var ccName: String = ""

--- a/firefox-ios/Storage/SQL/BrowserSchema.swift
+++ b/firefox-ios/Storage/SQL/BrowserSchema.swift
@@ -6,6 +6,9 @@ import Foundation
 import Common
 import Shared
 
+import enum MozillaAppServices.BookmarkNodeType
+import enum MozillaAppServices.BookmarkRoots
+
 let _TableBookmarks = "bookmarks"                                      // Removed in v12. Kept for migration.
 let TableBookmarksMirror = "bookmarksMirror"                           // Added in v9.
 let TableBookmarksMirrorStructure = "bookmarksMirrorStructure"         // Added in v10.

--- a/firefox-ios/Storage/Visit.swift
+++ b/firefox-ios/Storage/Visit.swift
@@ -5,6 +5,8 @@
 import Foundation
 import Shared
 
+import enum MozillaAppServices.VisitType
+
 /**
  * SiteVisit is a sop to the existing API, which expects to be able to go
  * backwards from a visit to a site, and preserve the ID of the database row.

--- a/firefox-ios/Sync/RustSyncManagerAPI.swift
+++ b/firefox-ios/Sync/RustSyncManagerAPI.swift
@@ -5,7 +5,11 @@
 import Foundation
 import Common
 import Shared
-@_exported import MozillaAppServices
+
+import class MozillaAppServices.SyncManagerComponent
+import enum MozillaAppServices.SyncManagerError
+import struct MozillaAppServices.SyncParams
+import struct MozillaAppServices.SyncResult
 
 open class RustSyncManagerAPI {
     private let logger: Logger

--- a/firefox-ios/firefox-ios-tests/Tests/AccountTests/Push/AutopushTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/AccountTests/Push/AutopushTests.swift
@@ -3,8 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import XCTest
 import MozillaAppServices
+import XCTest
+
 @testable import Account
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/AddressListViewModelTests.swift
@@ -2,10 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
-@testable import Client
-import Storage
 import Combine
+import MozillaAppServices
+import Storage
+import XCTest
+
+@testable import Client
 
 class AddressListViewModelTests: XCTestCase {
     var viewModel: AddressListViewModel!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/LoginListViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/LoginListViewModelTests.swift
@@ -2,10 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-@testable import Client
 import Foundation
-import XCTest
+import MozillaAppServices
 import Storage
+import XCTest
+
+@testable import Client
 
 class LoginListViewModelTests: XCTestCase {
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CanRemoveQuickActionBookmarkTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CanRemoveQuickActionBookmarkTests.swift
@@ -2,8 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import MozillaAppServices
 import Storage
+import XCTest
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -3,9 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import XCTest
-import WebKit
 import ComponentLibrary
+import MozillaAppServices
+import WebKit
+import XCTest
+
 @testable import Client
 
 final class BrowserCoordinatorTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CredentialAutofillCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CredentialAutofillCoordinatorTests.swift
@@ -2,10 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
 import ComponentLibrary
+import MozillaAppServices
 import Storage
 import SwiftUI
+import XCTest
+
 @testable import Client
 
 final class CredentialAutofillCoordinatorTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/ReadingListCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/ReadingListCoordinatorTests.swift
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import MozillaAppServices
 import Storage
+import XCTest
+
 @testable import Client
 
 final class ReadingListCoordinatorTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -3,9 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import WebKit
 import Storage
+import WebKit
+
 @testable import Client
+
+import struct MozillaAppServices.CreditCard
 
 class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegate {
     var showSettingsCalled = 0

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockLibraryCoordinatorDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockLibraryCoordinatorDelegate.swift
@@ -2,10 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import Storage
-import Common
+
 @testable import Client
+
+import enum MozillaAppServices.VisitType
 
 class MockLibraryCoordinatorDelegate: LibraryCoordinatorDelegate, LibraryPanelDelegate {
     var libraryPanelWindowUUID: WindowUUID { return WindowUUID.XCTestDefaultUUID }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
@@ -2,11 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import UIKit
-@testable import Client
-import Storage
+import MozillaAppServices
 import Shared
+import Storage
+import UIKit
 import XCTest
+
+@testable import Client
 
 class CreditCardBottomSheetViewModelTests: XCTestCase {
     private var profile: MockProfile!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
@@ -2,10 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Foundation
-import XCTest
 import Common
+import Foundation
+import MozillaAppServices
 import Storage
+import XCTest
+
 @testable import Client
 
 class CreditCardInputViewModelTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TopSitesHelperTests.swift
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-@testable import Client
-
-import Storage
+import MozillaAppServices
 import Shared
+import Storage
 import XCTest
+
+@testable import Client
 
 class TopSitesHelperTests: XCTestCase {
     private var profile: MockProfile!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/RecentlySaved/BookmarksHandlerMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/RecentlySaved/BookmarksHandlerMock.swift
@@ -6,6 +6,10 @@ import Foundation
 import Storage
 import Shared
 
+import class MozillaAppServices.BookmarkFolderData
+import class MozillaAppServices.BookmarkItemData
+import class MozillaAppServices.BookmarkNodeData
+
 class BookmarksHandlerMock: BookmarksHandler {
     var getRecentBookmarksCallCount = 0
     var getRecentBookmarksCompletion: (([BookmarkItemData]) -> Void)?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/RecentlySaved/RecentlySavedDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/RecentlySaved/RecentlySavedDataAdaptorTests.swift
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-@testable import Client
-import XCTest
+import MozillaAppServices
 import Storage
+import XCTest
+
+@testable import Client
 
 class RecentlySavedDataAdaptorTests: XCTestCase {
     let oneDay: TimeInterval = 86400

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/RatingPromptManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/RatingPromptManagerTests.swift
@@ -3,10 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import XCTest
-import StoreKit
+import MozillaAppServices
 import Shared
 import Storage
+import StoreKit
+import XCTest
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/RecentItemsHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/RecentItemsHelperTests.swift
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-@testable import Client
-
-import XCTest
-import Storage
+import MozillaAppServices
 import Shared
+import Storage
+import XCTest
+
+@testable import Client
 
 class RecentItemsHelperTests: XCTestCase {
     private let bookmarkCutoffDate = 10

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
@@ -2,11 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import MozillaAppServices
 import Shared
+import XCTest
 
 @testable import Client
 @testable import Storage
+
 // FXIOS-8331: Disable History Highlight tests while FXIOS-8059 (Epic) is in progress
 // FXIOS-8367: Added a ticket to enable these tests when we re-enable history highlights
 class HistoryHighlightsTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsTestEntryProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsTestEntryProvider.swift
@@ -4,9 +4,13 @@
 
 import Foundation
 import Storage
+import XCTest
 
 @testable import Client
-import XCTest
+
+import struct MozillaAppServices.HistoryMetadataKey
+import struct MozillaAppServices.HistoryMetadataObservation
+import struct MozillaAppServices.VisitObservation
 
 class HistoryHighlightsTestEntryProvider {
     private var profile: MockProfile!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/BookmarkPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/BookmarkPanelViewModelTests.swift
@@ -2,9 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
-import Storage
+import MozillaAppServices
 import Shared
+import Storage
+import XCTest
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
@@ -2,10 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
-import Storage
-import Shared
 import Common
+import MozillaAppServices
+import Shared
+import Storage
+import XCTest
+
 @testable import Client
 
 class HistoryPanelViewModelTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/NimbusMessagingMessageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/NimbusMessagingMessageTests.swift
@@ -6,7 +6,6 @@ import XCTest
 
 import Common
 import Foundation
-import MozillaAppServices
 import Shared
 
 @testable import Client

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -4,7 +4,10 @@
 
 import UIKit
 import Storage
+
 @testable import Client
+
+import enum MozillaAppServices.VisitType
 
 class MockBrowserViewController: BrowserViewController {
     var switchToPrivacyModeCalled = false

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
@@ -2,13 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-@testable import Client
-import Foundation
 import Account
+import Foundation
 import Shared
 import Storage
 import Sync
 import XCTest
+
+@testable import Client
+
+import enum MozillaAppServices.SyncReason
+import struct MozillaAppServices.SyncResult
 
 public typealias ClientSyncManager = Client.SyncManager
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
@@ -2,11 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-@testable import Client
 import Common
-import Storage
+import MozillaAppServices
 import Shared
+import Storage
 import XCTest
+
+@testable import Client
 
 class PasswordManagerViewModelTests: XCTestCase {
     var viewModel: PasswordManagerViewModel!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SearchViewControllerTests.swift
@@ -3,9 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import MozillaAppServices
+import Shared
 import Storage
 import XCTest
-import Shared
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabMetadataManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabMetadataManagerTests.swift
@@ -2,8 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import MozillaAppServices
 import Shared
+import XCTest
 
 @testable import Client
 @testable import Storage

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TestHistory.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TestHistory.swift
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-@testable import Client
 import Foundation
+import MozillaAppServices
 import Storage
-
 import XCTest
+
+@testable import Client
 
 class TestHistory: ProfileTest {
     fileprivate func addSite(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/HistoryDeletionUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/HistoryDeletionUtilityTests.swift
@@ -2,8 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import MozillaAppServices
 import Shared
+import XCTest
 
 @testable import Client
 @testable import Storage

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/SponsoredContentFilterUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/SponsoredContentFilterUtilityTests.swift
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import Common
+import MozillaAppServices
 import Shared
 import Storage
 import WebKit
-import Common
+import XCTest
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import MozillaAppServices
 import Shared
+import XCTest
+
 @testable import Storage
 
 class RustAutofillTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import MozillaAppServices
 import Shared
+import XCTest
+
 @testable import Storage
 
 class RustLoginsTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustPlacesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustPlacesTests.swift
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import MozillaAppServices
 import Shared
+import XCTest
+
 @testable import Storage
 
 class RustPlacesTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustRemoteTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustRemoteTabsTests.swift
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import MozillaAppServices
 import Shared
+import XCTest
+
 @testable import Storage
 
 class MockRustRemoteTabs: RustRemoteTabs {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/StorageTestUtils.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/StorageTestUtils.swift
@@ -11,6 +11,8 @@ import Shared
 
 import XCTest
 
+import struct MozillaAppServices.VisitObservation
+
 let threeMonthsInMillis: UInt64 = 3 * 30 * 24 * 60 * 60 * 1000
 let threeMonthsInMicros = UInt64(threeMonthsInMillis) * UInt64(1000)
 

--- a/firefox-ios/firefox-ios-tests/Tests/SyncTests/RustSyncManagerAPITests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncTests/RustSyncManagerAPITests.swift
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
 import Common
+import MozillaAppServices
+import XCTest
+
 @testable import Sync
 
 class RustSyncManagerAPITests: XCTestCase {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9246)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20478)

## :bulb: Description

This helps reduce the chance of name collisions caused by `MozillaAppServices` defining types with the same names as Firefox for iOS types.

Because of how we package Application Services, it can be difficult to tell where each type comes from, especially when other modules re-export those imports. This commit aims to help with that as well.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

