### PR TITLE
Add FXIOS-9053 pre push script to not allow direct pushes for main

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,14 +1,18 @@
 #!/bin/sh
 
-remote_url=$(git config --get remote.origin.url)
+# Get the current branch
+get_current_branch() {
+  current_branch=$(git symbolic-ref --short HEAD)
+  echo "$current_branch"
+}
 
-restricted_remote_url="https://github.com/mozilla-mobile/firefox-ios"
-restricted_branch="main"
+# Save the current branch
+current_branch=$(get_current_branch)
+echo "Current branch: $current_branch"
 
-current_branch=$(git symbolic-ref --short HEAD)
-
-if [[ "$remote_url" == "$restricted_remote_url" && "$current_branch" == "$restricted_branch" ]]; then
-  echo "Direct push to the main branch is not allowed for $restricted_remote_url."
+# Check if the current branch is the restricted branch 'main'
+if [ "$current_branch" = "main" ]; then
+  echo "Direct pushes to the 'main' branch are not allowed."
   exit 1
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+remote_url=$(git config --get remote.origin.url)
+
+restricted_remote_url="https://github.com/mozilla-mobile/firefox-ios"
+restricted_branch="main"
+
+current_branch=$(git symbolic-ref --short HEAD)
+
+if [[ "$remote_url" == "$restricted_remote_url" && "$current_branch" == "$restricted_branch" ]]; then
+  echo "Direct push to the main branch is not allowed for $restricted_remote_url."
+  exit 1
+fi
+
+exit 0

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -41,5 +41,11 @@ fi
 NIMBUS_FML_FILE=./firefox-ios/nimbus.fml.yaml
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/mozilla/application-services/main/components/nimbus/ios/scripts/bootstrap.sh | bash -s -- --directory ./firefox-ios/bin $NIMBUS_FML_FILE
 
+# Move hooks from .githooks to .git/hooks
+cp -r .githooks/* .git/hooks/
+
+# Make the hooks are executable
+chmod +x .git/hooks/*
+
 # Run and update content blocker
 ./content_blocker_update.sh


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
You need to run for `bootstrap.sh` for this to take effect and then anytime you try to push to main 
<img width="571" alt="image" src="https://github.com/mozilla-mobile/firefox-ios/assets/8919439/824e77e3-ab98-43bd-b4f5-4785b7449a9c">


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

