### PR TITLE
Bugfix MTE-2910 Download derived data prior to running the tests

### DIFF
--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -81,7 +81,10 @@ jobs:
               uses: actions/download-artifact@v4
               with:
                 name: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
-                path: ~/DerivedData/Build/Products
+            - name: Decompress derived data
+              id: decompress-dd
+              run: |
+                tar xzf derived-data.tar.gz -C /
             - name: Run tests
               id: run-tests
               run: |

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -68,6 +68,20 @@ jobs:
               run: |
                 gem install xcpretty -v 0.3.0
                 pip install blockkit==1.9.1
+            - name: Setup Xcode
+              id: xcode
+              run: |
+                sudo rm -rf /Applications/Xcode.app
+                sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app/Contents/Developer
+                xcodebuild -version
+                ./checkout.sh
+                ./bootstrap.sh --force
+            - name: Get derived data
+              id: download-derived-data
+              uses: actions/download-artifact@v4
+              with:
+                name: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
+                path: ~/DerivedData/Build/Products
             - name: Run tests
               id: run-tests
               run: |


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2910)

## :bulb: Description
I forgot to copy over the code to download and decompress the derived data so that no tests were run. Here are the steps to retrieve the derived data.

Github Actions Job: https://github.com/mozilla-mobile/firefox-ios/actions/runs/9895322474/job/27335407264

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

