### PR TITLE
Add FXIOS-9255 [Microsurvey] UI refinements

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -681,6 +681,8 @@ class BrowserCoordinator: BaseCoordinator,
         }
 
         let navigationController = DismissableNavigationViewController()
+        navigationController.sheetPresentationController?.detents = [.medium(), .large()]
+        navigationController.sheetPresentationController?.prefersGrabberVisible = true
         let coordinator = MicrosurveyCoordinator(
             model: model,
             router: DefaultRouter(

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
@@ -54,7 +54,7 @@ struct MicrosurveyModel: Equatable {
         AppName.shortName.rawValue
     )
     let promptButtonLabel: String = .Microsurvey.Prompt.TakeSurveyButton
-    let surveyQuestion = "How satisfied are you with printing in Firefox?"
+    let surveyQuestion = "How satisfied are you with your Firefox homepage?"
     let surveyOptions: [String] = [
         .Microsurvey.Survey.Options.LikertScaleOption1,
         .Microsurvey.Survey.Options.LikertScaleOption2,

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyConfirmationView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyConfirmationView.swift
@@ -31,6 +31,7 @@ class MicrosurveyConfirmationView: UIView, ThemeApplicable {
         label.text = .Microsurvey.Survey.ConfirmationPage.ConfirmationLabel
         label.font = FXFontStyles.Regular.title3.scaledFont()
         label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
     }
 
     override init(frame: CGRect) {

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
@@ -24,9 +24,9 @@ class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCell, The
     }
 
     private lazy var iconView: UIImageView = .build { imageView in
-        imageView.contentMode = .scaleAspectFit
         // TODO: FXIOS-9108: This image should come from the data source, based on the target feature
-        // imageView.image = UIImage(systemName: "printer")
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage(named: StandardImageIdentifiers.Large.lightbulb)?.withRenderingMode(.alwaysTemplate)
     }
 
     private lazy var questionLabel: UILabel = .build { label in

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableView.swift
@@ -15,6 +15,7 @@ class MicrosurveyTableView: UITableView {
         )
         register(cellType: MicrosurveyTableViewCell.self)
         rowHeight = UITableView.automaticDimension
+        separatorStyle = .none
     }
 
     required init?(coder: NSCoder) {

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
@@ -15,6 +15,7 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
             bottom: -10,
             trailing: -16
         )
+        static let separatorWidth = 0.5
 
         struct Images {
             // TODO: FXIOS-9028 Fix radio button for accessibility
@@ -22,6 +23,8 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
             static let notSelected = ImageIdentifiers.Onboarding.MultipleChoiceButtonImages.checkmarkEmpty
         }
     }
+
+    private var topSeparatorView: UIView = .build()
 
     private lazy var horizontalStackView: UIStackView = .build { stackView in
         stackView.axis = .horizontal
@@ -53,7 +56,7 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupLayout()
-        self.selectionStyle = .none
+        selectionStyle = .none
     }
 
     required init(coder aDecoder: NSCoder) {
@@ -64,15 +67,21 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         horizontalStackView.addArrangedSubview(radioButton)
         horizontalStackView.addArrangedSubview(optionLabel)
         horizontalStackView.accessibilityElements = [radioButton, optionLabel]
+        contentView.addSubview(topSeparatorView)
         contentView.addSubview(horizontalStackView)
 
         NSLayoutConstraint.activate(
             [
+                topSeparatorView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                topSeparatorView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                topSeparatorView.topAnchor.constraint(equalTo: contentView.topAnchor),
+                topSeparatorView.heightAnchor.constraint(equalToConstant: UX.separatorWidth),
+
                 radioButton.widthAnchor.constraint(equalToConstant: UX.radioButtonSize.width),
                 radioButton.heightAnchor.constraint(equalToConstant: UX.radioButtonSize.height),
 
                 horizontalStackView.topAnchor.constraint(
-                    equalTo: contentView.topAnchor,
+                    equalTo: topSeparatorView.bottomAnchor,
                     constant: UX.padding.top
                 ),
                 horizontalStackView.leadingAnchor.constraint(
@@ -99,6 +108,7 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     func applyTheme(theme: Theme) {
         let colors = theme.colors
         optionLabel.textColor = colors.textPrimary
-        backgroundColor = theme.colors.layer5
+        backgroundColor = theme.colors.layer2
+        topSeparatorView.backgroundColor = theme.colors.borderPrimary
     }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -42,6 +42,7 @@ final class MicrosurveyViewController: UIViewController,
             bottom: -16,
             trailing: -16
         )
+        static let contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0)
     }
 
     private lazy var headerView: UIStackView = .build { stack in
@@ -126,7 +127,6 @@ final class MicrosurveyViewController: UIViewController,
         setupNotifications(forObserver: self,
                            observing: [.DynamicFontChanged])
 
-        self.sheetPresentationController?.prefersGrabberVisible = true
         subscribeToRedux()
         configureUI()
         setupLayout()
@@ -185,7 +185,7 @@ final class MicrosurveyViewController: UIViewController,
             title: .Microsurvey.Survey.PrivacyPolicyLinkButtonTitle,
             a11yIdentifier: AccessibilityIdentifiers.Microsurvey.Survey.privacyPolicyLink,
             font: FXFontStyles.Regular.caption2.scaledFont(),
-            contentInsets: NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
+            contentInsets: UX.contentInsets,
             contentHorizontalAlignment: .center
         )
         privacyPolicyButton.configure(viewModel: privacyPolicyButtonViewModel)
@@ -269,6 +269,8 @@ final class MicrosurveyViewController: UIViewController,
         headerLabel.textColor = theme.colors.textPrimary
         closeButton.tintColor = theme.colors.textSecondary
         tableView.backgroundColor = theme.colors.layer2
+        tableView.layer.borderColor = theme.colors.borderPrimary.cgColor
+        tableView.separatorColor = theme.colors.borderPrimary
 
         containerView.backgroundColor = theme.colors.layer2
         containerView.layer.borderColor = theme.colors.borderPrimary.cgColor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9255)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20492)

## :bulb: Description
Add some UI refinements to the microsurvey feature
- add grabber
- add medium / large detents
- use custom view for separator (instead of default)
- update confirmation label to look better in large fonts
- update token colors

Next Steps: need to confirm some design tokens for the background colors.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
| iPhone | iPad |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 - 2024-06-03 at 13 29 21](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/f5f301b6-a5e8-462a-a79e-f73c41d0909d) |  ![simulator_screenshot_81257245-C093-48B6-92FB-A4D8EF688D33](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/59025df3-0fe9-48b1-8ac5-e6c7fc8470c8) |