### PR TITLE
Bugfix FXIOS-9232 [Multi-window] Show Default Browser UI in correct iPad window

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -14,7 +14,6 @@ protocol HomepageDataModelDelegate: AnyObject {
 }
 
 class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
-
     struct UX {
         static let spacingBetweenSections: CGFloat = 62
         static let standardInset: CGFloat = 16

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -13,7 +13,8 @@ protocol HomepageDataModelDelegate: AnyObject {
     func reloadView()
 }
 
-class HomepageViewModel: FeatureFlaggable {
+class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
+
     struct UX {
         static let spacingBetweenSections: CGFloat = 62
         static let standardInset: CGFloat = 16
@@ -61,6 +62,7 @@ class HomepageViewModel: FeatureFlaggable {
         }
     }
 
+    let windowUUID: WindowUUID
     let nimbus: FxNimbus
     let profile: Profile
     var isZeroSearch: Bool {
@@ -122,6 +124,7 @@ class HomepageViewModel: FeatureFlaggable {
         self.isZeroSearch = isZeroSearch
         self.theme = theme
         self.logger = logger
+        self.windowUUID = tabManager.windowUUID
 
         self.headerViewModel = HomepageHeaderViewModel(profile: profile, theme: theme, tabManager: tabManager)
         let messageCardAdaptor = MessageCardDataAdaptorImplementation()

--- a/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -46,7 +46,9 @@ class HomepageMessageCardViewModel: MessageSurfaceProtocol {
     }
 
     func handleMessagePressed() {
-        message.map(messagingManager.onMessagePressed)
+        guard let message else { return }
+        let uuid = (delegate as? InjectedThemeUUIDIdentifiable)?.windowUUID
+        messagingManager.onMessagePressed(message, window: uuid)
         dismissClosure?()
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
@@ -56,7 +56,8 @@ class MicrosurveySurfaceManager: MobileMessageSurfaceProtocol {
 
     func handleMessagePressed() {
         // TODO: FXIOS-8797: Add telemetry to capture user responses
-        message.map(messagingManager.onMessagePressed)
+        guard let message else { return }
+        messagingManager.onMessagePressed(message, window: nil)
     }
 
     func handleMessageDismiss() {

--- a/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
@@ -73,7 +73,7 @@ class NotificationSurfaceManager: NotificationSurfaceDelegate {
               let message = messagingManager.messageForId(messageId)
         else { return }
 
-        messagingManager.onMessagePressed(message)
+        messagingManager.onMessagePressed(message, window: nil)
     }
 
     func didDismissNotification(_ userInfo: [AnyHashable: Any]) {

--- a/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
@@ -78,7 +78,8 @@ class SurveySurfaceManager: SurveySurfaceDelegate {
     }
 
     func didTapTakeSurvey() {
-        message.map(messagingManager.onMessagePressed)
+        guard let message else { return }
+        messagingManager.onMessagePressed(message, window: nil)
     }
 
     func didTapDismissSurvey() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
@@ -199,7 +199,7 @@ class MockGleanPlumbMessageManagerProtocol: GleanPlumbMessageManagerProtocol {
     }
 
     var onMessagePressedCalled = 0
-    func onMessagePressed(_ message: GleanPlumbMessage) {
+    func onMessagePressed(_ message: GleanPlumbMessage, window: WindowUUID?) {
         onMessagePressedCalled += 1
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
@@ -251,7 +251,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
 
     func testManagerOnMessagePressed() {
         let message = createMessage(messageId: messageId, action: "://test-action")
-        subject.onMessagePressed(message)
+        subject.onMessagePressed(message, window: nil)
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
         XCTAssertTrue(messageMetadata.isExpired)
         XCTAssertEqual(applicationHelper.openURLCalled, 1)
@@ -265,7 +265,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
         // 2. an existing scheme is left in place.
         // 3. that there is no spurious question mark when there are no parameters
         let message = createMessage(messageId: messageId, action: "itms-apps://itunes.apple.com/app/id{uuid}")
-        subject.onMessagePressed(message)
+        subject.onMessagePressed(message, window: nil)
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
         XCTAssertTrue(messageMetadata.isExpired)
         XCTAssertEqual(applicationHelper.openURLCalled, 1)
@@ -277,7 +277,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
     func testManagerOnMessagePressed_linkWithEmbeddedParam() {
         // Test shows query params can be part of the action.
         let message = createMessage(messageId: messageId, action: "itms-apps://itunes.apple.com/app/id?utm_param=foo")
-        subject.onMessagePressed(message)
+        subject.onMessagePressed(message, window: nil)
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
         XCTAssertTrue(messageMetadata.isExpired)
         XCTAssertEqual(applicationHelper.openURLCalled, 1)
@@ -293,7 +293,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
                                     actionParams: [
                                         "url": "https://example.com"
                                     ])
-        subject.onMessagePressed(message)
+        subject.onMessagePressed(message, window: nil)
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
         XCTAssertTrue(messageMetadata.isExpired)
         XCTAssertEqual(applicationHelper.openURLCalled, 1)
@@ -308,7 +308,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
         // 2. that the mozInternalScheme is used if no scheme is found.
         // 3. that query param values are URL query encoded.
         let message = createMessage(messageId: messageId, action: "://open-url", actionParams: ["url": "https://example.com?foo={uuid}&bar=baz"])
-        subject.onMessagePressed(message)
+        subject.onMessagePressed(message, window: nil)
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
         XCTAssertTrue(messageMetadata.isExpired)
         XCTAssertEqual(applicationHelper.openURLCalled, 1)
@@ -325,7 +325,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
                                         "url": "https://example.com",
                                         "private": "true"
                                     ])
-        subject.onMessagePressed(message)
+        subject.onMessagePressed(message, window: nil)
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
         XCTAssertTrue(messageMetadata.isExpired)
         XCTAssertEqual(applicationHelper.openURLCalled, 1)
@@ -340,7 +340,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
     // Reloads for notification
     func testManagerOnMessagePressed_withMalformedURL() {
         let message = createMessage(messageId: messageId, action: "http://www.google.com?q=א")
-        subject.onMessagePressed(message)
+        subject.onMessagePressed(message, window: nil)
         let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
         XCTAssertTrue(messageMetadata.isExpired)
         XCTAssertEqual(applicationHelper.openURLCalled, 0)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9232)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20458)

## :bulb: Description

Ensures that tapping the default browser info card on the homepage opens the resulting UI in the iPad window where the action originated. (Without this fix, the window which shows the UI is determined by the OS and could be incorrect).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

