### PR TITLE
Add FXIOS-9305 [Microsurvey] Finalized strings

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
@@ -14,7 +14,8 @@ class MicrosurveySurfaceManager: MobileMessageSurfaceProtocol {
         .Microsurvey.Survey.Options.LikertScaleOption2,
         .Microsurvey.Survey.Options.LikertScaleOption3,
         .Microsurvey.Survey.Options.LikertScaleOption4,
-        .Microsurvey.Survey.Options.LikertScaleOption5
+        .Microsurvey.Survey.Options.LikertScaleOption5,
+        .Microsurvey.Survey.Options.LikertScaleOption6
     ]
 
     init(
@@ -28,16 +29,16 @@ class MicrosurveySurfaceManager: MobileMessageSurfaceProtocol {
     /// build a `MicrosurveyPromptView` to be presented.
     func showMicrosurveyPrompt() -> MicrosurveyModel? {
         retrieveMessage()
-        guard let surveyQuestion = message?.text else { return nil }
-
+        guard let message else { return nil }
+        let surveyQuestion = message.text
         let promptTitle = String(
-            format: message?.title ?? .Microsurvey.Prompt.TitleLabel,
+            format: message.title ?? .Microsurvey.Prompt.TitleLabel,
             AppName.shortName.rawValue
         )
-        let promptButtonLabel = message?.buttonLabel ?? .Microsurvey.Prompt.TakeSurveyButton
-        let options: [String] = message?.options ?? defaultSurveyOptions
-        let icon = message?.icon
-        let utmContent = message?.utmContent
+        let promptButtonLabel = message.buttonLabel ?? .Microsurvey.Prompt.TakeSurveyButton
+        let options = !message.options.isEmpty ? message.options : defaultSurveyOptions
+        let icon = message.icon
+        let utmContent = message.utmContent
 
         return MicrosurveyModel(
             promptTitle: promptTitle,

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1302,9 +1302,9 @@ extension String {
                 value: "%@ Logo",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the logo image that appears on the bottom sheet that informs the user that it is coming from the app specifically. Placeholder is for the app name.")
             public static let HeaderLabel = MZLocalizedString(
-                key: "Microsurvey.Survey.HeaderLabel.v127",
+                key: "Microsurvey.Survey.HeaderLabel.v129",
                 tableName: "Microsurvey",
-                value: "Complete this survey",
+                value: "Please complete survey",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the title for the header on the screen.")
             public static let CloseButtonAccessibilityLabel = MZLocalizedString(
                 key: "Microsurvey.Survey.Close.Button.AccessibilityLabel.v127",
@@ -1363,6 +1363,11 @@ extension String {
                     tableName: "Microsurvey",
                     value: "Very dissatisfied",
                     comment: "On the microsurvey, this is the title for one of the options that the user can select to answer the survey.")
+                public static let LikertScaleOption6 = MZLocalizedString(
+                    key: "Microsurvey.Survey.Options.LikertScaleOption6.v129",
+                    tableName: "Microsurvey",
+                    value: "I don't use it",
+                    comment: "On the microsurvey, this is the title for one of the options that the user can select to answer the survey. It indicates that the user has not use the feature that the survey is inquiring about.")
             }
 
             public struct ConfirmationPage {
@@ -6457,6 +6462,14 @@ extension String {
                 tableName: nil,
                 value: "When opening Firefox",
                 comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
+        }
+
+        struct v129 {
+            public static let HeaderLabel = MZLocalizedString(
+                key: "Microsurvey.Survey.HeaderLabel.v127",
+                tableName: "Microsurvey",
+                value: "Complete this survey",
+                comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the title for the header on the screen.")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20592)

## :bulb: Description
Confirmed in our weekly meeting that these strings should be finalized. 
Added new option and updated header label for the survey to be less aggressive.
Clean up optionals and fix fallback for survey options

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

