### PR TITLE
Add FXIOS-9028 [Microsurvey] A11y checks

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -151,6 +151,7 @@ public struct AccessibilityIdentifiers {
 
     struct Microsurvey {
         struct Prompt {
+            static let firefoxLogo = "Microsurvey.Prompt.FirefoxLogo"
             static let closeButton = "Microsurvey.Prompt.CloseButton"
             static let takeSurveyButton = "Microsurvey.Prompt.TakeSurveyButton"
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1305,7 +1305,6 @@ class BrowserViewController: UIViewController,
 
     private func createMicrosurveyPrompt(with state: MicrosurveyPromptState) {
         self.microsurvey = MicrosurveyPromptView(state: state, windowUUID: windowUUID)
-
         updateMicrosurveyConstraints()
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -6,6 +6,7 @@ import Common
 import Foundation
 import ComponentLibrary
 import Redux
+import Shared
 
 /*
  |----------------|
@@ -48,6 +49,11 @@ class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
     private var logoWidthConstraint: NSLayoutConstraint?
     private var logoHeightConstraint: NSLayoutConstraint?
 
+    private var logoSize: CGSize {
+        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        return contentSizeCategory.isAccessibilityCategory ? UX.logoLargeSize : UX.logoSize
+    }
+
     private let windowUUID: WindowUUID
     var notificationCenter: NotificationProtocol
 
@@ -56,6 +62,12 @@ class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
     private lazy var logoImage: UIImageView = .build { imageView in
         imageView.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoBall)
         imageView.contentMode = .scaleAspectFit
+        imageView.isAccessibilityElement = true
+        imageView.accessibilityLabel = String(
+            format: .Microsurvey.Prompt.LogoImageA11yLabel,
+            AppName.shortName.rawValue
+        )
+        imageView.accessibilityIdentifier = AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo
     }
 
     private var titleLabel: UILabel = .build { label in
@@ -114,6 +126,7 @@ class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
                            observing: [.DynamicFontChanged])
         configure(with: state)
         setupView()
+        UIAccessibility.post(notification: .layoutChanged, argument: titleLabel)
     }
 
     private func configure(with state: MicrosurveyPromptState) {
@@ -142,8 +155,8 @@ class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
         addSubview(toastView)
         leadingConstraint = toastView.leadingAnchor.constraint(equalTo: leadingAnchor)
         trailingConstraint = toastView.trailingAnchor.constraint(equalTo: trailingAnchor)
-        logoWidthConstraint = logoImage.widthAnchor.constraint(equalToConstant: UX.logoSize.width)
-        logoHeightConstraint = logoImage.heightAnchor.constraint(equalToConstant: UX.logoSize.height)
+        logoWidthConstraint = logoImage.widthAnchor.constraint(equalToConstant: logoSize.width)
+        logoHeightConstraint = logoImage.heightAnchor.constraint(equalToConstant: logoSize.height)
 
         leadingConstraint?.isActive = true
         trailingConstraint?.isActive = true
@@ -183,8 +196,6 @@ class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
     }
 
     private func adjustIconSize() {
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
-        let logoSize = contentSizeCategory.isAccessibilityCategory ? UX.logoLargeSize : UX.logoSize
         logoWidthConstraint?.constant = logoSize.width
         logoHeightConstraint?.constant = logoSize.height
     }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -21,9 +21,8 @@ class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
         static let headerStackSpacing: CGFloat = 8
         static let stackSpacing: CGFloat = 17
         static let closeButtonSize = CGSize(width: 30, height: 30)
-        static let logoSize = CGSize(width: 24, height: 24)
-        static let logoLargeSize = CGSize(width: 48, height: 48)
         static let borderThickness = 1.0
+        static let logoSize: CGFloat = 24
         static let padding = NSDirectionalEdgeInsets(
             top: 14,
             leading: 16,
@@ -49,9 +48,8 @@ class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
     private var logoWidthConstraint: NSLayoutConstraint?
     private var logoHeightConstraint: NSLayoutConstraint?
 
-    private var logoSize: CGSize {
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
-        return contentSizeCategory.isAccessibilityCategory ? UX.logoLargeSize : UX.logoSize
+    private var logoSizeScaled: CGFloat {
+        return UIFontMetrics.default.scaledValue(for: UX.logoSize)
     }
 
     private let windowUUID: WindowUUID
@@ -155,8 +153,8 @@ class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
         addSubview(toastView)
         leadingConstraint = toastView.leadingAnchor.constraint(equalTo: leadingAnchor)
         trailingConstraint = toastView.trailingAnchor.constraint(equalTo: trailingAnchor)
-        logoWidthConstraint = logoImage.widthAnchor.constraint(equalToConstant: logoSize.width)
-        logoHeightConstraint = logoImage.heightAnchor.constraint(equalToConstant: logoSize.height)
+        logoWidthConstraint = logoImage.widthAnchor.constraint(equalToConstant: logoSizeScaled)
+        logoHeightConstraint = logoImage.heightAnchor.constraint(equalToConstant: logoSizeScaled)
 
         leadingConstraint?.isActive = true
         trailingConstraint?.isActive = true
@@ -196,8 +194,8 @@ class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
     }
 
     private func adjustIconSize() {
-        logoWidthConstraint?.constant = logoSize.width
-        logoHeightConstraint?.constant = logoSize.height
+        logoWidthConstraint?.constant = logoSizeScaled
+        logoHeightConstraint?.constant = logoSizeScaled
     }
 
     // MARK: ThemeApplicable

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
@@ -57,7 +57,7 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     var optionA11yValue: String {
         let selectedLabel: String = .Microsurvey.Survey.SelectedRadioButtonAccessibilityLabel
-        let unselectedLabel: String = .Microsurvey.Survey.SelectedRadioButtonAccessibilityLabel
+        let unselectedLabel: String = .Microsurvey.Survey.UnselectedRadioButtonAccessibilityLabel
 
         var a11yValue = checked ? selectedLabel : unselectedLabel
         if let a11yOptionsOrderValue {
@@ -71,7 +71,7 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         setupLayout()
         selectionStyle = .none
         isAccessibilityElement = true
-        accessibilityIdentifier  = AccessibilityIdentifiers.Microsurvey.Survey.radioButton
+        accessibilityIdentifier = AccessibilityIdentifiers.Microsurvey.Survey.radioButton
         accessibilityTraits.insert(.button)
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
@@ -18,13 +18,13 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         static let separatorWidth = 0.5
 
         struct Images {
-            // TODO: FXIOS-9028 Fix radio button for accessibility
             static let selected = ImageIdentifiers.radioButtonSelected
             static let notSelected = ImageIdentifiers.radioButtonNotSelected
         }
     }
 
     private var topSeparatorView: UIView = .build()
+    private var a11yOptionsOrderValue: String?
 
     private lazy var horizontalStackView: UIStackView = .build { stackView in
         stackView.axis = .horizontal
@@ -35,7 +35,7 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private lazy var radioButton: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
         imageView.image = UIImage(named: UX.Images.notSelected)
-        imageView.accessibilityIdentifier = AccessibilityIdentifiers.Microsurvey.Survey.radioButton
+        imageView.isAccessibilityElement = false
     }
 
     private lazy var optionLabel: UILabel = .build { label in
@@ -43,6 +43,7 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
+        label.isAccessibilityElement = false
     }
 
     var checked = false {
@@ -50,13 +51,28 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
             let checkedButton = UIImage(named: UX.Images.selected)
             let uncheckedButton = UIImage(named: UX.Images.notSelected)
             self.radioButton.image = checked ? checkedButton : uncheckedButton
+            accessibilityValue = optionA11yValue
         }
+    }
+
+    var optionA11yValue: String {
+        let selectedLabel: String = .Microsurvey.Survey.SelectedRadioButtonAccessibilityLabel
+        let unselectedLabel: String = .Microsurvey.Survey.SelectedRadioButtonAccessibilityLabel
+
+        var a11yValue = checked ? selectedLabel : unselectedLabel
+        if let a11yOptionsOrderValue {
+            a11yValue.append(", \(a11yOptionsOrderValue)")
+        }
+        return a11yValue
     }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupLayout()
         selectionStyle = .none
+        isAccessibilityElement = true
+        accessibilityIdentifier  = AccessibilityIdentifiers.Microsurvey.Survey.radioButton
+        accessibilityTraits.insert(.button)
     }
 
     required init(coder aDecoder: NSCoder) {
@@ -102,6 +118,16 @@ class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     func configure(_ text: String) {
         optionLabel.text = text
+        accessibilityLabel = optionLabel.text
+    }
+
+    func setA11yValue(for index: Int, outOf totalCount: Int) {
+        a11yOptionsOrderValue = String(
+            format: .Microsurvey.Survey.OptionsOrderAccessibilityLabel,
+            NSNumber(value: index + 1 as Int),
+            NSNumber(value: totalCount as Int)
+        )
+        accessibilityValue = optionA11yValue
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -32,8 +32,7 @@ final class MicrosurveyViewController: UIViewController,
     private struct UX {
         static let headerStackSpacing: CGFloat = 8
         static let scrollStackSpacing: CGFloat = 22
-        static let logoSize = CGSize(width: 24, height: 24)
-        static let logoLargeSize = CGSize(width: 48, height: 48)
+        static let logoSize: CGFloat = 24
         static let borderWidth: CGFloat = 1
         static let cornerRadius: CGFloat = 8
         static let estimatedRowHeight: CGFloat = 44
@@ -46,9 +45,8 @@ final class MicrosurveyViewController: UIViewController,
         static let contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0)
     }
 
-    private var logoSize: CGSize {
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
-        return contentSizeCategory.isAccessibilityCategory ? UX.logoLargeSize : UX.logoSize
+    private var logoSizeScaled: CGFloat {
+        return UIFontMetrics.default.scaledValue(for: UX.logoSize)
     }
 
     private lazy var headerView: UIStackView = .build { stack in
@@ -222,8 +220,8 @@ final class MicrosurveyViewController: UIViewController,
 
         view.addSubviews(headerView, scrollView)
 
-        logoWidthConstraint = logoImage.widthAnchor.constraint(equalToConstant: logoSize.width)
-        logoHeightConstraint = logoImage.heightAnchor.constraint(equalToConstant: logoSize.height)
+        logoWidthConstraint = logoImage.widthAnchor.constraint(equalToConstant: logoSizeScaled)
+        logoHeightConstraint = logoImage.heightAnchor.constraint(equalToConstant: logoSizeScaled)
         logoWidthConstraint?.isActive = true
         logoHeightConstraint?.isActive = true
 
@@ -271,8 +269,8 @@ final class MicrosurveyViewController: UIViewController,
     }
 
     private func adjustIconSize() {
-        logoWidthConstraint?.constant = logoSize.width
-        logoHeightConstraint?.constant = logoSize.height
+        logoWidthConstraint?.constant = logoSizeScaled
+        logoHeightConstraint?.constant = logoSizeScaled
     }
 
     // MARK: ThemeApplicable

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -6,6 +6,7 @@ import Foundation
 import Common
 import ComponentLibrary
 import Redux
+import Shared
 
 final class MicrosurveyViewController: UIViewController,
                                  UITableViewDataSource,
@@ -45,6 +46,11 @@ final class MicrosurveyViewController: UIViewController,
         static let contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0)
     }
 
+    private var logoSize: CGSize {
+        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        return contentSizeCategory.isAccessibilityCategory ? UX.logoLargeSize : UX.logoSize
+    }
+
     private lazy var headerView: UIStackView = .build { stack in
         stack.distribution = .fillProportionally
         stack.axis = .horizontal
@@ -55,7 +61,11 @@ final class MicrosurveyViewController: UIViewController,
     private lazy var logoImage: UIImageView = .build { imageView in
         imageView.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoBall)
         imageView.contentMode = .scaleAspectFit
-        // TODO: FXIOS-9028: Add A11y strings
+        imageView.isAccessibilityElement = true
+        imageView.accessibilityLabel = String(
+            format: .Microsurvey.Prompt.LogoImageA11yLabel,
+            AppName.shortName.rawValue
+        )
         imageView.accessibilityIdentifier = AccessibilityIdentifiers.Microsurvey.Survey.firefoxLogo
     }
 
@@ -102,6 +112,7 @@ final class MicrosurveyViewController: UIViewController,
         button.addTarget(self, action: #selector(self.didTapPrivacyPolicy), for: .touchUpInside)
         button.setContentCompressionResistancePriority(.required, for: .vertical)
         button.accessibilityTraits.insert(.link)
+        button.accessibilityTraits.remove(.button)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
     }
 
@@ -169,6 +180,11 @@ final class MicrosurveyViewController: UIViewController,
         applyTheme()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        UIAccessibility.post(notification: .screenChanged, argument: nil)
+    }
+
     deinit {
         unsubscribeFromRedux()
         tableView.removeFromSuperview()
@@ -206,8 +222,8 @@ final class MicrosurveyViewController: UIViewController,
 
         view.addSubviews(headerView, scrollView)
 
-        logoWidthConstraint = logoImage.widthAnchor.constraint(equalToConstant: UX.logoSize.width)
-        logoHeightConstraint = logoImage.heightAnchor.constraint(equalToConstant: UX.logoSize.height)
+        logoWidthConstraint = logoImage.widthAnchor.constraint(equalToConstant: logoSize.width)
+        logoHeightConstraint = logoImage.heightAnchor.constraint(equalToConstant: logoSize.height)
         logoWidthConstraint?.isActive = true
         logoHeightConstraint?.isActive = true
 
@@ -255,8 +271,6 @@ final class MicrosurveyViewController: UIViewController,
     }
 
     private func adjustIconSize() {
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
-        let logoSize = contentSizeCategory.isAccessibilityCategory ? UX.logoLargeSize : UX.logoSize
         logoWidthConstraint?.constant = logoSize.width
         logoHeightConstraint?.constant = logoSize.height
     }
@@ -344,6 +358,7 @@ final class MicrosurveyViewController: UIViewController,
             return UITableViewCell()
         }
         cell.configure(model.surveyOptions[indexPath.row])
+        cell.setA11yValue(for: indexPath.row, outOf: tableView.numberOfRows(inSection: .zero))
         cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         return cell
     }

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1274,7 +1274,7 @@ extension String {
     public struct Microsurvey {
         public struct Prompt {
             public static let LogoImageA11yLabel = MZLocalizedString(
-                key: "Microsurvey.Prompt.LogoImage.AccessibilityLabel.v129",
+                key: "Microsurvey.Prompt.LogoImage.AccessibilityLabel.v128",
                 tableName: "Microsurvey",
                 value: "%@ Logo",
                 comment: "On top of the bottom toolbar, there can be a microsurvey prompt, this is the logo image that appears on the prompt to inform the prompt is coming from the app specifically. Placeholder is for the app name.")
@@ -1297,7 +1297,7 @@ extension String {
 
         public struct Survey {
             public static let LogoImageA11yLabel = MZLocalizedString(
-                key: "Microsurvey.Prompt.LogoImage.AccessibilityLabel.v129",
+                key: "Microsurvey.Prompt.LogoImage.AccessibilityLabel.v128",
                 tableName: "Microsurvey",
                 value: "%@ Logo",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the logo image that appears on the bottom sheet that informs the user that it is coming from the app specifically. Placeholder is for the app name.")
@@ -1312,17 +1312,17 @@ extension String {
                 value: "Close",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label for close button that dismisses the sheet.")
             public static let SelectedRadioButtonAccessibilityLabel = MZLocalizedString(
-                key: "Microsurvey.Survey.RadioButton.Selected.AccessibilityLabel.v129",
+                key: "Microsurvey.Survey.RadioButton.Selected.AccessibilityLabel.v128",
                 tableName: "Microsurvey",
                 value: "Selected",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states whether the survey option was selected.")
             public static let UnselectedRadioButtonAccessibilityLabel = MZLocalizedString(
-                key: "Microsurvey.Survey.RadioButton.Unselected.AccessibilityLabel.v129",
+                key: "Microsurvey.Survey.RadioButton.Unselected.AccessibilityLabel.v128",
                 tableName: "Microsurvey",
                 value: "Unselected",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states whether the survey option was not selected.")
             public static let OptionsOrderAccessibilityLabel = MZLocalizedString(
-                key: "Microsurvey.Survey.OptionsOrder.AccessibilityLabel.v129",
+                key: "Microsurvey.Survey.OptionsOrder.AccessibilityLabel.v128",
                 tableName: "Microsurvey",
                 value: "%@ out of %@",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states the order the survey option in the list of options. First placeholder is the number the option is in the list and the second placeholder is the total number of options such as 1 out of 6.")

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1274,7 +1274,7 @@ extension String {
     public struct Microsurvey {
         public struct Prompt {
             public static let LogoImageA11yLabel = MZLocalizedString(
-                key: "Microsurvey.Prompt.LogoImage.AccessibilityLabel.v128",
+                key: "Microsurvey.Prompt.LogoImage.AccessibilityLabel.v129",
                 tableName: "Microsurvey",
                 value: "%@ Logo",
                 comment: "On top of the bottom toolbar, there can be a microsurvey prompt, this is the logo image that appears on the prompt to inform the prompt is coming from the app specifically. Placeholder is for the app name.")
@@ -1297,7 +1297,7 @@ extension String {
 
         public struct Survey {
             public static let LogoImageA11yLabel = MZLocalizedString(
-                key: "Microsurvey.Prompt.LogoImage.AccessibilityLabel.v128",
+                key: "Microsurvey.Survey.LogoImage.AccessibilityLabel.v129",
                 tableName: "Microsurvey",
                 value: "%@ Logo",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the logo image that appears on the bottom sheet that informs the user that it is coming from the app specifically. Placeholder is for the app name.")
@@ -1312,17 +1312,17 @@ extension String {
                 value: "Close",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label for close button that dismisses the sheet.")
             public static let SelectedRadioButtonAccessibilityLabel = MZLocalizedString(
-                key: "Microsurvey.Survey.RadioButton.Selected.AccessibilityLabel.v128",
+                key: "Microsurvey.Survey.RadioButton.Selected.AccessibilityLabel.v129",
                 tableName: "Microsurvey",
                 value: "Selected",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states whether the survey option was selected.")
             public static let UnselectedRadioButtonAccessibilityLabel = MZLocalizedString(
-                key: "Microsurvey.Survey.RadioButton.Unselected.AccessibilityLabel.v128",
+                key: "Microsurvey.Survey.RadioButton.Unselected.AccessibilityLabel.v129",
                 tableName: "Microsurvey",
                 value: "Unselected",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states whether the survey option was not selected.")
             public static let OptionsOrderAccessibilityLabel = MZLocalizedString(
-                key: "Microsurvey.Survey.OptionsOrder.AccessibilityLabel.v128",
+                key: "Microsurvey.Survey.OptionsOrder.AccessibilityLabel.v129",
                 tableName: "Microsurvey",
                 value: "%@ out of %@",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states the order the survey option in the list of options. First placeholder is the number the option is in the list and the second placeholder is the total number of options such as 1 out of 6.")

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1273,6 +1273,11 @@ extension String {
 extension String {
     public struct Microsurvey {
         public struct Prompt {
+            public static let LogoImageA11yLabel = MZLocalizedString(
+                key: "Microsurvey.Prompt.LogoImage.AccessibilityLabel.v129",
+                tableName: "Microsurvey",
+                value: "%@ Logo",
+                comment: "On top of the bottom toolbar, there can be a microsurvey prompt, this is the logo image that appears on the prompt to inform the prompt is coming from the app specifically. Placeholder is for the app name.")
             public static let TitleLabel = MZLocalizedString(
                 key: "Microsurvey.Prompt.TitleLabel.v127",
                 tableName: "Microsurvey",
@@ -1291,6 +1296,11 @@ extension String {
         }
 
         public struct Survey {
+            public static let LogoImageA11yLabel = MZLocalizedString(
+                key: "Microsurvey.Prompt.LogoImage.AccessibilityLabel.v129",
+                tableName: "Microsurvey",
+                value: "%@ Logo",
+                comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the logo image that appears on the bottom sheet that informs the user that it is coming from the app specifically. Placeholder is for the app name.")
             public static let HeaderLabel = MZLocalizedString(
                 key: "Microsurvey.Survey.HeaderLabel.v127",
                 tableName: "Microsurvey",
@@ -1301,6 +1311,21 @@ extension String {
                 tableName: "Microsurvey",
                 value: "Close",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label for close button that dismisses the sheet.")
+            public static let SelectedRadioButtonAccessibilityLabel = MZLocalizedString(
+                key: "Microsurvey.Survey.RadioButton.Selected.AccessibilityLabel.v129",
+                tableName: "Microsurvey",
+                value: "Selected",
+                comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states whether the survey option was selected.")
+            public static let UnselectedRadioButtonAccessibilityLabel = MZLocalizedString(
+                key: "Microsurvey.Survey.RadioButton.Unselected.AccessibilityLabel.v129",
+                tableName: "Microsurvey",
+                value: "Unselected",
+                comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states whether the survey option was not selected.")
+            public static let OptionsOrderAccessibilityLabel = MZLocalizedString(
+                key: "Microsurvey.Survey.OptionsOrder.AccessibilityLabel.v129",
+                tableName: "Microsurvey",
+                value: "%@ out of %@",
+                comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states the order the survey option in the list of options. First placeholder is the number the option is in the list and the second placeholder is the total number of options such as 1 out of 6.")
             public static let PrivacyPolicyLinkButtonTitle = MZLocalizedString(
                 key: "Microsurvey.Survey.PrivacyPolicyLink.v127",
                 tableName: "Microsurvey",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9028)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19931)

## :bulb: Description
Add appropriate a11y labels and identifiers
- Verified with VoiceOver, VoiceControl (Item numbers), and Dynamic Text

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)