### PR TITLE
Refactor FXIOS-9084 re-add syncronous tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -32,5 +32,4 @@ public enum AppEvent: AppEventType {
 
     // Activities: Tabs
     case tabRestoration(WindowUUID)
-    case selectTab(URL?, WindowUUID)
 }

--- a/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -131,19 +131,8 @@ class RecentlyClosedTabsPanelSiteTableViewController: SiteTableViewController {
         let url = recentlyClosedTabs[indexPath.row].url
         recentlyClosedTabsDelegate?.openRecentlyClosedSiteInNewTab(url, isPrivate: false)
 
-        // The code above creates new tab and selects it, but TabManagerImplementation.selectTab()
-        // currently performs the actual selection update asynchronously via Swift Async + Task/Await.
-        // This means that selectTab() returns before the tab is actually selected. As a result, the
-        // delegate callback below will incorrectly cause a duplicate tab (since it will treat the
-        // url as having been applied to the current tab, not our newly-added tab from above). This
-        // is avoided by making sure we wait for our expected tab above to be selected before
-        // notifying our library panel delegate. [FXIOS-7741]
-
-        let tabWindowUUID = windowUUID
-        AppEventQueue.wait(for: .selectTab(url, tabWindowUUID)) {
-            let visitType = VisitType.typed    // Means History, too.
-            self.libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: visitType)
-        }
+        let visitType = VisitType.typed    // Means History, too.
+        self.libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: visitType)
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -372,8 +372,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
 
     @MainActor
     private func selectTabWithSession(tab: Tab, previous: Tab?, sessionData: Data?) {
-        guard tab == selectedTab else { return }
-
         selectedTab?.createWebview(with: sessionData)
         selectedTab?.lastExecutedTime = Date.now()
 

--- a/firefox-ios/nimbus-features/tabTrayRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/tabTrayRefactorFeature.yaml
@@ -12,7 +12,7 @@ features:
     defaults:
       - channel: beta
         value:
-          enabled: false
+          enabled: true
       - channel: developer
         value:
           enabled: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9084)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20122)

## :bulb: Description
Re-adds the change to make tab selection syncronous.
The only change here is there is no longer a guard to check for updating the session if the tab is the current selected tab. I cannot repo the reported issue but my assumption at the moment is that there is some weird timing during the start up path where the webview is created before the current tab is selected, but I can't narrow it down. I will keep an eye out for it and we have a good stretch of time until the next code freeze to investigate if the issue should persist. 
At the very least I do want to come back to this to re-add the check because it was added for a reason, this change could introduce a possible other race condition where the wrong tabs session data is restore in the event of tab being selected in quick succession.
Once it's confirmed if the issue persists or has been fixed it will dictate what change is needed next. For now this should unblock other PR's.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

