### PR TITLE
Bugfix FXIOS-7571 ⁃ Session restore fails to load pages in reader view

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -513,7 +513,9 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         if InternalURL.isValid(url: url) {
-            if navigationAction.navigationType != .backForward, navigationAction.isInternalUnprivileged {
+            if navigationAction.navigationType != .backForward,
+               navigationAction.isInternalUnprivileged,
+               !url.isReaderModeURL {
                 logger.log("Denying unprivileged request: \(navigationAction.request)",
                            level: .warning,
                            category: .webview)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7571)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16845)

## :bulb: Description
Allow to reload a page that is in readerView, after closing and reopening the app

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

