### PR TITLE
Add FXIOS-9391 Display menu and tabs button for regular horizontal size class

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1480,6 +1480,7 @@
 		E1463D022981DA190074E16E /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1463D012981DA190074E16E /* NotificationManager.swift */; };
 		E1463D042982D0240074E16E /* NotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1463D032982D0240074E16E /* NotificationManagerTests.swift */; };
 		E1463D0629830E4F0074E16E /* MockUserNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1463D0529830E4F0074E16E /* MockUserNotificationCenter.swift */; };
+		E14792A32C2C5C660058211C /* ToolbarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14792A22C2C5C660058211C /* ToolbarHelper.swift */; };
 		E14BF33E2950B1230039758D /* MailProvidersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14BF33D2950B1230039758D /* MailProvidersTests.swift */; };
 		E14C78962C105488002AD3C7 /* AddressToolbarContainerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14C78952C105488002AD3C7 /* AddressToolbarContainerModelTests.swift */; };
 		E14F7DF2288F3F9F00E3722C /* ThemedTableSectionHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14F7DF1288F3F9F00E3722C /* ThemedTableSectionHeaderFooterView.swift */; };
@@ -7833,6 +7834,7 @@
 		E1463D012981DA190074E16E /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		E1463D032982D0240074E16E /* NotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerTests.swift; sourceTree = "<group>"; };
 		E1463D0529830E4F0074E16E /* MockUserNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserNotificationCenter.swift; sourceTree = "<group>"; };
+		E14792A22C2C5C660058211C /* ToolbarHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarHelper.swift; sourceTree = "<group>"; };
 		E14BF33D2950B1230039758D /* MailProvidersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailProvidersTests.swift; sourceTree = "<group>"; };
 		E14C78952C105488002AD3C7 /* AddressToolbarContainerModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressToolbarContainerModelTests.swift; sourceTree = "<group>"; };
 		E14F7DF1288F3F9F00E3722C /* ThemedTableSectionHeaderFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedTableSectionHeaderFooterView.swift; sourceTree = "<group>"; };
@@ -11685,6 +11687,7 @@
 				E17798972BD6B44B00F6F0EB /* AddressToolbarContainer.swift */,
 				E18CE8D92BDA3F6B00EE2BCD /* NavigationToolbarContainer.swift */,
 				E17798952BD6B33300F6F0EB /* ToolbarFlagManager.swift */,
+				E14792A22C2C5C660058211C /* ToolbarHelper.swift */,
 			);
 			path = Toolbars;
 			sourceTree = "<group>";
@@ -15019,6 +15022,7 @@
 				E177989E2BD7D75A00F6F0EB /* ToolbarMiddleware.swift in Sources */,
 				C8CD80D72A1E2C6E0097C3AE /* NimbusMessagingHelperUtilityProtocol.swift in Sources */,
 				8ACE9BFB2A54A010001E7A73 /* ExpandButtonState.swift in Sources */,
+				E14792A32C2C5C660058211C /* ToolbarHelper.swift in Sources */,
 				8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */,
 				8AEDB11529F9F00400F2A53B /* SceneContainer.swift in Sources */,
 				B23620512B9BAAF3000B1DE7 /* AddressFormData.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -103,7 +103,7 @@ class BackForwardListViewController: UIViewController,
         view.addSubview(shadow)
         view.addSubview(tableView)
 
-        let toolBarShouldShow = shouldShowToolbarForTraitCollection(traitCollection)
+        let toolBarShouldShow = ToolbarHelper().shouldShowNavigationToolbarForTraitCollection(traitCollection)
         snappedToBottom = toolBarShouldShow || isBottomSearchBar
         tableViewHeightAnchor = tableView.heightAnchor.constraint(equalToConstant: 0)
         NSLayoutConstraint.activate([
@@ -116,11 +116,6 @@ class BackForwardListViewController: UIViewController,
         ])
         remakeVerticalConstraints()
         view.layoutIfNeeded()
-    }
-
-    private func shouldShowToolbarForTraitCollection(_ previousTraitCollection: UITraitCollection) -> Bool {
-        return previousTraitCollection.verticalSizeClass != .compact
-               && previousTraitCollection.horizontalSizeClass != .regular
     }
 
     private func currentTheme() -> Theme {
@@ -184,7 +179,8 @@ class BackForwardListViewController: UIViewController,
         with coordinator: UIViewControllerTransitionCoordinator
     ) {
         super.willTransition(to: newCollection, with: coordinator)
-        if shouldShowToolbarForTraitCollection(newCollection) != snappedToBottom, !isBottomSearchBar {
+        let shouldShowToolbar = ToolbarHelper().shouldShowNavigationToolbarForTraitCollection(newCollection)
+        if shouldShowToolbar != snappedToBottom, !isBottomSearchBar {
             if snappedToBottom {
                 tableViewBottomAnchor.constant = 0
             } else {

--- a/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -103,8 +103,8 @@ class BackForwardListViewController: UIViewController,
         view.addSubview(shadow)
         view.addSubview(tableView)
 
-        let toolBarShouldShow = ToolbarHelper().shouldShowNavigationToolbarForTraitCollection(traitCollection)
-        snappedToBottom = toolBarShouldShow || isBottomSearchBar
+        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: traitCollection)
+        snappedToBottom = showNavToolbar || isBottomSearchBar
         tableViewHeightAnchor = tableView.heightAnchor.constraint(equalToConstant: 0)
         NSLayoutConstraint.activate([
             tableViewHeightAnchor,
@@ -179,8 +179,8 @@ class BackForwardListViewController: UIViewController,
         with coordinator: UIViewControllerTransitionCoordinator
     ) {
         super.willTransition(to: newCollection, with: coordinator)
-        let shouldShowToolbar = ToolbarHelper().shouldShowNavigationToolbarForTraitCollection(newCollection)
-        if shouldShowToolbar != snappedToBottom, !isBottomSearchBar {
+        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: newCollection)
+        if showNavToolbar != snappedToBottom, !isBottomSearchBar {
             if snappedToBottom {
                 tableViewBottomAnchor.constant = 0
             } else {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -104,7 +104,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         let dataClearanceAnimation = DataClearanceAnimation()
         dataClearanceAnimation.startAnimation(
             with: view,
-            for: shouldShowTopTabsForTraitCollection(
+            for: ToolbarHelper().shouldShowTopTabsForTraitCollection(
                 traitCollection
             )
         )

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -104,9 +104,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         let dataClearanceAnimation = DataClearanceAnimation()
         dataClearanceAnimation.startAnimation(
             with: view,
-            for: ToolbarHelper().shouldShowTopTabsForTraitCollection(
-                traitCollection
-            )
+            for: ToolbarHelper().shouldShowTopTabs(for: traitCollection)
         )
 
         completion(timingToMatchGradientOverlay)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -356,16 +356,6 @@ class BrowserViewController: UIViewController,
         store.dispatch(action)
     }
 
-    func shouldShowToolbarForTraitCollection(_ traitCollection: UITraitCollection) -> Bool {
-        return traitCollection.verticalSizeClass != .compact
-               && traitCollection.horizontalSizeClass != .regular
-    }
-
-    func shouldShowTopTabsForTraitCollection(_ traitCollection: UITraitCollection) -> Bool {
-        return traitCollection.verticalSizeClass == .regular
-               && traitCollection.horizontalSizeClass == .regular
-    }
-
     @objc
     fileprivate func appMenuBadgeUpdate() {
         let actionNeeded = RustFirefoxAccounts.shared.isActionNeeded
@@ -378,11 +368,11 @@ class BrowserViewController: UIViewController,
     }
 
     func updateToolbarStateForTraitCollection(_ newCollection: UITraitCollection) {
-        let showToolbar = shouldShowToolbarForTraitCollection(newCollection)
-        let showTopTabs = shouldShowTopTabsForTraitCollection(newCollection)
+        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbarForTraitCollection(newCollection)
+        let showTopTabs = ToolbarHelper().shouldShowTopTabsForTraitCollection(newCollection)
 
         if isToolbarRefactorEnabled {
-            if showToolbar {
+            if showNavToolbar {
                 navigationToolbarContainer.isHidden = false
                 navigationToolbarContainer.applyTheme(theme: currentTheme())
                 updateTabCountUsingTabManager(self.tabManager)
@@ -391,10 +381,10 @@ class BrowserViewController: UIViewController,
             }
         } else {
             urlBar.topTabsIsShowing = showTopTabs
-            urlBar.setShowToolbar(!showToolbar)
-            toolbar.addNewTabButton.isHidden = showToolbar
+            urlBar.setShowToolbar(!showNavToolbar)
+            toolbar.addNewTabButton.isHidden = showNavToolbar
 
-            if showToolbar {
+            if showNavToolbar {
                 toolbar.isHidden = false
                 toolbar.tabToolbarDelegate = self
                 toolbar.applyUIMode(
@@ -704,7 +694,7 @@ class BrowserViewController: UIViewController,
         overKeyboardContainer.applyTheme(theme: theme)
         bottomContainer.applyTheme(theme: theme)
         bottomContentStackView.applyTheme(theme: theme)
-        statusBarOverlay.hasTopTabs = shouldShowTopTabsForTraitCollection(traitCollection)
+        statusBarOverlay.hasTopTabs = ToolbarHelper().shouldShowTopTabsForTraitCollection(traitCollection)
         statusBarOverlay.applyTheme(theme: theme)
 
         // Feature flag for credit card until we fully enable this feature
@@ -943,7 +933,7 @@ class BrowserViewController: UIViewController,
 
         // Adjustment for landscape on the urlbar
         // need to account for inset and remove it when keyboard is showing
-        let showToolBar = shouldShowToolbarForTraitCollection(traitCollection)
+        let showToolBar = ToolbarHelper().shouldShowNavigationToolbarForTraitCollection(traitCollection)
         let isKeyboardShowing = keyboardState != nil
 
         if !showToolBar && isBottomSearchBar &&
@@ -1149,7 +1139,7 @@ class BrowserViewController: UIViewController,
             return
         }
 
-        let showToolBar = shouldShowToolbarForTraitCollection(traitCollection)
+        let showToolBar = ToolbarHelper().shouldShowNavigationToolbarForTraitCollection(traitCollection)
         let toolBarHeight = showToolBar ? UIConstants.BottomToolbarHeight : 0
         let spacerHeight = keyboardHeight - toolBarHeight
         overKeyboardContainer.addKeyboardSpacer(spacerHeight: spacerHeight)
@@ -2534,7 +2524,7 @@ class BrowserViewController: UIViewController,
 
     func applyTheme() {
         let currentTheme = currentTheme()
-        statusBarOverlay.hasTopTabs = shouldShowTopTabsForTraitCollection(traitCollection)
+        statusBarOverlay.hasTopTabs = ToolbarHelper().shouldShowTopTabsForTraitCollection(traitCollection)
         statusBarOverlay.applyTheme(theme: currentTheme)
         keyboardBackdrop?.backgroundColor = currentTheme.colors.layer1
         webViewContainerBackdrop.backgroundColor = currentTheme.colors.layer3

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -356,14 +356,14 @@ class BrowserViewController: UIViewController,
         store.dispatch(action)
     }
 
-    func shouldShowToolbarForTraitCollection(_ previousTraitCollection: UITraitCollection) -> Bool {
-        return previousTraitCollection.verticalSizeClass != .compact
-               && previousTraitCollection.horizontalSizeClass != .regular
+    func shouldShowToolbarForTraitCollection(_ traitCollection: UITraitCollection) -> Bool {
+        return traitCollection.verticalSizeClass != .compact
+               && traitCollection.horizontalSizeClass != .regular
     }
 
-    func shouldShowTopTabsForTraitCollection(_ newTraitCollection: UITraitCollection) -> Bool {
-        return newTraitCollection.verticalSizeClass == .regular
-               && newTraitCollection.horizontalSizeClass == .regular
+    func shouldShowTopTabsForTraitCollection(_ traitCollection: UITraitCollection) -> Bool {
+        return traitCollection.verticalSizeClass == .regular
+               && traitCollection.horizontalSizeClass == .regular
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -368,8 +368,8 @@ class BrowserViewController: UIViewController,
     }
 
     func updateToolbarStateForTraitCollection(_ newCollection: UITraitCollection) {
-        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbarForTraitCollection(newCollection)
-        let showTopTabs = ToolbarHelper().shouldShowTopTabsForTraitCollection(newCollection)
+        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: newCollection)
+        let showTopTabs = ToolbarHelper().shouldShowTopTabs(for: newCollection)
 
         if isToolbarRefactorEnabled {
             if showNavToolbar {
@@ -694,7 +694,7 @@ class BrowserViewController: UIViewController,
         overKeyboardContainer.applyTheme(theme: theme)
         bottomContainer.applyTheme(theme: theme)
         bottomContentStackView.applyTheme(theme: theme)
-        statusBarOverlay.hasTopTabs = ToolbarHelper().shouldShowTopTabsForTraitCollection(traitCollection)
+        statusBarOverlay.hasTopTabs = ToolbarHelper().shouldShowTopTabs(for: traitCollection)
         statusBarOverlay.applyTheme(theme: theme)
 
         // Feature flag for credit card until we fully enable this feature
@@ -933,10 +933,10 @@ class BrowserViewController: UIViewController,
 
         // Adjustment for landscape on the urlbar
         // need to account for inset and remove it when keyboard is showing
-        let showToolBar = ToolbarHelper().shouldShowNavigationToolbarForTraitCollection(traitCollection)
+        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: traitCollection)
         let isKeyboardShowing = keyboardState != nil
 
-        if !showToolBar && isBottomSearchBar &&
+        if !showNavToolbar && isBottomSearchBar &&
         !isKeyboardShowing && UIDevice.current.orientation.isLandscape {
             overKeyboardContainer.addBottomInsetSpacer(spacerHeight: UIConstants.BottomInset)
         } else {
@@ -1139,8 +1139,8 @@ class BrowserViewController: UIViewController,
             return
         }
 
-        let showToolBar = ToolbarHelper().shouldShowNavigationToolbarForTraitCollection(traitCollection)
-        let toolBarHeight = showToolBar ? UIConstants.BottomToolbarHeight : 0
+        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: traitCollection)
+        let toolBarHeight = showNavToolbar ? UIConstants.BottomToolbarHeight : 0
         let spacerHeight = keyboardHeight - toolBarHeight
         overKeyboardContainer.addKeyboardSpacer(spacerHeight: spacerHeight)
     }
@@ -2565,7 +2565,7 @@ class BrowserViewController: UIViewController,
 
     func applyTheme() {
         let currentTheme = currentTheme()
-        statusBarOverlay.hasTopTabs = ToolbarHelper().shouldShowTopTabsForTraitCollection(traitCollection)
+        statusBarOverlay.hasTopTabs = ToolbarHelper().shouldShowTopTabs(for: traitCollection)
         statusBarOverlay.applyTheme(theme: currentTheme)
         keyboardBackdrop?.backgroundColor = currentTheme.colors.layer1
         webViewContainerBackdrop.backgroundColor = currentTheme.colors.layer3

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -75,6 +75,7 @@ class AddressToolbarContainerModel: Equatable {
         return actions.map { action in
             ToolbarElement(
                 iconName: action.iconName,
+                numberOfTabs: action.numberOfTabs,
                 isEnabled: action.isEnabled,
                 a11yLabel: action.a11yLabel,
                 a11yId: action.a11yId,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -81,7 +81,7 @@ class ToolbarMiddleware: FeatureFlaggable {
 
         return AddressToolbarModel(navigationActions: [ToolbarActionState](),
                                    pageActions: loadAddressToolbarPageElements(),
-                                   browserActions: [ToolbarActionState](),
+                                   browserActions: loadAddressToolbarBrowserElements(),
                                    borderPosition: borderPosition,
                                    url: nil)
     }
@@ -95,6 +95,22 @@ class ToolbarMiddleware: FeatureFlaggable {
             a11yLabel: .QRCode.ToolbarButtonA11yLabel,
             a11yId: AccessibilityIdentifiers.Browser.ToolbarButtons.qrCode))
         return pageActions
+    }
+
+    private func loadAddressToolbarBrowserElements() -> [ToolbarActionState] {
+        var elements = [ToolbarActionState]()
+        elements.append(ToolbarActionState(actionType: .tabs,
+                                           iconName: StandardImageIdentifiers.Large.tab,
+                                           numberOfTabs: 1,
+                                           isEnabled: true,
+                                           a11yLabel: .TabsButtonShowTabsAccessibilityLabel,
+                                           a11yId: AccessibilityIdentifiers.Toolbar.tabsButton))
+        elements.append(ToolbarActionState(actionType: .menu,
+                                           iconName: StandardImageIdentifiers.Large.appMenu,
+                                           isEnabled: true,
+                                           a11yLabel: .AppMenu.Toolbar.MenuButtonAccessibilityLabel,
+                                           a11yId: AccessibilityIdentifiers.Toolbar.settingsMenuButton))
+        return elements
     }
 
     private func loadInitialNavigationToolbarState(toolbarPosition: AddressToolbarPosition) -> NavigationToolbarModel {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 class ToolbarHelper {
-    func shouldShowNavigationToolbarForTraitCollection(_ traitCollection: UITraitCollection) -> Bool {
+    func shouldShowNavigationToolbar(for traitCollection: UITraitCollection) -> Bool {
         return traitCollection.verticalSizeClass != .compact
                && traitCollection.horizontalSizeClass != .regular
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class ToolbarHelper {
+    func shouldShowNavigationToolbarForTraitCollection(_ traitCollection: UITraitCollection) -> Bool {
+        return traitCollection.verticalSizeClass != .compact
+               && traitCollection.horizontalSizeClass != .regular
+    }
+
+    func shouldShowTopTabsForTraitCollection(_ traitCollection: UITraitCollection) -> Bool {
+        return traitCollection.verticalSizeClass == .regular
+               && traitCollection.horizontalSizeClass == .regular
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -10,7 +10,7 @@ class ToolbarHelper {
                && traitCollection.horizontalSizeClass != .regular
     }
 
-    func shouldShowTopTabsForTraitCollection(_ traitCollection: UITraitCollection) -> Bool {
+    func shouldShowTopTabs(for traitCollection: UITraitCollection) -> Bool {
         return traitCollection.verticalSizeClass == .regular
                && traitCollection.horizontalSizeClass == .regular
     }

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -29,6 +29,10 @@ protocol TopTabsDelegate: AnyObject {
 }
 
 class TopTabsViewController: UIViewController, Themeable, Notifiable {
+    private struct UX {
+        static let trailingEdgeSpace: CGFloat = 10
+    }
+
     // MARK: - Properties
     let tabManager: TabManager
     weak var delegate: TopTabsDelegate?
@@ -251,7 +255,11 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
     private func setupLayout() {
         view.addSubview(topTabFader)
         topTabFader.addSubview(collectionView)
-        view.addSubview(tabsButton)
+
+        if !ToolbarFlagManager.isRefactorEnabled {
+            view.addSubview(tabsButton)
+        }
+
         view.addSubview(newTab)
         view.addSubview(privateModeButton)
 
@@ -259,14 +267,8 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
             view.heightAnchor.constraint(equalToConstant: TopTabsUX.TopTabsViewHeight),
 
             newTab.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            newTab.trailingAnchor.constraint(equalTo: tabsButton.leadingAnchor),
             newTab.widthAnchor.constraint(equalTo: view.heightAnchor),
             newTab.heightAnchor.constraint(equalTo: view.heightAnchor),
-
-            tabsButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            tabsButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10),
-            tabsButton.widthAnchor.constraint(equalTo: view.heightAnchor),
-            tabsButton.heightAnchor.constraint(equalTo: view.heightAnchor),
 
             privateModeButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             privateModeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
@@ -283,6 +285,20 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
             collectionView.leadingAnchor.constraint(equalTo: topTabFader.leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: topTabFader.trailingAnchor),
         ])
+
+        if ToolbarFlagManager.isRefactorEnabled {
+            newTab.trailingAnchor.constraint(equalTo: view.trailingAnchor,
+                                             constant: -UX.trailingEdgeSpace).isActive = true
+        } else {
+            NSLayoutConstraint.activate([
+                newTab.trailingAnchor.constraint(equalTo: tabsButton.leadingAnchor),
+
+                tabsButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+                tabsButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -UX.trailingEdgeSpace),
+                tabsButton.widthAnchor.constraint(equalTo: view.heightAnchor),
+                tabsButton.heightAnchor.constraint(equalTo: view.heightAnchor),
+            ])
+        }
     }
 
     private func handleFadeOutAfterTabSelection() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9391)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20798)

## :bulb: Description
Displays the menu & tabs button for regular horizontal size class and hides the tabs button from top tabs.

![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-06-27 at 10 39 07](https://github.com/mozilla-mobile/firefox-ios/assets/4530/2cd5399f-4b5c-4753-aa10-775a5214ebab)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

