### PR TITLE
Bugfix FXIOS-7557 Long-press on a link using magic keyboard does not bring up the menu

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -133,13 +133,13 @@ extension BrowserViewController: WKUIDelegate {
         contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
         completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
     ) {
+        guard let url = elementInfo.linkURL else { return }
+
         completionHandler(
             UIContextMenuConfiguration(
                 identifier: nil,
                 previewProvider: {
-                    guard let url = elementInfo.linkURL,
-                          self.profile.prefs.boolForKey(PrefsKeys.ContextMenuShowLinkPreviews) ?? true
-                    else { return nil }
+                    guard self.profile.prefs.boolForKey(PrefsKeys.ContextMenuShowLinkPreviews) ?? true else { return nil }
 
                     let previewViewController = UIViewController()
                     previewViewController.view.isUserInteractionEnabled = false
@@ -159,8 +159,7 @@ extension BrowserViewController: WKUIDelegate {
                     return previewViewController
                 },
                 actionProvider: { [self] (suggested) -> UIMenu? in
-                    guard let url = elementInfo.linkURL,
-                          let currentTab = self.tabManager.selectedTab,
+                    guard let currentTab = tabManager.selectedTab,
                           let contextHelper = currentTab.getContentScript(
                             name: ContextMenuHelper.name()
                           ) as? ContextMenuHelper,

--- a/firefox-ios/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
@@ -14,9 +14,9 @@ class ContextMenuHelper: NSObject {
         let alt: String?
     }
 
-    fileprivate weak var tab: Tab?
+    private weak var tab: Tab?
 
-    fileprivate(set) var elements: Elements?
+    private(set) var elements: Elements?
 
     required init(tab: Tab) {
         super.init()
@@ -37,7 +37,7 @@ extension ContextMenuHelper: TabContentScript {
         _ userContentController: WKUserContentController,
         didReceiveScriptMessage message: WKScriptMessage
     ) {
-        guard let data = message.body as? [String: AnyObject] else { return }
+        guard let data = message.body as? [String: Any] else { return }
 
         if let x = data["touchX"] as? Double, let y = data["touchY"] as? Double {
             touchPoint = CGPoint(x: x, y: y)

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/ContextMenu.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/ContextMenu.js
@@ -8,7 +8,7 @@
 // Ensure this module only gets included once. This is
 // required for user scripts injected into all frames.
 window.__firefox__.includeOnce("ContextMenu", function() {
-  window.addEventListener("touchstart", function(evt) {
+  function sendMessage(evt) {
     var target = evt.target;
 
     var targetLink = target.closest("a");
@@ -20,8 +20,13 @@ window.__firefox__.includeOnce("ContextMenu", function() {
 
     var data = {};
 
-    data.touchX = evt.changedTouches[0].pageX - window.scrollX;
-    data.touchY = evt.changedTouches[0].pageY - window.scrollY;
+    if (evt.changedTouches) {
+      data.touchX = evt.changedTouches[0].pageX - window.scrollX;
+      data.touchY = evt.changedTouches[0].pageY - window.scrollY;
+    } else {
+      data.touchX = evt.pageX - window.scrollX;
+      data.touchY = evt.pageY - window.scrollY;
+    }
 
     if (targetLink) {
       data.link = targetLink.href;
@@ -37,5 +42,8 @@ window.__firefox__.includeOnce("ContextMenu", function() {
     if (data.link || data.image) {
       webkit.messageHandlers.contextMenuMessageHandler.postMessage(data);
     }
-  }, true);
+  }
+
+  window.addEventListener("touchstart", sendMessage, true);
+  window.addEventListener("mousedown", sendMessage, true);
 });

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -920,7 +920,6 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandler {
         }
     }
 
-    @objc
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         for helper in helpers.values {
             if let scriptMessageHandlerNames = helper.scriptMessageHandlerNames(),

--- a/firefox-ios/RustFxA/FxAWebViewController.swift
+++ b/firefox-ios/RustFxA/FxAWebViewController.swift
@@ -254,7 +254,7 @@ private class WKScriptMessageHandleDelegate: NSObject, WKScriptMessageHandler {
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        guard let delegate = delegate else { return }
+        guard let delegate else { return }
         delegate.userContentController(userContentController, didReceive: message)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7557)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16821)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- This PR addresses an issue where long press actions were not visible in the preview when using a mouse or trackpad. The `ContextMenu` script was previously only listening for `touchstart` events, which are triggered by touchscreen interactions. As a result, the long press actions were only visible after interacting with a touchscreen, due to the results being cached in the `elements` property of the `ContextMenuHelper` class.

- By adding a `mousedown` event listener, the script now also responds to interactions with a mouse or trackpad. The `sendMessage` function, which sends a message to the `contextMenuMessageHandler` with data about a link or image, is now triggered on both `touchstart` and `mousedown` events. This function has been updated to handle both types of events correctly.

- This enhancement ensures that the long press actions are correctly displayed in the preview regardless of whether the user is interacting with a touchscreen or a mouse/trackpad. 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

