### PR TITLE
Add FXIOS-9369 show/hide keyboard on edit mode toggle

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.mjs
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.mjs
@@ -3,8 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import "resource://gre/modules/shared/Helpers.ios.mjs";
-import { createFormLayoutFromRecord, getCurrentFormData } from "resource://gre/modules/shared/addressFormLayout.mjs";
+import {
+  createFormLayoutFromRecord,
+  getCurrentFormData,
+} from "resource://gre/modules/shared/addressFormLayout.mjs";
 
+// Expose getCurrentFormData to the window object.
+window.getCurrentFormData = getCurrentFormData;
 /**
  * Sets the theme of the webview.
  * @param {Boolean} isDarkTheme - Set to true if the dark theme should be applied.
@@ -12,6 +17,7 @@ import { createFormLayoutFromRecord, getCurrentFormData } from "resource://gre/m
 const setTheme = (isDarkTheme) => {
   document.body.classList.toggle("dark", isDarkTheme);
 };
+window.setTheme = setTheme;
 
 /**
  * Automatically resizes a textarea to fit its content.
@@ -73,10 +79,14 @@ const toggleEditMode = (isEditable = false) => {
   textFields.forEach((element) => (element.readOnly = !isEditable));
   selectElements.forEach((element) => (element.disabled = !isEditable));
 
-  textFields[0].focus();
+  if (isEditable) {
+    // Focus the first input field when entering edit mode.
+    // This will show the keyboard.
+    document.querySelector("input").focus();
+  } else {
+    // Remove focus from the input field when exiting edit mode.
+    // This will hide the keyboard.
+    document.activeElement.blur();
+  }
 };
 window.toggleEditMode = toggleEditMode;
-
-window.getCurrentFormData = getCurrentFormData;
-
-window.setTheme = setTheme;


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9369)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20737)

## :bulb: Description
This PR:
- Focuses first input on the form when edit mode is enabled resulting in showing the keyboard.
- Blurs active item when edit mode is disabled resulting in hiding the keyboard.

### Behaviour Comparison

| Comparison | Behaviour before | Behaviour after |
| ------------- | ------------- |  ------------- |
| | <video src="https://github.com/mozilla-mobile/firefox-ios/assets/26678795/60367b08-a90c-4249-af7e-ebecb893714f" />| <video src="https://github.com/mozilla-mobile/firefox-ios/assets/26678795/0cb10709-c49c-405e-ac46-93093c3c8a1d"/>|
|  keyboard shown when edit mode enabled | ❌  | ✅ |
|  keyboard hidden when edit mode disabled | ❌   | ✅  |
|  can immediately edit input after edit mode enabled | ❌    | ✅   |



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~~Wrote unit tests and/or ensured the tests suite is passing~~
- [ ] ~~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~~
- [ ] ~~If needed, I updated documentation / comments for complex code and public methods~~
- [ ] ~~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~~


