### PR TITLE
Add FXIOS-9388 [Microsurvey] Mark classes as final

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
@@ -6,9 +6,9 @@ import Foundation
 import Redux
 import Common
 
-class MicrosurveyPromptAction: Action { }
+final class MicrosurveyPromptAction: Action { }
 
-class MicrosurveyPromptMiddlewareAction: Action {
+final class MicrosurveyPromptMiddlewareAction: Action {
     let microsurveyModel: MicrosurveyModel?
     init(microsurveyModel: MicrosurveyModel? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
         self.microsurveyModel = microsurveyModel

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
@@ -7,7 +7,7 @@ import Redux
 import Shared
 import Common
 
-class MicrosurveyPromptMiddleware {
+final class MicrosurveyPromptMiddleware {
     private let microsurveyManager: MicrosurveyManager
 
     init(microsurveyManager: MicrosurveyManager = AppContainer.shared.resolve()) {

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -16,7 +16,7 @@ import Shared
  |----------------|
  */
 
-class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
+final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
     private struct UX {
         static let headerStackSpacing: CGFloat = 8
         static let stackSpacing: CGFloat = 17

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
@@ -5,8 +5,8 @@
 import Foundation
 import Redux
 
-class MicrosurveyAction: Action { }
-class MicrosurveyMiddlewareAction: Action { }
+final class MicrosurveyAction: Action { }
+final class MicrosurveyMiddlewareAction: Action { }
 
 enum MicrosurveyActionType: ActionType {
     case closeSurvey

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
@@ -7,7 +7,7 @@ import Redux
 import Shared
 import Common
 
-class MicrosurveyMiddleware {
+final class MicrosurveyMiddleware {
     private let microsurveySurfaceManager: MicrosurveyManager
 
     init(microsurveySurfaceManager: MicrosurveyManager = AppContainer.shared.resolve()) {

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyConfirmationView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyConfirmationView.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Common
 
-class MicrosurveyConfirmationView: UIView, ThemeApplicable {
+final class MicrosurveyConfirmationView: UIView, ThemeApplicable {
     private struct UX {
         static let stackSpacing: CGFloat = 28
         static let padding = NSDirectionalEdgeInsets(

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Common
 
-class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCell, ThemeApplicable {
+final class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCell, ThemeApplicable {
     private struct UX {
         static let radioButtonSize = CGSize(width: 24, height: 24)
         static let spacing: CGFloat = 12

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableView.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-class MicrosurveyTableView: UITableView {
+final class MicrosurveyTableView: UITableView {
     override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
         isScrollEnabled = false

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Common
 
-class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
+final class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private struct UX {
         static let radioButtonSize = CGSize(width: 24, height: 24)
         static let spacing: CGFloat = 12

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyMockModel.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyMockModel.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import Client
 
-class MicrosurveyMock {
+final class MicrosurveyMock {
     static var model: MicrosurveyModel {
         return MicrosurveyModel(
             promptTitle: "prompt title",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9388)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20781)

## :bulb: Description
Update the following classes related to the microsurvey work to use `final`
Ref: https://github.com/swiftlang/swift/blob/main/docs/OptimizationTips.rst#advice-use-final-when-you-know-the-declaration-does-not-need-to-be-overridden

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

