### PR TITLE
Bugfix FXIOS-9103 Fix favicons flickering when tab closes

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -390,16 +390,17 @@ class TabManagerMiddleware {
                                                           actionType: TabPanelMiddlewareActionType.showToast)
                     store.dispatch(action)
                 } else {
-                    let dismissAction = TabTrayAction(windowUUID: uuid,
-                                                      actionType: TabTrayActionType.dismissTabTray)
-                    store.dispatch(dismissAction)
-
                     let toastAction = GeneralBrowserAction(toastType: .closedAllTabs(count: normalCount),
                                                            windowUUID: uuid,
                                                            actionType: GeneralBrowserActionType.showToast)
                     store.dispatch(toastAction)
                 }
             }
+        }
+        if tabsState.isPrivateMode == false {
+            let dismissAction = TabTrayAction(windowUUID: uuid,
+                                              actionType: TabTrayActionType.dismissTabTray)
+            store.dispatch(dismissAction)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -397,7 +397,8 @@ class TabManagerMiddleware {
                 }
             }
         }
-        if tabsState.isPrivateMode == false {
+
+        if !tabsState.isPrivateMode {
             let dismissAction = TabTrayAction(windowUUID: uuid,
                                               actionType: TabTrayActionType.dismissTabTray)
             store.dispatch(dismissAction)

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -572,7 +572,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         self.updateIndexAfterRemovalOf(tab, deletedIndex: index, viableTabsIndex: viableTabsIndex)
 
         // TODO: FXIOS-9084 This is not ideal, follow up in this ticket to make tab selection reasonably synchronous
-        try? await Task.sleep(nanoseconds: NSEC_PER_SEC/10)
+       // try? await Task.sleep(nanoseconds: NSEC_PER_SEC/10)
 
         TelemetryWrapper.recordEvent(
             category: .action,

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -571,9 +571,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         self.removeTab(tab, flushToDisk: true)
         self.updateIndexAfterRemovalOf(tab, deletedIndex: index, viableTabsIndex: viableTabsIndex)
 
-        // TODO: FXIOS-9084 This is not ideal, follow up in this ticket to make tab selection reasonably synchronous
-       // try? await Task.sleep(nanoseconds: NSEC_PER_SEC/10)
-
         TelemetryWrapper.recordEvent(
             category: .action,
             method: .close,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9103)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20185)

## :bulb: Description
In the tab tray refactor I noticed when testing to repro this issue that in the Legacy Tab Tray we just dismiss the tab tray when we close all tabs. This results in us not seeing this flickering behavior in the favicons, and also more closely replicates the behavior of the original tab tray, which Andy approved.

### Before
https://github.com/mozilla-mobile/firefox-ios/assets/5545720/ccdf6a6c-d088-45e0-850d-b47d50c27d09

### After
https://github.com/mozilla-mobile/firefox-ios/assets/5545720/4545d297-d23a-49ec-80fd-e76138d1523c


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

