### PR TITLE
Refactor FXIOS-9383 - Update Fonts related to Onboarding to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardViewController.swift
@@ -10,10 +10,15 @@ class OnboardingCardViewController: UIViewController, Themeable {
     // MARK: - Common UX Elements
     struct SharedUX {
         static let topStackViewSpacing: CGFloat = 24
-        static let titleFontSize: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 28 : 22
+        static let titleFont: UIFont = {
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                return FXFontStyles.Bold.title1.scaledFont()
+            } else {
+                return FXFontStyles.Bold.title2.scaledFont()
+            }
+        }()
 
         // small device
-        static let smallTitleFontSize: CGFloat = 20
         static let smallStackViewSpacing: CGFloat = 8
         static let smallScrollViewVerticalPadding: CGFloat = 20
     }
@@ -67,8 +72,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     lazy var titleLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.textAlignment = .center
-        let fontSize = self.shouldUseSmallDeviceLayout ? SharedUX.smallTitleFontSize : SharedUX.titleFontSize
-        label.font = FXFontStyles.Bold.largeTitle.scaledFont().withSize(fontSize)
+        label.font = self.shouldUseSmallDeviceLayout ? FXFontStyles.Bold.title3.scaledFont() : SharedUX.titleFont
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)TitleLabel"
         label.accessibilityTraits.insert(.header)

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingCardViewController.swift
@@ -11,7 +11,6 @@ class OnboardingCardViewController: UIViewController, Themeable {
     struct SharedUX {
         static let topStackViewSpacing: CGFloat = 24
         static let titleFontSize: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 28 : 22
-        static let descriptionFontSize: CGFloat = 17
 
         // small device
         static let smallTitleFontSize: CGFloat = 20
@@ -69,8 +68,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
         label.numberOfLines = 0
         label.textAlignment = .center
         let fontSize = self.shouldUseSmallDeviceLayout ? SharedUX.smallTitleFontSize : SharedUX.titleFontSize
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .largeTitle,
-                                                                size: fontSize)
+        label.font = FXFontStyles.Bold.largeTitle.scaledFont().withSize(fontSize)
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)TitleLabel"
         label.accessibilityTraits.insert(.header)
@@ -79,10 +77,7 @@ class OnboardingCardViewController: UIViewController, Themeable {
     lazy var descriptionLabel: UILabel = .build { label in
         label.numberOfLines = 0
         label.textAlignment = .center
-        label.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .body,
-            size: SharedUX.descriptionFontSize
-        )
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.accessibilityIdentifier = "\(self.viewModel.a11yIdRoot)DescriptionLabel"
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9383)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20771)

## :bulb: Description
- This PR updates the font styles used in the OnboardingCardViewController class to improve consistency and adaptability to dynamic font sizes.

**iPhone 15 Pro - Before**
| Light Theme  | Dark Theme | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-06-25 at 00 37 20](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/4c55d6b2-cc4f-4583-b642-72b4401a8a04) | ![Simulator Screenshot - iPhone 15 Pro - 2024-06-25 at 00 37 51](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/63e3b7bf-b524-4c9a-8bef-c336e67e2c70) |

**iPhone 15 Pro - After**
| Light Theme  | Dark Theme | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-06-25 at 00 39 24](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/92f405be-dca2-4b36-95f3-31af2b5d3043) | ![Simulator Screenshot - iPhone 15 Pro - 2024-06-25 at 00 39 33](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/03c5c8fc-7a8e-42e7-abd8-f6375dfd4e1d) |


**iPhone SE (2nd generation) - Before**
| Light Theme  | Dark Theme | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone SE (2nd generation) - 2024-06-25 at 19 06 02](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/1300cca1-75e6-489d-9543-db7511a4203a) | ![Simulator Screenshot - iPhone SE (2nd generation) - 2024-06-25 at 19 06 15](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/e418c99c-a9ac-4bc2-9901-25d7b344290d) |

**iPhone SE (2nd generation) - After**
| Light Theme  | Dark Theme | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone SE (2nd generation) - 2024-06-25 at 19 06 02](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/1300cca1-75e6-489d-9543-db7511a4203a) | ![Simulator Screenshot - iPhone SE (2nd generation) - 2024-06-25 at 19 06 15](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/e418c99c-a9ac-4bc2-9901-25d7b344290d) |


**iPad Pro (M4) - Before**
| Portrait  | Landscape |
| -------- | ----------- |
| ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2024-06-25 at 19 15 27](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/cf21d168-5a07-483a-b3cd-720195330aa2) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2024-06-25 at 19 15 32](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/b82bf362-fc2b-4940-9f75-df2c14e526a3) |

**iPad Pro (M4) - After**
| Portrait  | Landscape |
| -------- | ----------- |
| ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2024-06-25 at 19 15 27](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/cf21d168-5a07-483a-b3cd-720195330aa2) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2024-06-25 at 19 15 32](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/b82bf362-fc2b-4940-9f75-df2c14e526a3) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)