### PR TITLE
Bugfix FXIOS-9479 [Microsurvey] Privacy notice does not open in correct mode

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyCoordinator.swift
@@ -42,13 +42,13 @@ final class MicrosurveyCoordinator: BaseCoordinator, FeatureFlaggable, Microsurv
     }
 
     func showPrivacy(with content: String?) {
-        // TODO: FXIOS-8976 - Add to Support Utils
         guard let url = SupportUtils.URLForPrivacyNotice(
             source: UTMParams.source,
             campaign: UTMParams.campaign,
             content: content
         ) else { return }
-        tabManager.addTabsForURLs([url], zombie: false, shouldSelectTab: true)
+        let currentTab = tabManager.selectedTab?.isPrivate ?? false
+        tabManager.addTabsForURLs([url], zombie: false, shouldSelectTab: true, isPrivate: currentTab)
         router.dismiss(animated: true, completion: nil)
         parentCoordinator?.didFinish(from: self)
     }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -359,14 +359,14 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
                       isPrivate: isPrivate)
     }
 
-    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool) {
+    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool, isPrivate: Bool) {
         if urls.isEmpty {
             return
         }
 
         var tab: Tab!
         for url in urls {
-            tab = addTab(URLRequest(url: url), flushToDisk: false, zombie: zombie)
+            tab = addTab(URLRequest(url: url), flushToDisk: false, zombie: zombie, isPrivate: isPrivate)
         }
 
         if shouldSelectTab {

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -36,7 +36,7 @@ protocol TabManager: AnyObject {
     func removeDelegate(_ delegate: TabManagerDelegate, completion: (() -> Void)?)
     func selectTab(_ tab: Tab?, previous: Tab?)
     func addTab(_ request: URLRequest?, afterTab: Tab?, isPrivate: Bool) -> Tab
-    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool)
+    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool, isPrivate: Bool)
     func removeTab(_ tab: Tab, completion: (() -> Void)?)
     func removeTabs(_ tabs: [Tab])
     func undoCloseTab()
@@ -148,7 +148,7 @@ extension TabManager {
                                 didClearTabs: didClearTabs)
     }
 
-    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool = true) {
-        addTabsForURLs(urls, zombie: zombie, shouldSelectTab: shouldSelectTab)
+    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool = true, isPrivate: Bool = false) {
+        addTabsForURLs(urls, zombie: zombie, shouldSelectTab: shouldSelectTab, isPrivate: isPrivate)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -77,7 +77,7 @@ class MockTabManager: TabManager {
 
     func removeDelegate(_ delegate: TabManagerDelegate, completion: (() -> Void)?) {}
 
-    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool) {
+    func addTabsForURLs(_ urls: [URL], zombie: Bool, shouldSelectTab: Bool, isPrivate: Bool) {
         addTabsForURLsCalled += 1
         addTabsURLs = urls
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -25,7 +25,6 @@ class TabManagerTests: XCTestCase {
 
         DependencyHelperMock().bootstrapDependencies()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
-    
         // For this test suite, use a consistent window UUID for all test cases
         let windowManager: WindowManager = AppContainer.shared.resolve()
         let uuid = windowManager.activeWindow

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -24,7 +24,8 @@ class TabManagerTests: XCTestCase {
         super.setUp()
 
         DependencyHelperMock().bootstrapDependencies()
-
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
+    
         // For this test suite, use a consistent window UUID for all test cases
         let windowManager: WindowManager = AppContainer.shared.resolve()
         let uuid = windowManager.activeWindow
@@ -184,6 +185,26 @@ class TabManagerTests: XCTestCase {
 
         // Expect 2 of 3 tabs are inactive (except 1st)
         XCTAssertEqual(inactiveTabs.count, expectedInactiveTabs)
+    }
+
+    func test_addTabsForURLs() {
+        let subject = createSubject()
+
+        subject.addTabsForURLs([URL(string: "https://www.mozilla.org/privacy/firefox")!], zombie: false, shouldSelectTab: false)
+
+        XCTAssertEqual(subject.tabs.count, 1)
+        XCTAssertEqual(subject.tabs.first?.url?.absoluteString, "https://www.mozilla.org/privacy/firefox")
+        XCTAssertEqual(subject.tabs.first?.isPrivate, false)
+    }
+
+    func test_addTabsForURLs_forPrivateMode() {
+        let subject = createSubject()
+
+        subject.addTabsForURLs([URL(string: "https://www.mozilla.org/privacy/firefox")!], zombie: false, shouldSelectTab: false, isPrivate: true)
+
+        XCTAssertEqual(subject.tabs.count, 1)
+        XCTAssertEqual(subject.tabs.first?.url?.absoluteString, "https://www.mozilla.org/privacy/firefox")
+        XCTAssertEqual(subject.tabs.first?.isPrivate, true)
     }
 
     // MARK: - Helper methods


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9479)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20973)

## :bulb: Description
Fix bug in which tapping privacy notice in private mode was opening in normal mode. This is due to `addTabsForURLs` not accounting for if the url should show as private tab or normal tab. Wrote some tests to verify. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots

https://github.com/mozilla-mobile/firefox-ios/assets/6743397/cce8a23b-e281-4139-994c-e0830fdcf836


