### PR TITLE
Add FXIOS-9393 [Telemetry] Added for Confirmation View

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTelemetry.swift
@@ -22,4 +22,8 @@ struct MicrosurveyTelemetry {
         let userSelectionExtra = GleanMetrics.Microsurvey.SubmitButtonTappedExtra(userSelection: userSelection)
         GleanMetrics.Microsurvey.submitButtonTapped.record(userSelectionExtra)
     }
+
+    func confirmationShown() {
+        GleanMetrics.Microsurvey.confirmationShown.record()
+    }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
@@ -21,6 +21,7 @@ enum MicrosurveyActionType: ActionType {
     case submitSurvey
     case tapPrivacyNotice
     case surveyDidAppear
+    case confirmationViewed
 }
 
 enum MicrosurveyMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
@@ -21,6 +21,8 @@ final class MicrosurveyMiddleware {
             self.sendTelemetryAndClosePrompt(windowUUID: windowUUID, action: action)
         case MicrosurveyActionType.surveyDidAppear:
             self.microsurveyTelemetry.surveyViewed()
+        case MicrosurveyActionType.confirmationViewed:
+            self.microsurveyTelemetry.confirmationShown()
         default:
            break
         }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -335,6 +335,9 @@ final class MicrosurveyViewController: UIViewController,
             ]
         )
         confirmationView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+        store.dispatch(
+            MicrosurveyAction(windowUUID: windowUUID, actionType: MicrosurveyActionType.confirmationViewed)
+        )
     }
 
     @objc

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -717,6 +717,18 @@ microsurvey:
       - interaction
     expires: "2025-01-01"
 
+  confirmation_shown:
+    type: event
+    description: |
+        Records that the confirmation message in the survey has been viewed by the user.
+    bugs:
+        - https://github.com/mozilla-mobile/firefox-ios/issues/20800
+    data_reviews:
+        - https://github.com/mozilla-mobile/firefox-ios/pull/20840
+    notification_emails:
+        - fx-ios-data-stewards@mozilla.com
+    expires: "2025-01-01"
+
 # Shopping Experience (Fakespot)
 shopping:
   product_page_visits:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
@@ -63,6 +63,18 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
         XCTAssertEqual(resultValue[0].extra?["user_selection"], "Neutral")
     }
 
+    func testConfirmationViewedAction() {
+        let mockStore = Store(
+            state: AppState(),
+            reducer: AppState.reducer,
+            middlewares: [MicrosurveyMiddleware().microsurveyProvider]
+        )
+
+        let action = getAction(for: .confirmationViewed)
+        mockStore.dispatch(action)
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Microsurvey.confirmationShown)
+    }
+
     private func getAction(for actionType: MicrosurveyActionType) -> MicrosurveyMiddlewareAction {
         return MicrosurveyMiddlewareAction(windowUUID: .XCTestDefaultUUID, actionType: actionType)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9393)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20800)

## :bulb: Description
Add telemetry for survey using new event names specified in this [document](https://docs.google.com/document/d/14hpCd1h-frPRQKRB3DeplhDRSVF-KyGa8mqimfZQuKQ/edit).

Added Telemetry event for when the user views the Confirmation Page.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

