### PR TITLE
Bugfix FXIOS-8567 Flicker bug on search

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
@@ -262,7 +262,7 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
                     limit: maxNumOfFirefoxSuggestions
             ) else { return }
             await MainActor.run {
-                guard self.searchQuery == tempSearchQuery else { return }
+                guard self.searchQuery == tempSearchQuery, self.firefoxSuggestions != suggestions else { return }
                 self.firefoxSuggestions = suggestions
                 self.delegate?.reloadTableView()
             }
@@ -355,13 +355,16 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
 
     // MARK: LoaderListener
     func loader(dataLoaded data: Cursor<Site>) {
+        let previousData = self.delegate?.searchData
         self.delegate?.searchData = if shouldShowSponsoredSuggestions {
             ArrayCursor<Site>(data: SponsoredContentFilterUtility().filterSponsoredSites(from: data.asArray()))
         } else {
             data
         }
 
-        delegate?.reloadTableView()
+        if previousData?.asArray() != self.delegate?.searchData.asArray() {
+            delegate?.reloadTableView()
+        }
     }
 }
 

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggestion.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggestion.swift
@@ -21,7 +21,14 @@ public enum RustFirefoxSuggestionTelemetryInfo {
 }
 /// A Firefox Suggest search suggestion. This struct is a Swiftier
 /// representation of the Rust `Suggestion` enum.
-public struct RustFirefoxSuggestion {
+public struct RustFirefoxSuggestion: Equatable {
+    public static func == (lhs: RustFirefoxSuggestion, rhs: RustFirefoxSuggestion) -> Bool {
+        return lhs.title == rhs.title &&
+        lhs.url == rhs.url &&
+        lhs.isSponsored == rhs.isSponsored &&
+        lhs.iconImage == rhs.iconImage
+    }
+
     public let title: String
     public let url: URL
     public let isSponsored: Bool


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8567)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19044)

## :bulb: Description
Discussed that I would like to explore diffable datasource, but at the current stage of the code base this requires more effort and time outside of work week. 

In the meantime, I added a check to only reload collection if the search suggestions data is different, which causes less flickering. Used TDD to test the areas to improve level of confidence in this update.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

# Screenshots 
| iPhone |
| --- |
| https://github.com/mozilla-mobile/firefox-ios/assets/6743397/98a66819-d45f-4c48-89a7-4ffba7f5ec50 |

