### PR TITLE
Bugfix FXIOS-9213 ⁃ [Tab tray refactor] - Synced tabs weird behaviour

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -112,21 +112,19 @@ class RemoteTabsTableViewController: UITableViewController,
     }
 
     private func reloadUI() {
-        emptyView.isHidden = !isShowingEmptyView
-
-        guard !isShowingEmptyView else {
-            configureEmptyView()
-            return
-        }
-
-        updateRefreshControl()
+        updateUI()
         tableView.reloadData()
     }
 
-    private func updateRefreshControl() {
+    private func updateUI() {
         if state.refreshState == .refreshing {
+            emptyView.isHidden = true
             refreshControl?.beginRefreshing()
         } else {
+            emptyView.isHidden = !isShowingEmptyView
+            if isShowingEmptyView {
+                configureEmptyView()
+            }
             refreshControl?.endRefreshing()
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9213)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20417)

## :bulb: Description
Enabling the refreshControl when the synced tabs are loading.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

