### PR TITLE
Bugfix FXIOS-8693 Fix 'Find In Page' not scrolling to matched item

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -684,9 +684,9 @@ public struct AccessibilityIdentifiers {
     }
 
     struct FindInPage {
-        static let findInPageCloseButton = "FindInPage.closeButton"
-        static let findNextButton = "FindInPage.find_next"
-        static let findPreviousButton = "FindInPage.find_previous"
+        static let findInPageCloseButton = "find.doneButton"
+        static let findNextButton = "find.nextButton"
+        static let findPreviousButton = "find.previousButton"
     }
 
     struct RememberCreditCard {

--- a/firefox-ios/Client/Extensions/UIViewController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIViewController+Extension.swift
@@ -64,12 +64,11 @@ extension UIViewController {
         guard let uuid = (view as ThemeUUIDIdentifiable).currentWindowUUID else { return }
 
         let vcToPresent = vcBeingPresented
-        let buttonItem = UIBarButtonItem(
-            title: navItemText.localizedString(),
-            style: .plain,
-            target: self,
-            action: #selector(dismissVC)
-        )
+        let buttonItem = UIBarButtonItem(title: navItemText.localizedString(), style: .plain) { [weak self] _ in
+            // Note: Do not initialize the back button action with an @objc selector, as `dismissVC`'s method signature
+            // no longer matches (will crash).
+            self?.dismissVC()
+        }
         switch navItemLocation {
         case .Left:
             vcToPresent.navigationItem.leftBarButtonItem = buttonItem
@@ -90,9 +89,8 @@ extension UIViewController {
         presentWithModalDismissIfNeeded(themedNavigationController, animated: true)
     }
 
-    @objc
-    func dismissVC() {
-        self.dismiss(animated: true, completion: nil)
+    func dismissVC(withCompletion completion: (() -> Void)? = nil) {
+        self.dismiss(animated: true, completion: completion)
     }
 
     /// A convenience function to dismiss modal presentation views if they are

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
@@ -6,6 +6,8 @@ import Shared
 
 extension BrowserViewController {
     func updateFindInPageVisibility(visible: Bool, tab: Tab? = nil) {
+        // TODO: The find interactions for iOS 16 close themselves, so once the min deployment target is iOS 16,
+        // we may be able to remove the `isVisible` flag and let the system manage dismissal.
         if #available(iOS 16, *) {
             useApplesFindInteraction(isVisible: visible)
         } else {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
@@ -5,18 +5,18 @@
 import Shared
 
 extension BrowserViewController {
-    func updateFindInPageVisibility(visible: Bool, tab: Tab? = nil) {
+    func updateFindInPageVisibility(isVisible: Bool, tab: Tab? = nil) {
         // TODO: The find interactions for iOS 16 close themselves, so once the min deployment target is iOS 16,
         // we may be able to remove the `isVisible` flag and let the system manage dismissal.
         if #available(iOS 16, *) {
-            useApplesFindInteraction(isVisible: visible)
+            useSystemFindInteraction(isVisible: isVisible)
         } else {
-            useCustomFindInteraction(visible: visible, tab: tab)
+            useCustomFindInteraction(isVisible: isVisible, tab: tab)
         }
     }
 
     @available(iOS 16, *)
-    private func useApplesFindInteraction(isVisible: Bool) {
+    private func useSystemFindInteraction(isVisible: Bool) {
         guard let webView = tabManager.selectedTab?.webView else { return }
 
         if isVisible {
@@ -28,8 +28,8 @@ extension BrowserViewController {
         }
     }
 
-    private func useCustomFindInteraction(visible: Bool, tab: Tab? = nil) {
-        if visible {
+    private func useCustomFindInteraction(isVisible: Bool, tab: Tab? = nil) {
+        if isVisible {
             if findInPageBar == nil { setupFindInPage() }
 
             self.findInPageBar?.becomeFirstResponder()
@@ -90,7 +90,7 @@ extension BrowserViewController: FindInPageBarDelegate, FindInPageHelperDelegate
     }
 
     func findInPageDidPressClose(_ findInPage: FindInPageBar) {
-        updateFindInPageVisibility(visible: false)
+        updateFindInPageVisibility(isVisible: false)
     }
 
     fileprivate func find(_ text: String, function: String) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
@@ -6,10 +6,29 @@ import Shared
 
 extension BrowserViewController {
     func updateFindInPageVisibility(visible: Bool, tab: Tab? = nil) {
+        if #available(iOS 16, *) {
+            useApplesFindInteraction(isVisible: visible)
+        } else {
+            useCustomFindInteraction(visible: visible, tab: tab)
+        }
+    }
+
+    @available(iOS 16, *)
+    private func useApplesFindInteraction(isVisible: Bool) {
+        guard let webView = tabManager.selectedTab?.webView else { return }
+
+        if isVisible {
+            webView.isFindInteractionEnabled = true
+            webView.findInteraction?.presentFindNavigator(showingReplace: false)
+        } else {
+            webView.findInteraction?.dismissFindNavigator()
+            webView.isFindInteractionEnabled = false
+        }
+    }
+
+    private func useCustomFindInteraction(visible: Bool, tab: Tab? = nil) {
         if visible {
-            if findInPageBar == nil {
-                setupFindInPage()
-            }
+            if findInPageBar == nil { setupFindInPage() }
 
             self.findInPageBar?.becomeFirstResponder()
         } else if let findInPageBar = self.findInPageBar {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -337,7 +337,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate {
     }
 
     func showFindInPage() {
-        updateFindInPageVisibility(visible: true)
+        updateFindInPageVisibility(isVisible: true)
     }
 
     func showCustomizeHomePage() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -34,7 +34,7 @@ class DismissableNavigationViewController: UINavigationController, OnViewDismiss
 extension BrowserViewController: URLBarDelegate {
     func showTabTray(withFocusOnUnselectedTab tabToFocus: Tab? = nil,
                      focusedSegment: TabTrayPanelType? = nil) {
-        updateFindInPageVisibility(visible: false)
+        updateFindInPageVisibility(isVisible: false)
 
         if isTabTrayRefactorEnabled {
             let isPrivateTab = tabManager.selectedTab?.isPrivate ?? false

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -466,7 +466,7 @@ extension BrowserViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         if tabManager.selectedTab?.webView !== webView { return }
 
-        updateFindInPageVisibility(visible: false)
+        updateFindInPageVisibility(isVisible: false)
 
         // If we are going to navigate to a new page, hide the reader mode button. Unless we
         // are going to a about:reader page. Then we keep it on screen: it will change status

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -464,9 +464,7 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        if tabManager.selectedTab?.webView !== webView {
-            return
-        }
+        if tabManager.selectedTab?.webView !== webView { return }
 
         updateFindInPageVisibility(visible: false)
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2836,7 +2836,7 @@ extension BrowserViewController: LegacyTabDelegate {
     }
 
     func tab(_ tab: Tab, didSelectFindInPageForSelection selection: String) {
-        updateFindInPageVisibility(visible: true)
+        updateFindInPageVisibility(isVisible: true)
         findInPageBar?.text = selection
     }
 
@@ -3131,7 +3131,7 @@ extension BrowserViewController: TabManagerDelegate {
             }
         }
 
-        updateFindInPageVisibility(visible: false, tab: previous)
+        updateFindInPageVisibility(isVisible: false, tab: previous)
         setupMiddleButtonStatus(isLoading: selected?.loading ?? false)
 
         if isToolbarRefactorEnabled {

--- a/firefox-ios/Client/Frontend/Browser/FindInPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/FindInPageBar.swift
@@ -67,7 +67,7 @@ class FindInPageBar: UIView, ThemeApplicable {
             for: .normal)
         button.accessibilityLabel = .FindInPageDoneAccessibilityLabel
         button.addTarget(self, action: #selector(self.didPressClose), for: .touchUpInside)
-        button.accessibilityIdentifier = "FindInPage.close"
+        button.accessibilityIdentifier = AccessibilityIdentifiers.FindInPage.findInPageCloseButton
     }
 
     var currentResult = 0 {

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -494,7 +494,7 @@ extension PhotonActionSheet: UITableViewDataSource, UITableViewDelegate {
 
 // MARK: - PhotonActionSheetViewDelegate
 extension PhotonActionSheet: PhotonActionSheetContainerCellDelegate {
-    func didClick(item: SingleActionViewModel?) {
-        dismissVC()
+    func didClick(item: SingleActionViewModel?, animationCompletion: @escaping () -> Void) {
+        dismissVC(withCompletion: animationCompletion)
     }
 }

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetContainerCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetContainerCell.swift
@@ -7,7 +7,7 @@ import Foundation
 import Shared
 
 protocol PhotonActionSheetContainerCellDelegate: AnyObject {
-    func didClick(item: SingleActionViewModel?)
+    func didClick(item: SingleActionViewModel?, animationCompletion: @escaping () -> Void)
 }
 
 // A PhotonActionSheet cell
@@ -83,7 +83,7 @@ class PhotonActionSheetContainerCell: UITableViewCell, ReusableCell, ThemeApplic
 
 // MARK: - PhotonActionSheetViewDelegate
 extension PhotonActionSheetContainerCell: PhotonActionSheetViewDelegate {
-    func didClick(item: SingleActionViewModel?) {
-        delegate?.didClick(item: item)
+    func didClick(item: SingleActionViewModel?, animationCompletion: @escaping () -> Void) {
+        delegate?.didClick(item: item, animationCompletion: animationCompletion)
     }
 }

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
@@ -9,7 +9,7 @@ import Shared
 
 // MARK: - PhotonActionSheetViewDelegate
 protocol PhotonActionSheetViewDelegate: AnyObject {
-    func didClick(item: SingleActionViewModel?)
+    func didClick(item: SingleActionViewModel?, animationCompletion: @escaping () -> Void)
 }
 
 // This is the view contained in PhotonActionSheetContainerCell in the PhotonActionSheet table view.
@@ -175,8 +175,12 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
         isSelected = (gestureRecognizer?.state == .began) || (gestureRecognizer?.state == .changed)
 
         item.isEnabled = !item.isEnabled
-        handler(item)
-        self.delegate?.didClick(item: item)
+
+        // Notify the delegate then wait until all animations are completed before handling the item
+        // (Note: The iOS16 system find interactor will only work if the settings menu dismiss animation has completed)
+        self.delegate?.didClick(item: item, animationCompletion: {
+            handler(item)
+        })
     }
 
     // MARK: Setup

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -16,7 +16,7 @@ class FindInPageTests: BaseTestCase {
 
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.FindInPage.findNextButton], timeout: 5)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.FindInPage.findPreviousButton], timeout: 5)
-        XCTAssertTrue(app.textFields["FindInPage.searchField"].exists)
+        XCTAssertTrue(app.searchFields["find.searchField"].exists)
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323463
@@ -34,9 +34,9 @@ class FindInPageTests: BaseTestCase {
         app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.search].tap()
 
         // Enter some text to start finding
-        app.textFields["FindInPage.searchField"].typeText("Book")
-        mozWaitForElementToExist(app.textFields["Book"], timeout: 15)
-        XCTAssertEqual(app.staticTexts["FindInPage.matchCount"].label, "1/500+", "The book word count does match")
+        app.searchFields["find.searchField"].typeText("Book")
+        mozWaitForElementToExist(app.searchFields["Book"], timeout: 15)
+        XCTAssertEqual(app.staticTexts["find.resultLabel"].label, "1 of 1,000", "The book word count does match")
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2306851
@@ -46,31 +46,32 @@ class FindInPageTests: BaseTestCase {
         openFindInPageFromMenu(openSite: userState.url!)
 
         // Enter some text to start finding
-        app.textFields["FindInPage.searchField"].typeText("Book")
+        app.searchFields["find.searchField"].typeText("Book")
 
         // Once there are matches, test previous/next buttons
-        mozWaitForElementToExist(app.staticTexts["1/6"], timeout: TIMEOUT)
-        XCTAssertTrue(app.staticTexts["1/6"].exists)
+        mozWaitForElementToExist(app.staticTexts["1 of 6"], timeout: TIMEOUT)
+        XCTAssertTrue(app.staticTexts["1 of 6"].exists)
 
         let nextInPageResultButton = app.buttons[AccessibilityIdentifiers.FindInPage.findNextButton]
         nextInPageResultButton.tap()
-        mozWaitForElementToExist(app.staticTexts["2/6"], timeout: TIMEOUT)
-        XCTAssertTrue(app.staticTexts["2/6"].exists)
+        mozWaitForElementToExist(app.staticTexts["2 of 6"], timeout: TIMEOUT)
+        XCTAssertTrue(app.staticTexts["2 of 6"].exists)
 
-        dismissSurveyPrompt()
+        // FIXME What is the survey prompt and is it expected that we don't see it now?
+//        dismissSurveyPrompt()
         nextInPageResultButton.tap()
-        mozWaitForElementToExist(app.staticTexts["3/6"], timeout: TIMEOUT)
-        XCTAssertTrue(app.staticTexts["3/6"].exists)
+        mozWaitForElementToExist(app.staticTexts["3 of 6"], timeout: TIMEOUT)
+        XCTAssertTrue(app.staticTexts["3 of 6"].exists)
 
         let previousInPageResultButton = app.buttons[AccessibilityIdentifiers.FindInPage.findPreviousButton]
         previousInPageResultButton.tap()
 
-        mozWaitForElementToExist(app.staticTexts["2/6"], timeout: TIMEOUT)
-        XCTAssertTrue(app.staticTexts["2/6"].exists)
+        mozWaitForElementToExist(app.staticTexts["2 of 6"], timeout: TIMEOUT)
+        XCTAssertTrue(app.staticTexts["2 of 6"].exists)
 
         previousInPageResultButton.tap()
-        mozWaitForElementToExist(app.staticTexts["1/6"], timeout: TIMEOUT)
-        XCTAssertTrue(app.staticTexts["1/6"].exists)
+        mozWaitForElementToExist(app.staticTexts["1 of 6"], timeout: TIMEOUT)
+        XCTAssertTrue(app.staticTexts["1 of 6"].exists)
 
         // Tapping on close dismisses the search bar
         navigator.goto(BrowserTab)
@@ -82,11 +83,11 @@ class FindInPageTests: BaseTestCase {
         userState.url = path(forTestPage: "test-mozilla-book.html")
         openFindInPageFromMenu(openSite: userState.url!)
         // Enter some text to start finding
-        app.textFields["FindInPage.searchField"].typeText("The Book of")
+        app.searchFields["find.searchField"].typeText("The Book of")
 
         // Once there are matches, test previous/next buttons
-        mozWaitForElementToExist(app.staticTexts["1/6"], timeout: TIMEOUT)
-        XCTAssertTrue(app.staticTexts["1/6"].exists)
+        mozWaitForElementToExist(app.staticTexts["1 of 6"], timeout: TIMEOUT)
+        XCTAssertTrue(app.staticTexts["1 of 6"].exists)
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323714
@@ -99,9 +100,9 @@ class FindInPageTests: BaseTestCase {
         app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].tap()
         // Enter some text to start finding
         app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.search].tap()
-        app.textFields["FindInPage.searchField"].typeText("The Book of")
-        mozWaitForElementToExist(app.textFields["The Book of"], timeout: 15)
-        XCTAssertEqual(app.staticTexts["FindInPage.matchCount"].label, "1/500+", "The book word count does match")
+        app.searchFields["find.searchField"].typeText("The Book of")
+        mozWaitForElementToExist(app.searchFields["The Book of"], timeout: 15)
+        XCTAssertEqual(app.staticTexts["find.resultLabel"].label, "1 of 1,000", "The book word count does match")
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323718
@@ -109,11 +110,11 @@ class FindInPageTests: BaseTestCase {
         userState.url = "lorem2.com"
         openFindInPageFromMenu(openSite: userState.url!)
         // Enter some text to start finding
-        app.textFields["FindInPage.searchField"].typeText("lorem")
+        app.searchFields["find.searchField"].typeText("lorem")
 
         // There should be matches
-        mozWaitForElementToExist(app.staticTexts["1/5"], timeout: TIMEOUT)
-        XCTAssertTrue(app.staticTexts["1/5"].exists)
+        mozWaitForElementToExist(app.staticTexts["1 of 5"], timeout: TIMEOUT)
+        XCTAssertTrue(app.staticTexts["1 of 5"].exists)
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323801
@@ -122,9 +123,9 @@ class FindInPageTests: BaseTestCase {
         openFindInPageFromMenu(openSite: userState.url!)
 
         // Try to find text which does not match and check that there are not results
-        app.textFields["FindInPage.searchField"].typeText("foo")
-        mozWaitForElementToExist(app.staticTexts["0/0"], timeout: TIMEOUT)
-        XCTAssertTrue(app.staticTexts["0/0"].exists, "There should not be any matches")
+        app.searchFields["find.searchField"].typeText("foo")
+        mozWaitForElementToExist(app.staticTexts["0"], timeout: TIMEOUT)
+        XCTAssertTrue(app.staticTexts["0"].exists, "There should not be any matches")
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323802
@@ -137,8 +138,8 @@ class FindInPageTests: BaseTestCase {
         app.textFields["address"].typeText("\n")
 
         // Once the page is reloaded the search bar should not appear
-        mozWaitForElementToNotExist(app.textFields[""])
-        XCTAssertFalse(app.textFields[""].exists)
+        mozWaitForElementToNotExist(app.searchFields["find.searchField"])
+        XCTAssertFalse(app.searchFields["find.searchField"].exists)
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323803
@@ -147,7 +148,7 @@ class FindInPageTests: BaseTestCase {
         openFindInPageFromMenu(openSite: userState.url!)
 
         // Dismiss keyboard
-        app.buttons["FindInPage.close"].tap()
+        app.buttons[AccessibilityIdentifiers.FindInPage.findInPageCloseButton].tap()
         navigator.nowAt(BrowserTab)
 
         // Going to tab tray and back to the website hides the search field.
@@ -155,7 +156,7 @@ class FindInPageTests: BaseTestCase {
 
         mozWaitForElementToExist(app.cells.staticTexts["The Book of Mozilla"])
         app.cells.staticTexts["The Book of Mozilla"].firstMatch.tap()
-        XCTAssertFalse(app.textFields[""].exists)
+        XCTAssertFalse(app.searchFields["find.searchField"].exists)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.FindInPage.findNextButton].exists)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.FindInPage.findPreviousButton].exists)
     }
@@ -192,8 +193,8 @@ class FindInPageTests: BaseTestCase {
         }
         mozWaitForElementToExist(app.menuItems["Find in Page"])
         app.menuItems["Find in Page"].tap()
-        mozWaitForElementToExist(app.textFields[textToFind])
-        XCTAssertTrue(app.textFields[textToFind].exists, "The bar does not appear with the text selected to be found")
+        mozWaitForElementToExist(app.searchFields[textToFind])
+        XCTAssertTrue(app.searchFields[textToFind].exists, "The bar does not appear with the text selected to be found")
         XCTAssertTrue(
             app.buttons[AccessibilityIdentifiers.FindInPage.findPreviousButton].exists,
             "Find previous button exists"

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -1037,7 +1037,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(FindInPage) { screenState in
-        screenState.tap(app.buttons["FindInPage.close"], to: BrowserTab)
+        screenState.tap(app.buttons[AccessibilityIdentifiers.FindInPage.findInPageCloseButton], to: BrowserTab)
     }
 
     map.addScreenState(PageZoom) { screenState in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8693)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19280)

## :bulb: Description

When browsing a webpage and choosing Settings > Find In Page and then typing a search query, the in-house `FindInPageBar` did not always properly scroll the `WKWebView` to the term found on the page.

For iOS16 and above, this fix replaces the `FindInPageBar` with the system [UIFindInteraction](https://developer.apple.com/documentation/uikit/uifindinteraction), which is automatically available on `WKWebView`s.

See the screenshots for the new appearance.

<img src="https://github.com/mozilla-mobile/firefox-ios/assets/173110554/3dc32700-3199-488a-8f71-1a1f52e5ca88.png" width=50% height=50%><img src="https://github.com/mozilla-mobile/firefox-ios/assets/173110554/8596e96e-0ad8-4c03-bf29-7fdf313c40d3.png" width=50% height=50%><img src="https://github.com/mozilla-mobile/firefox-ios/assets/173110554/9584f24d-190c-45dc-b43b-1cc249313d73.png" width=50% height=50%>

### Discussion

Simply adding the `useSystemFindInteraction(isVisible:)` method wasn't sufficient for the UIFindInteraction to work (@adudenamedruby). At best you'd see a glitchy screen dimming behaviour, but the find interactor would not appear. This was resolved by ensuring that the settings menu `PhotonActionSheet` was fully dismissed (animations complete) prior to calling `presentFindNavigator` on the `WKWebView`. This meant adding an `animationCompletion` block to some of the PhotonActionSheet delegates.

Alternatively, the `presentFindNavigator` may be called in a `DispatchQueue.main.asyncAfter` block or called after `RunLoop.current.run(mode: .default, before: Date())`, but these solutions seemed a bit hacky. However, if we want to avoid changes to the PhotonActionSheet, they're other options.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

