### PR TITLE
Refactor FXIOS-6353 Remove DefaultStandardFontSize

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -114,9 +114,7 @@ class SyncNowSetting: WithAccountSetting {
             return NSAttributedString(
                 string: .SyncingMessageWithEllipsis,
                 attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary,
-                             NSAttributedString.Key.font: UIFont.systemFont(
-                                ofSize: LegacyDynamicFontHelper.defaultHelper.DefaultStandardFontSize,
-                                weight: UIFont.Weight.regular)])
+                             NSAttributedString.Key.font: FXFontStyles.Regular.body.scaledFont()])
         default:
             return syncNowTitle
         }

--- a/firefox-ios/Client/Helpers/LegacyDynamicFontHelper.swift
+++ b/firefox-ios/Client/Helpers/LegacyDynamicFontHelper.swift
@@ -56,9 +56,6 @@ class LegacyDynamicFontHelper: NSObject {
      * Standard
      */
     fileprivate var defaultStandardFontSize: CGFloat
-    var DefaultStandardFontSize: CGFloat {
-        return defaultStandardFontSize
-    }
 
     /**
      * Reader mode


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-6353)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/14273)

## :bulb: Description
Replaces DefaultStandardFontSize with FXFontStyles.

Before:
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-31 at 16 58 15](https://github.com/mozilla-mobile/firefox-ios/assets/4530/7156362a-708d-474c-8311-99d528af6a6c)

After:
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-31 at 17 00 20](https://github.com/mozilla-mobile/firefox-ios/assets/4530/f826573d-4fd0-4217-b3d2-80ced90448b1)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

