### PR TITLE
Bugfix FXIOS-9387 Change to typographic apostrophe

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1381,7 +1381,7 @@ extension String {
                 public static let LikertScaleOption6 = MZLocalizedString(
                     key: "Microsurvey.Survey.Options.LikertScaleOption6.v129",
                     tableName: "Microsurvey",
-                    value: "I don't use it",
+                    value: "I don’t use it",
                     comment: "On the microsurvey, this is the title for one of the options that the user can select to answer the survey. It indicates that the user has not use the feature that the survey is inquiring about.")
             }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9387)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20779)

## :bulb: Description
Per comment [here](https://github.com/mozilla-l10n/firefoxios-l10n/pull/230#discussion_r1653775979), we should be using a typographic apostrophe instead.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

