### PR TITLE
Add FXIOS-9269 Create and add error toast for address saving failure

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -940,6 +940,7 @@
 		8CBDE8E32AB09804001985BF /* ProductAnalyzeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CBDE8E22AB09804001985BF /* ProductAnalyzeResponse.swift */; };
 		8CC033FA2BA476840033449E /* FormAutofillHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8CC033F92BA476840033449E /* FormAutofillHelper.js */; };
 		8CC617092C35463B001C7688 /* AddressModifiedStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC617082C35463B001C7688 /* AddressModifiedStatus.swift */; };
+		8CC6170B2C358BAC001C7688 /* ActionToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC6170A2C358BAC001C7688 /* ActionToast.swift */; };
 		8CCCB08B2AE26B5C0073ADB9 /* ReportResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CCCB08A2AE26B5C0073ADB9 /* ReportResponse.swift */; };
 		8CCD74732B90A945008F919B /* LoginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CCD74722B90A945008F919B /* LoginListViewModelTests.swift */; };
 		8CE1E4322B8C76AE0026530B /* LoginStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1E4312B8C76AE0026530B /* LoginStorage.swift */; };
@@ -6488,6 +6489,7 @@
 		8CBDE8E22AB09804001985BF /* ProductAnalyzeResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductAnalyzeResponse.swift; sourceTree = "<group>"; };
 		8CC033F92BA476840033449E /* FormAutofillHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = FormAutofillHelper.js; sourceTree = "<group>"; };
 		8CC617082C35463B001C7688 /* AddressModifiedStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressModifiedStatus.swift; sourceTree = "<group>"; };
+		8CC6170A2C358BAC001C7688 /* ActionToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionToast.swift; sourceTree = "<group>"; };
 		8CCA45EFA01D41F54715FBCC /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		8CCCB08A2AE26B5C0073ADB9 /* ReportResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportResponse.swift; sourceTree = "<group>"; };
 		8CCD74722B90A945008F919B /* LoginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -11530,6 +11532,7 @@
 				D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */,
 				8A9B87A92C1B30340042B894 /* Search */,
 				3BF56D261CDBBE1F00AC4D75 /* SimpleToast.swift */,
+				8CC6170A2C358BAC001C7688 /* ActionToast.swift */,
 				E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */,
 				213B67A527CE682B000542F5 /* StartAtHomeHelper.swift */,
 				DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */,
@@ -14723,6 +14726,7 @@
 				8AB8574827D97CD40075C173 /* HomePanelType.swift in Sources */,
 				E174963A2992B42C0096900A /* CreditCardSectionHeader.swift in Sources */,
 				8A3EF7F42A2FCF5700796E3A /* ExportBrowserDataSetting.swift in Sources */,
+				8CC6170B2C358BAC001C7688 /* ActionToast.swift in Sources */,
 				2128E27B292E624400FB91BE /* SendToDeviceActivity.swift in Sources */,
 				E63ED7D81BFCD9990097D08E /* LoginDetailTableViewCell.swift in Sources */,
 				C855728229AE7F1700AF32B0 /* SurveySurfaceManager.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
@@ -88,11 +88,22 @@ class AddressAutofillSettingsViewController: SensitiveViewController, Themeable 
         applyTheme()
         viewModel.addressListViewModel.presentToast = { [weak self] status in
             guard let self else { return }
-            SimpleToast().showAlertWithText(
-                status.message,
-                bottomContainer: view,
-                theme: themeManager.getCurrentTheme(for: windowUUID)
-            )
+            switch status {
+            case .error(let action):
+                ActionToast(
+                    text: status.message,
+                    bottomContainer: view,
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    buttonTitle: status.actionTitle,
+                    buttonAction: action
+                ).show()
+            default:
+                SimpleToast().showAlertWithText(
+                    status.message,
+                    bottomContainer: view,
+                    theme: themeManager.getCurrentTheme(for: windowUUID)
+                )
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
@@ -89,13 +89,13 @@ class AddressAutofillSettingsViewController: SensitiveViewController, Themeable 
         viewModel.addressListViewModel.presentToast = { [weak self] status in
             guard let self else { return }
             switch status {
-            case .error(let action):
+            case let .error(errorType):
                 ActionToast(
-                    text: status.message,
+                    text: errorType.message,
                     bottomContainer: view,
                     theme: themeManager.getCurrentTheme(for: windowUUID),
-                    buttonTitle: status.actionTitle,
-                    buttonAction: action
+                    buttonTitle: errorType.actionTitle,
+                    buttonAction: errorType.action
                 ).show()
             default:
                 SimpleToast().showAlertWithText(

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
@@ -8,12 +8,23 @@ enum AddressModifiedStatus {
     case saved
     case updated
     case removed
+    case error(action: () -> Void)
 
     var message: String {
         switch self {
         case .saved: return .Addresses.Settings.Edit.AddressSavedConfirmation
         case .updated: return .Addresses.Settings.Edit.AddressUpdatedConfirmation
         case .removed: return .Addresses.Settings.Edit.AddressRemovedConfirmation
+        case .error: return .Addresses.Settings.Edit.AddressSaveError
+        }
+    }
+
+    var actionTitle: String {
+        switch self {
+        case .saved: return ""
+        case .updated: return ""
+        case .removed: return ""
+        case .error: return .Addresses.Settings.Edit.AddressSaveRetrySuggestion
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
@@ -12,8 +12,7 @@ enum AddressModifiedStatus {
 
         var message: String {
             switch self {
-            case .save: return .Addresses.Settings.Edit.AddressSaveError
-            case .update: return .Addresses.Settings.Edit.AddressSaveError
+            case .save, .update: return .Addresses.Settings.Edit.AddressSaveError
             case .remove: return .Addresses.Settings.Edit.AddressRemoveError
             }
         }

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
@@ -5,26 +5,42 @@
 import Foundation
 
 enum AddressModifiedStatus {
+    enum ErrorType {
+        case save(action: () -> Void)
+        case update(action: () -> Void)
+        case remove(action: () -> Void)
+
+        var message: String {
+            switch self {
+            case .save: return .Addresses.Settings.Edit.AddressSaveError
+            case .update: return .Addresses.Settings.Edit.AddressSaveError
+            case .remove: return .Addresses.Settings.Edit.AddressRemoveError
+            }
+        }
+
+        var actionTitle: String {
+            return .Addresses.Settings.Edit.AddressSaveRetrySuggestion
+        }
+
+        var action: () -> Void {
+            switch self {
+            case .save(let action), .update(let action), .remove(let action):
+                return action
+            }
+        }
+    }
+
     case saved
     case updated
     case removed
-    case error(action: () -> Void)
+    case error(ErrorType)
 
     var message: String {
         switch self {
         case .saved: return .Addresses.Settings.Edit.AddressSavedConfirmation
         case .updated: return .Addresses.Settings.Edit.AddressUpdatedConfirmation
         case .removed: return .Addresses.Settings.Edit.AddressRemovedConfirmation
-        case .error: return .Addresses.Settings.Edit.AddressSaveError
-        }
-    }
-
-    var actionTitle: String {
-        switch self {
-        case .saved: return ""
-        case .updated: return ""
-        case .removed: return ""
-        case .error: return .Addresses.Settings.Edit.AddressSaveRetrySuggestion
+        case .error(let type): return type.message
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/ActionToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/ActionToast.swift
@@ -1,0 +1,161 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+
+class ActionToast: ThemeApplicable {
+    private let text: String
+    private let theme: Theme
+    private let buttonTitle: String
+    private let buttonAction: () -> Void
+    private var bottomConstraintPadding: CGFloat
+    private var bottomContainer: UIView
+
+    struct UX {
+        static let stackViewLayoutMargins = UIEdgeInsets(
+            top: 0,
+            left: 16,
+            bottom: 0,
+            right: 16
+        )
+        static let buttonStrokeWidth: CGFloat = 1
+        static let buttonCornerRadius: CGFloat = 8
+        static let buttonContentInsets = NSDirectionalEdgeInsets(
+            top: 8,
+            leading: 16,
+            bottom: 8,
+            trailing: 16
+        )
+        static let buttonHeight: CGFloat = 36
+    }
+
+    private lazy var stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 0
+        stack.alignment = .center
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.layoutMargins = UX.stackViewLayoutMargins
+        return stack
+    }()
+
+    private lazy var toastLabel: UILabel = {
+        let label = UILabel()
+        label.font = FXFontStyles.Bold.subheadline.scaledFont()
+        label.text = text
+        label.textAlignment  = .center
+        label.numberOfLines = 1
+        return label
+    }()
+
+    private lazy var actionButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.addAction(
+            UIAction { [weak self] _ in
+                guard let self else { return }
+                self.buttonAction()
+                self.dismiss(stackView)
+            }, for: .touchUpInside)
+        var config = UIButton.Configuration.plain()
+        config.title = buttonTitle
+        config.background.backgroundColor = .clear
+        config.background.strokeWidth = UX.buttonStrokeWidth
+        config.background.cornerRadius = UX.buttonCornerRadius
+        config.contentInsets = UX.buttonContentInsets
+        button.configuration = config
+        return button
+    }()
+
+    private lazy var heightConstraint: NSLayoutConstraint = {
+        self.toastLabel.heightAnchor.constraint(equalToConstant: Toast.UX.toastHeight)
+    }()
+
+    init(
+        text: String,
+        bottomContainer: UIView,
+        theme: Theme,
+        bottomConstraintPadding: CGFloat = 0,
+        buttonTitle: String,
+        buttonAction: @escaping () -> Void
+    ) {
+        self.text = text
+        self.bottomContainer = bottomContainer
+        self.theme = theme
+        self.bottomConstraintPadding = bottomConstraintPadding
+        self.buttonTitle = buttonTitle
+        self.buttonAction = buttonAction
+    }
+
+    func show() {
+        stackView.addArrangedSubview(toastLabel)
+        stackView.addArrangedSubview(UIView())
+        stackView.addArrangedSubview(actionButton)
+
+        bottomContainer.addSubview(stackView)
+
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate(
+            [
+                heightConstraint,
+                stackView.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
+                stackView.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor),
+                stackView.bottomAnchor.constraint(
+                    equalTo: bottomContainer.safeAreaLayoutGuide.bottomAnchor,
+                    constant: bottomConstraintPadding
+                ),
+                actionButton.heightAnchor.constraint(equalToConstant: UX.buttonHeight)
+            ]
+        )
+        applyTheme(theme: theme)
+        animate(stackView)
+
+        if UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .announcement, argument: text)
+        }
+    }
+
+    private func dismiss(_ toast: UIView) {
+        UIView.animate(
+            withDuration: Toast.UX.toastAnimationDuration,
+            animations: {
+                self.heightConstraint.constant = 0
+                toast.superview?.layoutIfNeeded()
+            },
+            completion: { finished in
+                toast.removeFromSuperview()
+            }
+        )
+    }
+
+    private func animate(_ toast: UIView) {
+        UIView.animate(
+            withDuration: Toast.UX.toastAnimationDuration,
+            animations: {
+                var frame = toast.frame
+                frame.origin.y = frame.origin.y - Toast.UX.toastHeight
+                frame.size.height = Toast.UX.toastHeight
+                toast.frame = frame
+            },
+            completion: { finished in
+                let thousandMilliseconds = DispatchTimeInterval.milliseconds(1000)
+                let zeroMilliseconds = DispatchTimeInterval.milliseconds(0)
+                let voiceOverDelay = UIAccessibility.isVoiceOverRunning ? thousandMilliseconds : zeroMilliseconds
+                let dispatchTime = DispatchTime.now() + Toast.UX.toastDismissAfter + voiceOverDelay
+
+                DispatchQueue.main.asyncAfter(deadline: dispatchTime, execute: {
+                    self.dismiss(toast)
+                })
+            }
+        )
+    }
+
+    func applyTheme(theme: Theme) {
+        stackView.backgroundColor = theme.colors.actionPrimary
+        toastLabel.textColor = theme.colors.textInverted
+        actionButton.configuration?.background.strokeColor = theme.colors.textInverted
+        actionButton.configuration?.baseForegroundColor = theme.colors.textInverted
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/ActionToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/ActionToast.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Common
 
-class ActionToast: ThemeApplicable {
+final class ActionToast: ThemeApplicable {
     private let text: String
     private let theme: Theme
     private let buttonTitle: String

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -294,6 +294,12 @@ extension String {
                     value: "Address Saved",
                     comment: "Toast message confirming that an address has been successfully saved."
                 )
+                public static let AddressRemoveError = MZLocalizedString(
+                    key: "Addresses.Toast.AddressSaveError.v130",
+                    tableName: "EditAddress",
+                    value: "Address Couldn’t Be Removed",
+                    comment: "Toast message indicating an error occurred while trying to remove an address."
+                )
                 public static let AddressSaveError = MZLocalizedString(
                     key: "Addresses.Toast.AddressSaveError.v129",
                     tableName: "EditAddress",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9269)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20521)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR introduces toast notifications to inform users of save address process failures.

Failure Notifications:
Immediate alert when the save/update operation fails.
Feedback for persistent failures after all retries.

Error then success
https://github.com/mozilla-mobile/firefox-ios/assets/26011662/9f452fc7-a18c-4592-8bfc-5d94380ab4a1

Retry failure
https://github.com/mozilla-mobile/firefox-ios/assets/26011662/140347d5-9d00-4c1e-b6b1-248f6ff76794


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

