### PR TITLE
Improved MTE-3044 - testLoadReaderContent smoke test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
@@ -10,7 +10,7 @@ class ReadingListTests: BaseTestCase {
     // Smoketest
     func testLoadReaderContent() {
         navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
-        navigator.goto(BrowserTab)
+        navigator.nowAt(BrowserTab)
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])
         mozWaitForElementToExist(app.buttons["Reader View"], timeout: TIMEOUT)
         app.buttons["Reader View"].tap()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3044

## :bulb: Description

<img width="644" alt="Screenshot 2024-07-02 at 11 04 10" src="https://github.com/mozilla-mobile/firefox-ios/assets/134391433/0ec68fe9-f1c3-4abb-b8b9-ea4121985d8e">
