### PR TITLE
Remove MTE-3109 - close all tabs workarounds

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -683,6 +683,7 @@ public struct AccessibilityIdentifiers {
         static let zoomPageZoomInButton = "ZoomPage.zoomInButton"
         static let zoomPageZoomOutButton = "ZoomPage.zoomOutButton"
         static let zoomPageZoomLevelLabel = "ZoomPage.zoomLevelLabel"
+        static let doneButton = "find.doneButton"
     }
 
     struct FindInPage {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -103,7 +103,6 @@ class ActivityStreamTest: BaseTestCase {
         }
         waitUntilPageLoad()
 
-        // Workaround to avoid https://github.com/mozilla-mobile/firefox-ios/issues/16810 crash
         // navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.goto(TabTray)
         mozWaitForElementToExist(app.collectionViews.buttons["crossLarge"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
@@ -26,22 +26,19 @@ class DesktopModeTestsIpad: IpadOnlyTestCase {
         waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
 
-        // Workaround: Open a new tab before closing all tabs.
-        // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
 
-        // Disabling next steps due to https://github.com/mozilla-mobile/firefox-ios/issues/16810 crash
-//        navigator.performAction(Action.AcceptRemovingAllTabs)
-//        waitUntilPageLoad()
-//
-//        // Covering scenario that when closing a tab and re-opening should preserve Mobile mode
-//        navigator.nowAt(NewTabScreen)
-//        navigator.createNewTab()
-//        navigator.openURL(path(forTestPage: "test-user-agent.html"))
-//        waitUntilPageLoad()
-//        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+        navigator.performAction(Action.AcceptRemovingAllTabs)
+        waitUntilPageLoad()
+
+        // Covering scenario that when closing a tab and re-opening should preserve Mobile mode
+        navigator.nowAt(NewTabScreen)
+        navigator.createNewTab()
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
     }
 }
 
@@ -213,21 +210,18 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         waitUntilPageLoad()
         XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
 
-        // Workaround: Open a new tab before closing all tabs.
-        // https://github.com/mozilla-mobile/firefox-ios/issues/16810
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
 
-        // Disabling next steps due to https://github.com/mozilla-mobile/firefox-ios/issues/16810 crash
-//        navigator.performAction(Action.AcceptRemovingAllTabs)
-//        waitUntilPageLoad()
-//        navigator.nowAt(NewTabScreen)
-//        // Covering scenario that when closing a tab and re-opening should preserve Desktop mode
-//        navigator.createNewTab()
-//        navigator.openURL(path(forTestPage: "test-user-agent.html"))
-//        waitUntilPageLoad()
-//        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
+        navigator.performAction(Action.AcceptRemovingAllTabs)
+        waitUntilPageLoad()
+        navigator.nowAt(NewTabScreen)
+        // Covering scenario that when closing a tab and re-opening should preserve Desktop mode
+        navigator.createNewTab()
+        navigator.openURL(path(forTestPage: "test-user-agent.html"))
+        waitUntilPageLoad()
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
     }
 }
 // swiftlint:enable empty_count

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
@@ -78,11 +78,8 @@ class DomainAutocompleteTests: BaseTestCase {
         waitUntilPageLoad()
         navigator.goto(TabTray)
 
-        // Workaround to avoid https://github.com/mozilla-mobile/firefox-ios/issues/16810 crash
-        // navigator.goto(CloseTabMenu)
-        // navigator.performAction(Action.AcceptRemovingAllTabs)
-        mozWaitForElementToExist(app.collectionViews.buttons["crossLarge"])
-        app.collectionViews.buttons["crossLarge"].tap()
+        navigator.goto(CloseTabMenu)
+        navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.nowAt(HomePanelsScreen)
 
         navigator.goto(URLBarOpen)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -1041,7 +1041,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(PageZoom) { screenState in
-        screenState.tap(app.buttons["FindInPage.closeButton"], to: BrowserTab)
+        screenState.tap(app.buttons[AccessibilityIdentifiers.ZoomPageBar.doneButton], to: BrowserTab)
     }
 
     map.addScreenState(RequestDesktopSite) { _ in }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -182,8 +182,7 @@ class HistoryTests: BaseTestCase {
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307479
-    // Disabling test due to https://github.com/mozilla-mobile/firefox-ios/issues/16810 crash
- /*   func testRemoveAllTabsButtonRecentlyClosedHistory() {
+    func testRemoveAllTabsButtonRecentlyClosedHistory() {
         // Open "Book of Mozilla"
         openBookOfMozilla()
 
@@ -200,7 +199,7 @@ class HistoryTests: BaseTestCase {
         mozWaitForElementToExist(app.tables["Recently Closed Tabs List"], timeout: TIMEOUT)
         XCTAssertTrue(app.tables.cells.staticTexts[bookOfMozilla["label"]!].exists)
     }
-*/
+
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307482
     func testClearRecentlyClosedHistory() {
         // Open "Book of Mozilla" and close the tab

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -142,30 +142,29 @@ class TopTabsTest: BaseTestCase {
         }
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
 
-        // Disabling next steps due to https://github.com/mozilla-mobile/firefox-ios/issues/16810 crash
         // Close all tabs, undo it and check that the number of tabs is correct
-//        navigator.performAction(Action.AcceptRemovingAllTabs)
-//
-//        mozWaitForElementToExist(app.otherElements.buttons.staticTexts["Undo"])
-//        app.otherElements.buttons.staticTexts["Undo"].tap()
-//
-//        mozWaitForElementToExist(
-//            app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell],
-//            timeout: 5
-//        )
-//        navigator.nowAt(BrowserTab)
-//        if !iPad() {
-//            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
-//        }
-//
-//        if iPad() {
-//            navigator.goto(TabTray)
-//        } else {
-//            navigator.performAction(Action.CloseURLBarOpen)
-//        }
-//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-//
-//        mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
+        navigator.performAction(Action.AcceptRemovingAllTabs)
+
+        mozWaitForElementToExist(app.otherElements.buttons.staticTexts["Undo"])
+        app.otherElements.buttons.staticTexts["Undo"].tap()
+
+        mozWaitForElementToExist(
+            app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell],
+            timeout: 5
+        )
+        navigator.nowAt(BrowserTab)
+        if !iPad() {
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: 5)
+        }
+
+        if iPad() {
+            navigator.goto(TabTray)
+        } else {
+            navigator.performAction(Action.CloseURLBarOpen)
+        }
+        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+
+        mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2354473
@@ -217,15 +216,14 @@ class TopTabsTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
 
-        // Disabling next steps due to https://github.com/mozilla-mobile/firefox-ios/issues/16810 crash
         // Close all tabs and check that the number of tabs is correct
-//        navigator.performAction(Action.AcceptRemovingAllTabs)
-//        if !iPad() {
-//            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
-//        }
-//        navigator.nowAt(NewTabScreen)
-//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
-//        mozWaitForElementToExist(app.cells.staticTexts["Homepage"])
+        navigator.performAction(Action.AcceptRemovingAllTabs)
+        if !iPad() {
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
+        }
+        navigator.nowAt(NewTabScreen)
+        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
+        mozWaitForElementToExist(app.cells.staticTexts["Homepage"])
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2354580


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3109

## :bulb: Description
Close all tabs crash is not reproducing anymore. 
Removed all workarounds
Improved navigation for page zoom in order to avoid "FindInPage.closeButton" related failures.

