### PR TITLE
Bugfix FXIOS-7127 ⁃ Incorrect redirect to the latest visited YouTube video, after undoing close tab action

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -646,6 +646,15 @@ extension BrowserViewController: WKNavigationDelegate {
                 }
             }
 
+            // Note: When "Undo" a tab with a Youtube video, navigationAction.request
+            // return the Youtube Homepage URL instead the video URL,
+            // even if the tab have the correct URL.
+            if let tabURL = tab.url, navigationAction.isIncorrectYoutubeURL(tabURL: tabURL) {
+                webView.load(URLRequest(url: tabURL))
+                decisionHandler(.cancel)
+                return
+            }
+
             decisionHandler(.allow)
             return
         }
@@ -1110,5 +1119,14 @@ extension WKNavigationAction {
         }
 
         return false
+    }
+
+    func isIncorrectYoutubeURL(tabURL: URL) -> Bool {
+        let youtubeShortDomain = "m.youtube"
+        guard let requestURL = request.url,
+              tabURL.shortDomain == youtubeShortDomain,
+              requestURL.shortDomain == youtubeShortDomain,
+              requestURL.absoluteString != tabURL.absoluteString else { return false }
+        return true
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7127)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/15837)

## :bulb: Description
When "Undo" a tab with a Youtube video, navigationAction.request return the Youtube Homepage URL instead the video URL, even if the tab have the correct URL.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

