### PR TITLE
Bugfix MTE-2907 Use mozWait for URLValidationTests

### DIFF
--- a/.github/workflows/focus-ios-smoke.yml
+++ b/.github/workflows/focus-ios-smoke.yml
@@ -15,7 +15,7 @@ env:
 jobs:
     compile:
         name: Compile
-        runs-on: macos-14-large
+        runs-on: macos-14-xlarge
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
@@ -49,7 +49,7 @@ jobs:
                 retention-days: 2          
     run-tests:
         name: Run tests
-        runs-on: macos-14-large
+        runs-on: macos-14-xlarge
         needs: compile
         strategy:
             fail-fast: false

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
@@ -25,17 +25,17 @@ class URLValidationTests: BaseTestCase {
         for i in urlTypes {
             navigator.openURL(i)
             waitUntilPageLoad()
-            XCTAssertTrue(app.otherElements.staticTexts["Mozilla"].exists, "The website was not loaded properly")
-            XCTAssertTrue(app.buttons["Menu"].exists)
-            XCTAssertEqual(app.textFields["url"].value as? String, "www.mozilla.org/en-US/")
+            mozWaitForElementToExist(app.otherElements.staticTexts["Mozilla"])
+            mozWaitForElementToExist(app.buttons["Menu"])
+            mozWaitForValueContains(app.textFields["url"], value: "www.mozilla.org/en-US/")
             clearURL()
         }
 
         for i in urlHttpTypes {
             navigator.openURL(i)
             waitUntilPageLoad()
-            XCTAssertTrue(app.otherElements.staticTexts["Example Domain"].exists, "The website was not loaded properly")
-            XCTAssertEqual(app.textFields["url"].value as? String, "example.com/")
+            mozWaitForElementToExist(app.otherElements.staticTexts["Example Domain"])
+            mozWaitForValueContains(app.textFields["url"], value: "example.com/")
             clearURL()
         }
     }

--- a/focus-ios/focus-ios-tests/XCUITest/BaseTestCase.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/BaseTestCase.swift
@@ -4,6 +4,8 @@
 
 import XCTest
 
+let TIMEOUT: TimeInterval = 15
+
 class BaseTestCase: XCTestCase {
     let app = XCUIApplication()
 
@@ -81,6 +83,18 @@ class BaseTestCase: XCTestCase {
                 self.record(issue)
             }
         }
+
+    func mozWaitForElementToExist(_ element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
+        let startTime = Date()
+
+        while !element.exists {
+            if let timeout = timeout, Date().timeIntervalSince(startTime) > timeout {
+                XCTFail("Timed out waiting for element \(element) to exist")
+                break
+            }
+            usleep(10000)
+        }
+    }
 
     func search(searchWord: String, waitForLoadToFinish: Bool = true) {
         let searchOrEnterAddressTextField = app.textFields["Search or enter address"]

--- a/focus-ios/focus-ios-tests/XCUITest/URLValidationTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/URLValidationTest.swift
@@ -29,17 +29,19 @@ class URLValidationTest: BaseTestCase {
     private func loadAndValidateURL(URL: String) {
         loadWebPage(URL)
         waitForWebPageLoad()
-        XCTAssertTrue(app.otherElements.staticTexts["Mozilla"].exists, "The website was not loaded properly")
+        mozWaitForElementToExist(app.otherElements.staticTexts["Mozilla"])
         if !iPad() {
-            XCTAssertTrue(app.buttons["Menu"].exists)
+            mozWaitForElementToExist(app.buttons["Menu"])
         }
-        XCTAssertEqual(app.textFields["URLBar.urlText"].value as? String, "www.mozilla.org")
+        mozWaitForElementToExist(app.textFields["URLBar.urlText"])
+        waitForValueContains(app.textFields["URLBar.urlText"], value: "www.mozilla.org")
     }
 
     private func loadAndValidateHttpURLs(URL: String) {
         loadWebPage(URL)
         waitForWebPageLoad()
-        XCTAssertTrue(app.otherElements.staticTexts["Example Domain"].exists, "The website was not loaded properly")
-        XCTAssertEqual(app.textFields["URLBar.urlText"].value as? String, "example.com")
+        mozWaitForElementToExist(app.otherElements.staticTexts["Example Domain"])
+        mozWaitForElementToExist(app.textFields["URLBar.urlText"])
+        waitForValueContains(app.textFields["URLBar.urlText"], value: "example.com")
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2907)

## :bulb: Description
The `URLValidationTests` for Focus fail intermittently on Github Actions. The corresponding tests for Firefox also fails (intermittently).

Let me use this PR to use `mozWait*` in `URLValidationTests` for both Firefox and Focus.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- X ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

