### PR TITLE
Bugfix FXIOS-9221 [Multi-window] Sync zoom level across multiple windows

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -783,6 +783,11 @@ class BrowserViewController: UIViewController,
             selector: #selector(updateForDefaultSearchEngineDidChange),
             name: .SearchSettingsDidUpdateDefaultSearchEngine,
             object: nil)
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(handlePageZoomLevelUpdated),
+            name: .PageZoomLevelUpdated,
+            object: nil)
     }
 
     func addSubviews() {
@@ -2351,6 +2356,16 @@ class BrowserViewController: UIViewController,
         } else {
             showSearchController()
         }
+    }
+
+    // MARK: Page Zoom
+
+    @objc
+    func handlePageZoomLevelUpdated(_ notification: Notification) {
+        guard let uuid = notification.windowUUID,
+              let zoomSetting = notification.userInfo?["zoom"] as? DomainZoomLevel,
+        uuid != windowUUID else { return }
+        updateForZoomChangedInOtherIPadWindow(zoom: zoomSetting)
     }
 
     // MARK: Themeable

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2364,7 +2364,7 @@ class BrowserViewController: UIViewController,
     func handlePageZoomLevelUpdated(_ notification: Notification) {
         guard let uuid = notification.windowUUID,
               let zoomSetting = notification.userInfo?["zoom"] as? DomainZoomLevel,
-        uuid != windowUUID else { return }
+              uuid != windowUUID else { return }
         updateForZoomChangedInOtherIPadWindow(zoom: zoomSetting)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/ZoomPageBar.swift
@@ -215,7 +215,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         gradient.frame = gradientView.bounds
     }
 
-    private func updateZoomLabel() {
+    func updateZoomLabel() {
         zoomLevel.text = NumberFormatter.localizedString(from: NSNumber(value: tab.pageZoom), number: .percent)
         zoomLevel.isEnabled = tab.pageZoom == 1.0 ? false : true
         gestureRecognizer.isEnabled = !(tab.pageZoom == 1.0)

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -7,11 +7,6 @@ import Shared
 import Storage
 import Common
 
-extension Notification.Name {
-    // General notification posted when a file has been deleted from the downloads manager
-    public static let DownloadPanelFileWasDeleted = Notification.Name("DownloadPanelFileWasDeleted")
-}
-
 class DownloadsPanel: UIViewController,
                       UITableViewDelegate,
                       UITableViewDataSource,

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -7,12 +7,6 @@ import Shared
 import ComponentLibrary
 import Common
 
-extension Notification.Name {
-    /// General notification posted when the default search engine has changed
-    public static let SearchSettingsDidUpdateDefaultSearchEngine =
-    Notification.Name("SearchSettingsDidUpdateDefaultSearchEngine")
-}
-
 protocol SearchEnginePickerDelegate: AnyObject {
     func searchEnginePicker(
         _ searchEnginePicker: SearchEnginePicker?,

--- a/firefox-ios/Shared/NotificationConstants.swift
+++ b/firefox-ios/Shared/NotificationConstants.swift
@@ -91,6 +91,11 @@ extension Notification.Name {
     // fired when user taps on undo button on Toast
     public static let DidTapUndoCloseAllTabToast = Notification.Name("DidTapUndoCloseAllTabToast")
 
+    // MARK: Downloads
+
+    // General notification posted when a file has been deleted from the downloads manager
+    public static let DownloadPanelFileWasDeleted = Notification.Name("DownloadPanelFileWasDeleted")
+
     // MARK: Settings
 
     public static let BlockPopup = Notification.Name("BlockPopup")
@@ -98,8 +103,11 @@ extension Notification.Name {
     public static let ReadingListUpdated = Notification.Name("ReadingListUpdated")
     public static let TopSitesUpdated = Notification.Name("TopSitesUpdated")
     public static let HistoryUpdated = Notification.Name("HistoryUpdated")
+    public static let PageZoomLevelUpdated = Notification.Name("PageZoomLevelUpdated")
 
     // Search
     public static let DefaultSearchEngineUpdated = Notification.Name("DefaultSearchEngineUpdated")
     public static let DisablePrivateModeSearchSuggests = Notification.Name("DisablePrivateModeSearchSuggests")
+    public static let SearchSettingsDidUpdateDefaultSearchEngine =
+    Notification.Name("SearchSettingsDidUpdateDefaultSearchEngine")
 }

--- a/firefox-ios/Storage/ZoomLevelStore.swift
+++ b/firefox-ios/Storage/ZoomLevelStore.swift
@@ -7,7 +7,7 @@ import Shared
 import Common
 
 public struct DomainZoomLevel: Codable, Equatable {
-    let host: String
+    public let host: String
     public let zoomLevel: CGFloat
 
     public init(host: String, zoomLevel: CGFloat) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9221)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20434)

## :bulb: Description

Fixes zoom levels so that they work across multiple windows when the same host is on the selected tab.

### Video

https://github.com/mozilla-mobile/firefox-ios/assets/145381717/f8d4cabd-7497-45a1-add9-e1a0e0d5efbc


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

