### PR TITLE
Bugfix FXIOS-9389 [Microsurvey] Fix UI constraints and appearance

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1358,6 +1358,7 @@ class BrowserViewController: UIViewController,
         if UIDevice.current.userInterfaceIdiom == .pad {
             topTabsViewController?.refreshTabs()
         }
+        setupMicrosurvey()
     }
 
     func updateInContentHomePanel(_ url: URL?, focusUrlBar: Bool = false) {
@@ -1382,8 +1383,6 @@ class BrowserViewController: UIViewController,
         if UIDevice.current.userInterfaceIdiom == .pad {
             topTabsViewController?.refreshTabs()
         }
-
-        setupMicrosurvey()
     }
 
     func showLibrary(panel: LibraryPanelType) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1283,7 +1283,7 @@ class BrowserViewController: UIViewController,
 
     // MARK: - Microsurvey
     private func setupMicrosurvey() {
-        guard featureFlags.isFeatureEnabled(.microsurvey, checking: .buildOnly) else { return }
+        guard featureFlags.isFeatureEnabled(.microsurvey, checking: .buildOnly), microsurvey == nil else { return }
 
         store.dispatch(
             MicrosurveyPromptAction(windowUUID: windowUUID, actionType: MicrosurveyPromptActionType.showPrompt)
@@ -1358,7 +1358,6 @@ class BrowserViewController: UIViewController,
         if UIDevice.current.userInterfaceIdiom == .pad {
             topTabsViewController?.refreshTabs()
         }
-        setupMicrosurvey()
     }
 
     func updateInContentHomePanel(_ url: URL?, focusUrlBar: Bool = false) {
@@ -1383,6 +1382,8 @@ class BrowserViewController: UIViewController,
         if UIDevice.current.userInterfaceIdiom == .pad {
             topTabsViewController?.refreshTabs()
         }
+
+        setupMicrosurvey()
     }
 
     func showLibrary(panel: LibraryPanelType) {

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -74,10 +74,7 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
         label.numberOfLines = 0
     }
 
-    private lazy var closeButton: UIButton = .build { button in
-        button.accessibilityLabel = .Microsurvey.Prompt.CloseButtonAccessibilityLabel
-        button.accessibilityIdentifier = AccessibilityIdentifiers.Microsurvey.Prompt.closeButton
-        button.setImage(UIImage(named: StandardImageIdentifiers.ExtraLarge.crossCircleFill), for: .normal)
+    private lazy var closeButton: CloseButton = .build { button in
         button.addTarget(self, action: #selector(self.closeMicroSurvey), for: .touchUpInside)
     }
 
@@ -134,7 +131,12 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
             title: state.model?.promptButtonLabel ?? "",
             a11yIdentifier: AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton
         )
+        let closeButtonViewModel = CloseButtonViewModel(
+            a11yLabel: .Microsurvey.Prompt.CloseButtonAccessibilityLabel,
+            a11yIdentifier: AccessibilityIdentifiers.Microsurvey.Prompt.closeButton
+        )
         surveyButton.configure(viewModel: roundedButtonViewModel)
+        closeButton.configure(viewModel: closeButtonViewModel)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -169,9 +171,9 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
 
             toastView.topAnchor.constraint(equalTo: topBorderView.bottomAnchor, constant: UX.padding.top),
             toastView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: UX.padding.bottom),
+
+            headerView.widthAnchor.constraint(equalTo: toastView.widthAnchor),
             titleLabel.heightAnchor.constraint(equalTo: headerView.heightAnchor),
-            closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize.width),
-            closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize.height),
         ])
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
@@ -23,6 +23,8 @@ final class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCel
         stackView.spacing = UX.spacing
     }
 
+    private lazy var iconContainer: UIView = .build()
+
     private lazy var iconView: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
     }
@@ -36,7 +38,8 @@ final class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCel
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
 
-        horizontalStackView.addArrangedSubview(iconView)
+        iconContainer.addSubview(iconView)
+        horizontalStackView.addArrangedSubview(iconContainer)
         horizontalStackView.addArrangedSubview(questionLabel)
         contentView.addSubview(horizontalStackView)
 
@@ -59,8 +62,12 @@ final class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCel
                     constant: UX.padding.bottom
                 ),
 
+                iconView.widthAnchor.constraint(equalToConstant: UX.radioButtonSize.width),
                 iconView.heightAnchor.constraint(equalToConstant: UX.radioButtonSize.height),
-                iconView.widthAnchor.constraint(equalToConstant: UX.radioButtonSize.width)
+                iconView.widthAnchor.constraint(
+                    equalTo: iconContainer.widthAnchor
+                ),
+                iconView.centerYAnchor.constraint(equalTo: iconContainer.centerYAnchor)
             ]
         )
     }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableHeaderView.swift
@@ -62,12 +62,18 @@ final class MicrosurveyTableHeaderView: UITableViewHeaderFooterView, ReusableCel
                     constant: UX.padding.bottom
                 ),
 
-                iconView.widthAnchor.constraint(equalToConstant: UX.radioButtonSize.width),
-                iconView.heightAnchor.constraint(equalToConstant: UX.radioButtonSize.height),
+                iconView.widthAnchor.constraint(
+                    equalToConstant: UX.radioButtonSize.width
+                ),
+                iconView.heightAnchor.constraint(
+                    equalToConstant: UX.radioButtonSize.height
+                ),
                 iconView.widthAnchor.constraint(
                     equalTo: iconContainer.widthAnchor
                 ),
-                iconView.centerYAnchor.constraint(equalTo: iconContainer.centerYAnchor)
+                iconView.centerYAnchor.constraint(
+                    equalTo: iconContainer.centerYAnchor
+                )
             ]
         )
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9389)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20783)

## :bulb: Description
Fix a couple of bugs + enhancements I found while testing the feature end-to-end:
- Fix constraint warnings for views
- Use CloseButton component properly
- Call setting up microsurvey in more places so that survey appears when user navigates away from home and back

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)