### PR TITLE
Bugfix FXIOS-5382 Prevent presenting FxAWebViewController when unexpected QR code is scanned during sync setup

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1086,6 +1086,7 @@
 		C4E398601D22C409004E89BA /* TopTabsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E3985F1D22C409004E89BA /* TopTabsLayout.swift */; };
 		C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */; };
 		C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F3B2991CFCF93A00966259 /* ButtonToast.swift */; };
+		C787D8C32C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */; };
 		C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80685D026A0C93900DCD895 /* UserResearch.swift */; };
 		C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */; };
 		C80C11EE28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80C11ED28B3C8B80062922A /* WallpaperMetadataTrackerTests.swift */; };
@@ -6837,6 +6838,7 @@
 		C6C94C1CB6286845DEAF8EDD /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C7354071A05454E7FF3C70D8 /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		C7664A29B78A808DC314353C /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Search.strings; sourceTree = "<group>"; };
+		C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxAccountSignInViewControllerTests.swift; sourceTree = "<group>"; };
 		C7A6413B89FE82B94F735FFD /* gl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gl; path = gl.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		C7C54345A164D550CF2BC575 /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		C7D341F8BA6A9E44518C11C8 /* oc */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = oc; path = oc.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
@@ -12177,6 +12179,7 @@
 				814A62452B587A3E00608195 /* DefaultThemeManagerTests.swift */,
 				E1E425312B5A2E9700899550 /* DownloadTests.swift */,
 				0AC659262BF35854005C614A /* FxAWebViewModelTests.swift */,
+				C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -15010,6 +15013,7 @@
 				8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */,
 				C8B394362A0ED55D00700E49 /* MockOnboardingCardDelegate.swift in Sources */,
 				8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */,
+				C787D8C32C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift in Sources */,
 				39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */,
 				8AAEB9FE2BF50718000C02B5 /* MicrosurveyViewControllerTests.swift in Sources */,
 				C8E531CC29E72A2F00E03FEF /* ShortcutRouteTests.swift in Sources */,

--- a/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
@@ -8,6 +8,8 @@ import Account
 import Common
 import ComponentLibrary
 
+import enum MozillaAppServices.OAuthScope
+
 /// Reflects parent page that launched FirefoxAccountSignInViewController
 enum FxASignInParentType {
     case settings
@@ -275,12 +277,33 @@ extension FirefoxAccountSignInViewController: QRCodeViewControllerDelegate {
             telemetryObj: telemetryObject
         )
 
-        let vc = FxAWebViewController(pageType: .qrCode(url: url.absoluteString),
-                                      profile: profile,
-                                      dismissalStyle: fxaDismissStyle,
-                                      deepLinkParams: deepLinkParams,
-                                      shouldAskForNotificationPermission: shouldAskForPermission)
-        navigationController?.pushViewController(vc, animated: true)
+        // Only show the FxAWebViewController if the correct FxA pairing QR code was captured
+        if let accountManager = profile.rustFxA.accountManager {
+            let entrypoint = self.deepLinkParams.entrypoint.rawValue
+            accountManager.getManageAccountURL(entrypoint: "ios_settings_\(entrypoint)") { [weak self] result in
+                guard let self = self else { return }
+                accountManager.beginPairingAuthentication(
+                    pairingUrl: url.absoluteString,
+                    entrypoint: "pairing_\(entrypoint)",
+                    // We ask for the session scope because the web content never
+                    // got the session as the user never entered their email and
+                    // password
+                    scopes: [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.session]
+                ) { [weak self] result in
+                    guard let self = self else { return }
+
+                    if case .success(let url) = result {
+                        let vc = FxAWebViewController(
+                            pageType: .qrCode(url: url),
+                            profile: profile,
+                            dismissalStyle: fxaDismissStyle,
+                            deepLinkParams: deepLinkParams,
+                            shouldAskForNotificationPermission: shouldAskForPermission)
+                        navigationController?.pushViewController(vc, animated: true)
+                    }
+                }
+            }
+        }
     }
 
     func didScanQRCodeWithText(_ text: String) {

--- a/firefox-ios/RustFxA/FxAWebViewController.swift
+++ b/firefox-ios/RustFxA/FxAWebViewController.swift
@@ -90,6 +90,10 @@ class FxAWebViewController: UIViewController {
             self?.endPairingConnectionBackgroundTask()
             self?.dismiss(animated: true)
         }
+
+        viewModel.onPopController = { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        }
     }
 
     /**

--- a/firefox-ios/RustFxA/FxAWebViewController.swift
+++ b/firefox-ios/RustFxA/FxAWebViewController.swift
@@ -90,10 +90,6 @@ class FxAWebViewController: UIViewController {
             self?.endPairingConnectionBackgroundTask()
             self?.dismiss(animated: true)
         }
-
-        viewModel.onPopController = { [weak self] in
-            self?.navigationController?.popViewController(animated: true)
-        }
     }
 
     /**

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -15,7 +15,7 @@ import struct MozillaAppServices.UserData
 
 enum FxAPageType: Equatable {
     case emailLoginFlow
-    case qrCode(url: String)
+    case qrCode(url: URL)
     case settingsPage
 }
 
@@ -106,6 +106,8 @@ class FxAWebViewModel: FeatureFlaggable {
 
     var onDismissController: (() -> Void)?
 
+    var onPopController: (() -> Void)?
+
     func composeTitle(basedOn url: URL?, hasOnlySecureContent: Bool) -> String {
         return (hasOnlySecureContent ? "🔒 " : "") + (url?.host ?? "")
     }
@@ -137,21 +139,8 @@ class FxAWebViewModel: FeatureFlaggable {
                         }
                     }
                 case let .qrCode(url):
-                    accountManager.beginPairingAuthentication(
-                        pairingUrl: url,
-                        entrypoint: "pairing_\(entrypoint)",
-                        // We ask for the session scope because the web content never
-                        // got the session as the user never entered their email and
-                        // password
-                        scopes: [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.session]
-                    ) { [weak self] result in
-                        guard let self = self else { return }
-
-                        if case .success(let url) = result {
-                            self.baseURL = url
-                            completion(self.makeRequest(url), .qrPairing)
-                        }
-                    }
+                    self.baseURL = url
+                    completion(self.makeRequest(url), .qrPairing)
                 case .settingsPage:
                     if case .success(let url) = result {
                         self.baseURL = url

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -106,8 +106,6 @@ class FxAWebViewModel: FeatureFlaggable {
 
     var onDismissController: (() -> Void)?
 
-    var onPopController: (() -> Void)?
-
     func composeTitle(basedOn url: URL?, hasOnlySecureContent: Bool) -> String {
         return (hasOnlySecureContent ? "🔒 " : "") + (url?.host ?? "")
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FirefoxAccountSignInViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FirefoxAccountSignInViewControllerTests.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+
+@testable import Client
+
+final class FirefoxAccountSignInViewControllerTests: XCTestCase {
+    let windowUUID: WindowUUID = .XCTestDefaultUUID
+    private var mockProfile: MockProfile!
+    var deeplinkParams: FxALaunchParams!
+
+    override class func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        mockProfile = MockProfile()
+        deeplinkParams = FxALaunchParams(entrypoint: .browserMenu, query: ["test_key": "test_value"])
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        DependencyHelperMock().reset()
+    }
+
+    func testFirefoxAccountSignInViewController_simpleCreation_hasNoLeaks() {
+        let testFirefoxAccountSignInViewController = FirefoxAccountSignInViewController(
+            profile: mockProfile,
+            parentType: .appMenu,
+            deepLinkParams: deeplinkParams,
+            windowUUID: windowUUID
+        )
+        trackForMemoryLeaks(testFirefoxAccountSignInViewController)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FirefoxAccountSignInViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FirefoxAccountSignInViewControllerTests.swift
@@ -12,7 +12,7 @@ final class FirefoxAccountSignInViewControllerTests: XCTestCase {
     private var mockProfile: MockProfile!
     var deeplinkParams: FxALaunchParams!
 
-    override class func setUp() {
+    override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         mockProfile = MockProfile()

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -95,6 +95,7 @@
     {
       "skippedTests" : [
         "ETPCoverSheetTests",
+        "FirefoxHomeViewModelTests\/testNumberOfSection_withoutUpdatingData_has2Sections()",
         "GleanPlumbMessageManagerTests\/testManagerOnMessagePressed_withMalformedURL()",
         "HistoryHighlightsDataAdaptorTests",
         "HistoryHighlightsDataAdaptorTests\/testReloadDataOnNotification()",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-5382)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/#12599)

## :bulb: Description
- This PR stops `FxAWebViewController` from being presented after scanning an unexpected QR code during sync setup. Before this fix, the web view was always presented and showed a blank web view when scanning an unexpected QR code. This required moving logic out of `FxAWebViewModel` and into `FirefoxAccountSignInViewController`
- The issue is resolved when initiating the sync setup flow from both the main app menu and the settings menu
- This issue only pertained to QR codes containing URLs (not text)

Notes:
* Out of scope for this ticket:
  * View presentation should be handled by a coordinator.
  * An error/alert should presented to the user (instead of it looking like nothing happened)

Videos:

<details>
<summary>Before</summary>

https://github.com/mozilla-mobile/firefox-ios/assets/15353801/a23bac2d-c738-4ca3-950d-4c4faecbc14c

</details>


<details>
<summary>After</summary>

https://github.com/mozilla-mobile/firefox-ios/assets/15353801/5bdd3639-6691-4c6b-ac9f-8a058a480495

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

