### PR TITLE
Add FXIOS-9058 [Microsurvey] Target feature for behavioral targeting

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -829,6 +829,7 @@
 		8AD08D1527E9198E00B8E907 /* TabsTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */; };
 		8AD08D1727E91AC800B8E907 /* TabsTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsTelemetryTests.swift */; };
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
+		8AD248F12C0F735200500AB7 /* BehavioralTargetingEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD248F02C0F735200500AB7 /* BehavioralTargetingEvent.swift */; };
 		8AD3271527E3B45D00EAF033 /* SponsoredTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD3271427E3B45D00EAF033 /* SponsoredTile.swift */; };
 		8AD40FC527BADC1F00672675 /* TabToolbarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */; };
 		8AD40FC727BADC3400672675 /* ToolbarTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC627BADC3400672675 /* ToolbarTextField.swift */; };
@@ -6113,6 +6114,7 @@
 		8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsTelemetry.swift; sourceTree = "<group>"; };
 		8AD08D1627E91AC800B8E907 /* TabsTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsTelemetryTests.swift; sourceTree = "<group>"; };
 		8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetViewModel.swift; sourceTree = "<group>"; };
+		8AD248F02C0F735200500AB7 /* BehavioralTargetingEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralTargetingEvent.swift; sourceTree = "<group>"; };
 		8AD3271427E3B45D00EAF033 /* SponsoredTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredTile.swift; sourceTree = "<group>"; };
 		8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabToolbarHelper.swift; sourceTree = "<group>"; };
 		8AD40FC627BADC3400672675 /* ToolbarTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTextField.swift; sourceTree = "<group>"; };
@@ -8935,6 +8937,7 @@
 			isa = PBXGroup;
 			children = (
 				39EF434D260A73950011E22E /* Experiments.swift */,
+				8AD248F02C0F735200500AB7 /* BehavioralTargetingEvent.swift */,
 				3964F5FB2656D2B500065278 /* initial_experiments.json */,
 				9636D92627F5D71A00771F5E /* Messaging */,
 				D51EA5B82640697100334331 /* Settings */,
@@ -14688,6 +14691,7 @@
 				8A9F0B5627C595F300FE09AE /* ImageIdentifiers.swift in Sources */,
 				7B844E3D1BBDDB9D00E733A2 /* ChevronView.swift in Sources */,
 				43A5643823CD1E1C00B6857D /* UpdateViewController.swift in Sources */,
+				8AD248F12C0F735200500AB7 /* BehavioralTargetingEvent.swift in Sources */,
 				E192C1412B57DC860003BC0B /* FakespotMessageCardButton.swift in Sources */,
 				437A9B682681256800FB41C1 /* LegacyInactiveTabCell.swift in Sources */,
 				1D69FF8D27B17286001F660E /* HomeLogoHeaderCell.swift in Sources */,

--- a/firefox-ios/Client/Experiments/BehavioralTargetingEvent.swift
+++ b/firefox-ios/Client/Experiments/BehavioralTargetingEvent.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct BehavioralTargetingEvent {
+    static let syncLoginCompletion = "sync.login_completed_view"
+    static let homepageViewed = "homepage_viewed"
+    static let appForeground = "app_cycle.foreground"
+}

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -196,6 +196,7 @@ class HomepageViewModel: FeatureFlaggable {
         guard !viewAppeared else { return }
 
         viewAppeared = true
+        Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
         nimbus.features.homescreenFeature.recordExposure()
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .view,

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -1576,7 +1576,7 @@ extension TelemetryWrapper {
         case (.firefoxAccount, .view, .fxaLoginCompleteWebpage, _, _):
             GleanMetrics.Sync.loginCompletedView.record()
             // record the same event for Nimbus' internal event store
-            Experiments.events.recordEvent("sync.login_completed_view")
+            Experiments.events.recordEvent(BehavioralTargetingEvent.syncLoginCompletion)
         case (.firefoxAccount, .view, .fxaConfirmSignUpCode, _, _):
             GleanMetrics.Sync.registrationCodeView.record()
         case (.firefoxAccount, .view, .fxaConfirmSignInToken, _, _):
@@ -1591,7 +1591,7 @@ extension TelemetryWrapper {
         case(.action, .foreground, .app, _, _):
             GleanMetrics.AppCycle.foreground.record()
             // record the same event for Nimbus' internal event store
-            Experiments.events.recordEvent("app_cycle.foreground")
+            Experiments.events.recordEvent(BehavioralTargetingEvent.appForeground)
         case(.action, .background, .app, _, _):
             GleanMetrics.AppCycle.background.record()
         // MARK: App icon

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/NimbusMessagingTriggerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/NimbusMessagingTriggerTests.swift
@@ -29,7 +29,7 @@ final class NimbusMessagingTriggerTests: XCTestCase {
 
     func testTriggers() throws {
         Experiments.events.clearEvents()
-        Experiments.events.recordEvent("app_cycle.foreground")
+        Experiments.events.recordEvent(BehavioralTargetingEvent.appForeground)
         let helper = Experiments.createJexlHelper()!
         let triggers = feature.triggers
 

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -59,7 +59,7 @@ import:
                 surface: microsurvey
                 style: MICROSURVEY
                 trigger-if-all:
-                  - NEVER
+                  - VIEWED_HOMEPAGE
                 title: Microsurvey/Microsurvey.Prompt.TitleLabel.v127
                 text: "How satisfied are you with printing in Firefox?" # Should not show this message if this is nil
                 button-label: Microsurvey/Microsurvey.Prompt.TakeSurveyButton.v127

--- a/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
@@ -36,6 +36,9 @@ import:
               INACTIVE_NEW_USER:        "is_inactive_new_user"
               ALLOWED_TIPS_NOTIFICATIONS: "allowed_tips_notifications"
 
+              # Behavioral Targeting Events
+              VIEWED_HOMEPAGE:  "'homepage_viewed'|eventLastSeen('Hours') <= 24"
+
             actions:
               OPEN_SETTINGS:                      ://deep-link?url=settings/general
               OPEN_SETTINGS_NEW_TAB:              ://deep-link?url=settings/newtab


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9058)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20053)

## :bulb: Description
Add trigger for viewing the homepage. We confirmed that this will be our main feature to use for the microsurvey for MVP.

Adding the values to the config files serve as an example for our behavioral targeting and for testing, but the experiment recipe can override this setting or use `VIEWED_HOMEPAGE`. 

In a future date, we can set the trigger back to NEVER to avoid the microsurvey popping up in the future. However, for testing purposes and to catch issues early, I would like it to show depending on the trigger.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

