### PR TITLE
Fix FXIOS-9368 Remove default webkit tap highlight color 

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.css
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.css
@@ -59,6 +59,7 @@ form {
     min-height: 68px;
     padding: 11px 16px;
     box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent; /* Remove tap highlight interaction */
 
     span {
       font: -apple-system-subheadline;


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9368)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20736)

## :bulb: Description
This PR:
- Sets ` -webkit-tap-highlight-color` to  `transparent`. By default this is set to a grayish color.

### Behaviour comparison

when tapping a grayish overlay is shown.

https://github.com/mozilla-mobile/firefox-ios/assets/26678795/4cf18caf-8b5a-4961-a96e-68d9d9d5ed8b

with `-webkit-tap-highlight-color`set to  `transparent` this is not the case anymore.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~~Wrote unit tests and/or ensured the tests suite is passing~~
- [ ] ~~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~~
- [ ] ~~If needed, I updated documentation / comments for complex code and public methods~~
- [ ] ~~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~~

