### PR TITLE
Refactor FXIOS-9384 - Update Fonts related to LabelButtonHeaderView to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Components/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Components/LabelButtonHeaderView.swift
@@ -25,7 +25,6 @@ struct LabelButtonHeaderViewModel {
 // Firefox home view controller header view
 class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
     struct UX {
-        static let titleLabelTextSize: CGFloat = 20
         static let inBetweenSpace: CGFloat = 12
         static let bottomSpace: CGFloat = 10
         static let bottomButtonSpace: CGFloat = 6
@@ -43,8 +42,7 @@ class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
 
     lazy var titleLabel: UILabel = .build { label in
         label.text = self.title
-        label.font = DefaultDynamicFontHelper.preferredBoldFont(withTextStyle: .title3,
-                                                                size: UX.titleLabelTextSize)
+        label.font = FXFontStyles.Bold.title3.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9384)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20772)

## :bulb: Description
- This PR updates the font style used in the LabelButtonHeaderView class to improve consistency and adaptability to dynamic font sizes.

**Before**
| Light Theme  | Dark Theme | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-06-25 at 00 52 07](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/b1035e27-66b9-4c95-9937-02130855db0b) | ![Simulator Screenshot - iPhone 15 Pro - 2024-06-25 at 00 52 16](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/8e90a2e8-0c5a-428d-bbb1-b734c470906f) |

**After**
| Light Theme  | Dark Theme | 
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-06-25 at 00 55 18](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/732a48ed-2298-46cb-a97e-18ba5c3d8cde) | ![Simulator Screenshot - iPhone 15 Pro - 2024-06-25 at 00 55 26](https://github.com/mozilla-mobile/firefox-ios/assets/74779930/8b8cbdce-2f46-4b52-b6de-c932622da790) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

