### PR TITLE
Add MTE-2908 Enable us to start tests manaully

### DIFF
--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -1,6 +1,7 @@
 name: "Focus UI Tests"
 
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: "0 1 * * *"
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2908)

## :bulb: Description
We should be able to trigger a workflow manually in addition to running the workflow nightly. In the case of release branches, this feature is needed because workflow does not run automatically on release branches.

I could trigger a workflow while maintaining the schedule: https://github.com/clarmso/firefox-ios/actions/runs/9900928287

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

