### PR TITLE
Fixes MTE-3032 for multiple tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
@@ -405,6 +405,9 @@ class FakespotTests: BaseTestCase {
     private func reachReviewChecker() {
         loadWebsiteAndPerformSearch()
         app.swipeDown()
+        if app.buttons["DONE"].exists {
+            app.buttons["DONE"].tap()
+        }
         app.webViews["contentView"].firstMatch.images.firstMatch.tap()
         waitUntilPageLoad()
         if !app.buttons[AccessibilityIdentifiers.Toolbar.shoppingButton].exists {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -107,14 +107,14 @@ class FindInPageTests: BaseTestCase {
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323718
     func testFindInPageResultsPageShowHideContent() {
-        userState.url = "lorem2.com"
+        userState.url = path(forTestPage: "test-mozilla-book.html")
         openFindInPageFromMenu(openSite: userState.url!)
         // Enter some text to start finding
-        app.searchFields["find.searchField"].typeText("lorem")
+        app.searchFields["find.searchField"].typeText("Mozilla")
 
         // There should be matches
-        mozWaitForElementToExist(app.staticTexts["1 of 5"], timeout: TIMEOUT)
-        XCTAssertTrue(app.staticTexts["1 of 5"].exists)
+        mozWaitForElementToExist(app.staticTexts["1 of 6"], timeout: TIMEOUT)
+        XCTAssertTrue(app.staticTexts["1 of 6"].exists)
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2323801

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
@@ -83,11 +83,15 @@ class ZoomingTests: BaseTestCase {
         tapZoomInButton(tapCount: 4)
         zoomLevel = app.buttons[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
         XCTAssertEqual(zoomLevel.label, "Current Zoom Level: 175%")
+        navigator.nowAt(BrowserTab)
+        navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         openWebsiteAndReachZoomSetting(website: 1)
         tapZoomInButton(tapCount: 1)
         zoomLevel = app.buttons[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
         XCTAssertEqual(zoomLevel.label, "Current Zoom Level: 110%")
+        navigator.nowAt(BrowserTab)
+        navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         openWebsiteAndReachZoomSetting(website: 2)
         zoomLevel = app.staticTexts[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
@@ -106,6 +110,7 @@ class ZoomingTests: BaseTestCase {
     }
 
     private func selectTabTrayWebsites(tab: Int) {
+        navigator.nowAt(BrowserTab)
         navigator.goto(TabTray)
         mozWaitForElementToExist(app.collectionViews.staticTexts.element)
         app.collectionViews.staticTexts.element(boundBy: tab).tap()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3032

## :bulb: Description
Fixes for:
testFindInPageResultsPageShowHideContent
testZoomForceCloseFirefox
testSwitchingZoomedTabsLandscape
testSwitchingZoomedTabs
and added a small fix for fakespot tests to reduce the number of failures.
