### PR TITLE
Refactor DISCO-2852 - Update SuggestStoreBuilder usage

### DIFF
--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -8,7 +8,7 @@ import class MozillaAppServices.SuggestStore
 import class MozillaAppServices.SuggestStoreBuilder
 import class MozillaAppServices.Viaduct
 import enum MozillaAppServices.SuggestionProvider
-import struct MozillaAppServices.RemoteSettingsConfig
+import enum MozillaAppServices.RemoteSettingsServer
 import struct MozillaAppServices.SuggestIngestionConstraints
 import struct MozillaAppServices.SuggestionQuery
 
@@ -40,13 +40,12 @@ public class RustFirefoxSuggest: RustFirefoxSuggestProtocol {
     private let writerQueue = DispatchQueue(label: "RustFirefoxSuggest.writer")
     private let readerQueue = DispatchQueue(label: "RustFirefoxSuggest.reader")
 
-    public init(dataPath: String, cachePath: String, remoteSettingsConfig: RemoteSettingsConfig? = nil) throws {
+    public init(dataPath: String, cachePath: String, remoteSettingsServer: RemoteSettingsServer? = nil) throws {
         var builder = SuggestStoreBuilder()
             .dataPath(path: dataPath)
-            .cachePath(path: cachePath)
 
-        if let remoteSettingsConfig {
-            builder = builder.remoteSettingsConfig(config: remoteSettingsConfig)
+        if let remoteSettingsServer {
+            builder = builder.remoteSettingsServer(server: remoteSettingsServer)
         }
 
         store = try builder.build()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/DISCO-2852)
[Bugzilla issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1902045)

## :bulb: Description

- Don't use `cachePath` it's a deprecated/ignored paramater
- Use `remoteSettingsServer` instead of `remoteSettingsConfig`.  AFAICT, this was never passed in so no other code needs to change.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

