### PR TITLE
Add FXIOS-9205 Create empty address middle view

### DIFF
--- a/firefox-ios/Client/Assets/Images.xcassets/locationLarge.imageset/Contents.json
+++ b/firefox-ios/Client/Assets/Images.xcassets/locationLarge.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
@@ -38,15 +38,21 @@ struct AddressCellView: View {
                         .foregroundColor(iconPrimary)
                         .offset(y: -14)
                     VStack(alignment: .leading) {
-                        Text(address.name)
-                            .font(.body)
-                            .foregroundColor(textColor)
-                        Text(address.streetAddress)
-                            .font(.subheadline)
-                            .foregroundColor(customLightGray)
-                        Text(address.addressCityStateZipcode)
-                            .font(.subheadline)
-                            .foregroundColor(customLightGray)
+                        if !address.name.isEmpty {
+                            Text(address.name)
+                                .font(.body)
+                                .foregroundColor(textColor)
+                        }
+                        if !address.streetAddress.isEmpty {
+                            Text(address.streetAddress)
+                                .font(.subheadline)
+                                .foregroundColor(customLightGray)
+                        }
+                        if !address.addressCityStateZipcode.isEmpty {
+                            Text(address.addressCityStateZipcode)
+                                .font(.subheadline)
+                                .foregroundColor(customLightGray)
+                        }
                     }
                     Spacer()
                 }
@@ -65,6 +71,7 @@ struct AddressCellView: View {
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
+        .accessibilityLabel(address.a11ySettingsRow)
     }
 
     // MARK: - Theme Application

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -11,6 +11,17 @@ import Storage
 
 /// A view displaying a list of addresses.
 struct AddressListView: View {
+    // MARK: - Constants
+
+    enum Constants {
+        static let imageWidth: CGFloat = 200
+        static let contentUnavailableViewPadding: CGFloat = 24
+        static let vStackSpacing: CGFloat = 0
+        static let titleFontSize: CGFloat = 22
+        static let subtitleFontSize: CGFloat = 16
+        static let contentUnavailableViewTopPadding: CGFloat = 125
+    }
+
     // MARK: - Properties
 
     let windowUUID: WindowUUID
@@ -19,30 +30,41 @@ struct AddressListView: View {
     @ObservedObject var viewModel: AddressListViewModel
     @State private var customLightGray: Color = .clear
 
+    @State var titleTextColor: Color = .clear
+    @State var subTextColor: Color = .clear
+    @State var imageColor: Color = .clear
+
     // MARK: - Body
 
     var body: some View {
-        List {
+        Group {
             if viewModel.showSection {
-                Section(header: Text(String.Addresses.Settings.SavedAddressesSectionTitle)) {
-                    ForEach(viewModel.addresses, id: \.self) { address in
-                        AddressCellView(
-                            windowUUID: windowUUID,
-                            address: address,
-                            onTap: {
-                                if viewModel.isEditingFeatureEnabled {
-                                    viewModel.addressTapped(address)
+                List {
+                    Section(header: Text(String.Addresses.Settings.SavedAddressesSectionTitle)) {
+                        ForEach(viewModel.addresses, id: \.self) { address in
+                            AddressCellView(
+                                windowUUID: windowUUID,
+                                address: address,
+                                onTap: {
+                                    if viewModel.isEditingFeatureEnabled {
+                                        viewModel.addressTapped(address)
+                                    }
                                 }
-                            }
-                        )
+                            )
+                        }
                     }
+                    .font(.caption)
+                    .foregroundColor(customLightGray)
                 }
-                .font(.caption)
-                .foregroundColor(customLightGray)
+                .listStyle(.plain)
+                .listRowInsets(EdgeInsets())
+            } else {
+                contentUnavailableView
+                    .padding(.top, Constants.contentUnavailableViewTopPadding)
+                    .padding(.horizontal, Constants.contentUnavailableViewPadding)
+                Spacer()
             }
         }
-        .listStyle(.plain)
-        .listRowInsets(EdgeInsets())
         .sheet(item: $viewModel.destination) { destination in
             NavigationView {
                 switch destination {
@@ -87,5 +109,36 @@ struct AddressListView: View {
     func applyTheme(theme: Theme) {
         let color = theme.colors
         customLightGray = Color(color.textSecondary)
+        titleTextColor = Color(color.textPrimary)
+        subTextColor = Color(color.textSecondary)
+        imageColor = Color(color.iconSecondary)
+    }
+
+    @ViewBuilder var contentUnavailableView: some View {
+        VStack {
+            Image(StandardImageIdentifiers.Large.location)
+                .resizable()
+                .renderingMode(.template)
+                .aspectRatio(contentMode: .fit)
+                .frame(width: Constants.imageWidth)
+                .foregroundColor(imageColor)
+                .accessibility(hidden: true)
+
+            VStack(spacing: Constants.vStackSpacing) {
+                Text(
+                    String(
+                        format: String.Addresses.Settings.SaveAddressesToFirefox,
+                        AppName.shortName.rawValue
+                    )
+                )
+                .preferredBodyFont(size: Constants.titleFontSize)
+                .foregroundColor(titleTextColor)
+
+                Text(String.Addresses.Settings.SecureSaveInfo)
+                    .preferredBodyFont(size: Constants.subtitleFontSize)
+                    .foregroundColor(subTextColor)
+            }
+            .multilineTextAlignment(.center)
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -58,7 +58,7 @@ struct AddressListView: View {
                 }
                 .listStyle(.plain)
                 .listRowInsets(EdgeInsets())
-            } else {
+            } else if viewModel.isEditingFeatureEnabled {
                 contentUnavailableView
                     .padding(.top, Constants.contentUnavailableViewTopPadding)
                     .padding(.horizontal, Constants.contentUnavailableViewPadding)

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -13,7 +13,7 @@ import Storage
 struct AddressListView: View {
     // MARK: - Constants
 
-    enum Constants {
+    private enum UX {
         static let imageWidth: CGFloat = 200
         static let contentUnavailableViewPadding: CGFloat = 24
         static let vStackSpacing: CGFloat = 0
@@ -60,8 +60,8 @@ struct AddressListView: View {
                 .listRowInsets(EdgeInsets())
             } else if viewModel.isEditingFeatureEnabled {
                 contentUnavailableView
-                    .padding(.top, Constants.contentUnavailableViewTopPadding)
-                    .padding(.horizontal, Constants.contentUnavailableViewPadding)
+                    .padding(.top, UX.contentUnavailableViewTopPadding)
+                    .padding(.horizontal, UX.contentUnavailableViewPadding)
                 Spacer()
             }
         }
@@ -120,22 +120,22 @@ struct AddressListView: View {
                 .resizable()
                 .renderingMode(.template)
                 .aspectRatio(contentMode: .fit)
-                .frame(width: Constants.imageWidth)
+                .frame(width: UX.imageWidth)
                 .foregroundColor(imageColor)
                 .accessibility(hidden: true)
 
-            VStack(spacing: Constants.vStackSpacing) {
+            VStack(spacing: UX.vStackSpacing) {
                 Text(
                     String(
                         format: String.Addresses.Settings.SaveAddressesToFirefox,
                         AppName.shortName.rawValue
                     )
                 )
-                .preferredBodyFont(size: Constants.titleFontSize)
+                .preferredBodyFont(size: UX.titleFontSize)
                 .foregroundColor(titleTextColor)
 
                 Text(String.Addresses.Settings.SecureSaveInfo)
-                    .preferredBodyFont(size: Constants.subtitleFontSize)
+                    .preferredBodyFont(size: UX.subtitleFontSize)
                     .foregroundColor(subTextColor)
             }
             .multilineTextAlignment(.center)

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -9,13 +9,6 @@ import Storage
 import struct MozillaAppServices.UpdatableAddressFields
 import struct MozillaAppServices.Address
 
-// TODO: Refactor the Address extension for global usage (FXIOS-8337)
-extension Address {
-    var addressCityStateZipcode: String {
-        return "\(addressLevel2), \(addressLevel1) \(postalCode)"
-    }
-}
-
 // AddressListViewModel: A view model for managing addresses.
 class AddressListViewModel: ObservableObject, FeatureFlaggable {
     enum Destination: Swift.Identifiable, Equatable {

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -185,7 +185,7 @@ class AddressListViewModel: ObservableObject, FeatureFlaggable {
             let addressString = try jsonString(from: address)
             let l10sString = try jsonString(from: EditAddressLocalization.editAddressLocalizationIDs)
 
-            let javascript = "init(\(addressString), \(l10sString), \(isDarkTheme(windowUUID));"
+            let javascript = "init(\(addressString), \(l10sString), \(isDarkTheme(windowUUID)));"
             return javascript
         } catch {
             logger.log("Failed to encode data",

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -213,7 +213,6 @@ class AddressListViewModel: ObservableObject, FeatureFlaggable {
 
             let addressString = try jsonString(from: address)
             let l10sString = try jsonString(from: EditAddressLocalization.editAddressLocalizationIDs)
-
             let isDarkTheme = isDarkTheme(windowUUID)
             let javascript = "init(\(addressString), \(l10sString), \(isDarkTheme));"
             return javascript

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/Address+Encodable.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/Address+Encodable.swift
@@ -64,3 +64,25 @@ extension Address: Encodable {
 extension Address: Swift.Identifiable {
     public var id: String { guid }
 }
+
+extension Address {
+    var addressCityStateZipcode: String {
+        var components = [addressLevel2, addressLevel1, postalCode]
+        components = components.compactMap { $0.isEmpty ? nil : $0 }
+        return components.joined(separator: ", ")
+    }
+
+    var a11ySettingsRow: String {
+        let components = [
+            name,
+            streetAddress,
+            addressLevel2,
+            addressLevel1,
+            postalCode
+        ]
+        let nonEmptyComponents = components.compactMap { $0.isEmpty ? nil : $0 }
+        let addressDetails = nonEmptyComponents.joined(separator: ", ")
+        let label = String(format: String.Addresses.Settings.ListItemA11y, addressDetails)
+        return label
+    }
+}

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -277,7 +277,7 @@ extension String {
                 value: "Securely save your information to get quick access to it later.",
                 comment: "Description text for the content unavailable view informing users they can create or add new addresses.")
             public static let ListItemA11y = MZLocalizedString(
-                key: "", //Addresses.Settings.ListItemA11y.v129
+                key: "", // Addresses.Settings.ListItemA11y.v129
                 tableName: "Settings",
                 value: "Address for %@",
                 comment: "Accessibility label for an address list item in autofill settings screen. The %@ parameter is the address of the user that will read the name, street, city, state, postal code if available.")

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -276,6 +276,11 @@ extension String {
                 tableName: "Settings",
                 value: "Securely save your information to get quick access to it later.",
                 comment: "Description text for the content unavailable view informing users they can create or add new addresses.")
+            public static let ListItemA11y = MZLocalizedString(
+                key: "", //Addresses.Settings.ListItemA11y.v129
+                tableName: "Settings",
+                value: "Address for %@",
+                comment: "Accessibility label for an address list item in autofill settings screen. The %@ parameter is the address of the user that will read the name, street, city, state, postal code if available.")
             public struct Edit {
                 public static let AutofillAddAddressTitle = MZLocalizedString(
                     key: "", // "Addresses.EditAddress.AutofillAddAddressTitle.v129"

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -266,6 +266,16 @@ extension String {
                 tableName: "Settings",
                 value: "Use saved address",
                 comment: "Displayed inside the keyboard hint when a user is entering their address and has at least one saved address. Indicates that there are stored addresses available for use in filling out a form.")
+            public static let SaveAddressesToFirefox = MZLocalizedString(
+                key: "", // Addresses.Settings.SaveToFirefox.Title.v129
+                tableName: "Settings",
+                value: "Save Addresses to %@",
+                comment: "Title text for the content unavailable view informing users they can create or add new addresses. %@ is the name of the app.")
+            public static let SecureSaveInfo = MZLocalizedString(
+                key: "", // Addresses.Settings.SecureSaveInfo.Description.v129
+                tableName: "Settings",
+                value: "Securely save your information to get quick access to it later.",
+                comment: "Description text for the content unavailable view informing users they can create or add new addresses.")
             public struct Edit {
                 public static let AutofillAddAddressTitle = MZLocalizedString(
                     key: "", // "Addresses.EditAddress.AutofillAddAddressTitle.v129"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20386)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Display a view in the middle informing the user they can add a new address.

<img src="https://github.com/mozilla-mobile/firefox-ios/assets/26011662/1892c5b8-1d35-4326-9af5-88e5054d211c" width="300">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

