### PR TITLE
Bugfix FXIOS-9371 Fix redraw loop and out-of-memory crash

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -138,8 +138,6 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         viewModel.theme = theme
         loginDataSource.viewModel = viewModel
-        tableView.reloadSections(IndexSet(integer: PasswordManagerListViewController.loginsSettingsSection),
-                                 with: .none)
 
         view.backgroundColor = theme.colors.layer1
         tableView.separatorColor = theme.colors.borderPrimary


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9371)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20743)

## :bulb: Description

Fixes a crash that occurs when opening the password VC. The view controller will frequently enter a redraw loop that increasingly consumes memory until the process crashes. This first began after [recent refactors](https://github.com/mozilla-mobile/firefox-ios/pull/20667) were merged, but it's not entirely clear yet why those caused this section reload to break in this way.

As a general rule I don't believe we should be reloading sections as part of `applyTheme` anyway, so if anyone has context on why that was there please LMK.

I tested basic theme updates with the password VC after making this change and didn't observe any regressions, and I couldn't see any obvious reason why the section reload was needed for the theme update code.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

