### PR TITLE
Add FXIOS-9355 Preload webview in address list view

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1046,6 +1046,7 @@
 		B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B640467D29B9B58200C5C7B6 /* TabLocationViewTests.swift */; };
 		BA1C68BA2B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1C68B92B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift */; };
 		BA1C68BC2B7ED153000D9397 /* MockWebKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */; };
+		BA7A14842C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7A14832C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift */; };
 		BA8E197F2BF2FB1900590B5F /* AddressFormManager.js in Resources */ = {isa = PBXBuildFile; fileRef = BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */; };
 		BC003F5E2B59F44600929ECB /* BrowserViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC003F5D2B59F44500929ECB /* BrowserViewControllerTests.swift */; };
 		BCFF93EE2AAA9F6E005B5B71 /* RustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFF93ED2AAA9C47005B5B71 /* RustFirefoxSuggest.swift */; };
@@ -6891,6 +6892,7 @@
 		BA1C68B92B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKFrameInfoExtensionsTest.swift; sourceTree = "<group>"; };
 		BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebKit.swift; sourceTree = "<group>"; };
 		BA354251BD3FFF63A161E385 /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
+		BA7A14832C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAddressWebViewManager.swift; sourceTree = "<group>"; };
 		BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AddressFormManager.js; sourceTree = "<group>"; };
 		BA904A3B89BC820A7A802D55 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/Storage.strings"; sourceTree = "<group>"; };
 		BAA64356B54F1CD258764620 /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/FindInPage.strings; sourceTree = "<group>"; };
@@ -10470,6 +10472,7 @@
 				8C4B0F5C2C076B12008B3E74 /* UpdatableAddressFields+Decodable.swift */,
 				8C29376D2BF79F0200146613 /* EditAddressLocalization.swift */,
 				8C29376E2BF79F0300146613 /* EditAddressViewController.swift */,
+				BA7A14832C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift */,
 			);
 			path = Edit;
 			sourceTree = "<group>";
@@ -15030,6 +15033,7 @@
 				C8741FE928C4D30F00030029 /* FileManagerInterface.swift in Sources */,
 				8A93F87229D3A5AD004159D9 /* BrowserCoordinator.swift in Sources */,
 				8A3233FE28627446003E1C33 /* LocalDesktopFolder.swift in Sources */,
+				BA7A14842C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift in Sources */,
 				8AD40FCA27BADC4B00672675 /* ReaderModeButton.swift in Sources */,
 				E1C437A32A96343A00D188CB /* FakespotFadeLabel.swift in Sources */,
 				8A3EF7FB2A2FCF9D00796E3A /* ForceCrashSetting.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -114,13 +114,14 @@ struct AddressListView: View {
         .onAppear {
             viewModel.fetchAddresses()
             applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+            viewModel.editAddressWebViewManager.preloadWebView()
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onDisappear {
-            viewModel.destroyWebView()
+            viewModel.editAddressWebViewManager.teardownWebView()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -119,6 +119,9 @@ struct AddressListView: View {
             guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
             applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
+        .onDisappear {
+            viewModel.destroyWebView()
+        }
     }
 
     // MARK: - Theme Application

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -50,7 +50,7 @@ class AddressListViewModel: ObservableObject, FeatureFlaggable {
         return themeManager.getCurrentTheme(for: windowUUID).type == .dark
     }
 
-    let editAddressWebViewManager: WebViewPreloadManaging = EditAddressWebViewManager()
+    let editAddressWebViewManager: WebViewPreloadManaging
 
     // MARK: - Initializer
 
@@ -58,11 +58,13 @@ class AddressListViewModel: ObservableObject, FeatureFlaggable {
     init(
         logger: Logger = DefaultLogger.shared,
         windowUUID: WindowUUID,
-        addressProvider: AddressProvider
+        addressProvider: AddressProvider,
+        editAddressWebViewManager: WebViewPreloadManaging = EditAddressWebViewManager()
     ) {
         self.logger = logger
         self.windowUUID = windowUUID
         self.addressProvider = addressProvider
+        self.editAddressWebViewManager = editAddressWebViewManager
     }
 
     // MARK: - Fetch Addresses

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -6,7 +6,6 @@ import SwiftUI
 import Common
 import Shared
 import Storage
-import WebKit
 import struct MozillaAppServices.UpdatableAddressFields
 import struct MozillaAppServices.Address
 
@@ -34,7 +33,6 @@ class AddressListViewModel: ObservableObject, FeatureFlaggable {
     @Published var isEditMode = false
 
     let windowUUID: WindowUUID
-    var webView: WKWebView?
 
     private let logger: Logger
 
@@ -52,6 +50,8 @@ class AddressListViewModel: ObservableObject, FeatureFlaggable {
         return themeManager.getCurrentTheme(for: windowUUID).type == .dark
     }
 
+    let editAddressWebViewManager: WebViewPreloadManaging = EditAddressWebViewManager()
+
     // MARK: - Initializer
 
     /// Initializes the AddressListViewModel.
@@ -63,31 +63,6 @@ class AddressListViewModel: ObservableObject, FeatureFlaggable {
         self.logger = logger
         self.windowUUID = windowUUID
         self.addressProvider = addressProvider
-        preloadWebView()
-    }
-
-    func preloadWebView() {
-        // Reuse existing webview if it exists
-        guard webView == nil else { return }
-        let webConfiguration = WKWebViewConfiguration()
-        webView = WKWebView(frame: .zero, configuration: webConfiguration)
-        webView?.translatesAutoresizingMaskIntoConstraints = false
-
-        // Allow Safari Web Inspector (requires toggle in Settings > Safari > Advanced).
-        if #available(iOS 16.4, *) {
-            webView?.isInspectable = true
-        }
-
-        if let url = Bundle.main.url(forResource: "AddressFormManager", withExtension: "html") {
-            let request = URLRequest(url: url)
-            webView?.loadFileURL(url, allowingReadAccessTo: url)
-            webView?.load(request)
-        }
-    }
-
-    func destroyWebView() {
-        webView?.removeFromSuperview()
-        webView = nil
     }
 
     // MARK: - Fetch Addresses

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -15,6 +15,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol = NotificationCenter.default
     var currentWindowUUID: WindowUUID? { model.windowUUID }
+    lazy var editAddressWebViewManager = model.editAddressWebViewManager
 
     init(
         themeManager: ThemeManager,
@@ -43,18 +44,18 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        model.webView?.removeFromSuperview()
-        self.evaluateJavaScript("teardownForm();")
+        editAddressWebViewManager.webView?.removeFromSuperview()
+        self.evaluateJavaScript("resetForm();")
     }
 
     private func setupWebView() {
-        guard let webView = model.webView else { return }
-        self.view.addSubview(webView)
+        guard let editAddressWebViewManager = editAddressWebViewManager.webView else { return }
+        self.view.addSubview(editAddressWebViewManager)
         NSLayoutConstraint.activate([
-            webView.topAnchor.constraint(equalTo: view.topAnchor),
-            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            editAddressWebViewManager.topAnchor.constraint(equalTo: view.topAnchor),
+            editAddressWebViewManager.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            editAddressWebViewManager.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            editAddressWebViewManager.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
 
         model.toggleEditModeAction = { [weak self] isEditMode in
@@ -88,7 +89,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
     }
 
     private func getCurrentFormData(completion: @escaping (UpdatableAddressFields) -> Void) {
-        guard let webView = model.webView else { return }
+        guard let webView = editAddressWebViewManager.webView else { return }
         webView.evaluateJavaScript("getCurrentFormData();") { [weak self] result, error in
             if let error = error {
                 self?.logger.log(
@@ -128,7 +129,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
     }
 
     private func evaluateJavaScript(_ jsCode: String) {
-        guard let webView = model.webView else { return }
+        guard let webView = editAddressWebViewManager.webView else { return }
         webView.evaluateJavaScript(jsCode) { result, error in
             if let error = error {
                 self.logger.log(

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -34,12 +34,8 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        listenForThemeChange(view)
-    }
-
-     override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
         setupWebView()
+        listenForThemeChange(view)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -15,7 +15,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol = NotificationCenter.default
     var currentWindowUUID: WindowUUID? { model.windowUUID }
-    lazy var editAddressWebViewManager = model.editAddressWebViewManager
+    var webView: WKWebView? { model.editAddressWebViewManager.webView }
 
     init(
         themeManager: ThemeManager,
@@ -42,20 +42,20 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
         setupWebView()
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        editAddressWebViewManager.webView?.removeFromSuperview()
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        webView?.removeFromSuperview()
         self.evaluateJavaScript("resetForm();")
     }
 
     private func setupWebView() {
-        guard let editAddressWebViewManager = editAddressWebViewManager.webView else { return }
-        self.view.addSubview(editAddressWebViewManager)
+        guard let webView else { return }
+        self.view.addSubview(webView)
         NSLayoutConstraint.activate([
-            editAddressWebViewManager.topAnchor.constraint(equalTo: view.topAnchor),
-            editAddressWebViewManager.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            editAddressWebViewManager.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            editAddressWebViewManager.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.topAnchor.constraint(equalTo: view.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
 
         model.toggleEditModeAction = { [weak self] isEditMode in
@@ -89,7 +89,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
     }
 
     private func getCurrentFormData(completion: @escaping (UpdatableAddressFields) -> Void) {
-        guard let webView = editAddressWebViewManager.webView else { return }
+        guard let webView else { return }
         webView.evaluateJavaScript("getCurrentFormData();") { [weak self] result, error in
             if let error = error {
                 self?.logger.log(
@@ -129,7 +129,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
     }
 
     private func evaluateJavaScript(_ jsCode: String) {
-        guard let webView = editAddressWebViewManager.webView else { return }
+        guard let webView else { return }
         webView.evaluateJavaScript(jsCode) { result, error in
             if let error = error {
                 self.logger.log(

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressWebViewManager.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressWebViewManager.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import WebKit
+
+protocol WebViewPreloadManaging {
+    var webView: WKWebView? { get }
+    func preloadWebView()
+    func teardownWebView()
+}
+
+class EditAddressWebViewManager: WebViewPreloadManaging {
+    private(set) var webView: WKWebView?
+
+    init() {
+        let webConfiguration = WKWebViewConfiguration()
+        self.webView = WKWebView(frame: .zero, configuration: webConfiguration)
+        self.webView?.translatesAutoresizingMaskIntoConstraints = false
+
+        #if targetEnvironment(simulator)
+        // Allow Safari Web Inspector only when running in simulator.
+        // Requires to toggle `show features for web developers` in
+        // Safari > Settings > Advanced menu.
+        if #available(iOS 16.4, *) {
+            self.webView?.isInspectable = true
+        }
+        #endif
+    }
+
+    func preloadWebView() {
+        loadLocalFile("AddressFormManager", relativeTo: Bundle.main.bundleURL)
+    }
+
+    private func loadLocalFile(_ filePath: String, relativeTo baseURL: URL) {
+        if let url = Bundle.main.url(forResource: filePath, withExtension: "html") {
+            let request = URLRequest(url: url)
+            webView?.loadFileURL(url, allowingReadAccessTo: url)
+            webView?.load(request)
+        }
+    }
+
+    func teardownWebView() {
+        webView?.removeFromSuperview()
+        webView = nil
+    }
+}

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.mjs
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.mjs
@@ -90,3 +90,11 @@ const toggleEditMode = (isEditable = false) => {
   }
 };
 window.toggleEditMode = toggleEditMode;
+
+/**
+ * Reset form inside the webview.
+ */
+const resetForm = () => {
+  document.querySelector("form").innerHTML = "";
+};
+window.teardownForm = resetForm;

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.mjs
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.mjs
@@ -97,4 +97,4 @@ window.toggleEditMode = toggleEditMode;
 const resetForm = () => {
   document.querySelector("form").innerHTML = "";
 };
-window.teardownForm = resetForm;
+window.resetForm = resetForm;


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9365)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20716)

## :bulb: Description
This PR:
- Preloads the address edit webview on the address list view.
- Recycles one webview for all edit screens.
- Adds code to teardown webview.
- Makes webview inspectable for easier debugging.


### Behaviour Comparison

| Comparison | Behaviour before | Behaviour after |
| ------------- | ------------- |  ------------- |
| | <video src="https://github.com/mozilla-mobile/firefox-ios/assets/26678795/e89c9138-bd59-48c7-a52d-c29c5f0f2e4e" />| <video src="https://github.com/mozilla-mobile/firefox-ios/assets/26678795/eeda65b8-68c6-4456-847a-5a87744f5441"/>|
|  fast loading | ❌  | ✅ |
|  janky | ✅  | ❌  |
|  needs a loading spinner | ✅   | ❌  |






## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~~Wrote unit tests and/or ensured the tests suite is passing~~
- [ ] ~~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~~
- [ ] ~~If needed, I updated documentation / comments for complex code and public methods~~
- [ ] ~~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~~

