### PR TITLE
Add FXIOS-9284 [Microsurvey] Add icon to mobile messaging configs

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -89,6 +89,12 @@ struct GleanPlumbMessage {
     var options: [String] {
         return data.microsurveyConfig?.options ?? []
     }
+
+    /// The icon for this message if it has a microsurvey configuration.
+    /// Embedding apps should not read from this directly.
+    var icon: UIImage? {
+        return data.microsurveyConfig?.icon
+    }
 }
 
 /// Public properties for this message.

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyModel.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyModel.swift
@@ -9,4 +9,5 @@ struct MicrosurveyModel: Equatable {
     let promptButtonLabel: String
     let surveyQuestion: String
     let surveyOptions: [String]
+    let icon: UIImage?
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
@@ -36,12 +36,14 @@ class MicrosurveySurfaceManager: MobileMessageSurfaceProtocol {
         )
         let promptButtonLabel = message?.buttonLabel ?? .Microsurvey.Prompt.TakeSurveyButton
         let options: [String] = message?.options ?? defaultSurveyOptions
+        let icon = message?.icon
 
         return MicrosurveyModel(
             promptTitle: promptTitle,
             promptButtonLabel: promptButtonLabel,
             surveyQuestion: surveyQuestion,
-            surveyOptions: options
+            surveyOptions: options,
+            icon: icon
         )
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
@@ -24,9 +24,7 @@ class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCell, The
     }
 
     private lazy var iconView: UIImageView = .build { imageView in
-        // TODO: FXIOS-9108: This image should come from the data source, based on the target feature
         imageView.contentMode = .scaleAspectFit
-        imageView.image = UIImage(named: StandardImageIdentifiers.Large.lightbulb)?.withRenderingMode(.alwaysTemplate)
     }
 
     private lazy var questionLabel: UILabel = .build { label in
@@ -38,9 +36,7 @@ class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCell, The
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
 
-        if iconView.image != nil {
-            horizontalStackView.addArrangedSubview(iconView)
-        }
+        horizontalStackView.addArrangedSubview(iconView)
         horizontalStackView.addArrangedSubview(questionLabel)
         contentView.addSubview(horizontalStackView)
 
@@ -73,8 +69,9 @@ class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCell, The
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(_ text: String) {
+    func configure(_ text: String, icon: UIImage?) {
         questionLabel.text = text
+        iconView.image = icon ?? UIImage(named: StandardImageIdentifiers.Large.lightbulb)?.withRenderingMode(.alwaysTemplate)
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
@@ -71,7 +71,11 @@ class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCell, The
 
     func configure(_ text: String, icon: UIImage?) {
         questionLabel.text = text
-        iconView.image = icon ?? UIImage(named: StandardImageIdentifiers.Large.lightbulb)?.withRenderingMode(.alwaysTemplate)
+        guard let icon else {
+            horizontalStackView.removeArrangedView(iconView)
+            return
+        }
+        iconView.image = icon.withRenderingMode(.alwaysTemplate)
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -355,7 +355,7 @@ final class MicrosurveyViewController: UIViewController,
         ) as? MicrosurveyTableHeaderView else {
             return nil
         }
-        headerView.configure(model.surveyQuestion)
+        headerView.configure(model.surveyQuestion, icon: model.icon)
         headerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
         return headerView
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMockModel.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMockModel.swift
@@ -14,7 +14,8 @@ class MicrosurveyMock {
             surveyOptions: [
                 "yes",
                 "no"
-            ]
+            ],
+            icon: nil
         )
     }
 }

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -64,6 +64,7 @@ import:
                 text: "How satisfied are you with your Firefox homepage?" # Should not show this message if this is nil
                 button-label: Microsurvey/Microsurvey.Prompt.Button.v127
                 microsurveyConfig:
+                  icon: homeLarge
                   options:
                     - Microsurvey/Microsurvey.Survey.Options.LikertScaleOption1.v127
                     - Microsurvey/Microsurvey.Survey.Options.LikertScaleOption2.v127

--- a/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
@@ -193,8 +193,8 @@ objects:
     fields:
       icon:
         description: The asset name in our bundle used as the icon shown in the survey.
-        type: Option<Image>
-        default: nil
+        type: Image
+        default: lightbulbLarge
       options:
         description: The list of survey options to present to the user.
         type: List<Text>

--- a/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
@@ -191,6 +191,10 @@ objects:
     description: >
         Attributes relating to microsurvey messaging.
     fields:
+      icon:
+        description: The asset name in our bundle used as the icon shown in the survey.
+        type: Option<Image>
+        default: nil
       options:
         description: The list of survey options to present to the user.
         type: List<Text>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9284)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20562)

## :bulb: Description
Add icon configuration to mobile messaging infrastructure

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

