### PR TITLE
Bugfix FXIOS-9104 Thumbnail lag when moving tabs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/TabTrayAnimationQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/TabTrayAnimationQueue.swift
@@ -35,7 +35,6 @@ class TabTrayAnimationQueueImplementation: TabTrayAnimationQueue {
         collectionView.performBatchUpdates({
             animation()
         }, completion: { [weak self] (done) in
-            collectionView.reloadData()
             self?.performingChainedOperations = false
             self?.performChainedOperations(for: collectionView)
         })


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9104)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20186)

## :bulb: Description
Remove `collectionView.reloadData()` from animation in perform batch updates fixes this bug. Apparently it's best practice to not call this in the animation block. This is a fix for the tab tray refactor.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

