### PR TITLE
Add FXIOS-9455 Debug settings for feature flags

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -712,6 +712,7 @@
 		8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */; };
 		8A57519927AD80B800A84DBF /* ReaderModeStyleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */; };
 		8A590C6128C123100032F1AA /* OpenPassBookHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */; };
+		8A5BC1EB2C4AA13F009A40A4 /* FeatureFlagsBoolSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BC1EA2C4AA13F009A40A4 /* FeatureFlagsBoolSetting.swift */; };
 		8A5BD95A28788A3D000FE773 /* TopSitesHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */; };
 		8A5BD95F2878B7B6000FE773 /* TopSitesWidgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BD95E2878B7B6000FE773 /* TopSitesWidgetManager.swift */; };
 		8A5C3BC5282ABF8E003A8CCF /* LegacyRemoteTabsPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5C3BC4282ABF8E003A8CCF /* LegacyRemoteTabsPanelTests.swift */; };
@@ -897,6 +898,8 @@
 		8AE80BBA2891C0C300BC12EA /* JumpBackInSectionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BB92891C0C300BC12EA /* JumpBackInSectionLayout.swift */; };
 		8AE80BBC2891C20D00BC12EA /* JumpBackInList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BBB2891C20D00BC12EA /* JumpBackInList.swift */; };
 		8AE80BBE2891C21A00BC12EA /* JumpBackInSyncedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BBD2891C21A00BC12EA /* JumpBackInSyncedTab.swift */; };
+		8AEAD9F32C3D7B3E001A2C5A /* FeatureFlagsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEAD9F22C3D7B3E001A2C5A /* FeatureFlagsSettings.swift */; };
+		8AEAD9F52C3D7BA9001A2C5A /* FeatureFlagsDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEAD9F42C3D7BA9001A2C5A /* FeatureFlagsDebugViewController.swift */; };
 		8AEAD9F92C3DB0CD001A2C5A /* MicrosurveyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEAD9F62C3DB0BF001A2C5A /* MicrosurveyTests.swift */; };
 		8AED23C527AC1F9500DE7E97 /* BaseContentStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */; };
 		8AED868328CA3B3400351A50 /* BookmarkPanelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED868228CA3B3400351A50 /* BookmarkPanelViewModelTests.swift */; };
@@ -6349,6 +6352,7 @@
 		8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleViewModel.swift; sourceTree = "<group>"; };
 		8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPassBookHelper.swift; sourceTree = "<group>"; };
+		8A5BC1EA2C4AA13F009A40A4 /* FeatureFlagsBoolSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsBoolSetting.swift; sourceTree = "<group>"; };
 		8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesHelperTests.swift; sourceTree = "<group>"; };
 		8A5BD95B2878AA74000FE773 /* PinnedSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedSite.swift; sourceTree = "<group>"; };
 		8A5BD95E2878B7B6000FE773 /* TopSitesWidgetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesWidgetManager.swift; sourceTree = "<group>"; };
@@ -6544,6 +6548,8 @@
 		8AE80BB92891C0C300BC12EA /* JumpBackInSectionLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInSectionLayout.swift; sourceTree = "<group>"; };
 		8AE80BBB2891C20D00BC12EA /* JumpBackInList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInList.swift; sourceTree = "<group>"; };
 		8AE80BBD2891C21A00BC12EA /* JumpBackInSyncedTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInSyncedTab.swift; sourceTree = "<group>"; };
+		8AEAD9F22C3D7B3E001A2C5A /* FeatureFlagsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsSettings.swift; sourceTree = "<group>"; };
+		8AEAD9F42C3D7BA9001A2C5A /* FeatureFlagsDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsDebugViewController.swift; sourceTree = "<group>"; };
 		8AEAD9F62C3DB0BF001A2C5A /* MicrosurveyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyTests.swift; sourceTree = "<group>"; };
 		8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseContentStackView.swift; sourceTree = "<group>"; };
 		8AED868228CA3B3400351A50 /* BookmarkPanelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkPanelViewModelTests.swift; sourceTree = "<group>"; };
@@ -10036,6 +10042,7 @@
 		8A3EF7EE2A2FCF0000796E3A /* Debug */ = {
 			isa = PBXGroup;
 			children = (
+				8ABCBE622C485CAA00480A21 /* FeatureFlags */,
 				8CFD56872AAF057D003157A6 /* SwitchFakespotProduction.swift */,
 				8A3EF7FC2A2FCFAC00796E3A /* AppReviewPromptSetting.swift */,
 				1DA710062AE7106B00677F6B /* AppDataUsageReportSetting.swift */,
@@ -10370,6 +10377,16 @@
 				8AB8573627D951640075C173 /* HomeLogoHeaderViewModel.swift */,
 			);
 			path = LogoHeader;
+			sourceTree = "<group>";
+		};
+		8ABCBE622C485CAA00480A21 /* FeatureFlags */ = {
+			isa = PBXGroup;
+			children = (
+				8A5BC1EA2C4AA13F009A40A4 /* FeatureFlagsBoolSetting.swift */,
+				8AEAD9F22C3D7B3E001A2C5A /* FeatureFlagsSettings.swift */,
+				8AEAD9F42C3D7BA9001A2C5A /* FeatureFlagsDebugViewController.swift */,
+			);
+			path = FeatureFlags;
 			sourceTree = "<group>";
 		};
 		8AC225632B6D3F9600CDA7FD /* Telemetry */ = {
@@ -14559,6 +14576,7 @@
 				EBFDB790211C83A5005CCA2F /* BrowserViewController+FindInPage.swift in Sources */,
 				21B359C62AEAC20300FF09E3 /* TabsSectionManager.swift in Sources */,
 				21BFEEF52A040EF40033048D /* TabMigrationUtility.swift in Sources */,
+				8AEAD9F52C3D7BA9001A2C5A /* FeatureFlagsDebugViewController.swift in Sources */,
 				A55319BB2B5D5A850051559F /* SearchSettingsAction.swift in Sources */,
 				810CD9C12BB346D800E290C2 /* OnboardingCardViewController.swift in Sources */,
 				C8A012F126AB07D70096A7A7 /* JumpBackInViewModel.swift in Sources */,
@@ -14773,10 +14791,12 @@
 				964FA97528A1A8F20024BB3B /* ContextualHintEligibilityUtility.swift in Sources */,
 				439C489C29760575007C3DCD /* CreditCardValidator.swift in Sources */,
 				8ADC2A122A3375B900543DAA /* FxAEntryPoint.swift in Sources */,
+				8AEAD9F32C3D7B3E001A2C5A /* FeatureFlagsSettings.swift in Sources */,
 				216A0D7B2A40F08B008077BA /* ThemeSettingsAction.swift in Sources */,
 				C2506C932A6A863600F2B76E /* HistoryCoordinator.swift in Sources */,
 				8A3EF8012A2FCFC900796E3A /* FasterInactiveTabs.swift in Sources */,
 				CA7FC7D324A6A9B70012F347 /* PasswordManagerDataSourceHelper.swift in Sources */,
+				8A5BC1EB2C4AA13F009A40A4 /* FeatureFlagsBoolSetting.swift in Sources */,
 				43AB6FA425DC53D30016B015 /* LabelButtonHeaderView.swift in Sources */,
 				43D16B7C29831CD0009F8279 /* CreditCardItemRow.swift in Sources */,
 				39673BC12B6D82F400653F4A /* FxNimbusMessaging.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -198,6 +198,11 @@ class SettingsCoordinator: BaseCoordinator,
         parentCoordinator?.openDebugTestTabs(count: count)
     }
 
+    func showDebugFeatureFlags() {
+        let featureFlagsViewController = FeatureFlagsDebugViewController(windowUUID: windowUUID)
+        router.push(featureFlagsViewController)
+    }
+
     func showPasswordManager(shouldShowOnboarding: Bool) {
         let passwordCoordinator = PasswordManagerCoordinator(
             router: router,

--- a/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
+++ b/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
@@ -100,9 +100,17 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
     }
 
     /// Set a feature that has a binary state to on or off
-    public func set(feature featureID: NimbusFeatureFlagID, to desiredState: Bool) {
+    public func set(feature featureID: NimbusFeatureFlagID, to desiredState: Bool, isDebug: Bool = false) {
         let feature = NimbusFlaggableFeature(withID: featureID, and: profile)
+        #if MOZ_CHANNEL_BETA || MOZ_CHANNEL_FENNEC
+        if isDebug {
+            feature.setDebugPreference(to: desiredState)
+        } else {
+            feature.setUserPreference(to: desiredState)
+        }
+        #else
         feature.setUserPreference(to: desiredState)
+        #endif
     }
 
     /// Set a feature that has a custom state to that custom state. More information

--- a/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
+++ b/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
@@ -52,8 +52,7 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
                                  checking channelsToCheck: FlaggableFeatureCheckOptions
     ) -> Bool {
         let feature = NimbusFlaggableFeature(withID: featureID, and: profile)
-
-        let nimbusSetting = feature.isNimbusEnabled(using: nimbusFlags)
+        let nimbusSetting = getNimbusOrDebugSetting(with: feature)
         let userSetting = feature.isUserEnabled(using: nimbusFlags)
 
         switch channelsToCheck {
@@ -64,6 +63,15 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
         case .userOnly:
             return userSetting
         }
+    }
+
+    /// Allows us to override nimbus feature flags for a specific build using the debug menu
+    private func getNimbusOrDebugSetting(with feature: NimbusFlaggableFeature) -> Bool {
+        #if MOZ_CHANNEL_BETA || MOZ_CHANNEL_FENNEC
+        return feature.isDebugEnabled(using: nimbusFlags)
+        #else
+        return feature.isNimbusEnabled(using: nimbusFlags)
+        #endif
     }
 
     /// Retrieves a custom state for any type of feature that has more than just a

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -126,7 +126,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
         return option
     }
 
-    /// Returns whether or not the feature's state was changed by using our Feature Flags debug setting. If no preference exists, then the underlying Nimbus default is used. If a specific
+    /// Returns whether or not the feature's state was changed by using our Feature Flags debug setting. 
+    /// If no preference exists, then the underlying Nimbus default is used. If a specific
     /// setting is used, then we should check for the debug key used.
     public func isDebugEnabled(using nimbusLayer: NimbusFeatureFlagLayer) -> Bool {
         guard let optionsKey = featureKey,

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -66,6 +66,10 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
         case .jumpBackIn:
             return FlagKeys.JumpBackInSection
 
+        // Cases where users manipulate a setting via debug menu.
+        case .microsurvey:
+            return featureID.rawValue + FlagKeys.DebugPrefixKey
+
         // Cases where users do not have the option to manipulate a setting.
         case .contextualHintForToolbar,
                 .accountSettingsRedux,
@@ -78,7 +82,6 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .isToolbarCFREnabled,
                 .loginAutofill,
                 .menuRefactor,
-                .microsurvey,
                 .nightMode,
                 .preferSwitchToOpenTabOverDuplicate,
                 .reduxSearchSettings,
@@ -117,6 +120,17 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
     /// then we should be using `getUserPreference`
     public func isUserEnabled(using nimbusLayer: NimbusFeatureFlagLayer) -> Bool {
         guard let optionsKey = featureKey,
+              let option = profile.prefs.boolForKey(optionsKey)
+        else { return isNimbusEnabled(using: nimbusLayer) }
+
+        return option
+    }
+
+    /// Returns whether or not the feature's state was changed by using our Feature Flags debug setting. If no preference exists, then the underlying Nimbus default is used. If a specific
+    /// setting is used, then we should check for the debug key used.
+    public func isDebugEnabled(using nimbusLayer: NimbusFeatureFlagLayer) -> Bool {
+        guard let optionsKey = featureKey,
+              optionsKey.contains(PrefsKeys.FeatureFlags.DebugPrefixKey),
               let option = profile.prefs.boolForKey(optionsKey)
         else { return isNimbusEnabled(using: nimbusLayer) }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -20,6 +20,7 @@ protocol SettingsFlowDelegate: AnyObject,
     func showExperiments()
     func showFirefoxSuggest()
     func openDebugTestTabs(count: Int)
+    func showDebugFeatureFlags()
     func showPasswordManager(shouldShowOnboarding: Bool)
     func didFinishShowingSettings()
 }
@@ -341,7 +342,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getDebugSettings() -> [SettingSection] {
-        let hiddenDebugOptions = [
+        var hiddenDebugOptions = [
             ExperimentsSettings(settings: self, settingsDelegate: self),
             ExportLogDataSetting(settings: self),
             ExportBrowserDataSetting(settings: self),
@@ -357,9 +358,13 @@ class AppSettingsTableViewController: SettingsTableViewController,
             SentryIDSetting(settings: self, settingsDelegate: self),
             FasterInactiveTabs(settings: self, settingsDelegate: self),
             OpenFiftyTabsDebugOption(settings: self, settingsDelegate: self),
-            FirefoxSuggestSettings(settings: self, settingsDelegate: self),
+            FirefoxSuggestSettings(settings: self, settingsDelegate: self)
         ]
 
+        #if MOZ_CHANNEL_BETA || MOZ_CHANNEL_FENNEC
+        hiddenDebugOptions.append(FeatureFlagsSettings(settings: self, settingsDelegate: self))
+        #endif
+        
         return [SettingSection(title: NSAttributedString(string: "Debug"), children: hiddenDebugOptions)]
     }
 
@@ -393,6 +398,10 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
     func pressedOpenFiftyTabs() {
         parentCoordinator?.openDebugTestTabs(count: 50)
+    }
+
+    func pressedDebugFeatureFlags() {
+        parentCoordinator?.showDebugFeatureFlags()
     }
 
     // MARK: SharedSettingsDelegate

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -364,7 +364,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         #if MOZ_CHANNEL_BETA || MOZ_CHANNEL_FENNEC
         hiddenDebugOptions.append(FeatureFlagsSettings(settings: self, settingsDelegate: self))
         #endif
-        
+
         return [SettingSection(title: NSAttributedString(string: "Debug"), children: hiddenDebugOptions)]
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/DebugSettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/DebugSettingsDelegate.swift
@@ -12,4 +12,5 @@ protocol DebugSettingsDelegate: AnyObject, SharedSettingsDelegate {
     func pressedExperiments()
     func pressedFirefoxSuggest()
     func pressedOpenFiftyTabs()
+    func pressedDebugFeatureFlags()
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsBoolSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsBoolSetting.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class FeatureFlagsBoolSetting: BoolSetting {
+    override func displayBool(_ control: UISwitch) {
+        if let featureFlagName = getFeatureFlagName() {
+            control.isOn = featureFlags.isFeatureEnabled(
+                featureFlagName,
+                checking: .buildOnly
+            )
+        } else {
+            guard let key = prefKey, let defaultValue = getDefaultValue(), let prefs = getPrefs() else { return }
+            control.isOn = prefs.boolForKey(key) ?? defaultValue
+        }
+    }
+
+    override func writeBool(_ control: UISwitch) {
+        if let featureFlagName = getFeatureFlagName() {
+            featureFlags.set(feature: featureFlagName, to: control.isOn)
+        } else {
+            guard let key = prefKey, let prefs = getPrefs() else {
+                return
+            }
+            prefs.setBool(control.isOn, forKey: key)
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsBoolSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsBoolSetting.swift
@@ -19,11 +19,9 @@ class FeatureFlagsBoolSetting: BoolSetting {
 
     override func writeBool(_ control: UISwitch) {
         if let featureFlagName = getFeatureFlagName() {
-            featureFlags.set(feature: featureFlagName, to: control.isOn)
+            featureFlags.set(feature: featureFlagName, to: control.isOn, isDebug: true)
         } else {
-            guard let key = prefKey, let prefs else {
-                return
-            }
+            guard let key = prefKey, let prefs else { return }
             prefs.setBool(control.isOn, forKey: key)
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsBoolSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsBoolSetting.swift
@@ -12,7 +12,7 @@ class FeatureFlagsBoolSetting: BoolSetting {
                 checking: .buildOnly
             )
         } else {
-            guard let key = prefKey, let defaultValue = getDefaultValue(), let prefs = getPrefs() else { return }
+            guard let key = prefKey, let defaultValue = getDefaultValue(), let prefs else { return }
             control.isOn = prefs.boolForKey(key) ?? defaultValue
         }
     }
@@ -21,7 +21,7 @@ class FeatureFlagsBoolSetting: BoolSetting {
         if let featureFlagName = getFeatureFlagName() {
             featureFlags.set(feature: featureFlagName, to: control.isOn)
         } else {
-            guard let key = prefKey, let prefs = getPrefs() else {
+            guard let key = prefKey, let prefs else {
                 return
             }
             prefs.setBool(control.isOn, forKey: key)

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+
+/// A view controller that manages the hidden Firefox Suggest debug settings.
+final class FeatureFlagsDebugViewController: SettingsTableViewController, FeatureFlaggable {
+    init(windowUUID: WindowUUID) {
+        super.init(style: .grouped, windowUUID: windowUUID)
+        self.title = "Feature Flags"
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func generateSettings() -> [SettingSection] {
+        return [generateFeatureFlagToggleSettings(), generateFeatureFlagList()]
+    }
+
+    private func generateFeatureFlagToggleSettings() -> SettingSection {
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        let microsurveySetting = FeatureFlagsBoolSetting(
+            with: .microsurvey,
+            titleText: NSAttributedString(
+                string: "Enable Microsurvey",
+                attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]),
+            statusText: NSAttributedString(
+                string: "Toggle to reset microsurvey expiration",
+                attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
+        ) { [weak self] _ in
+            UserDefaults.standard.set(nil, forKey: "\(GleanPlumbMessageStore.rootKey)\("homepage-microsurvey-message")")
+            guard let self else { return }
+            self.reloadView()
+        }
+        return SettingSection(title: nil, children: [microsurveySetting])
+    }
+
+    private func generateFeatureFlagList() -> SettingSection {
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        let flags = NimbusFeatureFlagID.allCases
+        let settingsList = flags.compactMap { flagID in
+            return Setting(title: NSAttributedString(
+                string: "\(flagID): \(featureFlags.isFeatureEnabled(flagID, checking: .buildOnly))",
+                attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
+            )
+        }
+        return SettingSection(
+            title: NSAttributedString(string: "Build only status"),
+            children: settingsList
+        )
+    }
+
+    private func reloadView() {
+        self.settings = self.generateSettings()
+        self.tableView.reloadData()
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -32,8 +32,7 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
         ) { [weak self] _ in
             UserDefaults.standard.set(nil, forKey: "\(GleanPlumbMessageStore.rootKey)\("homepage-microsurvey-message")")
-            guard let self else { return }
-            self.reloadView()
+            self?.reloadView()
         }
         return SettingSection(title: nil, children: [microsurveySetting])
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsSettings.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsSettings.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// A hidden setting for accessing the Feature Flags debug settings.
+final class FeatureFlagsSettings: HiddenSetting {
+    private weak var settingsDelegate: DebugSettingsDelegate?
+
+    override var title: NSAttributedString? { return NSAttributedString(string: "Feature Flags") }
+
+    init(settings: SettingsTableViewController, settingsDelegate: DebugSettingsDelegate) {
+        self.settingsDelegate = settingsDelegate
+        super.init(settings: settings)
+    }
+
+    override func onClick(_: UINavigationController?) {
+        settingsDelegate?.pressedDebugFeatureFlags()
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -206,7 +206,7 @@ class BoolSetting: Setting, FeatureFlaggable {
     // Sometimes a subclass will manage its own pref setting. In that case the prefkey will be nil
     let prefKey: String?
 
-    private let prefs: Prefs?
+    let prefs: Prefs?
     private let defaultValue: Bool?
     private let settingDidChange: ((Bool) -> Void)?
     private let statusText: NSAttributedString?
@@ -352,10 +352,6 @@ class BoolSetting: Setting, FeatureFlaggable {
 
     func getDefaultValue() -> Bool? {
         return defaultValue
-    }
-
-    func getPrefs() -> Prefs? {
-        return prefs
     }
 
     // These methods allow a subclass to control how the pref is saved

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -354,6 +354,10 @@ class BoolSetting: Setting, FeatureFlaggable {
         return defaultValue
     }
 
+    func getPrefs() -> Prefs? {
+        return prefs
+    }
+
     // These methods allow a subclass to control how the pref is saved
     func displayBool(_ control: UISwitch) {
         if let featureFlagName = featureFlagName {

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -71,7 +71,7 @@ public struct PrefsKeys {
 
     // For ease of use, please list keys alphabetically.
     public struct FeatureFlags {
-        public static let DebugPrefixKey = "DebugKey"
+        public static let DebugSuffixKey = "DebugKey"
         public static let FirefoxSuggest = "FirefoxSuggest"
         public static let HistoryHighlightsSection = "HistoryHighlightsSectionUserPrefsKey"
         public static let InactiveTabs = "InactiveTabsUserPrefsKey"

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -71,6 +71,7 @@ public struct PrefsKeys {
 
     // For ease of use, please list keys alphabetically.
     public struct FeatureFlags {
+        public static let DebugPrefixKey = "DebugKey"
         public static let FirefoxSuggest = "FirefoxSuggest"
         public static let HistoryHighlightsSection = "HistoryHighlightsSectionUserPrefsKey"
         public static let InactiveTabs = "InactiveTabsUserPrefsKey"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockAppSettingsDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockAppSettingsDelegate.swift
@@ -30,6 +30,8 @@ class MockDebugSettingsDelegate: DebugSettingsDelegate {
 
     func pressedOpenFiftyTabs() {}
 
+    func pressedDebugFeatureFlags() {}
+
     func askedToShow(alert: AlertController) {
         askedToShowAlertCalled += 1
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -40,6 +40,8 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
 
     func openDebugTestTabs(count: Int) {}
 
+    func showDebugFeatureFlags() { }
+
     func showPasswordManager(shouldShowOnboarding: Bool) {
         savedShouldShowOnboarding = shouldShowOnboarding
         showPasswordManagerCalled += 1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9455)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20936)

## :bulb: Description
Proposal to add a debug menu setting for feature flags. Added an example with microsurvey in allowing user to enable / disable feature flags as well as having this to trigger a microsurvey prompt.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots 
| Page 1 | Page 2 |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 - 2024-07-19 at 12 30 48](https://github.com/user-attachments/assets/5de744d5-4e1a-4e5a-9129-dd32ac26ff87) | ![simulator_screenshot_35B69675-BF23-45DF-A161-213D8874B916](https://github.com/mozilla-mobile/firefox-ios/assets/6743397/132fd863-e47e-492f-a3b7-f5ae26d7a161) |