### PR TITLE
Bugfix FXIOS-9144 Bring back Send to Device to Share Sheet

### DIFF
--- a/firefox-ios/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -18,7 +18,8 @@ class ShareExtensionHelper: NSObject, FeatureFlaggable {
     private let pocketActionExtension = "com.ideashower.ReadItLaterPro.Action-Extension"
 
     private var excludingActivities: [UIActivity.ActivityType] {
-        return [UIActivity.ActivityType.addToReadingList]
+        return [UIActivity.ActivityType.addToReadingList,
+                 UIActivity.ActivityType.copyToPasteboard]
     }
 
     // Can be a file:// or http(s):// url
@@ -39,8 +40,11 @@ class ShareExtensionHelper: NSObject, FeatureFlaggable {
         if #available(iOS 16.4, *), let webView = webView {
             activityItems.append(webView)
         }
-        let activityViewController = UIActivityViewController(activityItems: activityItems,
-                                                              applicationActivities: nil)
+        let appActivities = getApplicationActivities()
+        let activityViewController = UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: appActivities
+        )
 
         activityViewController.excludedActivityTypes = excludingActivities
 
@@ -96,6 +100,17 @@ class ShareExtensionHelper: NSObject, FeatureFlaggable {
         activityItems.append(self)
 
         return activityItems
+    }
+
+    private func getApplicationActivities() -> [UIActivity] {
+        var appActivities = [UIActivity]()
+        let copyLinkActivity = CopyLinkActivity(activityType: .copyLink, url: url)
+        appActivities.append(copyLinkActivity)
+
+        let sendToDeviceActivity = SendToDeviceActivity(activityType: .sendToDevice, url: url)
+        appActivities.append(sendToDeviceActivity)
+
+        return appActivities
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9144)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20257)

## :bulb: Description
Add back Send to Device + Copy to share sheet. It was removed previously, but we want to add it back in. See ticket for more details.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

| iPhone - Sim | iPad |
| --- | --- |
|![simulator_screenshot_5DE8EBE0-8FC8-4D4B-92B1-D89BD60D6556](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/51164521-8d1a-4da1-87cc-77ebefdee1e8)| ![Screenshot 2024-06-12 at 15 36 08](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/d1673ab2-2c76-424c-964c-56cfd0825dd1)|
