### PR TITLE
Bugfix FXIOS-8406 ⁃ Add a11y labels and a11y ids to accessory view items

### DIFF
--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -196,6 +196,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
             currentAccessoryView,
             flexibleSpacer,
             previousButton,
+            fixedSpacer,
             nextButton,
             fixedSpacer,
             doneButton

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -42,23 +42,23 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
     }
 
     private lazy var previousButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(image: UIImage(named: StandardImageIdentifiers.Large.chevronUp),
-                                     style: .plain,
-                                     target: self,
-                                     action: #selector(tappedPreviousButton))
-        button.accessibilityIdentifier = AccessibilityIdentifiers.Browser.KeyboardAccessory.previousButton
-        button.accessibilityLabel = .KeyboardAccessory.PreviousButtonA11yLabel
-        return button
+        let button = UIButton(type: .system)
+        button.addTarget(self, action: #selector(self.tappedPreviousButton), for: .touchUpInside)
+        button.setImage(UIImage(named: StandardImageIdentifiers.Large.chevronUp), for: .normal)
+        let barButton = UIBarButtonItem(customView: button)
+        barButton.accessibilityIdentifier = AccessibilityIdentifiers.Browser.KeyboardAccessory.previousButton
+        barButton.accessibilityLabel = .KeyboardAccessory.PreviousButtonA11yLabel
+        return barButton
     }()
 
     private lazy var nextButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(image: UIImage(named: StandardImageIdentifiers.Large.chevronDown),
-                                     style: .plain,
-                                     target: self,
-                                     action: #selector(tappedNextButton))
-        button.accessibilityIdentifier = AccessibilityIdentifiers.Browser.KeyboardAccessory.nextButton
-        button.accessibilityLabel = .KeyboardAccessory.NextButtonA11yLabel
-        return button
+        let button = UIButton(type: .system)
+        button.addTarget(self, action: #selector(self.tappedNextButton), for: .touchUpInside)
+        button.setImage(UIImage(named: StandardImageIdentifiers.Large.chevronDown), for: .normal)
+        let barButton = UIBarButtonItem(customView: button)
+        barButton.accessibilityIdentifier = AccessibilityIdentifiers.Browser.KeyboardAccessory.nextButton
+        barButton.accessibilityLabel = .KeyboardAccessory.NextButtonA11yLabel
+        return barButton
     }()
 
     private lazy var doneButton: UIBarButtonItem = {
@@ -203,9 +203,9 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
 
         toolbar.accessibilityElements = [
             currentAccessoryView?.customView,
-            previousButton,
-            nextButton,
-            doneButton
+            previousButton.customView,
+            nextButton.customView,
+            doneButton.customView
         ].compactMap { $0 }
 
         addSubview(toolbar)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8406)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18633)

## :bulb: Description
Changed the implementation for **next** and **previous** buttons, from keyboard toolbar.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

