### PR TITLE
Add FXIOS-8893 [Microsurvey] Telemetry for prompt

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -28,7 +28,7 @@ protocol GleanPlumbMessageManagerProtocol {
     /// An optional UUID for the originating window can be provided to ensure any
     /// resulting UI is displayed in the correct window.
     /// Surface calls.
-    func onMessagePressed(_ message: GleanPlumbMessage, window: WindowUUID?)
+    func onMessagePressed(_ message: GleanPlumbMessage, window: WindowUUID?, shouldExpire: Bool)
 
     /// Handles what to do with a message when a user has dismissed it.
     /// Surface calls.
@@ -191,8 +191,8 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     }
 
     /// Handle when a user hits the CTA of the surface, and forward the bookkeeping to the store.
-    func onMessagePressed(_ message: GleanPlumbMessage, window: WindowUUID?) {
-        messagingStore.onMessagePressed(message)
+    func onMessagePressed(_ message: GleanPlumbMessage, window: WindowUUID?, shouldExpire: Bool) {
+        messagingStore.onMessagePressed(message, shouldExpire: shouldExpire)
 
         guard let helper = createMessagingHelper.createNimbusMessagingHelper() else { return }
 

--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageManager.swift
@@ -191,7 +191,7 @@ class GleanPlumbMessageManager: GleanPlumbMessageManagerProtocol {
     }
 
     /// Handle when a user hits the CTA of the surface, and forward the bookkeeping to the store.
-    func onMessagePressed(_ message: GleanPlumbMessage, window: WindowUUID?, shouldExpire: Bool) {
+    func onMessagePressed(_ message: GleanPlumbMessage, window: WindowUUID?, shouldExpire: Bool = true) {
         messagingStore.onMessagePressed(message, shouldExpire: shouldExpire)
 
         guard let helper = createMessagingHelper.createNimbusMessagingHelper() else { return }

--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessageStore.swift
@@ -15,7 +15,7 @@ protocol GleanPlumbMessageStoreProtocol {
     func onMessageDisplayed(_ message: GleanPlumbMessage)
 
     /// Track and persist user interactions with the message.
-    func onMessagePressed(_ message: GleanPlumbMessage)
+    func onMessagePressed(_ message: GleanPlumbMessage, shouldExpire: Bool)
 
     /// Do the bookkeeping for message dismissed Counts and expiry.
     func onMessageDismissed(_ message: GleanPlumbMessage)
@@ -60,11 +60,12 @@ class GleanPlumbMessageStore: GleanPlumbMessageStoreProtocol {
         set(key: message.id, metadata: message.metadata)
     }
 
-    /// For the MVP, we always expire the message.
-    func onMessagePressed(_ message: GleanPlumbMessage) {
-        onMessageExpired(message.metadata,
-                         surface: message.surface,
-                         shouldReport: false)
+    func onMessagePressed(_ message: GleanPlumbMessage, shouldExpire: Bool) {
+        if shouldExpire {
+            onMessageExpired(message.metadata,
+                             surface: message.surface,
+                             shouldReport: false)
+        }
 
         set(key: message.id, metadata: message.metadata)
     }

--- a/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -48,7 +48,7 @@ class HomepageMessageCardViewModel: MessageSurfaceProtocol {
     func handleMessagePressed() {
         guard let message else { return }
         let uuid = (delegate as? InjectedThemeUUIDIdentifiable)?.windowUUID
-        messagingManager.onMessagePressed(message, window: uuid)
+        messagingManager.onMessagePressed(message, window: uuid, shouldExpire: true)
         dismissClosure?()
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
@@ -65,7 +65,7 @@ class MicrosurveySurfaceManager: MicrosurveyManager {
 
     func handleMessagePressed() {
         guard let message else { return }
-        messagingManager.onMessagePressed(message, window: nil)
+        messagingManager.onMessagePressed(message, window: nil, shouldExpire: false)
     }
 
     func handleMessageDismiss() {

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
@@ -62,6 +62,6 @@ final class MicrosurveyPromptMiddleware {
             actionType: MicrosurveyPromptMiddlewareActionType.openSurvey
         )
         store.dispatch(newAction)
-        // TODO: FXIOS-8993 - Add Telemetry
+        microsurveyManager.handleMessagePressed()
     }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
@@ -48,7 +48,6 @@ final class MicrosurveyMiddleware {
     }
 
     private func sendTelemetryAndClosePrompt(windowUUID: WindowUUID) {
-        microsurveySurfaceManager.handleMessagePressed()
         closeMicrosurveyPrompt(windowUUID: windowUUID)
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
@@ -49,6 +49,7 @@ final class MicrosurveyMiddleware {
 
     private func sendTelemetryAndClosePrompt(windowUUID: WindowUUID) {
         closeMicrosurveyPrompt(windowUUID: windowUUID)
+        // TODO: FXIOS-8797 - Add Telemetry
     }
 
     private func closeMicrosurveyPrompt(windowUUID: WindowUUID) {

--- a/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/NotificationSurface/NotificationSurfaceManager.swift
@@ -73,7 +73,7 @@ class NotificationSurfaceManager: NotificationSurfaceDelegate {
               let message = messagingManager.messageForId(messageId)
         else { return }
 
-        messagingManager.onMessagePressed(message, window: nil)
+        messagingManager.onMessagePressed(message, window: nil, shouldExpire: true)
     }
 
     func didDismissNotification(_ userInfo: [AnyHashable: Any]) {

--- a/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceManager.swift
@@ -79,7 +79,7 @@ class SurveySurfaceManager: SurveySurfaceDelegate {
 
     func didTapTakeSurvey() {
         guard let message else { return }
-        messagingManager.onMessagePressed(message, window: nil)
+        messagingManager.onMessagePressed(message, window: nil, shouldExpire: true)
     }
 
     func didTapDismissSurvey() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
@@ -199,7 +199,7 @@ class MockGleanPlumbMessageManagerProtocol: GleanPlumbMessageManagerProtocol {
     }
 
     var onMessagePressedCalled = 0
-    func onMessagePressed(_ message: GleanPlumbMessage, window: WindowUUID?) {
+    func onMessagePressed(_ message: GleanPlumbMessage, window: WindowUUID?, shouldExpire: Bool) {
         onMessagePressedCalled += 1
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
@@ -258,6 +258,15 @@ class GleanPlumbMessageManagerTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.Messaging.clicked)
     }
 
+    func testManagerOnMessagePressed_withoutExpiring() {
+        let message = createMessage(messageId: messageId, action: "://test-action")
+        subject.onMessagePressed(message, window: nil, shouldExpire: false)
+        let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
+        XCTAssertFalse(messageMetadata.isExpired)
+        XCTAssertEqual(applicationHelper.openURLCalled, 1)
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Messaging.clicked)
+    }
+
     func testManagerOnMessagePressed_linkWithScheme() {
         // {uuid} works for the mock message helper, but in reality, you'd use {app_id};
         // this test is showing that:
@@ -436,8 +445,9 @@ class MockGleanPlumbMessageStore: GleanPlumbMessageStoreProtocol {
         }
     }
 
-    func onMessagePressed(_ message: GleanPlumbMessage) {
+    func onMessagePressed(_ message: GleanPlumbMessage, shouldExpire: Bool) {
         let metadata = metadata(for: message)
+        guard shouldExpire else { return }
         onMessageExpired(metadata, surface: message.surface, shouldReport: false)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageStoreTests.swift
@@ -33,10 +33,19 @@ class GleanPlumbMessageStoreTests: XCTestCase {
     func testOnMessageExpired_WhenPressed() {
         let message = createMessage(messageId: messageId)
         subject.onMessageDisplayed(message)
-        subject.onMessagePressed(message)
+        subject.onMessagePressed(message, shouldExpire: true)
 
         XCTAssertEqual(message.metadata.impressions, 1)
         XCTAssertTrue(message.metadata.isExpired)
+    }
+
+    func testOnMessageExpired_WhenPressedAndShouldNotExpire() {
+        let message = createMessage(messageId: messageId)
+        subject.onMessageDisplayed(message)
+        subject.onMessagePressed(message, shouldExpire: false)
+
+        XCTAssertEqual(message.metadata.impressions, 1)
+        XCTAssertFalse(message.metadata.isExpired)
     }
 
     func testOnMessageExpired_WhenDismiss() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
@@ -41,7 +41,7 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
 
         let action = getAction(for: .submitSurvey)
         mockStore.dispatch(action)
-        XCTAssertEqual(microsurveyManager.handleMessagePressedCount, 1)
+        // TODO: FXIOS-8797 - Add Telemetry
     }
 
     private func getAction(for actionType: MicrosurveyActionType) -> MicrosurveyMiddlewareAction {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyPromptMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyPromptMiddlewareTests.swift
@@ -69,6 +69,18 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
         XCTAssertEqual(microsurveyManager.handleMessageDismissCount, 1)
     }
 
+    func testContinueToSurveyAction() {
+        let mockStore = Store(
+            state: AppState(),
+            reducer: AppState.reducer,
+            middlewares: [MicrosurveyPromptMiddleware().microsurveyProvider]
+        )
+
+        let action = getAction(for: .continueToSurvey)
+        mockStore.dispatch(action)
+        XCTAssertEqual(microsurveyManager.handleMessagePressedCount, 1)
+    }
+
     private func getAction(for actionType: MicrosurveyPromptActionType) -> MicrosurveyPromptMiddlewareAction {
         return MicrosurveyPromptMiddlewareAction(windowUUID: .XCTestDefaultUUID, actionType: actionType)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8893)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19845)

## :bulb: Description
Add telemetry for prompt using existing telemetry from mobile messaging infrastructure. The telemetry for the microsurvey prompt should be using the mobile messaging built-in telemetry. In this PR, I moved the `messaging_clicked` call to the prompt. The issue with this is that the `onMessagePressed` calls the telemetry, but also expires the message. We don't want this, so I decided to add `shouldExpire` check to determine whether the message expires.

**Prompt impression** (already implemented previously)
https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_shown
**Dismiss button** (already implemented previously)
https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_dismissed
**CTA button (Continue)** (needed to add `shouldExpire` boolean to avoid expiring the messaging)
https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/messaging_clicked

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

