### PR TITLE
Refactor MTE-2907 Use Github Actions to run Focus smoke tests

### DIFF
--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -1,30 +1,124 @@
----
-name: "Focus Smoke Tests"
-
+name: "Focus/Firefox Tests"
+    
 on:
-  workflow_dispatch:
+    workflow_dispatch:
 
 env:
-  XCODE_VERSION: 15.4
-  RUNNER: macos-14
-
+    browser: focus-ios
+    xcode_version: 15.4
+    ios_version: 17.4
+    ios_simulator: iPhone 15
+    xcodebuild_test_plan: SmokeTest
+    xcodebuild_scheme: Focus
+    xcodebuild_target: XCUITest
+    test_results_directory: /Users/runner/tmp
+    
 jobs:
-  compile:
-    name: Compile source code
-    runs-on: ${{ env.RUNNER }}
-    steps:
-      - name: Check out source code
-        uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-            python-version: '3.11'
-      - name: Install Python packages required
-        run: |
-          brew update
-          pip3 install virtualenv pipenv
-      - name: Setup Xcode
-        run: |
-          sudo rm -rf /Applications/Xcode.app
-          sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
-          xcodebuild -version
+    run-tests:
+        name: Build and run tests
+        runs-on: macos-14
+        steps:
+            - name: Check out source code
+              uses: actions/checkout@v4.1.7
+            - name: Setup Python
+              uses: actions/setup-python@v5.1.0
+              with:
+                python-version: '3.11'
+            - name: Install packages
+              id: packages
+              run: |
+                brew update
+                pip3 install virtualenv pipenv
+                brew install xctesthtmlreport
+            - name: Setup Xcode
+              id: xcode
+              run: |
+                sudo rm -rf /Applications/Xcode.app
+                sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app/Contents/Developer
+                xcodebuild -version
+                xcrun simctl shutdown all
+                xcrun simctl erase all
+                ./checkout.sh
+                ./bootstrap.sh --force
+            - name: Compile source code
+              id: compile
+              run: |
+                xcodebuild \
+                    -resolvePackageDependencies \
+                    -onlyUsePackageVersionsFromResolvedFile
+                xcodebuild \
+                    build-for-testing \
+                    -scheme ${{ env.xcodebuild_scheme }} \
+                    -target ${{ env.xcodebuild_target }} \
+                    -destination 'platform=iOS Simulator,name=${{ env.ios_simulator }},OS=${{ env.ios_version }}'
+              working-directory: ${{ env.browser }}
+            - name: Run tests
+              id: run-tests
+              run: |
+                xcodebuild \
+                    test-without-building \
+                    -scheme ${{ env.xcodebuild_scheme }} \
+                    -target ${{ env.xcodebuild_target }} \
+                    -destination 'platform=iOS Simulator,name=${{ env.ios_simulator }},OS=${{ env.ios_version }}' \
+                    -testPlan ${{ env.xcodebuild_test_plan }} \
+                    -resultBundlePath ${{ env.test_results_directory }}/results \
+                    || touch ${{ env.test_results_directory }}/fail.txt && exit 0
+              working-directory:  ${{ env.browser }}
+            - name: Prettyprint test report
+              id: test-report
+              run: |
+                xchtmlreport ${{ env.test_results_directory }}/results.xcresult
+            - name: Authenticate to Google Cloud
+              id: auth-gcloud
+              uses: google-github-actions/auth@v2.1.3
+              with:
+                credentials_json: ${{ secrets.GCP_SA_KEY }}
+            - name: Upload report to Google Cloud bucket
+              id: upload-gcloud
+              uses: google-github-actions/upload-cloud-storage@v2.1.0
+              with:
+               process_gcloudignore: false
+               path: '${{ env.test_results_directory }}/index.html'
+               destination: 'mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result_${{ github.run_number }}'
+            - name: Upload xcresult file to Github
+              id: upload-github
+              uses: actions/upload-artifact@v4.3.3
+              with:
+                name: ${{ env.browser }}-${{ env.xcodebuild_test_plan }}-${{ github.run_number }}
+                path: ${{ env.test_results_directory }}/index.html
+            - name : Process pass/fail info
+              id: pass-fail
+              run: |
+                # fail.txt is created when at least one test fails.
+                # job.status can't be used because the subsequent steps are not
+                # executed once a step fails.
+                if [ -e ${{ env.test_results_directory }}/fail.txt ]; then
+                    echo "pass_fail=❌ Fail" >> "$GITHUB_OUTPUT"
+                    echo "exit_value=1" >> "$GITHUB_OUTPUT"
+                else
+                    echo "pass_fail=✅ Pass" >> "$GITHUB_OUTPUT"
+                    echo "exit_value=0" >> "$GITHUB_OUTPUT"
+                fi
+            - name: Report to Slack
+              id: slack
+              uses: slackapi/slack-github-action@v1.26.0
+              with:
+                # This data can be any valid JSON from a previous step in the GitHub Action
+                payload: |
+                  {
+                    "browser": "${{ env.browser }}",
+                    "status": "${{ steps.pass-fail.outputs.pass_fail }}",
+                    "run_number": "${{ github.run_number }}",
+                    "branch": "${{ github.ref_name }}",
+                    "xcode_version": "${{ env.xcode_version }}",
+                    "ios_simulator": "${{ env.ios_simulator }}",
+                    "ios_version": "${{ env.ios_version }}",
+                    "test_plan": "${{ env.xcodebuild_test_plan }}",
+                    "github_actions_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                    "test_report_url": "https://storage.googleapis.com/mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result_${{ github.run_number }}/index.html"
+                  }
+              env:
+                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            - name: Report status
+              run: |
+                exit ${{ steps.pass-fail.outputs.exit_value }}

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - cs/MTE-2907-focus-smoke
+    workflow_dispatch: {}
 
 env:
   XCODE_VERSION: 15.4

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -1,4 +1,4 @@
-name: "Focus iPhone/iPad Smoke Tests"
+name: "Focus Smoke Tests"
     
 on:
     workflow_dispatch:
@@ -7,32 +7,19 @@ env:
     browser: focus-ios
     xcode_version: 15.4
     ios_version: 17.5
+    ios_simulator_default: iPhone 15
     xcodebuild_test_plan: SmokeTest
     xcodebuild_scheme: Focus
     xcodebuild_target: XCUITest
     test_results_directory: /Users/runner/tmp
     
 jobs:
-    run-tests:
-        strategy:
-            fail-fast: false
-            matrix:
-                ios_simulator: ['iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
-        name: Build and run tests
+    compile:
+        name: Compile
         runs-on: macos-14-large
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
-            - name: Setup Python
-              uses: actions/setup-python@v5.1.0
-              with:
-                python-version: '3.11'
-            - name: Install packages
-              id: packages
-              run: |
-                brew update
-                pip3 install virtualenv pipenv
-                brew install xctesthtmlreport
             - name: Setup Xcode
               id: xcode
               run: |
@@ -45,14 +32,52 @@ jobs:
               id: compile
               run: |
                 xcodebuild \
-                    -resolvePackageDependencies \
-                    -onlyUsePackageVersionsFromResolvedFile
+                  -resolvePackageDependencies \
+                  -onlyUsePackageVersionsFromResolvedFile
                 xcodebuild \
-                    build-for-testing \
-                    -scheme ${{ env.xcodebuild_scheme }} \
-                    -target ${{ env.xcodebuild_target }} \
-                    -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}'
+                  build-for-testing \
+                  -scheme ${{ env.xcodebuild_scheme }} \
+                  -target ${{ env.xcodebuild_target }} \
+                  -derivedDataPath ~/DerivedData \
+                  -destination 'platform=iOS Simulator,name=${{ env.ios_simulator_default }},OS=${{ env.ios_version }}'
               working-directory: ${{ env.browser }}
+            - name: Save Derived Data
+              id: upload-derived-data
+              uses: actions/upload-artifact@v4.3.3
+              with:
+                name: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
+                path: ~/DerivedData/Build/Products
+                retention-days: 2          
+    run-tests:
+        name: Run tests
+        runs-on: macos-14-large
+        needs: compile
+        strategy:
+            fail-fast: false
+            matrix:
+                ios_simulator: [ 'iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
+        steps:
+            - name: Check out source code
+              uses: actions/checkout@v4.1.7
+            - name: Install packages
+              id: packages
+              run: |
+                brew update
+                brew install xctesthtmlreport
+            - name: Setup Xcode
+              id: xcode
+              run: |
+                sudo rm -rf /Applications/Xcode.app
+                sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app/Contents/Developer
+                xcodebuild -version
+                ./checkout.sh
+                ./bootstrap.sh --force
+            - name: Get derived data
+              id: download-derived-data
+              uses: actions/download-artifact@v4
+              with:
+                name: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
+                path: ~/DerivedData/Build/Products
             - name: Run tests
               id: run-tests
               run: |
@@ -60,6 +85,7 @@ jobs:
                     test-without-building \
                     -scheme ${{ env.xcodebuild_scheme }} \
                     -target ${{ env.xcodebuild_target }} \
+                    -derivedDataPath ~/DerivedData \
                     -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
                     -testPlan ${{ env.xcodebuild_test_plan }} \
                     -resultBundlePath ${{ env.test_results_directory }}/results

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -1,10 +1,6 @@
 name: "Focus Smoke Tests"
 
-on:
-  push:
-    branches:
-      - cs/MTE-2907-focus-smoke
-    workflow_dispatch: {}
+on: [push]
 
 env:
   XCODE_VERSION: 15.4

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -1,4 +1,4 @@
-name: "Focus iPhone Smoke Tests"
+name: "Focus iPhone/iPad Smoke Tests"
     
 on:
     workflow_dispatch:
@@ -7,7 +7,6 @@ env:
     browser: focus-ios
     xcode_version: 15.4
     ios_version: 17.5
-    ios_simulator: iPhone 15
     xcodebuild_test_plan: SmokeTest
     xcodebuild_scheme: Focus
     xcodebuild_target: XCUITest
@@ -15,6 +14,9 @@ env:
     
 jobs:
     run-tests:
+        strategy:
+            matrix:
+                ios_simulator: ['iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
         name: Build and run tests
         runs-on: macos-14-large
         steps:
@@ -48,7 +50,7 @@ jobs:
                     build-for-testing \
                     -scheme ${{ env.xcodebuild_scheme }} \
                     -target ${{ env.xcodebuild_target }} \
-                    -destination 'platform=iOS Simulator,name=${{ env.ios_simulator }},OS=${{ env.ios_version }}'
+                    -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}'
               working-directory: ${{ env.browser }}
             - name: Run tests
               id: run-tests
@@ -57,7 +59,7 @@ jobs:
                     test-without-building \
                     -scheme ${{ env.xcodebuild_scheme }} \
                     -target ${{ env.xcodebuild_target }} \
-                    -destination 'platform=iOS Simulator,name=${{ env.ios_simulator }},OS=${{ env.ios_version }}' \
+                    -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
                     -testPlan ${{ env.xcodebuild_test_plan }} \
                     -resultBundlePath ${{ env.test_results_directory }}/results \
                     || touch ${{ env.test_results_directory }}/fail.txt && exit 0
@@ -77,12 +79,12 @@ jobs:
               with:
                process_gcloudignore: false
                path: '${{ env.test_results_directory }}/index.html'
-               destination: 'mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result_${{ github.run_number }}'
+               destination: 'mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result_${{ matrix.ios_simulator }}_${{ github.run_number }}'
             - name: Upload xcresult file to Github
               id: upload-github
               uses: actions/upload-artifact@v4.3.3
               with:
-                name: ${{ env.browser }}-${{ env.xcodebuild_test_plan }}-${{ github.run_number }}
+                name: ${{ env.browser }}-${{ env.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-${{ github.run_number }}
                 path: ${{ env.test_results_directory }}/index.html
             - name : Process pass/fail info
               id: pass-fail
@@ -101,53 +103,19 @@ jobs:
               id: slack
               uses: slackapi/slack-github-action@v1.26.0
               with:
-                payload: |
-                  {
-                    "blocks":[
-                      {
-                        "type": "header",
-                        "text": {
-                          "type": "plain_text",
-                          "text": "${{ steps.pass-fail.outputs.pass_fail }} ${{ env.browser }} :firefox: ${{ env.xcodebuild_test_plan }} - ${{ env.ios_simulator }} iOS ${{ env.ios_version }}",
-                          "emoji": true
-                        }
-                      },
-                      {
-                        "type":"divider"
-                      },
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": "*Branch*: `${{ github.ref_name }}`"
-                        },
-                        "fields": [
-                          {
-                            "type": "mrkdwn",
-                            "text": "<https://storage.googleapis.com/mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result_${{ github.run_number }}/index.html|*Test Report*> :debug:"
-                          },
-                          {
-                            "type": "mrkdwn",
-                            "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Github Actions Job*> :github:"
-                          }
-                        ]
-                      },
-                      {
-                        "type":"divider"
-                      },
-                      {
-                        "type": "context",
-                        "elements": [
-                          {
-                            "type": "mrkdwn",
-                            "text": ":testops-notify: created by <https://mozilla-hub.atlassian.net/wiki/spaces/MTE/overview|Mobile Test Engineering>"
-                          }
-                        ]
-                      }
-                    ]
-                  }
+                payload-file-path: "./test-fixtures/ci/slack-notification-xcuitest.json"
               env:
                 SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+                SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+                ios_simulator: ${{ matrix.ios_simulator }}
+                pass_fail: ${{ steps.pass-fail.outputs.pass_fail }}
+                ref_name: ${{ github.ref_name }}
+                repository: ${{ github.repository }}
+                run_id: ${{ github.run_id }}
+                run_number: ${{ github.run_number }}
+                server_url: ${{ github.server_url }}
+
             - name: Report status
               run: |
                 exit ${{ steps.pass-fail.outputs.exit_value }}
+              continue-on-error: true

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -119,36 +119,18 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": "*Test plan*: ${{ env.xcodebuild_test_plan }}"
-                        }
-                      },
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
                           "text": "*Branch*: `${{ github.ref_name }}`"
-                        }
-                      },
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": "*Simulator*: ${{ env.ios_simulator }} iOS ${{ env.ios_version }}"
-                        }
-                      },
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": "<https://storage.googleapis.com/mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result_${{ github.run_number }}/index.html|*Test Report*> :debug:"
-                        }
-                      },
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Github Actions Job*> :github:"
-                        }
+                        },
+                        fields: [
+                          {
+                            "type": "mrkdwn",
+                            "text": "<https://storage.googleapis.com/mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result_${{ github.run_number }}/index.html|*Test Report*> :debug:"
+                          },
+                          {
+                            "type": "mrkdwn",
+                            "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Github Actions Job*> :github:"
+                          }
+                        ]
                       },
                       {
                         "type":"divider"
@@ -165,7 +147,7 @@ jobs:
                     ]
                   }
               env:
-                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_T_WEBHOOK }}
+                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
             - name: Report status
               run: |
                 exit ${{ steps.pass-fail.outputs.exit_value }}

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -19,7 +19,7 @@ jobs:
             matrix:
                 ios_simulator: ['iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
         name: Build and run tests
-        runs-on: macos-14-large
+        runs-on: macos-14
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
@@ -90,3 +90,6 @@ jobs:
                 repository: ${{ github.repository }}
                 run_id: ${{ github.run_id }}
                 server_url: ${{ github.server_url }}
+            - name: Return fail status if a test fails
+              run: |
+                exit ${{ steps.run-tests.outcome == 'success' && '0' || '1' }}

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -15,10 +15,11 @@ env:
 jobs:
     run-tests:
         strategy:
+            fail-fast: false
             matrix:
                 ios_simulator: ['iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
         name: Build and run tests
-        runs-on: macos-14
+        runs-on: macos-14-large
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
@@ -61,9 +62,9 @@ jobs:
                     -target ${{ env.xcodebuild_target }} \
                     -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
                     -testPlan ${{ env.xcodebuild_test_plan }} \
-                    -resultBundlePath ${{ env.test_results_directory }}/results \
-                    || touch ${{ env.test_results_directory }}/fail.txt && exit 0
+                    -resultBundlePath ${{ env.test_results_directory }}/results
               working-directory:  ${{ env.browser }}
+              continue-on-error: true
             - name: Prettyprint test report
               id: test-report
               run: |
@@ -74,19 +75,7 @@ jobs:
               with:
                 name: ${{ env.browser }}-${{ env.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-${{ github.run_number }}
                 path: ${{ env.test_results_directory }}/index.html
-            - name : Process pass/fail info
-              id: pass-fail
-              run: |
-                # fail.txt is created when at least one test fails.
-                # job.status can't be used because the subsequent steps are not
-                # executed once a step fails.
-                if [ -e ${{ env.test_results_directory }}/fail.txt ]; then
-                    echo "pass_fail=❌" >> "$GITHUB_OUTPUT"
-                    echo "exit_value=1" >> "$GITHUB_OUTPUT"
-                else
-                    echo "pass_fail=✅" >> "$GITHUB_OUTPUT"
-                    echo "exit_value=0" >> "$GITHUB_OUTPUT"
-                fi
+                retention-days: 90
             - name: Report to Slack
               id: slack
               uses: slackapi/slack-github-action@v1.26.0
@@ -96,13 +85,8 @@ jobs:
                 SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
                 SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
                 ios_simulator: ${{ matrix.ios_simulator }}
-                pass_fail: ${{ steps.pass-fail.outputs.pass_fail }}
+                pass_fail:  ${{ steps.run-tests.outcome == 'success' && ':white_check_mark:' || ':x:' }}
                 ref_name: ${{ github.ref_name }}
                 repository: ${{ github.repository }}
                 run_id: ${{ github.run_id }}
                 server_url: ${{ github.server_url }}
-
-            - name: Report status
-              run: |
-                exit ${{ steps.pass-fail.outputs.exit_value }}
-              continue-on-error: true

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -115,13 +115,13 @@ jobs:
                       {
                         "type":"divider"
                       },
-                    	{
+                      {
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
                           "text": "*Branch*: `${{ github.ref_name }}`"
                         },
-                        fields: [
+                        "fields": [
                           {
                             "type": "mrkdwn",
                             "text": "<https://storage.googleapis.com/mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result_${{ github.run_number }}/index.html|*Test Report*> :debug:"

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -2,13 +2,9 @@ name: "Focus Smoke Tests"
 
 on:
   push:
-    branches:
-      - "cs/MTE-2907-focus-smoke"
+    branches: [ cs/MTE-2907-focus-smoke ]
   pull_request:
-    branches:
-      - "main" 
-    paths:
-      - ".github/workflows/focus-ios-smoke.yaml"
+    branches: [ main ]
 
 env:
   XCODE_VERSION: 15.4

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -19,7 +19,7 @@ jobs:
             matrix:
                 ios_simulator: ['iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
         name: Build and run tests
-        runs-on: macos-14
+        runs-on: macos-14-large
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -18,7 +18,7 @@ jobs:
             matrix:
                 ios_simulator: ['iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
         name: Build and run tests
-        runs-on: macos-14-large
+        runs-on: macos-14
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
@@ -68,23 +68,11 @@ jobs:
               id: test-report
               run: |
                 xchtmlreport ${{ env.test_results_directory }}/results.xcresult
-            - name: Authenticate to Google Cloud
-              id: auth-gcloud
-              uses: google-github-actions/auth@v2.1.3
-              with:
-                credentials_json: ${{ secrets.GCP_SA_KEY }}
-            - name: Upload report to Google Cloud bucket
-              id: upload-gcloud
-              uses: google-github-actions/upload-cloud-storage@v2.1.0
-              with:
-               process_gcloudignore: false
-               path: '${{ env.test_results_directory }}/index.html'
-               destination: 'mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result_${{ matrix.ios_simulator }}_${{ github.run_number }}'
             - name: Upload xcresult file to Github
               id: upload-github
               uses: actions/upload-artifact@v4.3.3
               with:
-                name: ${{ env.browser }}-${{ env.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-${{ github.run_number }}
+                name: ${{ env.browser }}-${{ env.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-${{ github.id }}
                 path: ${{ env.test_results_directory }}/index.html
             - name : Process pass/fail info
               id: pass-fail
@@ -112,7 +100,6 @@ jobs:
                 ref_name: ${{ github.ref_name }}
                 repository: ${{ github.repository }}
                 run_id: ${{ github.run_id }}
-                run_number: ${{ github.run_number }}
                 server_url: ${{ github.server_url }}
 
             - name: Report status

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -1,7 +1,9 @@
 name: "Focus Smoke Tests"
 
-on: [push]
-
+on:
+  push:
+    branches:
+      - cs/MTE-2907-focus-smoke
 env:
   XCODE_VERSION: 15.4
   RUNNER: macos-14

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -72,7 +72,7 @@ jobs:
               id: upload-github
               uses: actions/upload-artifact@v4.3.3
               with:
-                name: ${{ env.browser }}-${{ env.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-${{ github.id }}
+                name: ${{ env.browser }}-${{ env.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-${{ github.run_number }}
                 path: ${{ env.test_results_directory }}/index.html
             - name : Process pass/fail info
               id: pass-fail

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -16,7 +16,7 @@ env:
 jobs:
     run-tests:
         name: Build and run tests
-        runs-on: macos-14
+        runs-on: macos-14-large
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -1,4 +1,4 @@
-name: "Focus/Firefox Tests"
+name: "Focus iPhone Smoke Tests"
     
 on:
     workflow_dispatch:
@@ -36,8 +36,6 @@ jobs:
                 sudo rm -rf /Applications/Xcode.app
                 sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app/Contents/Developer
                 xcodebuild -version
-                xcrun simctl shutdown all
-                xcrun simctl erase all
                 ./checkout.sh
                 ./bootstrap.sh --force
             - name: Compile source code
@@ -93,32 +91,81 @@ jobs:
                 # job.status can't be used because the subsequent steps are not
                 # executed once a step fails.
                 if [ -e ${{ env.test_results_directory }}/fail.txt ]; then
-                    echo "pass_fail=❌ Fail" >> "$GITHUB_OUTPUT"
+                    echo "pass_fail=❌" >> "$GITHUB_OUTPUT"
                     echo "exit_value=1" >> "$GITHUB_OUTPUT"
                 else
-                    echo "pass_fail=✅ Pass" >> "$GITHUB_OUTPUT"
+                    echo "pass_fail=✅" >> "$GITHUB_OUTPUT"
                     echo "exit_value=0" >> "$GITHUB_OUTPUT"
                 fi
             - name: Report to Slack
               id: slack
               uses: slackapi/slack-github-action@v1.26.0
               with:
-                # This data can be any valid JSON from a previous step in the GitHub Action
                 payload: |
                   {
-                    "browser": "${{ env.browser }}",
-                    "status": "${{ steps.pass-fail.outputs.pass_fail }}",
-                    "run_number": "${{ github.run_number }}",
-                    "branch": "${{ github.ref_name }}",
-                    "xcode_version": "${{ env.xcode_version }}",
-                    "ios_simulator": "${{ env.ios_simulator }}",
-                    "ios_version": "${{ env.ios_version }}",
-                    "test_plan": "${{ env.xcodebuild_test_plan }}",
-                    "github_actions_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                    "test_report_url": "https://storage.googleapis.com/mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result_${{ github.run_number }}/index.html"
+                    "blocks":[
+                      {
+                        "type": "header",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "${{ steps.pass-fail.outputs.pass_fail }} ${{ env.browser }} :firefox: ${{ env.xcodebuild_test_plan }} - ${{ env.ios_simulator }} iOS ${{ env.ios_version }}",
+                          "emoji": true
+                        }
+                      },
+                      {
+                        "type":"divider"
+                      },
+                    	{
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": "*Test plan*: ${{ env.xcodebuild_test_plan }}"
+                        }
+                      },
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": "*Branch*: `${{ github.ref_name }}`"
+                        }
+                      },
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": "*Simulator*: ${{ env.ios_simulator }} iOS ${{ env.ios_version }}"
+                        }
+                      },
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": "<https://storage.googleapis.com/mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result_${{ github.run_number }}/index.html|*Test Report*> :debug:"
+                        }
+                      },
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Github Actions Job*> :github:"
+                        }
+                      },
+                      {
+                        "type":"divider"
+                      },
+                      {
+                        "type": "context",
+                        "elements": [
+                          {
+                            "type": "mrkdwn",
+                            "text": ":testops-notify: created by <https://mozilla-hub.atlassian.net/wiki/spaces/MTE/overview|Mobile Test Engineering>"
+                          }
+                        ]
+                      }
+                    ]
                   }
               env:
-                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_T_WEBHOOK }}
             - name: Report status
               run: |
                 exit ${{ steps.pass-fail.outputs.exit_value }}

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -3,7 +3,13 @@ name: "Focus Smoke Tests"
 on:
   push:
     branches:
-      - cs/MTE-2907-focus-smoke
+      - "cs/MTE-2907-focus-smoke"
+  pull_request:
+    branches:
+      - "main" 
+    paths:
+      - ".github/workflows/focus-ios-smoke.yaml"
+
 env:
   XCODE_VERSION: 15.4
   RUNNER: macos-14

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -1,0 +1,31 @@
+name: "Focus Smoke Tests"
+
+on:
+  push:
+    branches:
+      - cs/MTE-2907-focus-smoke
+
+env:
+  XCODE_VERSION: 15.4
+  RUNNER: macos-14
+
+jobs:
+  compile:
+    name: Compile source code
+    runs-on: ${{ env.RUNNER }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+            python-version: '3.11'
+      - name: Install Python packages required
+        run: |
+          brew update
+          pip3 install virtualenv pipenv
+      - name: Setup Xcode
+        run: |
+          sudo rm -rf /Applications/Xcode.app
+          sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+          xcodebuild -version

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -6,7 +6,7 @@ on:
 env:
     browser: focus-ios
     xcode_version: 15.4
-    ios_version: 17.4
+    ios_version: 17.5
     ios_simulator: iPhone 15
     xcodebuild_test_plan: SmokeTest
     xcodebuild_scheme: Focus

--- a/.github/workflows/focus-ios-smoke
+++ b/.github/workflows/focus-ios-smoke
@@ -1,10 +1,8 @@
+---
 name: "Focus Smoke Tests"
 
 on:
-  push:
-    branches: [ cs/MTE-2907-focus-smoke ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 env:
   XCODE_VERSION: 15.4

--- a/test-fixtures/ci/slack-notification-xcuitest.json
+++ b/test-fixtures/ci/slack-notification-xcuitest.json
@@ -15,7 +15,7 @@
         "type": "section",
         "text": {
           "type": "mrkdwn",
-          "text": "*Branch*: `${{ env.ref_name }}`\n<https://storage.googleapis.com/mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result__${{ env.ios_simulator }}_${{ env.run_number }}/index.html|*Test Report*> :debug:\n<${{ env.server_url }}/${{ env.repository }}/actions/runs/${{ env.run_id }}|*Github Actions Job*> :github:"
+          "text": "*Branch*: `${{ env.ref_name }}`\n<${{ env.server_url }}/${{ env.repository }}/actions/runs/${{ env.run_id }}|*Github Actions Job*> :github:"
         }
       },
       {

--- a/test-fixtures/ci/slack-notification-xcuitest.json
+++ b/test-fixtures/ci/slack-notification-xcuitest.json
@@ -1,0 +1,34 @@
+{
+    "blocks":[
+      {
+        "type": "header",
+        "text": {
+          "type": "plain_text",
+          "text": "${{ env.pass_fail }} ${{ env.browser }} :firefox: ${{ env.xcodebuild_test_plan }} - ${{ env.ios_simulator }} iOS ${{ env.ios_version }}",
+          "emoji": true
+        }
+      },
+      {
+        "type":"divider"
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": "*Branch*: `${{ env.ref_name }}`\n<https://storage.googleapis.com/mobile-reports/public/${{ env.browser }}/${{ env.xcodebuild_test_plan }}/result__${{ env.ios_simulator }}_${{ env.run_number }}/index.html|*Test Report*> :debug:\n<${{ env.server_url }}/${{ env.repository }}/actions/runs/${{ env.run_id }}|*Github Actions Job*> :github:"
+        }
+      },
+      {
+        "type":"divider"
+      },
+      {
+        "type": "context",
+        "elements": [
+          {
+            "type": "mrkdwn",
+            "text": ":testops-notify: created by <https://mozilla-hub.atlassian.net/wiki/spaces/MTE/overview|Mobile Test Engineering>"
+          }
+        ]
+      }
+    ]
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2907)

## :bulb: Description
Focus smoke tests could be run on Github Actions. This workflow could report back to Slack and upload the report to Google Cloud and Github.

The following *Repository Secrets* must be added to the repository to have this workflow working:
* `SLACK_WEBHOOK_URL`: The webhook from Slack "Firefox and Focus iOS XCUITests" workflow

Here is a test run on this workflow from my fork: https://github.com/clarmso/firefox-ios/actions/runs/9646612929/job/26603450219

Please also note that I use only the reusable Github Actions from the few organizations.
https://github.com/MoCo-GHE-Admin/Approved-GHE-add-ons/blob/main/New_Org_Default_settings.md

I'd like to get some feedback on Focus smoke tests first before optimizing for other test plans.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

