### PR TITLE
Bugfix FXIOS-9407: Open deeplinks in correct browsing mode

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "08194054c9f54a430a0101d682382150984231bc",
-        "version" : "130.0.20240713050324"
+        "revision" : "370f597c49bc1519e803e436712ea3e703fa15a6",
+        "version" : "130.0.20240709050338"
       }
     },
     {

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -230,11 +230,11 @@ class BrowserCoordinator: BaseCoordinator,
 
         logger.log("Handling a route", level: .info, category: .coordinator)
         switch route {
-        case let .searchQuery(query):
-            handle(query: query)
+        case let .searchQuery(query, options):
+            handle(query: query, options: options)
 
-        case let .search(url, isPrivate, options):
-            handle(url: url, isPrivate: isPrivate, options: options)
+        case let .search(url, options):
+            handle(url: url, options: options)
 
         case let .searchURL(url, tabId):
             handle(searchURL: url, tabId: tabId)
@@ -308,12 +308,12 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
-    private func handle(query: String) {
-        browserViewController.handle(query: query)
+    private func handle(query: String, options: Set<Route.SearchOptions>? = nil) {
+        browserViewController.handle(query: query, options: options)
     }
 
-    private func handle(url: URL?, isPrivate: Bool, options: Set<Route.SearchOptions>? = nil) {
-        browserViewController.handle(url: url, isPrivate: isPrivate, options: options)
+    private func handle(url: URL?, options: Set<Route.SearchOptions>? = nil) {
+        browserViewController.handle(url: url, options: options)
     }
 
     private func handle(searchURL: URL?, tabId: String) {

--- a/firefox-ios/Client/Coordinators/Router/Route.swift
+++ b/firefox-ios/Client/Coordinators/Router/Route.swift
@@ -11,9 +11,8 @@ enum Route: Equatable {
     ///
     /// - Parameters:
     ///   - url: A `URL` object representing the URL to be searched. Pass `nil` if the search does not require a URL.
-    ///   - isPrivate: A boolean value indicating whether the search is private or not.
     ///   - options: An optional set of `SearchOptions` values that can be used to customize the search behavior.
-    case search(url: URL?, isPrivate: Bool, options: Set<SearchOptions>? = nil)
+    case search(url: URL?, options: Set<SearchOptions>? = nil)
 
     /// Represents a search route that takes a URL and a tab identifier.
     ///
@@ -25,7 +24,7 @@ enum Route: Equatable {
     /// Represents a search route that takes a query string.
     ///
     /// - Parameter query: A string representing the query to be searched.
-    case searchQuery(query: String)
+    case searchQuery(query: String, options: Set<SearchOptions>? = nil)
 
     /// Represents a route for sending Glean data.
     ///
@@ -127,5 +126,7 @@ enum Route: Equatable {
 
         /// An option to switch to a privacy mode that may hide or obscure search results and prevent data sharing.
         case switchToPrivacyMode
+
+        case useCurrentBrowsingMode
     }
 }

--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -27,7 +27,7 @@ final class RouteBuilder {
             // use the last browsing mode the user was in.
             let isPrivate = Bool(urlScanner.value(query: "private") ?? "") ?? false
             var options: Set<Route.SearchOptions> = isPrivate ? [Route.SearchOptions.switchToPrivacyMode] :
-            [Route.SearchOptions.switchToNormalMode]
+            [Route.SearchOptions.useCurrentBrowsingMode]
 
             recordTelemetry(input: host, isPrivate: isPrivate)
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2069,17 +2069,22 @@ class BrowserViewController: UIViewController,
                                     topTabsVisible: UIDevice.current.userInterfaceIdiom == .pad)
     }
 
-    func handle(query: String) {
-        openBlankNewTab(focusLocationField: false)
+    func handle(query: String, options: Set<Route.SearchOptions>? = nil) {
+        let useCurrentBrowsingMode = options?.contains(.useCurrentBrowsingMode) ?? false
+        let isPrivate = useCurrentBrowsingMode ? tabManager.selectedTab?.isPrivate ?? false : false
+        openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
         if !isToolbarRefactorEnabled {
             urlBar(urlBar, didSubmitText: query)
         }
     }
 
-    func handle(url: URL?, isPrivate: Bool, options: Set<Route.SearchOptions>? = nil) {
+    func handle(url: URL?, options: Set<Route.SearchOptions>? = nil) {
+        let isPrivate = ((options?.contains(.useCurrentBrowsingMode) == true && tabManager.selectedTab?.isPrivate ?? false)
+                         || options?.contains(.switchToPrivacyMode) == true)
+
         if let url = url {
             if options?.contains(.switchToNormalMode) == true {
-                switchToPrivacyMode(isPrivate: false)
+                switchToPrivacyMode(isPrivate: isPrivate)
             }
             switchToTabForURLOrOpen(url, isPrivate: isPrivate)
         } else {

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -439,7 +439,11 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         return SingleActionViewModel(title: .AppMenu.Help,
                                      iconString: StandardImageIdentifiers.Large.helpCircle) { _ in
             if let url = URL(string: "https://support.mozilla.org/products/ios") {
-                self.delegate?.openURLInNewTab(url, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false, completion: nil)
+                self.delegate?.openURLInNewTab(
+                    url,
+                    isPrivate: self.tabManager.selectedTab?.isPrivate ?? false,
+                    completion: nil
+                )
             }
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .help)
         }.items
@@ -554,7 +558,11 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                                                isEnabled: showBadgeForWhatsNew) { _ in
             if let whatsNewURL = SupportUtils.URLForWhatsNew {
                 TelemetryWrapper.recordEvent(category: .action, method: .open, object: .whatsNew)
-                self.delegate?.openURLInNewTab(whatsNewURL, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false, completion: nil)
+                self.delegate?.openURLInNewTab(
+                    whatsNewURL,
+                    isPrivate: self.tabManager.selectedTab?.isPrivate ?? false,
+                    completion: nil
+                )
             }
         }.items
         return whatsNewAction

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -15,7 +15,7 @@ protocol ToolBarActionMenuDelegate: AnyObject {
     func addBookmark(url: String, title: String?)
 
     @discardableResult
-    func openURLInNewTab(_ url: URL?, isPrivate: Bool) -> Tab
+    func openURLInNewTab(_ url: URL?, isPrivate: Bool, completion: (() -> Void)?) -> Tab
     func openNewTabFromMenu(focusLocationField: Bool, isPrivate: Bool)
 
     func showLibrary(panel: LibraryPanelType)
@@ -430,7 +430,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         return SingleActionViewModel(title: .AppMenu.AppMenuReportSiteIssueTitleString,
                                      iconString: StandardImageIdentifiers.Large.lightbulb) { _ in
             guard let tabURL = self.selectedTab?.url?.absoluteString else { return }
-            self.delegate?.openURLInNewTab(SupportUtils.URLForReportSiteIssue(tabURL), isPrivate: false)
+            self.delegate?.openURLInNewTab(SupportUtils.URLForReportSiteIssue(tabURL), isPrivate: false, completion: nil)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .reportSiteIssue)
         }.items
     }
@@ -439,7 +439,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         return SingleActionViewModel(title: .AppMenu.Help,
                                      iconString: StandardImageIdentifiers.Large.helpCircle) { _ in
             if let url = URL(string: "https://support.mozilla.org/products/ios") {
-                self.delegate?.openURLInNewTab(url, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false)
+                self.delegate?.openURLInNewTab(url, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false, completion: nil)
             }
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .help)
         }.items
@@ -554,7 +554,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                                                isEnabled: showBadgeForWhatsNew) { _ in
             if let whatsNewURL = SupportUtils.URLForWhatsNew {
                 TelemetryWrapper.recordEvent(category: .action, method: .open, object: .whatsNew)
-                self.delegate?.openURLInNewTab(whatsNewURL, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false)
+                self.delegate?.openURLInNewTab(whatsNewURL, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false, completion: nil)
             }
         }.items
         return whatsNewAction

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -68,7 +68,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     }
 
     func switchTo(tab: Tab) {
-        tabManager.selectTab(tab, previous: nil)
+        tabManager.selectTab(tab, previous: nil, completion: nil)
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .tap,

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
@@ -83,7 +83,7 @@ class WallpaperSettingsViewModel {
             let tab = strongSelf.tabManager.addTab(URLRequest(url: learnMoreUrl),
                                                    afterTab: strongSelf.tabManager.selectedTab,
                                                    isPrivate: false)
-            strongSelf.tabManager.selectTab(tab, previous: nil)
+            strongSelf.tabManager.selectTab(tab, previous: nil, completion: nil)
         }
 
         return WallpaperSettingsHeaderViewModel(
@@ -152,7 +152,7 @@ class WallpaperSettingsViewModel {
     func selectHomepageTab() {
         let homepageTab = getHomepageTab(isPrivate: tabManager.selectedTab?.isPrivate ?? false)
 
-        tabManager.selectTab(homepageTab, previous: nil)
+        tabManager.selectTab(homepageTab, previous: nil, completion: nil)
     }
 
     /// Get mostRecentHomePage used if none is available we add and select a new homepage Tab

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -261,7 +261,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     // MARK: - Select tab
 
     // TODO: FXIOS-7596 Remove when moving the TabManager protocol to TabManagerImplementation
-    func selectTab(_ tab: Tab?, previous: Tab? = nil) { fatalError("should never be called") }
+    func selectTab(_ tab: Tab?, previous: Tab? = nil, completion: (() -> Void)? = nil) { fatalError("should never be called") }
 
     func getMostRecentHomepageTab() -> Tab? {
         let tabsToFilter = selectedTab?.isPrivate ?? false ? privateTabs : normalTabs

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -261,7 +261,11 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     // MARK: - Select tab
 
     // TODO: FXIOS-7596 Remove when moving the TabManager protocol to TabManagerImplementation
-    func selectTab(_ tab: Tab?, previous: Tab? = nil, completion: (() -> Void)? = nil) { fatalError("should never be called") }
+    func selectTab(
+        _ tab: Tab?,
+        previous: Tab? = nil,
+        completion: (() -> Void)? = nil
+    ) { fatalError("should never be called") }
 
     func getMostRecentHomepageTab() -> Tab? {
         let tabsToFilter = selectedTab?.isPrivate ?? false ? privateTabs : normalTabs

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -34,7 +34,7 @@ protocol TabManager: AnyObject {
     func addDelegate(_ delegate: TabManagerDelegate)
     func addNavigationDelegate(_ delegate: WKNavigationDelegate)
     func removeDelegate(_ delegate: TabManagerDelegate, completion: (() -> Void)?)
-    func selectTab(_ tab: Tab?, previous: Tab?)
+    func selectTab(_ tab: Tab?, previous: Tab?, completion: (() -> Void)?)
     func addTab(_ request: URLRequest?, afterTab: Tab?, isPrivate: Bool) -> Tab
     func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool, isPrivate: Bool)
     func removeTab(_ tab: Tab, completion: (() -> Void)?)
@@ -101,8 +101,8 @@ extension TabManager {
         removeDelegate(delegate, completion: nil)
     }
 
-    func selectTab(_ tab: Tab?) {
-        selectTab(tab, previous: nil)
+    func selectTab(_ tab: Tab?, completion: (() -> Void)? = nil ) {
+        selectTab(tab, previous: nil, completion: completion)
     }
 
     func removeTab(_ tab: Tab) {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -307,7 +307,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
     /// This function updates the _selectedIndex.
     /// Note: it is safe to call this with `tab` and `previous` as the same tab, for use in the case
     /// where the index of the tab has changed (such as after deletion).
-    override func selectTab(_ tab: Tab?, previous: Tab? = nil) {
+    override func selectTab(_ tab: Tab?, previous: Tab? = nil, completion: (() -> Void)? = nil) {
         let url = tab?.url
         guard let tab = tab,
               let tabUUID = UUID(uuidString: tab.tabUUID)
@@ -353,8 +353,10 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
                                        actionType: PrivateModeActionType.setPrivateModeTo)
         store.dispatch(action)
 
-        didSelectTab(url)
-        updateMenuItemsForSelectedTab()
+            didSelectTab(url)
+            updateMenuItemsForSelectedTab()
+            completion?()
+        }
     }
 
     private func willSelectTab(_ url: URL?) {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -353,10 +353,9 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
                                        actionType: PrivateModeActionType.setPrivateModeTo)
         store.dispatch(action)
 
-            didSelectTab(url)
-            updateMenuItemsForSelectedTab()
-            completion?()
-        }
+        didSelectTab(url)
+        updateMenuItemsForSelectedTab()
+        completion?()
     }
 
     private func willSelectTab(_ url: URL?) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BaseCoordinatorTests.swift
@@ -48,7 +48,7 @@ final class BaseCoordinatorTests: XCTestCase {
         childCoordinator.add(child: grandChildCoordinator)
 
         // When
-        let route = Route.search(url: URL(string: "https://www.google.com"), isPrivate: false)
+        let route = Route.search(url: URL(string: "https://www.google.com"), options: [.switchToNormalMode])
         let matchingCoordinator = subject.findAndHandle(route: route)
 
         // Then
@@ -67,7 +67,7 @@ final class BaseCoordinatorTests: XCTestCase {
         childCoordinator.add(child: grandChildCoordinator)
 
         // When
-        let route = Route.search(url: URL(string: "https://www.google.com"), isPrivate: false)
+        let route = Route.search(url: URL(string: "https://www.google.com"), options: [.switchToNormalMode])
         let matchingCoordinator = subject.findAndHandle(route: route)
 
         // Then
@@ -85,7 +85,7 @@ final class BaseCoordinatorTests: XCTestCase {
         childCoordinator.add(child: grandChildCoordinator)
 
         // When
-        let route = Route.search(url: URL(string: "https://www.google.com"), isPrivate: false)
+        let route = Route.search(url: URL(string: "https://www.google.com"), options: [.switchToNormalMode])
         let matchingCoordinator = subject.findAndHandle(route: route)
 
         // Then
@@ -102,7 +102,7 @@ final class BaseCoordinatorTests: XCTestCase {
         childCoordinator.add(child: grandChildCoordinator)
 
         // When
-        let route = Route.search(url: URL(string: "https://www.google.com"), isPrivate: false)
+        let route = Route.search(url: URL(string: "https://www.google.com"), options: [.switchToNormalMode])
         let matchingCoordinator = subject.findAndHandle(route: route)
 
         // Then

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -358,8 +358,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserHasLoaded()
 
         let result = testCanHandleAndHandle(subject, route: .search(url: URL(string: "https://example.com")!,
-                                                                    isPrivate: false,
-                                                                    options: nil))
+                                                                    options: [.switchToNormalMode]))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.switchToTabForURLOrOpenCalled)
@@ -374,7 +373,6 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserHasLoaded()
 
         let result = testCanHandleAndHandle(subject, route: .search(url: URL(string: "https://example.com")!,
-                                                                    isPrivate: false,
                                                                     options: [.switchToNormalMode]))
 
         XCTAssertTrue(result)
@@ -391,7 +389,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = testCanHandleAndHandle(subject, route: .search(url: nil, isPrivate: false))
+        let result = testCanHandleAndHandle(subject, route: .search(url: nil, options: [.switchToNormalMode]))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.openBlankNewTabCalled)
@@ -516,7 +514,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserHasLoaded()
 
         // When
-        let result = testCanHandleAndHandle(subject, route: .search(url: nil, isPrivate: true))
+        let result = testCanHandleAndHandle(subject, route: .search(url: nil, options: [.switchToPrivacyMode]))
 
         // Then
         XCTAssertTrue(result)
@@ -533,7 +531,7 @@ final class BrowserCoordinatorTests: XCTestCase {
         subject.browserHasLoaded()
 
         // When
-        let result = testCanHandleAndHandle(subject, route: .search(url: nil, isPrivate: false))
+        let result = testCanHandleAndHandle(subject, route: .search(url: nil, options: [.switchToNormalMode]))
 
         // Then
         XCTAssertTrue(result)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -27,7 +27,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "http://google.com?a=1&b=2&c=foo%20bar"), options: [.switchToNormalMode]))
+        XCTAssertEqual(route, .search(url: URL(string: "http://google.com?a=1&b=2&c=foo%20bar"), options: [.useCurrentBrowsingMode]))
     }
 
     func testSearchRouteWithPrivateFlag() {
@@ -227,7 +227,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), options: [.switchToNormalMode]))
+        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), options: [.useCurrentBrowsingMode]))
     }
 
     func testWidgetSmallQuicklinkOpenUrlWithPrivateFlag() {
@@ -250,7 +250,7 @@ class RouteTests: XCTestCase {
 
         XCTAssertEqual(
             route,
-            .search(url: URL(string: "https://google.com"), options: [.focusLocationField, .switchToNormalMode])
+            .search(url: URL(string: "https://google.com"), options: [.focusLocationField, .useCurrentBrowsingMode])
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -16,8 +16,7 @@ class RouteTests: XCTestCase {
             route,
             .search(
                 url: URL(string: "http://google.com?a=1&b=2&c=foo%20bar")!,
-                isPrivate: false,
-                options: [.focusLocationField]
+                options: [.switchToNormalMode, .focusLocationField]
             )
         )
     }
@@ -28,7 +27,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "http://google.com?a=1&b=2&c=foo%20bar"), isPrivate: false))
+        XCTAssertEqual(route, .search(url: URL(string: "http://google.com?a=1&b=2&c=foo%20bar"), options: [.switchToNormalMode]))
     }
 
     func testSearchRouteWithPrivateFlag() {
@@ -37,7 +36,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: true))
+        XCTAssertEqual(route, .search(url: nil, options: [.switchToPrivacyMode]))
     }
 
     func testSettingsRouteWithClearPrivateData() {
@@ -228,7 +227,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: false))
+        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), options: [.switchToNormalMode]))
     }
 
     func testWidgetSmallQuicklinkOpenUrlWithPrivateFlag() {
@@ -239,7 +238,7 @@ class RouteTests: XCTestCase {
 
         XCTAssertEqual(
             route,
-            .search(url: URL(string: "https://google.com"), isPrivate: true, options: [.focusLocationField])
+            .search(url: URL(string: "https://google.com"), options: [.focusLocationField, .switchToPrivacyMode])
         )
     }
 
@@ -251,7 +250,7 @@ class RouteTests: XCTestCase {
 
         XCTAssertEqual(
             route,
-            .search(url: URL(string: "https://google.com"), isPrivate: false, options: [.focusLocationField])
+            .search(url: URL(string: "https://google.com"), options: [.focusLocationField, .switchToNormalMode])
         )
     }
 
@@ -262,7 +261,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .searchQuery(query: "test search text"))
+        XCTAssertEqual(route, .searchQuery(query: "test search text", options: [.switchToCurrentBrowsingMode]))
     }
 
     func testWidgetSmallQuicklinkOpenCopiedWithUrl() {
@@ -272,7 +271,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), isPrivate: false))
+        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), options: [.switchToCurrentBrowsingMode]))
     }
 
     func testWidgetSmallQuicklinkClosePrivateTabs() {
@@ -326,7 +325,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: false))
+        XCTAssertEqual(route, .search(url: nil, options: [.switchToNormalMode]))
     }
 
     func testInvalidFxaSignIn() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -261,7 +261,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .searchQuery(query: "test search text", options: [.switchToCurrentBrowsingMode]))
+        XCTAssertEqual(route, .searchQuery(query: "test search text", options: [.useCurrentBrowsingMode]))
     }
 
     func testWidgetSmallQuicklinkOpenCopiedWithUrl() {
@@ -271,7 +271,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), options: [.switchToCurrentBrowsingMode]))
+        XCTAssertEqual(route, .search(url: URL(string: "https://google.com"), options: [.useCurrentBrowsingMode]))
     }
 
     func testWidgetSmallQuicklinkClosePrivateTabs() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
@@ -38,7 +38,7 @@ final class ShortcutRouteTests: XCTestCase {
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
 
         XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"),
-                                      options: [.switchToCurrentBrowsingMode]))
+                                      options: [.useCurrentBrowsingMode]))
     }
 
     // FXIOS-8107: Disabled test as history highlights has been disabled to fix app hangs / slowness

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
@@ -13,7 +13,7 @@ final class ShortcutRouteTests: XCTestCase {
 
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: false, options: [.focusLocationField]))
+        XCTAssertEqual(route, .search(url: nil, options: [.focusLocationField, .switchToNormalMode]))
     }
 
     func testNewPrivateTabShortcut() {
@@ -23,7 +23,7 @@ final class ShortcutRouteTests: XCTestCase {
 
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: true, options: [.focusLocationField]))
+        XCTAssertEqual(route, .search(url: nil, options: [.focusLocationField, .switchToPrivacyMode]))
     }
 
     func testOpenLastBookmarkShortcutWithValidUrl() {
@@ -38,8 +38,7 @@ final class ShortcutRouteTests: XCTestCase {
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
 
         XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"),
-                                      isPrivate: false,
-                                      options: [.switchToNormalMode]))
+                                      options: [.switchToCurrentBrowsingMode]))
     }
 
     // FXIOS-8107: Disabled test as history highlights has been disabled to fix app hangs / slowness

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/UserActivityRouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/UserActivityRouteTests.swift
@@ -15,7 +15,7 @@ class UserActivityRouteTests: XCTestCase {
 
         let route = subject.makeRoute(userActivity: userActivity)
 
-        XCTAssertEqual(route, .search(url: nil, isPrivate: false))
+        XCTAssertEqual(route, .search(url: nil, options: [.switchToNormalMode]))
     }
 
     // Test the Route initializer with a deep link user activity.
@@ -26,7 +26,7 @@ class UserActivityRouteTests: XCTestCase {
 
         let route = subject.makeRoute(userActivity: userActivity)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), isPrivate: false))
+        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), options: [.switchToNormalMode]))
     }
 
     // Test the Route initializer with a CoreSpotlight user activity.
@@ -37,7 +37,7 @@ class UserActivityRouteTests: XCTestCase {
 
         let route = subject.makeRoute(userActivity: userActivity)
 
-        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), isPrivate: false))
+        XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"), options: [.switchToNormalMode]))
     }
 
     // Test the Route initializer with an unsupported user activity.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -75,8 +75,7 @@ class MockBrowserViewController: BrowserViewController {
         focusLocationField: Bool,
         isPrivate: Bool,
         searchFor searchText: String?,
-        completion: (() -> Void)? = nil)
-    {
+        completion: (() -> Void)? = nil) {
         openBlankNewTabCalled = true
         openBlankNewTabFocusLocationField = focusLocationField
         openBlankNewTabIsPrivate = isPrivate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -71,7 +71,7 @@ class MockBrowserViewController: BrowserViewController {
         switchToTabForURLOrOpenCount += 1
     }
 
-    override func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool, searchFor searchText: String?) {
+    override func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool, searchFor searchText: String?, completion: (() -> Void)? = nil) {
         openBlankNewTabCalled = true
         openBlankNewTabFocusLocationField = focusLocationField
         openBlankNewTabIsPrivate = isPrivate
@@ -92,7 +92,7 @@ class MockBrowserViewController: BrowserViewController {
         showLibraryCount += 1
     }
 
-    override func openURLInNewTab(_ url: URL?, isPrivate: Bool) -> Tab {
+    override func openURLInNewTab(_ url: URL?, isPrivate: Bool, completion: (() -> Void)? = nil) -> Tab {
         openURLInNewTabCalled = true
         openURLInNewTabURL = url
         openURLInNewTabIsPrivate = isPrivate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -71,7 +71,12 @@ class MockBrowserViewController: BrowserViewController {
         switchToTabForURLOrOpenCount += 1
     }
 
-    override func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool, searchFor searchText: String?, completion: (() -> Void)? = nil) {
+    override func openBlankNewTab(
+        focusLocationField: Bool,
+        isPrivate: Bool,
+        searchFor searchText: String?,
+        completion: (() -> Void)? = nil)
+    {
         openBlankNewTabCalled = true
         openBlankNewTabFocusLocationField = focusLocationField
         openBlankNewTabIsPrivate = isPrivate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -24,6 +24,7 @@ class MockBrowserViewController: BrowserViewController {
 
     var handleQueryCalled = false
     var handleQuery: String?
+    var handleSearchOptions: Set<Route.SearchOptions>?
     var showLibraryCalled = false
     var showLibraryPanel: LibraryPanelType?
 
@@ -78,9 +79,10 @@ class MockBrowserViewController: BrowserViewController {
         openBlankNewTabCount += 1
     }
 
-    override func handle(query: String) {
+    override func handle(query: String, options: Set<Route.SearchOptions>? = nil) {
         handleQueryCalled = true
         handleQuery = query
+        handleSearchOptions = options
         handleQueryCount += 1
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -49,7 +49,7 @@ class MockTabManager: TabManager {
         return nil
     }
 
-    func selectTab(_ tab: Tab?, previous: Tab?) {
+    func selectTab(_ tab: Tab?, previous: Tab?, completion: (() -> Void)? = nil) {
         if let tab = tab {
             lastSelectedTabs.append(tab)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9407)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20832)

## :bulb: Description
This bug essentially states that all links opened from outside the apps main target will open in regular browsing mode. Although all private browsing data is cleared when the app is killed, these paths may not always be initiated while the app is not in memory, and therefore, could happen while the app is currently in private browsing (via a private `selectedTab`). To prevent the user from accidentally switching browsing modes, the following changes were made:

- The “Go to copied link” widget action will now open the copied link (search query or URL) in the current browsing mode
- The “Open last bookmark” home screen quick action will now open the most recently bookmarked URL in the current browsing mode
- The "Open in Firefox" share sheet action will now open the target URL in the current browsing mode
- The "Top sites" widget action will now open the selected URL in the current borwsing mode

Also fixed was a bug where search queries (saved in the pasteboard as strings instead or URL's, even if they are well-formed URL's) opened via “Go to copied link” widget would navigate to the respective web page before the newly created tab was selected, causing the app to display a blank/homescreen tab to the user, while the navigation intended to take place on the new tab, happened in the previously open tab

### Notes:
- We handle opening pasteboard text vs pasteboard URL's a bit different. When using the "Go to copied link" widget or "Open in Firefox" share sheet action, opening a URL from the pasteboard, we will first search for a tab already containing that URL and switch to it if possible (preferring regular browsing over private if the URL is open in both browsing modes), while opening text from the pasteboard will always open in a new tab, even if it is formed as a URL that is already open in another tab.
  - The "Open last bookmark" follows the same policy as pasteboard URL's mentioned above in that it will not create a new tab if the URL is already open in at least one of the browsing modes, and prefers regular over private.

## Testing:
To test these changes, ensure all links opened in Firefox from outside the app open in Firefoxes current browsing mode (regular or private). This includes:
- The "Go to copied link" widget action
- The "Open last bookmark" home screen quick action"
- The "Open in Firefox" share sheet action
- The "Load in background" share sheet action

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

