### PR TITLE
Bugfix FXIOS-9311 Fix bookmark removal toast undo action

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1499,17 +1499,17 @@ class BrowserViewController: UIViewController,
                                                                              withUserData: userData,
                                                                              toApplication: .shared)
 
-        showBookmarkToast(for: .add)
+        showBookmarkToast(action: .add)
     }
 
     func removeBookmark(url: URL, title: String?) {
         profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
             guard result.isSuccess else { return }
-            self.showBookmarkToast(url, title, for: .remove)
+            self.showBookmarkToast(bookmarkURL: url, title: title, action: .remove)
         }
     }
 
-    private func showBookmarkToast(_ bookmarkURL: URL? = nil, _ title: String? = nil, for action: BookmarkAction) {
+    private func showBookmarkToast(bookmarkURL: URL? = nil, title: String? = nil, action: BookmarkAction) {
         switch action {
         case .add:
             self.showToast(message: .AppMenu.AddBookmarkConfirmMessage, toastAction: .bookmarkPage)
@@ -3047,8 +3047,8 @@ extension BrowserViewController: HomePanelDelegate {
         navigationHandler?.show(settings: settingsPage)
     }
 
-    func homePanelDidRequestBookmarkToast(for action: BookmarkAction) {
-        showBookmarkToast(for: action)
+    func homePanelDidRequestBookmarkToast(url: URL?, action: BookmarkAction) {
+        showBookmarkToast(bookmarkURL: url, action: action)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/HomePanelDelegate.swift
+++ b/firefox-ios/Client/Frontend/Home/HomePanelDelegate.swift
@@ -13,7 +13,7 @@ protocol HomePanelDelegate: AnyObject {
     func homePanelDidRequestToOpenLibrary(panel: LibraryPanelType)
     func homePanelDidRequestToOpenTabTray(withFocusedTab tabToFocus: Tab?, focusedSegment: TabTrayPanelType?)
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection)
-    func homePanelDidRequestBookmarkToast(for action: BookmarkAction)
+    func homePanelDidRequestBookmarkToast(url: URL?, action: BookmarkAction)
 }
 
 extension HomePanelDelegate {

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -13,7 +13,7 @@ import enum MozillaAppServices.BookmarkRoots
 protocol HomepageContextMenuHelperDelegate: UIViewController {
     func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool, selectNewTab: Bool)
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection)
-    func homePanelDidRequestBookmarkToast(for action: BookmarkAction)
+    func homePanelDidRequestBookmarkToast(url: URL?, action: BookmarkAction)
 }
 // swiftlint:enable class_delegate_protocol
 
@@ -202,7 +202,8 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
                 site.setBookmarked(false)
             }
 
-            self.delegate?.homePanelDidRequestBookmarkToast(for: .remove)
+            let url = URL(string: site.url)
+            self.delegate?.homePanelDidRequestBookmarkToast(url: url, action: .remove)
 
             TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .activityStream)
         })
@@ -229,7 +230,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
                                                                                  toApplication: .shared)
             site.setBookmarked(true)
 
-            self.delegate?.homePanelDidRequestBookmarkToast(for: .add)
+            self.delegate?.homePanelDidRequestBookmarkToast(url: nil, action: .add)
 
             TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .activityStream)
         })

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -805,8 +805,8 @@ extension HomepageViewController: HomepageContextMenuHelperDelegate {
         homePanelDelegate?.homePanelDidRequestToOpenSettings(at: settingsPage)
     }
 
-    func homePanelDidRequestBookmarkToast(for action: BookmarkAction) {
-        homePanelDelegate?.homePanelDidRequestBookmarkToast(for: action)
+    func homePanelDidRequestBookmarkToast(url: URL?, action: BookmarkAction) {
+        homePanelDelegate?.homePanelDidRequestBookmarkToast(url: url, action: action)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9311)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20627)

## :bulb: Description
- Selecting the "Undo" button from the bookmark removal toast will now re-add the bookmark with the expected url/title instead of the link to the home panel

### Videos

<details>
<summary>Before</summary>

https://github.com/mozilla-mobile/firefox-ios/assets/15353801/9701ca02-9a83-4b0f-a7eb-638a6a2a0289

</details>

<details>
<summary>After</summary>

https://github.com/mozilla-mobile/firefox-ios/assets/15353801/0b03fe2d-e3ba-45b4-b2dc-a2265cedba65

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

