### PR TITLE
Add FXIOS-9456 Add reload/stop button to address toolbar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -58,6 +58,7 @@ class ToolbarButton: UIButton, ThemeApplicable {
         isEnabled = element.isEnabled
         accessibilityIdentifier = element.a11yId
         accessibilityLabel = element.a11yLabel
+        accessibilityHint = element.a11yHint
         addAction(action, for: .touchUpInside)
 
         showsLargeContentViewer = true

--- a/BrowserKit/Sources/ToolbarKit/ToolbarElement.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarElement.swift
@@ -23,6 +23,9 @@ public struct ToolbarElement: Equatable {
     /// Accessibility label of the toolbar element
     let a11yLabel: String
 
+    /// Accessibility hint of the toolbar element
+    let a11yHint: String?
+
     /// Accessibility identifier of the toolbar element
     let a11yId: String
 
@@ -40,6 +43,7 @@ public struct ToolbarElement: Equatable {
                 isEnabled: Bool,
                 shouldDisplayAsHighlighted: Bool = false,
                 a11yLabel: String,
+                a11yHint: String?,
                 a11yId: String,
                 onSelected: ((UIButton) -> Void)?,
                 onLongPress: (() -> Void)? = nil) {
@@ -51,6 +55,7 @@ public struct ToolbarElement: Equatable {
         self.onSelected = onSelected
         self.onLongPress = onLongPress
         self.a11yLabel = a11yLabel
+        self.a11yHint = a11yHint
         self.a11yId = a11yId
     }
 
@@ -61,6 +66,7 @@ public struct ToolbarElement: Equatable {
         lhs.isEnabled == rhs.isEnabled &&
         lhs.shouldDisplayAsHighlighted == rhs.shouldDisplayAsHighlighted &&
         lhs.a11yLabel == rhs.a11yLabel &&
+        lhs.a11yHint == rhs.a11yHint &&
         lhs.a11yId == rhs.a11yId
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -43,6 +43,8 @@ enum GeneralBrowserActionType: ActionType {
     case showTrackingProtectionDetails
     case showTabsLongPressActions
     case showMenu
+    case stopLoadingWebsite
+    case reloadWebsite
 }
 
 class GeneralBrowserMiddlewareAction: Action {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -62,6 +62,6 @@ class GeneralBrowserMiddlewareAction: Action {
 
 enum GeneralBrowserMiddlewareActionType: ActionType {
     case browserDidLoad
-    case didScroll
     case toolbarPositionChanged
+    case websiteDidScroll
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -12,6 +12,8 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         case home
         case back
         case forward
+        case reload
+        case stopLoading
     }
 
     enum DisplayType {
@@ -287,6 +289,26 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 windowUUID: state.windowUUID,
                 browserViewType: state.browserViewType,
                 displayView: .tabTray,
+                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
+        case GeneralBrowserActionType.reloadWebsite:
+            return BrowserViewControllerState(
+                searchScreenState: state.searchScreenState,
+                showDataClearanceFlow: state.showDataClearanceFlow,
+                fakespotState: state.fakespotState,
+                toast: state.toast,
+                windowUUID: state.windowUUID,
+                browserViewType: state.browserViewType,
+                navigateTo: .reload,
+                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
+        case GeneralBrowserActionType.stopLoadingWebsite:
+            return BrowserViewControllerState(
+                searchScreenState: state.searchScreenState,
+                showDataClearanceFlow: state.showDataClearanceFlow,
+                fakespotState: state.fakespotState,
+                toast: state.toast,
+                windowUUID: state.windowUUID,
+                browserViewType: state.browserViewType,
+                navigateTo: .stopLoading,
                 microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
         default:
             return state

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -12,7 +12,6 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         case home
         case back
         case forward
-        case tabTray
     }
 
     enum DisplayType {
@@ -21,6 +20,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         case trackingProtectionDetails
         case tabsLongPressActions
         case menu
+        case tabTray
     }
 
     let windowUUID: WindowUUID
@@ -286,7 +286,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 toast: state.toast,
                 windowUUID: state.windowUUID,
                 browserViewType: state.browserViewType,
-                navigateTo: .tabTray,
+                displayView: .tabTray,
                 microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
         default:
             return state

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1846,6 +1846,14 @@ class BrowserViewController: UIViewController,
             navigationHandler?.showEnhancedTrackingProtection(sourceView: view)
         case .menu:
         	didTapOnMenu(button: state.buttonTapped)
+        case .tabTray:
+            focusOnTabSegment()
+            TelemetryWrapper.recordEvent(
+                category: .action,
+                method: .press,
+                object: .tabToolbar,
+                value: .tabView
+            )
         }
     }
 
@@ -1860,14 +1868,6 @@ class BrowserViewController: UIViewController,
             didTapOnBack()
         case .forward:
             didTapOnForward()
-        case .tabTray:
-            focusOnTabSegment()
-            TelemetryWrapper.recordEvent(
-                category: .action,
-                method: .press,
-                object: .tabToolbar,
-                value: .tabView
-            )
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1854,7 +1854,7 @@ class BrowserViewController: UIViewController,
             TelemetryWrapper.recordEvent(category: .action, method: .press, object: .trackingProtectionMenu)
             navigationHandler?.showEnhancedTrackingProtection(sourceView: view)
         case .menu:
-        	didTapOnMenu(button: state.buttonTapped)
+            didTapOnMenu(button: state.buttonTapped)
         case .tabTray:
             focusOnTabSegment()
             TelemetryWrapper.recordEvent(

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1666,6 +1666,15 @@ class BrowserViewController: UIViewController,
             setupMiddleButtonStatus(isLoading: loading)
             setupLoadingSpinnerFor(webView, isLoading: loading)
 
+            if isToolbarRefactorEnabled {
+                let action = ToolbarMiddlewareAction(
+                    isLoading: loading,
+                    windowUUID: windowUUID,
+                    actionType: ToolbarMiddlewareActionType.websiteLoadingStateDidChange
+                )
+                store.dispatch(action)
+            }
+
         case .URL:
             // Special case for "about:blank" popups, if the webView.url is nil, keep the tab url as "about:blank"
             if tab.url?.absoluteString == "about:blank" && webView.url == nil {
@@ -1868,6 +1877,11 @@ class BrowserViewController: UIViewController,
             didTapOnBack()
         case .forward:
             didTapOnForward()
+        case .reload:
+            tabManager.selectedTab?.reload()
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .reloadFromUrlBar)
+        case .stopLoading:
+            tabManager.selectedTab?.stop()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -487,7 +487,7 @@ extension TabScrollingController: UIScrollViewDelegate {
             lastContentOffsetY = scrollView.contentOffset.y
             let action = GeneralBrowserMiddlewareAction(scrollOffset: scrollView.contentOffset,
                                                         windowUUID: windowUUID,
-                                                        actionType: GeneralBrowserMiddlewareActionType.didScroll)
+                                                        actionType: GeneralBrowserMiddlewareActionType.websiteDidScroll)
             store.dispatch(action)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -79,6 +79,7 @@ class AddressToolbarContainerModel: Equatable {
                 numberOfTabs: action.numberOfTabs,
                 isEnabled: action.isEnabled,
                 a11yLabel: action.a11yLabel,
+                a11yHint: action.a11yHint,
                 a11yId: action.a11yId,
                 onSelected: { button in
                     let action = ToolbarMiddlewareAction(buttonType: action.actionType,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/NavigationToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/NavigationToolbarContainerModel.swift
@@ -23,6 +23,7 @@ struct NavigationToolbarContainerModel: Equatable {
                 numberOfTabs: action.numberOfTabs,
                 isEnabled: action.isEnabled,
                 a11yLabel: action.a11yLabel,
+                a11yHint: action.a11yHint,
                 a11yId: action.a11yId,
                 onSelected: { button in
                     let action = ToolbarMiddlewareAction(buttonType: action.actionType,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -14,6 +14,7 @@ struct AddressBarState: StateType, Equatable {
     var borderPosition: AddressToolbarBorderPosition?
     var url: URL?
     var isEditing: Bool
+    var isLoading: Bool
 
     init(windowUUID: WindowUUID) {
         self.init(windowUUID: windowUUID,
@@ -22,7 +23,8 @@ struct AddressBarState: StateType, Equatable {
                   browserActions: [],
                   borderPosition: nil,
                   url: nil,
-                  isEditing: false)
+                  isEditing: false,
+                  isLoading: false)
     }
 
     init(windowUUID: WindowUUID,
@@ -31,7 +33,8 @@ struct AddressBarState: StateType, Equatable {
          browserActions: [ToolbarActionState],
          borderPosition: AddressToolbarBorderPosition?,
          url: URL?,
-         isEditing: Bool = false) {
+         isEditing: Bool = false,
+         isLoading: Bool = false) {
         self.windowUUID = windowUUID
         self.navigationActions = navigationActions
         self.pageActions = pageActions
@@ -39,6 +42,7 @@ struct AddressBarState: StateType, Equatable {
         self.borderPosition = borderPosition
         self.url = url
         self.isEditing = isEditing
+        self.isLoading = isLoading
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -81,7 +85,7 @@ struct AddressBarState: StateType, Equatable {
             return AddressBarState(
                 windowUUID: state.windowUUID,
                 navigationActions: addressToolbarModel.navigationActions ?? state.navigationActions,
-                pageActions: state.pageActions,
+                pageActions: addressToolbarModel.pageActions ?? state.pageActions,
                 browserActions: state.browserActions,
                 borderPosition: state.borderPosition,
                 url: state.url,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -54,15 +54,18 @@ class ToolbarMiddlewareAction: Action {
     let buttonType: ToolbarActionState.ActionType?
     let buttonTapped: UIButton?
     let gestureType: ToolbarButtonGesture?
+    let isLoading: Bool?
 
     init(buttonType: ToolbarActionState.ActionType? = nil,
          buttonTapped: UIButton? = nil,
          gestureType: ToolbarButtonGesture? = nil,
+         isLoading: Bool? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
         self.buttonType = buttonType
         self.buttonTapped = buttonTapped
         self.gestureType = gestureType
+        self.isLoading = isLoading
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
@@ -92,4 +95,5 @@ enum ToolbarMiddlewareActionType: ActionType {
     case urlDidChange
     case didStartEditingUrl
     case cancelEdit
+    case websiteLoadingStateDidChange
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionState.swift
@@ -27,6 +27,7 @@ struct ToolbarActionState: Equatable {
     var numberOfTabs: Int?
     var isEnabled: Bool
     var a11yLabel: String
+    var a11yHint: String?
     var a11yId: String
 
     var canPerformLongPressAction: Bool {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionState.swift
@@ -15,6 +15,7 @@ struct ToolbarActionState: Equatable {
         case qrCode
         case share
         case reload
+        case stopLoading
         case trackingProtection
         case readerMode
         case dataClearance

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -45,7 +45,7 @@ class ToolbarMiddleware: FeatureFlaggable {
                                        actionType: ToolbarActionType.didLoadToolbars)
             store.dispatch(action)
 
-        case GeneralBrowserMiddlewareActionType.didScroll:
+        case GeneralBrowserMiddlewareActionType.websiteDidScroll:
             updateBorderPosition(action: action, state: state)
 
         case GeneralBrowserMiddlewareActionType.toolbarPositionChanged:

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -371,7 +371,7 @@ class ToolbarMiddleware: FeatureFlaggable {
         let urlChangeAction = action as? ToolbarMiddlewareUrlChangeAction
         let url = urlChangeAction != nil ? urlChangeAction?.url : toolbarState.addressToolbar.url
 
-        guard let url else {
+        guard url != nil else {
             // On homepage we only show the QR code button
             return [qrCodeScanAction]
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -143,39 +143,22 @@ class ToolbarMiddleware: FeatureFlaggable {
         let borderPosition = getAddressBorderPosition(toolbarPosition: toolbarPosition)
 
         return AddressToolbarModel(navigationActions: [ToolbarActionState](),
-                                   pageActions: loadAddressToolbarPageElements(),
-                                   browserActions: loadAddressToolbarBrowserElements(),
+                                   pageActions: [qrCodeScanAction],
+                                   browserActions: [tabsAction, menuAction],
                                    borderPosition: borderPosition,
                                    url: nil)
     }
 
-    private func loadAddressToolbarPageElements() -> [ToolbarActionState] {
-        var pageActions = [ToolbarActionState]()
-        pageActions.append(qrCodeScanAction)
-        return pageActions
-    }
-
-    private func loadAddressToolbarBrowserElements() -> [ToolbarActionState] {
-        var elements = [ToolbarActionState]()
-        elements.append(tabsAction)
-        elements.append(menuAction)
-        return elements
-    }
-
     private func loadInitialNavigationToolbarState(toolbarPosition: AddressToolbarPosition) -> NavigationToolbarModel {
-        let actions = loadNavigationToolbarElements()
+        let actions = [
+            backAction(enabled: false),
+            forwardAction(enabled: false),
+            homeAction,
+            tabsAction,
+            menuAction
+        ]
         let displayBorder = shouldDisplayNavigationToolbarBorder(toolbarPosition: toolbarPosition)
         return NavigationToolbarModel(actions: actions, displayBorder: displayBorder)
-    }
-
-    private func loadNavigationToolbarElements() -> [ToolbarActionState] {
-        var elements = [ToolbarActionState]()
-        elements.append(backAction(enabled: false))
-        elements.append(forwardAction(enabled: false))
-        elements.append(homeAction)
-        elements.append(tabsAction)
-        elements.append(menuAction)
-        return elements
     }
 
     private func getAddressBorderPosition(toolbarPosition: AddressToolbarPosition,
@@ -458,7 +441,7 @@ class ToolbarMiddleware: FeatureFlaggable {
         return addressToolbarModel
     }
 
-    private func backAction(enabled: Bool) {
+    private func backAction(enabled: Bool) -> ToolbarActionState {
         return ToolbarActionState(
             actionType: .back,
             iconName: StandardImageIdentifiers.Large.back,
@@ -467,7 +450,7 @@ class ToolbarMiddleware: FeatureFlaggable {
             a11yId: AccessibilityIdentifiers.Toolbar.backButton)
     }
 
-    private func forwardAction(enabled: Bool) {
+    private func forwardAction(enabled: Bool) -> ToolbarActionState {
         return ToolbarActionState(
             actionType: .forward,
             iconName: StandardImageIdentifiers.Large.forward,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -161,16 +161,6 @@ class ToolbarMiddleware: FeatureFlaggable {
         return NavigationToolbarModel(actions: actions, displayBorder: displayBorder)
     }
 
-    private func getAddressBorderPosition(toolbarPosition: AddressToolbarPosition,
-                                          isPrivate: Bool = false,
-                                          scrollY: CGFloat = 0) -> AddressToolbarBorderPosition? {
-        return manager.getAddressBorderPosition(for: toolbarPosition, isPrivate: isPrivate, scrollY: scrollY)
-    }
-
-    private func shouldDisplayNavigationToolbarBorder(toolbarPosition: AddressToolbarPosition) -> Bool {
-        return manager.shouldDisplayNavigationBorder(toolbarPosition: toolbarPosition)
-    }
-
     private func handleToolbarButtonTapActions(action: ToolbarMiddlewareAction, state: AppState) {
         switch action.buttonType {
         case .home:
@@ -441,6 +431,8 @@ class ToolbarMiddleware: FeatureFlaggable {
         return addressToolbarModel
     }
 
+    // MARK: - Helper
+
     private func backAction(enabled: Bool) -> ToolbarActionState {
         return ToolbarActionState(
             actionType: .back,
@@ -457,5 +449,15 @@ class ToolbarMiddleware: FeatureFlaggable {
             isEnabled: enabled,
             a11yLabel: .TabToolbarForwardAccessibilityLabel,
             a11yId: AccessibilityIdentifiers.Toolbar.forwardButton)
+    }
+
+    private func getAddressBorderPosition(toolbarPosition: AddressToolbarPosition,
+                                          isPrivate: Bool = false,
+                                          scrollY: CGFloat = 0) -> AddressToolbarBorderPosition? {
+        return manager.getAddressBorderPosition(for: toolbarPosition, isPrivate: isPrivate, scrollY: scrollY)
+    }
+
+    private func shouldDisplayNavigationToolbarBorder(toolbarPosition: AddressToolbarPosition) -> Bool {
+        return manager.shouldDisplayNavigationBorder(toolbarPosition: toolbarPosition)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -27,6 +27,57 @@ class ToolbarMiddleware: FeatureFlaggable {
         }
     }
 
+    lazy var stopLoadingAction = ToolbarActionState(
+        actionType: .stopLoading,
+        iconName: StandardImageIdentifiers.Large.cross,
+        isEnabled: true,
+        a11yLabel: .TabToolbarStopAccessibilityLabel,
+        a11yId: AccessibilityIdentifiers.Toolbar.stopButton)
+
+    lazy var reloadAction = ToolbarActionState(
+        actionType: .reload,
+        iconName: StandardImageIdentifiers.Large.arrowClockwise,
+        isEnabled: true,
+        a11yLabel: .TabLocationReloadAccessibilityLabel,
+        a11yHint: .TabLocationReloadAccessibilityHint,
+        a11yId: AccessibilityIdentifiers.Toolbar.reloadButton)
+
+    lazy var qrCodeScanAction = ToolbarActionState(
+        actionType: .qrCode,
+        iconName: StandardImageIdentifiers.Large.qrCode,
+        isEnabled: true,
+        a11yLabel: .QRCode.ToolbarButtonA11yLabel,
+        a11yId: AccessibilityIdentifiers.Browser.ToolbarButtons.qrCode)
+
+    lazy var cancelEditAction = ToolbarActionState(
+        actionType: .cancelEdit,
+        iconName: StandardImageIdentifiers.Large.chevronLeft,
+        isEnabled: true,
+        a11yLabel: AccessibilityIdentifiers.GeneralizedIdentifiers.back,
+        a11yId: AccessibilityIdentifiers.Browser.UrlBar.cancelButton)
+
+    lazy var menuAction = ToolbarActionState(
+        actionType: .menu,
+        iconName: StandardImageIdentifiers.Large.appMenu,
+        isEnabled: true,
+        a11yLabel: .AppMenu.Toolbar.MenuButtonAccessibilityLabel,
+        a11yId: AccessibilityIdentifiers.Toolbar.settingsMenuButton)
+
+    lazy var tabsAction = ToolbarActionState(
+        actionType: .tabs,
+        iconName: StandardImageIdentifiers.Large.tab,
+        numberOfTabs: 1,
+        isEnabled: true,
+        a11yLabel: .TabsButtonShowTabsAccessibilityLabel,
+        a11yId: AccessibilityIdentifiers.Toolbar.tabsButton)
+
+    lazy var homeAction = ToolbarActionState(
+        actionType: .home,
+        iconName: StandardImageIdentifiers.Large.home,
+        isEnabled: true,
+        a11yLabel: .TabToolbarHomeAccessibilityLabel,
+        a11yId: AccessibilityIdentifiers.Toolbar.homeButton)
+
     private func resolveGeneralBrowserMiddlewareActions(action: GeneralBrowserMiddlewareAction, state: AppState) {
         let uuid = action.windowUUID
 
@@ -100,28 +151,14 @@ class ToolbarMiddleware: FeatureFlaggable {
 
     private func loadAddressToolbarPageElements() -> [ToolbarActionState] {
         var pageActions = [ToolbarActionState]()
-        pageActions.append(ToolbarActionState(
-            actionType: .qrCode,
-            iconName: StandardImageIdentifiers.Large.qrCode,
-            isEnabled: true,
-            a11yLabel: .QRCode.ToolbarButtonA11yLabel,
-            a11yId: AccessibilityIdentifiers.Browser.ToolbarButtons.qrCode))
+        pageActions.append(qrCodeScanAction)
         return pageActions
     }
 
     private func loadAddressToolbarBrowserElements() -> [ToolbarActionState] {
         var elements = [ToolbarActionState]()
-        elements.append(ToolbarActionState(actionType: .tabs,
-                                           iconName: StandardImageIdentifiers.Large.tab,
-                                           numberOfTabs: 1,
-                                           isEnabled: true,
-                                           a11yLabel: .TabsButtonShowTabsAccessibilityLabel,
-                                           a11yId: AccessibilityIdentifiers.Toolbar.tabsButton))
-        elements.append(ToolbarActionState(actionType: .menu,
-                                           iconName: StandardImageIdentifiers.Large.appMenu,
-                                           isEnabled: true,
-                                           a11yLabel: .AppMenu.Toolbar.MenuButtonAccessibilityLabel,
-                                           a11yId: AccessibilityIdentifiers.Toolbar.settingsMenuButton))
+        elements.append(tabsAction)
+        elements.append(menuAction)
         return elements
     }
 
@@ -133,32 +170,11 @@ class ToolbarMiddleware: FeatureFlaggable {
 
     private func loadNavigationToolbarElements() -> [ToolbarActionState] {
         var elements = [ToolbarActionState]()
-        elements.append(ToolbarActionState(actionType: .back,
-                                           iconName: StandardImageIdentifiers.Large.back,
-                                           isEnabled: false,
-                                           a11yLabel: .TabToolbarBackAccessibilityLabel,
-                                           a11yId: AccessibilityIdentifiers.Toolbar.backButton))
-        elements.append(ToolbarActionState(actionType: .forward,
-                                           iconName: StandardImageIdentifiers.Large.forward,
-                                           isEnabled: false,
-                                           a11yLabel: .TabToolbarForwardAccessibilityLabel,
-                                           a11yId: AccessibilityIdentifiers.Toolbar.forwardButton))
-        elements.append(ToolbarActionState(actionType: .home,
-                                           iconName: StandardImageIdentifiers.Large.home,
-                                           isEnabled: true,
-                                           a11yLabel: .TabToolbarHomeAccessibilityLabel,
-                                           a11yId: AccessibilityIdentifiers.Toolbar.homeButton))
-        elements.append(ToolbarActionState(actionType: .tabs,
-                                           iconName: StandardImageIdentifiers.Large.tab,
-                                           numberOfTabs: 1,
-                                           isEnabled: true,
-                                           a11yLabel: .TabsButtonShowTabsAccessibilityLabel,
-                                           a11yId: AccessibilityIdentifiers.Toolbar.tabsButton))
-        elements.append(ToolbarActionState(actionType: .menu,
-                                           iconName: StandardImageIdentifiers.Large.appMenu,
-                                           isEnabled: true,
-                                           a11yLabel: .AppMenu.Toolbar.MenuButtonAccessibilityLabel,
-                                           a11yId: AccessibilityIdentifiers.Toolbar.settingsMenuButton))
+        elements.append(backAction(enabled: false))
+        elements.append(forwardAction(enabled: false))
+        elements.append(homeAction)
+        elements.append(tabsAction)
+        elements.append(menuAction)
         return elements
     }
 
@@ -325,14 +341,10 @@ class ToolbarMiddleware: FeatureFlaggable {
     ) -> [ToolbarActionState] {
         var actions = [ToolbarActionState]()
 
-        switch action.actionType as? ToolbarMiddlewareActionType {
-        case .didStartEditingUrl:
+        switch action.actionType {
+        case ToolbarMiddlewareActionType.didStartEditingUrl:
             // back carrot when in edit mode
-            actions.append(ToolbarActionState(actionType: .cancelEdit,
-                                              iconName: StandardImageIdentifiers.Large.chevronLeft,
-                                              isEnabled: true,
-                                              a11yLabel: AccessibilityIdentifiers.GeneralizedIdentifiers.back,
-                                              a11yId: AccessibilityIdentifiers.Browser.UrlBar.cancelButton))
+            actions.append(cancelEditAction)
             return actions
 
         default:
@@ -353,17 +365,48 @@ class ToolbarMiddleware: FeatureFlaggable {
             // back/forward when url exists and nav toolbar is not shown
             let isBackButtonEnabled = action.canGoBack
             let isForwardButtonEnabled = action.canGoForward
-            actions.append(ToolbarActionState(actionType: .back,
-                                              iconName: StandardImageIdentifiers.Large.back,
-                                              isEnabled: isBackButtonEnabled,
-                                              a11yLabel: .TabToolbarBackAccessibilityLabel,
-                                              a11yId: AccessibilityIdentifiers.Toolbar.backButton))
-            actions.append(ToolbarActionState(actionType: .forward,
-                                              iconName: StandardImageIdentifiers.Large.forward,
-                                              isEnabled: isForwardButtonEnabled,
-                                              a11yLabel: .TabToolbarForwardAccessibilityLabel,
-                                              a11yId: AccessibilityIdentifiers.Toolbar.forwardButton))
+            actions.append(backAction(enabled: isBackButtonEnabled))
+            actions.append(forwardAction(enabled: isForwardButtonEnabled))
         }
+        return actions
+    }
+
+    private func addressToolbarPageActions(
+        action: ToolbarMiddlewareAction,
+        state: AppState
+    ) -> [ToolbarActionState] {
+        var actions = [ToolbarActionState]()
+
+        guard let toolbarState = state.screenState(ToolbarState.self,
+                                                   for: .toolbar,
+                                                   window: action.windowUUID)
+        else { return actions }
+
+        var url = toolbarState.addressToolbar.url
+        if let action = action as? ToolbarMiddlewareUrlChangeAction {
+            url = action.url
+        }
+
+        guard let url else {
+            // On homepage we only show the QR code button
+            actions.append(qrCodeScanAction)
+            return actions
+        }
+
+        var isLoading = false
+
+        // share, reload if url exists + potentially reader mode & fakespot
+        switch action.actionType {
+        case ToolbarMiddlewareActionType.websiteLoadingStateDidChange:
+            if action.isLoading == true {
+                actions.append(stopLoadingAction)
+            } else if action.isLoading == false {
+                actions.append(reloadAction)
+            }
+        default:
+            return actions
+        }
+
         return actions
     }
 
@@ -413,5 +456,23 @@ class ToolbarMiddleware: FeatureFlaggable {
             url: url ?? toolbarState.addressToolbar.url,
             isEditing: isEditing)
         return addressToolbarModel
+    }
+
+    private func backAction(enabled: Bool) {
+        return ToolbarActionState(
+            actionType: .back,
+            iconName: StandardImageIdentifiers.Large.back,
+            isEnabled: enabled,
+            a11yLabel: .TabToolbarBackAccessibilityLabel,
+            a11yId: AccessibilityIdentifiers.Toolbar.backButton)
+    }
+
+    private func forwardAction(enabled: Bool) {
+        return ToolbarActionState(
+            actionType: .forward,
+            iconName: StandardImageIdentifiers.Large.forward,
+            isEnabled: enabled,
+            a11yLabel: .TabToolbarForwardAccessibilityLabel,
+            a11yId: AccessibilityIdentifiers.Toolbar.forwardButton)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -388,7 +388,7 @@ class HomepageViewController:
             lastContentOffsetY = scrollView.contentOffset.y
             let action = GeneralBrowserMiddlewareAction(scrollOffset: scrollView.contentOffset,
                                                         windowUUID: windowUUID,
-                                                        actionType: GeneralBrowserMiddlewareActionType.didScroll)
+                                                        actionType: GeneralBrowserMiddlewareActionType.websiteDidScroll)
             store.dispatch(action)
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TOD9456O)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20938)

## :bulb: Description
Displays the reload or stop button in the address toolbar depending on the loading state. This also adds the actions to reload and stop the website from loading.
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-07-10 at 16 20 57](https://github.com/mozilla-mobile/firefox-ios/assets/4530/30ff5cd9-3e49-42f4-815e-b6889994aab5)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

