### PR TITLE
Bugfix FXIOS-9276 - Navigation not working properly after session restore

### DIFF
--- a/firefox-ios/Shared/InternalURL.swift
+++ b/firefox-ios/Shared/InternalURL.swift
@@ -7,7 +7,20 @@ import Foundation
 
 // Internal URLs helps with error pages, session restore and about pages
 public struct InternalURL {
-    public static let uuid = UUID().uuidString
+    public static var uuid: String {
+        if let storedUUID = UserDefaults.standard.string(
+            forKey: PrefsKeys.Session.InternalURLUUID
+        ) {
+            return storedUUID
+        } else {
+            let newUUID = UUID().uuidString
+            UserDefaults.standard.set(
+                newUUID,
+                forKey: PrefsKeys.Session.InternalURLUUID
+            )
+            return newUUID
+        }
+    }
     public static let scheme = "internal"
     public static let baseUrl = "\(scheme)://local"
     public enum Path: String {

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -47,6 +47,7 @@ public struct PrefsKeys {
         public static let firstWeekAppOpenTimestamps = "firstWeekAppOpenTimestamps"
         public static let firstWeekSearchesTimestamps = "firstWeekSearchesTimestamps"
         public static let didUpdateConversionValue = "didUpdateConversionValue"
+        public static let InternalURLUUID = "InternalURLUUID"
     }
 
     public struct AppVersion {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9276)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20541)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

- This PR addresses an issue where the `isAuthorized` check in the `InternalURL` struct was failing when the app was closed and reopened. The root cause of this issue was that a new UUID was being generated each time the app was launched due to `InternalURL.uuid` being a static property. This new UUID did not match the UUID in the internal URL that was saved before the app was closed, causing the `isAuthorized` check to fail.

- To resolve this issue, I've modified the `uuid` property in the `InternalURL` struct to persist the UUID across app sessions. Now, instead of generating a new UUID each time the app is launched, the UUID is stored in `UserDefaults`. When the app is launched, it first checks if a UUID is stored in UserDefaults. If it is, it uses the stored UUID. If not, it generates a new UUID, stores it in `UserDefaults`, and uses it.

- This change ensures that the UUID remains consistent across different app sessions, which should allow the `isAuthorized` check to pass as expected.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

