### PR TITLE
Bugfix FXIOS-9314 Remove Send to Device as an option on the tab tray refactor

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPeekAction.swift
@@ -24,7 +24,6 @@ enum TabPeekActionType: ActionType {
     // MARK: - View Actions
     case didLoadTabPeek
     case addToBookmarks
-    case sendToDevice
     case copyURL
     case closeTab
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -41,9 +41,6 @@ class TabManagerMiddleware {
         case TabPeekActionType.addToBookmarks:
             addToBookmarks(with: tabUUID, uuid: action.windowUUID)
 
-        case TabPeekActionType.sendToDevice:
-            sendToDevice(tabID: tabUUID, uuid: action.windowUUID)
-
         case TabPeekActionType.copyURL:
             copyURL(tabID: tabUUID, uuid: action.windowUUID)
 
@@ -576,19 +573,6 @@ class TabManagerMiddleware {
                                      method: .add,
                                      object: .bookmark,
                                      value: .tabTray)
-    }
-
-    private func sendToDevice(tabID: TabUUID, uuid: WindowUUID) {
-        let tabManager = tabManager(for: uuid)
-        guard let tabToShare = tabManager.getTabForUUID(uuid: tabID),
-              let url = tabToShare.url
-        else { return }
-
-        let action = TabPanelViewAction(panelType: .tabs,
-                                        shareSheetURL: url,
-                                        windowUUID: uuid,
-                                        actionType: TabPanelViewActionType.showShareSheet)
-        store.dispatch(action)
     }
 
     private func copyURL(tabID: TabUUID, uuid: WindowUUID) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabPeekViewController.swift
@@ -107,19 +107,6 @@ class TabPeekViewController: UIViewController,
                 return
             })
         }
-        if tabPeekState.showSendToDevice {
-            actions.append(UIAction(
-                title: .AppMenu.TouchActions.SendToDeviceTitle,
-                image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.shareApple),
-                identifier: nil) { [weak self] _ in
-                    guard let self else { return }
-                    let action = TabPeekAction(tabUUID: self.tab.tabUUID,
-                                               windowUUID: self.windowUUID,
-                                               actionType: TabPeekActionType.sendToDevice)
-                    store.dispatch(action)
-                    return
-            })
-        }
         if tabPeekState.showCopyURL {
             actions.append(UIAction(title: .TabPeekCopyUrl,
                                     image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.link),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9314)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20637)

## :bulb: Description
Remove Send to Device as an option on the tab tray refactor long press context menus on tabs when user is logged in and site is not bookmarked

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

