### PR TITLE
Bugfix AE-460 Update URLs for Sponsored Tiles

### DIFF
--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
@@ -25,8 +25,8 @@ extension ContileProviderInterface {
 /// `Contile` is short for contextual tiles. This provider returns data that is used in
 /// Shortcuts (Top Sites) section on the Firefox home page.
 class ContileProvider: ContileProviderInterface, URLCaching, FeatureFlaggable {
-    private static let contileProdResourceEndpoint = "https://contile.services.mozilla.com/v1/tiles"
-    static let contileStagingResourceEndpoint = "https://contile-stage.topsites.nonprod.cloudops.mozgcp.net/v1/tiles"
+    private static let contileProdResourceEndpoint = "https://ads.mozilla.org/v1/tiles"
+    static let contileStagingResourceEndpoint = "https://ads.allizom.org/v1/tiles"
 
     var urlCache: URLCache
     private var logger: Logger


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/AE-460)

## :bulb: Description
Contile is deprecated, and has been replaced by MARS. While we have retained the production URL for backwards compatibility, the staging URL for Contile will stop working soon.

This changes both URLs (production and staging) to point at newer, shorter URLs for MARS.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
