### PR TITLE
Add FXIOS-9301 [Microsurvey] Redux cleanup

### DIFF
--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -38,6 +38,9 @@ class DependencyHelper {
         let themeManager: ThemeManager = appDelegate.themeManager
         AppContainer.shared.register(service: themeManager)
 
+        let microsurveyManager = MicrosurveySurfaceManager()
+        AppContainer.shared.register(service: microsurveyManager)
+
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
@@ -57,7 +57,6 @@ class MicrosurveySurfaceManager: MobileMessageSurfaceProtocol {
     }
 
     func handleMessagePressed() {
-        // TODO: FXIOS-8797: Add telemetry to capture user responses
         guard let message else { return }
         messagingManager.onMessagePressed(message, window: nil)
     }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
@@ -7,7 +7,14 @@ import Redux
 import Common
 
 class MicrosurveyPromptAction: Action { }
-class MicrosurveyPromptMiddlewareAction: Action { }
+
+class MicrosurveyPromptMiddlewareAction: Action {
+    let microsurveyModel: MicrosurveyModel?
+    init(microsurveyModel: MicrosurveyModel? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
+        self.microsurveyModel = microsurveyModel
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
 
 enum MicrosurveyPromptActionType: ActionType {
     case showPrompt
@@ -16,7 +23,7 @@ enum MicrosurveyPromptActionType: ActionType {
 }
 
 enum MicrosurveyPromptMiddlewareActionType: ActionType {
-    case initialize(MicrosurveyModel)
+    case initialize
     case dismissPrompt
     case openSurvey
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
@@ -8,7 +8,11 @@ import Shared
 import Common
 
 class MicrosurveyPromptMiddleware {
-    let microsurveySurfaceManager = MicrosurveySurfaceManager()
+    private let microsurveySurfaceManager: MicrosurveySurfaceManager
+
+    init(microsurveySurfaceManager: MicrosurveySurfaceManager = AppContainer.shared.resolve()) {
+        self.microsurveySurfaceManager = microsurveySurfaceManager
+    }
 
     lazy var microsurveyProvider: Middleware<AppState> = { state, action in
         let windowUUID = action.windowUUID
@@ -35,8 +39,9 @@ class MicrosurveyPromptMiddleware {
 
     private func initializeMicrosurvey(windowUUID: WindowUUID, model: MicrosurveyModel) {
         let newAction = MicrosurveyPromptMiddlewareAction(
+            microsurveyModel: model,
             windowUUID: windowUUID,
-            actionType: MicrosurveyPromptMiddlewareActionType.initialize(model)
+            actionType: MicrosurveyPromptMiddlewareActionType.initialize
         )
         store.dispatch(newAction)
         microsurveySurfaceManager.handleMessageDisplayed()

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -31,9 +31,11 @@ struct MicrosurveyPromptState: StateType, Equatable {
     }
 
     static let reducer: Reducer<Self> = { state, action in
-        // TODO: FXIOS-9068 Need to test this experience with multiwindow
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
+
         switch action.actionType {
-        case MicrosurveyPromptMiddlewareActionType.initialize(let model):
+        case MicrosurveyPromptMiddlewareActionType.initialize:
+            let model = (action as? MicrosurveyPromptMiddlewareAction)?.microsurveyModel
             return MicrosurveyPromptState(
                 windowUUID: state.windowUUID,
                 showPrompt: true,

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
@@ -8,6 +8,12 @@ import Shared
 import Common
 
 class MicrosurveyMiddleware {
+    private let microsurveySurfaceManager: MicrosurveySurfaceManager
+
+    init(microsurveySurfaceManager: MicrosurveySurfaceManager = AppContainer.shared.resolve()) {
+        self.microsurveySurfaceManager = microsurveySurfaceManager
+    }
+
     lazy var microsurveyProvider: Middleware<AppState> = { state, action in
         let windowUUID = action.windowUUID
         switch action.actionType {
@@ -40,7 +46,7 @@ class MicrosurveyMiddleware {
     }
 
     private func sendTelemetryAndClosePrompt(windowUUID: WindowUUID) {
-        // TODO: FXIOS-8990 - Send telemetry via Mobile messaging infrastructure
+        microsurveySurfaceManager.handleMessagePressed()
         closeMicrosurveyPrompt(windowUUID: windowUUID)
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
@@ -45,7 +45,8 @@ struct MicrosurveyState: ScreenState, Equatable {
     }
 
     static let reducer: Reducer<Self> = { state, action in
-        // TODO: FXIOS-9068 Need to test this experience with multiwindow
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
+
         switch action.actionType {
         case MicrosurveyMiddlewareActionType.dismissSurvey:
             return MicrosurveyState(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -45,6 +45,9 @@ class DependencyHelperMock {
         AppContainer.shared.register(service: windowManager)
         windowManager.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: windowUUID)
 
+        let microsurveyManager = MicrosurveySurfaceManager()
+        AppContainer.shared.register(service: microsurveyManager)
+
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
@@ -24,7 +24,7 @@ final class MicrosurveyPromptStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.showPrompt, false)
 
-        let action = getAction(for: .initialize(MicrosurveyMock.model))
+        let action = getAction(for: .initialize)
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.showPrompt, true)

--- a/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
@@ -68,7 +68,7 @@ import:
                 max-display-count: 5
               MICROSURVEY:
                 priority: 50
-                max-display-count: 5
+                max-display-count: 1
               NOTIFICATION:
                 priority: 50
                 max-display-count: 1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20592)

## :bulb: Description
Update redux changes to microsurvey
- Remove associated value
- Move dependency to be resolved by app container; add missing telemetry call
- Add guard so that actions are only applied to the specific windowUUID
- Update microsurvey display count for multiwindow and tested with redux

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
