### PR TITLE
Refactor FXIOS-9331 [Theming] Fix ThemeManager issues

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -142,13 +142,13 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     // MARK: - Automatic brightness theme functions
     public func setAutomaticBrightness(isOn: Bool) {
         guard automaticBrightnessIsOn != isOn else { return }
-
         userDefaults.set(isOn, forKey: ThemeKeys.AutomaticBrightness.isOn)
         applyThemeUpdatesToWindows()
     }
 
     public func setAutomaticBrightnessValue(_ value: Float) {
         userDefaults.set(value, forKey: ThemeKeys.AutomaticBrightness.thresholdValue)
+        applyThemeUpdatesToWindows()
     }
 
     private func getThemeTypeBasedOnBrightness() -> ThemeType {
@@ -187,8 +187,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     }
 
     private func applyThemeChanges(for window: WindowUUID, using newTheme: ThemeType) {
-        guard getcurrentTheme(for: window).type != newTheme else { return }
-
         // Overwrite the user interface style on the window attached to our scene
         // once we have multiple scenes we need to update all of them
         let style = self.getcurrentTheme(for: window).type.getInterfaceStyle()

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -158,7 +158,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         if isOn {
             systemThemeChanged()
         } else if automaticBrightnessIsOn {
-            updateThemeBasedOnBrightness()
+            updateThemeBasedOnBrightess()
         } else {
             allWindowUUIDs.forEach { reloadTheme(for: $0) }
         }
@@ -193,30 +193,24 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         guard automaticBrightnessIsOn != isOn else { return }
 
         userDefaults.set(isOn, forKey: ThemeKeys.AutomaticBrightness.isOn)
-        brightnessChanged()
+        updateThemeBasedOnBrightess()
     }
 
     public func setAutomaticBrightnessValue(_ value: Float) {
         userDefaults.set(value, forKey: ThemeKeys.AutomaticBrightness.thresholdValue)
-        brightnessChanged()
+        updateThemeBasedOnBrightess()
     }
 
-    public func brightnessChanged() {
+    public func updateThemeBasedOnBrightess() {
         if automaticBrightnessIsOn {
-            updateThemeBasedOnBrightness()
-        }
-    }
-
-    private func updateThemeBasedOnBrightness() {
-        allWindowUUIDs.forEach { uuid in
-            let currentValue = Float(UIScreen.main.brightness)
-
-            if currentValue < automaticBrightnessValue {
-                changeCurrentTheme(.dark, for: uuid)
-            } else {
-                changeCurrentTheme(.light, for: uuid)
+            allWindowUUIDs.forEach { uuid in
+                changeCurrentTheme(getThemeTypeBasedOnBrightness(), for: uuid)
             }
         }
+    }
+
+    private func getThemeTypeBasedOnBrightness() -> ThemeType {
+        return Float(UIScreen.main.brightness) < automaticBrightnessValue ? .dark : .light
     }
 
     // MARK: - Private methods
@@ -256,6 +250,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         if privateModeIsOn(for: window) { return .privateMode }
         if nightModeIsOn { return .nightMode }
         if systemThemeIsOn { return getSystemThemeType() }
+        if automaticBrightnessIsOn { return getThemeTypeBasedOnBrightness() }
 
         return getSavedTheme()
     }
@@ -282,7 +277,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     public func handleNotifications(_ notification: Notification) {
         switch notification.name {
         case UIScreen.brightnessDidChangeNotification:
-            brightnessChanged()
+            updateThemeBasedOnBrightess()
         case UIApplication.didBecomeActiveNotification:
             self.systemThemeChanged()
         default:

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -79,7 +79,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     }
 
     // MARK: - Themeing general functions
-    public func getcurrentTheme(for window: WindowUUID?) -> Theme {
+    public func getCurrentTheme(for window: WindowUUID?) -> Theme {
         guard let window else {
             assertionFailure("Attempt to get the theme for a nil window UUID.")
             return DarkTheme()
@@ -189,7 +189,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     private func applyThemeChanges(for window: WindowUUID, using newTheme: ThemeType) {
         // Overwrite the user interface style on the window attached to our scene
         // once we have multiple scenes we need to update all of them
-        let style = self.getcurrentTheme(for: window).type.getInterfaceStyle()
+        let style = self.getCurrentTheme(for: window).type.getInterfaceStyle()
         self.windows[window]?.overrideUserInterfaceStyle = style
         notifyCurrentThemeDidChange(for: window)
     }

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -126,12 +126,12 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         notifyCurrentThemeDidChange(for: window)
     }
 
-    public func reloadTheme(for window: WindowUUID) {
-        updateTheme(for: window, to: fetchSavedThemeType(for: window))
-    }
-
     public func reloadThemeForAllWindows() {
         allWindowUUIDs.forEach { reloadTheme(for: $0) }
+    }
+
+    public func reloadTheme(for window: WindowUUID) {
+        updateTheme(for: window, to: fetchSavedThemeType(for: window))
     }
 
     public func getUserManualTheme() -> ThemeType {
@@ -143,17 +143,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     }
 
     // MARK: - System theme functions
-    public func systemThemeChanged() {
-        allWindowUUIDs.forEach { uuid in
-            guard systemThemeIsOn,
-                  !nightModeIsOn,
-                  !privateModeIsOn(for: uuid)
-            else { return }
-
-            updateTheme(for: uuid, to: getSystemThemeType())
-        }
-    }
-
     public func setSystemTheme(isOn: Bool) {
         userDefaults.set(isOn, forKey: ThemeKeys.systemThemeIsOn)
 
@@ -163,6 +152,18 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
             updateThemeBasedOnBrightess()
         } else {
             allWindowUUIDs.forEach { reloadTheme(for: $0) }
+        }
+    }
+
+
+    public func systemThemeChanged() {
+        allWindowUUIDs.forEach { uuid in
+            guard systemThemeIsOn,
+                  !nightModeIsOn,
+                  !privateModeIsOn(for: uuid)
+            else { return }
+
+            updateTheme(for: uuid, to: getSystemThemeType())
         }
     }
 

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -31,7 +31,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     // MARK: - Variables
 
-    private var windowThemeState: [WindowUUID: Theme] = [:]
     private var windows: [WindowUUID: UIWindow] = [:]
     private var allWindowUUIDs: [WindowUUID] { return Array(windows.keys) }
     public var notificationCenter: NotificationProtocol
@@ -93,7 +92,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     public func windowDidClose(uuid: WindowUUID) {
         windows.removeValue(forKey: uuid)
-        windowThemeState.removeValue(forKey: uuid)
     }
 
     public func setWindow(_ window: UIWindow, for uuid: WindowUUID) {
@@ -109,11 +107,10 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
             return DarkTheme()
         }
 
-//        return windowThemeState[window] ?? DarkTheme()
         return getThemeFromType(fetchSavedThemeType(for: window))
     }
 
-    public func changeCurrentTheme(_ newTheme: ThemeType, for window: WindowUUID) {
+    public func changeManualTheme(to newTheme: ThemeType, for window: WindowUUID) {
         guard currentTheme(for: window).type != newTheme else { return }
 
         updateSavedTheme(to: newTheme)
@@ -154,7 +151,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
             else { return }
 
             updateTheme(for: uuid, to: getSystemThemeType())
-//            changeCurrentTheme(getSystemThemeType(), for: uuid)
         }
     }
 
@@ -208,7 +204,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         if automaticBrightnessIsOn {
             allWindowUUIDs.forEach { uuid in
                 updateTheme(for: uuid, to: getThemeTypeBasedOnBrightness())
-//                changeCurrentTheme(getThemeTypeBasedOnBrightness(), for: uuid)
             }
         } else {
             allWindowUUIDs.forEach { reloadTheme(for: $0) }
@@ -240,8 +235,6 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         to newTheme: ThemeType,
         notify: Bool = true
     ) {
-        windowThemeState[window] = getThemeFromType(newTheme)
-
         // Overwrite the user interface style on the window attached to our scene
         // once we have multiple scenes we need to update all of them
         let style = self.currentTheme(for: window).type.getInterfaceStyle()

--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -166,8 +166,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     // MARK: - Private theme functions
     public func setPrivateTheme(isOn: Bool, for window: WindowUUID) {
-        let currentSetting = getPrivateThemeIsOn(for: window)
-        guard currentSetting != isOn else { return }
+        guard getPrivateThemeIsOn(for: window) != isOn else { return }
 
         var settings: KeyedPrivateModeFlags
         = userDefaults.object(forKey: ThemeKeys.PrivateMode.byWindowUUID) as? KeyedPrivateModeFlags ?? [:]
@@ -180,9 +179,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     public func getPrivateThemeIsOn(for window: WindowUUID) -> Bool {
         let settings = userDefaults.object(forKey: ThemeKeys.PrivateMode.byWindowUUID) as? KeyedPrivateModeFlags
-        if settings == nil {
-            migrateSingleWindowPrivateDefaultsToMultiWindow(for: window)
-        }
+        if settings == nil { migrateSingleWindowPrivateDefaultsToMultiWindow(for: window) }
 
         let boxedBool = settings?[window.uuidString] as? NSNumber
         return boxedBool?.boolValue ?? false
@@ -228,7 +225,11 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         userDefaults.set(newTheme.rawValue, forKey: ThemeKeys.themeName)
     }
 
-    private func updateTheme(for window: WindowUUID, to newTheme: ThemeType, notify: Bool = true) {
+    private func updateTheme(
+        for window: WindowUUID,
+        to newTheme: ThemeType,
+        notify: Bool = true
+    ) {
         windowThemeState[window] = getThemeFromType(newTheme)
 
         // Overwrite the user interface style on the window attached to our scene
@@ -242,7 +243,10 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
     private func notifyCurrentThemeDidChange(for window: WindowUUID) {
         mainQueue.ensureMainThread { [weak self] in
-            self?.notificationCenter.post(name: .ThemeDidChange, withUserInfo: window.userInfo)
+            self?.notificationCenter.post(
+                name: .ThemeDidChange,
+                withUserInfo: window.userInfo
+            )
         }
     }
 
@@ -279,7 +283,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         case UIScreen.brightnessDidChangeNotification:
             updateThemeBasedOnBrightess()
         case UIApplication.didBecomeActiveNotification:
-            self.systemThemeChanged()
+            systemThemeChanged()
         default:
             return
         }

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -6,24 +6,22 @@ import UIKit
 
 public protocol ThemeManager {
     // Current theme
-    func currentTheme(for window: WindowUUID?) -> Theme
+    func getcurrentTheme(for window: WindowUUID?) -> Theme
 
     // System theme and brightness settings
     var systemThemeIsOn: Bool { get }
     var automaticBrightnessIsOn: Bool { get }
     var automaticBrightnessValue: Float { get }
-    func systemThemeChanged()
     func setSystemTheme(isOn: Bool)
+    func setManualTheme(to newTheme: ThemeType)
+    func getUserManualTheme() -> ThemeType
     func setAutomaticBrightness(isOn: Bool)
     func setAutomaticBrightnessValue(_ value: Float)
-    func updateThemeBasedOnBrightess()
-    func getUserManualTheme() -> ThemeType
 
     // Window management and window-specific themeing
-    func changeManualTheme(to newTheme: ThemeType, for window: WindowUUID)
+    func reloadThemeForAllWindows()
     func setPrivateTheme(isOn: Bool, for window: WindowUUID)
     func getPrivateThemeIsOn(for window: WindowUUID) -> Bool
-    func reloadTheme(for window: WindowUUID)
     func setWindow(_ window: UIWindow, for uuid: WindowUUID)
     func windowDidClose(uuid: WindowUUID)
 

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -17,7 +17,7 @@ public protocol ThemeManager {
     func setAutomaticBrightness(isOn: Bool)
     func setAutomaticBrightnessValue(_ value: Float)
     func updateThemeBasedOnBrightess()
-    func getSavedTheme() -> ThemeType
+    func getUserManualTheme() -> ThemeType
 
     // Window management and window-specific themeing
     func changeCurrentTheme(_ newTheme: ThemeType, for window: WindowUUID)

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -17,7 +17,7 @@ public protocol ThemeManager {
     func setAutomaticBrightness(isOn: Bool)
     func setAutomaticBrightnessValue(_ value: Float)
     func brightnessChanged()
-    func getNormalSavedTheme() -> ThemeType
+    func getSavedTheme() -> ThemeType
 
     // Window management and window-specific themeing
     func changeCurrentTheme(_ newTheme: ThemeType, for window: WindowUUID)

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -19,7 +19,7 @@ public protocol ThemeManager {
     func setAutomaticBrightnessValue(_ value: Float)
 
     // Window management and window-specific themeing
-    func reloadThemeForAllWindows()
+    func applyThemeUpdatesToWindows()
     func setPrivateTheme(isOn: Bool, for window: WindowUUID)
     func getPrivateThemeIsOn(for window: WindowUUID) -> Bool
     func setWindow(_ window: UIWindow, for uuid: WindowUUID)

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -20,7 +20,7 @@ public protocol ThemeManager {
     func getUserManualTheme() -> ThemeType
 
     // Window management and window-specific themeing
-    func changeCurrentTheme(_ newTheme: ThemeType, for window: WindowUUID)
+    func changeManualTheme(to newTheme: ThemeType, for window: WindowUUID)
     func setPrivateTheme(isOn: Bool, for window: WindowUUID)
     func getPrivateThemeIsOn(for window: WindowUUID) -> Bool
     func reloadTheme(for window: WindowUUID)

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -6,7 +6,7 @@ import UIKit
 
 public protocol ThemeManager {
     // Current theme
-    func getcurrentTheme(for window: WindowUUID?) -> Theme
+    func getCurrentTheme(for window: WindowUUID?) -> Theme
 
     // System theme and brightness settings
     var systemThemeIsOn: Bool { get }

--- a/BrowserKit/Sources/Common/Theming/ThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeManager.swift
@@ -16,7 +16,7 @@ public protocol ThemeManager {
     func setSystemTheme(isOn: Bool)
     func setAutomaticBrightness(isOn: Bool)
     func setAutomaticBrightnessValue(_ value: Float)
-    func brightnessChanged()
+    func updateThemeBasedOnBrightess()
     func getSavedTheme() -> ThemeType
 
     // Window management and window-specific themeing

--- a/BrowserKit/Sources/Common/Theming/ThemeType.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeType.swift
@@ -39,14 +39,4 @@ public enum ThemeType: String {
         case .light: UIBlurEffect.Style.extraLight
         }
     }
-
-    /// An overriding theme is a type of theme that overrides whatever theme
-    /// the user currently has selected, because they would be in a special
-    /// theming case, like private mode.
-    public func isOverridingThemeType() -> Bool {
-        switch self {
-        case .nightMode, .privateMode: return true
-        case .dark, .light: return false
-        }
-    }
 }

--- a/BrowserKit/Sources/Common/Theming/Themeable.swift
+++ b/BrowserKit/Sources/Common/Theming/Themeable.swift
@@ -39,7 +39,7 @@ extension Themeable {
     public func updateThemeApplicableSubviews(_ view: UIView, for window: WindowUUID?) {
         guard let uuid = (view as? ThemeUUIDIdentifiable)?.currentWindowUUID ?? window else { return }
         assert(uuid != .unavailable, "Theme applicable view has `unavailable` window UUID. Unexpected.")
-        let theme = themeManager.currentTheme(for: uuid)
+        let theme = themeManager.getcurrentTheme(for: uuid)
         let themeViews = getAllSubviews(for: view, ofType: ThemeApplicable.self)
         themeViews.forEach { $0.applyTheme(theme: theme) }
     }

--- a/BrowserKit/Sources/Common/Theming/Themeable.swift
+++ b/BrowserKit/Sources/Common/Theming/Themeable.swift
@@ -39,7 +39,7 @@ extension Themeable {
     public func updateThemeApplicableSubviews(_ view: UIView, for window: WindowUUID?) {
         guard let uuid = (view as? ThemeUUIDIdentifiable)?.currentWindowUUID ?? window else { return }
         assert(uuid != .unavailable, "Theme applicable view has `unavailable` window UUID. Unexpected.")
-        let theme = themeManager.getcurrentTheme(for: uuid)
+        let theme = themeManager.getCurrentTheme(for: uuid)
         let themeViews = getAllSubviews(for: view, ofType: ThemeApplicable.self)
         themeViews.forEach { $0.applyTheme(theme: theme) }
     }

--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -137,7 +137,7 @@ public class BottomSheetViewController: UIViewController,
 
     public func applyTheme() {
         guard let uuid = (self.view as? ThemeUUIDIdentifiable)?.currentWindowUUID else { return }
-        contentView.backgroundColor = themeManager.currentTheme(for: uuid).colors.layer1
+        contentView.backgroundColor = themeManager.getcurrentTheme(for: uuid).colors.layer1
         sheetView.layer.shadowOpacity = viewModel.shadowOpacity
 
         if useDimmedBackground {

--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -137,7 +137,7 @@ public class BottomSheetViewController: UIViewController,
 
     public func applyTheme() {
         guard let uuid = (self.view as? ThemeUUIDIdentifiable)?.currentWindowUUID else { return }
-        contentView.backgroundColor = themeManager.getcurrentTheme(for: uuid).colors.layer1
+        contentView.backgroundColor = themeManager.getCurrentTheme(for: uuid).colors.layer1
         sheetView.layer.shadowOpacity = viewModel.shadowOpacity
 
         if useDimmedBackground {

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -220,7 +220,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
 
         backgroundColor = theme.colors.layer5
         [previousButton, nextButton, doneButton].forEach {

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -220,7 +220,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
 
         backgroundColor = theme.colors.layer5
         [previousButton, nextButton, doneButton].forEach {

--- a/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
@@ -40,7 +40,7 @@ class CredentialAutofillCoordinator: BaseCoordinator {
     // MARK: - Methods
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func showCreditCardAutofill(creditCard: CreditCard?,

--- a/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
@@ -40,7 +40,7 @@ class CredentialAutofillCoordinator: BaseCoordinator {
     // MARK: - Methods
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func showCreditCardAutofill(creditCard: CreditCard?,

--- a/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
@@ -41,7 +41,7 @@ struct SceneSetupHelper {
         // Setting the initial theme correctly as we don't have a window attached yet to let ThemeManager set it
         let themeManager: ThemeManager = AppContainer.shared.resolve()
         themeManager.setWindow(window, for: windowUUID)
-        window.overrideUserInterfaceStyle = themeManager.getcurrentTheme(for: windowUUID).type.getInterfaceStyle()
+        window.overrideUserInterfaceStyle = themeManager.getCurrentTheme(for: windowUUID).type.getInterfaceStyle()
 
         return window
     }

--- a/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
@@ -41,7 +41,7 @@ struct SceneSetupHelper {
         // Setting the initial theme correctly as we don't have a window attached yet to let ThemeManager set it
         let themeManager: ThemeManager = AppContainer.shared.resolve()
         themeManager.setWindow(window, for: windowUUID)
-        window.overrideUserInterfaceStyle = themeManager.currentTheme(for: windowUUID).type.getInterfaceStyle()
+        window.overrideUserInterfaceStyle = themeManager.getcurrentTheme(for: windowUUID).type.getInterfaceStyle()
 
         return window
     }

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -124,7 +124,7 @@ class SettingsCoordinator: BaseCoordinator,
                 let viewModel = WallpaperSettingsViewModel(
                     wallpaperManager: wallpaperManager,
                     tabManager: tabManager,
-                    theme: themeManager.getcurrentTheme(for: windowUUID)
+                    theme: themeManager.getCurrentTheme(for: windowUUID)
                 )
                 let wallpaperVC = WallpaperSettingsViewController(viewModel: viewModel, windowUUID: windowUUID)
                 wallpaperVC.settingsDelegate = self

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -124,7 +124,7 @@ class SettingsCoordinator: BaseCoordinator,
                 let viewModel = WallpaperSettingsViewModel(
                     wallpaperManager: wallpaperManager,
                     tabManager: tabManager,
-                    theme: themeManager.currentTheme(for: windowUUID)
+                    theme: themeManager.getcurrentTheme(for: windowUUID)
                 )
                 let wallpaperVC = WallpaperSettingsViewController(viewModel: viewModel, windowUUID: windowUUID)
                 wallpaperVC.settingsDelegate = self

--- a/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
@@ -80,7 +80,7 @@ class ShareExtensionCoordinator: BaseCoordinator,
             SimpleToast().showAlertWithText(
                 .AppMenu.AppMenuCopyURLConfirmMessage,
                 bottomContainer: alertContainer,
-                theme: themeManager.getcurrentTheme(for: windowUUID))
+                theme: themeManager.getCurrentTheme(for: windowUUID))
             dequeueNotShownJSAlert()
         default:
             dequeueNotShownJSAlert()
@@ -95,7 +95,7 @@ class ShareExtensionCoordinator: BaseCoordinator,
             shareItem = ShareItem(url: url.absoluteString, title: nil)
         }
 
-        let themeColors = themeManager.getcurrentTheme(for: windowUUID).colors
+        let themeColors = themeManager.getCurrentTheme(for: windowUUID).colors
         let colors = SendToDeviceHelper.Colors(defaultBackground: themeColors.layer1,
                                                textColor: themeColors.textPrimary,
                                                iconColor: themeColors.iconDisabled)
@@ -165,7 +165,7 @@ class ShareExtensionCoordinator: BaseCoordinator,
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 SimpleToast().showAlertWithText(.AppMenu.AppMenuTabSentConfirmMessage,
                                                 bottomContainer: self.alertContainer,
-                                                theme: self.themeManager.getcurrentTheme(for: self.windowUUID))
+                                                theme: self.themeManager.getCurrentTheme(for: self.windowUUID))
             }
         }
     }

--- a/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
@@ -80,7 +80,7 @@ class ShareExtensionCoordinator: BaseCoordinator,
             SimpleToast().showAlertWithText(
                 .AppMenu.AppMenuCopyURLConfirmMessage,
                 bottomContainer: alertContainer,
-                theme: themeManager.currentTheme(for: windowUUID))
+                theme: themeManager.getcurrentTheme(for: windowUUID))
             dequeueNotShownJSAlert()
         default:
             dequeueNotShownJSAlert()
@@ -95,7 +95,7 @@ class ShareExtensionCoordinator: BaseCoordinator,
             shareItem = ShareItem(url: url.absoluteString, title: nil)
         }
 
-        let themeColors = themeManager.currentTheme(for: windowUUID).colors
+        let themeColors = themeManager.getcurrentTheme(for: windowUUID).colors
         let colors = SendToDeviceHelper.Colors(defaultBackground: themeColors.layer1,
                                                textColor: themeColors.textPrimary,
                                                iconColor: themeColors.iconDisabled)
@@ -165,7 +165,7 @@ class ShareExtensionCoordinator: BaseCoordinator,
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 SimpleToast().showAlertWithText(.AppMenu.AppMenuTabSentConfirmMessage,
                                                 bottomContainer: self.alertContainer,
-                                                theme: self.themeManager.currentTheme(for: self.windowUUID))
+                                                theme: self.themeManager.getcurrentTheme(for: self.windowUUID))
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutoFillBottomSheetView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutoFillBottomSheetView.swift
@@ -27,6 +27,6 @@ struct AddressAutoFillBottomSheetView: View {
             Spacer()
         }
         .padding()
-        .background(Color(themeManager.currentTheme(for: windowUUID).colors.layer1))
+        .background(Color(themeManager.getcurrentTheme(for: windowUUID).colors.layer1))
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutoFillBottomSheetView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutoFillBottomSheetView.swift
@@ -27,6 +27,6 @@ struct AddressAutoFillBottomSheetView: View {
             Spacer()
         }
         .padding()
-        .background(Color(themeManager.getcurrentTheme(for: windowUUID).colors.layer1))
+        .background(Color(themeManager.getCurrentTheme(for: windowUUID).colors.layer1))
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
@@ -44,11 +44,11 @@ struct AddressAutofillSettingsView: View {
         }
         .onAppear {
             // Apply the theme when the view appears
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
@@ -44,11 +44,11 @@ struct AddressAutofillSettingsView: View {
         }
         .onAppear {
             // Apply the theme when the view appears
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
@@ -115,7 +115,7 @@ class AddressAutofillSettingsViewController: SensitiveViewController, Themeable 
 
     /// Applies the current theme to the view.
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
@@ -115,7 +115,7 @@ class AddressAutofillSettingsViewController: SensitiveViewController, Themeable 
 
     /// Applies the current theme to the view.
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -86,11 +86,11 @@ struct AddressAutofillToggle: View {
         .background(backgroundColor)
         .onAppear {
             // Apply theme when the view appears
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -86,11 +86,11 @@ struct AddressAutofillToggle: View {
         .background(backgroundColor)
         .onAppear {
             // Apply theme when the view appears
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
@@ -56,14 +56,14 @@ struct AddressCellView: View {
             Divider().frame(height: 1)
         }
         .listRowInsets(EdgeInsets())
-        .buttonStyle(AddressButtonStyle(theme: themeManager.currentTheme(for: windowUUID)))
+        .buttonStyle(AddressButtonStyle(theme: themeManager.getcurrentTheme(for: windowUUID)))
         .listRowSeparator(.hidden)
         .onAppear {
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
@@ -56,14 +56,14 @@ struct AddressCellView: View {
             Divider().frame(height: 1)
         }
         .listRowInsets(EdgeInsets())
-        .buttonStyle(AddressButtonStyle(theme: themeManager.getcurrentTheme(for: windowUUID)))
+        .buttonStyle(AddressButtonStyle(theme: themeManager.getCurrentTheme(for: windowUUID)))
         .listRowSeparator(.hidden)
         .onAppear {
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -72,11 +72,11 @@ struct AddressListView: View {
         }
         .onAppear {
             viewModel.fetchAddresses()
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -72,11 +72,11 @@ struct AddressListView: View {
         }
         .onAppear {
             viewModel.fetchAddresses()
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -52,7 +52,7 @@ class AddressListViewModel: ObservableObject, FeatureFlaggable {
     var currentRegionCode: () -> String = { Locale.current.regionCode ?? "" }
     var isDarkTheme: (WindowUUID) -> Bool = { windowUUID in
         let themeManager: ThemeManager = AppContainer.shared.resolve()
-        return themeManager.currentTheme(for: windowUUID).type == .dark
+        return themeManager.getcurrentTheme(for: windowUUID).type == .dark
     }
 
     // MARK: - Initializer

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -52,7 +52,7 @@ class AddressListViewModel: ObservableObject, FeatureFlaggable {
     var currentRegionCode: () -> String = { Locale.current.regionCode ?? "" }
     var isDarkTheme: (WindowUUID) -> Bool = { windowUUID in
         let themeManager: ThemeManager = AppContainer.shared.resolve()
-        return themeManager.getcurrentTheme(for: windowUUID).type == .dark
+        return themeManager.getCurrentTheme(for: windowUUID).type == .dark
     }
 
     // MARK: - Initializer

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressScrollView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressScrollView.swift
@@ -44,11 +44,11 @@ struct AddressScrollView: View {
         .listRowInsets(EdgeInsets())
         .onAppear {
             viewModel.fetchAddresses()
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressScrollView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressScrollView.swift
@@ -44,11 +44,11 @@ struct AddressScrollView: View {
         .listRowInsets(EdgeInsets())
         .onAppear {
             viewModel.fetchAddresses()
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -125,7 +125,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
 
     func applyTheme() {
         guard let currentWindowUUID else { return }
-        let isDarkTheme = themeManager.currentTheme(for: currentWindowUUID).type == .dark
+        let isDarkTheme = themeManager.getcurrentTheme(for: currentWindowUUID).type == .dark
         evaluateJavaScript("setTheme(\(isDarkTheme));")
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -125,7 +125,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
 
     func applyTheme() {
         guard let currentWindowUUID else { return }
-        let isDarkTheme = themeManager.getcurrentTheme(for: currentWindowUUID).type == .dark
+        let isDarkTheme = themeManager.getCurrentTheme(for: currentWindowUUID).type == .dark
         evaluateJavaScript("setTheme(\(isDarkTheme));")
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/AutofillFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillFooterView.swift
@@ -44,11 +44,11 @@ struct AutofillFooterView: View {
             .accessibility(identifier: AccessibilityIdentifiers.Autofill.footerPrimaryAction)
         }
         .onAppear {
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/AutofillFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillFooterView.swift
@@ -44,11 +44,11 @@ struct AutofillFooterView: View {
             .accessibility(identifier: AccessibilityIdentifiers.Autofill.footerPrimaryAction)
         }
         .onAppear {
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/AutofillHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillHeaderView.swift
@@ -57,11 +57,11 @@ struct AutofillHeaderView: View {
         .padding(.bottom, UX.bottomSpacing)
 
         .onAppear {
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/AutofillHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillHeaderView.swift
@@ -57,11 +57,11 @@ struct AutofillHeaderView: View {
         .padding(.bottom, UX.bottomSpacing)
 
         .onAppear {
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -150,7 +150,7 @@ class CreditCardBottomSheetViewController: UIViewController,
                 a11yIdentifier: AccessibilityIdentifiers.RememberCreditCard.yesButton
             )
             yesButton.configure(viewModel: buttonViewModel)
-            yesButton.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            yesButton.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
 
         contentView.addSubviews(cardTableView, buttonsContainerStackView)
@@ -311,7 +311,7 @@ class CreditCardBottomSheetViewController: UIViewController,
         ) as? CreditCardBottomSheetHeaderView else {
             return nil
         }
-        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         headerView.viewModel = viewModel
         return headerView
     }
@@ -327,7 +327,7 @@ class CreditCardBottomSheetViewController: UIViewController,
             ) as? CreditCardBottomSheetFooterView else {
                 return nil
             }
-            footerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            footerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             if !footerView.manageCardsButton.responds(
                 to: #selector(CreditCardBottomSheetViewController.didTapManageCards)
             ) {
@@ -363,7 +363,7 @@ class CreditCardBottomSheetViewController: UIViewController,
 
     // MARK: Themable
     func applyTheme() {
-        let currentTheme = themeManager.getcurrentTheme(for: windowUUID).colors
+        let currentTheme = themeManager.getCurrentTheme(for: windowUUID).colors
         view.backgroundColor = currentTheme.layer1
         cardTableView.reloadData()
     }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -150,7 +150,7 @@ class CreditCardBottomSheetViewController: UIViewController,
                 a11yIdentifier: AccessibilityIdentifiers.RememberCreditCard.yesButton
             )
             yesButton.configure(viewModel: buttonViewModel)
-            yesButton.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            yesButton.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
 
         contentView.addSubviews(cardTableView, buttonsContainerStackView)
@@ -311,7 +311,7 @@ class CreditCardBottomSheetViewController: UIViewController,
         ) as? CreditCardBottomSheetHeaderView else {
             return nil
         }
-        headerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         headerView.viewModel = viewModel
         return headerView
     }
@@ -327,7 +327,7 @@ class CreditCardBottomSheetViewController: UIViewController,
             ) as? CreditCardBottomSheetFooterView else {
                 return nil
             }
-            footerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            footerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
             if !footerView.manageCardsButton.responds(
                 to: #selector(CreditCardBottomSheetViewController.didTapManageCards)
             ) {
@@ -363,7 +363,7 @@ class CreditCardBottomSheetViewController: UIViewController,
 
     // MARK: Themable
     func applyTheme() {
-        let currentTheme = themeManager.currentTheme(for: windowUUID).colors
+        let currentTheme = themeManager.getcurrentTheme(for: windowUUID).colors
         view.backgroundColor = currentTheme.layer1
         cardTableView.reloadData()
     }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -104,11 +104,11 @@ struct CreditCardInputView: View {
             }
             .blur(radius: isBlurred ? 10 : 0)
             .onAppear {
-                applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+                applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
             }
             .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
                 guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-                applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+                applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
             }
             .onReceive(NotificationCenter.default.publisher(
                 for: UIApplication.willResignActiveNotification)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -104,11 +104,11 @@ struct CreditCardInputView: View {
             }
             .blur(radius: isBlurred ? 10 : 0)
             .onAppear {
-                applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+                applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             }
             .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
                 guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-                applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+                applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             }
             .onReceive(NotificationCenter.default.publisher(
                 for: UIApplication.willResignActiveNotification)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -99,11 +99,11 @@ struct CreditCardItemRow: View {
         .background(ClearBackgroundView())
         .padding(.vertical, addPadding ? 8 : 0)
         .onAppear {
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -99,11 +99,11 @@ struct CreditCardItemRow: View {
         .background(ClearBackgroundView())
         .padding(.vertical, addPadding ? 8 : 0)
         .onAppear {
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSectionHeader.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSectionHeader.swift
@@ -26,11 +26,11 @@ struct CreditCardSectionHeader: View {
                             bottom: 8,
                             trailing: 16))
         .onAppear {
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSectionHeader.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSectionHeader.swift
@@ -26,11 +26,11 @@ struct CreditCardSectionHeader: View {
                             bottom: 8,
                             trailing: 16))
         .onAppear {
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
@@ -65,11 +65,11 @@ struct CreditCardSettingsEmptyView: View {
             }
         }
         .onAppear {
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
@@ -65,11 +65,11 @@ struct CreditCardSettingsEmptyView: View {
             }
         }
         .onAppear {
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -146,7 +146,7 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {
@@ -194,7 +194,7 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
         guard status != .none else { return }
         SimpleToast().showAlertWithText(status.message,
                                         bottomContainer: view,
-                                        theme: self.themeManager.getcurrentTheme(for: self.windowUUID))
+                                        theme: self.themeManager.getCurrentTheme(for: self.windowUUID))
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -146,7 +146,7 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {
@@ -194,7 +194,7 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
         guard status != .none else { return }
         SimpleToast().showAlertWithText(status.message,
                                         bottomContainer: view,
-                                        theme: self.themeManager.currentTheme(for: self.windowUUID))
+                                        theme: self.themeManager.getcurrentTheme(for: self.windowUUID))
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
@@ -106,7 +106,7 @@ class CreditCardTableViewController: UIViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
         tableView.backgroundColor = theme.colors.layer1
     }
@@ -156,7 +156,7 @@ extension CreditCardTableViewController: UITableViewDelegate,
                 ) as? HostingTableViewSectionHeader<CreditCardSectionHeader>
         else { return nil }
 
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let headerView = CreditCardSectionHeader(windowUUID: windowUUID, textColor: theme.colors.textSecondary.color)
         hostingCell.host(headerView, parentController: self)
         return hostingCell
@@ -180,7 +180,7 @@ extension CreditCardTableViewController: UITableViewDelegate,
             return UITableViewCell()
         }
 
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let row = CreditCardAutofillToggle(windowUUID: windowUUID,
                                            textColor: theme.colors.textPrimary.color,
                                            model: model)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
@@ -106,7 +106,7 @@ class CreditCardTableViewController: UIViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
         tableView.backgroundColor = theme.colors.layer1
     }
@@ -156,7 +156,7 @@ extension CreditCardTableViewController: UITableViewDelegate,
                 ) as? HostingTableViewSectionHeader<CreditCardSectionHeader>
         else { return nil }
 
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let headerView = CreditCardSectionHeader(windowUUID: windowUUID, textColor: theme.colors.textSecondary.color)
         hostingCell.host(headerView, parentController: self)
         return hostingCell
@@ -180,7 +180,7 @@ extension CreditCardTableViewController: UITableViewDelegate,
             return UITableViewCell()
         }
 
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let row = CreditCardAutofillToggle(windowUUID: windowUUID,
                                            textColor: theme.colors.textPrimary.color,
                                            model: model)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
@@ -55,11 +55,11 @@ struct CreditCardAutofillToggle: View {
         }
         .background(backgroundColor)
         .onAppear {
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
@@ -55,11 +55,11 @@ struct CreditCardAutofillToggle: View {
         }
         .background(backgroundColor)
         .onAppear {
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
@@ -113,11 +113,11 @@ struct CreditCardInputField: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.leading, 20)
         .onAppear {
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
@@ -113,11 +113,11 @@ struct CreditCardInputField: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.leading, 20)
         .onAppear {
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
@@ -60,11 +60,11 @@ struct RemoveCardButton: View {
             }.background(backgroundColor.edgesIgnoringSafeArea(.bottom))
         }
         .onAppear {
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
             // part of FXIOS-6797, if the app goes to the background and

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
@@ -60,11 +60,11 @@ struct RemoveCardButton: View {
             }.background(backgroundColor.edgesIgnoringSafeArea(.bottom))
         }
         .onAppear {
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
             // part of FXIOS-6797, if the app goes to the background and

--- a/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
@@ -32,11 +32,11 @@ struct LoginAutofillView: View {
         .padding()
         .background(backgroundColor)
         .onAppear {
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
@@ -32,11 +32,11 @@ struct LoginAutofillView: View {
         .padding()
         .background(backgroundColor)
         .onAppear {
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
@@ -60,14 +60,14 @@ struct LoginCellView: View {
             }
             .padding()
         }
-        .buttonStyle(LoginButtonStyle(theme: themeManager.getcurrentTheme(for: windowUUID)))
+        .buttonStyle(LoginButtonStyle(theme: themeManager.getCurrentTheme(for: windowUUID)))
         .listRowSeparator(.hidden)
         .onAppear {
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
@@ -60,14 +60,14 @@ struct LoginCellView: View {
             }
             .padding()
         }
-        .buttonStyle(LoginButtonStyle(theme: themeManager.currentTheme(for: windowUUID)))
+        .buttonStyle(LoginButtonStyle(theme: themeManager.getcurrentTheme(for: windowUUID)))
         .listRowSeparator(.hidden)
         .onAppear {
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/LoginListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginListView.swift
@@ -35,11 +35,11 @@ struct LoginListView: View {
         }
         .task {
             await viewModel.fetchLogins()
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/LoginListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginListView.swift
@@ -35,11 +35,11 @@ struct LoginListView: View {
         }
         .task {
             await viewModel.fetchLogins()
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -124,7 +124,7 @@ class BackForwardListViewController: UIViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -124,7 +124,7 @@ class BackForwardListViewController: UIViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
@@ -61,7 +61,7 @@ extension BrowserViewController: ReaderModeStyleViewModelDelegate {
 extension BrowserViewController {
     func updateReaderModeBar() {
         guard let readerModeBar = readerModeBar else { return }
-        readerModeBar.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        readerModeBar.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
 
         if let url = self.tabManager.selectedTab?.url?.displayURL?.absoluteString,
            let record = profile.readingList.getRecordWithURL(url).value.successValue {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
@@ -61,7 +61,7 @@ extension BrowserViewController: ReaderModeStyleViewModelDelegate {
 extension BrowserViewController {
     func updateReaderModeBar() {
         guard let readerModeBar = readerModeBar else { return }
-        readerModeBar.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        readerModeBar.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
 
         if let url = self.tabManager.selectedTab?.url?.displayURL?.absoluteString,
            let record = profile.readingList.getRecordWithURL(url).value.successValue {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
@@ -32,7 +32,7 @@ extension BrowserViewController {
         zoomPageBar.heightAnchor
             .constraint(greaterThanOrEqualToConstant: UIConstants.ZoomPageBarHeight)
             .isActive = true
-        zoomPageBar.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        zoomPageBar.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
 
         if UIDevice.current.userInterfaceIdiom != .pad {
             updateViewConstraints()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ZoomPage.swift
@@ -32,7 +32,7 @@ extension BrowserViewController {
         zoomPageBar.heightAnchor
             .constraint(greaterThanOrEqualToConstant: UIConstants.ZoomPageBarHeight)
             .isActive = true
-        zoomPageBar.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        zoomPageBar.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
 
         if UIDevice.current.userInterfaceIdiom != .pad {
             updateViewConstraints()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -541,7 +541,7 @@ class BrowserViewController: UIViewController,
         if NightModeHelper.isActivated(),
            !featureFlags.isFeatureEnabled(.nightMode, checking: .buildOnly) {
             NightModeHelper.turnOff()
-            themeManager.reloadThemeForAllWindows()
+            themeManager.applyThemeUpdatesToWindows()
         }
 
         NightModeHelper.cleanNightModeDefaults()
@@ -1008,7 +1008,7 @@ class BrowserViewController: UIViewController,
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-            themeManager.reloadThemeForAllWindows()
+            themeManager.applyThemeUpdatesToWindows()
         }
         setupMiddleButtonStatus(isLoading: false)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -541,7 +541,7 @@ class BrowserViewController: UIViewController,
         if NightModeHelper.isActivated(),
            !featureFlags.isFeatureEnabled(.nightMode, checking: .buildOnly) {
             NightModeHelper.turnOff()
-            themeManager.reloadTheme(for: windowUUID)
+            themeManager.reloadThemeForAllWindows()
         }
 
         NightModeHelper.cleanNightModeDefaults()
@@ -1008,7 +1008,7 @@ class BrowserViewController: UIViewController,
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-            themeManager.systemThemeChanged()
+            themeManager.reloadThemeForAllWindows()
         }
         setupMiddleButtonStatus(isLoading: false)
     }
@@ -1298,7 +1298,7 @@ class BrowserViewController: UIViewController,
             })
         }
 
-        microsurvey.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        microsurvey.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
 
         updateViewConstraints()
     }
@@ -2493,7 +2493,7 @@ class BrowserViewController: UIViewController,
     // MARK: Themeable
 
     func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1298,7 +1298,7 @@ class BrowserViewController: UIViewController,
             })
         }
 
-        microsurvey.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        microsurvey.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
 
         updateViewConstraints()
     }
@@ -2493,7 +2493,7 @@ class BrowserViewController: UIViewController,
     // MARK: Themeable
 
     func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionDetailsVC.swift
+++ b/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionDetailsVC.swift
@@ -186,7 +186,7 @@ class EnhancedTrackingProtectionDetailsVC: UIViewController, Themeable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionDetailsVC.swift
+++ b/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionDetailsVC.swift
@@ -186,7 +186,7 @@ class EnhancedTrackingProtectionDetailsVC: UIViewController, Themeable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -501,7 +501,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
+++ b/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVC.swift
@@ -501,7 +501,7 @@ class EnhancedTrackingProtectionMenuVC: UIViewController, Themeable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -398,7 +398,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                   let url = selectedTab.canonicalURL?.displayURL
             else { return }
 
-            let themeColors = self.themeManager.currentTheme(for: uuid).colors
+            let themeColors = self.themeManager.getcurrentTheme(for: uuid).colors
             let colors = SendToDeviceHelper.Colors(defaultBackground: themeColors.layer1,
                                                    textColor: themeColors.textPrimary,
                                                    iconColor: themeColors.iconPrimary)
@@ -475,11 +475,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                 TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .nightModeDisabled)
             }
 
-            let windowManager: WindowManager = AppContainer.shared.resolve()
-            let allWindowUUIDS = windowManager.allWindowUUIDs(includingReserved: false)
-            allWindowUUIDS.forEach { uuid in
-                self.themeManager.reloadTheme(for: uuid)
-            }
+            self.themeManager.reloadThemeForAllWindows()
         }.items
         items.append(nightMode)
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -398,7 +398,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                   let url = selectedTab.canonicalURL?.displayURL
             else { return }
 
-            let themeColors = self.themeManager.getcurrentTheme(for: uuid).colors
+            let themeColors = self.themeManager.getCurrentTheme(for: uuid).colors
             let colors = SendToDeviceHelper.Colors(defaultBackground: themeColors.layer1,
                                                    textColor: themeColors.textPrimary,
                                                    iconColor: themeColors.iconPrimary)

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -475,7 +475,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                 TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .nightModeDisabled)
             }
 
-            self.themeManager.reloadThemeForAllWindows()
+            self.themeManager.applyThemeUpdatesToWindows()
         }.items
         items.append(nightMode)
 

--- a/firefox-ios/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -104,7 +104,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
         let cell = dequeueCellFor(indexPath: indexPath)
         let option = mailProviderSource[indexPath.row]
 
-        cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
 
         cell.textLabel?.attributedText = tableRowTitle(option.name, enabled: option.enabled)
         cell.accessoryType = (currentChoice == option.scheme && option.enabled) ? .checkmark : .none
@@ -142,7 +142,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
 
     private func tableRowTitle(_ string: String, enabled: Bool) -> NSAttributedString {
         var color: [NSAttributedString.Key: UIColor]
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         if enabled {
             color = [
                 NSAttributedString.Key.foregroundColor: theme.colors.textPrimary

--- a/firefox-ios/Client/Frontend/Browser/OpenWithSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenWithSettingsViewController.swift
@@ -104,7 +104,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
         let cell = dequeueCellFor(indexPath: indexPath)
         let option = mailProviderSource[indexPath.row]
 
-        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
 
         cell.textLabel?.attributedText = tableRowTitle(option.name, enabled: option.enabled)
         cell.accessoryType = (currentChoice == option.scheme && option.enabled) ? .checkmark : .none
@@ -142,7 +142,7 @@ class OpenWithSettingsViewController: ThemedTableViewController {
 
     private func tableRowTitle(_ string: String, enabled: Bool) -> NSAttributedString {
         var color: [NSAttributedString.Key: UIColor]
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         if enabled {
             color = [
                 NSAttributedString.Key.foregroundColor: theme.colors.textPrimary

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -507,7 +507,7 @@ class SearchViewController: SiteTableViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     override func tableView(

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -507,7 +507,7 @@ class SearchViewController: SiteTableViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     override func tableView(

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -177,7 +177,7 @@ class LegacyGridTabViewController: UIViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     private func setupView() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -177,7 +177,7 @@ class LegacyGridTabViewController: UIViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     private func setupView() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
@@ -106,7 +106,7 @@ class LegacyTabTrayViewController: UIViewController, Themeable, TabTrayControlle
     private func syncLoadingView() -> UIStackView {
         let syncingLabel = UILabel()
         syncingLabel.text = .SyncingMessageWithEllipsis
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         syncingLabel.textColor = theme.colors.textPrimary
 
         let activityIndicator = UIActivityIndicatorView(style: .medium)
@@ -505,8 +505,8 @@ class LegacyTabTrayViewController: UIViewController, Themeable, TabTrayControlle
     // MARK: - Themable
 
     func applyTheme() {
-        view.backgroundColor = themeManager.getcurrentTheme(for: windowUUID).colors.layer4
-        navigationToolbar.barTintColor = themeManager.getcurrentTheme(for: windowUUID).colors.layer1
+        view.backgroundColor = themeManager.getCurrentTheme(for: windowUUID).colors.layer4
+        navigationToolbar.barTintColor = themeManager.getCurrentTheme(for: windowUUID).colors.layer1
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
@@ -106,7 +106,7 @@ class LegacyTabTrayViewController: UIViewController, Themeable, TabTrayControlle
     private func syncLoadingView() -> UIStackView {
         let syncingLabel = UILabel()
         syncingLabel.text = .SyncingMessageWithEllipsis
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         syncingLabel.textColor = theme.colors.textPrimary
 
         let activityIndicator = UIActivityIndicatorView(style: .medium)
@@ -505,8 +505,8 @@ class LegacyTabTrayViewController: UIViewController, Themeable, TabTrayControlle
     // MARK: - Themable
 
     func applyTheme() {
-        view.backgroundColor = themeManager.currentTheme(for: windowUUID).colors.layer4
-        navigationToolbar.barTintColor = themeManager.currentTheme(for: windowUUID).colors.layer1
+        view.backgroundColor = themeManager.getcurrentTheme(for: windowUUID).colors.layer4
+        navigationToolbar.barTintColor = themeManager.getcurrentTheme(for: windowUUID).colors.layer1
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsPanel.swift
@@ -81,7 +81,7 @@ class LegacyRemoteTabsPanel: UIViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsPanel.swift
@@ -81,7 +81,7 @@ class LegacyRemoteTabsPanel: UIViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsTableViewController.swift
@@ -109,7 +109,7 @@ class LegacyRemoteTabsTableViewController: UITableViewController, Themeable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/RemoteTabs/LegacyRemoteTabsTableViewController.swift
@@ -109,7 +109,7 @@ class LegacyRemoteTabsTableViewController: UITableViewController, Themeable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -100,7 +100,7 @@ class RemoteTabsPanel: UIViewController,
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer4
         tableViewController.tableView.backgroundColor =  theme.colors.layer3
         tableViewController.tableView.separatorColor = theme.colors.borderPrimary

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -100,7 +100,7 @@ class RemoteTabsPanel: UIViewController,
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer4
         tableViewController.tableView.backgroundColor =  theme.colors.layer3
         tableViewController.tableView.separatorColor = theme.colors.borderPrimary

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -130,7 +130,7 @@ class RemoteTabsTableViewController: UITableViewController,
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         emptyView.applyTheme(theme: theme)
         tableView.visibleCells.forEach { ($0 as? ThemeApplicable)?.applyTheme(theme: theme) }
     }
@@ -138,7 +138,7 @@ class RemoteTabsTableViewController: UITableViewController,
     private func configureEmptyView() {
         guard let emptyState = state.showingEmptyState else { return }
         emptyView.configure(state: emptyState, delegate: remoteTabsPanel)
-        emptyView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        emptyView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
     }
 
     // MARK: - Refreshing TableView
@@ -262,7 +262,7 @@ class RemoteTabsTableViewController: UITableViewController,
         cell.descriptionLabel.text = tab.URL.absoluteString
         cell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: tab.URL.absoluteString))
         cell.accessoryView = nil
-        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
     }
 
     @objc
@@ -300,7 +300,7 @@ class RemoteTabsTableViewController: UITableViewController,
         let tapGesture = UITapGestureRecognizer(target: self,
                                                 action: #selector(sectionHeaderTapped(sender:)))
         headerView.addGestureRecognizer(tapGesture)
-        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         /*
         * (Copied from legacy RemoteTabsClientAndTabsDataSource)
         * A note on timestamps.

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -130,7 +130,7 @@ class RemoteTabsTableViewController: UITableViewController,
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         emptyView.applyTheme(theme: theme)
         tableView.visibleCells.forEach { ($0 as? ThemeApplicable)?.applyTheme(theme: theme) }
     }
@@ -138,7 +138,7 @@ class RemoteTabsTableViewController: UITableViewController,
     private func configureEmptyView() {
         guard let emptyState = state.showingEmptyState else { return }
         emptyView.configure(state: emptyState, delegate: remoteTabsPanel)
-        emptyView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        emptyView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
     }
 
     // MARK: - Refreshing TableView
@@ -262,7 +262,7 @@ class RemoteTabsTableViewController: UITableViewController,
         cell.descriptionLabel.text = tab.URL.absoluteString
         cell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: tab.URL.absoluteString))
         cell.accessoryView = nil
-        cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
     }
 
     @objc
@@ -300,7 +300,7 @@ class RemoteTabsTableViewController: UITableViewController,
         let tapGesture = UITapGestureRecognizer(target: self,
                                                 action: #selector(sectionHeaderTapped(sender:)))
         headerView.addGestureRecognizer(tapGesture)
-        headerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         /*
         * (Copied from legacy RemoteTabsClientAndTabsDataSource)
         * A note on timestamps.

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -110,7 +110,7 @@ class TabDisplayPanel: UIViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -110,7 +110,7 @@ class TabDisplayPanel: UIViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -145,10 +145,10 @@ class TabTrayViewController: UIViewController,
     private lazy var syncLoadingView: UIStackView = .build { [self] stackView in
         let syncingLabel = UILabel()
         syncingLabel.text = .SyncingMessageWithEllipsis
-        syncingLabel.textColor = themeManager.getcurrentTheme(for: windowUUID).colors.textPrimary
+        syncingLabel.textColor = themeManager.getCurrentTheme(for: windowUUID).colors.textPrimary
 
         let activityIndicator = UIActivityIndicatorView(style: .medium)
-        activityIndicator.color = themeManager.getcurrentTheme(for: windowUUID).colors.textPrimary
+        activityIndicator.color = themeManager.getCurrentTheme(for: windowUUID).colors.textPrimary
         activityIndicator.startAnimating()
 
         stackView.addArrangedSubview(syncingLabel)
@@ -302,7 +302,7 @@ class TabTrayViewController: UIViewController,
 
     // MARK: Themeable
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
         navigationToolbar.barTintColor = theme.colors.layer1
         deleteButton.tintColor = theme.colors.iconPrimary

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -145,10 +145,10 @@ class TabTrayViewController: UIViewController,
     private lazy var syncLoadingView: UIStackView = .build { [self] stackView in
         let syncingLabel = UILabel()
         syncingLabel.text = .SyncingMessageWithEllipsis
-        syncingLabel.textColor = themeManager.currentTheme(for: windowUUID).colors.textPrimary
+        syncingLabel.textColor = themeManager.getcurrentTheme(for: windowUUID).colors.textPrimary
 
         let activityIndicator = UIActivityIndicatorView(style: .medium)
-        activityIndicator.color = themeManager.currentTheme(for: windowUUID).colors.textPrimary
+        activityIndicator.color = themeManager.getcurrentTheme(for: windowUUID).colors.textPrimary
         activityIndicator.startAnimating()
 
         stackView.addArrangedSubview(syncingLabel)
@@ -302,7 +302,7 @@ class TabTrayViewController: UIViewController,
 
     // MARK: Themeable
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
         navigationToolbar.barTintColor = theme.colors.layer1
         deleteButton.tintColor = theme.colors.iconPrimary

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -117,7 +117,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
                                                        reuseID: TopTabCell.cellIdentifier,
                                                        tabDisplayType: .TopTabTray,
                                                        profile: profile,
-                                                       theme: themeManager.getcurrentTheme(for: windowUUID))
+                                                       theme: themeManager.getCurrentTheme(for: windowUUID))
         self.tabManager.tabDisplayType = .TopTabTray
         collectionView.dataSource = topTabDisplayManager
         collectionView.delegate = tabLayoutDelegate
@@ -168,17 +168,17 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
         let uiLargeContentViewInteraction = UILargeContentViewerInteraction()
         view.addInteraction(uiLargeContentViewInteraction)
 
-        tabsButton.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        tabsButton.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         applyUIMode(
             isPrivate: tabManager.selectedTab?.isPrivate ?? false,
-            theme: themeManager.getcurrentTheme(for: windowUUID)
+            theme: themeManager.getCurrentTheme(for: windowUUID)
         )
 
         updateTabCount(topTabDisplayManager.dataStore.count, animated: false)
     }
 
     func applyTheme() {
-        let currentTheme = themeManager.getcurrentTheme(for: windowUUID)
+        let currentTheme = themeManager.getCurrentTheme(for: windowUUID)
         let colors = currentTheme.colors
 
         view.backgroundColor = ToolbarFlagManager.isRefactorEnabled ? colors.layer1 : colors.layer3
@@ -323,7 +323,7 @@ extension TopTabsViewController: TabDisplayerDelegate {
         guard let tabCell = cell as? TopTabCell else { return UICollectionViewCell() }
         tabCell.delegate = self
         let isSelected = (tab == tabManager.selectedTab)
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         tabCell.configureLegacyCellWith(tab: tab,
                                         isSelected: isSelected,
                                         theme: theme)

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -117,7 +117,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
                                                        reuseID: TopTabCell.cellIdentifier,
                                                        tabDisplayType: .TopTabTray,
                                                        profile: profile,
-                                                       theme: themeManager.currentTheme(for: windowUUID))
+                                                       theme: themeManager.getcurrentTheme(for: windowUUID))
         self.tabManager.tabDisplayType = .TopTabTray
         collectionView.dataSource = topTabDisplayManager
         collectionView.delegate = tabLayoutDelegate
@@ -168,14 +168,17 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
         let uiLargeContentViewInteraction = UILargeContentViewerInteraction()
         view.addInteraction(uiLargeContentViewInteraction)
 
-        tabsButton.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
-        applyUIMode(isPrivate: tabManager.selectedTab?.isPrivate ?? false, theme: themeManager.currentTheme(for: windowUUID))
+        tabsButton.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        applyUIMode(
+            isPrivate: tabManager.selectedTab?.isPrivate ?? false,
+            theme: themeManager.getcurrentTheme(for: windowUUID)
+        )
 
         updateTabCount(topTabDisplayManager.dataStore.count, animated: false)
     }
 
     func applyTheme() {
-        let currentTheme = themeManager.currentTheme(for: windowUUID)
+        let currentTheme = themeManager.getcurrentTheme(for: windowUUID)
         let colors = currentTheme.colors
 
         view.backgroundColor = ToolbarFlagManager.isRefactorEnabled ? colors.layer1 : colors.layer3
@@ -320,7 +323,7 @@ extension TopTabsViewController: TabDisplayerDelegate {
         guard let tabCell = cell as? TopTabCell else { return UICollectionViewCell() }
         tabCell.delegate = self
         let isSelected = (tab == tabManager.selectedTab)
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         tabCell.configureLegacyCellWith(tab: tab,
                                         isSelected: isSelected,
                                         theme: theme)

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewController.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewController.swift
@@ -189,7 +189,7 @@ class ContextualHintViewController: UIViewController,
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         hintView.applyTheme(theme: theme)
     }
 

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewController.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewController.swift
@@ -189,7 +189,7 @@ class ContextualHintViewController: UIViewController,
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         hintView.applyTheme(theme: theme)
     }
 

--- a/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -128,7 +128,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func initialViewSetup() {

--- a/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/DefaultBrowserOnboarding/DefaultBrowserOnboardingViewController.swift
@@ -128,7 +128,7 @@ class DefaultBrowserOnboardingViewController: UIViewController, OnViewDismissabl
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func initialViewSetup() {

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -257,7 +257,7 @@ class FakespotViewController: UIViewController,
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         shadowView.layer.shadowColor = theme.colors.shadowDefault.cgColor
         shadowView.backgroundColor = theme.colors.layer1
         view.backgroundColor = theme.colors.layer1

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotViewController.swift
@@ -257,7 +257,7 @@ class FakespotViewController: UIViewController,
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         shadowView.layer.shadowColor = theme.colors.shadowDefault.cgColor
         shadowView.backgroundColor = theme.colors.layer1
         view.backgroundColor = theme.colors.layer1

--- a/firefox-ios/Client/Frontend/Fakespot/Views/CircularProgressView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/CircularProgressView.swift
@@ -20,11 +20,11 @@ struct CircularProgressView: View, ThemeApplicable {
     var body: some View {
         progressCircularView
             .onAppear {
-                applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+                applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             }
             .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
                 guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-                applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+                applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             }
     }
 

--- a/firefox-ios/Client/Frontend/Fakespot/Views/CircularProgressView.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/Views/CircularProgressView.swift
@@ -20,11 +20,11 @@ struct CircularProgressView: View, ThemeApplicable {
     var body: some View {
         progressCircularView
             .onAppear {
-                applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+                applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
             }
             .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
                 guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-                applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+                applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
             }
     }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -81,7 +81,7 @@ class HomepageViewController:
         self.viewModel = HomepageViewModel(profile: profile,
                                            isPrivate: isPrivate,
                                            tabManager: tabManager,
-                                           theme: themeManager.getcurrentTheme(for: tabManager.windowUUID))
+                                           theme: themeManager.getCurrentTheme(for: tabManager.windowUUID))
 
         let jumpBackInContextualViewProvider = ContextualHintViewProvider(forHintType: .jumpBackIn,
                                                                           with: viewModel.profile)
@@ -350,7 +350,7 @@ class HomepageViewController:
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         viewModel.theme = theme
         view.backgroundColor = theme.colors.layer1
     }
@@ -370,7 +370,7 @@ class HomepageViewController:
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         // We only handle status bar overlay alpha if there's a wallpaper applied on the homepage
         if WallpaperManager().currentWallpaper.type != .defaultWallpaper {
-            let theme = themeManager.getcurrentTheme(for: windowUUID)
+            let theme = themeManager.getCurrentTheme(for: windowUUID)
             statusBarScrollDelegate?.scrollViewDidScroll(scrollView,
                                                          statusBarFrame: statusBarFrame,
                                                          theme: theme)
@@ -490,7 +490,7 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
             let headerViewModel = sectionViewModel.shouldShow ? sectionViewModel.headerViewModel : LabelButtonHeaderViewModel.emptyHeader
             // swiftlint:enable line_length
             headerView.configure(viewModel: headerViewModel,
-                                 theme: themeManager.getcurrentTheme(for: windowUUID))
+                                 theme: themeManager.getCurrentTheme(for: windowUUID))
 
             // Jump back in header specific setup
             if sectionViewModel.sectionType == .jumpBackIn {
@@ -518,7 +518,7 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
                 }
                 self.showSiteWithURLHandler(learnMoreURL)
             }
-            footerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            footerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             return footerView
         }
         return reusableView

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -81,7 +81,7 @@ class HomepageViewController:
         self.viewModel = HomepageViewModel(profile: profile,
                                            isPrivate: isPrivate,
                                            tabManager: tabManager,
-                                           theme: themeManager.currentTheme(for: tabManager.windowUUID))
+                                           theme: themeManager.getcurrentTheme(for: tabManager.windowUUID))
 
         let jumpBackInContextualViewProvider = ContextualHintViewProvider(forHintType: .jumpBackIn,
                                                                           with: viewModel.profile)
@@ -350,7 +350,7 @@ class HomepageViewController:
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         viewModel.theme = theme
         view.backgroundColor = theme.colors.layer1
     }
@@ -370,7 +370,7 @@ class HomepageViewController:
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         // We only handle status bar overlay alpha if there's a wallpaper applied on the homepage
         if WallpaperManager().currentWallpaper.type != .defaultWallpaper {
-            let theme = themeManager.currentTheme(for: windowUUID)
+            let theme = themeManager.getcurrentTheme(for: windowUUID)
             statusBarScrollDelegate?.scrollViewDidScroll(scrollView,
                                                          statusBarFrame: statusBarFrame,
                                                          theme: theme)
@@ -490,7 +490,7 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
             let headerViewModel = sectionViewModel.shouldShow ? sectionViewModel.headerViewModel : LabelButtonHeaderViewModel.emptyHeader
             // swiftlint:enable line_length
             headerView.configure(viewModel: headerViewModel,
-                                 theme: themeManager.currentTheme(for: windowUUID))
+                                 theme: themeManager.getcurrentTheme(for: windowUUID))
 
             // Jump back in header specific setup
             if sectionViewModel.sectionType == .jumpBackIn {
@@ -518,7 +518,7 @@ extension HomepageViewController: UICollectionViewDelegate, UICollectionViewData
                 }
                 self.showSiteWithURLHandler(learnMoreURL)
             }
-            footerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            footerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
             return footerView
         }
         return reusableView

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -84,14 +84,14 @@ final class PrivateHomepageViewController:
             body: String(format: .FirefoxHomepage.FeltPrivacyUI.Body, AppName.shortName.rawValue),
             link: .FirefoxHomepage.FeltPrivacyUI.Link
         )
-        messageCard.configure(with: messageCardModel, and: themeManager.currentTheme(for: windowUUID))
+        messageCard.configure(with: messageCardModel, and: themeManager.getcurrentTheme(for: windowUUID))
         messageCard.privateBrowsingLinkTapped = learnMore
         return messageCard
     }()
 
     private lazy var homepageHeaderCell: HomepageHeaderCell = {
         let header = HomepageHeaderCell()
-        header.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        header.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         header.configure(with: headerViewModel)
         return header
     }()
@@ -199,7 +199,7 @@ final class PrivateHomepageViewController:
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         gradient.colors = theme.colors.layerHomepage.cgColors
         homepageHeaderCell.applyTheme(theme: theme)
         privateMessageCardCell.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -84,14 +84,14 @@ final class PrivateHomepageViewController:
             body: String(format: .FirefoxHomepage.FeltPrivacyUI.Body, AppName.shortName.rawValue),
             link: .FirefoxHomepage.FeltPrivacyUI.Link
         )
-        messageCard.configure(with: messageCardModel, and: themeManager.getcurrentTheme(for: windowUUID))
+        messageCard.configure(with: messageCardModel, and: themeManager.getCurrentTheme(for: windowUUID))
         messageCard.privateBrowsingLinkTapped = learnMore
         return messageCard
     }()
 
     private lazy var homepageHeaderCell: HomepageHeaderCell = {
         let header = HomepageHeaderCell()
-        header.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        header.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         header.configure(with: headerViewModel)
         return header
     }()
@@ -199,7 +199,7 @@ final class PrivateHomepageViewController:
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         gradient.colors = theme.colors.layerHomepage.cgColors
         homepageHeaderCell.applyTheme(theme: theme)
         privateMessageCardCell.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -104,7 +104,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         contentView.backgroundColor = theme.colors.layer1
         headerLabel.textColor = theme.colors.textPrimary
         instructionLabel.textColor = theme.colors.textPrimary
@@ -129,7 +129,7 @@ extension WallpaperSelectorViewController: UICollectionViewDelegate, UICollectio
         else { return UICollectionViewCell() }
 
         cell.viewModel = cellViewModel
-        cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         return cell
     }
 

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -104,7 +104,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         contentView.backgroundColor = theme.colors.layer1
         headerLabel.textColor = theme.colors.textPrimary
         instructionLabel.textColor = theme.colors.textPrimary
@@ -129,7 +129,7 @@ extension WallpaperSelectorViewController: UICollectionViewDelegate, UICollectio
         else { return UICollectionViewCell() }
 
         cell.viewModel = cellViewModel
-        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return cell
     }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -222,7 +222,7 @@ class BookmarkDetailPanel: SiteTableViewController {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     override func applyTheme() {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarkDetailPanel.swift
@@ -222,7 +222,7 @@ class BookmarkDetailPanel: SiteTableViewController {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     override func applyTheme() {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -486,7 +486,7 @@ class BookmarksPanel: SiteTableViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -486,7 +486,7 @@ class BookmarksPanel: SiteTableViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -188,7 +188,7 @@ class DownloadsPanel: UIViewController,
     ) -> UIImage? {
         let radius: CGFloat = 5.0
         let strokeWidth: CGFloat = 1.0
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let strokeColor: UIColor = theme.colors.iconSecondary
         let fontSize: CGFloat = 9.0
 
@@ -245,7 +245,7 @@ class DownloadsPanel: UIViewController,
     }
 
     private func createEmptyStateOverlayView() -> UIView {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let overlayView: UIView = .build { view in
             view.backgroundColor = theme.colors.layer1
             view.translatesAutoresizingMaskIntoConstraints = false
@@ -291,7 +291,7 @@ class DownloadsPanel: UIViewController,
 
     func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         if let header = view as? UITableViewHeaderFooterView {
-            let theme = themeManager.currentTheme(for: windowUUID)
+            let theme = themeManager.getcurrentTheme(for: windowUUID)
             header.textLabel?.textColor = theme.colors.textPrimary
             header.contentView.backgroundColor = theme.colors.layer1
         }
@@ -317,7 +317,7 @@ class DownloadsPanel: UIViewController,
                                                        collapsibleState: nil)
         headerView.configure(headerViewModel)
         headerView.showBorder(for: .top, !viewModel.isFirstSection(section))
-        headerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
 
         return headerView
     }
@@ -328,7 +328,7 @@ class DownloadsPanel: UIViewController,
             cell.titleLabel.text = downloadedFile.filename
             cell.descriptionLabel.text = downloadedFile.formattedSize
             cell.leftImageView.manuallySetImage(iconForFileExtension(downloadedFile.fileExtension) ?? UIImage())
-            cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
         return cell
     }
@@ -414,7 +414,7 @@ class DownloadsPanel: UIViewController,
         emptyStateOverlayView = createEmptyStateOverlayView()
         updateEmptyPanelState()
 
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         tableView.backgroundColor = theme.colors.layer1
         tableView.separatorColor = theme.colors.borderPrimary
 

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -188,7 +188,7 @@ class DownloadsPanel: UIViewController,
     ) -> UIImage? {
         let radius: CGFloat = 5.0
         let strokeWidth: CGFloat = 1.0
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let strokeColor: UIColor = theme.colors.iconSecondary
         let fontSize: CGFloat = 9.0
 
@@ -245,7 +245,7 @@ class DownloadsPanel: UIViewController,
     }
 
     private func createEmptyStateOverlayView() -> UIView {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let overlayView: UIView = .build { view in
             view.backgroundColor = theme.colors.layer1
             view.translatesAutoresizingMaskIntoConstraints = false
@@ -291,7 +291,7 @@ class DownloadsPanel: UIViewController,
 
     func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         if let header = view as? UITableViewHeaderFooterView {
-            let theme = themeManager.getcurrentTheme(for: windowUUID)
+            let theme = themeManager.getCurrentTheme(for: windowUUID)
             header.textLabel?.textColor = theme.colors.textPrimary
             header.contentView.backgroundColor = theme.colors.layer1
         }
@@ -317,7 +317,7 @@ class DownloadsPanel: UIViewController,
                                                        collapsibleState: nil)
         headerView.configure(headerViewModel)
         headerView.showBorder(for: .top, !viewModel.isFirstSection(section))
-        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
 
         return headerView
     }
@@ -328,7 +328,7 @@ class DownloadsPanel: UIViewController,
             cell.titleLabel.text = downloadedFile.filename
             cell.descriptionLabel.text = downloadedFile.formattedSize
             cell.leftImageView.manuallySetImage(iconForFileExtension(downloadedFile.fileExtension) ?? UIImage())
-            cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         return cell
     }
@@ -414,7 +414,7 @@ class DownloadsPanel: UIViewController,
         emptyStateOverlayView = createEmptyStateOverlayView()
         updateEmptyPanelState()
 
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         tableView.backgroundColor = theme.colors.layer1
         tableView.separatorColor = theme.colors.borderPrimary
 

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
@@ -150,7 +150,7 @@ class SearchGroupedItemsViewController: UIViewController, UITableViewDelegate, T
                 cell.descriptionLabel.isHidden = false
                 cell.leftImageView.layer.borderWidth = 0.5
                 cell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: site.url))
-                cell.applyTheme(theme: self.themeManager.currentTheme(for: windowUUID))
+                cell.applyTheme(theme: self.themeManager.getcurrentTheme(for: windowUUID))
 
                 return cell
             }
@@ -210,7 +210,7 @@ class SearchGroupedItemsViewController: UIViewController, UITableViewDelegate, T
     // MARK: - Themeable
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         tableView.backgroundColor = theme.colors.layer1
         view.backgroundColor = theme.colors.layer1
         tableView.separatorColor = theme.colors.borderPrimary

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/GeneralizedTableView/SearchGroupedItemsViewController.swift
@@ -150,7 +150,7 @@ class SearchGroupedItemsViewController: UIViewController, UITableViewDelegate, T
                 cell.descriptionLabel.isHidden = false
                 cell.leftImageView.layer.borderWidth = 0.5
                 cell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: site.url))
-                cell.applyTheme(theme: self.themeManager.getcurrentTheme(for: windowUUID))
+                cell.applyTheme(theme: self.themeManager.getCurrentTheme(for: windowUUID))
 
                 return cell
             }
@@ -210,7 +210,7 @@ class SearchGroupedItemsViewController: UIViewController, UITableViewDelegate, T
     // MARK: - Themeable
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         tableView.backgroundColor = theme.colors.layer1
         view.backgroundColor = theme.colors.layer1
         tableView.separatorColor = theme.colors.borderPrimary

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryActionables.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryActionables.swift
@@ -38,7 +38,7 @@ struct HistoryActionablesModel: Hashable {
         if let imageName = imageName {
             let themeManager: ThemeManager = AppContainer.shared.resolve()
             self.itemImage = UIImage(named: imageName)?
-                .withTintColor(themeManager.currentTheme(for: window).colors.iconSecondary)
+                .withTintColor(themeManager.getcurrentTheme(for: window).colors.iconSecondary)
         } else {
             self.itemImage = nil
         }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryActionables.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryActionables.swift
@@ -38,7 +38,7 @@ struct HistoryActionablesModel: Hashable {
         if let imageName = imageName {
             let themeManager: ThemeManager = AppContainer.shared.resolve()
             self.itemImage = UIImage(named: imageName)?
-                .withTintColor(themeManager.getcurrentTheme(for: window).colors.iconSecondary)
+                .withTintColor(themeManager.getCurrentTheme(for: window).colors.iconSecondary)
         } else {
             self.itemImage = nil
         }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -210,7 +210,7 @@ class HistoryPanel: UIViewController,
     // MARK: - Private helpers
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     private func setupLayout() {

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -210,7 +210,7 @@ class HistoryPanel: UIViewController,
     // MARK: - Private helpers
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     private func setupLayout() {

--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -314,7 +314,7 @@ class LibraryViewController: UIViewController, Themeable {
     }
 
     private func setupToolBarAppearance() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let standardAppearance = UIToolbarAppearance()
         standardAppearance.configureWithDefaultBackground()
         standardAppearance.backgroundColor = theme.colors.layer1
@@ -332,7 +332,7 @@ class LibraryViewController: UIViewController, Themeable {
         navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
         navigationController?.navigationBar.shadowImage = UIImage()
 
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer3
         navigationController?.navigationBar.barTintColor = theme.colors.layer1
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary

--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -314,7 +314,7 @@ class LibraryViewController: UIViewController, Themeable {
     }
 
     private func setupToolBarAppearance() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let standardAppearance = UIToolbarAppearance()
         standardAppearance.configureWithDefaultBackground()
         standardAppearance.backgroundColor = theme.colors.layer1
@@ -332,7 +332,7 @@ class LibraryViewController: UIViewController, Themeable {
         navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
         navigationController?.navigationBar.shadowImage = UIImage()
 
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer3
         navigationController?.navigationBar.barTintColor = theme.colors.layer1
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary

--- a/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
@@ -261,7 +261,7 @@ class ReadingListPanel: UITableViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/ReaderPanel.swift
@@ -261,7 +261,7 @@ class ReadingListPanel: UITableViewController,
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -77,7 +77,7 @@ class RecentlyClosedTabsPanel: UIViewController, LibraryPanel, Themeable {
     }
 
     func applyTheme() {
-        view.backgroundColor = themeManager.currentTheme(for: windowUUID).colors.layer1
+        view.backgroundColor = themeManager.getcurrentTheme(for: windowUUID).colors.layer1
     }
 }
 
@@ -122,7 +122,7 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         twoLineCell.descriptionLabel.text = displayURL.absoluteDisplayString
         twoLineCell.leftImageView.layer.borderWidth = RecentlyClosedPanelUX.IconBorderWidth
         twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: displayURL.absoluteString))
-        twoLineCell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        twoLineCell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         return twoLineCell
     }
 

--- a/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -77,7 +77,7 @@ class RecentlyClosedTabsPanel: UIViewController, LibraryPanel, Themeable {
     }
 
     func applyTheme() {
-        view.backgroundColor = themeManager.getcurrentTheme(for: windowUUID).colors.layer1
+        view.backgroundColor = themeManager.getCurrentTheme(for: windowUUID).colors.layer1
     }
 }
 
@@ -122,7 +122,7 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         twoLineCell.descriptionLabel.text = displayURL.absoluteDisplayString
         twoLineCell.leftImageView.layer.borderWidth = RecentlyClosedPanelUX.IconBorderWidth
         twoLineCell.leftImageView.setFavicon(FaviconImageViewModel(siteURLString: displayURL.absoluteString))
-        twoLineCell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        twoLineCell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return twoLineCell
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -275,7 +275,7 @@ final class MicrosurveyViewController: UIViewController,
 
     // MARK: ThemeApplicable
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
 
         headerLabel.textColor = theme.colors.textPrimary
@@ -326,7 +326,7 @@ final class MicrosurveyViewController: UIViewController,
                 confirmationView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
             ]
         )
-        confirmationView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        confirmationView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
     }
 
     @objc
@@ -357,7 +357,7 @@ final class MicrosurveyViewController: UIViewController,
         }
         cell.configure(model.surveyOptions[indexPath.row])
         cell.setA11yValue(for: indexPath.row, outOf: tableView.numberOfRows(inSection: .zero))
-        cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         return cell
     }
 
@@ -369,7 +369,7 @@ final class MicrosurveyViewController: UIViewController,
             return nil
         }
         headerView.configure(model.surveyQuestion, icon: model.icon)
-        headerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         return headerView
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -275,7 +275,7 @@ final class MicrosurveyViewController: UIViewController,
 
     // MARK: ThemeApplicable
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
 
         headerLabel.textColor = theme.colors.textPrimary
@@ -326,7 +326,7 @@ final class MicrosurveyViewController: UIViewController,
                 confirmationView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
             ]
         )
-        confirmationView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        confirmationView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
     }
 
     @objc
@@ -357,7 +357,7 @@ final class MicrosurveyViewController: UIViewController,
         }
         cell.configure(model.surveyOptions[indexPath.row])
         cell.setA11yValue(for: indexPath.row, outOf: tableView.numberOfRows(inSection: .zero))
-        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return cell
     }
 
@@ -369,7 +369,7 @@ final class MicrosurveyViewController: UIViewController,
             return nil
         }
         headerView.configure(model.surveyQuestion, icon: model.icon)
-        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return headerView
     }
 

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
@@ -143,7 +143,7 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
             style: .plain,
             target: self,
             action: selector)
-        buttonItem.tintColor = themeManager.currentTheme(for: windowUUID).colors.actionPrimary
+        buttonItem.tintColor = themeManager.getcurrentTheme(for: windowUUID).colors.actionPrimary
         singInSyncVC.navigationItem.rightBarButtonItem = buttonItem
         (singInSyncVC as? FirefoxAccountSignInViewController)?.qrCodeNavigationHandler = qrCodeNavigationHandler
 

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardDelegate.swift
@@ -143,7 +143,7 @@ extension OnboardingCardDelegate where Self: OnboardingViewControllerProtocol,
             style: .plain,
             target: self,
             action: selector)
-        buttonItem.tintColor = themeManager.getcurrentTheme(for: windowUUID).colors.actionPrimary
+        buttonItem.tintColor = themeManager.getCurrentTheme(for: windowUUID).colors.actionPrimary
         singInSyncVC.navigationItem.rightBarButtonItem = buttonItem
         (singInSyncVC as? FirefoxAccountSignInViewController)?.qrCodeNavigationHandler = qrCodeNavigationHandler
 

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardViewController.swift
@@ -122,7 +122,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     }
 
     func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func updateLayout() {
@@ -147,7 +147,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
         )
 
         primaryButton.configure(viewModel: buttonViewModel)
-        primaryButton.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        primaryButton.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
     }
 
     func setupSecondaryButton() {

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardViewController.swift
@@ -122,7 +122,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     }
 
     func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func updateLayout() {
@@ -147,7 +147,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
         )
 
         primaryButton.configure(viewModel: buttonViewModel)
-        primaryButton.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        primaryButton.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
     }
 
     func setupSecondaryButton() {

--- a/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
@@ -229,7 +229,7 @@ class IntroViewController: UIViewController,
 
     // MARK: - Themable
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer2
 
         pageControl.currentPageIndicatorTintColor = theme.colors.actionPrimary

--- a/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
@@ -229,7 +229,7 @@ class IntroViewController: UIViewController,
 
     // MARK: - Themable
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer2
 
         pageControl.currentPageIndicatorTintColor = theme.colors.actionPrimary

--- a/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingInstructionPopupViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingInstructionPopupViewController.swift
@@ -251,7 +251,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
 
     // MARK: - Themeable
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         titleLabel.textColor = theme.colors.textPrimary
         numeratedLabels.forEach { $0.textColor = theme.colors.textPrimary }
 

--- a/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingInstructionPopupViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingInstructionPopupViewController.swift
@@ -251,7 +251,7 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
 
     // MARK: - Themeable
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         titleLabel.textColor = theme.colors.textPrimary
         numeratedLabels.forEach { $0.textColor = theme.colors.textPrimary }
 

--- a/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceButtonView.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceButtonView.swift
@@ -174,9 +174,9 @@ class OnboardingMultipleChoiceButtonView: UIView, Themeable {
     // MARK: - Theme
     func applyTheme() {
         backgroundColor = .clear
-        titleLabel.textColor = themeManager.getcurrentTheme(for: windowUUID).colors.textPrimary
+        titleLabel.textColor = themeManager.getCurrentTheme(for: windowUUID).colors.textPrimary
         imageView.layer.borderColor = if viewModel.isSelected {
-            themeManager.getcurrentTheme(for: windowUUID).colors.actionPrimary.cgColor
+            themeManager.getCurrentTheme(for: windowUUID).colors.actionPrimary.cgColor
         } else {
             UIColor.clear.cgColor
         }

--- a/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceButtonView.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingMultipleChoiceButtonView.swift
@@ -174,9 +174,9 @@ class OnboardingMultipleChoiceButtonView: UIView, Themeable {
     // MARK: - Theme
     func applyTheme() {
         backgroundColor = .clear
-        titleLabel.textColor = themeManager.currentTheme(for: windowUUID).colors.textPrimary
+        titleLabel.textColor = themeManager.getcurrentTheme(for: windowUUID).colors.textPrimary
         imageView.layer.borderColor = if viewModel.isSelected {
-            themeManager.currentTheme(for: windowUUID).colors.actionPrimary.cgColor
+            themeManager.getcurrentTheme(for: windowUUID).colors.actionPrimary.cgColor
         } else {
             UIColor.clear.cgColor
         }

--- a/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPolicyViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPolicyViewController.swift
@@ -89,7 +89,7 @@ class PrivacyPolicyViewController: UIViewController, Themeable {
 
     // MARK: - Theming
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         navigationItem.rightBarButtonItem?.tintColor = theme.colors.actionPrimary
     }
 }

--- a/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPolicyViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPolicyViewController.swift
@@ -89,7 +89,7 @@ class PrivacyPolicyViewController: UIViewController, Themeable {
 
     // MARK: - Theming
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         navigationItem.rightBarButtonItem?.tintColor = theme.colors.actionPrimary
     }
 }

--- a/firefox-ios/Client/Frontend/Onboarding/Views/UpdateViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/UpdateViewController.swift
@@ -159,7 +159,7 @@ class UpdateViewController: UIViewController,
     // MARK: - Theme
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Onboarding/Views/UpdateViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/UpdateViewController.swift
@@ -159,7 +159,7 @@ class UpdateViewController: UIViewController,
     // MARK: - Theme
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
@@ -59,7 +59,7 @@ class AddCredentialViewController: UIViewController, Themeable {
             action: #selector(addCredential)
         )
         button.isEnabled = false
-        button.tintColor = themeManager.getcurrentTheme(for: windowUUID).colors.actionPrimary
+        button.tintColor = themeManager.getCurrentTheme(for: windowUUID).colors.actionPrimary
         return button
     }()
 
@@ -162,7 +162,7 @@ extension AddCredentialViewController: UITableViewDataSource {
                 a11yId: AccessibilityIdentifiers.Settings.Passwords.usernameField,
                 isEditingFieldData: true)
             loginCell.configure(viewModel: cellModel)
-            loginCell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            loginCell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             usernameField = loginCell.descriptionLabel
             if isRTLLanguage {
                 usernameField.textAlignment = .right
@@ -176,7 +176,7 @@ extension AddCredentialViewController: UITableViewDataSource {
                 a11yId: AccessibilityIdentifiers.Settings.Passwords.passwordField,
                 isEditingFieldData: true)
             loginCell.configure(viewModel: cellModel)
-            loginCell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            loginCell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             passwordField = loginCell.descriptionLabel
             return loginCell
 
@@ -188,7 +188,7 @@ extension AddCredentialViewController: UITableViewDataSource {
                 a11yId: AccessibilityIdentifiers.Settings.Passwords.websiteField,
                 isEditingFieldData: true)
             loginCell.configure(viewModel: cellModel)
-            loginCell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            loginCell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             websiteField = loginCell.descriptionLabel
             if isRTLLanguage {
                 websiteField.textAlignment = .right
@@ -213,7 +213,7 @@ extension AddCredentialViewController: UITableViewDataSource {
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         tableView.separatorColor = theme.colors.borderPrimary
         tableView.backgroundColor = theme.colors.layer1
 

--- a/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
@@ -59,7 +59,7 @@ class AddCredentialViewController: UIViewController, Themeable {
             action: #selector(addCredential)
         )
         button.isEnabled = false
-        button.tintColor = themeManager.currentTheme(for: windowUUID).colors.actionPrimary
+        button.tintColor = themeManager.getcurrentTheme(for: windowUUID).colors.actionPrimary
         return button
     }()
 
@@ -162,7 +162,7 @@ extension AddCredentialViewController: UITableViewDataSource {
                 a11yId: AccessibilityIdentifiers.Settings.Passwords.usernameField,
                 isEditingFieldData: true)
             loginCell.configure(viewModel: cellModel)
-            loginCell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            loginCell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
             usernameField = loginCell.descriptionLabel
             if isRTLLanguage {
                 usernameField.textAlignment = .right
@@ -176,7 +176,7 @@ extension AddCredentialViewController: UITableViewDataSource {
                 a11yId: AccessibilityIdentifiers.Settings.Passwords.passwordField,
                 isEditingFieldData: true)
             loginCell.configure(viewModel: cellModel)
-            loginCell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            loginCell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
             passwordField = loginCell.descriptionLabel
             return loginCell
 
@@ -188,7 +188,7 @@ extension AddCredentialViewController: UITableViewDataSource {
                 a11yId: AccessibilityIdentifiers.Settings.Passwords.websiteField,
                 isEditingFieldData: true)
             loginCell.configure(viewModel: cellModel)
-            loginCell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            loginCell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
             websiteField = loginCell.descriptionLabel
             if isRTLLanguage {
                 websiteField.textAlignment = .right
@@ -213,7 +213,7 @@ extension AddCredentialViewController: UITableViewDataSource {
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         tableView.separatorColor = theme.colors.borderPrimary
         tableView.backgroundColor = theme.colors.layer1
 

--- a/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
@@ -81,7 +81,7 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
     override func applyTheme() {
         super.applyTheme()
 
-        let currentTheme = themeManager.currentTheme(for: windowUUID)
+        let currentTheme = themeManager.getcurrentTheme(for: windowUUID)
         learnMoreButton.applyTheme(theme: currentTheme)
     }
 }

--- a/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/DevicePasscodeRequiredViewController.swift
@@ -81,7 +81,7 @@ class DevicePasscodeRequiredViewController: SettingsViewController {
     override func applyTheme() {
         super.applyTheme()
 
-        let currentTheme = themeManager.getcurrentTheme(for: windowUUID)
+        let currentTheme = themeManager.getCurrentTheme(for: windowUUID)
         learnMoreButton.applyTheme(theme: currentTheme)
     }
 }

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -47,7 +47,7 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         self.viewModel = PasswordManagerViewModel(
             profile: profile,
             searchController: searchController,
-            theme: themeManager.getcurrentTheme(for: windowUUID)
+            theme: themeManager.getCurrentTheme(for: windowUUID)
         )
         self.loginDataSource = LoginDataSource(viewModel: viewModel)
         self.themeManager = themeManager
@@ -135,7 +135,7 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         viewModel.theme = theme
         loginDataSource.viewModel = viewModel
         tableView.reloadSections(IndexSet(integer: PasswordManagerListViewController.loginsSettingsSection),
@@ -269,7 +269,7 @@ private extension PasswordManagerListViewController {
 
     func loadLogins(_ query: String? = nil) {
         loadingView.isHidden = false
-        loadingView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        loadingView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         viewModel.loadLogins(query, loginDataSource: self.loginDataSource)
     }
 
@@ -377,7 +377,7 @@ extension PasswordManagerListViewController: UITableViewDelegate {
         // not using a grouped table: show header borders
         headerView.showBorder(for: .top, true)
         headerView.showBorder(for: .bottom, true)
-        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return headerView
     }
 

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -47,7 +47,7 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         self.viewModel = PasswordManagerViewModel(
             profile: profile,
             searchController: searchController,
-            theme: themeManager.currentTheme(for: windowUUID)
+            theme: themeManager.getcurrentTheme(for: windowUUID)
         )
         self.loginDataSource = LoginDataSource(viewModel: viewModel)
         self.themeManager = themeManager
@@ -135,7 +135,7 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         viewModel.theme = theme
         loginDataSource.viewModel = viewModel
         tableView.reloadSections(IndexSet(integer: PasswordManagerListViewController.loginsSettingsSection),
@@ -269,7 +269,7 @@ private extension PasswordManagerListViewController {
 
     func loadLogins(_ query: String? = nil) {
         loadingView.isHidden = false
-        loadingView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        loadingView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         viewModel.loadLogins(query, loginDataSource: self.loginDataSource)
     }
 
@@ -377,7 +377,7 @@ extension PasswordManagerListViewController: UITableViewDelegate {
         // not using a grouped table: show header borders
         headerView.showBorder(for: .top, true)
         headerView.showBorder(for: .bottom, true)
-        headerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         return headerView
     }
 

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -130,7 +130,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     override func applyTheme() {
         super.applyTheme()
 
-        let currentTheme = themeManager.getcurrentTheme(for: windowUUID)
+        let currentTheme = themeManager.getCurrentTheme(for: windowUUID)
         learnMoreButton.applyTheme(theme: currentTheme)
         continueButton.applyTheme(theme: currentTheme)
     }

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -130,7 +130,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     override func applyTheme() {
         super.applyTheme()
 
-        let currentTheme = themeManager.currentTheme(for: windowUUID)
+        let currentTheme = themeManager.getcurrentTheme(for: windowUUID)
         learnMoreButton.applyTheme(theme: currentTheme)
         continueButton.applyTheme(theme: currentTheme)
     }

--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -35,7 +35,7 @@ enum ReaderModeTheme: String {
 
         let appTheme: Theme = {
             guard let uuid = window else { return themeManager.windowNonspecificTheme() }
-            return themeManager.currentTheme(for: uuid)
+            return themeManager.getcurrentTheme(for: uuid)
         }()
 
         guard appTheme.type != .dark else { return .dark }

--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -35,7 +35,7 @@ enum ReaderModeTheme: String {
 
         let appTheme: Theme = {
             guard let uuid = window else { return themeManager.windowNonspecificTheme() }
-            return themeManager.getcurrentTheme(for: uuid)
+            return themeManager.getCurrentTheme(for: uuid)
         }()
 
         guard appTheme.type != .dark else { return .dark }

--- a/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewController.swift
+++ b/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewController.swift
@@ -206,7 +206,7 @@ class ReaderModeStyleViewController: UIViewController, Themeable {
 
     // MARK: - Applying Theme
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         popoverPresentationController?.backgroundColor = theme.colors.layer1
 
         slider.tintColor = theme.colors.actionPrimary

--- a/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewController.swift
+++ b/firefox-ios/Client/Frontend/Reader/View/ReaderModeStyleViewController.swift
@@ -206,7 +206,7 @@ class ReaderModeStyleViewController: UIViewController, Themeable {
 
     // MARK: - Applying Theme
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         popoverPresentationController?.backgroundColor = theme.colors.layer1
 
         slider.tintColor = theme.colors.actionPrimary

--- a/firefox-ios/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -72,7 +72,7 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
     override func generateSettings() -> [SettingSection] {
         let prefs = profile.prefs
 
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let attributes = [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]
         let useStage = BoolSetting(
             prefs: prefs,

--- a/firefox-ios/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -72,7 +72,7 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
     override func generateSettings() -> [SettingSection] {
         let prefs = profile.prefs
 
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let attributes = [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]
         let useStage = BoolSetting(
             prefs: prefs,

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -75,7 +75,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -75,7 +75,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -31,7 +31,7 @@ class CustomSearchViewController: SettingsTableViewController {
     var successCallback: (() -> Void)?
     private lazy var spinnerView: UIActivityIndicatorView = .build { [self] spinner in
         spinner.style = .medium
-        spinner.color = themeManager.currentTheme(for: windowUUID).colors.iconSpinner
+        spinner.color = themeManager.getcurrentTheme(for: windowUUID).colors.iconSpinner
         spinner.hidesWhenStopped = true
     }
 

--- a/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -31,7 +31,7 @@ class CustomSearchViewController: SettingsTableViewController {
     var successCallback: (() -> Void)?
     private lazy var spinnerView: UIActivityIndicatorView = .build { [self] spinner in
         spinner.style = .medium
-        spinner.color = themeManager.getcurrentTheme(for: windowUUID).colors.iconSpinner
+        spinner.color = themeManager.getCurrentTheme(for: windowUUID).colors.iconSpinner
         spinner.hidesWhenStopped = true
     }
 

--- a/firefox-ios/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
@@ -20,7 +20,7 @@ class FirefoxSuggestSettingsViewController: SettingsTableViewController, Feature
     }
 
     override func generateSettings() -> [SettingSection] {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let enabled = BoolSetting(
             with: .firefoxSuggestFeature,
             titleText: NSAttributedString(

--- a/firefox-ios/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
@@ -20,7 +20,7 @@ class FirefoxSuggestSettingsViewController: SettingsTableViewController, Feature
     }
 
     override func generateSettings() -> [SettingSection] {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let enabled = BoolSetting(
             with: .firefoxSuggestFeature,
             titleText: NSAttributedString(

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -134,7 +134,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
 
         let pocketSetting = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.getcurrentTheme(for: windowUUID),
+            theme: themeManager.getCurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.UserFeatureFlagPrefs.ASPocketStories,
             defaultValue: true,
             titleText: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStories,
@@ -148,7 +148,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
 
         let bookmarksSetting = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.getcurrentTheme(for: windowUUID),
+            theme: themeManager.getCurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.UserFeatureFlagPrefs.BookmarksSection,
             defaultValue: true,
             titleText: .Settings.Homepage.CustomizeFirefoxHome.Bookmarks
@@ -315,7 +315,7 @@ extension HomePageSettingViewController {
         override func onClick(_ navigationController: UINavigationController?) {
             guard wallpaperManager.canSettingsBeShown else { return }
 
-            let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+            let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
             let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
                                                        tabManager: tabManager,
                                                        theme: theme)

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -134,7 +134,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
 
         let pocketSetting = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.currentTheme(for: windowUUID),
+            theme: themeManager.getcurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.UserFeatureFlagPrefs.ASPocketStories,
             defaultValue: true,
             titleText: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStories,
@@ -148,7 +148,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
 
         let bookmarksSetting = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.currentTheme(for: windowUUID),
+            theme: themeManager.getcurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.UserFeatureFlagPrefs.BookmarksSection,
             defaultValue: true,
             titleText: .Settings.Homepage.CustomizeFirefoxHome.Bookmarks
@@ -315,7 +315,7 @@ extension HomePageSettingViewController {
         override func onClick(_ navigationController: UINavigationController?) {
             guard wallpaperManager.canSettingsBeShown else { return }
 
-            let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+            let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
             let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
                                                        tabManager: tabManager,
                                                        theme: theme)

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -31,7 +31,7 @@ class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlagga
         var sections = [Setting]()
         let topSitesSetting = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.getcurrentTheme(for: windowUUID),
+            theme: themeManager.getCurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.UserFeatureFlagPrefs.TopSiteSection,
             defaultValue: true,
             titleText: .Settings.Homepage.Shortcuts.ShortcutsToggle
@@ -40,7 +40,7 @@ class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlagga
 
         let sponsoredShortcutSetting = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.getcurrentTheme(for: windowUUID),
+            theme: themeManager.getCurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.UserFeatureFlagPrefs.SponsoredShortcuts,
             defaultValue: true,
             titleText: .Settings.Homepage.Shortcuts.SponsoredShortcutsToggle
@@ -79,7 +79,7 @@ extension TopSitesSettingsViewController {
         init(settings: SettingsTableViewController) {
             self.profile = settings.profile
             self.windowUUID = settings.windowUUID
-            let theme = settings.themeManager.getcurrentTheme(for: windowUUID)
+            let theme = settings.themeManager.getCurrentTheme(for: windowUUID)
             super.init(
                 title: NSAttributedString(
                     string: .Settings.Homepage.Shortcuts.Rows,

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -31,7 +31,7 @@ class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlagga
         var sections = [Setting]()
         let topSitesSetting = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.currentTheme(for: windowUUID),
+            theme: themeManager.getcurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.UserFeatureFlagPrefs.TopSiteSection,
             defaultValue: true,
             titleText: .Settings.Homepage.Shortcuts.ShortcutsToggle
@@ -40,7 +40,7 @@ class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlagga
 
         let sponsoredShortcutSetting = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.currentTheme(for: windowUUID),
+            theme: themeManager.getcurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.UserFeatureFlagPrefs.SponsoredShortcuts,
             defaultValue: true,
             titleText: .Settings.Homepage.Shortcuts.SponsoredShortcutsToggle
@@ -79,7 +79,7 @@ extension TopSitesSettingsViewController {
         init(settings: SettingsTableViewController) {
             self.profile = settings.profile
             self.windowUUID = settings.windowUUID
-            let theme = settings.themeManager.currentTheme(for: windowUUID)
+            let theme = settings.themeManager.getcurrentTheme(for: windowUUID)
             super.init(
                 title: NSAttributedString(
                     string: .Settings.Homepage.Shortcuts.Rows,

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
@@ -97,7 +97,7 @@ class WallpaperSettingsViewController: WallpaperBaseViewController, Themeable {
     }
 
     func applyTheme() {
-        contentView.backgroundColor = themeManager.currentTheme(for: windowUUID).colors.layer5
+        contentView.backgroundColor = themeManager.getcurrentTheme(for: windowUUID).colors.layer5
     }
 }
 
@@ -139,7 +139,7 @@ extension WallpaperSettingsViewController: UICollectionViewDelegate, UICollectio
         else { return UICollectionViewCell() }
 
         cell.viewModel = cellViewModel
-        cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         return cell
     }
 
@@ -225,7 +225,7 @@ private extension WallpaperSettingsViewController {
                                              buttonText: WallpaperSettingsViewModel.Constants.Strings.Toast.button)
         let toast = ButtonToast(
             viewModel: viewModel,
-            theme: themeManager.currentTheme(for: windowUUID),
+            theme: themeManager.getcurrentTheme(for: windowUUID),
             completion: { buttonPressed in
                 if buttonPressed { self.dismissView() }
             })

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewController.swift
@@ -97,7 +97,7 @@ class WallpaperSettingsViewController: WallpaperBaseViewController, Themeable {
     }
 
     func applyTheme() {
-        contentView.backgroundColor = themeManager.getcurrentTheme(for: windowUUID).colors.layer5
+        contentView.backgroundColor = themeManager.getCurrentTheme(for: windowUUID).colors.layer5
     }
 }
 
@@ -139,7 +139,7 @@ extension WallpaperSettingsViewController: UICollectionViewDelegate, UICollectio
         else { return UICollectionViewCell() }
 
         cell.viewModel = cellViewModel
-        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return cell
     }
 
@@ -225,7 +225,7 @@ private extension WallpaperSettingsViewController {
                                              buttonText: WallpaperSettingsViewModel.Constants.Strings.Toast.button)
         let toast = ButtonToast(
             viewModel: viewModel,
-            theme: themeManager.getcurrentTheme(for: windowUUID),
+            theme: themeManager.getCurrentTheme(for: windowUUID),
             completion: { buttonPressed in
                 if buttonPressed { self.dismissView() }
             })

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -182,7 +182,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
             string: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerDescription)
 
         return [SettingSection(footerTitle: footerTitle,
-                               children: [DefaultBrowserSetting(theme: themeManager.currentTheme(for: windowUUID))])]
+                               children: [DefaultBrowserSetting(theme: themeManager.getcurrentTheme(for: windowUUID))])]
     }
 
     private func getAccountSetting() -> [SettingSection] {
@@ -231,7 +231,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         if inactiveTabsAreBuildActive {
             generalSettings.insert(
                 TabsSetting(
-                    theme: themeManager.currentTheme(for: windowUUID),
+                    theme: themeManager.getcurrentTheme(for: windowUUID),
                     settingsDelegate: parentCoordinator
                 ),
                 at: 3
@@ -240,7 +240,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         let offerToOpenCopiedLinksSettings = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.currentTheme(for: windowUUID),
+            theme: themeManager.getcurrentTheme(for: windowUUID),
             prefKey: "showClipboardBar",
             defaultValue: false,
             titleText: .SettingsOfferClipboardBarTitle,
@@ -249,7 +249,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         let showLinksPreviewSettings = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.currentTheme(for: windowUUID),
+            theme: themeManager.getcurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.ContextMenuShowLinkPreviews,
             defaultValue: true,
             titleText: .SettingsShowLinkPreviewsTitle,
@@ -258,7 +258,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         let blockOpeningExternalAppsSettings = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.currentTheme(for: windowUUID),
+            theme: themeManager.getcurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.BlockOpeningExternalApps,
             defaultValue: false,
             titleText: .SettingsBlockOpeningExternalAppsTitle
@@ -285,7 +285,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         let autofillAddressStatus = featureFlags.isFeatureEnabled(.addressAutofill, checking: .buildOnly)
         if autofillAddressStatus {
-            privacySettings.append(AddressAutofillSetting(theme: themeManager.currentTheme(for: windowUUID),
+            privacySettings.append(AddressAutofillSetting(theme: themeManager.getcurrentTheme(for: windowUUID),
                                                           profile: profile,
                                                           settingsDelegate: parentCoordinator))
         }
@@ -294,12 +294,12 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         privacySettings.append(ContentBlockerSetting(settings: self, settingsDelegate: parentCoordinator))
 
-        privacySettings.append(NotificationsSetting(theme: themeManager.currentTheme(for: windowUUID),
+        privacySettings.append(NotificationsSetting(theme: themeManager.getcurrentTheme(for: windowUUID),
                                                     profile: profile,
                                                     settingsDelegate: parentCoordinator))
 
         privacySettings += [
-            PrivacyPolicySetting(theme: themeManager.currentTheme(for: windowUUID),
+            PrivacyPolicySetting(theme: themeManager.getcurrentTheme(for: windowUUID),
                                  settingsDelegate: parentCoordinator)
         ]
 
@@ -313,14 +313,14 @@ class AppSettingsTableViewController: SettingsTableViewController,
             SendFeedbackSetting(settingsDelegate: parentCoordinator),
             SendAnonymousUsageDataSetting(prefs: profile.prefs,
                                           delegate: settingsDelegate,
-                                          theme: themeManager.currentTheme(for: windowUUID),
+                                          theme: themeManager.getcurrentTheme(for: windowUUID),
                                           settingsDelegate: parentCoordinator),
             StudiesToggleSetting(prefs: profile.prefs,
                                  delegate: settingsDelegate,
-                                 theme: themeManager.currentTheme(for: windowUUID),
+                                 theme: themeManager.getcurrentTheme(for: windowUUID),
                                  settingsDelegate: parentCoordinator),
             OpenSupportPageSetting(delegate: settingsDelegate,
-                                   theme: themeManager.currentTheme(for: windowUUID),
+                                   theme: themeManager.getcurrentTheme(for: windowUUID),
                                    settingsDelegate: parentCoordinator),
         ]
 

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -182,7 +182,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
             string: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerDescription)
 
         return [SettingSection(footerTitle: footerTitle,
-                               children: [DefaultBrowserSetting(theme: themeManager.getcurrentTheme(for: windowUUID))])]
+                               children: [DefaultBrowserSetting(theme: themeManager.getCurrentTheme(for: windowUUID))])]
     }
 
     private func getAccountSetting() -> [SettingSection] {
@@ -231,7 +231,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         if inactiveTabsAreBuildActive {
             generalSettings.insert(
                 TabsSetting(
-                    theme: themeManager.getcurrentTheme(for: windowUUID),
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
                     settingsDelegate: parentCoordinator
                 ),
                 at: 3
@@ -240,7 +240,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         let offerToOpenCopiedLinksSettings = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.getcurrentTheme(for: windowUUID),
+            theme: themeManager.getCurrentTheme(for: windowUUID),
             prefKey: "showClipboardBar",
             defaultValue: false,
             titleText: .SettingsOfferClipboardBarTitle,
@@ -249,7 +249,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         let showLinksPreviewSettings = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.getcurrentTheme(for: windowUUID),
+            theme: themeManager.getCurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.ContextMenuShowLinkPreviews,
             defaultValue: true,
             titleText: .SettingsShowLinkPreviewsTitle,
@@ -258,7 +258,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         let blockOpeningExternalAppsSettings = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.getcurrentTheme(for: windowUUID),
+            theme: themeManager.getCurrentTheme(for: windowUUID),
             prefKey: PrefsKeys.BlockOpeningExternalApps,
             defaultValue: false,
             titleText: .SettingsBlockOpeningExternalAppsTitle
@@ -285,7 +285,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         let autofillAddressStatus = featureFlags.isFeatureEnabled(.addressAutofill, checking: .buildOnly)
         if autofillAddressStatus {
-            privacySettings.append(AddressAutofillSetting(theme: themeManager.getcurrentTheme(for: windowUUID),
+            privacySettings.append(AddressAutofillSetting(theme: themeManager.getCurrentTheme(for: windowUUID),
                                                           profile: profile,
                                                           settingsDelegate: parentCoordinator))
         }
@@ -294,12 +294,12 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
         privacySettings.append(ContentBlockerSetting(settings: self, settingsDelegate: parentCoordinator))
 
-        privacySettings.append(NotificationsSetting(theme: themeManager.getcurrentTheme(for: windowUUID),
+        privacySettings.append(NotificationsSetting(theme: themeManager.getCurrentTheme(for: windowUUID),
                                                     profile: profile,
                                                     settingsDelegate: parentCoordinator))
 
         privacySettings += [
-            PrivacyPolicySetting(theme: themeManager.getcurrentTheme(for: windowUUID),
+            PrivacyPolicySetting(theme: themeManager.getCurrentTheme(for: windowUUID),
                                  settingsDelegate: parentCoordinator)
         ]
 
@@ -313,14 +313,14 @@ class AppSettingsTableViewController: SettingsTableViewController,
             SendFeedbackSetting(settingsDelegate: parentCoordinator),
             SendAnonymousUsageDataSetting(prefs: profile.prefs,
                                           delegate: settingsDelegate,
-                                          theme: themeManager.getcurrentTheme(for: windowUUID),
+                                          theme: themeManager.getCurrentTheme(for: windowUUID),
                                           settingsDelegate: parentCoordinator),
             StudiesToggleSetting(prefs: profile.prefs,
                                  delegate: settingsDelegate,
-                                 theme: themeManager.getcurrentTheme(for: windowUUID),
+                                 theme: themeManager.getCurrentTheme(for: windowUUID),
                                  settingsDelegate: parentCoordinator),
             OpenSupportPageSetting(delegate: settingsDelegate,
-                                   theme: themeManager.getcurrentTheme(for: windowUUID),
+                                   theme: themeManager.getCurrentTheme(for: windowUUID),
                                    settingsDelegate: parentCoordinator),
         ]
 

--- a/firefox-ios/Client/Frontend/Settings/Main/General/HomeSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/HomeSetting.swift
@@ -26,7 +26,7 @@ class HomeSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsHomePageSectionName,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/HomeSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/HomeSetting.swift
@@ -26,7 +26,7 @@ class HomeSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsHomePageSectionName,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/NewTabPageSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/NewTabPageSetting.swift
@@ -26,7 +26,7 @@ class NewTabPageSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsNewTabSectionName,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/NewTabPageSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/NewTabPageSetting.swift
@@ -26,7 +26,7 @@ class NewTabPageSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsNewTabSectionName,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/OpenWithSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/OpenWithSetting.swift
@@ -41,7 +41,7 @@ class OpenWithSetting: Setting {
         self.windowUUID = settings.windowUUID
         self.settingsDelegate = settingsDelegate
 
-        let theme = settings.themeManager.getcurrentTheme(for: windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsOpenWithSectionName,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/OpenWithSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/OpenWithSetting.swift
@@ -41,7 +41,7 @@ class OpenWithSetting: Setting {
         self.windowUUID = settings.windowUUID
         self.settingsDelegate = settingsDelegate
 
-        let theme = settings.themeManager.currentTheme(for: windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsOpenWithSectionName,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SearchBarSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SearchBarSetting.swift
@@ -26,7 +26,7 @@ class SearchBarSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?) {
         self.viewModel = SearchBarSettingsViewModel(prefs: settings.profile.prefs)
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: viewModel.title,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SearchBarSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SearchBarSetting.swift
@@ -26,7 +26,7 @@ class SearchBarSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?) {
         self.viewModel = SearchBarSettingsViewModel(prefs: settings.profile.prefs)
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: viewModel.title,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
@@ -28,7 +28,7 @@ class SearchSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .AppSettingsSearch,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
@@ -28,7 +28,7 @@ class SearchSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .AppSettingsSearch,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SiriPageSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SiriPageSetting.swift
@@ -20,7 +20,7 @@ class SiriPageSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsSiriSectionName,

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SiriPageSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SiriPageSetting.swift
@@ -20,7 +20,7 @@ class SiriPageSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?) {
         self.profile = settings.profile
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsSiriSectionName,

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/AutofillCreditCardSettings.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/AutofillCreditCardSettings.swift
@@ -23,7 +23,7 @@ class AutofillCreditCardSettings: Setting, FeatureFlaggable {
         self.settings = settings as? AppSettingsTableViewController
         self.settingsDelegate = settingsDelegate
 
-        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsAutofillCreditCard,

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/AutofillCreditCardSettings.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/AutofillCreditCardSettings.swift
@@ -23,7 +23,7 @@ class AutofillCreditCardSettings: Setting, FeatureFlaggable {
         self.settings = settings as? AppSettingsTableViewController
         self.settingsDelegate = settingsDelegate
 
-        let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsAutofillCreditCard,

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/ClearPrivateDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/ClearPrivateDataSetting.swift
@@ -22,7 +22,7 @@ class ClearPrivateDataSetting: Setting {
         self.settingsDelegate = settingsDelegate
 
         let clearTitle: String = .SettingsDataManagementSectionName
-        let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: clearTitle,

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/ClearPrivateDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/ClearPrivateDataSetting.swift
@@ -22,7 +22,7 @@ class ClearPrivateDataSetting: Setting {
         self.settingsDelegate = settingsDelegate
 
         let clearTitle: String = .SettingsDataManagementSectionName
-        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: clearTitle,

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/PasswordManagerSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/PasswordManagerSetting.swift
@@ -18,7 +18,7 @@ class PasswordManagerSetting: Setting {
     init(settings: SettingsTableViewController,
          settingsDelegate: PrivacySettingsDelegate?) {
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .Settings.Passwords.Title,

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/PasswordManagerSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/PasswordManagerSetting.swift
@@ -18,7 +18,7 @@ class PasswordManagerSetting: Setting {
     init(settings: SettingsTableViewController,
          settingsDelegate: PrivacySettingsDelegate?) {
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .Settings.Passwords.Title,

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/ShowIntroductionSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/ShowIntroductionSetting.swift
@@ -15,7 +15,7 @@ class ShowIntroductionSetting: Setting {
     init(settings: SettingsTableViewController,
          settingsDelegate: DebugSettingsDelegate?) {
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         let attributes = [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]
         super.init(title: NSAttributedString(string: .AppSettingsShowTour,
                                              attributes: attributes))

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/ShowIntroductionSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/ShowIntroductionSetting.swift
@@ -15,7 +15,7 @@ class ShowIntroductionSetting: Setting {
     init(settings: SettingsTableViewController,
          settingsDelegate: DebugSettingsDelegate?) {
         self.settingsDelegate = settingsDelegate
-        let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
         let attributes = [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]
         super.init(title: NSAttributedString(string: .AppSettingsShowTour,
                                              attributes: attributes))

--- a/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -115,7 +115,7 @@ class PasswordDetailViewController: SensitiveViewController, Themeable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -115,7 +115,7 @@ class PasswordDetailViewController: SensitiveViewController, Themeable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Settings/SearchEnginePicker.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchEnginePicker.swift
@@ -28,7 +28,7 @@ class SearchEnginePicker: ThemedTableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let engine = engines[indexPath.item]
         let cell = dequeueCellFor(indexPath: indexPath)
-        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         cell.textLabel?.text = engine.shortName
         let size = CGSize(width: OpenSearchEngine.UX.preferredIconSize,
                           height: OpenSearchEngine.UX.preferredIconSize)

--- a/firefox-ios/Client/Frontend/Settings/SearchEnginePicker.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchEnginePicker.swift
@@ -28,7 +28,7 @@ class SearchEnginePicker: ThemedTableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let engine = engines[indexPath.item]
         let cell = dequeueCellFor(indexPath: indexPath)
-        cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         cell.textLabel?.text = engine.shortName
         let size = CGSize(width: OpenSearchEngine.UX.preferredIconSize,
                           height: OpenSearchEngine.UX.preferredIconSize)

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -158,7 +158,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 cell.imageView?.image = engine.image.createScaled(IconSize)
                 cell.imageView?.layer.cornerRadius = 4
                 cell.imageView?.layer.masksToBounds = true
-                cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+                cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
 
         case .alternateEngines:
             // The default engine is not an alternate search engine.
@@ -168,7 +168,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 cell.showsReorderControl = true
 
                 let toggle = ThemedSwitch()
-                toggle.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+                toggle.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
                 // This is an easy way to get from the toggle control to the corresponding index.
                 toggle.tag = index
                 toggle.addTarget(self, action: #selector(didToggleEngine), for: .valueChanged)
@@ -183,13 +183,13 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 cell.imageView?.layer.cornerRadius = 4
                 cell.imageView?.layer.masksToBounds = true
                 cell.selectionStyle = .none
-                cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+                cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
             } else {
                 cell.editingAccessoryType = .disclosureIndicator
                 cell.accessibilityLabel = .SettingsAddCustomEngineTitle
                 cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Search.customEngineViewButton
                 cell.textLabel?.text = .SettingsAddCustomEngine
-                cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+                cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
             }
 
         case .searchEnginesSuggestions:
@@ -316,7 +316,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 cell.imageView?.layer.cornerRadius = 4
                 cell.imageView?.layer.masksToBounds = true
                 cell.selectionStyle = .none
-                cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+                cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
 
             default:
                 break
@@ -378,7 +378,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 guard let window = self.view.window else { return }
                 SimpleToast().showAlertWithText(.ThirdPartySearchEngineAdded,
                                                 bottomContainer: window,
-                                                theme: self.themeManager.currentTheme(for: self.windowUUID))
+                                                theme: self.themeManager.getcurrentTheme(for: self.windowUUID))
             }
             navigationController?.pushViewController(customSearchEngineForm, animated: true)
         case .searchEnginesSuggestions:
@@ -541,13 +541,13 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     ) {
         let setting = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.currentTheme(for: windowUUID),
+            theme: themeManager.getcurrentTheme(for: windowUUID),
             prefKey: prefKey,
             defaultValue: defaultValue,
             titleText: titleText,
             statusText: statusText
         )
-        setting.onConfigureCell(cell, theme: themeManager.currentTheme(for: windowUUID))
+        setting.onConfigureCell(cell, theme: themeManager.getcurrentTheme(for: windowUUID))
         setting.control.switchView.addTarget(
             self,
             action: selector,
@@ -606,7 +606,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     // MARK: - Theming System
     override func applyTheme() {
         super.applyTheme()
-        tableView.separatorColor = themeManager.currentTheme(for: windowUUID).colors.borderPrimary
+        tableView.separatorColor = themeManager.getcurrentTheme(for: windowUUID).colors.borderPrimary
     }
 }
 

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -158,7 +158,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 cell.imageView?.image = engine.image.createScaled(IconSize)
                 cell.imageView?.layer.cornerRadius = 4
                 cell.imageView?.layer.masksToBounds = true
-                cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+                cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
 
         case .alternateEngines:
             // The default engine is not an alternate search engine.
@@ -168,7 +168,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 cell.showsReorderControl = true
 
                 let toggle = ThemedSwitch()
-                toggle.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+                toggle.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
                 // This is an easy way to get from the toggle control to the corresponding index.
                 toggle.tag = index
                 toggle.addTarget(self, action: #selector(didToggleEngine), for: .valueChanged)
@@ -183,13 +183,13 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 cell.imageView?.layer.cornerRadius = 4
                 cell.imageView?.layer.masksToBounds = true
                 cell.selectionStyle = .none
-                cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+                cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             } else {
                 cell.editingAccessoryType = .disclosureIndicator
                 cell.accessibilityLabel = .SettingsAddCustomEngineTitle
                 cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Search.customEngineViewButton
                 cell.textLabel?.text = .SettingsAddCustomEngine
-                cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+                cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             }
 
         case .searchEnginesSuggestions:
@@ -316,7 +316,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 cell.imageView?.layer.cornerRadius = 4
                 cell.imageView?.layer.masksToBounds = true
                 cell.selectionStyle = .none
-                cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+                cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
 
             default:
                 break
@@ -378,7 +378,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
                 guard let window = self.view.window else { return }
                 SimpleToast().showAlertWithText(.ThirdPartySearchEngineAdded,
                                                 bottomContainer: window,
-                                                theme: self.themeManager.getcurrentTheme(for: self.windowUUID))
+                                                theme: self.themeManager.getCurrentTheme(for: self.windowUUID))
             }
             navigationController?.pushViewController(customSearchEngineForm, animated: true)
         case .searchEnginesSuggestions:
@@ -541,13 +541,13 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     ) {
         let setting = BoolSetting(
             prefs: profile.prefs,
-            theme: themeManager.getcurrentTheme(for: windowUUID),
+            theme: themeManager.getCurrentTheme(for: windowUUID),
             prefKey: prefKey,
             defaultValue: defaultValue,
             titleText: titleText,
             statusText: statusText
         )
-        setting.onConfigureCell(cell, theme: themeManager.getcurrentTheme(for: windowUUID))
+        setting.onConfigureCell(cell, theme: themeManager.getCurrentTheme(for: windowUUID))
         setting.control.switchView.addTarget(
             self,
             action: selector,
@@ -606,7 +606,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     // MARK: - Theming System
     override func applyTheme() {
         super.applyTheme()
-        tableView.separatorColor = themeManager.getcurrentTheme(for: windowUUID).colors.borderPrimary
+        tableView.separatorColor = themeManager.getCurrentTheme(for: windowUUID).colors.borderPrimary
     }
 }
 

--- a/firefox-ios/Client/Frontend/Settings/SettingsContentViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsContentViewController.swift
@@ -158,7 +158,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate, The
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     private func makeInterstitialViews() -> InterstitialViews {

--- a/firefox-ios/Client/Frontend/Settings/SettingsContentViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsContentViewController.swift
@@ -158,7 +158,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate, The
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     private func makeInterstitialViews() -> InterstitialViews {

--- a/firefox-ios/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -62,7 +62,7 @@ class ThemedNavigationController: DismissableNavigationViewController, Themeable
     }
 
     func applyTheme() {
-        setupNavigationBarAppearance(theme: themeManager.getcurrentTheme(for: windowUUID))
+        setupNavigationBarAppearance(theme: themeManager.getCurrentTheme(for: windowUUID))
         setNeedsStatusBarAppearanceUpdate()
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -62,7 +62,7 @@ class ThemedNavigationController: DismissableNavigationViewController, Themeable
     }
 
     func applyTheme() {
-        setupNavigationBarAppearance(theme: themeManager.currentTheme(for: windowUUID))
+        setupNavigationBarAppearance(theme: themeManager.getcurrentTheme(for: windowUUID))
         setNeedsStatusBarAppearanceUpdate()
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -916,7 +916,7 @@ class SettingsTableViewController: ThemedTableViewController {
     }
 
     func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     override func applyTheme() {
@@ -982,7 +982,7 @@ class SettingsTableViewController: ThemedTableViewController {
         let section = settings[indexPath.section]
         if let setting = section[indexPath.row] {
             let cell = dequeueCellFor(indexPath: indexPath, setting: setting)
-            setting.onConfigureCell(cell, theme: themeManager.getcurrentTheme(for: windowUUID))
+            setting.onConfigureCell(cell, theme: themeManager.getCurrentTheme(for: windowUUID))
             return cell
         }
         return super.tableView(tableView, cellForRowAt: indexPath)
@@ -995,8 +995,8 @@ class SettingsTableViewController: ThemedTableViewController {
     ) {
         let section = settings[indexPath.section]
         if let setting = section[indexPath.row], let themedCell = cell as? ThemedTableViewCell {
-            setting.onConfigureCell(themedCell, theme: themeManager.getcurrentTheme(for: windowUUID))
-            themedCell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+            setting.onConfigureCell(themedCell, theme: themeManager.getCurrentTheme(for: windowUUID))
+            themedCell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 
@@ -1040,7 +1040,7 @@ class SettingsTableViewController: ThemedTableViewController {
         if let sectionTitle = sectionSetting.title?.string {
             headerView.titleLabel.text = sectionTitle.uppercased()
         }
-        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return headerView
     }
 
@@ -1054,7 +1054,7 @@ class SettingsTableViewController: ThemedTableViewController {
 
         footerView.titleLabel.text = sectionFooter
         footerView.titleAlignment = .top
-        footerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        footerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return footerView
     }
 

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -916,7 +916,7 @@ class SettingsTableViewController: ThemedTableViewController {
     }
 
     func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     override func applyTheme() {
@@ -982,7 +982,7 @@ class SettingsTableViewController: ThemedTableViewController {
         let section = settings[indexPath.section]
         if let setting = section[indexPath.row] {
             let cell = dequeueCellFor(indexPath: indexPath, setting: setting)
-            setting.onConfigureCell(cell, theme: themeManager.currentTheme(for: windowUUID))
+            setting.onConfigureCell(cell, theme: themeManager.getcurrentTheme(for: windowUUID))
             return cell
         }
         return super.tableView(tableView, cellForRowAt: indexPath)
@@ -995,8 +995,8 @@ class SettingsTableViewController: ThemedTableViewController {
     ) {
         let section = settings[indexPath.section]
         if let setting = section[indexPath.row], let themedCell = cell as? ThemedTableViewCell {
-            setting.onConfigureCell(themedCell, theme: themeManager.currentTheme(for: windowUUID))
-            themedCell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+            setting.onConfigureCell(themedCell, theme: themeManager.getcurrentTheme(for: windowUUID))
+            themedCell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         }
     }
 
@@ -1040,7 +1040,7 @@ class SettingsTableViewController: ThemedTableViewController {
         if let sectionTitle = sectionSetting.title?.string {
             headerView.titleLabel.text = sectionTitle.uppercased()
         }
-        headerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         return headerView
     }
 
@@ -1054,7 +1054,7 @@ class SettingsTableViewController: ThemedTableViewController {
 
         footerView.titleLabel.text = sectionFooter
         footerView.titleAlignment = .top
-        footerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        footerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         return footerView
     }
 

--- a/firefox-ios/Client/Frontend/Settings/SettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsViewController.swift
@@ -43,7 +43,7 @@ class SettingsViewController: UIViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: currentWindowUUID)
+        let theme = themeManager.getcurrentTheme(for: currentWindowUUID)
         view.backgroundColor = theme.colors.layer1
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/SettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsViewController.swift
@@ -43,7 +43,7 @@ class SettingsViewController: UIViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: currentWindowUUID)
+        let theme = themeManager.getCurrentTheme(for: currentWindowUUID)
         view.backgroundColor = theme.colors.layer1
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -39,7 +39,7 @@ class SiriOpenURLSetting: Setting {
     override var accessibilityIdentifier: String? { return "SiriSettings" }
 
     init(settings: SettingsTableViewController) {
-        let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsSiriOpenURL,

--- a/firefox-ios/Client/Frontend/Settings/SiriSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SiriSettingsViewController.swift
@@ -39,7 +39,7 @@ class SiriOpenURLSetting: Setting {
     override var accessibilityIdentifier: String? { return "SiriSettings" }
 
     init(settings: SettingsTableViewController) {
-        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .SettingsSiriOpenURL,

--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -18,7 +18,7 @@ class ManageFxAccountSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        let theme = settings.themeManager.currentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .FxAManageAccount,
@@ -46,7 +46,7 @@ class DisconnectSetting: Setting {
     override var textAlignment: NSTextAlignment { return .center }
 
     override var title: NSAttributedString? {
-        let theme = settingsVC.themeManager.currentTheme(for: settingsVC.windowUUID)
+        let theme = settingsVC.themeManager.getcurrentTheme(for: settingsVC.windowUUID)
         return NSAttributedString(
             string: .SettingsDisconnectSyncButton,
             attributes: [

--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -18,7 +18,7 @@ class ManageFxAccountSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
 
-        let theme = settings.themeManager.getcurrentTheme(for: settings.windowUUID)
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(
             title: NSAttributedString(
                 string: .FxAManageAccount,
@@ -46,7 +46,7 @@ class DisconnectSetting: Setting {
     override var textAlignment: NSTextAlignment { return .center }
 
     override var title: NSAttributedString? {
-        let theme = settingsVC.themeManager.getcurrentTheme(for: settingsVC.windowUUID)
+        let theme = settingsVC.themeManager.getCurrentTheme(for: settingsVC.windowUUID)
         return NSAttributedString(
             string: .SettingsDisconnectSyncButton,
             attributes: [

--- a/firefox-ios/Client/Frontend/Settings/TPAccessoryInfo.swift
+++ b/firefox-ios/Client/Frontend/Settings/TPAccessoryInfo.swift
@@ -24,7 +24,7 @@ class TPAccessoryInfo: ThemedTableViewController {
     }
 
     func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func headerView() -> UIView {

--- a/firefox-ios/Client/Frontend/Settings/TPAccessoryInfo.swift
+++ b/firefox-ios/Client/Frontend/Settings/TPAccessoryInfo.swift
@@ -24,7 +24,7 @@ class TPAccessoryInfo: ThemedTableViewController {
     }
 
     func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func headerView() -> UIView {

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -103,7 +103,7 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
     }
 
     func updateThemeFromSystemBrightnessChange(with action: ThemeSettingsViewAction) {
-        themeManager.reloadThemeForAllWindows()
+        themeManager.applyThemeUpdatesToWindows()
         dispatchMiddlewareAction(from: action, to: .systemBrightnessChanged)
     }
 

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -7,10 +7,12 @@ import Redux
 
 protocol ThemeManagerProvider {
     func getCurrentThemeManagerState(windowUUID: WindowUUID) -> ThemeSettingsState
-    func toggleUseSystemAppearance(_ enabled: Bool)
-    func toggleAutomaticBrightness(_ enabled: Bool)
-    func updateManualTheme(_ theme: ThemeType, for window: WindowUUID)
-    func updateUserBrightness(_ value: Float)
+    func updateManualTheme(with action: ThemeSettingsViewAction)
+    func updateSystemTheme(with action: ThemeSettingsViewAction)
+    func updateAutomaticBrightness(with action: ThemeSettingsViewAction)
+    func updateAutomaticBrightnessValue(with action: ThemeSettingsViewAction)
+    func updateThemeFromSystemBrightnessChange(with action: ThemeSettingsViewAction)
+    func updatePrivateMode(with action: PrivateModeAction)
 }
 
 class ThemeManagerMiddleware: ThemeManagerProvider {
@@ -20,83 +22,43 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
         self.themeManager = themeManager
     }
 
-    lazy var themeManagerProvider: Middleware<AppState> = { state, action in
+    lazy var themeManagerProvider: Middleware<AppState> = { _, action in
         if let action = action as? ThemeSettingsViewAction {
-            self.resolveThemeSettingsViewActionType(action: action, state: state)
+            self.resolveThemeSettingsViewActionType(action: action)
         } else if let action = action as? PrivateModeAction {
-            self.resolvePrivateModeAction(action: action, state: state)
+            self.resolvePrivateModeAction(action: action)
         }
     }
 
-    private func resolvePrivateModeAction(action: PrivateModeAction, state: AppState) {
+    private func resolvePrivateModeAction(action: PrivateModeAction) {
         switch action.actionType {
         case PrivateModeActionType.privateModeUpdated:
-            guard let isPrivate = action.isPrivate else { return }
-            self.toggleUsePrivateTheme(to: isPrivate, for: action.windowUUID)
+            updatePrivateMode(with: action)
 
         default:
             break
         }
     }
 
-    private func resolveThemeSettingsViewActionType(action: ThemeSettingsViewAction, state: AppState) {
+    private func resolveThemeSettingsViewActionType(action: ThemeSettingsViewAction) {
         switch action.actionType {
         case ThemeSettingsViewActionType.themeSettingsDidAppear:
-            let currentThemeState = self.getCurrentThemeManagerState(windowUUID: action.windowUUID)
-            let newAction = ThemeSettingsMiddlewareAction(
-                themeSettingsState: currentThemeState,
-                windowUUID: action.windowUUID,
-                actionType: ThemeSettingsMiddlewareActionType.receivedThemeManagerValues)
-            store.dispatch(newAction)
+            dispatchMiddlewareAction(from: action, to: .receivedThemeManagerValues)
 
         case ThemeSettingsViewActionType.toggleUseSystemAppearance:
-            guard let useSystemAppearance = action.useSystemAppearance else { return }
-            self.toggleUseSystemAppearance(useSystemAppearance)
-            let currentThemeState = self.getCurrentThemeManagerState(windowUUID: action.windowUUID)
-            let action = ThemeSettingsMiddlewareAction(
-                themeSettingsState: currentThemeState,
-                windowUUID: action.windowUUID,
-                actionType: ThemeSettingsMiddlewareActionType.systemThemeChanged)
-            store.dispatch(action)
+            updateSystemTheme(with: action)
 
         case ThemeSettingsViewActionType.enableAutomaticBrightness:
-            guard let automaticBrightnessEnabled = action.automaticBrightnessEnabled else { return }
-            self.toggleAutomaticBrightness(automaticBrightnessEnabled)
-            let currentThemeState = self.getCurrentThemeManagerState(windowUUID: action.windowUUID)
-            let action = ThemeSettingsMiddlewareAction(
-                themeSettingsState: currentThemeState,
-                windowUUID: action.windowUUID,
-                actionType: ThemeSettingsMiddlewareActionType.automaticBrightnessChanged)
-            store.dispatch(action)
+            updateAutomaticBrightness(with: action)
 
         case ThemeSettingsViewActionType.switchManualTheme:
-            guard let manualThemeType = action.manualThemeType else { return }
-            self.updateManualTheme(manualThemeType, for: action.windowUUID)
-            let currentThemeState = self.getCurrentThemeManagerState(windowUUID: action.windowUUID)
-            let action = ThemeSettingsMiddlewareAction(
-                themeSettingsState: currentThemeState,
-                windowUUID: action.windowUUID,
-                actionType: ThemeSettingsMiddlewareActionType.manualThemeChanged)
-            store.dispatch(action)
+            updateManualTheme(with: action)
 
         case ThemeSettingsViewActionType.updateUserBrightness:
-            guard let userBrightness = action.userBrightness else { return }
-            self.updateUserBrightness(userBrightness)
-            let currentThemeState = self.getCurrentThemeManagerState(windowUUID: action.windowUUID)
-            let action = ThemeSettingsMiddlewareAction(
-                themeSettingsState: currentThemeState,
-                windowUUID: action.windowUUID,
-                actionType: ThemeSettingsMiddlewareActionType.userBrightnessChanged)
-            store.dispatch(action)
+            updateAutomaticBrightnessValue(with: action)
 
         case ThemeSettingsViewActionType.receivedSystemBrightnessChange:
-            self.updateThemeBasedOnSystemBrightness()
-            let currentThemeState = self.getCurrentThemeManagerState(windowUUID: action.windowUUID)
-            let action = ThemeSettingsMiddlewareAction(
-                themeSettingsState: currentThemeState,
-                windowUUID: action.windowUUID,
-                actionType: ThemeSettingsMiddlewareActionType.systemBrightnessChanged)
-            store.dispatch(action)
+            updateThemeFromSystemBrightnessChange(with: action)
 
         default:
             break
@@ -113,31 +75,54 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
                            systemBrightness: getScreenBrightness())
     }
 
-    func toggleUseSystemAppearance(_ enabled: Bool) {
-        themeManager.setSystemTheme(isOn: enabled)
-    }
-
-    func toggleUsePrivateTheme(to state: Bool, for window: WindowUUID) {
-        themeManager.setPrivateTheme(isOn: state, for: window)
-    }
-
-    func toggleAutomaticBrightness(_ enabled: Bool) {
-        themeManager.setAutomaticBrightness(isOn: enabled)
-    }
-
-    func updateManualTheme(_ newTheme: ThemeType, for window: UUID) {
-        themeManager.changeManualTheme(to: newTheme, for: window)
-    }
-
-    func updateUserBrightness(_ value: Float) {
-        themeManager.setAutomaticBrightnessValue(value)
-    }
-
-    func updateThemeBasedOnSystemBrightness() {
-        themeManager.updateThemeBasedOnBrightess()
-    }
-
     func getScreenBrightness() -> Float {
         return Float(UIScreen.main.brightness)
+    }
+
+    func updatePrivateMode(with action: PrivateModeAction) {
+        guard let privateModeState = action.isPrivate else { return }
+        themeManager.setPrivateTheme(isOn: privateModeState, for: action.windowUUID)
+    }
+
+    func updateSystemTheme(with action: ThemeSettingsViewAction) {
+        guard let useSystemAppearance = action.useSystemAppearance else { return }
+        themeManager.setSystemTheme(isOn: useSystemAppearance)
+        dispatchMiddlewareAction(from: action, to: .systemThemeChanged)
+    }
+
+    func updateAutomaticBrightness(with action: ThemeSettingsViewAction) {
+        guard let automaticBrightnessEnabled = action.automaticBrightnessEnabled else { return }
+        themeManager.setAutomaticBrightness(isOn: automaticBrightnessEnabled)
+        dispatchMiddlewareAction(from: action, to: .automaticBrightnessChanged)
+    }
+
+    func updateAutomaticBrightnessValue(with action: ThemeSettingsViewAction) {
+        guard let userBrightness = action.userBrightness else { return }
+        themeManager.setAutomaticBrightnessValue(userBrightness)
+        dispatchMiddlewareAction(from: action, to: .userBrightnessChanged)
+    }
+
+    func updateThemeFromSystemBrightnessChange(with action: ThemeSettingsViewAction) {
+        themeManager.reloadThemeForAllWindows()
+        dispatchMiddlewareAction(from: action, to: .systemBrightnessChanged)
+    }
+
+    func updateManualTheme(with action: ThemeSettingsViewAction) {
+        guard let manualThemeType = action.manualThemeType else { return }
+        themeManager.setManualTheme(to: manualThemeType)
+        dispatchMiddlewareAction(from: action, to: .manualThemeChanged)
+    }
+
+    private func dispatchMiddlewareAction(
+        from oldAction: ThemeSettingsViewAction,
+        to newActionType: ThemeSettingsMiddlewareActionType
+    ) {
+        let currentThemeState = getCurrentThemeManagerState(windowUUID: oldAction.windowUUID)
+        let action = ThemeSettingsMiddlewareAction(
+            themeSettingsState: currentThemeState,
+            windowUUID: oldAction.windowUUID,
+            actionType: newActionType)
+
+        store.dispatch(action)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -108,7 +108,7 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
         ThemeSettingsState(windowUUID: windowUUID,
                            useSystemAppearance: themeManager.systemThemeIsOn,
                            isAutomaticBrightnessEnable: themeManager.automaticBrightnessIsOn,
-                           manualThemeSelected: themeManager.getSavedTheme(),
+                           manualThemeSelected: themeManager.getUserManualTheme(),
                            userBrightnessThreshold: themeManager.automaticBrightnessValue,
                            systemBrightness: getScreenBrightness())
     }
@@ -126,7 +126,7 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
     }
 
     func updateManualTheme(_ newTheme: ThemeType, for window: UUID) {
-        themeManager.setSystemTheme(isOn: false)
+//        themeManager.setSystemTheme(isOn: false)
         themeManager.changeCurrentTheme(newTheme, for: window)
     }
 

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -135,7 +135,7 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
     }
 
     func updateThemeBasedOnSystemBrightness() {
-        themeManager.brightnessChanged()
+        themeManager.updateThemeBasedOnBrightess()
     }
 
     func getScreenBrightness() -> Float {

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -108,7 +108,7 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
         ThemeSettingsState(windowUUID: windowUUID,
                            useSystemAppearance: themeManager.systemThemeIsOn,
                            isAutomaticBrightnessEnable: themeManager.automaticBrightnessIsOn,
-                           manualThemeSelected: themeManager.getNormalSavedTheme(),
+                           manualThemeSelected: themeManager.getSavedTheme(),
                            userBrightnessThreshold: themeManager.automaticBrightnessValue,
                            systemBrightness: getScreenBrightness())
     }

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -126,8 +126,7 @@ class ThemeManagerMiddleware: ThemeManagerProvider {
     }
 
     func updateManualTheme(_ newTheme: ThemeType, for window: UUID) {
-//        themeManager.setSystemTheme(isOn: false)
-        themeManager.changeCurrentTheme(newTheme, for: window)
+        themeManager.changeManualTheme(to: newTheme, for: window)
     }
 
     func updateUserBrightness(_ value: Float) {

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -148,7 +148,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
     }
 
     private func makeSlider(parent: UIView) -> UISlider {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let size = CGSize(width: UX.moonSunIconSize, height: UX.moonSunIconSize)
         let images = [StandardImageIdentifiers.Medium.nightMode, StandardImageIdentifiers.Medium.sun].map { name in
             UIImage(imageLiteralResourceName: name)
@@ -202,7 +202,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
             label.text = .DisplayThemeSectionFooter
             label.numberOfLines = 0
             label.font = FXFontStyles.Regular.caption1.scaledFont()
-            label.textColor = self.themeManager.getcurrentTheme(for: self.windowUUID).colors.textSecondary
+            label.textColor = self.themeManager.getCurrentTheme(for: self.windowUUID).colors.textSecondary
         }
         footer.addSubview(label)
         NSLayoutConstraint.activate([
@@ -229,7 +229,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
         let cell = dequeueCellFor(indexPath: indexPath)
         cell.selectionStyle = .none
         let section = Section(rawValue: indexPath.section) ?? .automaticBrightness
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         switch section {
         case .systemTheme:
             cell.textLabel?.text = .SystemThemeSectionSwitchTitle
@@ -364,7 +364,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
     }
 
     private func configureAutomaticBrightness(cell: ThemedTableViewCell) {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let deviceBrightnessIndicator = makeSlider(parent: cell.contentView)
         let slider = makeSlider(parent: cell.contentView)
         slider.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsController.swift
@@ -148,7 +148,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
     }
 
     private func makeSlider(parent: UIView) -> UISlider {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let size = CGSize(width: UX.moonSunIconSize, height: UX.moonSunIconSize)
         let images = [StandardImageIdentifiers.Medium.nightMode, StandardImageIdentifiers.Medium.sun].map { name in
             UIImage(imageLiteralResourceName: name)
@@ -202,7 +202,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
             label.text = .DisplayThemeSectionFooter
             label.numberOfLines = 0
             label.font = FXFontStyles.Regular.caption1.scaledFont()
-            label.textColor = self.themeManager.currentTheme(for: self.windowUUID).colors.textSecondary
+            label.textColor = self.themeManager.getcurrentTheme(for: self.windowUUID).colors.textSecondary
         }
         footer.addSubview(label)
         NSLayoutConstraint.activate([
@@ -229,7 +229,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
         let cell = dequeueCellFor(indexPath: indexPath)
         cell.selectionStyle = .none
         let section = Section(rawValue: indexPath.section) ?? .automaticBrightness
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         switch section {
         case .systemTheme:
             cell.textLabel?.text = .SystemThemeSectionSwitchTitle
@@ -364,7 +364,7 @@ class ThemeSettingsController: ThemedTableViewController, StoreSubscriber {
     }
 
     private func configureAutomaticBrightness(cell: ThemedTableViewCell) {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let deviceBrightnessIndicator = makeSlider(parent: cell.contentView)
         let slider = makeSlider(parent: cell.contentView)
         slider.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -52,7 +52,7 @@ class WebsiteDataManagementViewController: UIViewController,
                                                                                           windowUUID: windowUUID)
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -52,7 +52,7 @@ class WebsiteDataManagementViewController: UIViewController,
                                                                                           windowUUID: windowUUID)
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
@@ -42,7 +42,7 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
 
         let footer = ThemedTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width,
                                                                       height: SettingsUX.TableViewHeaderFooterHeight))
-        footer.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        footer.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         footer.showBorder(for: .top, true)
         tableView.tableFooterView = footer
 
@@ -69,7 +69,7 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = dequeueCellFor(indexPath: indexPath)
-        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         let section = Section(rawValue: indexPath.section)!
         switch section {
         case .sites:
@@ -84,7 +84,7 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
         case .clearButton:
             cell.textLabel?.text = viewModel.clearButtonTitle
             cell.textLabel?.textAlignment = .center
-            cell.textLabel?.textColor = themeManager.getcurrentTheme(for: windowUUID).colors.textWarning
+            cell.textLabel?.textColor = themeManager.getCurrentTheme(for: windowUUID).colors.textWarning
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ClearAllWebsiteData"
         }

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
@@ -42,7 +42,7 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
 
         let footer = ThemedTableSectionHeaderFooterView(frame: CGRect(width: tableView.bounds.width,
                                                                       height: SettingsUX.TableViewHeaderFooterHeight))
-        footer.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        footer.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         footer.showBorder(for: .top, true)
         tableView.tableFooterView = footer
 
@@ -69,7 +69,7 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = dequeueCellFor(indexPath: indexPath)
-        cell.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        cell.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         let section = Section(rawValue: indexPath.section)!
         switch section {
         case .sites:
@@ -84,7 +84,7 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
         case .clearButton:
             cell.textLabel?.text = viewModel.clearButtonTitle
             cell.textLabel?.textAlignment = .center
-            cell.textLabel?.textColor = themeManager.currentTheme(for: windowUUID).colors.textWarning
+            cell.textLabel?.textColor = themeManager.getcurrentTheme(for: windowUUID).colors.textWarning
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ClearAllWebsiteData"
         }

--- a/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -235,7 +235,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     // MARK: - Themable
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -235,7 +235,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     // MARK: - Themable
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 
     func applyTheme() {

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewController.swift
@@ -57,7 +57,7 @@ class ThemedTableViewController: UITableViewController, Themeable, InjectedTheme
             withIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier
         ) as? ThemedTableSectionHeaderFooterView
         else { return nil }
-        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return headerView
     }
 
@@ -69,7 +69,7 @@ class ThemedTableViewController: UITableViewController, Themeable, InjectedTheme
             withIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier
         ) as? ThemedTableSectionHeaderFooterView
         else { return nil }
-        footerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        footerView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return footerView
     }
 
@@ -81,7 +81,7 @@ class ThemedTableViewController: UITableViewController, Themeable, InjectedTheme
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         tableView.separatorColor = theme.colors.borderPrimary
         tableView.backgroundColor = theme.colors.layer1
         tableView.reloadData()

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewController.swift
@@ -57,7 +57,7 @@ class ThemedTableViewController: UITableViewController, Themeable, InjectedTheme
             withIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier
         ) as? ThemedTableSectionHeaderFooterView
         else { return nil }
-        headerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        headerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         return headerView
     }
 
@@ -69,7 +69,7 @@ class ThemedTableViewController: UITableViewController, Themeable, InjectedTheme
             withIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier
         ) as? ThemedTableSectionHeaderFooterView
         else { return nil }
-        footerView.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        footerView.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         return footerView
     }
 
@@ -81,7 +81,7 @@ class ThemedTableViewController: UITableViewController, Themeable, InjectedTheme
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         tableView.separatorColor = theme.colors.borderPrimary
         tableView.backgroundColor = theme.colors.layer1
         tableView.reloadData()

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -419,7 +419,7 @@ class TabLocationView: UIView, FeatureFlaggable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.currentTheme(for: windowUUID)
+        return themeManager.getcurrentTheme(for: windowUUID)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -419,7 +419,7 @@ class TabLocationView: UIView, FeatureFlaggable {
     }
 
     private func currentTheme() -> Theme {
-        return themeManager.getcurrentTheme(for: windowUUID)
+        return themeManager.getCurrentTheme(for: windowUUID)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -268,7 +268,7 @@ class PhotonActionSheet: UIViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
 
         if viewModel.presentationStyle == .centered {
             setupBackgroundBlur()
@@ -460,7 +460,7 @@ extension PhotonActionSheet: UITableViewDataSource, UITableViewDelegate {
         else { return UITableViewCell() }
 
         let actions = viewModel.actions[indexPath.section][indexPath.row]
-        cell.configure(actions: actions, viewModel: viewModel, theme: themeManager.currentTheme(for: windowUUID))
+        cell.configure(actions: actions, viewModel: viewModel, theme: themeManager.getcurrentTheme(for: windowUUID))
         cell.delegate = self
 
         if viewModel.isMainMenuInverted {
@@ -487,7 +487,7 @@ extension PhotonActionSheet: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header = viewModel.getViewHeader(tableView: tableView, section: section)
-        (header as? ThemeApplicable)?.applyTheme(theme: themeManager.currentTheme(for: windowUUID))
+        (header as? ThemeApplicable)?.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
         return header
     }
 }

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -268,7 +268,7 @@ class PhotonActionSheet: UIViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
 
         if viewModel.presentationStyle == .centered {
             setupBackgroundBlur()
@@ -460,7 +460,7 @@ extension PhotonActionSheet: UITableViewDataSource, UITableViewDelegate {
         else { return UITableViewCell() }
 
         let actions = viewModel.actions[indexPath.section][indexPath.row]
-        cell.configure(actions: actions, viewModel: viewModel, theme: themeManager.getcurrentTheme(for: windowUUID))
+        cell.configure(actions: actions, viewModel: viewModel, theme: themeManager.getCurrentTheme(for: windowUUID))
         cell.delegate = self
 
         if viewModel.isMainMenuInverted {
@@ -487,7 +487,7 @@ extension PhotonActionSheet: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header = viewModel.getViewHeader(tableView: tableView, section: section)
-        (header as? ThemeApplicable)?.applyTheme(theme: themeManager.getcurrentTheme(for: windowUUID))
+        (header as? ThemeApplicable)?.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return header
     }
 }

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -69,7 +69,7 @@ extension PhotonActionSheetProtocol {
                 UIPasteboard.general.url = url
                 SimpleToast().showAlertWithText(.AppMenu.AppMenuCopyURLConfirmMessage,
                                                 bottomContainer: alertContainer,
-                                                theme: themeManager.getcurrentTheme(for: tabManager.windowUUID))
+                                                theme: themeManager.getCurrentTheme(for: tabManager.windowUUID))
             }
         }
 

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -69,7 +69,7 @@ extension PhotonActionSheetProtocol {
                 UIPasteboard.general.url = url
                 SimpleToast().showAlertWithText(.AppMenu.AppMenuCopyURLConfirmMessage,
                                                 bottomContainer: alertContainer,
-                                                theme: themeManager.currentTheme(for: tabManager.windowUUID))
+                                                theme: themeManager.getcurrentTheme(for: tabManager.windowUUID))
             }
         }
 

--- a/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -143,7 +143,7 @@ class SiteTableViewController: UIViewController,
         if self.tableView(tableView, hasFullWidthSeparatorForRowAtIndexPath: indexPath) {
             cell.separatorInset = .zero
         }
-        cell.textLabel?.textColor = themeManager.currentTheme(for: windowUUID).colors.textPrimary
+        cell.textLabel?.textColor = themeManager.getcurrentTheme(for: windowUUID).colors.textPrimary
         return cell
     }
 
@@ -157,8 +157,8 @@ class SiteTableViewController: UIViewController,
 
     func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         if let header = view as? UITableViewHeaderFooterView {
-            header.textLabel?.textColor = themeManager.currentTheme(for: windowUUID).colors.textPrimary
-            header.contentView.backgroundColor = themeManager.currentTheme(for: windowUUID).colors.layer1
+            header.textLabel?.textColor = themeManager.getcurrentTheme(for: windowUUID).colors.textPrimary
+            header.contentView.backgroundColor = themeManager.getcurrentTheme(for: windowUUID).colors.layer1
         }
     }
 
@@ -184,7 +184,7 @@ class SiteTableViewController: UIViewController,
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         navigationController?.navigationBar.barTintColor = theme.colors.layer1
         navigationController?.navigationBar.tintColor = theme.colors.iconAction
         navigationController?.navigationBar.titleTextAttributes = [

--- a/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -143,7 +143,7 @@ class SiteTableViewController: UIViewController,
         if self.tableView(tableView, hasFullWidthSeparatorForRowAtIndexPath: indexPath) {
             cell.separatorInset = .zero
         }
-        cell.textLabel?.textColor = themeManager.getcurrentTheme(for: windowUUID).colors.textPrimary
+        cell.textLabel?.textColor = themeManager.getCurrentTheme(for: windowUUID).colors.textPrimary
         return cell
     }
 
@@ -157,8 +157,8 @@ class SiteTableViewController: UIViewController,
 
     func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         if let header = view as? UITableViewHeaderFooterView {
-            header.textLabel?.textColor = themeManager.getcurrentTheme(for: windowUUID).colors.textPrimary
-            header.contentView.backgroundColor = themeManager.getcurrentTheme(for: windowUUID).colors.layer1
+            header.textLabel?.textColor = themeManager.getCurrentTheme(for: windowUUID).colors.textPrimary
+            header.contentView.backgroundColor = themeManager.getCurrentTheme(for: windowUUID).colors.layer1
         }
     }
 
@@ -184,7 +184,7 @@ class SiteTableViewController: UIViewController,
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         navigationController?.navigationBar.barTintColor = theme.colors.layer1
         navigationController?.navigationBar.tintColor = theme.colors.iconAction
         navigationController?.navigationBar.titleTextAttributes = [

--- a/firefox-ios/Client/Frontend/Widgets/ThemedDefaultNavigationController.swift
+++ b/firefox-ios/Client/Frontend/Widgets/ThemedDefaultNavigationController.swift
@@ -35,7 +35,7 @@ class ThemedDefaultNavigationController: DismissableNavigationViewController, Th
     }
 
     private func setupNavigationBarAppearance() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let standardAppearance = UINavigationBarAppearance()
         standardAppearance.configureWithDefaultBackground()
         standardAppearance.backgroundColor = theme.colors.layer1
@@ -52,7 +52,7 @@ class ThemedDefaultNavigationController: DismissableNavigationViewController, Th
     }
 
     private func setupToolBarAppearance() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let standardAppearance = UIToolbarAppearance()
         standardAppearance.configureWithDefaultBackground()
         standardAppearance.backgroundColor = theme.colors.layer1

--- a/firefox-ios/Client/Frontend/Widgets/ThemedDefaultNavigationController.swift
+++ b/firefox-ios/Client/Frontend/Widgets/ThemedDefaultNavigationController.swift
@@ -35,7 +35,7 @@ class ThemedDefaultNavigationController: DismissableNavigationViewController, Th
     }
 
     private func setupNavigationBarAppearance() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let standardAppearance = UINavigationBarAppearance()
         standardAppearance.configureWithDefaultBackground()
         standardAppearance.backgroundColor = theme.colors.layer1
@@ -52,7 +52,7 @@ class ThemedDefaultNavigationController: DismissableNavigationViewController, Th
     }
 
     private func setupToolBarAppearance() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let standardAppearance = UIToolbarAppearance()
         standardAppearance.configureWithDefaultBackground()
         standardAppearance.backgroundColor = theme.colors.layer1

--- a/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
@@ -227,7 +227,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.getcurrentTheme(for: windowUUID)
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         let colors = theme.colors
         view.backgroundColor = colors.layer1
         qrSignInLabel.textColor = colors.textPrimary

--- a/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
@@ -227,7 +227,7 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
     }
 
     func applyTheme() {
-        let theme = themeManager.currentTheme(for: windowUUID)
+        let theme = themeManager.getcurrentTheme(for: windowUUID)
         let colors = theme.colors
         view.backgroundColor = colors.layer1
         qrSignInLabel.textColor = colors.textPrimary

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -68,7 +68,7 @@ final class DefaultThemeManagerTests: XCTestCase {
         let sut = createSubject(with: userDefaults)
         let expectedResult = ThemeType.dark
 
-        sut.setManualTheme(to: .dark, for: windowUUID)
+        sut.setManualTheme(to: .dark)
 
         XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
         XCTAssertEqual(
@@ -81,8 +81,8 @@ final class DefaultThemeManagerTests: XCTestCase {
         let sut = createSubject(with: userDefaults)
         let expectedResult = ThemeType.light
 
-        sut.setManualTheme(to: .dark, for: windowUUID)
-        sut.setManualTheme(to: .light, for: windowUUID)
+        sut.setManualTheme(to: .dark)
+        sut.setManualTheme(to: .light)
 
         XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
         XCTAssertEqual(
@@ -137,7 +137,7 @@ final class DefaultThemeManagerTests: XCTestCase {
         let sut = createSubject(with: userDefaults)
         let expectedResult = ThemeType.dark.rawValue
 
-        sut.setManualTheme(to: .dark, for: windowUUID)
+        sut.setManualTheme(to: .dark)
         sut.setPrivateTheme(isOn: true, for: windowUUID)
 
         XCTAssertEqual(
@@ -153,9 +153,9 @@ final class DefaultThemeManagerTests: XCTestCase {
         let expectedResult = ThemeType.light
         let currentThemeExpectedResult = ThemeType.privateMode
 
-        sut.setManualTheme(to: .dark, for: windowUUID)
+        sut.setManualTheme(to: .dark)
         sut.setPrivateTheme(isOn: true, for: windowUUID)
-        sut.setManualTheme(to: .light, for: windowUUID)
+        sut.setManualTheme(to: .light)
 
         XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, currentThemeExpectedResult)
         XCTAssertEqual(sut.getUserManualTheme(), expectedResult)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -158,7 +158,7 @@ final class DefaultThemeManagerTests: XCTestCase {
         sut.changeCurrentTheme(.light, for: windowUUID)
 
         XCTAssertEqual(sut.currentTheme(for: windowUUID).type, currentThemeExpectedResult)
-        XCTAssertEqual(sut.getSavedTheme(), expectedResult)
+        XCTAssertEqual(sut.getUserManualTheme(), expectedResult)
     }
 
     // MARK: - Brightness Tests

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -59,7 +59,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         let expectedResult = ThemeType.light
 
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedResult)
     }
 
     // MARK: - Changing current theme tests
@@ -70,7 +70,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         sut.setManualTheme(to: .dark)
 
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedResult)
         XCTAssertEqual(
             userDefaults.string(forKey: DefaultThemeManager.ThemeKeys.themeName),
             expectedResult.rawValue
@@ -84,7 +84,7 @@ final class DefaultThemeManagerTests: XCTestCase {
         sut.setManualTheme(to: .dark)
         sut.setManualTheme(to: .light)
 
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedResult)
         XCTAssertEqual(
             userDefaults.string(forKey: DefaultThemeManager.ThemeKeys.themeName),
             expectedResult.rawValue
@@ -99,7 +99,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         sut.setSystemTheme(isOn: false)
 
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedResult)
     }
 
     func testDTM_systemThemeTurnedOffThenOn_returnsDefaultTheme() {
@@ -109,7 +109,7 @@ final class DefaultThemeManagerTests: XCTestCase {
         sut.setSystemTheme(isOn: false)
         sut.setSystemTheme(isOn: true)
 
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedResult)
     }
 
     // MARK: - Private theme tests
@@ -120,7 +120,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         sut.setPrivateTheme(isOn: true, for: windowUUID)
 
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedResult)
     }
 
     func testDTM_privateModeEnabledAndThenDisabled_returnsOriginalTheme() {
@@ -130,7 +130,7 @@ final class DefaultThemeManagerTests: XCTestCase {
         sut.setPrivateTheme(isOn: true, for: windowUUID)
         sut.setPrivateTheme(isOn: false, for: windowUUID)
 
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedResult)
     }
 
     func testDTM_privateModeEnabled_originalThemeRemainsSaved() {
@@ -157,7 +157,7 @@ final class DefaultThemeManagerTests: XCTestCase {
         sut.setPrivateTheme(isOn: true, for: windowUUID)
         sut.setManualTheme(to: .light)
 
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, currentThemeExpectedResult)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, currentThemeExpectedResult)
         XCTAssertEqual(sut.getUserManualTheme(), expectedResult)
     }
 
@@ -180,7 +180,7 @@ final class DefaultThemeManagerTests: XCTestCase {
             userDefaults.float(forKey: DefaultThemeManager.ThemeKeys.AutomaticBrightness.thresholdValue),
             expectedBrightnessValue
         )
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedTheme)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedTheme)
     }
 
     func testDTM_settingAutoBrightnessThresholdValue_changesToNewValue() {
@@ -207,7 +207,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         testBrightnessWith(threshold: 0.25, in: sut)
 
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedTheme)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedTheme)
     }
 
     func testDTM_autoBrightnessOnThresholdEqualToScreenBrigthness_returnsLightTheme() {
@@ -216,7 +216,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         testBrightnessWith(threshold: 0.50, in: sut)
 
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedTheme)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedTheme)
     }
 
     func testDTM_autoBrightnessOnThresholdGreaterThanScreenBrigthness_returnsDarkTheme() {
@@ -225,7 +225,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         testBrightnessWith(threshold: 0.75, in: sut)
 
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedTheme)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedTheme)
     }
 
     func testDTM_autoBrightnessOn_changeValues_thenOff_returnsToExpectedSystemTheme() {
@@ -234,10 +234,10 @@ final class DefaultThemeManagerTests: XCTestCase {
         let expectedThemeInSystemMode = ThemeType.light
 
         testBrightnessWith(threshold: 0.75, in: sut)
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedThemeInBrightnessMode)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedThemeInBrightnessMode)
 
         sut.setSystemTheme(isOn: true)
-        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedThemeInSystemMode)
+        XCTAssertEqual(sut.getCurrentTheme(for: windowUUID).type, expectedThemeInSystemMode)
     }
 
     // MARK: - Helper methods

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -59,7 +59,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         let expectedResult = ThemeType.light
 
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
     }
 
     // MARK: - Changing current theme tests
@@ -68,9 +68,9 @@ final class DefaultThemeManagerTests: XCTestCase {
         let sut = createSubject(with: userDefaults)
         let expectedResult = ThemeType.dark
 
-        sut.changeManualTheme(to: .dark, for: windowUUID)
+        sut.setManualTheme(to: .dark, for: windowUUID)
 
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
         XCTAssertEqual(
             userDefaults.string(forKey: DefaultThemeManager.ThemeKeys.themeName),
             expectedResult.rawValue
@@ -81,10 +81,10 @@ final class DefaultThemeManagerTests: XCTestCase {
         let sut = createSubject(with: userDefaults)
         let expectedResult = ThemeType.light
 
-        sut.changeManualTheme(to: .dark, for: windowUUID)
-        sut.changeManualTheme(to: .light, for: windowUUID)
+        sut.setManualTheme(to: .dark, for: windowUUID)
+        sut.setManualTheme(to: .light, for: windowUUID)
 
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
         XCTAssertEqual(
             userDefaults.string(forKey: DefaultThemeManager.ThemeKeys.themeName),
             expectedResult.rawValue
@@ -99,7 +99,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         sut.setSystemTheme(isOn: false)
 
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
     }
 
     func testDTM_systemThemeTurnedOffThenOn_returnsDefaultTheme() {
@@ -109,7 +109,7 @@ final class DefaultThemeManagerTests: XCTestCase {
         sut.setSystemTheme(isOn: false)
         sut.setSystemTheme(isOn: true)
 
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
     }
 
     // MARK: - Private theme tests
@@ -120,7 +120,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         sut.setPrivateTheme(isOn: true, for: windowUUID)
 
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
     }
 
     func testDTM_privateModeEnabledAndThenDisabled_returnsOriginalTheme() {
@@ -130,14 +130,14 @@ final class DefaultThemeManagerTests: XCTestCase {
         sut.setPrivateTheme(isOn: true, for: windowUUID)
         sut.setPrivateTheme(isOn: false, for: windowUUID)
 
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedResult)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedResult)
     }
 
     func testDTM_privateModeEnabled_originalThemeRemainsSaved() {
         let sut = createSubject(with: userDefaults)
         let expectedResult = ThemeType.dark.rawValue
 
-        sut.changeManualTheme(to: .dark, for: windowUUID)
+        sut.setManualTheme(to: .dark, for: windowUUID)
         sut.setPrivateTheme(isOn: true, for: windowUUID)
 
         XCTAssertEqual(
@@ -153,11 +153,11 @@ final class DefaultThemeManagerTests: XCTestCase {
         let expectedResult = ThemeType.light
         let currentThemeExpectedResult = ThemeType.privateMode
 
-        sut.changeManualTheme(to: .dark, for: windowUUID)
+        sut.setManualTheme(to: .dark, for: windowUUID)
         sut.setPrivateTheme(isOn: true, for: windowUUID)
-        sut.changeManualTheme(to: .light, for: windowUUID)
+        sut.setManualTheme(to: .light, for: windowUUID)
 
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, currentThemeExpectedResult)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, currentThemeExpectedResult)
         XCTAssertEqual(sut.getUserManualTheme(), expectedResult)
     }
 
@@ -180,7 +180,7 @@ final class DefaultThemeManagerTests: XCTestCase {
             userDefaults.float(forKey: DefaultThemeManager.ThemeKeys.AutomaticBrightness.thresholdValue),
             expectedBrightnessValue
         )
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedTheme)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedTheme)
     }
 
     func testDTM_settingAutoBrightnessThresholdValue_changesToNewValue() {
@@ -207,7 +207,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         testBrightnessWith(threshold: 0.25, in: sut)
 
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedTheme)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedTheme)
     }
 
     func testDTM_autoBrightnessOnThresholdEqualToScreenBrigthness_returnsLightTheme() {
@@ -216,7 +216,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         testBrightnessWith(threshold: 0.50, in: sut)
 
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedTheme)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedTheme)
     }
 
     func testDTM_autoBrightnessOnThresholdGreaterThanScreenBrigthness_returnsDarkTheme() {
@@ -225,7 +225,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         testBrightnessWith(threshold: 0.75, in: sut)
 
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedTheme)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedTheme)
     }
 
     func testDTM_autoBrightnessOn_changeValues_thenOff_returnsToExpectedSystemTheme() {
@@ -234,10 +234,10 @@ final class DefaultThemeManagerTests: XCTestCase {
         let expectedThemeInSystemMode = ThemeType.light
 
         testBrightnessWith(threshold: 0.75, in: sut)
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedThemeInBrightnessMode)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedThemeInBrightnessMode)
 
         sut.setSystemTheme(isOn: true)
-        XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedThemeInSystemMode)
+        XCTAssertEqual(sut.getcurrentTheme(for: windowUUID).type, expectedThemeInSystemMode)
     }
 
     // MARK: - Helper methods

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -68,7 +68,7 @@ final class DefaultThemeManagerTests: XCTestCase {
         let sut = createSubject(with: userDefaults)
         let expectedResult = ThemeType.dark
 
-        sut.changeCurrentTheme(.dark, for: windowUUID)
+        sut.changeManualTheme(to: .dark, for: windowUUID)
 
         XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedResult)
         XCTAssertEqual(
@@ -81,8 +81,8 @@ final class DefaultThemeManagerTests: XCTestCase {
         let sut = createSubject(with: userDefaults)
         let expectedResult = ThemeType.light
 
-        sut.changeCurrentTheme(.dark, for: windowUUID)
-        sut.changeCurrentTheme(.light, for: windowUUID)
+        sut.changeManualTheme(to: .dark, for: windowUUID)
+        sut.changeManualTheme(to: .light, for: windowUUID)
 
         XCTAssertEqual(sut.currentTheme(for: windowUUID).type, expectedResult)
         XCTAssertEqual(
@@ -137,7 +137,7 @@ final class DefaultThemeManagerTests: XCTestCase {
         let sut = createSubject(with: userDefaults)
         let expectedResult = ThemeType.dark.rawValue
 
-        sut.changeCurrentTheme(.dark, for: windowUUID)
+        sut.changeManualTheme(to: .dark, for: windowUUID)
         sut.setPrivateTheme(isOn: true, for: windowUUID)
 
         XCTAssertEqual(
@@ -153,9 +153,9 @@ final class DefaultThemeManagerTests: XCTestCase {
         let expectedResult = ThemeType.light
         let currentThemeExpectedResult = ThemeType.privateMode
 
-        sut.changeCurrentTheme(.dark, for: windowUUID)
+        sut.changeManualTheme(to: .dark, for: windowUUID)
         sut.setPrivateTheme(isOn: true, for: windowUUID)
-        sut.changeCurrentTheme(.light, for: windowUUID)
+        sut.changeManualTheme(to: .light, for: windowUUID)
 
         XCTAssertEqual(sut.currentTheme(for: windowUUID).type, currentThemeExpectedResult)
         XCTAssertEqual(sut.getUserManualTheme(), expectedResult)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -158,7 +158,7 @@ final class DefaultThemeManagerTests: XCTestCase {
         sut.changeCurrentTheme(.light, for: windowUUID)
 
         XCTAssertEqual(sut.currentTheme(for: windowUUID).type, currentThemeExpectedResult)
-        XCTAssertEqual(sut.getNormalSavedTheme(), expectedResult)
+        XCTAssertEqual(sut.getSavedTheme(), expectedResult)
     }
 
     // MARK: - Brightness Tests

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
@@ -60,7 +60,7 @@ class MockThemeManager: ThemeManager {
         }
     }
 
-    func brightnessChanged() { }
+    func updateThemeBasedOnBrightess() { }
 
     func getSavedTheme() -> ThemeType { return currentThemeStorage.type }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
@@ -25,7 +25,7 @@ class MockThemeManager: ThemeManager {
         return .light
     }
 
-    func changeCurrentTheme(_ newTheme: ThemeType, for window: UUID) {
+    func changeManualTheme(to newTheme: ThemeType, for window: UUID) {
         switch newTheme {
         case .light:
             currentThemeStorage = LightTheme()
@@ -54,9 +54,9 @@ class MockThemeManager: ThemeManager {
         let screenLessThanPref = Float(UIScreen.main.brightness) < value
 
         if screenLessThanPref, currentTheme(for: windowUUID).type == .light {
-            changeCurrentTheme(.dark, for: windowUUID)
+            changeManualTheme(to: .dark, for: windowUUID)
         } else if !screenLessThanPref, currentTheme(for: windowUUID).type == .dark {
-            changeCurrentTheme(.light, for: windowUUID)
+            changeManualTheme(to: .light, for: windowUUID)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
@@ -8,7 +8,7 @@ import Shared
 class MockThemeManager: ThemeManager {
     private var currentThemeStorage: Theme = LightTheme()
 
-    func getcurrentTheme(for window: UUID?) -> Theme {
+    func getCurrentTheme(for window: UUID?) -> Theme {
         return currentThemeStorage
     }
 
@@ -55,9 +55,9 @@ class MockThemeManager: ThemeManager {
     func setAutomaticBrightnessValue(_ value: Float) {
         let screenLessThanPref = Float(UIScreen.main.brightness) < value
 
-        if screenLessThanPref, getcurrentTheme(for: windowUUID).type == .light {
+        if screenLessThanPref, getCurrentTheme(for: windowUUID).type == .light {
             setManualTheme(to: .dark)
-        } else if !screenLessThanPref, getcurrentTheme(for: windowUUID).type == .dark {
+        } else if !screenLessThanPref, getCurrentTheme(for: windowUUID).type == .dark {
             setManualTheme(to: .light)
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
@@ -62,7 +62,7 @@ class MockThemeManager: ThemeManager {
 
     func brightnessChanged() { }
 
-    func getNormalSavedTheme() -> ThemeType { return currentThemeStorage.type }
+    func getSavedTheme() -> ThemeType { return currentThemeStorage.type }
 
     func reloadTheme(for window: UUID) { }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
@@ -25,7 +25,7 @@ class MockThemeManager: ThemeManager {
         return .light
     }
 
-    func setManualTheme(to newTheme: ThemeType, for window: UUID) {
+    func setManualTheme(to newTheme: ThemeType) {
         switch newTheme {
         case .light:
             currentThemeStorage = LightTheme()
@@ -37,6 +37,8 @@ class MockThemeManager: ThemeManager {
             currentThemeStorage = PrivateModeTheme()
         }
     }
+
+    func applyThemeUpdatesToWindows() { }
 
     func systemThemeChanged() {}
 
@@ -54,9 +56,9 @@ class MockThemeManager: ThemeManager {
         let screenLessThanPref = Float(UIScreen.main.brightness) < value
 
         if screenLessThanPref, getcurrentTheme(for: windowUUID).type == .light {
-            setManualTheme(to: .dark, for: windowUUID)
+            setManualTheme(to: .dark)
         } else if !screenLessThanPref, getcurrentTheme(for: windowUUID).type == .dark {
-            setManualTheme(to: .light, for: windowUUID)
+            setManualTheme(to: .light)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
@@ -62,7 +62,7 @@ class MockThemeManager: ThemeManager {
 
     func updateThemeBasedOnBrightess() { }
 
-    func getSavedTheme() -> ThemeType { return currentThemeStorage.type }
+    func getUserManualTheme() -> ThemeType { return currentThemeStorage.type }
 
     func reloadTheme(for window: UUID) { }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockThemeManager.swift
@@ -8,7 +8,7 @@ import Shared
 class MockThemeManager: ThemeManager {
     private var currentThemeStorage: Theme = LightTheme()
 
-    func currentTheme(for window: UUID?) -> Theme {
+    func getcurrentTheme(for window: UUID?) -> Theme {
         return currentThemeStorage
     }
 
@@ -25,7 +25,7 @@ class MockThemeManager: ThemeManager {
         return .light
     }
 
-    func changeManualTheme(to newTheme: ThemeType, for window: UUID) {
+    func setManualTheme(to newTheme: ThemeType, for window: UUID) {
         switch newTheme {
         case .light:
             currentThemeStorage = LightTheme()
@@ -53,10 +53,10 @@ class MockThemeManager: ThemeManager {
     func setAutomaticBrightnessValue(_ value: Float) {
         let screenLessThanPref = Float(UIScreen.main.brightness) < value
 
-        if screenLessThanPref, currentTheme(for: windowUUID).type == .light {
-            changeManualTheme(to: .dark, for: windowUUID)
-        } else if !screenLessThanPref, currentTheme(for: windowUUID).type == .dark {
-            changeManualTheme(to: .light, for: windowUUID)
+        if screenLessThanPref, getcurrentTheme(for: windowUUID).type == .light {
+            setManualTheme(to: .dark, for: windowUUID)
+        } else if !screenLessThanPref, getcurrentTheme(for: windowUUID).type == .dark {
+            setManualTheme(to: .light, for: windowUUID)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ReaderModeStyleTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ReaderModeStyleTests.swift
@@ -91,32 +91,32 @@ class ReaderModeStyleTests: XCTestCase {
     // MARK: - ReaderModeTheme
 
     func test_defaultReaderModeTheme_returnsLight() {
-        themeManager.changeCurrentTheme(.light, for: windowUUID)
+        themeManager.changeManualTheme(to: .light, for: windowUUID)
         let defaultTheme = ReaderModeTheme.preferredTheme(for: nil, window: windowUUID)
         XCTAssertEqual(defaultTheme, .light, "Expected light theme (default) if not theme is selected")
     }
 
     func test_appWideThemeDark_returnsDark() {
-        themeManager.changeCurrentTheme(.dark, for: windowUUID)
+        themeManager.changeManualTheme(to: .dark, for: windowUUID)
         let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.light, window: windowUUID)
 
         XCTAssertEqual(theme, .dark, "Expected dark theme because of the app theme")
     }
 
     func test_readerThemeSepia_returnsSepia() {
-        themeManager.changeCurrentTheme(.light, for: windowUUID)
+        themeManager.changeManualTheme(to: .light, for: windowUUID)
         let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.sepia, window: windowUUID)
         XCTAssertEqual(theme, .sepia, "Expected sepia theme if App theme is not dark")
     }
 
     func test_readerThemeSepiaWithAppDark_returnsSepia() {
-        themeManager.changeCurrentTheme(.dark, for: windowUUID)
+        themeManager.changeManualTheme(to: .dark, for: windowUUID)
         let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.sepia, window: windowUUID)
         XCTAssertEqual(theme, .dark, "Expected dark theme if App theme is dark")
     }
 
     func test_preferredColorTheme_changesFromLightToDark() {
-        themeManager.changeCurrentTheme(.dark, for: windowUUID)
+        themeManager.changeManualTheme(to: .dark, for: windowUUID)
         var readerModeStyle = ReaderModeStyle(windowUUID: windowUUID,
                                               theme: .light,
                                               fontType: .sansSerif,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ReaderModeStyleTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ReaderModeStyleTests.swift
@@ -91,32 +91,32 @@ class ReaderModeStyleTests: XCTestCase {
     // MARK: - ReaderModeTheme
 
     func test_defaultReaderModeTheme_returnsLight() {
-        themeManager.setManualTheme(to: .light, for: windowUUID)
+        themeManager.setManualTheme(to: .light)
         let defaultTheme = ReaderModeTheme.preferredTheme(for: nil, window: windowUUID)
         XCTAssertEqual(defaultTheme, .light, "Expected light theme (default) if not theme is selected")
     }
 
     func test_appWideThemeDark_returnsDark() {
-        themeManager.setManualTheme(to: .dark, for: windowUUID)
+        themeManager.setManualTheme(to: .dark)
         let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.light, window: windowUUID)
 
         XCTAssertEqual(theme, .dark, "Expected dark theme because of the app theme")
     }
 
     func test_readerThemeSepia_returnsSepia() {
-        themeManager.setManualTheme(to: .light, for: windowUUID)
+        themeManager.setManualTheme(to: .light)
         let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.sepia, window: windowUUID)
         XCTAssertEqual(theme, .sepia, "Expected sepia theme if App theme is not dark")
     }
 
     func test_readerThemeSepiaWithAppDark_returnsSepia() {
-        themeManager.setManualTheme(to: .dark, for: windowUUID)
+        themeManager.setManualTheme(to: .dark)
         let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.sepia, window: windowUUID)
         XCTAssertEqual(theme, .dark, "Expected dark theme if App theme is dark")
     }
 
     func test_preferredColorTheme_changesFromLightToDark() {
-        themeManager.setManualTheme(to: .dark, for: windowUUID)
+        themeManager.setManualTheme(to: .dark)
         var readerModeStyle = ReaderModeStyle(windowUUID: windowUUID,
                                               theme: .light,
                                               fontType: .sansSerif,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ReaderModeStyleTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ReaderModeStyleTests.swift
@@ -91,32 +91,32 @@ class ReaderModeStyleTests: XCTestCase {
     // MARK: - ReaderModeTheme
 
     func test_defaultReaderModeTheme_returnsLight() {
-        themeManager.changeManualTheme(to: .light, for: windowUUID)
+        themeManager.setManualTheme(to: .light, for: windowUUID)
         let defaultTheme = ReaderModeTheme.preferredTheme(for: nil, window: windowUUID)
         XCTAssertEqual(defaultTheme, .light, "Expected light theme (default) if not theme is selected")
     }
 
     func test_appWideThemeDark_returnsDark() {
-        themeManager.changeManualTheme(to: .dark, for: windowUUID)
+        themeManager.setManualTheme(to: .dark, for: windowUUID)
         let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.light, window: windowUUID)
 
         XCTAssertEqual(theme, .dark, "Expected dark theme because of the app theme")
     }
 
     func test_readerThemeSepia_returnsSepia() {
-        themeManager.changeManualTheme(to: .light, for: windowUUID)
+        themeManager.setManualTheme(to: .light, for: windowUUID)
         let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.sepia, window: windowUUID)
         XCTAssertEqual(theme, .sepia, "Expected sepia theme if App theme is not dark")
     }
 
     func test_readerThemeSepiaWithAppDark_returnsSepia() {
-        themeManager.changeManualTheme(to: .dark, for: windowUUID)
+        themeManager.setManualTheme(to: .dark, for: windowUUID)
         let theme = ReaderModeTheme.preferredTheme(for: ReaderModeTheme.sepia, window: windowUUID)
         XCTAssertEqual(theme, .dark, "Expected dark theme if App theme is dark")
     }
 
     func test_preferredColorTheme_changesFromLightToDark() {
-        themeManager.changeManualTheme(to: .dark, for: windowUUID)
+        themeManager.setManualTheme(to: .dark, for: windowUUID)
         var readerModeStyle = ReaderModeStyle(windowUUID: windowUUID,
                                               theme: .light,
                                               fontType: .sansSerif,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
@@ -98,7 +98,7 @@ class ThemeSettingsControllerTests: XCTestCase {
         subject.themeManager.setAutomaticBrightnessValue(userBrightness)
 
         subject.systemBrightnessChanged()
-        XCTAssertEqual(subject.themeManager.currentTheme(for: windowUUID).type, .light)
+        XCTAssertEqual(subject.themeManager.getcurrentTheme(for: windowUUID).type, .light)
     }
 
     func testSystemBrightnessChanged_ForDarkTheme_WithRedux() {
@@ -114,7 +114,7 @@ class ThemeSettingsControllerTests: XCTestCase {
         subject.themeManager.setAutomaticBrightnessValue(userBrightness)
 
         subject.systemBrightnessChanged()
-        XCTAssertEqual(subject.themeManager.currentTheme(for: windowUUID).type, .dark)
+        XCTAssertEqual(subject.themeManager.getcurrentTheme(for: windowUUID).type, .dark)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
@@ -98,7 +98,7 @@ class ThemeSettingsControllerTests: XCTestCase {
         subject.themeManager.setAutomaticBrightnessValue(userBrightness)
 
         subject.systemBrightnessChanged()
-        XCTAssertEqual(subject.themeManager.getcurrentTheme(for: windowUUID).type, .light)
+        XCTAssertEqual(subject.themeManager.getCurrentTheme(for: windowUUID).type, .light)
     }
 
     func testSystemBrightnessChanged_ForDarkTheme_WithRedux() {
@@ -114,7 +114,7 @@ class ThemeSettingsControllerTests: XCTestCase {
         subject.themeManager.setAutomaticBrightnessValue(userBrightness)
 
         subject.systemBrightnessChanged()
-        XCTAssertEqual(subject.themeManager.getcurrentTheme(for: windowUUID).type, .dark)
+        XCTAssertEqual(subject.themeManager.getCurrentTheme(for: windowUUID).type, .dark)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/VersionSettingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/VersionSettingTests.swift
@@ -31,7 +31,7 @@ class VersionSettingTests: XCTestCase {
         let versionSetting = VersionSetting(settingsDelegate: delegate)
         versionSetting.theme = DefaultThemeManager(
             sharedContainerIdentifier: AppInfo.sharedContainerIdentifier
-        ).currentTheme(for: windowUUID)
+        ).getcurrentTheme(for: windowUUID)
 
         // When
         versionSetting.onLongPress(navigationController)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/VersionSettingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/VersionSettingTests.swift
@@ -31,7 +31,7 @@ class VersionSettingTests: XCTestCase {
         let versionSetting = VersionSetting(settingsDelegate: delegate)
         versionSetting.theme = DefaultThemeManager(
             sharedContainerIdentifier: AppInfo.sharedContainerIdentifier
-        ).getcurrentTheme(for: windowUUID)
+        ).getCurrentTheme(for: windowUUID)
 
         // When
         versionSetting.onLongPress(navigationController)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9331)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20663)

## :bulb: Description
OK. So, I was fixing a bug, and then another bug would pop up. I got tired of it, and decided to fix everything in one go by fixing the underlying logic of the theming system.

Changes of note:
- If you want to do something theming related, now you use the appropriate, clearly-named function, instead of the confusing chain of oddly-named function calls from before
- Standardized function naming re: get & set
- `determineThemeType(for...` is now the heart of the theming system when it comes to deciding what theme needs to be shown instead of managing that in a bunch of different places
- Removed `windowThemeState` 🎉 
- Removed the use of `window` throughout the theming system as much as possible. `window` is really only needed for private mode stuff, but it started getting introduced in a bunch of places because of the chain calls. I've just simplified this to only the stuff needed 🥳 
- Refactored the theme settings middleware to 1) adapt to the new changes, and b) make it easier to read 🤓 

For review:
The bulk of the meaningful changes are in `DefaultThemeManager` and in `ThemeMiddleware`. Everything else is mostly updates from naming and such.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

