### PR TITLE
Bugfix FXIOS-9190 Hide username-less logins from autofill

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -567,9 +567,9 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     @MainActor
-    func showSavedLoginAutofill(tabURL: URL, currentRequestId: String) {
+    func showSavedLoginAutofill(tabURL: URL, currentRequestId: String, field: FocusFieldType) {
         let bottomSheetCoordinator = makeCredentialAutofillCoordinator()
-        bottomSheetCoordinator.showSavedLoginAutofill(tabURL: tabURL, currentRequestId: currentRequestId)
+        bottomSheetCoordinator.showSavedLoginAutofill(tabURL: tabURL, currentRequestId: currentRequestId, field: field)
     }
 
     func showAddressAutofill(frame: WKFrameInfo?) {

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -76,7 +76,7 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 
     /// Displays an autofill interface for saved logins, allowing the user to select from stored login credentials 
     /// to autofill login forms on the specified web page.
-    func showSavedLoginAutofill(tabURL: URL, currentRequestId: String)
+    func showSavedLoginAutofill(tabURL: URL, currentRequestId: String, field: FocusFieldType)
 
     /// Shows an AddressAutofill view for selecting addresses in order to autofill forms.
     func showAddressAutofill(frame: WKFrameInfo?)

--- a/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
@@ -123,9 +123,10 @@ class CredentialAutofillCoordinator: BaseCoordinator {
     }
 
     @MainActor
-    func showSavedLoginAutofill(tabURL: URL, currentRequestId: String) {
+    func showSavedLoginAutofill(tabURL: URL, currentRequestId: String, field: FocusFieldType) {
         let viewModel = LoginListViewModel(
             tabURL: tabURL,
+            field: field,
             loginStorage: profile.logins,
             logger: logger,
             onLoginCellTap: { [weak self] login in

--- a/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
@@ -51,6 +51,7 @@ struct LoginAutofillView: View {
         windowUUID: .XCTestDefaultUUID,
         viewModel: LoginListViewModel(
             tabURL: URL(string: "http://www.example.com", invalidCharacters: false)!,
+            field: FocusFieldType.username,
             loginStorage: MockLoginStorage(),
             logger: MockLogger(),
             onLoginCellTap: { _ in },

--- a/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginCellView.swift
@@ -48,7 +48,8 @@ struct LoginCellView: View {
                     .foregroundColor(iconPrimary)
                     .alignmentGuide(.midAccountAndName) { $0[VerticalAlignment.center] }
                 VStack(alignment: .leading) {
-                    Text(login.decryptedUsername.isEmpty ? login.hostname : login.decryptedUsername)
+                    Text(login.decryptedUsername.isEmpty ? String.PasswordAutofill.LoginListCellNoUsername
+                         : login.decryptedUsername)
                         .font(.body)
                         .foregroundColor(textColor)
                         .alignmentGuide(.midAccountAndName) { $0[VerticalAlignment.center] }

--- a/firefox-ios/Client/Frontend/Autofill/LoginListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginListView.swift
@@ -55,6 +55,7 @@ struct LoginListView_Previews: PreviewProvider {
             windowUUID: .XCTestDefaultUUID,
             viewModel: LoginListViewModel(
                 tabURL: URL(string: "http://www.example.com", invalidCharacters: false)!,
+                field: FocusFieldType.username,
                 loginStorage: MockLoginStorage(),
                 logger: MockLogger(),
                 onLoginCellTap: { _ in },

--- a/firefox-ios/Client/Frontend/Autofill/LoginListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginListViewModel.swift
@@ -13,6 +13,7 @@ class LoginListViewModel: ObservableObject {
     @Published var logins: [EncryptedLogin] = []
 
     private let tabURL: URL
+    private let field: FocusFieldType
     private let loginStorage: LoginStorage
     private let logger: Logger
     let onLoginCellTap: (EncryptedLogin) -> Void
@@ -24,12 +25,14 @@ class LoginListViewModel: ObservableObject {
 
     init(
         tabURL: URL,
+        field: FocusFieldType,
         loginStorage: LoginStorage,
         logger: Logger,
         onLoginCellTap: @escaping (EncryptedLogin) -> Void,
         manageLoginInfoAction: @escaping () -> Void
     ) {
         self.tabURL = tabURL
+        self.field = field
         self.loginStorage = loginStorage
         self.logger = logger
         self.onLoginCellTap = onLoginCellTap
@@ -40,6 +43,7 @@ class LoginListViewModel: ObservableObject {
         do {
             let logins = try await loginStorage.listLogins()
             self.logins = logins.filter { login in
+                if field == FocusFieldType.username && login.decryptedUsername.isEmpty { return false }
                 guard let recordHostnameURL = URL(string: login.hostname) else { return false }
                 return recordHostnameURL.baseDomain == tabURL.baseDomain
             }

--- a/firefox-ios/Client/Frontend/Autofill/LoginStorage.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginStorage.swift
@@ -52,14 +52,6 @@ class MockLoginStorage: LoginStorage {
                         persistence: .permanent
                     ),
                     protectionSpace: URLProtectionSpace.fromOrigin("https://test.com")
-                ),
-                EncryptedLogin(
-                    credentials: URLCredential(
-                        user: "",
-                        password: "doubletest",
-                        persistence: .permanent
-                    ),
-                    protectionSpace: URLProtectionSpace.fromOrigin("https://test.com")
                 )
             ]
 

--- a/firefox-ios/Client/Frontend/Autofill/LoginStorage.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginStorage.swift
@@ -52,6 +52,14 @@ class MockLoginStorage: LoginStorage {
                         persistence: .permanent
                     ),
                     protectionSpace: URLProtectionSpace.fromOrigin("https://test.com")
+                ),
+                EncryptedLogin(
+                    credentials: URLCredential(
+                        user: "",
+                        password: "doubletest",
+                        persistence: .permanent
+                    ),
+                    protectionSpace: URLProtectionSpace.fromOrigin("https://test.com")
                 )
             ]
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2785,7 +2785,9 @@ extension BrowserViewController: LegacyTabDelegate {
                         guard let recordHostnameURL = URL(string: login.hostname) else { return false }
                         return recordHostnameURL.baseDomain == tabURL.baseDomain
                     }
-                    if !loginsForCurrentTab.isEmpty {
+                    if loginsForCurrentTab.isEmpty {
+                        tab?.webView?.accessoryView.reloadViewFor(.standard)
+                    } else {
                         tab?.webView?.accessoryView.reloadViewFor(.login)
                         tab?.webView?.reloadInputViews()
                         TelemetryWrapper.recordEvent(
@@ -2793,8 +2795,6 @@ extension BrowserViewController: LegacyTabDelegate {
                             method: .view,
                             object: .loginsAutofillPromptShown
                         )
-                    } else {
-                        tab?.webView?.accessoryView.reloadViewFor(.standard)
                     }
                     tab?.webView?.accessoryView.savedLoginsClosure = {
                         Task { @MainActor [weak self] in

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -6318,6 +6318,11 @@ extension String {
             tableName: "PasswordAutofill",
             value: "Use saved password?",
             comment: "This label is used in the password list screen header as a question, prompting the user if they want to use a saved password for logging in.")
+        public static let LoginListCellNoUsername = MZLocalizedString(
+            key: "PasswordAutofill.LoginListCellNoUsername.v129",
+            tableName: "PasswordAutofill",
+            value: "(no username)",
+            comment: "This label is used in a cell found in the list of autofill login options in place of an actual username to denote that no username was saved for this login")
         public static let ManagePasswordsButton = MZLocalizedString(
             key: "PasswordAutofill.ManagePasswordsButton.v124",
             tableName: "PasswordAutofill",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/LoginListViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/LoginListViewModelTests.swift
@@ -14,7 +14,7 @@ class LoginListViewModelTests: XCTestCase {
     func testInitialization() {
         let viewModel = LoginListViewModel(
             tabURL: URL(string: "https://example.com")!,
-            field: FocusFieldType.username,
+            field: FocusFieldType.password,
             loginStorage: MockLoginStorage(),
             logger: MockLogger(),
             onLoginCellTap: { _ in },
@@ -26,25 +26,7 @@ class LoginListViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testFetchLoginsSuccessUsernameField() async {
-        let mockLoginStorage = MockLoginStorage()
-
-        let viewModel = LoginListViewModel(
-            tabURL: URL(string: "https://test.com")!,
-            field: FocusFieldType.username,
-            loginStorage: mockLoginStorage,
-            logger: MockLogger(),
-            onLoginCellTap: { _ in },
-            manageLoginInfoAction: { }
-        )
-
-        await viewModel.fetchLogins()
-
-        XCTAssertEqual(viewModel.logins.count, 2)
-    }
-
-    @MainActor
-    func testFetchLoginsSuccessPaswordField() async {
+    func testFetchLoginsSuccess() async {
         let mockLoginStorage = MockLoginStorage()
 
         let viewModel = LoginListViewModel(
@@ -58,7 +40,7 @@ class LoginListViewModelTests: XCTestCase {
 
         await viewModel.fetchLogins()
 
-        XCTAssertEqual(viewModel.logins.count, 3)
+        XCTAssertEqual(viewModel.logins.count, 2)
     }
 
     @MainActor
@@ -71,7 +53,7 @@ class LoginListViewModelTests: XCTestCase {
 
         let viewModel = LoginListViewModel(
             tabURL: URL(string: "https://example.com")!,
-            field: FocusFieldType.username,
+            field: FocusFieldType.password,
             loginStorage: mockLoginStorage,
             logger: mockLogger,
             onLoginCellTap: { _ in },
@@ -91,7 +73,7 @@ class LoginListViewModelTests: XCTestCase {
 
         let viewModel = LoginListViewModel(
             tabURL: URL(string: "https://example.com")!,
-            field: FocusFieldType.username,
+            field: FocusFieldType.password,
             loginStorage: MockLoginStorage(),
             logger: MockLogger(),
             onLoginCellTap: { _ in didTapLogin = true },
@@ -117,7 +99,7 @@ class LoginListViewModelTests: XCTestCase {
 
         let viewModel = LoginListViewModel(
             tabURL: URL(string: "https://example.com")!,
-            field: FocusFieldType.username,
+            field: FocusFieldType.password,
             loginStorage: MockLoginStorage(),
             logger: MockLogger(),
             onLoginCellTap: { _ in },

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/LoginListViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/LoginListViewModelTests.swift
@@ -14,6 +14,7 @@ class LoginListViewModelTests: XCTestCase {
     func testInitialization() {
         let viewModel = LoginListViewModel(
             tabURL: URL(string: "https://example.com")!,
+            field: FocusFieldType.username,
             loginStorage: MockLoginStorage(),
             logger: MockLogger(),
             onLoginCellTap: { _ in },
@@ -25,11 +26,12 @@ class LoginListViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testFetchLoginsSuccess() async {
+    func testFetchLoginsSuccessUsernameField() async {
         let mockLoginStorage = MockLoginStorage()
 
         let viewModel = LoginListViewModel(
             tabURL: URL(string: "https://test.com")!,
+            field: FocusFieldType.username,
             loginStorage: mockLoginStorage,
             logger: MockLogger(),
             onLoginCellTap: { _ in },
@@ -42,6 +44,25 @@ class LoginListViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testFetchLoginsSuccessPaswordField() async {
+        let mockLoginStorage = MockLoginStorage()
+
+        let viewModel = LoginListViewModel(
+            tabURL: URL(string: "https://test.com")!,
+            field: FocusFieldType.password,
+            loginStorage: mockLoginStorage,
+            logger: MockLogger(),
+            onLoginCellTap: { _ in },
+            manageLoginInfoAction: { }
+        )
+
+        await viewModel.fetchLogins()
+
+        XCTAssertEqual(viewModel.logins.count, 3)
+    }
+
+
+    @MainActor
     func testFetchLoginsFailure() async {
         let mockLoginStorage = MockLoginStorage()
         // Configure mock to throw an error
@@ -51,6 +72,7 @@ class LoginListViewModelTests: XCTestCase {
 
         let viewModel = LoginListViewModel(
             tabURL: URL(string: "https://example.com")!,
+            field: FocusFieldType.username,
             loginStorage: mockLoginStorage,
             logger: mockLogger,
             onLoginCellTap: { _ in },
@@ -70,6 +92,7 @@ class LoginListViewModelTests: XCTestCase {
 
         let viewModel = LoginListViewModel(
             tabURL: URL(string: "https://example.com")!,
+            field: FocusFieldType.username,
             loginStorage: MockLoginStorage(),
             logger: MockLogger(),
             onLoginCellTap: { _ in didTapLogin = true },
@@ -95,6 +118,7 @@ class LoginListViewModelTests: XCTestCase {
 
         let viewModel = LoginListViewModel(
             tabURL: URL(string: "https://example.com")!,
+            field: FocusFieldType.username,
             loginStorage: MockLoginStorage(),
             logger: MockLogger(),
             onLoginCellTap: { _ in },

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/LoginListViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/LoginListViewModelTests.swift
@@ -61,7 +61,6 @@ class LoginListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.logins.count, 3)
     }
 
-
     @MainActor
     func testFetchLoginsFailure() async {
         let mockLoginStorage = MockLoginStorage()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -242,7 +242,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let testURL = URL(string: "https://example.com")!
         let currentRequestId = "testRequestID"
-        let field = FocusFieldType.username
+        let field = FocusFieldType.password
         subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId, field: field)
 
         XCTAssertEqual(subject.childCoordinators.count, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -242,7 +242,8 @@ final class BrowserCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let testURL = URL(string: "https://example.com")!
         let currentRequestId = "testRequestID"
-        subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId)
+        let field = FocusFieldType.username
+        subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId, field: field)
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertTrue(subject.childCoordinators.first is CredentialAutofillCoordinator)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CredentialAutofillCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CredentialAutofillCoordinatorTests.swift
@@ -61,7 +61,7 @@ final class CredentialAutofillCoordinatorTests: XCTestCase {
 
         let testURL = URL(string: "https://example.com")!
         let currentRequestId = "testRequestID"
-        let field = FocusFieldType.username
+        let field = FocusFieldType.password
 
         subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId, field: field)
 
@@ -75,7 +75,7 @@ final class CredentialAutofillCoordinatorTests: XCTestCase {
 
         let testURL = URL(string: "https://example.com")!
         let currentRequestId = "testRequestID"
-        let field = FocusFieldType.username
+        let field = FocusFieldType.password
 
         subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId, field: field)
 
@@ -100,7 +100,7 @@ final class CredentialAutofillCoordinatorTests: XCTestCase {
 
         let testURL = URL(string: "https://example.com")!
         let currentRequestId = "testRequestID"
-        let field = FocusFieldType.username
+        let field = FocusFieldType.password
 
         subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId, field: field)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CredentialAutofillCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CredentialAutofillCoordinatorTests.swift
@@ -61,8 +61,9 @@ final class CredentialAutofillCoordinatorTests: XCTestCase {
 
         let testURL = URL(string: "https://example.com")!
         let currentRequestId = "testRequestID"
+        let field = FocusFieldType.username
 
-        subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId)
+        subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId, field: field)
 
         XCTAssertTrue(router.presentedViewController is BottomSheetViewController)
         XCTAssertEqual(router.presentCalled, 1)
@@ -74,8 +75,9 @@ final class CredentialAutofillCoordinatorTests: XCTestCase {
 
         let testURL = URL(string: "https://example.com")!
         let currentRequestId = "testRequestID"
+        let field = FocusFieldType.username
 
-        subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId)
+        subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId, field: field)
 
         if let bottomSheetViewController = router.presentedViewController as? BottomSheetViewController {
             bottomSheetViewController.loadViewIfNeeded()
@@ -98,8 +100,9 @@ final class CredentialAutofillCoordinatorTests: XCTestCase {
 
         let testURL = URL(string: "https://example.com")!
         let currentRequestId = "testRequestID"
+        let field = FocusFieldType.username
 
-        subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId)
+        subject.showSavedLoginAutofill(tabURL: testURL, currentRequestId: currentRequestId, field: field)
 
         if let bottomSheetViewController = router.presentedViewController as? BottomSheetViewController {
             bottomSheetViewController.loadViewIfNeeded()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -49,7 +49,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
         showCreditCardAutofillCalled += 1
     }
 
-    func showSavedLoginAutofill(tabURL: URL, currentRequestId: String) {
+    func showSavedLoginAutofill(tabURL: URL, currentRequestId: String, field: FocusFieldType) {
         showLoginAutofillCalled += 1
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9190)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20357)

## :bulb: Description
Although not possible to create directly from Firefox for iOS, it is possible that saved logins with empty username fields can be synced over (i.e. via desktop). To manage this, we will still show synced username-less logins in the logins list (settings -> passwords), but will conditionally hide them from the login autofill sheet that is presented when attempting to autofill a login. The UX changes are as follows:
- Username-less logins _WILL NOT_ appear in the list of logins in the login autofill sheet if the sheet is accessed via the username field
  - Conversely, username-less logins _WILL_ appear in the list when accessed via the password field (no change), and will now report `(no username)` above the `********` password mark instead of the URL hostname
- The `Used saved password` accessory view button will no longer appear above the system keyboard when a username field gains first responder unless there are saved logins that contain a username

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

