### PR TITLE
Revert "Bugfix FXIOS-9103 [Tab Tray Refactor] Favicons blink when all…

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -390,14 +390,15 @@ class TabManagerMiddleware {
                                                           actionType: TabPanelMiddlewareActionType.showToast)
                     store.dispatch(action)
                 } else {
+                    let dismissAction = TabTrayAction(windowUUID: uuid,
+                                                      actionType: TabTrayActionType.dismissTabTray)
+                    store.dispatch(dismissAction)
+
                     let toastAction = GeneralBrowserAction(toastType: .closedAllTabs(count: normalCount),
                                                            windowUUID: uuid,
                                                            actionType: GeneralBrowserActionType.showToast)
                     store.dispatch(toastAction)
                 }
-                let dismissAction = TabTrayAction(windowUUID: uuid,
-                                                  actionType: TabTrayActionType.dismissTabTray)
-                store.dispatch(dismissAction)
             }
         }
     }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -557,7 +557,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     @MainActor
-    func removeTab(_ tabUUID: TabUUID) {
+    func removeTab(_ tabUUID: TabUUID) async {
         guard let index = tabs.firstIndex(where: { $0.tabUUID == tabUUID }) else { return }
 
         let tab = tabs[index]
@@ -570,6 +570,9 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         }
         self.removeTab(tab, flushToDisk: true)
         self.updateIndexAfterRemovalOf(tab, deletedIndex: index, viableTabsIndex: viableTabsIndex)
+
+        // TODO: FXIOS-9084 This is not ideal, follow up in this ticket to make tab selection reasonably synchronous
+        try? await Task.sleep(nanoseconds: NSEC_PER_SEC/10)
 
         TelemetryWrapper.recordEvent(
             category: .action,
@@ -638,7 +641,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         }
         backupCloseTabs = tabs
         for tab in currentModeTabs {
-            self.removeTab(tab.tabUUID)
+            await self.removeTab(tab.tabUUID)
         }
         storeChanges()
     }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -451,7 +451,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
         backupCloseTabs = getInactiveTabs()
         let currentModeTabs = backupCloseTabs
         for tab in currentModeTabs {
-            self.removeTab(tab.tabUUID)
+            await self.removeTab(tab.tabUUID)
         }
         storeChanges()
     }


### PR DESCRIPTION
This reverts commit e772acadc35e2592492db1bb5dc62f7679edc822.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9411)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20841)

## :bulb: Description
Reverts the commit for the favicons blinking bug fix that introduced the regression.
After fixing the regression here I will make another PR to fix [FXIOS-9103](https://mozilla-hub.atlassian.net/browse/FXIOS-9103)
## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

