### PR TITLE
Add FXIOS-9459 [Microsurvey] Add initial UI tests

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -893,6 +893,7 @@
 		8AE80BBA2891C0C300BC12EA /* JumpBackInSectionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BB92891C0C300BC12EA /* JumpBackInSectionLayout.swift */; };
 		8AE80BBC2891C20D00BC12EA /* JumpBackInList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BBB2891C20D00BC12EA /* JumpBackInList.swift */; };
 		8AE80BBE2891C21A00BC12EA /* JumpBackInSyncedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BBD2891C21A00BC12EA /* JumpBackInSyncedTab.swift */; };
+		8AEAD9F92C3DB0CD001A2C5A /* MicrosurveyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEAD9F62C3DB0BF001A2C5A /* MicrosurveyTests.swift */; };
 		8AED23C527AC1F9500DE7E97 /* BaseContentStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */; };
 		8AED868328CA3B3400351A50 /* BookmarkPanelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED868228CA3B3400351A50 /* BookmarkPanelViewModelTests.swift */; };
 		8AEDB11529F9F00400F2A53B /* SceneContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEDB11429F9F00400F2A53B /* SceneContainer.swift */; };
@@ -6503,6 +6504,7 @@
 		8AE80BB92891C0C300BC12EA /* JumpBackInSectionLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInSectionLayout.swift; sourceTree = "<group>"; };
 		8AE80BBB2891C20D00BC12EA /* JumpBackInList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInList.swift; sourceTree = "<group>"; };
 		8AE80BBD2891C21A00BC12EA /* JumpBackInSyncedTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInSyncedTab.swift; sourceTree = "<group>"; };
+		8AEAD9F62C3DB0BF001A2C5A /* MicrosurveyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyTests.swift; sourceTree = "<group>"; };
 		8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseContentStackView.swift; sourceTree = "<group>"; };
 		8AED868228CA3B3400351A50 /* BookmarkPanelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkPanelViewModelTests.swift; sourceTree = "<group>"; };
 		8AEDB11429F9F00400F2A53B /* SceneContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneContainer.swift; sourceTree = "<group>"; };
@@ -9357,6 +9359,7 @@
 				787EDD832943EE75002B93AE /* JumpBackInTests.swift */,
 				D4C4BDCD2253725E00986F04 /* LibraryTests.swift */,
 				2CCB296620A99C9500121DD8 /* LoginsTests.swift */,
+				8AEAD9F62C3DB0BF001A2C5A /* MicrosurveyTests.swift */,
 				2CF449A41E7BFE2C00FD7595 /* NavigationTest.swift */,
 				2CB1A6591FDEA8B60084E96D /* NewTabSettings.swift */,
 				3D9CA9831EF456A8002434DD /* NightModeTests.swift */,
@@ -14198,6 +14201,7 @@
 				787EDD852943EE75002B93AE /* JumpBackInTests.swift in Sources */,
 				B15058812AA0A878008B7382 /* OpeningScreenTests.swift in Sources */,
 				B1F90EC12BB3F6B600A4D431 /* ZoomingTests.swift in Sources */,
+				8AEAD9F92C3DB0CD001A2C5A /* MicrosurveyTests.swift in Sources */,
 				D4AFA84E2AFA5482000BFEAA /* ExperimentIntegrationTests.swift in Sources */,
 				3DEFED081F55EBE300F8620C /* TrackingProtectionTests.swift in Sources */,
 				2CEDADA220207EC400223A89 /* SyncFAUITests.swift in Sources */,

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -189,6 +189,13 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
             profile.prefs.setBool(true, forKey: PrefsKeys.splashScreenShownKey)
         }
 
+        if launchArguments.contains(LaunchArguments.ResetMicrosurveyExpirationCount) {
+            // String is pulled from our "evergreen" messages configurations 
+            // that are displayed via the Nimbus Messaging system.
+            let microsurveyID = "homepage-microsurvey-message"
+            UserDefaults.standard.set(nil, forKey: "\(GleanPlumbMessageStore.rootKey)\(microsurveyID)")
+        }
+
         self.profile = profile
         return profile
     }

--- a/firefox-ios/Shared/LaunchArguments.swift
+++ b/firefox-ios/Shared/LaunchArguments.swift
@@ -23,6 +23,7 @@ public struct LaunchArguments {
     public static let ExperimentFeatureName = "EXPERIMENT_FEATURE_NAME"
     public static let DisableAnimations = "DISABLE_ANIMATIONS"
     public static let SkipSplashScreenExperiment = "SKIP_SPLASH_SCREEN_EXPERIMENT"
+    public static let ResetMicrosurveyExpirationCount = "RESET_MICROSURVEY_EXPIRATION_COUNT"
 
     // After the colon, put the name of the file to load from test bundle
     public static let LoadDatabasePrefix = "FIREFOX_LOAD_DB_NAMED:"

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -73,6 +73,7 @@
         "JumpBackInTests",
         "LibraryTestsIpad",
         "LoginTest",
+        "MicrosurveyTests",
         "NightModeTests",
         "OpeningScreenTests",
         "PerformanceTests",

--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -48,6 +48,7 @@
         "JumpBackInTests",
         "LibraryTestsIpad",
         "LoginTest",
+        "MicrosurveyTests",
         "NavigationTest",
         "NewTabSettingsTest",
         "NightModeTests",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
@@ -144,6 +144,7 @@
         "LibraryTestsIpad",
         "LibraryTestsIphone",
         "LoginTest",
+        "MicrosurveyTests",
         "NavigationTest",
         "NavigationTest\/testCopyLink()",
         "NavigationTest\/testCopyLinkPrivateMode()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
@@ -64,6 +64,7 @@
         "LibraryTestsIpad",
         "LibraryTestsIphone",
         "LoginTest",
+        "MicrosurveyTests",
         "NavigationTest",
         "NewTabSettingsTest\/testChangeNewTabSettingsLabel()",
         "NewTabSettingsTest\/testChangeNewTabSettingsShowBlankPage()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
@@ -92,6 +92,7 @@
         "JumpBackInTests\/testLongTapOnJumpBackInLink()",
         "LibraryTestsIpad",
         "LoginTest",
+        "MicrosurveyTests",
         "NavigationTest\/testBookmarkLink()",
         "NavigationTest\/testCopyLink()",
         "NavigationTest\/testCopyLinkPrivateMode()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
@@ -81,6 +81,7 @@
         "LoginTest\/testLoginsListFromBrowserTabMenu()",
         "LoginTest\/testSavedLoginSelectUnselect()",
         "LoginTest\/testSearchLogin()",
+        "MicrosurveyTests",
         "NavigationTest\/testBookmarkLink()",
         "NavigationTest\/testCopyLink()",
         "NavigationTest\/testCopyLinkPrivateMode()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+final class MicrosurveyTests: BaseTestCase {
+    override func setUp() {
+        launchArguments = [
+            LaunchArguments.SkipIntro,
+            LaunchArguments.ResetMicrosurveyExpirationCount
+        ]
+        super.setUp()
+    }
+
+    func testShowMicrosurveyPromptFromHomepageTrigger() {
+        generateTriggerForMicrosurvey()
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton].exists)
+        XCTAssertTrue(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo].exists)
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists)
+    }
+
+    func testCloseButtonDismissesMicrosurveyPrompt() {
+        generateTriggerForMicrosurvey()
+        app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].tap()
+        XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton].exists)
+        XCTAssertFalse(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo].exists)
+        XCTAssertFalse(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists)
+    }
+
+    func testShowMicrosurvey() {
+        generateTriggerForMicrosurvey()
+        let continueButton = app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton]
+        continueButton.tap()
+
+        XCTAssertTrue(app.images[AccessibilityIdentifiers.Microsurvey.Survey.firefoxLogo].exists)
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Survey.closeButton].exists)
+    }
+
+    func testCloseButtonDismissesSurveyAndPrompt() {
+        generateTriggerForMicrosurvey()
+        let continueButton = app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton]
+        continueButton.tap()
+
+        app.buttons[AccessibilityIdentifiers.Microsurvey.Survey.closeButton].tap()
+
+        XCTAssertFalse(app.images[AccessibilityIdentifiers.Microsurvey.Survey.firefoxLogo].exists)
+        XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Microsurvey.Survey.closeButton].exists)
+        XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton].exists)
+        XCTAssertFalse(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo].exists)
+        XCTAssertFalse(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists)
+    }
+
+    private func generateTriggerForMicrosurvey() {
+        let homepageToggleButton = app
+            .collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView]
+            .buttons[AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton]
+        homepageToggleButton.tap()
+        let privateHomepageToggleButton = app
+            .scrollViews
+            .otherElements
+            .buttons[AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton]
+        privateHomepageToggleButton.tap()
+        mozWaitForElementToExist(app.collectionViews["FxCollectionView"])
+    }
+}

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -39,7 +39,7 @@ import:
             triggers:
               ON_FOURTH_LAUNCH_THIS_YEAR: "'app_cycle.foreground'|eventSum('Years', 1, 0) > 3"
 
-        - channel: beta
+        - channel: beta, developer
           value:
             messages:
               # Serves as an example of how microsurveys may look like


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9459)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20943)

## :bulb: Description
Add initial UI tests for microsurvey tests to assist automation team on writing UI tests for microsurveys. The microsurvey feature requires a trigger and a reset to show the survey and I added `generateTriggerForMicrosurvey` to set this up for the tests.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

