### PR TITLE
Refactor FXIOS-20674 - Refactored Learn More button in EmptyPrivateTabsView to use LinkButton

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
@@ -6,6 +6,7 @@ import Common
 import UIKit
 import Foundation
 import Shared
+import ComponentLibrary
 
 protocol EmptyPrivateTabsViewDelegate: AnyObject {
     func didTapLearnMore(urlRequest: URLRequest)
@@ -46,10 +47,9 @@ class EmptyPrivateTabsView: UIView {
         label.text = .TabTrayPrivateBrowsingDescription
     }
 
-    let learnMoreButton: UIButton = .build { button in
-        button.setTitle( .PrivateBrowsingLearnMore, for: [])
+    private lazy var learnMoreButton: LinkButton = .build { button in
         button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.titleLabel?.font = FXFontStyles.Regular.subheadline.scaledFont()
+        button.addTarget(self, action: #selector(self.didTapLearnMore), for: .touchUpInside)
     }
 
     private let iconImageView: UIImageView = .build { imageView in
@@ -67,11 +67,17 @@ class EmptyPrivateTabsView: UIView {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    private func configureLearnMoreButton() {
+        let viewModel = LinkButtonViewModel(title: .PrivateBrowsingLearnMore,
+                                            a11yIdentifier: "a11yLearnMoreButton",
+                                            font: FXFontStyles.Regular.subheadline.scaledFont(),
+                                            contentHorizontalAlignment: .center)
+        learnMoreButton.configure(viewModel: viewModel)
+    }
 
     private func setupLayout() {
-        learnMoreButton.addTarget(self,
-                                  action: #selector(didTapLearnMore),
-                                  for: .touchUpInside)
+        configureLearnMoreButton()
         containerView.addSubviews(iconImageView, titleLabel, descriptionLabel, learnMoreButton)
         scrollView.addSubview(containerView)
         addSubview(scrollView)
@@ -121,7 +127,7 @@ class EmptyPrivateTabsView: UIView {
     func applyTheme(_ theme: Theme) {
         titleLabel.textColor = theme.colors.textPrimary
         descriptionLabel.textColor = theme.colors.textPrimary
-        learnMoreButton.setTitleColor(theme.colors.borderAccentPrivate, for: [])
+        learnMoreButton.applyTheme(theme: theme)
         iconImageView.tintColor = theme.colors.iconDisabled
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9338)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20674)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Updated the Learn More button in EmptyPrivateTabsView to use LinkButton instead of UIButton. 

### Before 
<img src="https://github.com/mozilla-mobile/firefox-ios/assets/39747003/e89676ec-6d06-455a-9484-7fef61b641f9" width=300 />

### After 
#### (Accessibility Large Text off) 
<img src="https://github.com/mozilla-mobile/firefox-ios/assets/39747003/b42c9d06-c378-406f-a335-882165733caf" width=300 />
<img src="https://github.com/mozilla-mobile/firefox-ios/assets/39747003/2b320ddb-e972-403a-8b09-0dd3871ba824" width=300 />

#### (Accessibility Large Text on) 
<img src="https://github.com/mozilla-mobile/firefox-ios/assets/39747003/5b6fa413-3110-4e02-8421-868e84c6aa5d" width=300 />
<img src="https://github.com/mozilla-mobile/firefox-ios/assets/39747003/26f511fe-f1a5-4b2c-a772-3a28507b6c43" width=300 />




## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

