### PR TITLE
Bugfix FXIOS-9289 [Multi-window] Fix blur when backgrounding app

### DIFF
--- a/firefox-ios/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/firefox-ios/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -25,18 +25,18 @@ class SensitiveViewController: UIViewController {
         }
 
         didEnterBackgroundObserver = observe(UIApplication.didEnterBackgroundNotification) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
             self.isAuthenticated = false
             self.installBlurredOverlay()
         }
 
         willResignActiveObserver = observe(UIApplication.willResignActiveNotification) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
             self.installBlurredOverlay()
         }
 
         didBecomeActiveObserver = observe(UIApplication.didBecomeActiveNotification) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
             if isAuthenticated {
                 self.removedBlurredOverlay()
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9289)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20569)

## :bulb: Description

In practice iPadOS does not update the window thumbnails in time for the blur to be visible in the app switcher. The fix here is to also blur when the app resigns active status, and to remove the blur (if authenticated) when active status is regained. If the loss of active status is also coupled with a change in foreground/background status then the normal authentication logic will run as usual.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

