### PR TITLE
Add FXIOS-8797 [Microsurvey] Telemetry for survey

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -753,6 +753,7 @@
 		8A7AE4442BAB510B0072DAEC /* LibraryPanelCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7AE4432BAB510B0072DAEC /* LibraryPanelCoordinatorDelegate.swift */; };
 		8A7AE4472BAC78230072DAEC /* MockLibraryNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7AE4452BAC76B00072DAEC /* MockLibraryNavigationHandler.swift */; };
 		8A7D1AC52BA3542600162F4B /* splashScreen.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A7D1AC42BA3542600162F4B /* splashScreen.json */; };
+		8A8158CB2C2C77B000281F72 /* MicrosurveyTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8158CA2C2C77B000281F72 /* MicrosurveyTelemetry.swift */; };
 		8A827E302C20C7F5008D5E3C /* MicrosurveyMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A827E2E2C20C55E008D5E3C /* MicrosurveyMiddlewareTests.swift */; };
 		8A827E322C20C8AE008D5E3C /* MockMicrosurveySurfaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A827E312C20C8AE008D5E3C /* MockMicrosurveySurfaceManager.swift */; };
 		8A827E362C20CB5B008D5E3C /* MicrosurveyPromptMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A827E342C20CB44008D5E3C /* MicrosurveyPromptMiddlewareTests.swift */; };
@@ -6234,6 +6235,7 @@
 		8A7AE4432BAB510B0072DAEC /* LibraryPanelCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPanelCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		8A7AE4452BAC76B00072DAEC /* MockLibraryNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLibraryNavigationHandler.swift; sourceTree = "<group>"; };
 		8A7D1AC42BA3542600162F4B /* splashScreen.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = splashScreen.json; sourceTree = "<group>"; };
+		8A8158CA2C2C77B000281F72 /* MicrosurveyTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyTelemetry.swift; sourceTree = "<group>"; };
 		8A827E2E2C20C55E008D5E3C /* MicrosurveyMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyMiddlewareTests.swift; sourceTree = "<group>"; };
 		8A827E312C20C8AE008D5E3C /* MockMicrosurveySurfaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMicrosurveySurfaceManager.swift; sourceTree = "<group>"; };
 		8A827E342C20CB44008D5E3C /* MicrosurveyPromptMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MicrosurveyPromptMiddlewareTests.swift; path = Mock/MicrosurveyPromptMiddlewareTests.swift; sourceTree = "<group>"; };
@@ -9967,6 +9969,7 @@
 		8A6A3D452BD038EF00BFDB64 /* Microsurvey */ = {
 			isa = PBXGroup;
 			children = (
+				8A8158CA2C2C77B000281F72 /* MicrosurveyTelemetry.swift */,
 				8A4EA0D02C010BE700E4E4F1 /* MicrosurveySurfaceManager.swift */,
 				8A4EA0DC2C0117F200E4E4F1 /* MicrosurveyModel.swift */,
 				8AAEB9FF2BF510E4000C02B5 /* Survey */,
@@ -14878,6 +14881,7 @@
 				961577922A38FDB300391E8D /* SponsoredTileDataUtility.swift in Sources */,
 				D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */,
 				C8445A14264428DC00B83F53 /* LibraryPanelViewState.swift in Sources */,
+				8A8158CB2C2C77B000281F72 /* MicrosurveyTelemetry.swift in Sources */,
 				D5D052D92645ABF400759F85 /* ExperimentsSettingsView.swift in Sources */,
 				E134D5802B31FF3100C6B17B /* FakespotAdLinkButton.swift in Sources */,
 				8AE0BF4F2819B10E00F33EC4 /* TopSitesSettingsViewController.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTelemetry.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+struct MicrosurveyTelemetry {
+    func surveyViewed() {
+        GleanMetrics.Microsurvey.shown.record()
+    }
+
+    func privacyNoticeTapped() {
+        GleanMetrics.Microsurvey.privacyNoticeTapped.record()
+    }
+
+    func dismissButtonTapped() {
+        GleanMetrics.Microsurvey.dismissButtonTapped.record()
+    }
+
+    func userResponseSubmitted(userSelection: String) {
+        let userSelectionExtra = GleanMetrics.Microsurvey.SubmitButtonTappedExtra(userSelection: userSelection)
+        GleanMetrics.Microsurvey.submitButtonTapped.record(userSelectionExtra)
+    }
+}

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
@@ -4,14 +4,23 @@
 
 import Foundation
 import Redux
+import Common
 
-final class MicrosurveyAction: Action { }
+final class MicrosurveyAction: Action {
+    let userSelection: String?
+
+    init(userSelection: String? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
+        self.userSelection = userSelection
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
 final class MicrosurveyMiddlewareAction: Action { }
 
 enum MicrosurveyActionType: ActionType {
     case closeSurvey
     case submitSurvey
     case tapPrivacyNotice
+    case surveyDidAppear
 }
 
 enum MicrosurveyMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
@@ -8,11 +8,7 @@ import Shared
 import Common
 
 final class MicrosurveyMiddleware {
-    private let microsurveySurfaceManager: MicrosurveyManager
-
-    init(microsurveySurfaceManager: MicrosurveyManager = AppContainer.shared.resolve()) {
-        self.microsurveySurfaceManager = microsurveySurfaceManager
-    }
+    private let microsurveyTelemetry = MicrosurveyTelemetry()
 
     lazy var microsurveyProvider: Middleware<AppState> = { state, action in
         let windowUUID = action.windowUUID
@@ -22,7 +18,9 @@ final class MicrosurveyMiddleware {
         case MicrosurveyActionType.tapPrivacyNotice:
             self.navigateToPrivacyNotice(windowUUID: windowUUID)
         case MicrosurveyActionType.submitSurvey:
-            self.sendTelemetryAndClosePrompt(windowUUID: windowUUID)
+            self.sendTelemetryAndClosePrompt(windowUUID: windowUUID, action: action)
+        case MicrosurveyActionType.surveyDidAppear:
+            self.microsurveyTelemetry.surveyViewed()
         default:
            break
         }
@@ -34,8 +32,8 @@ final class MicrosurveyMiddleware {
             actionType: MicrosurveyMiddlewareActionType.dismissSurvey
         )
         store.dispatch(newAction)
+        microsurveyTelemetry.dismissButtonTapped()
         closeMicrosurveyPrompt(windowUUID: windowUUID)
-        // TODO: FXIOS-8993 - Add Telemetry
     }
 
     private func navigateToPrivacyNotice(windowUUID: WindowUUID) {
@@ -44,12 +42,13 @@ final class MicrosurveyMiddleware {
             actionType: MicrosurveyMiddlewareActionType.navigateToPrivacyNotice
         )
         store.dispatch(newAction)
-        // TODO: FXIOS-8993 - Add Telemetry
+        microsurveyTelemetry.privacyNoticeTapped()
     }
 
-    private func sendTelemetryAndClosePrompt(windowUUID: WindowUUID) {
+    private func sendTelemetryAndClosePrompt(windowUUID: WindowUUID, action: Action) {
         closeMicrosurveyPrompt(windowUUID: windowUUID)
-        // TODO: FXIOS-8797 - Add Telemetry
+        guard let userSelection = (action as? MicrosurveyAction)?.userSelection else { return }
+        microsurveyTelemetry.userResponseSubmitted(userSelection: userSelection)
     }
 
     private func closeMicrosurveyPrompt(windowUUID: WindowUUID) {
@@ -59,6 +58,5 @@ final class MicrosurveyMiddleware {
                 actionType: MicrosurveyPromptActionType.closePrompt
             )
         )
-        // TODO: FXIOS-8993 - Add Telemetry
     }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
@@ -46,6 +46,10 @@ final class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplic
         label.isAccessibilityElement = false
     }
 
+    var title: String? {
+        optionLabel.text
+    }
+
     var checked = false {
         didSet {
             let checkedButton = UIImage(named: UX.Images.selected)

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -27,6 +27,7 @@ final class MicrosurveyViewController: UIViewController,
     private let windowUUID: WindowUUID
     private let model: MicrosurveyModel
     private var microsurveyState: MicrosurveyState
+    private var selectedOption: String?
 
     // MARK: UI Elements
     private struct UX {
@@ -180,6 +181,9 @@ final class MicrosurveyViewController: UIViewController,
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        store.dispatch(
+            MicrosurveyAction(windowUUID: windowUUID, actionType: MicrosurveyActionType.surveyDidAppear)
+        )
         UIAccessibility.post(notification: .screenChanged, argument: nil)
     }
 
@@ -309,7 +313,11 @@ final class MicrosurveyViewController: UIViewController,
 
     private func sendTelemetry() {
         store.dispatch(
-            MicrosurveyAction(windowUUID: windowUUID, actionType: MicrosurveyActionType.submitSurvey)
+            MicrosurveyAction(
+                userSelection: selectedOption,
+                windowUUID: windowUUID,
+                actionType: MicrosurveyActionType.submitSurvey
+            )
         )
     }
 
@@ -378,6 +386,7 @@ final class MicrosurveyViewController: UIViewController,
         let selectedCell = tableView.cellForRow(at: indexPath) as? MicrosurveyTableViewCell
         if selectedCell?.checked == false {
             (tableView.cellForRow(at: indexPath) as? MicrosurveyTableViewCell)?.checked.toggle()
+            selectedOption = selectedCell?.title
         }
     }
 

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -656,6 +656,67 @@ downloads:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-01-01"
 
+# Microsurvey
+microsurvey:
+  shown:
+    type: event
+    description: |
+        The survey surface (bottom sheet) was shown and visible.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/19506
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/20801
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-01-01"
+
+  privacy_notice_tapped:
+    type: event
+    description: |
+        Records that the user tapped on the privacy notice.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/19506
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/20801
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    data_sensitivity:
+      - interaction
+    expires: "2025-01-01"
+
+  dismiss_button_tapped:
+    type: event
+    description: |
+        Records that the user tapped on the close button to dismiss the survey.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/19506
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/20801
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    data_sensitivity:
+      - interaction
+    expires: "2025-01-01"
+
+  submit_button_tapped:
+    type: event
+    description: |
+        Records that the user tapped on the submit button to respond to the survey.
+    extra_keys:
+      user_selection:
+        type: string
+        description: |
+          The user's selected option e.g. "satisfied".
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/19506
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/20801
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    data_sensitivity:
+      - interaction
+    expires: "2025-01-01"
+
 # Shopping Experience (Fakespot)
 shopping:
   product_page_visits:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
@@ -2,29 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Glean
 import Redux
 import XCTest
 
 @testable import Client
 
 final class MicrosurveyMiddlewareTests: XCTestCase {
-    private var microsurveyManager: MockMicrosurveySurfaceManager!
     override func setUp() {
         super.setUp()
-        let model = MicrosurveyModel(
-            promptTitle: "title",
-            promptButtonLabel: "button label",
-            surveyQuestion: "survey question",
-            surveyOptions: [
-                "yes",
-                "no",
-                "maybe"
-            ],
-            icon: nil,
-            utmContent: nil
-        )
-        microsurveyManager = MockMicrosurveySurfaceManager(with: model)
-        DependencyHelperMock().bootstrapDependencies(injectedMicrosurveyManager: microsurveyManager)
+        Glean.shared.resetGlean(clearStores: true)
+        Glean.shared.enableTestingMode()
+        DependencyHelperMock().bootstrapDependencies()
     }
 
     override func tearDown() {
@@ -32,16 +21,46 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
         DependencyHelperMock().reset()
     }
 
-    func testSubmitSurveyAction() {
+    func testDismissSurveyAction() {
         let mockStore = Store(
             state: AppState(),
             reducer: AppState.reducer,
             middlewares: [MicrosurveyMiddleware().microsurveyProvider]
         )
 
-        let action = getAction(for: .submitSurvey)
+        let action = getAction(for: .closeSurvey)
         mockStore.dispatch(action)
-        // TODO: FXIOS-8797 - Add Telemetry
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Microsurvey.dismissButtonTapped)
+    }
+
+    func testPrivacyNoticeTappedAction() {
+        let mockStore = Store(
+            state: AppState(),
+            reducer: AppState.reducer,
+            middlewares: [MicrosurveyMiddleware().microsurveyProvider]
+        )
+
+        let action = getAction(for: .tapPrivacyNotice)
+        mockStore.dispatch(action)
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Microsurvey.privacyNoticeTapped)
+    }
+
+    func testSubmitSurveyAction() throws {
+        let mockStore = Store(
+            state: AppState(),
+            reducer: AppState.reducer,
+            middlewares: [MicrosurveyMiddleware().microsurveyProvider]
+        )
+
+        let action = MicrosurveyAction(
+            userSelection: "Neutral",
+            windowUUID: .XCTestDefaultUUID,
+            actionType: MicrosurveyActionType.submitSurvey
+        )
+        mockStore.dispatch(action)
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Microsurvey.submitButtonTapped)
+        let resultValue = try XCTUnwrap(GleanMetrics.Microsurvey.submitButtonTapped.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?["user_selection"], "Neutral")
     }
 
     private func getAction(for actionType: MicrosurveyActionType) -> MicrosurveyMiddlewareAction {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8797)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19506)

## :bulb: Description
Add telemetry for survey using new event names specified in this [document](https://docs.google.com/document/d/14hpCd1h-frPRQKRB3DeplhDRSVF-KyGa8mqimfZQuKQ/edit). 
- Created new telemetry struct `MicrosurveyTelemetry` to hold the telemetry calls
- Added new `userSelection` property to `MicrosurveyAction` in order to hold the extra telemetry data of the survey option the user selected.

**Four Telemetry Calls**
- survey impression
- privacy notice link tapped
- dismiss button tapped
- user responded to survey (extrakey = user selected option)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

