### PR TITLE
Refactor FXIOS-9265 - Decreased Spacing Between Site Title & URL on TwoLineImageOverlayCell

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
@@ -41,7 +41,7 @@ class TwoLineImageOverlayCell: UITableViewCell,
     }
 
     lazy var stackView: UIStackView = .build { stackView in
-        stackView.spacing = 8
+        stackView.spacing = 4
         stackView.axis = .vertical
         stackView.distribution = .fillProportionally
     }

--- a/firefox-ios/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
@@ -41,7 +41,7 @@ class TwoLineImageOverlayCell: UITableViewCell,
     }
 
     lazy var stackView: UIStackView = .build { stackView in
-        stackView.spacing = 4
+        stackView.spacing = 2
         stackView.axis = .vertical
         stackView.distribution = .fillProportionally
     }

--- a/firefox-ios/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TwoLineImageOverlayCell.swift
@@ -47,7 +47,7 @@ class TwoLineImageOverlayCell: UITableViewCell,
     }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.callout.scaledFont()
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.textAlignment = .natural
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9265)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20512)

## :bulb: Description
Decreased spacing between `titleLabel` and `descriptionLabel` on `TwoLineImageOverlayCell` from 8 to 4.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

