### PR TITLE
Refactor FXIOS-9242 - Updated Fonts On ThemedTable

### DIFF
--- a/firefox-ios/Client/Frontend/Theme/ThemedTableSectionHeaderFooterView.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableSectionHeaderFooterView.swift
@@ -49,7 +49,7 @@ class ThemedTableSectionHeaderFooterView: UITableViewHeaderFooterView, ReusableC
     }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .subheadline, size: 15)
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
         label.numberOfLines = 0
     }
 

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
@@ -53,7 +53,7 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         super.prepareForReuse()
         textLabel?.text = nil
         textLabel?.textAlignment = .natural
-        textLabel?.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 17, weight: .regular)
+        textLabel?.font = FXFontStyles.Regular.body.scaledFont()
         detailTextLabel?.text = nil
         accessoryView = nil
         accessoryType = .none


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9242)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20468)

## :bulb: Description
Updated `ThemedTableViewCell` and `ThemedTableSectionHeaderFooterView` to use `FXFontsStyle` instead of `DefaultDynamicFontHelper` or `UIFont`. This eliminates the need to specify font sizes in the view controllers.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

