### PR TITLE
Bugfix FXIOS-9334 ⁃ Display buttons in settings centered

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		047F9B4224E1FF4000CD7DF7 /* ImageButtonWithLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047F9B3C24E1FF4000CD7DF7 /* ImageButtonWithLabel.swift */; };
 		0AC659272BF35854005C614A /* FxAWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC659262BF35854005C614A /* FxAWebViewModelTests.swift */; };
 		0AC659292BF493CE005C614A /* MockFxAWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */; };
+		0AD3EEAC2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD3EEAB2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift */; };
 		0B305E1B1E3A98A900BE0767 /* BookmarksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B305E1A1E3A98A900BE0767 /* BookmarksTests.swift */; };
 		0B3D670E1E09B90B00C1EFC7 /* AuthenticationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3D670D1E09B90B00C1EFC7 /* AuthenticationTest.swift */; };
 		0B54BD191B698B7C004C822C /* SuggestedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B54BD181B698B7C004C822C /* SuggestedSites.swift */; };
@@ -2118,6 +2119,7 @@
 		0A7D41DB98DDB127A2B8C544 /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/Menu.strings; sourceTree = "<group>"; };
 		0AC659262BF35854005C614A /* FxAWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAWebViewModelTests.swift; sourceTree = "<group>"; };
 		0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFxAWebViewModel.swift; sourceTree = "<group>"; };
+		0AD3EEAB2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedCenteredTableViewCell.swift; sourceTree = "<group>"; };
 		0AE9462E8A8E05CE07D4973D /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		0B305E1A1E3A98A900BE0767 /* BookmarksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksTests.swift; sourceTree = "<group>"; };
 		0B3D670D1E09B90B00C1EFC7 /* AuthenticationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationTest.swift; sourceTree = "<group>"; };
@@ -10650,6 +10652,7 @@
 				C2D71B962A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift */,
 				C2D71B942A384F11003DEC7A /* ThemedTableViewCell.swift */,
 				C2D71B9A2A3850B4003DEC7A /* ThemedTableViewCellViewModel.swift */,
+				0AD3EEAB2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift */,
 			);
 			path = ThemedTableViewCells;
 			sourceTree = "<group>";
@@ -14554,6 +14557,7 @@
 				8C6F94662A972EB300415FF6 /* FakespotStarRatingView.swift in Sources */,
 				C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */,
 				1D7B78972ADF32590011E9F2 /* EventQueue.swift in Sources */,
+				0AD3EEAC2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift in Sources */,
 				C81B78A4280752A20000C15F /* NimbusFeatureFlagLayer.swift in Sources */,
 				4345441D26D2E52600D5EEAA /* SearchTermGroupsUtility.swift in Sources */,
 				2165B2CC28748CD7004C0786 /* LibraryPanelDescriptor.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -525,6 +525,7 @@ public struct AccessibilityIdentifiers {
             static let title = "ClearPrivateData"
             static let websiteDataSection = "WebsiteData"
             static let clearPrivateDataSection = "ClearPrivateData"
+            static let clearAllWebsiteData = "ClearAllWebsiteData"
         }
 
         struct Notifications {

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -94,8 +94,6 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == sectionArrow {
-            let cell = dequeueCellFor(indexPath: indexPath)
-            cell.applyTheme(theme: currentTheme())
             cell.accessoryType = .disclosureIndicator
             cell.textLabel?.text = .SettingsWebsiteDataTitle
             cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.ClearData.websiteDataSection

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -83,7 +83,6 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
         title = .SettingsDataManagementTitle
 
-        tableView.register(cellType: ThemedCenteredTableViewCell.self)
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
 
@@ -117,7 +116,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             control.tag = indexPath.item
             return cell
         } else {
-            let cell = dequeueCellFor(indexPath: indexPath, isCenteredTableViewCell: true) as? ThemedCenteredTableViewCell
+            let cell = dequeueCellFor(indexPath: indexPath) as? ThemedCenteredTableViewCell
             cell?.applyTheme(theme: currentTheme())
             cell?.setTitle(to: .SettingsClearPrivateDataClearButton)
             cell?.setAccessibilities(
@@ -168,26 +167,20 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         tableView.deselectRow(at: indexPath, animated: false)
     }
 
-    private func dequeueCellFor(indexPath: IndexPath, isCenteredTableViewCell: Bool = false) -> ThemedTableViewCell {
-        if isCenteredTableViewCell {
-            guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
-                for: indexPath
-            ) as? ThemedCenteredTableViewCell
-            else {
-                return ThemedCenteredTableViewCell()
-            }
-            return cell
-        } else {
-            guard let cell = tableView.dequeueReusableCell(
+    override func dequeueCellFor(indexPath: IndexPath) -> ThemedTableViewCell {
+        if indexPath.section == sectionArrow || indexPath.section == sectionToggles {
+            if let cell = tableView.dequeueReusableCell(
                 withIdentifier: ThemedTableViewCell.cellIdentifier,
-                for: indexPath
-            ) as? ThemedTableViewCell
-            else {
-                return ThemedTableViewCell()
+                for: indexPath) as? ThemedTableViewCell {
+                return cell
             }
+        }
+        if let cell = tableView.dequeueReusableCell(
+            withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
+            for: indexPath) as? ThemedCenteredTableViewCell {
             return cell
         }
+        return ThemedTableViewCell()
     }
 
     private func clearPrivateData(_ action: UIAlertAction) {

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -93,6 +93,8 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = dequeueCellFor(indexPath: indexPath)
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         if indexPath.section == sectionArrow {
             cell.accessoryType = .disclosureIndicator
             cell.textLabel?.text = .SettingsWebsiteDataTitle
@@ -111,15 +113,15 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             cell.selectionStyle = .none
             control.tag = indexPath.item
             return cell
-        } else {
-            let cell = dequeueCellFor(indexPath: indexPath) as? ThemedCenteredTableViewCell
-            cell?.applyTheme(theme: currentTheme())
-            cell?.setTitle(to: .SettingsClearPrivateDataClearButton)
-            cell?.setAccessibilities(
+        } else if let cell = cell as? ThemedCenteredTableViewCell {
+            cell.setTitle(to: .SettingsClearPrivateDataClearButton)
+            cell.setAccessibilities(
                 traits: .button,
                 identifier: AccessibilityIdentifiers.Settings.ClearData.clearPrivateDataSection)
             clearButton = cell
-            return cell ?? ThemedTableViewCell()
+            return cell
+        } else {
+            return ThemedTableViewCell()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -168,13 +168,10 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     override func dequeueCellFor(indexPath: IndexPath) -> ThemedTableViewCell {
-        if indexPath.section == sectionArrow || indexPath.section == sectionToggles {
-            if let cell = tableView.dequeueReusableCell(
-                withIdentifier: ThemedTableViewCell.cellIdentifier,
-                for: indexPath) as? ThemedTableViewCell {
-                return cell
-            }
+        guard indexPath.section == sectionButton else {
+            return super.dequeueCellFor(indexPath: indexPath)
         }
+
         if let cell = tableView.dequeueReusableCell(
             withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
             for: indexPath) as? ThemedCenteredTableViewCell {
@@ -182,7 +179,6 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
         }
         return ThemedTableViewCell()
     }
-
     private func clearPrivateData(_ action: UIAlertAction) {
         let toggles = self.toggles
         self.clearables

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -113,9 +113,9 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             cell.selectionStyle = .none
             control.tag = indexPath.item
         } else {
-            cell.textLabel?.text = .SettingsClearPrivateDataClearButton
-            cell.textLabel?.textAlignment = .center
-            cell.textLabel?.textColor = currentTheme().colors.textWarning
+            cell.centeredButtonLabel.text = .SettingsClearPrivateDataClearButton
+            cell.centeredButtonLabel.textAlignment = .center
+            cell.centeredButtonLabel.textColor = currentTheme().colors.textWarning
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.ClearData.clearPrivateDataSection
             clearButton = cell

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -83,6 +83,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
 
         title = .SettingsDataManagementTitle
 
+        tableView.register(cellType: ThemedCenteredTableViewCell.self)
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
 
@@ -93,15 +94,17 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = dequeueCellFor(indexPath: indexPath)
-        cell.applyTheme(theme: currentTheme())
-
         if indexPath.section == sectionArrow {
+            let cell = dequeueCellFor(indexPath: indexPath)
+            cell.applyTheme(theme: currentTheme())
             cell.accessoryType = .disclosureIndicator
             cell.textLabel?.text = .SettingsWebsiteDataTitle
             cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.ClearData.websiteDataSection
             clearButton = cell
+            return cell
         } else if indexPath.section == sectionToggles {
+            let cell = dequeueCellFor(indexPath: indexPath)
+            cell.applyTheme(theme: currentTheme())
             cell.textLabel?.text = clearables[indexPath.item].clearable.label
             cell.textLabel?.numberOfLines = 0
             let control = ThemedSwitch()
@@ -112,16 +115,17 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             cell.accessoryView = control
             cell.selectionStyle = .none
             control.tag = indexPath.item
+            return cell
         } else {
-            cell.centeredButtonLabel.text = .SettingsClearPrivateDataClearButton
-            cell.centeredButtonLabel.textAlignment = .center
-            cell.centeredButtonLabel.textColor = currentTheme().colors.textWarning
-            cell.accessibilityTraits = UIAccessibilityTraits.button
-            cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.ClearData.clearPrivateDataSection
+            let cell = dequeueCellFor(indexPath: indexPath, isCenteredTableViewCell: true) as? ThemedCenteredTableViewCell
+            cell?.applyTheme(theme: currentTheme())
+            cell?.setTitle(to: .SettingsClearPrivateDataClearButton)
+            cell?.setAccessibilities(
+                traits: .button,
+                identifier: AccessibilityIdentifiers.Settings.ClearData.clearPrivateDataSection)
             clearButton = cell
+            return cell ?? ThemedTableViewCell()
         }
-
-        return cell
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -162,6 +166,28 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             present(alert, animated: true, completion: nil)
         }
         tableView.deselectRow(at: indexPath, animated: false)
+    }
+
+    private func dequeueCellFor(indexPath: IndexPath, isCenteredTableViewCell: Bool = false) -> ThemedTableViewCell {
+        if isCenteredTableViewCell {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
+                for: indexPath
+            ) as? ThemedCenteredTableViewCell
+            else {
+                return ThemedCenteredTableViewCell()
+            }
+            return cell
+        } else {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: ThemedTableViewCell.cellIdentifier,
+                for: indexPath
+            ) as? ThemedTableViewCell
+            else {
+                return ThemedTableViewCell()
+            }
+            return cell
+        }
     }
 
     private func clearPrivateData(_ action: UIAlertAction) {

--- a/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -100,8 +100,6 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             clearButton = cell
             return cell
         } else if indexPath.section == sectionToggles {
-            let cell = dequeueCellFor(indexPath: indexPath)
-            cell.applyTheme(theme: currentTheme())
             cell.textLabel?.text = clearables[indexPath.item].clearable.label
             cell.textLabel?.numberOfLines = 0
             let control = ThemedSwitch()

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -121,7 +121,6 @@ class Setting: NSObject {
 
     init(
         title: NSAttributedString? = nil,
-        centeredTitle: NSAttributedString? = nil,
         footerTitle: NSAttributedString? = nil,
         cellHeight: CGFloat? = nil,
         delegate: SettingsDelegate? = nil,
@@ -878,7 +877,6 @@ class SettingsTableViewController: ThemedTableViewController {
 
         tableView.register(cellType: ThemedLeftAlignedTableViewCell.self)
         tableView.register(cellType: ThemedSubtitleTableViewCell.self)
-        tableView.register(cellType: ThemedCenteredTableViewCell.self)
         tableView.register(
             ThemedTableSectionHeaderFooterView.self,
             forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -76,8 +76,10 @@ class Setting: NSObject {
         cell.detailTextLabel?.numberOfLines = 0
         if let cell = cell as? ThemedCenteredTableViewCell {
             cell.applyTheme(theme: theme)
-            cell.setTitle(to: .SettingsDisconnectSyncButton)
-            cell.accessibilityLabel = .SettingsDisconnectSyncButton
+            if let title = title?.string {
+                cell.setTitle(to: title)
+                cell.accessibilityLabel = title
+            }
         } else {
             cell.textLabel?.assign(attributed: title, theme: theme)
             cell.textLabel?.textAlignment = textAlignment

--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -45,7 +45,7 @@ class DisconnectSetting: Setting {
     override var accessoryType: UITableViewCell.AccessoryType { return .none }
     override var textAlignment: NSTextAlignment { return .center }
 
-    override var title: NSAttributedString? {
+    override var centeredTitle: NSAttributedString? {
         let theme = settingsVC.themeManager.getCurrentTheme(for: settingsVC.windowUUID)
         return NSAttributedString(
             string: .SettingsDisconnectSyncButton,

--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -43,17 +43,6 @@ class DisconnectSetting: Setting {
     let settingsVC: SettingsTableViewController
     let profile: Profile
     override var accessoryType: UITableViewCell.AccessoryType { return .none }
-    override var textAlignment: NSTextAlignment { return .center }
-
-    override var centeredTitle: NSAttributedString? {
-        let theme = settingsVC.themeManager.getCurrentTheme(for: settingsVC.windowUUID)
-        return NSAttributedString(
-            string: .SettingsDisconnectSyncButton,
-            attributes: [
-                NSAttributedString.Key.foregroundColor: theme.colors.textWarning
-            ]
-        )
-    }
 
     init(settings: SettingsTableViewController) {
         self.settingsVC = settings

--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -47,6 +47,7 @@ class DisconnectSetting: Setting {
     init(settings: SettingsTableViewController) {
         self.settingsVC = settings
         self.profile = settings.profile
+        super.init(title: NSAttributedString(string: .SettingsDisconnectSyncButton))
     }
 
     override var accessibilityIdentifier: String? { return "SignOut" }

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -177,10 +177,11 @@ class WebsiteDataManagementViewController: UIViewController,
                 theme: currentTheme(),
                 type: .destructive
             )
-            cell.textLabel?.text = viewModel.clearButtonTitle
-            cell.textLabel?.textAlignment = .center
+            cell.centeredButtonLabel.text = viewModel.clearButtonTitle
+            cell.centeredButtonLabel.textAlignment = .center
+            cell.centeredButtonLabel.textColor = themeManager.getCurrentTheme(for: windowUUID).colors.textWarning
             cell.accessibilityTraits = UIAccessibilityTraits.button
-            cell.accessibilityIdentifier = "ClearAllWebsiteData"
+            cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.ClearData.clearAllWebsiteData
             cell.configure(viewModel: cellViewModel)
         }
 

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -179,7 +179,7 @@ class WebsiteDataManagementViewController: UIViewController,
             showMoreButton = cell
             return cell
         case .clearButton:
-            let cell = dequeueCellFor(indexPath: indexPath, isCenteredTableViewCell: true) as? ThemedCenteredTableViewCell
+            let cell = dequeueCellFor(indexPath: indexPath) as? ThemedCenteredTableViewCell
             cell?.setTitle(to: viewModel.clearButtonTitle)
             cell?.setAccessibilities(
                 traits: .button,
@@ -189,26 +189,30 @@ class WebsiteDataManagementViewController: UIViewController,
         }
     }
 
-    private func dequeueCellFor(indexPath: IndexPath, isCenteredTableViewCell: Bool = false) -> ThemedTableViewCell {
-        if isCenteredTableViewCell {
-            guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
-                for: indexPath
-            ) as? ThemedCenteredTableViewCell
-            else {
-                return ThemedCenteredTableViewCell()
+    private func dequeueCellFor(indexPath: IndexPath) -> ThemedTableViewCell {
+        if let section = Section(rawValue: indexPath.section) {
+            switch section {
+            case .sites, .showMore:
+                guard let cell = tableView.dequeueReusableCell(
+                    withIdentifier: ThemedTableViewCell.cellIdentifier,
+                    for: indexPath
+                ) as? ThemedTableViewCell
+                else {
+                    return ThemedTableViewCell()
+                }
+                return cell
+            case .clearButton:
+                guard let cell = tableView.dequeueReusableCell(
+                    withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
+                    for: indexPath
+                ) as? ThemedCenteredTableViewCell
+                else {
+                    return ThemedCenteredTableViewCell()
+                }
+                return cell
             }
-            return cell
-        } else {
-            guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: ThemedTableViewCell.cellIdentifier,
-                for: indexPath
-            ) as? ThemedTableViewCell
-            else {
-                return ThemedTableViewCell()
-            }
-            return cell
         }
+        return ThemedTableViewCell()
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -69,6 +69,7 @@ class WebsiteDataManagementViewController: UIViewController,
         tableView.allowsMultipleSelectionDuringEditing = true
         tableView.allowsSelectionDuringEditing = true
         tableView.register(cellType: ThemedTableViewCell.self)
+        tableView.register(cellType: ThemedCenteredTableViewCell.self)
         tableView.register(
             ThemedTableSectionHeaderFooterView.self,
             forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier
@@ -144,10 +145,11 @@ class WebsiteDataManagementViewController: UIViewController,
         _ tableView: UITableView,
         cellForRowAt indexPath: IndexPath
     ) -> UITableViewCell {
-        let cell = dequeueCellFor(indexPath: indexPath)
         let section = Section(rawValue: indexPath.section)!
         switch section {
         case .sites:
+            let cell = dequeueCellFor(indexPath: indexPath)
+            cell.applyTheme(theme: currentTheme())
             if let record = viewModel.siteRecords[safe: indexPath.row] {
                 cell.textLabel?.text = record.displayName
                 if viewModel.selectedRecords.contains(record) {
@@ -161,7 +163,10 @@ class WebsiteDataManagementViewController: UIViewController,
                 type: .standard
             )
             cell.configure(viewModel: cellViewModel)
+            return cell
         case .showMore:
+            let cell = dequeueCellFor(indexPath: indexPath)
+            cell.applyTheme(theme: currentTheme())
             let cellType: ThemedTableViewCellType = showMoreButtonEnabled ? .actionPrimary : .disabled
             let cellViewModel = ThemedTableViewCellViewModel(
                 theme: currentTheme(),
@@ -172,32 +177,38 @@ class WebsiteDataManagementViewController: UIViewController,
             cell.accessibilityIdentifier = "ShowMoreWebsiteData"
             cell.configure(viewModel: cellViewModel)
             showMoreButton = cell
+            return cell
         case .clearButton:
-            let cellViewModel = ThemedTableViewCellViewModel(
-                theme: currentTheme(),
-                type: .destructive
-            )
-            cell.centeredButtonLabel.text = viewModel.clearButtonTitle
-            cell.centeredButtonLabel.textAlignment = .center
-            cell.centeredButtonLabel.textColor = themeManager.getCurrentTheme(for: windowUUID).colors.textWarning
-            cell.accessibilityTraits = UIAccessibilityTraits.button
-            cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.ClearData.clearAllWebsiteData
-            cell.configure(viewModel: cellViewModel)
+            let cell = dequeueCellFor(indexPath: indexPath, isCenteredTableViewCell: true) as? ThemedCenteredTableViewCell
+            cell?.setTitle(to: viewModel.clearButtonTitle)
+            cell?.setAccessibilities(
+                traits: .button,
+                identifier: AccessibilityIdentifiers.Settings.ClearData.clearAllWebsiteData)
+            cell?.applyTheme(theme: currentTheme())
+            return cell ?? ThemedCenteredTableViewCell()
         }
-
-        cell.applyTheme(theme: currentTheme())
-        return cell
     }
 
-    private func dequeueCellFor(indexPath: IndexPath) -> ThemedTableViewCell {
-        guard let cell = tableView.dequeueReusableCell(
-            withIdentifier: ThemedTableViewCell.cellIdentifier,
-            for: indexPath
-        ) as? ThemedTableViewCell
-        else {
-            return ThemedTableViewCell()
+    private func dequeueCellFor(indexPath: IndexPath, isCenteredTableViewCell: Bool = false) -> ThemedTableViewCell {
+        if isCenteredTableViewCell {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
+                for: indexPath
+            ) as? ThemedCenteredTableViewCell
+            else {
+                return ThemedCenteredTableViewCell()
+            }
+            return cell
+        } else {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: ThemedTableViewCell.cellIdentifier,
+                for: indexPath
+            ) as? ThemedTableViewCell
+            else {
+                return ThemedTableViewCell()
+            }
+            return cell
         }
-        return cell
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -236,6 +247,7 @@ class WebsiteDataManagementViewController: UIViewController,
             generator.impactOccurred()
             let alert = viewModel.createAlertToRemove()
             present(alert, animated: true, completion: nil)
+            tableView.deselectRow(at: indexPath, animated: true)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -190,29 +190,29 @@ class WebsiteDataManagementViewController: UIViewController,
     }
 
     private func dequeueCellFor(indexPath: IndexPath) -> ThemedTableViewCell {
-        if let section = Section(rawValue: indexPath.section) {
-            switch section {
-            case .sites, .showMore:
-                guard let cell = tableView.dequeueReusableCell(
-                    withIdentifier: ThemedTableViewCell.cellIdentifier,
-                    for: indexPath
-                ) as? ThemedTableViewCell
-                else {
-                    return ThemedTableViewCell()
-                }
-                return cell
-            case .clearButton:
-                guard let cell = tableView.dequeueReusableCell(
-                    withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
-                    for: indexPath
-                ) as? ThemedCenteredTableViewCell
-                else {
-                    return ThemedCenteredTableViewCell()
-                }
-                return cell
-            }
+        guard let section = Section(rawValue: indexPath.section) else {
+            return ThemedTableViewCell()
         }
-        return ThemedTableViewCell()
+        switch section {
+        case .sites, .showMore:
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: ThemedTableViewCell.cellIdentifier,
+                for: indexPath
+            ) as? ThemedTableViewCell
+            else {
+                return ThemedTableViewCell()
+            }
+            return cell
+        case .clearButton:
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
+                for: indexPath
+            ) as? ThemedCenteredTableViewCell
+            else {
+                return ThemedCenteredTableViewCell()
+            }
+            return cell
+        }
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
@@ -50,27 +50,14 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
     }
 
     override func dequeueCellFor(indexPath: IndexPath) -> ThemedTableViewCell {
-        if let section = Section(rawValue: indexPath.section) {
-            switch section {
-            case .sites:
-                guard let cell = tableView.dequeueReusableCell(
-                    withIdentifier: ThemedTableViewCell.cellIdentifier,
-                    for: indexPath
-                ) as? ThemedTableViewCell
-                else {
-                    return ThemedTableViewCell()
-                }
-                return cell
-            case .clearButton:
-                guard let cell = tableView.dequeueReusableCell(
-                    withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
-                    for: indexPath
-                ) as? ThemedCenteredTableViewCell
-                else {
-                    return ThemedCenteredTableViewCell()
-                }
-                return cell
-            }
+        guard let section = Section(rawValue: indexPath.section), section == .clearButton else {
+            return super.dequeueCellFor(indexPath: indexPath)
+        }
+
+        if let cell = tableView.dequeueReusableCell(
+            withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
+            for: indexPath) as? ThemedCenteredTableViewCell {
+            return cell
         }
         return ThemedTableViewCell()
     }

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
@@ -37,7 +37,6 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
 
         tableView.isEditing = true
         tableView.allowsMultipleSelectionDuringEditing = true
-        tableView.register(cellType: ThemedCenteredTableViewCell.self)
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
 
@@ -50,26 +49,30 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
         KeyboardHelper.defaultHelper.addDelegate(self)
     }
 
-    private func dequeueCellFor(indexPath: IndexPath, isCenteredTableViewCell: Bool = false) -> ThemedTableViewCell {
-        if isCenteredTableViewCell {
-            guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
-                for: indexPath
-            ) as? ThemedCenteredTableViewCell
-            else {
-                return ThemedCenteredTableViewCell()
+    override func dequeueCellFor(indexPath: IndexPath) -> ThemedTableViewCell {
+        if let section = Section(rawValue: indexPath.section) {
+            switch section {
+            case .sites:
+                guard let cell = tableView.dequeueReusableCell(
+                    withIdentifier: ThemedTableViewCell.cellIdentifier,
+                    for: indexPath
+                ) as? ThemedTableViewCell
+                else {
+                    return ThemedTableViewCell()
+                }
+                return cell
+            case .clearButton:
+                guard let cell = tableView.dequeueReusableCell(
+                    withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
+                    for: indexPath
+                ) as? ThemedCenteredTableViewCell
+                else {
+                    return ThemedCenteredTableViewCell()
+                }
+                return cell
             }
-            return cell
-        } else {
-            guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: ThemedTableViewCell.cellIdentifier,
-                for: indexPath
-            ) as? ThemedTableViewCell
-            else {
-                return ThemedTableViewCell()
-            }
-            return cell
         }
+        return ThemedTableViewCell()
     }
 
     func reloadData() {
@@ -106,7 +109,7 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
             }
             return cell
         case .clearButton:
-            let cell = dequeueCellFor(indexPath: indexPath, isCenteredTableViewCell: true) as? ThemedCenteredTableViewCell
+            let cell = dequeueCellFor(indexPath: indexPath) as? ThemedCenteredTableViewCell
             cell?.setTitle(to: viewModel.clearButtonTitle)
             cell?.setAccessibilities(
                 traits: .button,

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
@@ -82,11 +82,11 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
                 }
             }
         case .clearButton:
-            cell.textLabel?.text = viewModel.clearButtonTitle
-            cell.textLabel?.textAlignment = .center
-            cell.textLabel?.textColor = themeManager.getCurrentTheme(for: windowUUID).colors.textWarning
+            cell.centeredButtonLabel.text = viewModel.clearButtonTitle
+            cell.centeredButtonLabel.textAlignment = .center
+            cell.centeredButtonLabel.textColor = themeManager.getCurrentTheme(for: windowUUID).colors.textWarning
             cell.accessibilityTraits = UIAccessibilityTraits.button
-            cell.accessibilityIdentifier = "ClearAllWebsiteData"
+            cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.ClearData.clearAllWebsiteData
         }
         return cell
     }

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
@@ -37,6 +37,7 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
 
         tableView.isEditing = true
         tableView.allowsMultipleSelectionDuringEditing = true
+        tableView.register(cellType: ThemedCenteredTableViewCell.self)
         tableView.register(ThemedTableSectionHeaderFooterView.self,
                            forHeaderFooterViewReuseIdentifier: ThemedTableSectionHeaderFooterView.cellIdentifier)
 
@@ -47,6 +48,28 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
         tableView.tableFooterView = footer
 
         KeyboardHelper.defaultHelper.addDelegate(self)
+    }
+
+    private func dequeueCellFor(indexPath: IndexPath, isCenteredTableViewCell: Bool = false) -> ThemedTableViewCell {
+        if isCenteredTableViewCell {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
+                for: indexPath
+            ) as? ThemedCenteredTableViewCell
+            else {
+                return ThemedCenteredTableViewCell()
+            }
+            return cell
+        } else {
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: ThemedTableViewCell.cellIdentifier,
+                for: indexPath
+            ) as? ThemedTableViewCell
+            else {
+                return ThemedTableViewCell()
+            }
+            return cell
+        }
     }
 
     func reloadData() {
@@ -68,11 +91,11 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = dequeueCellFor(indexPath: indexPath)
-        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         let section = Section(rawValue: indexPath.section)!
         switch section {
         case .sites:
+            let cell = dequeueCellFor(indexPath: indexPath)
+            cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             if let record = filteredSiteRecords[safe: indexPath.row] {
                 cell.textLabel?.text = record.displayName
                 if viewModel.selectedRecords.contains(record) {
@@ -81,14 +104,16 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
                     tableView.deselectRow(at: indexPath, animated: false)
                 }
             }
+            return cell
         case .clearButton:
-            cell.centeredButtonLabel.text = viewModel.clearButtonTitle
-            cell.centeredButtonLabel.textAlignment = .center
-            cell.centeredButtonLabel.textColor = themeManager.getCurrentTheme(for: windowUUID).colors.textWarning
-            cell.accessibilityTraits = UIAccessibilityTraits.button
-            cell.accessibilityIdentifier = AccessibilityIdentifiers.Settings.ClearData.clearAllWebsiteData
+            let cell = dequeueCellFor(indexPath: indexPath, isCenteredTableViewCell: true) as? ThemedCenteredTableViewCell
+            cell?.setTitle(to: viewModel.clearButtonTitle)
+            cell?.setAccessibilities(
+                traits: .button,
+                identifier: AccessibilityIdentifiers.Settings.ClearData.clearAllWebsiteData)
+            cell?.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+            return cell ?? ThemedCenteredTableViewCell()
         }
-        return cell
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -103,6 +128,7 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
             generator.impactOccurred()
             let alert = viewModel.createAlertToRemove()
             present(alert, animated: true, completion: nil)
+            tableView.deselectRow(at: indexPath, animated: true)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
@@ -81,7 +81,11 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let section = Section(rawValue: indexPath.section)!
+        let cell = dequeueCellFor(indexPath: indexPath)
+        cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+        guard let section = Section(rawValue: indexPath.section) else {
+            return ThemedTableViewCell()
+        }
         switch section {
         case .sites:
             if let record = filteredSiteRecords[safe: indexPath.row] {

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
@@ -84,8 +84,6 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
         let section = Section(rawValue: indexPath.section)!
         switch section {
         case .sites:
-            let cell = dequeueCellFor(indexPath: indexPath)
-            cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             if let record = filteredSiteRecords[safe: indexPath.row] {
                 cell.textLabel?.text = record.displayName
                 if viewModel.selectedRecords.contains(record) {

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataSearchResultsViewController.swift
@@ -94,13 +94,14 @@ class WebsiteDataSearchResultsViewController: ThemedTableViewController {
             }
             return cell
         case .clearButton:
-            let cell = dequeueCellFor(indexPath: indexPath) as? ThemedCenteredTableViewCell
-            cell?.setTitle(to: viewModel.clearButtonTitle)
-            cell?.setAccessibilities(
+            guard let cell = cell as? ThemedCenteredTableViewCell else { return ThemedCenteredTableViewCell() }
+
+            cell.setTitle(to: viewModel.clearButtonTitle)
+            cell.setAccessibilities(
                 traits: .button,
                 identifier: AccessibilityIdentifiers.Settings.ClearData.clearAllWebsiteData)
-            cell?.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
-            return cell ?? ThemedCenteredTableViewCell()
+            cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+            return cell
         }
     }
 

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedCenteredTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedCenteredTableViewCell.swift
@@ -10,7 +10,7 @@ class ThemedCenteredTableViewCell: ThemedTableViewCell {
         static let labelMargin: CGFloat = 15
     }
 
-    lazy var centeredLabel: UILabel = .build { label in
+    private lazy var centeredLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.textAlignment = .center
         label.font = FXFontStyles.Regular.body.scaledFont()
@@ -18,7 +18,7 @@ class ThemedCenteredTableViewCell: ThemedTableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        contentView.addSubview(centeredLabel)
+        setupLayout()
     }
 
     func setTitle(to title: String) {
@@ -34,7 +34,8 @@ class ThemedCenteredTableViewCell: ThemedTableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func setConstraints() {
+    private func setupLayout() {
+        contentView.addSubview(centeredLabel)
         NSLayoutConstraint.activate([
             centeredLabel.topAnchor.constraint(
                 greaterThanOrEqualTo: contentView.topAnchor,
@@ -55,12 +56,12 @@ class ThemedCenteredTableViewCell: ThemedTableViewCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        setConstraints()
+        setupLayout()
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        contentView.addSubview(centeredLabel)
+        centeredLabel.text = nil
     }
 
     override func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedCenteredTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedCenteredTableViewCell.swift
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+class ThemedCenteredTableViewCell: ThemedTableViewCell {
+    private struct UX {
+        static let labelMargin: CGFloat = 15
+    }
+
+    lazy var centeredLabel: UILabel = .build { label in
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.font = FXFontStyles.Regular.body.scaledFont()
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.addSubview(centeredLabel)
+    }
+
+    func setTitle(to title: String) {
+        centeredLabel.text = title
+    }
+
+    func setAccessibilities(traits: UIAccessibilityTraits, identifier: String) {
+        accessibilityTraits = traits
+        accessibilityIdentifier = identifier
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setConstraints() {
+        NSLayoutConstraint.activate([
+            centeredLabel.topAnchor.constraint(
+                greaterThanOrEqualTo: contentView.topAnchor,
+                constant: UX.labelMargin),
+            centeredLabel.bottomAnchor.constraint(
+                greaterThanOrEqualTo: contentView.bottomAnchor,
+                constant: -UX.labelMargin),
+            centeredLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            centeredLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            centeredLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: contentView.leadingAnchor,
+                constant: UX.labelMargin),
+            centeredLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: contentView.trailingAnchor,
+                constant: -UX.labelMargin)
+        ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        setConstraints()
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        contentView.addSubview(centeredLabel)
+    }
+
+    override func applyTheme(theme: Theme) {
+        super.applyTheme(theme: theme)
+        centeredLabel.textColor = theme.colors.textWarning
+    }
+}

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedCenteredTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedCenteredTableViewCell.swift
@@ -54,14 +54,10 @@ class ThemedCenteredTableViewCell: ThemedTableViewCell {
         ])
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        setupLayout()
-    }
-
     override func prepareForReuse() {
         super.prepareForReuse()
         centeredLabel.text = nil
+        setupLayout()
     }
 
     override func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
@@ -10,9 +10,13 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     var viewModel: ThemedTableViewCellViewModel?
     var cellStyle: UITableViewCell.CellStyle
 
+    private var centeredButtonLabelMargin = 15.0
+    lazy var centeredButtonLabel: UILabel = .build()
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         self.cellStyle = style
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.initCenteredButtonLabel()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -30,7 +34,11 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         var size = super.systemLayoutSizeFitting(targetSize,
                                                  withHorizontalFittingPriority: horizontalFittingPriority,
                                                  verticalFittingPriority: verticalFittingPriority)
-        if cellStyle == .value2 || cellStyle == .value1 {
+        if cellStyle == .default, centeredButtonLabel.text != nil  {
+            let textHeight = centeredButtonLabel.frame.size.height
+            size.height += textHeight
+            return size
+        } else if cellStyle == .value2 || cellStyle == .value1 {
             if let textLabel = self.textLabel, let detailTextLabel = self.detailTextLabel {
                 let detailHeight = detailTextLabel.frame.size.height
                 let isValueTextEmpty = detailTextLabel.text?.isEmpty ?? false
@@ -66,6 +74,8 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         subviews.forEach {
             $0.alpha = 1.0
         }
+
+        initCenteredButtonLabel()
     }
 
     func applyTheme(theme: Theme) {
@@ -79,5 +89,26 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     func configure(viewModel: ThemedTableViewCellViewModel) {
         self.viewModel = viewModel
+    }
+
+    private func initCenteredButtonLabel() {
+        centeredButtonLabel.text = nil
+        centeredButtonLabel.numberOfLines = 0
+        centeredButtonLabel.font = FXFontStyles.Regular.body.scaledFont()
+        setupCenteredButtonLabelConstraints()
+    }
+
+    private func setupCenteredButtonLabelConstraints() {
+        contentView.addSubview(centeredButtonLabel)
+        NSLayoutConstraint.activate([
+            centeredButtonLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            centeredButtonLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            centeredButtonLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: contentView.leadingAnchor,
+                constant: centeredButtonLabelMargin),
+            centeredButtonLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: contentView.trailingAnchor,
+                constant: -centeredButtonLabelMargin)
+        ])
     }
 }

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
@@ -10,13 +10,9 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     var viewModel: ThemedTableViewCellViewModel?
     var cellStyle: UITableViewCell.CellStyle
 
-    private var centeredButtonLabelMargin = 15.0
-    lazy var centeredButtonLabel: UILabel = .build()
-
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         self.cellStyle = style
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        self.initCenteredButtonLabel()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -34,11 +30,7 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         var size = super.systemLayoutSizeFitting(targetSize,
                                                  withHorizontalFittingPriority: horizontalFittingPriority,
                                                  verticalFittingPriority: verticalFittingPriority)
-        if cellStyle == .default, centeredButtonLabel.text != nil {
-            let textHeight = centeredButtonLabel.frame.size.height
-            size.height += textHeight
-            return size
-        } else if cellStyle == .value2 || cellStyle == .value1 {
+        if cellStyle == .value2 || cellStyle == .value1 {
             if let textLabel = self.textLabel, let detailTextLabel = self.detailTextLabel {
                 let detailHeight = detailTextLabel.frame.size.height
                 let isValueTextEmpty = detailTextLabel.text?.isEmpty ?? false
@@ -74,8 +66,6 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         subviews.forEach {
             $0.alpha = 1.0
         }
-
-        initCenteredButtonLabel()
     }
 
     func applyTheme(theme: Theme) {
@@ -89,26 +79,5 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     func configure(viewModel: ThemedTableViewCellViewModel) {
         self.viewModel = viewModel
-    }
-
-    private func initCenteredButtonLabel() {
-        centeredButtonLabel.text = nil
-        centeredButtonLabel.numberOfLines = 0
-        centeredButtonLabel.font = FXFontStyles.Regular.body.scaledFont()
-        setupCenteredButtonLabelConstraints()
-    }
-
-    private func setupCenteredButtonLabelConstraints() {
-        contentView.addSubview(centeredButtonLabel)
-        NSLayoutConstraint.activate([
-            centeredButtonLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-            centeredButtonLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            centeredButtonLabel.leadingAnchor.constraint(
-                greaterThanOrEqualTo: contentView.leadingAnchor,
-                constant: centeredButtonLabelMargin),
-            centeredButtonLabel.trailingAnchor.constraint(
-                lessThanOrEqualTo: contentView.trailingAnchor,
-                constant: -centeredButtonLabelMargin)
-        ])
     }
 }

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
@@ -34,7 +34,7 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         var size = super.systemLayoutSizeFitting(targetSize,
                                                  withHorizontalFittingPriority: horizontalFittingPriority,
                                                  verticalFittingPriority: verticalFittingPriority)
-        if cellStyle == .default, centeredButtonLabel.text != nil  {
+        if cellStyle == .default, centeredButtonLabel.text != nil {
             let textHeight = centeredButtonLabel.frame.size.height
             size.height += textHeight
             return size

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewController.swift
@@ -76,6 +76,7 @@ class ThemedTableViewController: UITableViewController, Themeable, InjectedTheme
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.register(cellType: ThemedTableViewCell.self)
+        tableView.register(cellType: ThemedCenteredTableViewCell.self)
         applyTheme()
         listenForThemeChange(view)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -122,6 +122,7 @@ class SettingsTests: BaseTestCase {
         navigator.goto(SettingsScreen)
         navigator.nowAt(SettingsScreen)
         mozWaitForElementToExist(blockImagesSwitch)
+        app.swipeUp()
         navigator.performAction(Action.ToggleNoImageMode)
         checkShowImages(showImages: false)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9334)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20668)

## :bulb: Description
Fixed **Clear All Website Data, Disconnect Sync** and **Clear Private Data** buttons in order to be centered (regardless to the text size)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

