### PR TITLE
Bugfix FXIOS-9272 [Multi-window] Apply No Image Mode to all open windows

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/General/NoImageModeSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/NoImageModeSetting.swift
@@ -8,9 +8,7 @@ class NoImageModeSetting: BoolSetting {
     init(settings: SettingsTableViewController) {
         let noImageEnabled = NoImageModeHelper.isActivated(settings.profile.prefs)
         let didChange = { (isEnabled: Bool) in
-            NoImageModeHelper.toggle(isEnabled: isEnabled,
-                                     profile: settings.profile,
-                                     tabManager: settings.tabManager)
+            NoImageModeHelper.toggle(isEnabled: isEnabled, profile: settings.profile)
         }
 
         super.init(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9272)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20529)

## :bulb: Description

Fixes No Image mode so that it immediately applies to all open windows. This fixes a bug where toggling the setting with multiple windows open would only apply it to the active window.

### Video

https://github.com/mozilla-mobile/firefox-ios/assets/145381717/762c83ac-fcc5-4968-b12d-85230d639a88


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

