### PR TITLE
Bugfix FXIOS-9429 [Microsurvey] Add surface id to telemetry events

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyModel.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyModel.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 struct MicrosurveyModel: Equatable {
+    let id: String
     let promptTitle: String
     let promptButtonLabel: String
     let surveyQuestion: String

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveySurfaceManager.swift
@@ -45,6 +45,7 @@ class MicrosurveySurfaceManager: MicrosurveyManager {
         let utmContent = message.utmContent
 
         return MicrosurveyModel(
+            id: message.id,
             promptTitle: promptTitle,
             promptButtonLabel: promptButtonLabel,
             surveyQuestion: surveyQuestion,

--- a/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/MicrosurveyTelemetry.swift
@@ -6,24 +6,28 @@ import Foundation
 import Glean
 
 struct MicrosurveyTelemetry {
-    func surveyViewed() {
-        GleanMetrics.Microsurvey.shown.record()
+    func surveyViewed(surveyId: String) {
+        let surveyIdExtra = GleanMetrics.Microsurvey.ShownExtra(surveyId: surveyId)
+        GleanMetrics.Microsurvey.shown.record(surveyIdExtra)
     }
 
-    func privacyNoticeTapped() {
-        GleanMetrics.Microsurvey.privacyNoticeTapped.record()
+    func privacyNoticeTapped(surveyId: String) {
+        let surveyIdExtra = GleanMetrics.Microsurvey.PrivacyNoticeTappedExtra(surveyId: surveyId)
+        GleanMetrics.Microsurvey.privacyNoticeTapped.record(surveyIdExtra)
     }
 
-    func dismissButtonTapped() {
-        GleanMetrics.Microsurvey.dismissButtonTapped.record()
+    func dismissButtonTapped(surveyId: String) {
+        let surveyIdExtra = GleanMetrics.Microsurvey.DismissButtonTappedExtra(surveyId: surveyId)
+        GleanMetrics.Microsurvey.dismissButtonTapped.record(surveyIdExtra)
     }
 
-    func userResponseSubmitted(userSelection: String) {
-        let userSelectionExtra = GleanMetrics.Microsurvey.SubmitButtonTappedExtra(userSelection: userSelection)
-        GleanMetrics.Microsurvey.submitButtonTapped.record(userSelectionExtra)
+    func userResponseSubmitted(surveyId: String, userSelection: String) {
+        let submitExtra = GleanMetrics.Microsurvey.SubmitButtonTappedExtra(surveyId: surveyId, userSelection: userSelection)
+        GleanMetrics.Microsurvey.submitButtonTapped.record(submitExtra)
     }
 
-    func confirmationShown() {
-        GleanMetrics.Microsurvey.confirmationShown.record()
+    func confirmationShown(surveyId: String) {
+        let surveyIdExtra = GleanMetrics.Microsurvey.ConfirmationShownExtra(surveyId: surveyId)
+        GleanMetrics.Microsurvey.confirmationShown.record(surveyIdExtra)
     }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
@@ -8,8 +8,10 @@ import Common
 
 final class MicrosurveyAction: Action {
     let userSelection: String?
+    let surveyId: String
 
-    init(userSelection: String? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
+    init(surveyId: String, userSelection: String? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
+        self.surveyId = surveyId
         self.userSelection = userSelection
         super.init(windowUUID: windowUUID, actionType: actionType)
     }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -182,7 +182,7 @@ final class MicrosurveyViewController: UIViewController,
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         store.dispatch(
-            MicrosurveyAction(windowUUID: windowUUID, actionType: MicrosurveyActionType.surveyDidAppear)
+            MicrosurveyAction(surveyId: model.id, windowUUID: windowUUID, actionType: MicrosurveyActionType.surveyDidAppear)
         )
         UIAccessibility.post(notification: .screenChanged, argument: nil)
     }
@@ -314,6 +314,7 @@ final class MicrosurveyViewController: UIViewController,
     private func sendTelemetry() {
         store.dispatch(
             MicrosurveyAction(
+                surveyId: model.id,
                 userSelection: selectedOption,
                 windowUUID: windowUUID,
                 actionType: MicrosurveyActionType.submitSurvey
@@ -336,21 +337,33 @@ final class MicrosurveyViewController: UIViewController,
         )
         confirmationView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         store.dispatch(
-            MicrosurveyAction(windowUUID: windowUUID, actionType: MicrosurveyActionType.confirmationViewed)
+            MicrosurveyAction(
+                surveyId: model.id,
+                windowUUID: windowUUID,
+                actionType: MicrosurveyActionType.confirmationViewed
+            )
         )
     }
 
     @objc
     private func didTapClose() {
         store.dispatch(
-            MicrosurveyAction(windowUUID: windowUUID, actionType: MicrosurveyActionType.closeSurvey)
+            MicrosurveyAction(
+                surveyId: model.id,
+                windowUUID: windowUUID,
+                actionType: MicrosurveyActionType.closeSurvey
+            )
         )
     }
 
     @objc
     private func didTapPrivacyPolicy() {
         store.dispatch(
-            MicrosurveyAction(windowUUID: windowUUID, actionType: MicrosurveyActionType.tapPrivacyNotice)
+            MicrosurveyAction(
+                surveyId: model.id,
+                windowUUID: windowUUID,
+                actionType: MicrosurveyActionType.tapPrivacyNotice
+            )
         )
     }
 

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -662,6 +662,11 @@ microsurvey:
     type: event
     description: |
         The survey surface (bottom sheet) was shown and visible.
+    extra_keys:
+      survey_id:
+        type: string
+        description: |
+          The id of the survey.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/19506
     data_reviews:
@@ -674,6 +679,11 @@ microsurvey:
     type: event
     description: |
         Records that the user tapped on the privacy notice.
+    extra_keys:
+      survey_id:
+        type: string
+        description: |
+          The id of the survey.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/19506
     data_reviews:
@@ -688,6 +698,11 @@ microsurvey:
     type: event
     description: |
         Records that the user tapped on the close button to dismiss the survey.
+    extra_keys:
+      survey_id:
+        type: string
+        description: |
+          The id of the survey.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/19506
     data_reviews:
@@ -707,6 +722,10 @@ microsurvey:
         type: string
         description: |
           The user's selected option e.g. "satisfied".
+      survey_id:
+        type: string
+        description: |
+          The id of the survey.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/19506
     data_reviews:
@@ -721,6 +740,11 @@ microsurvey:
     type: event
     description: |
         Records that the confirmation message in the survey has been viewed by the user.
+    extra_keys:
+      survey_id:
+        type: string
+        description: |
+          The id of the survey.
     bugs:
         - https://github.com/mozilla-mobile/firefox-ios/issues/20800
     data_reviews:

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -669,8 +669,10 @@ microsurvey:
           The id of the survey.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/19506
+      - https://github.com/mozilla-mobile/firefox-ios/issues/20875
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/20801
+      - https://github.com/mozilla-mobile/firefox-ios/pull/20903
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-01-01"
@@ -686,8 +688,10 @@ microsurvey:
           The id of the survey.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/19506
+      - https://github.com/mozilla-mobile/firefox-ios/issues/20875
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/20801
+      - https://github.com/mozilla-mobile/firefox-ios/pull/20903
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
@@ -705,8 +709,10 @@ microsurvey:
           The id of the survey.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/19506
+      - https://github.com/mozilla-mobile/firefox-ios/issues/20875
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/20801
+      - https://github.com/mozilla-mobile/firefox-ios/pull/20903
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
@@ -728,8 +734,10 @@ microsurvey:
           The id of the survey.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/19506
+      - https://github.com/mozilla-mobile/firefox-ios/issues/20875
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/20801
+      - https://github.com/mozilla-mobile/firefox-ios/pull/20903
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     data_sensitivity:
@@ -746,9 +754,11 @@ microsurvey:
         description: |
           The id of the survey.
     bugs:
-        - https://github.com/mozilla-mobile/firefox-ios/issues/20800
+      - https://github.com/mozilla-mobile/firefox-ios/issues/20800
+      - https://github.com/mozilla-mobile/firefox-ios/issues/20875
     data_reviews:
-        - https://github.com/mozilla-mobile/firefox-ios/pull/20840
+      - https://github.com/mozilla-mobile/firefox-ios/pull/20840
+      - https://github.com/mozilla-mobile/firefox-ios/pull/20903
     notification_emails:
         - fx-ios-data-stewards@mozilla.com
     expires: "2025-01-01"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
@@ -83,7 +83,11 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
         XCTAssertEqual(resultValue[0].extra?["survey_id"], "microsurvey-id")
     }
 
-    private func getAction(for actionType: MicrosurveyActionType) -> MicrosurveyMiddlewareAction {
-        return MicrosurveyMiddlewareAction(windowUUID: .XCTestDefaultUUID, actionType: actionType)
+    private func getAction(for actionType: MicrosurveyActionType) -> MicrosurveyAction {
+        return MicrosurveyAction(
+            surveyId: "microsurvey-id",
+            windowUUID: .XCTestDefaultUUID,
+            actionType: actionType
+        )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
@@ -21,7 +21,7 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
         DependencyHelperMock().reset()
     }
 
-    func testDismissSurveyAction() {
+    func testDismissSurveyAction() throws {
         let mockStore = Store(
             state: AppState(),
             reducer: AppState.reducer,
@@ -31,9 +31,11 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
         let action = getAction(for: .closeSurvey)
         mockStore.dispatch(action)
         testEventMetricRecordingSuccess(metric: GleanMetrics.Microsurvey.dismissButtonTapped)
+        let resultValue = try XCTUnwrap(GleanMetrics.Microsurvey.dismissButtonTapped.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?["survey_id"], "microsurvey-id")
     }
 
-    func testPrivacyNoticeTappedAction() {
+    func testPrivacyNoticeTappedAction() throws {
         let mockStore = Store(
             state: AppState(),
             reducer: AppState.reducer,
@@ -43,6 +45,8 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
         let action = getAction(for: .tapPrivacyNotice)
         mockStore.dispatch(action)
         testEventMetricRecordingSuccess(metric: GleanMetrics.Microsurvey.privacyNoticeTapped)
+        let resultValue = try XCTUnwrap(GleanMetrics.Microsurvey.privacyNoticeTapped.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?["survey_id"], "microsurvey-id")
     }
 
     func testSubmitSurveyAction() throws {
@@ -53,6 +57,7 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
         )
 
         let action = MicrosurveyAction(
+            surveyId: "microsurvey-id",
             userSelection: "Neutral",
             windowUUID: .XCTestDefaultUUID,
             actionType: MicrosurveyActionType.submitSurvey
@@ -60,10 +65,11 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
         mockStore.dispatch(action)
         testEventMetricRecordingSuccess(metric: GleanMetrics.Microsurvey.submitButtonTapped)
         let resultValue = try XCTUnwrap(GleanMetrics.Microsurvey.submitButtonTapped.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?["survey_id"], "microsurvey-id")
         XCTAssertEqual(resultValue[0].extra?["user_selection"], "Neutral")
     }
 
-    func testConfirmationViewedAction() {
+    func testConfirmationViewedAction() throws {
         let mockStore = Store(
             state: AppState(),
             reducer: AppState.reducer,
@@ -73,6 +79,8 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
         let action = getAction(for: .confirmationViewed)
         mockStore.dispatch(action)
         testEventMetricRecordingSuccess(metric: GleanMetrics.Microsurvey.confirmationShown)
+        let resultValue = try XCTUnwrap(GleanMetrics.Microsurvey.confirmationShown.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?["survey_id"], "microsurvey-id")
     }
 
     private func getAction(for actionType: MicrosurveyActionType) -> MicrosurveyMiddlewareAction {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyMockModel.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyMockModel.swift
@@ -8,6 +8,7 @@ import Foundation
 final class MicrosurveyMock {
     static var model: MicrosurveyModel {
         return MicrosurveyModel(
+            id: "survey-id",
             promptTitle: "prompt title",
             promptButtonLabel: "prompt button label",
             surveyQuestion: "is this a survey question?",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyPromptMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyPromptMiddlewareTests.swift
@@ -12,6 +12,7 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
     override func setUp() {
         super.setUp()
         let model = MicrosurveyModel(
+            id: "survey-id",
             promptTitle: "title",
             promptButtonLabel: "button label",
             surveyQuestion: "survey question",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9429)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20875)

## :bulb: Description
Updated requirement in adding the survey id to each of the analytics call. This way we know which analytic event is associated to which messaging.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

# Screenshots
<img width="1146" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/6743397/6f922315-70b1-4352-9f62-da5b68c74376">
