### PR TITLE
For #20515 - Sets `ignoresViewportScaleLimits` on `WKWebViewConfiguration`

### DIFF
--- a/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
+++ b/focus-ios/Blockzilla/Modules/WebView/LegacyWebViewController.swift
@@ -151,6 +151,7 @@ class LegacyWebViewController: UIViewController, LegacyWebController {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
         configuration.allowsInlineMediaPlayback = true
+        configuration.ignoresViewportScaleLimits = true
 
         // For consistency we set our user agent similar to Firefox iOS.
         //


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20515)

## :bulb: Description
Sets `ignoresViewportScaleLimits` on `WKWebViewConfiguration` so that a user can zoom on every page.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

