### PR TITLE
Bugfix FXIOS-9413 Long press Find In Page should pre-populate the iOS16 UIFindInteractor bar

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
@@ -5,22 +5,23 @@
 import Shared
 
 extension BrowserViewController {
-    func updateFindInPageVisibility(isVisible: Bool, tab: Tab? = nil) {
+    func updateFindInPageVisibility(isVisible: Bool, tab: Tab? = nil, withSearchText searchText: String? = nil) {
         // TODO: The find interactions for iOS 16 close themselves, so once the min deployment target is iOS 16,
         // we may be able to remove the `isVisible` flag and let the system manage dismissal.
         if #available(iOS 16, *) {
-            useSystemFindInteraction(isVisible: isVisible)
+            useSystemFindInteraction(isVisible: isVisible, withSearchText: searchText)
         } else {
             useCustomFindInteraction(isVisible: isVisible, tab: tab)
         }
     }
 
     @available(iOS 16, *)
-    private func useSystemFindInteraction(isVisible: Bool) {
+    private func useSystemFindInteraction(isVisible: Bool, withSearchText searchText: String?) {
         guard let webView = tabManager.selectedTab?.webView else { return }
 
         if isVisible {
             webView.isFindInteractionEnabled = true
+            webView.findInteraction?.searchText = searchText
             webView.findInteraction?.presentFindNavigator(showingReplace: false)
         } else {
             webView.findInteraction?.dismissFindNavigator()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2946,7 +2946,7 @@ extension BrowserViewController: LegacyTabDelegate {
     }
 
     func tab(_ tab: Tab, didSelectFindInPageForSelection selection: String) {
-        updateFindInPageVisibility(isVisible: true)
+        updateFindInPageVisibility(isVisible: true, withSearchText: selection)
         findInPageBar?.text = selection
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9413)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20844)

## :bulb: Description
The custom built FindInPageBar had functionality to pre-populate the search field from the long press “Find in page” option when a user highlights text on a webpage. The new UIFindInteractor used to fix [FXIOS-8693 ](https://mozilla-hub.atlassian.net/browse/FXIOS-8693) did not behave the same. This PR restores that functionality.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

