### PR TITLE
Bugfix FXIOS-9438 Clear "Add card" form after dismissal

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1099,6 +1099,7 @@
 		C4E398601D22C409004E89BA /* TopTabsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E3985F1D22C409004E89BA /* TopTabsLayout.swift */; };
 		C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */; };
 		C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F3B2991CFCF93A00966259 /* ButtonToast.swift */; };
+		C706CBEF2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C706CBEE2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift */; };
 		C787D8C32C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */; };
 		C80685D126A0C93900DCD895 /* UserResearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80685D026A0C93900DCD895 /* UserResearch.swift */; };
 		C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C807CCCB28367446008E6A5A /* FeatureFlagManagerTests.swift */; };
@@ -7151,6 +7152,7 @@
 		C6A44DE7A0A9155777FDAD1C /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C6AF4D4DBE2C76759B1DDE6B /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C6C94C1CB6286845DEAF8EDD /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		C706CBEE2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardSettingsViewControllerTests.swift; sourceTree = "<group>"; };
 		C7354071A05454E7FF3C70D8 /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		C7664A29B78A808DC314353C /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Search.strings; sourceTree = "<group>"; };
 		C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxAccountSignInViewControllerTests.swift; sourceTree = "<group>"; };
@@ -9464,6 +9466,7 @@
 				967EDABE29D769A10089208D /* CreditCardInputFieldTests.swift */,
 				43B658D829CE251C00C9EF08 /* CreditCardInputViewModelTests.swift */,
 				967EDABC29D705300089208D /* CreditCardValidatorTests.swift */,
+				C706CBEE2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift */,
 			);
 			path = CreditCard;
 			sourceTree = "<group>";
@@ -15268,6 +15271,7 @@
 				E14C78962C105488002AD3C7 /* AddressToolbarContainerModelTests.swift in Sources */,
 				C889D7D52858CD8800121E1D /* HistoryHighlightsTestEntryProvider.swift in Sources */,
 				C2A72A6B2A77AC10002ACCE2 /* ReadingListCoordinatorTests.swift in Sources */,
+				C706CBEF2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift in Sources */,
 				E19B38B128A3E69300D8C541 /* WallpaperCollectionAvailabilityTests.swift in Sources */,
 				8A359EF62A1FE840004A5BB7 /* MockAdjustWrapper.swift in Sources */,
 				8AC225662B6D403200CDA7FD /* HomepageTelemetryTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewController.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 import struct MozillaAppServices.CreditCard
 
-class CreditCardSettingsViewController: SensitiveViewController, Themeable {
+class CreditCardSettingsViewController: SensitiveViewController, UIAdaptivePresentationControllerDelegate, Themeable {
     var viewModel: CreditCardSettingsViewModel
     var themeObserver: NSObjectProtocol?
     var themeManager: ThemeManager
@@ -187,6 +187,7 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
         guard let creditCardAddEditView = creditCardAddEditView else { return}
         creditCardAddEditView.view.backgroundColor = .clear
         creditCardAddEditView.modalPresentationStyle = .formSheet
+        creditCardAddEditView.presentationController?.delegate = self
         present(creditCardAddEditView, animated: true, completion: nil)
     }
 
@@ -249,5 +250,12 @@ class CreditCardSettingsViewController: SensitiveViewController, Themeable {
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .change,
                                      object: .creditCardModified)
+    }
+
+    // MARK: - UIAdaptivePresentationControllerDelegate
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        if presentationController.presentedViewController is UIHostingController<CreditCardInputView> {
+            viewModel.cardInputViewModel.clearValues()
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardSettingsViewControllerTests.swift
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import SwiftUI
+import Common
+@testable import Client
+
+final class CreditCardSettingsViewControllerTests: XCTestCase {
+    var profile: MockProfile!
+    var viewModel: CreditCardInputViewModel!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        profile = MockProfile()
+        viewModel = CreditCardInputViewModel(profile: profile)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        DependencyHelperMock().reset()
+        profile = nil
+        viewModel = nil
+    }
+
+    func testInputViewFormValuesClearedOnDismiss() {
+        let subject = createSubject()
+        subject.viewModel.cardInputViewModel.nameOnCard = "Ashton Mealy"
+        subject.viewModel.cardInputViewModel.cardNumber = "4268811063712243"
+        subject.viewModel.cardInputViewModel.expirationDate = "1288"
+        let creditCardInputView = CreditCardInputView(viewModel: viewModel, windowUUID: WindowUUID.XCTestDefaultUUID)
+        let hostingController = UIHostingController(rootView: creditCardInputView)
+        subject.present(hostingController, animated: true)
+        let presentationController = UIPresentationController(
+            presentedViewController: hostingController,
+            presenting: subject
+        )
+
+        // Dismissing CreditCardInputView should clear form values
+        subject.presentationControllerDidDismiss(presentationController)
+
+        XCTAssertTrue(subject.viewModel.cardInputViewModel.nameOnCard.isEmpty)
+        XCTAssertTrue(subject.viewModel.cardInputViewModel.cardNumber.isEmpty)
+        XCTAssertTrue(subject.viewModel.cardInputViewModel.expirationDate.isEmpty)
+    }
+
+    private func createSubject() -> CreditCardSettingsViewController {
+        let creditCardSettingsViewModel = CreditCardSettingsViewModel(
+            profile: profile,
+            windowUUID: WindowUUID.XCTestDefaultUUID
+        )
+        creditCardSettingsViewModel.toggleModel = ToggleModel(isEnabled: false)
+        let subject = CreditCardSettingsViewController(creditCardViewModel: creditCardSettingsViewModel)
+        return subject
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9438)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20889)

## :bulb: Description
- Clear the values in the fields of the "Add card" form when the sheet is dismissed via swiping down so that they do not re-appear when the form is presented next time

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

