### PR TITLE
Bugfix FXIOS-9416 Fix selected tab after undo tab close

### DIFF
--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -847,6 +847,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     func undoCloseTab() {
         guard let backupCloseTab = self.backupCloseTab else { return }
 
+        let previouslySelectedTab = selectedTab
         if let index = backupCloseTab.restorePosition {
             tabs.insert(backupCloseTab.tab, at: index)
         } else {
@@ -855,6 +856,8 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
 
         if backupCloseTab.isSelected {
             self.selectTab(backupCloseTab.tab)
+        } else if let tabToSelect = previouslySelectedTab {
+            self.selectTab(tabToSelect)
         }
 
         delegates.forEach { $0.get()?.tabManagerUpdateCount() }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9416)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20850)

## :bulb: Description

Fixes selected tab after undoing closing of a tab. Inserting the new tab as part of `LegacyTabManager.undoCloseTab()` changes the selected tab; the fix added is to check the selected tab before the undo and ensure it's still selected afterwards (unless the closed tab itself is selected).

## Video

https://github.com/mozilla-mobile/firefox-ios/assets/145381717/a3eb257b-589a-438e-8668-30be37fbd972


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

