### PR TITLE
Add Bug 1823688 - add Server Knobs validation metric

### DIFF
--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -1593,6 +1593,7 @@ extension TelemetryWrapper {
         // MARK: App cycle
         case(.action, .foreground, .app, _, _):
             GleanMetrics.AppCycle.foreground.record()
+            GleanMetrics.ServerKnobs.validation.record()
             // record the same event for Nimbus' internal event store
             Experiments.events.recordEvent(BehavioralTargetingEvent.appForeground)
         case(.action, .background, .app, _, _):

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -5555,3 +5555,21 @@ windows:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-01-01"
     unit: quantity of iPad windows
+
+# Server Knobs validation
+server_knobs:
+  validation:
+    disabled: true
+    type: event
+    description: |
+      Temporary metric recorded at the same time as
+      "app_cycle.foreground" to validate that the Glean Server Knobs
+      functionality is working correctly.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1823688
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1823688#c2
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+      - brosa@mozilla.com
+    expires: "2024-09-01"


### PR DESCRIPTION
## :scroll: Tickets
[Bugzilla Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1823688)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Add the Server Knobs test metric to record along-side the selected example metric.

Approved proposal for running this validation: https://docs.google.com/document/d/1SxRoXHPAZZonubUgBk_H2vx73NFPpdQontmSVLXW0Us/edit#heading=h.eipwttxz6uzx

**Callouts**
- This new metric is **disabled** by default. It will only be turned on when we run the validation experiment via Nimbus.
- This metric is called `server_knobs.validation`.
- This metric will only be collected for a short period of time. I chose the expiration date as `09-01-2024` but it likely will be turned off before that. We only need 28 days of data from this metric to compare with the existing metric.

Example ping with the test metric turned on: https://debug-ping-preview.firebaseapp.com/pings/bruno-ios/33e73c12-dd5f-4c58-82a2-c12dbb8b8702#L48-L63

Example ping with the test metric turned off: https://debug-ping-preview.firebaseapp.com/pings/bruno-ios/50d8066a-bd6c-4fde-a606-2b9cea52e7fa#L48-L55

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

