### PR TITLE
Bugfix FXIOS-9236, 9237, 9257 [Multi-window] Fix sync and QR code panels on multi-window

### DIFF
--- a/firefox-ios/Client/Application/WindowEventCoordinator.swift
+++ b/firefox-ios/Client/Application/WindowEventCoordinator.swift
@@ -23,6 +23,9 @@ enum WindowEvent {
 
     /// Sync & sign-in, or sync settings, presented.
     case syncMenuOpened
+
+    /// QR code scanner is opened
+    case qrScannerOpened
 }
 
 /// Abstract protocol that any Coordinator can conform to in order to respond

--- a/firefox-ios/Client/Application/WindowEventCoordinator.swift
+++ b/firefox-ios/Client/Application/WindowEventCoordinator.swift
@@ -20,6 +20,9 @@ enum WindowEvent {
 
     /// A window opened the settings menu.
     case settingsOpened
+
+    /// Sync & sign-in, or sync settings, presented.
+    case syncMenuOpened
 }
 
 /// Abstract protocol that any Coordinator can conform to in order to respond

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -615,6 +615,7 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController?) {
+        windowManager.postWindowEvent(event: .qrScannerOpened, windowUUID: windowUUID)
         var coordinator: QRCodeCoordinator
         if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
             coordinator = qrCodeCoordinator
@@ -769,6 +770,14 @@ class BrowserCoordinator: BaseCoordinator,
                    $0 is FirefoxAccountSignInViewController || $0 is SyncContentSettingsViewController
                }) {
                 router.dismiss(animated: true, completion: nil)
+            }
+        case .qrScannerOpened:
+            guard uuid != windowUUID else { return }
+            let browserPresentedVC = router.navigationController.presentedViewController
+            let rootVC = (browserPresentedVC as? UINavigationController)?.viewControllers.first
+            if rootVC is QRCodeViewController {
+                router.dismiss(animated: true, completion: nil)
+                remove(child: childCoordinators.first(where: { $0 is QRCodeCoordinator }))
             }
         }
     }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -761,6 +761,13 @@ class BrowserCoordinator: BaseCoordinator,
             performIfCoordinatorRootVCIsPresented(SettingsCoordinator.self) {
                 didFinishSettings(from: $0)
             }
+        case .syncMenuOpened:
+            guard uuid != windowUUID else { return }
+            let browserPresentedVC = router.navigationController.presentedViewController
+            if let navVCs = (browserPresentedVC as? UINavigationController)?.viewControllers,
+               navVCs.contains(where: { $0 is FirefoxAccountSignInViewController }) {
+                router.dismiss(animated: true, completion: nil)
+            }
         }
     }
 

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -765,7 +765,9 @@ class BrowserCoordinator: BaseCoordinator,
             guard uuid != windowUUID else { return }
             let browserPresentedVC = router.navigationController.presentedViewController
             if let navVCs = (browserPresentedVC as? UINavigationController)?.viewControllers,
-               navVCs.contains(where: { $0 is FirefoxAccountSignInViewController }) {
+               navVCs.contains(where: {
+                   $0 is FirefoxAccountSignInViewController || $0 is SyncContentSettingsViewController
+               }) {
                 router.dismiss(animated: true, completion: nil)
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1783,6 +1783,8 @@ class BrowserViewController: UIViewController,
     func presentSignInViewController(_ fxaOptions: FxALaunchParams,
                                      flowType: FxAPageType = .emailLoginFlow,
                                      referringPage: ReferringPage = .none) {
+        let windowManager: WindowManager = AppContainer.shared.resolve()
+        windowManager.postWindowEvent(event: .syncMenuOpened, windowUUID: windowUUID)
         let vcToPresent = FirefoxAccountSignInViewController.getSignInOrFxASettingsVC(
             fxaOptions,
             flowType: flowType,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9236)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9237)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9257)

## :bulb: Description

Fixes several issues where sync settings or QR code scanners could be opened simultaneously across multiple iPad windows. To avoid this we auto-close them similarly to the treatment for app settings etc.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

