### PR TITLE
Fix MTE-3061 - home page and domain autocomplete tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
@@ -49,6 +49,7 @@ class DomainAutocompleteTests: BaseTestCase {
         // The autocomplete does not display the history item from the DB. Workaround is to manually visit "mozilla.org".
         navigator.openURL("mozilla.org")
         waitUntilPageLoad()
+        navigator.nowAt(BrowserTab)
         if isTablet {
             navigator.performAction(Action.AcceptRemovingAllTabs)
         } else {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -150,6 +150,7 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitForTabsButton()
+        navigator.nowAt(BrowserTab)
         navigator.performAction(Action.GoToHomePage)
 
         // Workaround needed after Xcode 11.3 update Issue 5937


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3061

## :bulb: Description
Fixes for:
testSetCustomURLAsHome
test1Autocomplete

