### PR TITLE
Fixes MTE-2968 for changes on recently saved section

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -365,9 +365,9 @@ class BookmarksTests: BaseTestCase {
         waitForTabsButton()
         bookmark()
         navigator.performAction(Action.GoToHomePage)
-        mozWaitForElementToExist(app.staticTexts["Recently Saved"])
-        mozWaitForElementToExist(app.cells["RecentlySavedCell"])
-        app.cells["RecentlySavedCell"].press(forDuration: 1.5)
+        mozWaitForElementToExist(app.staticTexts["Bookmarks"])
+        mozWaitForElementToExist(app.cells["BookmarksCell"])
+        app.cells["BookmarksCell"].press(forDuration: 1.5)
         // The context menu opens, having the correct options
         let ContextMenuTable = app.tables["Context Menu"]
         mozWaitForElementToExist(ContextMenuTable)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -57,8 +57,8 @@ class HomePageSettingsUITests: BaseTestCase {
         XCTAssertTrue(app.tables.cells["TopSitesSettings"].staticTexts["On"].exists)
         let jumpBackIn = app.tables.cells.switches["Jump Back In"].value
         XCTAssertEqual("1", jumpBackIn as? String)
-        let recentlySaved = app.tables.cells.switches["Recently Saved"].value
-        XCTAssertEqual("1", recentlySaved as? String)
+        let bookmarks = app.tables.cells.switches["Bookmarks"].value
+        XCTAssertEqual("1", bookmarks as? String)
         // FXIOS-8107: Commented out as history highlights has been disabled to fix app hangs / slowness
         // Reloads for notification
         // let recentlyVisited = app.tables.cells.switches["Recently Visited"].value


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-2968

## :bulb: Description
Recently saved section has been renamed to bookmarks. 
Changed affected tests by this.
