### PR TITLE
Bugfix FXIOS-9379 Memory exhaustion crash

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -953,12 +953,7 @@ class BrowserViewController: UIViewController,
             overKeyboardContainer.removeBottomInsetSpacer()
         }
 
-        // We have to deactivate the original constraint, and remake the constraint
-        // or else funky conflicts happen
-        urlBarHeightConstraint.deactivate()
-        urlBar.snp.makeConstraints { make in
-            self.urlBarHeightConstraint = make.height.equalTo(heightWithPadding).constraint
-        }
+        urlBarHeightConstraint.update(offset: heightWithPadding)
     }
 
     override func willTransition(

--- a/firefox-ios/Client/Frontend/Components/BaseContentStackView.swift
+++ b/firefox-ios/Client/Frontend/Components/BaseContentStackView.swift
@@ -80,25 +80,31 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
 
     // MARK: - Spacer view
 
-     private var insetSpacer: UIView?
+    private var insetSpacer: UIView?
 
-     func addBottomInsetSpacer(spacerHeight: CGFloat) {
-         guard insetSpacer == nil else { return }
+    func addBottomInsetSpacer(spacerHeight: CGFloat) {
+        guard insetSpacer == nil else { return }
 
-         insetSpacer = UIView()
-         insetSpacer!.snp.makeConstraints { make in
-             make.height.equalTo(spacerHeight)
-         }
-         addArrangedViewToBottom(insetSpacer!)
-     }
+        let spacer = UIView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        addArrangedViewToBottom(spacer)
+        NSLayoutConstraint.activate([
+            spacer.heightAnchor.constraint(equalToConstant: spacerHeight),
+            spacer.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            spacer.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            spacer.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
+        insetSpacer = spacer
+        layoutIfNeeded()
+    }
 
-     func removeBottomInsetSpacer() {
-         guard let insetSpacer = self.insetSpacer else { return }
+    func removeBottomInsetSpacer() {
+        guard let insetSpacer = self.insetSpacer else { return }
 
-         removeArrangedView(insetSpacer)
-         self.insetSpacer = nil
-         self.layoutIfNeeded()
-     }
+        removeArrangedView(insetSpacer)
+        self.insetSpacer = nil
+        layoutIfNeeded()
+    }
 
     func applyTheme(theme: Theme) {
         let color = isClearBackground ? .clear : theme.colors.layer1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9379)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20764)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Wanted to remove most of snapkit from the area but since this particular file heavily uses snapkit that would mean re-writing completely so trying out another method from snapkit to help lower and fix the memory issue. 

My idea is its better to use the same constraint rather than deactivating and activating it as snapkit should handle it here.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

