### PR TITLE
Bugfix FXIOS-9350 ⁃ Investigate and re-enable FirefoxHomeViewModelTests:testNumberOfSection_withoutUpdatingData_has2Sections()

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
@@ -20,11 +20,13 @@ class FirefoxHomeViewModelTests: XCTestCase {
         if let bundleID = Bundle.main.bundleIdentifier {
             UserDefaults.standard.removePersistentDomain(forName: bundleID)
         }
+        DependencyHelperMock().bootstrapDependencies()
     }
 
     override func tearDown() {
         super.tearDown()
         profile = nil
+        AppContainer.shared.reset()
     }
 
     // MARK: Number of sections

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -95,7 +95,6 @@
     {
       "skippedTests" : [
         "ETPCoverSheetTests",
-        "FirefoxHomeViewModelTests\/testNumberOfSection_withoutUpdatingData_has2Sections()",
         "GleanPlumbMessageManagerTests\/testManagerOnMessagePressed_withMalformedURL()",
         "HistoryHighlightsDataAdaptorTests",
         "HistoryHighlightsDataAdaptorTests\/testReloadDataOnNotification()",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9350)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20709)

## :bulb: Description
Re-enabled FirefoxHomeViewModelTests:testNumberOfSection_withoutUpdatingData_has2Sections()

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

