### PR TITLE
[Remote Tab Management] Receive Close Tab commands from other devices

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate+SyncSentTabs.swift
+++ b/firefox-ios/Client/Application/AppDelegate+SyncSentTabs.swift
@@ -10,16 +10,17 @@ import Account
 import Common
 
 extension UIApplication {
-    var sendTabDelegate: SendTabDelegate {
-        return AppSendTabDelegate(app: self)
+    var fxaCommandsDelegate: FxACommandsDelegate {
+        return AppFxACommandsDelegate(app: self)
     }
 }
 
-/// Sent tabs can be displayed not only by receiving push notifications, but by sync.
+/// Close and Sent tabs can be displayed not only by receiving push notifications,
+/// but by sync.
 /// Sync will get the list of sent tabs, and try to display any in that list.
-/// Thus, push notifications are not needed to receive sent tabs, they can be handled
-/// when the app performs a sync.
-class AppSendTabDelegate: SendTabDelegate {
+/// Thus, push notifications are not needed to receive sent or closed tabs;
+/// they can be handled when the app performs a sync.
+class AppFxACommandsDelegate: FxACommandsDelegate {
     private let app: ApplicationStateProvider
     private let logger: Logger
     private var applicationHelper: ApplicationHelper
@@ -44,6 +45,12 @@ class AppSendTabDelegate: SendTabDelegate {
                 guard let url = URL(string: urlString) else { continue }
                 self.applicationHelper.open(url)
             }
+        }
+    }
+
+    func closeTabs(for urls: [URL]) {
+        Task {
+            await self.applicationHelper.closeTabs(urls)
         }
     }
 }

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     lazy var profile: Profile = BrowserProfile(
         localName: "profile",
-        sendTabDelegate: UIApplication.shared.sendTabDelegate,
+        fxaCommandsDelegate: UIApplication.shared.fxaCommandsDelegate,
         creditCardAutofillEnabled: creditCardAutofillStatus
     )
 

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -78,7 +78,13 @@ class AppLaunchUtil {
             }
         }
 
-        RustFirefoxAccounts.startup(prefs: profile.prefs) { _ in
+        // RustFirefoxAccounts doesn't have access to the feature flags
+        // So we check the nimbus flag here before sending it to the startup
+        var fxaFeatures: RustFxAFeatures = []
+        if LegacyFeatureFlagsManager.shared.isFeatureEnabled(.closeRemoteTabs, checking: .buildAndUser) {
+            fxaFeatures.insert(.closeRemoteTabs)
+        }
+        RustFirefoxAccounts.startup(prefs: profile.prefs, features: fxaFeatures) { _ in
             self.logger.log("RustFirefoxAccounts started", level: .info, category: .sync)
             AppEventQueue.signal(event: .accountManagerInitialized)
         }

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -134,13 +134,13 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
             // Use a clean profile for each test session.
             profile = BrowserProfile(
                 localName: "testProfile",
-                sendTabDelegate: application.sendTabDelegate,
+                fxaCommandsDelegate: application.fxaCommandsDelegate,
                 clear: true
             )
         } else {
             profile = BrowserProfile(
                 localName: "testProfile",
-                sendTabDelegate: application.sendTabDelegate
+                fxaCommandsDelegate: application.fxaCommandsDelegate
             )
         }
 

--- a/firefox-ios/Client/ApplicationHelper.swift
+++ b/firefox-ios/Client/ApplicationHelper.swift
@@ -9,6 +9,7 @@ protocol ApplicationHelper {
     func openSettings()
     func open(_ url: URL)
     func open(_ url: URL, inWindow: WindowUUID)
+    func closeTabs(_ urls: [URL]) async
 }
 
 /// UIApplication.shared wrapper
@@ -44,6 +45,19 @@ struct DefaultApplicationHelper: ApplicationHelper {
         })
         if !foundTargetScene {
             open(url)
+        }
+    }
+
+    /// Closes all tabs that match the url passed in
+    /// This is most likely from other clients connected to the same
+    /// account requesting to close the tab on this device
+    ///
+    /// - Parameters:
+    ///   - urls: an array of URLs requested to be closed
+    func closeTabs(_ urls: [URL]) async {
+        let windowManager = AppContainer.shared.resolve() as WindowManager
+        for tabManager in windowManager.allWindowTabManagers() {
+            await tabManager.removeTabs(by: urls)
         }
     }
 }

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -30,6 +30,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case nightMode
     case preferSwitchToOpenTabOverDuplicate
     case reduxSearchSettings
+    case closeRemoteTabs
     case reportSiteIssue
     case searchHighlights
     case splashScreen
@@ -41,7 +42,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
 
     var debugKey: String? {
         switch self {
-        case .microsurvey:
+        case .microsurvey, .closeRemoteTabs:
             return rawValue + PrefsKeys.FeatureFlags.DebugSuffixKey
         default:
             return nil
@@ -79,6 +80,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .accountSettingsRedux,
                 .addressAutofillEdit,
                 .creditCardAutofillStatus,
+                .closeRemoteTabs,
                 .fakespotBackInStock,
                 .fakespotFeature,
                 .fakespotProductAds,

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -367,7 +367,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
             SentryIDSetting(settings: self, settingsDelegate: self),
             FasterInactiveTabs(settings: self, settingsDelegate: self),
             OpenFiftyTabsDebugOption(settings: self, settingsDelegate: self),
-            FirefoxSuggestSettings(settings: self, settingsDelegate: self)
+            FirefoxSuggestSettings(settings: self, settingsDelegate: self),
         ]
 
         #if MOZ_CHANNEL_BETA || MOZ_CHANNEL_FENNEC

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -34,7 +34,8 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
             UserDefaults.standard.set(nil, forKey: "\(GleanPlumbMessageStore.rootKey)\("homepage-microsurvey-message")")
             self?.reloadView()
         }
-        return SettingSection(title: nil, children: [microsurveySetting])
+        let closeRemoteTabsSetting = getCloseRemoteTabSetting(theme)
+        return SettingSection(title: nil, children: [microsurveySetting, closeRemoteTabsSetting])
     }
 
     private func generateFeatureFlagList() -> SettingSection {
@@ -50,6 +51,20 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
             title: NSAttributedString(string: "Build only status"),
             children: settingsList
         )
+    }
+
+    private func getCloseRemoteTabSetting(_ theme: Theme) -> FeatureFlagsBoolSetting {
+        FeatureFlagsBoolSetting(
+            with: .closeRemoteTabs,
+            titleText: NSAttributedString(
+                string: "Enable Close Remote Tabs",
+                attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]),
+            statusText: NSAttributedString(
+                string: "Toggle to enable closing tabs remotely feature",
+                attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
+        ) { [weak self] _ in
+            self?.reloadView()
+        }
     }
 
     private func reloadView() {

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -67,6 +67,9 @@ final class NimbusFeatureFlagLayer {
         case .reduxSearchSettings:
             return checkReduxSearchSettingsFeature(from: nimbus)
 
+        case .closeRemoteTabs:
+            return checkCloseRemoteTabsFeature(from: nimbus)
+
         case .reportSiteIssue:
             return checkGeneralFeature(for: featureID, from: nimbus)
 
@@ -288,5 +291,10 @@ final class NimbusFeatureFlagLayer {
         let config = nimbus.features.nightModeFeature.value()
 
         return config.enabled
+    }
+
+    private func checkCloseRemoteTabsFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.remoteTabManagement.value()
+        return config.closeTabsEnabled
     }
 }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -640,6 +640,20 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     @MainActor
+    func removeTabs(by urls: [URL]) async {
+        let urls = Set(urls)
+        let tabsToRemove = normalTabs.filter { tab in
+            guard let url = tab.url else { return false }
+            return urls.contains(url)
+        }
+        for tab in tabsToRemove {
+            await withCheckedContinuation { continuation in
+                removeTab(tab) { continuation.resume() }
+            }
+        }
+    }
+
+    @MainActor
     func removeAllTabs(isPrivateMode: Bool) async {
         let currentModeTabs = tabs.filter { $0.isPrivate == isPrivateMode }
         var currentSelectedTab: BackupCloseTab?

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -83,6 +83,9 @@ protocol TabManager: AnyObject {
     /// Undo close all tabs, it will restore the tabs that were backed up when the close action was called.
     func undoCloseAllTabs()
 
+    /// Removes all tabs matching the urls, used when other clients request to close tabs on this device.
+    func removeTabs(by urls: [URL]) async
+
     /// Get inactive tabs from the list of tabs based on the time condition to be considered inactive.
     /// Replaces LegacyInactiveTabModel and related classes
     /// 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppSendTabDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppSendTabDelegateTests.swift
@@ -5,7 +5,7 @@
 import XCTest
 @testable import Client
 
-final class AppSendTabDelegateTests: XCTestCase {
+final class AppFxACommandsTests: XCTestCase {
     private var applicationStateProvider: MockApplicationStateProvider!
     private var applicationHelper: MockApplicationHelper!
 
@@ -57,12 +57,39 @@ final class AppSendTabDelegateTests: XCTestCase {
         XCTAssertEqual(applicationHelper.openURLCalled, 3)
     }
 
+    // MARK: - Close Remote Tabs Tests
+    func testCloseSendTabs_activeWithOneURL_callsDeeplink() async {
+        let url = URL(string: "https://mozilla.com", invalidCharacters: false)!
+        let subject = createSubject()
+        let expectation = XCTestExpectation(description: "Close tabs called")
+        subject.closeTabs(for: [url])
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation.fulfill()
+            XCTAssertEqual(self.applicationHelper.closeTabsCalled, 1)
+        }
+        await fulfillment(of: [expectation])
+    }
+
+    func testCloseSendTabs_activeWithMultipleURLs_callsDeeplink() async {
+        let url1 = URL(string: "https://example.com", invalidCharacters: false)!
+        let url2 = URL(string: "https://example.com/1", invalidCharacters: false)!
+        let url3 = URL(string: "https://example.com/2", invalidCharacters: false)!
+        let subject = createSubject()
+        let expectation = XCTestExpectation(description: "Close tabs called multiple times")
+        subject.closeTabs(for: [url1, url2, url3])
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation.fulfill()
+            XCTAssertEqual(self.applicationHelper.closeTabsCalled, 1)
+        }
+        await fulfillment(of: [expectation])
+    }
+
     // MARK: - Helper methods
 
-    func createSubject() -> AppSendTabDelegate {
-        let subject = AppSendTabDelegate(app: applicationStateProvider,
-                                         applicationHelper: applicationHelper,
-                                         mainQueue: MockDispatchQueue())
+    func createSubject() -> AppFxACommandsDelegate {
+        let subject = AppFxACommandsDelegate(app: applicationStateProvider,
+                                             applicationHelper: applicationHelper,
+                                             mainQueue: MockDispatchQueue())
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockApplicationHelper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockApplicationHelper.swift
@@ -11,6 +11,7 @@ class MockApplicationHelper: ApplicationHelper {
     var openURLCalled = 0
     var openURLInWindowCalled = 0
     var lastOpenURL: URL?
+    var closeTabsCalled = 0
 
     func openSettings() {
         openSettingsCalled += 1
@@ -24,5 +25,9 @@ class MockApplicationHelper: ApplicationHelper {
     func open(_ url: URL, inWindow: WindowUUID) {
         openURLInWindowCalled += 1
         lastOpenURL = url
+    }
+
+    func closeTabs(_ urls: [URL]) {
+        closeTabsCalled += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -37,6 +37,8 @@ class MockTabManager: TabManager {
     var addTabsForURLsCalled = 0
     var addTabsURLs: [URL] = []
 
+    var removeTabsByURLCalled = 0
+
     init(windowUUID: WindowUUID = WindowUUID.XCTestDefaultUUID) {
         self.windowUUID = windowUUID
     }
@@ -91,6 +93,10 @@ class MockTabManager: TabManager {
     func removeTab(_ tabUUID: String) async {}
 
     func removeAllTabs(isPrivateMode: Bool) async {}
+
+    func removeTabs(by urls: [URL]) async {
+        removeTabsByURLCalled += 1
+    }
 
     func undoCloseAllTabs() {}
 

--- a/firefox-ios/nimbus-features/remoteTabManagement.yaml
+++ b/firefox-ios/nimbus-features/remoteTabManagement.yaml
@@ -1,0 +1,22 @@
+# The configuration for the remoteTabManagement feature
+features:
+  remote-tab-management:
+    description: >
+      Features that let users manage tabs on other devices that are
+      connected to the same Mozilla account.
+    variables:
+      close-tabs-enabled:
+        description: >
+          Whether the feature to close synced tabs is enabled. When enabled,
+          this device will allow other devices to close tabs that are open on this device, and
+          show a "close" button for tabs that are currently open on other supported devices
+          in the synced tabs tray.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          close-tabs-enabled: false
+      - channel: developer
+        value:
+          close-tabs-enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -29,6 +29,7 @@ include:
   - nimbus-features/nightModeFeature.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml
   - nimbus-features/reduxSearchSettingsFeature.yaml
+  - nimbus-features/remoteTabManagement.yaml
   - nimbus-features/searchFeature.yaml
   - nimbus-features/splashScreenFeature.yaml
   - nimbus-features/spotlightSearchFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9398)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20808)

First of the Remote Tab Management PRs. Couple of things here:
- Add Nimbus feature flag to be able to control it while developing on it
- Added a secret menu option
- Renamed SendTabDelegate to FxACommandsDelegate to encompass CloseTab command and future ones
- Upon receiving a "CloseTab" command from FxA, go through all tabs and close the first matching Url

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

