### PR TITLE
Bugfix FXIOS-9022 ⁃ [Credit card] Error is generated only after the user leaves the field when trying to add an invalid CC data

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -62,7 +62,7 @@ struct CreditCardInputView: View {
                     Group {
                         CreditCardInputField(windowUUID: windowUUID,
                                              inputType: .expiration,
-                                             showError: !viewModel.expirationIsValid,
+                                             showError: viewModel.showExpirationError,
                                              inputViewModel: viewModel)
                         .padding(.top, 11)
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -118,7 +118,7 @@ class CreditCardInputViewModel: ObservableObject {
     @Published var cardType: CreditCardType?
     @Published var nameIsValid = true
     @Published var numberIsValid = true
-    @Published var expirationIsValid = true
+    @Published var showExpirationError = false
     @Published var nameOnCard: String = ""
 
     @Published var expirationDate: String = "" {
@@ -274,7 +274,7 @@ class CreditCardInputViewModel: ObservableObject {
         cardNumber = ""
         expirationDate = ""
         nameIsValid = true
-        expirationIsValid = true
+        showExpirationError = false
         numberIsValid = true
         creditCard = nil
     }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
@@ -183,7 +183,7 @@ struct CreditCardInputField: View {
         // TODO: FXIOS-6984 - use FocusState when iOS 14 is dropped
         TextField(text, text: $text, onEditingChanged: { (changed) in
             if !changed {
-                _ = self.updateInputValidity()
+                _ = self.updateInputValidity(fieldChanged: !changed)
             }
         })
         .preferredBodyFont(size: 17)
@@ -201,6 +201,9 @@ struct CreditCardInputField: View {
         .onChange(of: text) { [oldValue = text] newValue in
             handleTextInputWith(oldValue, and: newValue)
             viewModel.updateRightButtonState()
+            if inputType == .expiration {
+                _ = self.updateInputValidity()
+            }
         }.accessibilityLabel(fieldHeadline)
     }
 
@@ -234,7 +237,7 @@ struct CreditCardInputField: View {
         return creditCardValidator.isExpirationValidFor(date: val)
     }
 
-    func updateInputValidity() -> Bool? {
+    func updateInputValidity(fieldChanged: Bool = false) -> Bool? {
         switch inputType {
         case .name:
             let validity = isNameValid(val: text)
@@ -251,7 +254,7 @@ struct CreditCardInputField: View {
         case .expiration:
             let sanitizedValue = inputFieldHelper.sanitizeInputOn(text)
             let validity = isExpirationValid(val: sanitizedValue)
-            viewModel.expirationIsValid = validity
+            viewModel.showExpirationError = !validity && (sanitizedValue.count == 4 || fieldChanged)
             return validity
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputFieldTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputFieldTests.swift
@@ -147,7 +147,7 @@ class CreditCardInputFieldTests: XCTestCase {
 
         inputField.handleTextInputWith("125", and: "1250")
         XCTAssertTrue(inputField.isExpirationValid(val: "1250"))
-        XCTAssert(viewModel.expirationIsValid)
+        XCTAssertFalse(viewModel.showExpirationError)
     }
 
     func testInvalidShortenedExpirationInput() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardInputViewModelTests.swift
@@ -185,7 +185,7 @@ class CreditCardInputViewModelTests: XCTestCase {
         viewModel.expirationDate = "12 / 39"
         viewModel.cardNumber = "4717219604213696"
         viewModel.nameIsValid = false
-        viewModel.expirationIsValid = false
+        viewModel.showExpirationError = true
         viewModel.numberIsValid = false
         viewModel.creditCard = CreditCard(guid: "1",
                                           ccName: "Allen Burges",
@@ -205,7 +205,7 @@ class CreditCardInputViewModelTests: XCTestCase {
         XCTAssert(viewModel.cardNumber.isEmpty)
         XCTAssert(viewModel.expirationDate.isEmpty)
         XCTAssert(viewModel.nameIsValid)
-        XCTAssert(viewModel.expirationIsValid)
+        XCTAssertFalse(viewModel.showExpirationError)
         XCTAssert(viewModel.numberIsValid)
         XCTAssertNil(viewModel.creditCard)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9022)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19923)

## :bulb: Description
Changed the logic for the expiration date field.
Also, fixed the Unit Tests impacted by this change.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

