### PR TITLE
Bugfix FXIOS-9381 Fix sample Component Library failing to build

### DIFF
--- a/SampleComponentLibraryApp/SampleComponentLibraryApp/Theme+Extensions.swift
+++ b/SampleComponentLibraryApp/SampleComponentLibraryApp/Theme+Extensions.swift
@@ -9,7 +9,7 @@ let defaultSampleComponentUUID = UUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E
 
 extension ThemeManager {
     var currentTheme: Theme {
-        return currentTheme(for: defaultSampleComponentUUID)
+        return getCurrentTheme(for: defaultSampleComponentUUID)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9381)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20769)

## :bulb: Description
Fix for the Sample Component Library, which no longer builds after the theming refactor in #20667.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

