### PR TITLE
Bugfix FXIOS-9103 [Tab Tray Refactor] Favicons blink when all tabs closed

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -390,7 +390,6 @@ class TabManagerMiddleware {
                                                           actionType: TabPanelMiddlewareActionType.showToast)
                     store.dispatch(action)
                 } else {
-
                     let toastAction = GeneralBrowserAction(toastType: .closedAllTabs(count: normalCount),
                                                            windowUUID: uuid,
                                                            actionType: GeneralBrowserActionType.showToast)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -390,15 +390,15 @@ class TabManagerMiddleware {
                                                           actionType: TabPanelMiddlewareActionType.showToast)
                     store.dispatch(action)
                 } else {
-                    let dismissAction = TabTrayAction(windowUUID: uuid,
-                                                      actionType: TabTrayActionType.dismissTabTray)
-                    store.dispatch(dismissAction)
 
                     let toastAction = GeneralBrowserAction(toastType: .closedAllTabs(count: normalCount),
                                                            windowUUID: uuid,
                                                            actionType: GeneralBrowserActionType.showToast)
                     store.dispatch(toastAction)
                 }
+                let dismissAction = TabTrayAction(windowUUID: uuid,
+                                                  actionType: TabTrayActionType.dismissTabTray)
+                store.dispatch(dismissAction)
             }
         }
     }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -556,8 +556,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         )
     }
 
-    @MainActor
-    func removeTab(_ tabUUID: TabUUID) async {
+    func removeTab(_ tabUUID: TabUUID) {
         guard let index = tabs.firstIndex(where: { $0.tabUUID == tabUUID }) else { return }
 
         let tab = tabs[index]
@@ -570,9 +569,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         }
         self.removeTab(tab, flushToDisk: true)
         self.updateIndexAfterRemovalOf(tab, deletedIndex: index, viableTabsIndex: viableTabsIndex)
-
-        // TODO: FXIOS-9084 This is not ideal, follow up in this ticket to make tab selection reasonably synchronous
-        try? await Task.sleep(nanoseconds: NSEC_PER_SEC/10)
 
         TelemetryWrapper.recordEvent(
             category: .action,
@@ -641,7 +637,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         }
         backupCloseTabs = tabs
         for tab in currentModeTabs {
-            await self.removeTab(tab.tabUUID)
+            self.removeTab(tab.tabUUID)
         }
         storeChanges()
     }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -451,7 +451,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
         backupCloseTabs = getInactiveTabs()
         let currentModeTabs = backupCloseTabs
         for tab in currentModeTabs {
-            await self.removeTab(tab.tabUUID)
+            self.removeTab(tab.tabUUID)
         }
         storeChanges()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9103)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20185)

## :bulb: Description
Favicons were blinking when we closed all tabs, this was particularly noticeable with multiple tabs.

When testing the behavior between the legacy tab tray and tab tray refactor I noticed that the legacy tab tray dismissed the tab tray and then performed the deletion, so I have changed this behavior after running it by Andy and Orla for approval.

I also cleaned up some more async tab code that looked like it could be removed.

## Behavior before
https://github.com/mozilla-mobile/firefox-ios/assets/5545720/215b3afe-d181-40c4-a73d-e7a24b5b362f

## Behavior after
https://github.com/mozilla-mobile/firefox-ios/assets/5545720/4e07a42e-0e58-41cb-9163-e397a4d9ae76


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

