### PR TITLE
Bugfix FXIOS-9229 [Multi-window] Fix search icon update when changed from another iPad window

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -775,10 +775,16 @@ class BrowserViewController: UIViewController,
             selector: #selector(didFinishAnnouncement),
             name: UIAccessibility.announcementDidFinishNotification,
             object: nil)
-        notificationCenter.addObserver(self,
-                                       selector: #selector(didAddPendingBlobDownloadToQueue),
-                                       name: .PendingBlobDownloadAddedToQueue,
-                                       object: nil)
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(didAddPendingBlobDownloadToQueue),
+            name: .PendingBlobDownloadAddedToQueue,
+            object: nil)
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(updateForDefaultSearchEngineDidChange),
+            name: .SearchSettingsDidUpdateDefaultSearchEngine,
+            object: nil)
     }
 
     func addSubviews() {
@@ -2817,17 +2823,18 @@ extension BrowserViewController: SearchViewControllerDelegate {
 
     func presentSearchSettingsController() {
         let searchSettingsTableViewController = SearchSettingsTableViewController(profile: profile, windowUUID: windowUUID)
-
-        // Update search icon when the searchengine changes
-        searchSettingsTableViewController.updateSearchIcon = {
-            if !self.isToolbarRefactorEnabled {
-                self.urlBar.searchEnginesDidUpdate()
-            }
-            self.searchController?.reloadSearchEngines()
-            self.searchController?.reloadData()
-        }
         let navController = ModalSettingsNavigationController(rootViewController: searchSettingsTableViewController)
         self.present(navController, animated: true, completion: nil)
+    }
+
+    @objc
+    func updateForDefaultSearchEngineDidChange(_ notification: Notification) {
+        // Update search icon when the search engine changes
+        if !self.isToolbarRefactorEnabled {
+            self.urlBar.searchEnginesDidUpdate()
+        }
+        self.searchController?.reloadSearchEngines()
+        self.searchController?.reloadData()
     }
 
     func searchViewController(

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2830,11 +2830,11 @@ extension BrowserViewController: SearchViewControllerDelegate {
     @objc
     func updateForDefaultSearchEngineDidChange(_ notification: Notification) {
         // Update search icon when the search engine changes
-        if !self.isToolbarRefactorEnabled {
-            self.urlBar.searchEnginesDidUpdate()
+        if !isToolbarRefactorEnabled {
+            urlBar.searchEnginesDidUpdate()
         }
-        self.searchController?.reloadSearchEngines()
-        self.searchController?.reloadData()
+        searchController?.reloadSearchEngines()
+        searchController?.reloadData()
     }
 
     func searchViewController(

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -7,6 +7,11 @@ import Shared
 import ComponentLibrary
 import Common
 
+extension Notification.Name {
+    /// General notification posted when the default search engine has changed
+    public static let SearchSettingsDidUpdateDefaultSearchEngine = Notification.Name("SearchSettingsDidUpdateDefaultSearchEngine")
+}
+
 protocol SearchEnginePickerDelegate: AnyObject {
     func searchEnginePicker(
         _ searchEnginePicker: SearchEnginePicker?,
@@ -71,7 +76,6 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     private var showDeletion = false
     private var sectionsToDisplay: [SearchSettingsTableViewController.Section] = []
 
-    var updateSearchIcon: (() -> Void)?
     private var isEditable: Bool {
         guard let defaultEngine = model.defaultEngine else { return false }
 
@@ -694,7 +698,7 @@ extension SearchSettingsTableViewController: SearchEnginePickerDelegate {
     ) {
         if let engine = searchEngine {
             model.defaultEngine = engine
-            updateSearchIcon?()
+            NotificationCenter.default.post(name: .SearchSettingsDidUpdateDefaultSearchEngine)
             self.tableView.reloadData()
 
             let extras = [TelemetryWrapper.EventExtraKey.preference.rawValue: "defaultSearchEngine",

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -9,7 +9,8 @@ import Common
 
 extension Notification.Name {
     /// General notification posted when the default search engine has changed
-    public static let SearchSettingsDidUpdateDefaultSearchEngine = Notification.Name("SearchSettingsDidUpdateDefaultSearchEngine")
+    public static let SearchSettingsDidUpdateDefaultSearchEngine =
+    Notification.Name("SearchSettingsDidUpdateDefaultSearchEngine")
 }
 
 protocol SearchEnginePickerDelegate: AnyObject {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9229)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20455)

## :bulb: Description

Fixes an issue where the search icon would not update in some flows if the default search engine was changed from a different iPad window. This removes the direct callback closure in favor of a broadcasted notification, since this change is now relevant for all windows across the client app.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

