### PR TITLE
Refactor FXIOS-9084 update select tab to be syncronous

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -32,5 +32,4 @@ public enum AppEvent: AppEventType {
 
     // Activities: Tabs
     case tabRestoration(WindowUUID)
-    case selectTab(URL?, WindowUUID)
 }

--- a/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -131,19 +131,8 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         let url = recentlyClosedTabs[indexPath.row].url
         recentlyClosedTabsDelegate?.openRecentlyClosedSiteInNewTab(url, isPrivate: false)
 
-        // The code above creates new tab and selects it, but TabManagerImplementation.selectTab()
-        // currently performs the actual selection update asynchronously via Swift Async + Task/Await.
-        // This means that selectTab() returns before the tab is actually selected. As a result, the
-        // delegate callback below will incorrectly cause a duplicate tab (since it will treat the
-        // url as having been applied to the current tab, not our newly-added tab from above). This
-        // is avoided by making sure we wait for our expected tab above to be selected before
-        // notifying our library panel delegate. [FXIOS-7741]
-
-        let tabWindowUUID = windowUUID
-        AppEventQueue.wait(for: .selectTab(url, tabWindowUUID)) {
-            let visitType = VisitType.typed    // Means History, too.
-            self.libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: visitType)
-        }
+        let visitType = VisitType.typed    // Means History, too.
+        self.libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: visitType)
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -372,6 +372,8 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
 
     @MainActor
     private func selectTabWithSession(tab: Tab, previous: Tab?, sessionData: Data?) {
+        guard tab == selectedTab else { return }
+
         selectedTab?.createWebview(with: sessionData)
         selectedTab?.lastExecutedTime = Date.now()
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -359,13 +359,10 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
 
     private func willSelectTab(_ url: URL?) {
         tabsTelemetry.startTabSwitchMeasurement()
-        guard let url else { return }
-        AppEventQueue.started(.selectTab(url, windowUUID))
     }
 
     private func didSelectTab(_ url: URL?) {
         tabsTelemetry.stopTabSwitchMeasurement()
-        AppEventQueue.completed(.selectTab(url, windowUUID))
         let action = GeneralBrowserAction(selectedTabURL: url,
                                           isPrivateBrowsing: selectedTab?.isPrivate ?? false,
                                           windowUUID: windowUUID,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9084)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20122)

## :bulb: Description
Refactor the select tab flow so that the only part that happens asyncronously is loading the previous session from disk and updating/creating the webview.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

