### PR TITLE
Bugfix FXIOS-9097 [Theming] Theme setting wrong checkmark and theme not changing

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -154,6 +154,8 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
             systemThemeChanged()
         } else if automaticBrightnessIsOn {
             updateThemeBasedOnBrightness()
+        } else {
+            allWindowUUIDs.forEach { reloadTheme(for: $0) }
         }
     }
 
@@ -199,12 +201,11 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     }
 
     public func getNormalSavedTheme() -> ThemeType {
-        if let savedThemeDescription = userDefaults.string(forKey: ThemeKeys.themeName),
-           let savedTheme = ThemeType(rawValue: savedThemeDescription) {
-            return savedTheme
-        }
+        guard let savedThemeDescription = userDefaults.string(forKey: ThemeKeys.themeName),
+              let savedTheme = ThemeType(rawValue: savedThemeDescription)
+        else { return getSystemThemeType() }
 
-        return getSystemThemeType()
+        return savedTheme
     }
 
     // MARK: - Private methods
@@ -218,6 +219,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     private func updateSavedTheme(to newTheme: ThemeType) {
         guard !newTheme.isOverridingThemeType() else { return }
+        guard !systemThemeIsOn else { return }
         userDefaults.set(newTheme.rawValue, forKey: ThemeKeys.themeName)
     }
 
@@ -226,7 +228,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
         // Overwrite the user interface style on the window attached to our scene
         // once we have multiple scenes we need to update all of them
-
         let style = self.currentTheme(for: window).type.getInterfaceStyle()
         self.windows[window]?.overrideUserInterfaceStyle = style
         if notify {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9097)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20176)

## :bulb: Description
Fixed this by:
- preventing the theme to be saved from when the system theme is set
- making sure the theme is reloaded if the system theme turned off

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

