### PR TITLE
Add FXIOS-9399 Display back/forward buttons for regular horizontal size class

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -103,8 +103,7 @@ class BackForwardListViewController: UIViewController,
         view.addSubview(shadow)
         view.addSubview(tableView)
 
-        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: traitCollection)
-        snappedToBottom = showNavToolbar || isBottomSearchBar
+        snappedToBottom = isDisplayedAtBottom(for: traitCollection, isBottomSearchBar: isBottomSearchBar)
         tableViewHeightAnchor = tableView.heightAnchor.constraint(equalToConstant: 0)
         NSLayoutConstraint.activate([
             tableViewHeightAnchor,
@@ -179,15 +178,14 @@ class BackForwardListViewController: UIViewController,
         with coordinator: UIViewControllerTransitionCoordinator
     ) {
         super.willTransition(to: newCollection, with: coordinator)
-        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: newCollection)
-        if showNavToolbar != snappedToBottom, !isBottomSearchBar {
-            if snappedToBottom {
-                tableViewBottomAnchor.constant = 0
-            } else {
-                tableViewTopAnchor.constant = 0
-            }
+
+        let isDisplayedAtBottom = isDisplayedAtBottom(for: newCollection, isBottomSearchBar: isBottomSearchBar)
+
+        if snappedToBottom != isDisplayedAtBottom {
+            snappedToBottom = isDisplayedAtBottom
+            let anchor = snappedToBottom ? tableViewTopAnchor : tableViewBottomAnchor
+            anchor?.constant = 0
             tableViewHeightAnchor.constant = 0
-            snappedToBottom = !snappedToBottom
         }
     }
 
@@ -203,6 +201,13 @@ class BackForwardListViewController: UIViewController,
             self.remakeVerticalConstraints()
             correctHeight()
         }
+    }
+
+    // the back/forward list can be shown at the top or bottom of the screen
+    // the position depends on the address bar position and whether the navigation toolbar is shown or not
+    private func isDisplayedAtBottom(for traitCollection: UITraitCollection, isBottomSearchBar: Bool) -> Bool {
+        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: traitCollection)
+        return showNavToolbar || isBottomSearchBar
     }
 
     func remakeVerticalConstraints() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1734,9 +1734,13 @@ class BrowserViewController: UIViewController,
     /// Call this whenever the page URL changes.
     fileprivate func updateURLBarDisplayURL(_ tab: Tab) {
         guard !isToolbarRefactorEnabled else {
-            let action = ToolbarAction(url: tab.url?.displayURL,
-                                       windowUUID: windowUUID,
-                                       actionType: ToolbarActionType.urlDidChange)
+            let action = ToolbarMiddlewareAction(
+                url: tab.url?.displayURL,
+                traitCollection: traitCollection,
+                canGoForward: tab.canGoForward,
+                canGoBack: tab.canGoBack,
+                windowUUID: windowUUID,
+                actionType: ToolbarMiddlewareActionType.urlDidChange)
             store.dispatch(action)
             return
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -72,9 +72,10 @@ struct AddressBarState: StateType, Equatable {
             )
 
         case ToolbarActionType.urlDidChange:
+            var addressToolbarModel = (action as? ToolbarAction)?.addressToolbarModel
             return AddressBarState(
                 windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
+                navigationActions: addressToolbarModel?.navigationActions ?? state.navigationActions,
                 pageActions: state.pageActions,
                 browserActions: state.browserActions,
                 borderPosition: state.borderPosition,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -49,19 +49,32 @@ class ToolbarMiddlewareAction: Action {
     let buttonType: ToolbarActionState.ActionType?
     let buttonTapped: UIButton?
     let gestureType: ToolbarButtonGesture?
+    let url: URL?
+    let traitCollection: UITraitCollection?
+    let canGoForward: Bool?
+    let canGoBack: Bool?
 
     init(buttonType: ToolbarActionState.ActionType? = nil,
          buttonTapped: UIButton? = nil,
          gestureType: ToolbarButtonGesture? = nil,
+         url: URL? = nil,
+         traitCollection: UITraitCollection? = nil,
+         canGoForward: Bool? = nil,
+         canGoBack: Bool? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
         self.buttonType = buttonType
         self.buttonTapped = buttonTapped
         self.gestureType = gestureType
+        self.url = url
+        self.traitCollection = traitCollection
+        self.canGoForward = canGoForward
+        self.canGoBack = canGoBack
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 
 enum ToolbarMiddlewareActionType: ActionType {
     case didTapButton
+    case urlDidChange
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9399)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20816)

## :bulb: Description
Shows the back/forward buttons in the address toolbar for regular horizontal traitCollections.
![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-07-02 at 16 41 28](https://github.com/mozilla-mobile/firefox-ios/assets/4530/0a711a90-8e73-4c32-8020-7c698bd0890a)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

