### PR TITLE
Bugfix FXIOS-9437 Fix address toolbar not changing position when settings change

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -324,10 +324,9 @@ class BrowserViewController: UIViewController,
 
     @objc
     func searchBarPositionDidChange(notification: Notification) {
-        guard !isToolbarRefactorEnabled,
-              let dict = notification.object as? NSDictionary,
+        guard let dict = notification.object as? NSDictionary,
               let newSearchBarPosition = dict[PrefsKeys.FeatureFlags.SearchBarPosition] as? SearchBarPosition,
-              urlBar != nil
+              (!isToolbarRefactorEnabled && urlBar != nil) || isToolbarRefactorEnabled
         else { return }
 
         let searchBarView: TopBottomInterchangeable = isToolbarRefactorEnabled ? addressToolbarContainer : urlBar

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -117,7 +117,8 @@ struct AddressBarState: StateType, Equatable {
                 url: state.url
             )
 
-        case ToolbarActionType.scrollOffsetChanged:
+        case ToolbarActionType.scrollOffsetChanged,
+            ToolbarActionType.toolbarPositionChanged:
             let borderPosition = (action as? ToolbarAction)?.addressToolbarModel?.borderPosition
 
             return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -83,7 +83,8 @@ struct NavigationBarState: StateType, Equatable {
                 displayBorder: state.displayBorder
             )
 
-        case ToolbarActionType.scrollOffsetChanged:
+        case ToolbarActionType.scrollOffsetChanged,
+            ToolbarActionType.toolbarPositionChanged:
             guard let displayBorder = (action as? ToolbarAction)?.navigationToolbarModel?.displayBorder
             else { return state }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -249,15 +249,29 @@ class ToolbarMiddleware: FeatureFlaggable {
     }
 
     private func updateToolbarPosition(action: GeneralBrowserMiddlewareAction, state: AppState) {
-        guard let toolbarPosition = action.toolbarPosition else { return }
+        guard let toolbarPosition = action.toolbarPosition,
+              let scrollOffset = action.scrollOffset,
+              let toolbarState = state.screenState(ToolbarState.self,
+                                                   for: .toolbar,
+                                                   window: action.windowUUID)
+        else { return }
 
         let position = addressToolbarPositionFromSearchBarPosition(toolbarPosition)
-        let toolbarAction = ToolbarAction(toolbarPosition: position,
+
+        let addressToolbarState = toolbarState.addressToolbar
+        let addressBorderPosition = getAddressBorderPosition(toolbarPosition: position,
+                                                             isPrivate: toolbarState.isPrivateMode,
+                                                             scrollY: scrollOffset.y)
+        let displayNavToolbarBorder = shouldDisplayNavigationToolbarBorder(toolbarPosition: position)
+        let addressToolbarModel = AddressToolbarModel(borderPosition: addressBorderPosition)
+        let navToolbarModel = NavigationToolbarModel(displayBorder: displayNavToolbarBorder)
+
+        let toolbarAction = ToolbarAction(addressToolbarModel: addressToolbarModel,
+                                          navigationToolbarModel: navToolbarModel,
+                                          toolbarPosition: position,
                                           windowUUID: action.windowUUID,
                                           actionType: ToolbarActionType.toolbarPositionChanged)
         store.dispatch(toolbarAction)
-
-        updateBorderPosition(action: action, state: state)
     }
 
     private func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition) -> AddressToolbarPosition {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -258,7 +258,6 @@ class ToolbarMiddleware: FeatureFlaggable {
 
         let position = addressToolbarPositionFromSearchBarPosition(toolbarPosition)
 
-        let addressToolbarState = toolbarState.addressToolbar
         let addressBorderPosition = getAddressBorderPosition(toolbarPosition: position,
                                                              isPrivate: toolbarState.isPrivateMode,
                                                              scrollY: scrollOffset.y)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9437)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20887)

## :bulb: Description
Updates the address toolbar position and the toolbar borders when the user preference changes.
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-07-02 at 17 24 16](https://github.com/mozilla-mobile/firefox-ios/assets/4530/df1a94c4-cc17-448b-9825-66d879f38dea)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

