### PR TITLE
Add FXIOS-8976 [Microsurvey] Privacy notice

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -95,6 +95,10 @@ struct GleanPlumbMessage {
     var icon: UIImage? {
         return data.microsurveyConfig?.icon
     }
+
+    var utmContent: String? {
+        return data.microsurveyConfig?.utmContent
+    }
 }
 
 /// Public properties for this message.

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyModel.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyModel.swift
@@ -10,4 +10,5 @@ struct MicrosurveyModel: Equatable {
     let surveyQuestion: String
     let surveyOptions: [String]
     let icon: UIImage?
+    let utmContent: String?
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
@@ -37,13 +37,15 @@ class MicrosurveySurfaceManager: MobileMessageSurfaceProtocol {
         let promptButtonLabel = message?.buttonLabel ?? .Microsurvey.Prompt.TakeSurveyButton
         let options: [String] = message?.options ?? defaultSurveyOptions
         let icon = message?.icon
+        let utmContent = message?.utmContent
 
         return MicrosurveyModel(
             promptTitle: promptTitle,
             promptButtonLabel: promptButtonLabel,
             surveyQuestion: surveyQuestion,
             surveyOptions: options,
-            icon: icon
+            icon: icon,
+            utmContent: utmContent
         )
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyCoordinator.swift
@@ -8,10 +8,15 @@ import Shared
 
 protocol MicrosurveyCoordinatorDelegate: AnyObject {
     func dismissFlow()
-    func showPrivacy()
+    func showPrivacy(with content: String?)
 }
 
 final class MicrosurveyCoordinator: BaseCoordinator, FeatureFlaggable, MicrosurveyCoordinatorDelegate {
+    private struct UTMParams {
+        static let source = "modal"
+        static let campaign = "microsurvey"
+    }
+
     weak var parentCoordinator: ParentCoordinatorDelegate?
     private let tabManager: TabManager
     private var windowUUID: WindowUUID { return tabManager.windowUUID }
@@ -36,9 +41,15 @@ final class MicrosurveyCoordinator: BaseCoordinator, FeatureFlaggable, Microsurv
         parentCoordinator?.didFinish(from: self)
     }
 
-    func showPrivacy() {
+    func showPrivacy(with content: String?) {
         // TODO: FXIOS-8976 - Add to Support Utils
-        guard let url = URL(string: "https://www.mozilla.org/privacy/firefox") else { return }
+        guard let url = SupportUtils.URLForPrivacyNotice(
+            source: UTMParams.source,
+            campaign: UTMParams.campaign,
+            content: content
+        ) else {
+            return
+        }
         tabManager.addTabsForURLs([url], zombie: false, shouldSelectTab: true)
         router.dismiss(animated: true, completion: nil)
         parentCoordinator?.didFinish(from: self)

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyCoordinator.swift
@@ -47,9 +47,7 @@ final class MicrosurveyCoordinator: BaseCoordinator, FeatureFlaggable, Microsurv
             source: UTMParams.source,
             campaign: UTMParams.campaign,
             content: content
-        ) else {
-            return
-        }
+        ) else { return }
         tabManager.addTabsForURLs([url], zombie: false, shouldSelectTab: true)
         router.dismiss(animated: true, completion: nil)
         parentCoordinator?.didFinish(from: self)

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -138,7 +138,7 @@ final class MicrosurveyViewController: UIViewController,
         if microsurveyState.shouldDismiss {
             coordinator?.dismissFlow()
         } else if microsurveyState.showPrivacy {
-            coordinator?.showPrivacy()
+            coordinator?.showPrivacy(with: model.utmContent)
         }
     }
 

--- a/firefox-ios/Shared/SupportUtils.swift
+++ b/firefox-ios/Shared/SupportUtils.swift
@@ -42,9 +42,8 @@ public struct SupportUtils {
 
         guard let languageIdentifier = Locale.preferredLanguages.first else {
             return defaultURL
-
         }
-        
+
         var privacyNoticeString =
                     "https://www.mozilla.org/\(languageIdentifier)/privacy/firefox/?utm_medium=firefox-mobile&utm_source=\(source)&utm_campaign=\(campaign)"
 

--- a/firefox-ios/Shared/SupportUtils.swift
+++ b/firefox-ios/Shared/SupportUtils.swift
@@ -37,6 +37,24 @@ public struct SupportUtils {
         return URL(string: "https://support.mozilla.org/1/mobile/\(AppInfo.appVersion)/iOS/\(languageIdentifier)/\(escapedTopic)")
     }
 
+    public static func URLForPrivacyNotice(source: String, campaign: String, content: String?) -> URL? {
+        let defaultURL = URL(string: "https://www.mozilla.org/privacy/firefox")
+
+        guard let languageIdentifier = Locale.preferredLanguages.first else {
+            return defaultURL
+
+        }
+        
+        var privacyNoticeString =
+                    "https://www.mozilla.org/\(languageIdentifier)/privacy/firefox/?utm_medium=firefox-mobile&utm_source=\(source)&utm_campaign=\(campaign)"
+
+        if let content {
+            privacyNoticeString.append("&utm_content=\(content)")
+        }
+
+        return URL(string: privacyNoticeString) ?? defaultURL
+    }
+
     public static func URLForReportSiteIssue(_ siteUrl: String?) -> URL? {
         // Construct a NSURL pointing to the webcompat.com server to report an issue.
         //

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyCoordinatorTests.swift
@@ -52,11 +52,22 @@ final class MicrosurveyCoordinatorTests: XCTestCase {
         let subject = createSubject()
 
         subject.start()
-        subject.showPrivacy()
+        subject.showPrivacy(with: nil)
 
         XCTAssertEqual(mockRouter.dismissCalled, 1)
         XCTAssertEqual(mockTabManager.addTabsForURLsCalled, 1)
-        XCTAssertEqual(mockTabManager.addTabsURLs, [URL(string: "https://www.mozilla.org/privacy/firefox")])
+        XCTAssertEqual(mockTabManager.addTabsURLs, [URL(string: "https://www.mozilla.org/en-US/privacy/firefox/?utm_medium=firefox-mobile&utm_source=modal&utm_campaign=microsurvey")])
+    }
+
+    func testMicrosurveyDelegate_showPrivacyWithContentParams_callsRouterDismiss_andCreatesNewTab() throws {
+        let subject = createSubject()
+
+        subject.start()
+        subject.showPrivacy(with: "homepage")
+
+        XCTAssertEqual(mockRouter.dismissCalled, 1)
+        XCTAssertEqual(mockTabManager.addTabsForURLsCalled, 1)
+        XCTAssertEqual(mockTabManager.addTabsURLs, [URL(string: "https://www.mozilla.org/en-US/privacy/firefox/?utm_medium=firefox-mobile&utm_source=modal&utm_campaign=microsurvey&utm_content=homepage")])
     }
 
     private func createSubject(file: StaticString = #file,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMockModel.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMockModel.swift
@@ -15,7 +15,8 @@ class MicrosurveyMock {
                 "yes",
                 "no"
             ],
-            icon: nil
+            icon: nil,
+            utmContent: nil
         )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyViewControllerTests.swift
@@ -10,7 +10,7 @@ import Common
 final class MicrosurveyViewControllerTests: XCTestCase {
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
-    override class func setUp() {
+    override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/SupportUtilsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/SupportUtilsTests.swift
@@ -19,4 +19,36 @@ class SupportUtilsTests: XCTestCase {
     func testURLForWhatsNew() {
         XCTAssertEqual(SupportUtils.URLForWhatsNew?.absoluteString, "https://www.mozilla.org/en-US/firefox/ios/notes/")
     }
+
+    func testURLForPrivacyNotice_withoutContentParam() {
+        let appVersion = AppInfo.appVersion
+        let languageIdentifier = Locale.preferredLanguages.first!
+
+        let urlString = SupportUtils.URLForPrivacyNotice(
+            source: "modal",
+            campaign: "microsurvey",
+            content: nil
+        )?.absoluteString
+
+        XCTAssertEqual(
+            urlString,
+            "https://www.mozilla.org/\(languageIdentifier)/privacy/firefox/?utm_medium=firefox-mobile&utm_source=modal&utm_campaign=microsurvey"
+        )
+    }
+
+    func testURLForPrivacyNotice_withContentParam() {
+        let appVersion = AppInfo.appVersion
+        let languageIdentifier = Locale.preferredLanguages.first!
+
+        let urlString = SupportUtils.URLForPrivacyNotice(
+            source: "modal",
+            campaign: "microsurvey",
+            content: "homepage"
+        )?.absoluteString
+
+        XCTAssertEqual(
+            urlString,
+            "https://www.mozilla.org/\(languageIdentifier)/privacy/firefox/?utm_medium=firefox-mobile&utm_source=modal&utm_campaign=microsurvey&utm_content=homepage"
+        )
+    }
 }

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -64,6 +64,7 @@ import:
                 text: "How satisfied are you with your Firefox homepage?" # Should not show this message if this is nil
                 button-label: Microsurvey/Microsurvey.Prompt.Button.v127
                 microsurveyConfig:
+                  utm-content: homepage
                   icon: homeLarge
                   options:
                     - Microsurvey/Microsurvey.Survey.Options.LikertScaleOption1.v127

--- a/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
@@ -191,6 +191,10 @@ objects:
     description: >
         Attributes relating to microsurvey messaging.
     fields:
+      utm-content:
+        description: The name used to provide as the utm_content parameter for the privacy notice.
+        type: Option<String>
+        default: null
       icon:
         description: The asset name in our bundle used as the icon shown in the survey.
         type: Image


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8976)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19819)

## :bulb: Description
Add privacy notice URL to `SupportUtils` so it can be more reusable instead of hard coded in the app. 
Example Privacy notice:
`https://www.mozilla.org/en-US/privacy/firefox/?utm_medium=firefox-mobile&utm_source=modal&utm_campaign=microsurvey&utm_content=homepage`

- content can be optional if the feature is not provided in the experiment recipe

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

# Screenshots
| English | German |
| --- | --- |
|![simulator_screenshot_6943487D-DC63-4E29-BDC5-85EED8A1AABD](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/e6f9e00b-4f74-4d99-b604-218f75dc5a47)| ![simulator_screenshot_2DADBC35-FECD-4062-A85E-42CE0517076B](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/f19110e1-6aae-4f3e-b4fc-538ef944c694)|
