### PR TITLE
Add FXIOS-9305 enhanced tracking protection string corrections 

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4052,6 +4052,24 @@ extension String {
                 value: "No trackers found",
                 comment: "Text to let users know that no trackers were found on the current website.")
 
+            public static let crossSiteTrackersBlockedLabel = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Details.Trackers.CrossSite.v129",
+                tableName: "EnhancedTrackingProtection",
+                value: "Cross-site tracking cookies: %@",
+                comment: "Text to let users know how many cross-site tracking cookies were blocked on the current website. The placeholder will show the number of such cookies detected")
+
+            public static let socialMediaTrackersBlockedLabel = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Details.Trackers.SocialMedia.v129",
+                tableName: "EnhancedTrackingProtection",
+                value: "Social media trackers: %@",
+                comment: "Text to let users know how many social media trackers were blocked on the current website. The placeholder will show the number of such cookies detected")
+
+            public static let fingerprinterBlockedLabel = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Details.Trackers.Fingerprinter.v129",
+                tableName: "EnhancedTrackingProtection",
+                value: "Fingerprinters: %@",
+                comment: "Text to let users know how many fingerprinters were blocked on the current website. The placeholder will show the number of fingerprinters detected")
+
             public static let connectionSecureLabel = MZLocalizedString(
                 key: "Menu.EnhancedTrackingProtection.Details.ConnectionSecure.v128",
                 tableName: "EnhancedTrackingProtection",
@@ -4079,7 +4097,7 @@ extension String {
             public static let switchOffText = MZLocalizedString(
                 key: "Menu.EnhancedTrackingProtection.SwitchOff.Text.v128",
                 tableName: "EnhancedTrackingProtection",
-                value: "Protections are OFF. We suggest turning it back on.",
+                value: "Protections are OFF. We suggest turning them back on.",
                 comment: "A switch to disable enhanced tracking protection inside the menu.")
 
             public static let clearDataButtonTitle = MZLocalizedString(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9305)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20619)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Changed the trackers strings to remove the need of a plural form and fixed the grammar for the "protection are OFF" text
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

