### PR TITLE
Refactor FXIOS-9270 Add debug logging for intermittent ContentBlockerTest failure

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -24,6 +24,6 @@ final class ContentBlockerTests: XCTestCase {
         ContentBlocker.shared.compileListsNotInStore {
             expectation.fulfill()
         }
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: 3.0)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -20,13 +20,12 @@ final class ContentBlockerTests: XCTestCase {
     }
 
     func testCompileListsNotInStore_callsCompletionHandlerSuccessfully() {
-        let expectation = XCTestExpectation()
-        let startDate = Date()
-        ContentBlocker.shared.compileListsNotInStore {
-            let finishDate = Date()
-            NSLog("MT Test Time - \(finishDate.timeIntervalSince(startDate))")
-            expectation.fulfill()
+        measure {
+            let expectation = XCTestExpectation()
+            ContentBlocker.shared.compileListsNotInStore {
+                expectation.fulfill()
+            }
+            wait(for: [expectation], timeout: 1.0)
         }
-        wait(for: [expectation], timeout: 1.0)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -24,7 +24,7 @@ final class ContentBlockerTests: XCTestCase {
         let startDate = Date()
         ContentBlocker.shared.compileListsNotInStore {
             let finishDate = Date()
-            print(finishDate.timeIntervalSince(startDate))
+            NSLog("MT Test Time - \(finishDate.timeIntervalSince(startDate))")
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1.0)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -21,9 +21,12 @@ final class ContentBlockerTests: XCTestCase {
 
     func testCompileListsNotInStore_callsCompletionHandlerSuccessfully() {
         let expectation = XCTestExpectation()
+        let startDate = Date()
         ContentBlocker.shared.compileListsNotInStore {
+            let finishDate = Date()
+            print(finishDate.timeIntervalSince(startDate))
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 3.0)
+        wait(for: [expectation], timeout: 1.0)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9270)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20525)

## :bulb: Description
- `testCompileListsNotInStore_callsCompletionHandlerSuccessfully` seems to be failing intermittently on Bitrise, but not locally. Here we are adding a timeout and measuring elapsed time to the flaky test to determine if it is timing issue.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

