### PR TITLE
Bugfix FXIOS-9410 [Microsurvey] Add throttle to trigger

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -94,6 +94,7 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
     weak var delegate: HomepageViewModelDelegate?
     private var wallpaperManager: WallpaperManager
     private var logger: Logger
+    private let throttler = Throttler(seconds: 0.1)
 
     // Child View models
     private var childViewModels: [HomepageViewModelProtocol]
@@ -198,7 +199,9 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
         guard !viewAppeared else { return }
 
         viewAppeared = true
-        Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
+        throttler.throttle {
+            Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
+        }
         nimbus.features.homescreenFeature.recordExposure()
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .view,

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -94,7 +94,7 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
     weak var delegate: HomepageViewModelDelegate?
     private var wallpaperManager: WallpaperManager
     private var logger: Logger
-    private let throttler = Throttler(seconds: 0.1)
+    private let viewWillAppearEventThrottler = Throttler(seconds: 0.1)
 
     // Child View models
     private var childViewModels: [HomepageViewModelProtocol]
@@ -199,7 +199,8 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
         guard !viewAppeared else { return }
 
         viewAppeared = true
-        throttler.throttle {
+        // TODO: FXIOS-9428 - Need to fix issue where viewWillAppear is called twice so we can remove the throttle workaround
+        viewWillAppearEventThrottler.throttle {
             Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
         }
         nimbus.features.homescreenFeature.recordExposure()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -21,6 +21,7 @@ class HomepageViewControllerTests: XCTestCase {
         super.tearDown()
         AppContainer.shared.reset()
         profile = nil
+        Experiments.events.clearEvents()
     }
 
     func testHomepageViewController_simpleCreation_hasNoLeaks() {
@@ -35,5 +36,38 @@ class HomepageViewControllerTests: XCTestCase {
                                                                overlayManager: overlayManager)
 
         trackForMemoryLeaks(firefoxHomeViewController)
+    }
+
+    func testHomepage_viewWillAppear_sendsBehavioralTargetingEvent() {
+        Experiments.events.clearEvents()
+        let tabManager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
+        let urlBar = URLBarView(profile: profile, windowUUID: .XCTestDefaultUUID)
+        let overlayManager = MockOverlayModeManager()
+        overlayManager.setURLBar(urlBarView: urlBar)
+
+        let subject = HomepageViewController(
+            profile: profile,
+            toastContainer: UIView(),
+            tabManager: tabManager,
+            overlayManager: overlayManager
+        )
+        XCTAssertFalse(
+            try Experiments.createJexlHelper()!.evalJexl(
+                expression: "'homepage_viewed'|eventSum('Days', 1, 0) > 0"
+            )
+        )
+        subject.viewWillAppear(false)
+        let expectation = self.expectation(description: "Record event called")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            expectation.fulfill()
+            guard let hasValue = try? Experiments.createJexlHelper()!.evalJexl(
+                expression: "'homepage_viewed'|eventSum('Days', 1, 0) > 0"
+            ) else {
+                XCTFail("should not be nil")
+                return
+            }
+            XCTAssertTrue(hasValue)
+        }
+        waitForExpectations(timeout: 1)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9410)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20839)

## :bulb: Description
Currently, we have cases where our `viewWillAppear` gets called twice for `HomepageViewController`, this makes the method unreliable in determining how many times the view has been shown from a user's perspective. Created a separate ticket [here](https://mozilla-hub.atlassian.net/browse/FXIOS-9428).

As a bandaid / workaround so that the microsurvey trigger is not affected by the amount of calls, we are throttling the method. I estimated the throttle time by using the following logs. The ones that are same seconds are where you can see the double calls.

Thanks @mattreaganmozilla for helping me investigating and suggesting a temporary workaround as we have excessive updates in the app.

![CYN Current timestamp 2024-07-01 150358 142](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/5df4816f-dbe8-4af8-905a-11a7bd085eb3)

![CYN Current timestamp 2024-07-01 150811 686](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/b5fc5a77-9c41-47dc-909d-a3e0d818b890)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

