### PR TITLE
Refactor FXIOS-9385: Use TabsStore directly instead of TabsStorage

### DIFF
--- a/firefox-ios/Client/TabManagement/WindowTabsSyncCoordinator.swift
+++ b/firefox-ios/Client/TabManagement/WindowTabsSyncCoordinator.swift
@@ -49,7 +49,14 @@ final class WindowTabsSyncCoordinator {
         // work like querying for top sites.
         DispatchQueue.main.asyncAfter(deadline: .now() + Timing.dbInsertionDelay) { [weak self] in
             self?.logger.log("Storing \(storedTabs.count) total tabs for \(windowCount) windows", level: .info, category: .sync)
-            self?.profile.storeTabs(storedTabs)
+            self?.profile.storeTabs(storedTabs).upon { result in
+                switch result {
+                case .success(let tabCount):
+                    self?.logger.log("Successfully stored \(tabCount) tabs", level: .info, category: .sync)
+                case .failure(let error):
+                    self?.logger.log("Failed to store tabs: \(error.localizedDescription)", level: .warning, category: .sync)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9385)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20775)

## :bulb: Description
Remove the thin wrapper of `Tabs.swift` in application-services to just directly call the TabStore APIs. I don't think we'll need the DispatchQueue that was in Tabs.swift https://github.com/mozilla/application-services/blob/main/components/tabs/ios/Tabs/Tabs.swift but happy to hear thoughts if there is a concurrency issue here.

From a testing standpoint, everything seems okay but don't know if the `queue.sync` will be needed?

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

