### PR TITLE
Add MTE-2910 Compile Firefox iOS and run full functional tests on Github Actions

### DIFF
--- a/.github/workflows/firefox-ios-tests.yml
+++ b/.github/workflows/firefox-ios-tests.yml
@@ -69,3 +69,50 @@ jobs:
                 gem install xcpretty -v 0.3.0
                 pip install blockkit==1.9.1
                 npm install -g junit-report-merger@7.0.0
+            - name: Run tests
+              id: run-tests
+              run: |
+                xcodebuild \
+                  test-without-building \
+                  -scheme ${{ env.xcodebuild_scheme }} \
+                  -target ${{ env.xcodebuild_target }} \
+                  -derivedDataPath ~/DerivedData \
+                  -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
+                  -testPlan FullFunctionalTestPlan \
+                  -resultBundlePath ${{ env.test_results_directory }}/results \
+                  | tee xcodebuild.log | xcpretty -r junit && exit ${PIPESTATUS[0]}
+              working-directory:  ${{ env.browser }}
+              continue-on-error: true
+            - name: Print test report
+              id: test-report
+              run: |
+                python ../test-fixtures/ci/convert_junit_to_markdown.py --github --${{ env.browser }} ./build/reports/junit.xml ./github.md
+                cat github.md >> $GITHUB_STEP_SUMMARY
+                python ../test-fixtures/ci/convert_junit_to_markdown.py --slack --${{ env.browser }} ./build/reports/junit.xml ./slack.json
+              working-directory:  ${{ env.browser }}
+            - name: Upload log file
+              id: upload-log
+              uses: actions/upload-artifact@v4.3.3
+              with:
+                name: ${{ env.browser }}-FullFunctionalTestPlan-${{ matrix.ios_simulator }}-xcodebuildlog-${{ github.run_number }}
+                path: ${{ env.browser }}/xcodebuild.log
+                retention-days: 90
+            - name: Report to Slack
+              id: slack
+              uses: slackapi/slack-github-action@v1.26.0
+              with:
+                payload-file-path: ${{ env.browser }}/slack.json
+              env:
+                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+                SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+                ios_simulator: ${{ matrix.ios_simulator }}
+                pass_fail:  ${{ steps.run-tests.outcome == 'success' && ':white_check_mark:' || ':x:' }}
+                xcodebuild_test_plan: FullFunctionalTestPlan
+                ref_name: ${{ github.ref_name }}
+                repository: ${{ github.repository }}
+                run_id: ${{ github.run_id }}
+                server_url: ${{ github.server_url }}
+                sha: ${{ github.sha }}
+            - name: Return fail status if a test fails
+              run: |
+                exit ${{ steps.run-tests.outcome == 'success' && '0' || '1' }}

--- a/.github/workflows/firefox-ios-tests.yml
+++ b/.github/workflows/firefox-ios-tests.yml
@@ -15,7 +15,7 @@ env:
 jobs:
     compile:
         name: Compile
-        runs-on: macos-14-xlarge
+        runs-on: macos-14
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
@@ -54,7 +54,7 @@ jobs:
                 
     run-fullfunctionaltests:
         name: Run full functional tests
-        runs-on: macos-14-xlarge
+        runs-on: macos-14
         needs: compile
         strategy:
             fail-fast: false

--- a/.github/workflows/firefox-ios-tests.yml
+++ b/.github/workflows/firefox-ios-tests.yml
@@ -68,7 +68,6 @@ jobs:
               run: |
                 gem install xcpretty -v 0.3.0
                 pip install blockkit==1.9.1
-                npm install -g junit-report-merger@7.0.0
             - name: Run tests
               id: run-tests
               run: |

--- a/.github/workflows/firefox-ios-tests.yml
+++ b/.github/workflows/firefox-ios-tests.yml
@@ -1,0 +1,71 @@
+name: "Firefox Tests"
+    
+on:
+    workflow_dispatch:
+
+env:
+    browser: firefox-ios
+    xcode_version: 15.4
+    ios_version: 17.5
+    ios_simulator_default: iPhone 15
+    xcodebuild_scheme: Fennec
+    xcodebuild_target: Client
+    test_results_directory: /Users/runner/tmp
+    
+jobs:
+    compile:
+        name: Compile
+        runs-on: macos-14-xlarge
+        steps:
+            - name: Check out source code
+              uses: actions/checkout@v4.1.7
+            - name: Setup Xcode
+              id: xcode
+              run: |
+                sudo rm -rf /Applications/Xcode.app
+                sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app/Contents/Developer
+                xcodebuild -version
+                ./checkout.sh
+                ./bootstrap.sh --force
+            - name: Compile source code
+              id: compile
+              run: |
+                xcodebuild \
+                  -resolvePackageDependencies \
+                  -onlyUsePackageVersionsFromResolvedFile
+                xcodebuild \
+                  build-for-testing \
+                  -scheme ${{ env.xcodebuild_scheme }} \
+                  -target ${{ env.xcodebuild_target }} \
+                  -derivedDataPath ~/DerivedData \
+                  -destination 'platform=iOS Simulator,name=${{ env.ios_simulator_default }},OS=${{ env.ios_version }}'
+              working-directory: ${{ env.browser }}
+            - name: Compress Derived Data
+              id: compress-dd
+              run: |
+                tar czf derived-data.tar.gz ~/DerivedData/Build/Products
+            - name: Save Derived Data
+              id: upload-derived-data
+              uses: actions/upload-artifact@v4.3.4
+              with:
+                name: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
+                path: ./derived-data.tar.gz
+                retention-days: 2
+                
+    run-fullfunctionaltests:
+        name: Run full functional tests
+        runs-on: macos-14-xlarge
+        needs: compile
+        strategy:
+            fail-fast: false
+            matrix:
+                ios_simulator: ['iPhone 15 Plus']
+        steps:
+            - name: Check out source code
+              uses: actions/checkout@v4.1.7
+            - name: Install packages
+              id: packages
+              run: |
+                gem install xcpretty -v 0.3.0
+                pip install blockkit==1.9.1
+                npm install -g junit-report-merger@7.0.0

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -1,4 +1,4 @@
-name: "Firefox Tests"
+name: "Firefox UI Tests"
     
 on:
     workflow_dispatch:

--- a/test-fixtures/ci/convert_junit_to_markdown.py
+++ b/test-fixtures/ci/convert_junit_to_markdown.py
@@ -7,8 +7,8 @@
 import getopt, sys
 import xml.etree.ElementTree as ET
 import json
-from blockkit import Context, Divider, Header, Message, Section
 import re
+from blockkit import Context, Divider, Header, Message, Section
 
 # Modified from junit_to_markdown
 # https://github.com/stevengoossensB/junit_to_markdown/tree/main

--- a/test-fixtures/ci/convert_junit_to_markdown.py
+++ b/test-fixtures/ci/convert_junit_to_markdown.py
@@ -170,7 +170,7 @@ def convert_to_github_markdown(test_suites, is_smoke = True):
     for test_suite in test_suites:
         if int(test_suite['failures']):
             markdown += '## {name}\n\n'.format(name=re.sub('XCUITests?.', '', test_suite.get('name', '')))
-            markdown += convert_test_cases_to_github_markdown(test_suite.get('test_cases', []), is_smoke = True)
+            markdown += convert_test_cases_to_github_markdown(test_suite.get('test_cases', []), is_smoke = is_smoke)
     
     if markdown == '':
         markdown += '## :tada: No test failures :tada:'


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2910)

## :bulb: Description
Similar to the effort for Focus iOS, let me compile Firefox iOS and run the full functional tests on Github Action. I'd like to see if the `xlarge` runner avoid some timeout from tests.

I will put back the iPad simulator once the iPhone simulator works.

A sample run of the Github Action on smaller runner: https://github.com/clarmso/firefox-ios/actions/runs/9867727877/job/27248864463

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

