### PR TITLE
Refactor FXIOS-9249 - Removing 'Everything' from history no longer reorders tabs

### DIFF
--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -321,18 +321,17 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         for tab in tabs where tab !== selectedTab {
             tab.clearAndResetTabHistory()
         }
-
-        removeTab(selectedTab)
-
         let tabToSelect: Tab
         if url.isFxHomeUrl {
-            tabToSelect = addTab(PrivilegedRequest(url: url) as URLRequest, isPrivate: selectedTab.isPrivate)
+            tabToSelect = addTab(PrivilegedRequest(url: url) as URLRequest,
+                                 afterTab: selectedTab,
+                                 isPrivate: selectedTab.isPrivate)
         } else {
             let request = URLRequest(url: url)
-            tabToSelect = addTab(request, isPrivate: selectedTab.isPrivate)
+            tabToSelect = addTab(request, afterTab: selectedTab, isPrivate: selectedTab.isPrivate)
         }
-
         selectTab(tabToSelect)
+        removeTab(selectedTab)
     }
 
     // MARK: - Add tabs


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9249)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20485)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I changed history deletion to not remove and re-add the selected tab, but to now add the new tab in the correct location, select it and remove the old tab. This results in clearing everything from history not re-ordering the tabs.
NOTE: Avoiding tabs refreshing after clearing everything from history has not been done in this ticket as it seems to require a larger refactor to be done.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

