### PR TITLE
Fix MTE-2958 testCheckSetting focus smoke test

### DIFF
--- a/focus-ios/focus-ios-tests/XCUITest/SettingTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/SettingTest.swift
@@ -102,8 +102,11 @@ class SettingTest: BaseTestCase {
         let reviewCell = app.cells["settingsViewController.rateFocus"]
         let safariApp = XCUIApplication(privateWithPath: nil, bundleID: "com.apple.mobilesafari")!
 
-        app.tables.firstMatch.swipeUp()
-        waitForHittable(reviewCell)
+        var swipes = 3
+        while !reviewCell.isHittable && swipes > 0 {
+            app.swipeUp()
+            swipes = swipes - 1
+        }
         reviewCell.tap()
         waitForExistence(safariApp, timeout: 10)
         XCTAssert(safariApp.state == .runningForeground)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-2958

## :bulb: Description
Fixed by making sure rate focus is hittable.
