### PR TITLE
Bugfix FXIOS-9423 Fix address autofill settings UI

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
@@ -45,6 +45,7 @@ struct AddressAutofillSettingsView: View {
             .background(viewBackground)
         }
         .onAppear {
+            addressListViewModel.fetchAddresses()
             // Apply the theme when the view appears
             applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
@@ -37,10 +37,12 @@ struct AddressAutofillSettingsView: View {
                     .padding(.top, 25)
                     .frame(maxWidth: .infinity)
 
-                // Address list view
-                AddressListView(windowUUID: windowUUID, viewModel: addressListViewModel)
-
-                Spacer()
+                if addressListViewModel.showSection || addressListViewModel.isEditingFeatureEnabled {
+                    // Address list view
+                    AddressListView(windowUUID: windowUUID, viewModel: addressListViewModel)
+                } else {
+                    Spacer()
+                }
             }
             .background(viewBackground)
         }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
@@ -39,6 +39,8 @@ struct AddressAutofillSettingsView: View {
 
                 // Address list view
                 AddressListView(windowUUID: windowUUID, viewModel: addressListViewModel)
+
+                Spacer()
             }
             .background(viewBackground)
         }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsView.swift
@@ -38,7 +38,6 @@ struct AddressAutofillSettingsView: View {
                     .frame(maxWidth: .infinity)
 
                 if addressListViewModel.showSection || addressListViewModel.isEditingFeatureEnabled {
-                    // Address list view
                     AddressListView(windowUUID: windowUUID, viewModel: addressListViewModel)
                 } else {
                     Spacer()
@@ -48,7 +47,6 @@ struct AddressAutofillSettingsView: View {
         }
         .onAppear {
             addressListViewModel.fetchAddresses()
-            // Apply the theme when the view appears
             applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -112,7 +112,6 @@ struct AddressListView: View {
             }
         }
         .onAppear {
-            viewModel.fetchAddresses()
             applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             viewModel.editAddressWebViewManager.preloadWebView()
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/9423)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20864)

## :bulb: Description

### Background
- Disabling the `address-autofill-edit` feature flag caused the `Group` in `AddressListView` to be be empty, resulting in the `AddressAutofillToggle` becoming centered in the screen, and preventing the `Group`'s `onAppear` modifier from running which ultimately stopped the list of saved addresses from being fetched. 

### Resolution
- Conditionally show a `Spacer` underneath the toggle when there are no views to push the toggle to the top of the view (when the feature flag is disabled and there are no addresses to show)
-  Move the address fetching to `AddressAutofillSettingsView.swift` so that saved addresses are always fetched

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

