### PR TITLE
Bugfix FXIOS-9304 ⁃ Add placeholder for app name in Strings

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -244,7 +244,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
             prefKey: "showClipboardBar",
             defaultValue: false,
             titleText: .SettingsOfferClipboardBarTitle,
-            statusText: .SettingsOfferClipboardBarStatus
+            statusText: String(format: .SettingsOfferClipboardBarStatus, "Firefox")
         )
 
         let showLinksPreviewSettings = BoolSetting(

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -244,7 +244,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
             prefKey: "showClipboardBar",
             defaultValue: false,
             titleText: .SettingsOfferClipboardBarTitle,
-            statusText: String(format: .SettingsOfferClipboardBarStatus, "Firefox")
+            statusText: String(format: .SettingsOfferClipboardBarStatus, AppName.shortName.rawValue)
         )
 
         let showLinksPreviewSettings = BoolSetting(

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3201,7 +3201,7 @@ extension String {
         value: "Offer to Open Copied Links",
         comment: "Title of setting to enable the Go to Copied URL feature. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
     public static let SettingsOfferClipboardBarStatus = MZLocalizedString(
-        key: "Settings.OfferClipboardBar.StatusV3",
+        key: "Settings.OfferClipboardBar.Status.v128",
         tableName: nil,
         value: "When opening %@",
         comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349. Placeholder is for the app name.")
@@ -6437,6 +6437,14 @@ extension String {
                 tableName: "Microsurvey",
                 value: "Close Survey",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label for close button that dismisses the sheet.")
+        }
+
+        struct v128 {
+            public static let SettingsOfferClipboardBarStatus = MZLocalizedString(
+                key: "Settings.OfferClipboardBar.StatusV2",
+                tableName: nil,
+                value: "When opening Firefox",
+                comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3203,8 +3203,8 @@ extension String {
     public static let SettingsOfferClipboardBarStatus = MZLocalizedString(
         key: "Settings.OfferClipboardBar.StatusV2",
         tableName: nil,
-        value: "When opening Firefox",
-        comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
+        value: "When opening %@",
+        comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349. Placeholder is for the app name.")
 }
 
 // MARK: - Link Previews

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3201,7 +3201,7 @@ extension String {
         value: "Offer to Open Copied Links",
         comment: "Title of setting to enable the Go to Copied URL feature. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
     public static let SettingsOfferClipboardBarStatus = MZLocalizedString(
-        key: "Settings.OfferClipboardBar.StatusV2",
+        key: "Settings.OfferClipboardBar.StatusV3",
         tableName: nil,
         value: "When opening %@",
         comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349. Placeholder is for the app name.")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9304)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20605)

## :bulb: Description
Added a placeholder for app name

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

