### PR TITLE
Refactor FXIOS-9256 - Remove unnecessary nil coalescing in `RustFirefoxSuggest.query()`.

### DIFF
--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -81,7 +81,7 @@ public class RustFirefoxSuggest: RustFirefoxSuggestProtocol {
                         keyword: keyword,
                         providers: providers,
                         limit: limit
-                    )).compactMap(RustFirefoxSuggestion.init) ?? []
+                    )).compactMap(RustFirefoxSuggestion.init)
                     continuation.resume(returning: suggestions)
                 } catch {
                     continuation.resume(throwing: error)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9256)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20495)

## :bulb: Description

`RustFirefoxSuggest.query()` captures `self` strongly, so the `?? []` nil coalescing doesn't do anything—and Xcode warns about it. Let's drop it and save a warning.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

