### PR TITLE
Refactor FXIOS-9472 - Remove version number from credential provider script title and commit message

### DIFF
--- a/.github/workflows/firefox-ios-update_credential_provider_script.yml
+++ b/.github/workflows/firefox-ios-update_credential_provider_script.yml
@@ -41,10 +41,10 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v6
       with:
-        commit-message: Refactor [vXXX] auto update credential provider script
+        commit-message: Refactor - auto update credential provider script
         author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
         committer: GitHub <noreply@github.com>
-        title: Refactor [vXXX] auto update credential provider script
+        title: Refactor - auto update credential provider script
         branch: update-cred-provider-script
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set job log URL


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9472)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20964)

## :bulb: Description
We don't need to set the version number in PRs anymore. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~Wrote unit tests and/or ensured the tests suite is passing~
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed, I updated documentation / comments for complex code and public methods~
- [ ] ~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~

