### PR TITLE
Add FXIOS-9305 Correct pluralization on Strings

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4020,19 +4020,19 @@ extension String {
             public static let crossSiteTrackersBlockedLabel = MZLocalizedString(
                 key: "Menu.EnhancedTrackingProtection.Details.Trackers.CrossSite.v128",
                 tableName: "EnhancedTrackingProtection",
-                value: "%@ Cross-site tracking cookies",
+                value: "Cross-site tracking cookies: %@",
                 comment: "Text to let users know how many cross-site tracking cookies were blocked on the current website. The placeholder will show the number of such cookies detected")
 
             public static let socialMediaTrackersBlockedLabel = MZLocalizedString(
                 key: "Menu.EnhancedTrackingProtection.Details.Trackers.SocialMedia.v128",
                 tableName: "EnhancedTrackingProtection",
-                value: "%@ Social media tracker",
+                value: "Social media trackers: %@",
                 comment: "Text to let users know how many social media trackers were blocked on the current website. The placeholder will show the number of such cookies detected")
 
             public static let fingerprinterBlockedLabel = MZLocalizedString(
                 key: "Menu.EnhancedTrackingProtection.Details.Trackers.Fingerprinter.v128",
                 tableName: "EnhancedTrackingProtection",
-                value: "%@ Fingerprinter",
+                value: "Fingerprinters: %@",
                 comment: "Text to let users know how many fingerprinters were blocked on the current website. The placeholder will show the number of fingerprinters detected")
 
             public static let connectionSecureLabel = MZLocalizedString(

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4017,24 +4017,6 @@ extension String {
                 value: "No trackers found",
                 comment: "Text to let users know that no trackers were found on the current website.")
 
-            public static let crossSiteTrackersBlockedLabel = MZLocalizedString(
-                key: "Menu.EnhancedTrackingProtection.Details.Trackers.CrossSite.v128",
-                tableName: "EnhancedTrackingProtection",
-                value: "Cross-site tracking cookies: %@",
-                comment: "Text to let users know how many cross-site tracking cookies were blocked on the current website. The placeholder will show the number of such cookies detected")
-
-            public static let socialMediaTrackersBlockedLabel = MZLocalizedString(
-                key: "Menu.EnhancedTrackingProtection.Details.Trackers.SocialMedia.v128",
-                tableName: "EnhancedTrackingProtection",
-                value: "Social media trackers: %@",
-                comment: "Text to let users know how many social media trackers were blocked on the current website. The placeholder will show the number of such cookies detected")
-
-            public static let fingerprinterBlockedLabel = MZLocalizedString(
-                key: "Menu.EnhancedTrackingProtection.Details.Trackers.Fingerprinter.v128",
-                tableName: "EnhancedTrackingProtection",
-                value: "Fingerprinters: %@",
-                comment: "Text to let users know how many fingerprinters were blocked on the current website. The placeholder will show the number of fingerprinters detected")
-
             public static let connectionSecureLabel = MZLocalizedString(
                 key: "Menu.EnhancedTrackingProtection.Details.ConnectionSecure.v128",
                 tableName: "EnhancedTrackingProtection",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9222)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20436)

## :bulb: Description
Remove strings since they do not satisfy pluralization requirements for l10n. The feature for these strings is not targeted for v128, so they can be added on a later date.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

