### PR TITLE
Add FXIOS-9462 Move edit flag as a variable for nimbus experiment

### DIFF
--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -253,9 +253,9 @@ final class NimbusFeatureFlagLayer {
     }
 
     private func checkAddressAutofillEditing(from nimbus: FxNimbus) -> Bool {
-        let config = nimbus.features.addressAutofillEdit.value()
+        let config = nimbus.features.addressAutofillFeature.value()
 
-        return config.status
+        return config.addressAutofillEdit
     }
 
     private func checkZoomFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/nimbus-features/addressAutofillFeature.yaml
+++ b/firefox-ios/nimbus-features/addressAutofillFeature.yaml
@@ -7,17 +7,7 @@ features:
         description: If true, we will allow user to use the address autofill feature
         type: Boolean
         default: false
-    defaults:
-      - channel: beta
-        value:
-          status: true
-      - channel: developer
-        value:
-          status: true
-  address-autofill-edit:
-    description: This property defines if the address editing is enabled in Settings
-    variables:
-      status:
+      address-autofill-edit:
         description: If true, we will allow user to edit the address
         type: Boolean
         default: false
@@ -25,6 +15,8 @@ features:
       - channel: beta
         value:
           status: false
+          address-autofill-edit: false
       - channel: developer
         value:
           status: true
+          address-autofill-edit: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9462)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20949)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Move edit flag as a variable for nimbus experiment

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~~Wrote unit tests and/or ensured the tests suite is passing~~ 
- [ ] ~~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~~ 
- [ ] ~~If needed, I updated documentation / comments for complex code and public methods~~ 
- [ ] ~~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~~ 

