### PR TITLE
Add MTE-2909 Add Firefox smoke tests

### DIFF
--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -1,7 +1,9 @@
 name: "Firefox UI Tests"
     
 on:
-    workflow_dispatch:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 2 * * *"
 
 env:
     browser: firefox-ios

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -51,7 +51,151 @@ jobs:
                 name: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
                 path: ./derived-data.tar.gz
                 retention-days: 2
-                
+
+    run-smoketests:
+      name: Run smoke tests
+      runs-on: macos-14
+      needs: compile
+      strategy:
+        fail-fast: false
+        matrix:
+          ios_simulator: ['iPhone 15 Plus']
+      steps:
+      - name: Check out source code
+        uses: actions/checkout@v4.1.7
+      - name: Install packages
+        id: packages
+        run: |
+          gem install xcpretty -v 0.3.0
+          pip install blockkit==1.9.1
+          npm install -g junit-report-merger@7.0.0       
+      - name: Setup Xcode
+        id: xcode
+        run: |
+          sudo rm -rf /Applications/Xcode.app
+          sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app/Contents/Developer
+          xcodebuild -version
+          ./checkout.sh
+          ./bootstrap.sh --force
+      - name: Get derived data
+        id: download-derived-data
+        uses: actions/download-artifact@v4
+        with:
+          name: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
+      - name: Decompress derived data
+        id: decompress-dd
+        run: |
+          tar xzf derived-data.tar.gz -C /
+      - name: Run Smoketest1
+        id: run-smoketest1
+        run: |
+          xcodebuild \
+            test-without-building \
+            -scheme ${{ env.xcodebuild_scheme }} \
+            -target ${{ env.xcodebuild_target }} \
+            -derivedDataPath ~/DerivedData \
+            -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
+            -testPlan Smoketest1 \
+            -resultBundlePath ${{ env.test_results_directory }}/results-smoketest1 \
+            | tee xcodebuild.log | xcpretty -r junit --output ./junit-smoketest1.xml && exit ${PIPESTATUS[0]}
+        working-directory:  ${{ env.browser }}
+        continue-on-error: true
+      - name: Run Smoketest2
+        id: run-smoketest2
+        run: |
+          xcodebuild \
+            test-without-building \
+            -scheme ${{ env.xcodebuild_scheme }} \
+            -target ${{ env.xcodebuild_target }} \
+            -derivedDataPath ~/DerivedData \
+            -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
+            -testPlan Smoketest2 \
+            -resultBundlePath ${{ env.test_results_directory }}/results-smoketest2 \
+            | tee xcodebuild.log | xcpretty -r junit --output ./junit-smoketest2.xml && exit ${PIPESTATUS[0]}
+        working-directory:  ${{ env.browser }}
+        continue-on-error: true
+      - name: Run Smoketest3
+        id: run-smoketest3
+        run: |
+          xcodebuild \
+            test-without-building \
+            -scheme ${{ env.xcodebuild_scheme }} \
+            -target ${{ env.xcodebuild_target }} \
+            -derivedDataPath ~/DerivedData \
+            -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
+            -testPlan Smoketest3 \
+            -resultBundlePath ${{ env.test_results_directory }}/results-smoketest3 \
+            | tee xcodebuild.log | xcpretty -r junit --output ./junit-smoketest3.xml && exit ${PIPESTATUS[0]}
+        working-directory:  ${{ env.browser }}
+        continue-on-error: true
+      - name: Run Smoketest4
+        id: run-smoketest4
+        run: |
+          xcodebuild \
+            test-without-building \
+            -scheme ${{ env.xcodebuild_scheme }} \
+            -target ${{ env.xcodebuild_target }} \
+            -derivedDataPath ~/DerivedData \
+            -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
+            -testPlan Smoketest4 \
+            -resultBundlePath ${{ env.test_results_directory }}/results-smoketest4 \
+            | tee xcodebuild.log | xcpretty -r junit --output ./junit-smoketest4.xml && exit ${PIPESTATUS[0]}
+        working-directory:  ${{ env.browser }}
+        continue-on-error: true
+      - name: Determine pass/fail status
+        id: passfail
+        run: |
+          if [[ ${{ steps.run-smoketest1.outcome }} != 'success' 
+                || ${{ steps.run-smoketest2.outcome }} != 'success'  
+                || ${{ steps.run-smoketest3.outcome }} != 'success' 
+                || ${{ steps.run-smoketest4.outcome }} != 'success' ]]; then
+            exit 1
+          else
+            exit 0
+          fi
+        continue-on-error: true
+      - name: Print test report
+        id: test-report
+        run: |
+          jrm combined.xml junit-*.xml
+          python ../test-fixtures/ci/convert_junit_to_markdown.py --smoke --github --${{ env.browser }} ./combined.xml ./github.md
+          cat github.md >> $GITHUB_STEP_SUMMARY
+          python ../test-fixtures/ci/convert_junit_to_markdown.py --smoke --slack --${{ env.browser }} ./combined.xml ./slack.json
+          working-directory:  ${{ env.browser }}
+      - name: Upload junit files
+        id: upload-junit
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: ${{ env.browser }}-smoketests-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
+          path: ${{ env.browser }}/junit-*.xml
+          retention-days: 90
+      - name: Upload log file
+        id: upload-log
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: ${{ env.browser }}-smoketests-${{ matrix.ios_simulator }}-xcodebuildlog-${{ github.run_number }}
+          path: ${{ env.browser }}/xcodebuild.log
+          retention-days: 90
+      - name: Report to Slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload-file-path: ${{ env.browser }}/slack.json
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          ios_simulator: ${{ matrix.ios_simulator }}
+          pass_fail:  ${{ steps.passfail.outcome == 'success' && ':white_check_mark:' || ':x:' }}
+          xcodebuild_test_plan: Smoketests
+          ref_name: ${{ github.ref_name }}
+          repository: ${{ github.repository }}
+          run_id: ${{ github.run_id }}
+          server_url: ${{ github.server_url }}
+          sha: ${{ github.sha }}
+      - name: Return fail status if a test fails
+        run: |
+          exit ${{ steps.passfail.outcome == 'success' && '0' || '1' }}   
+
     run-fullfunctionaltests:
         name: Run full functional tests
         runs-on: macos-14
@@ -68,6 +212,15 @@ jobs:
               run: |
                 gem install xcpretty -v 0.3.0
                 pip install blockkit==1.9.1
+            - name: Get derived data
+              id: download-derived-data
+              uses: actions/download-artifact@v4
+              with:
+                name: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
+            - name: Decompress derived data
+              id: decompress-dd
+              run: |
+                tar xzf derived-data.tar.gz -C /
             - name: Run tests
               id: run-tests
               run: |
@@ -89,11 +242,18 @@ jobs:
                 cat github.md >> $GITHUB_STEP_SUMMARY
                 python ../test-fixtures/ci/convert_junit_to_markdown.py --slack --${{ env.browser }} ./build/reports/junit.xml ./slack.json
               working-directory:  ${{ env.browser }}
+            - name: Upload junit files
+              id: upload-junit
+              uses: actions/upload-artifact@v4.3.3
+              with:
+                name: ${{ env.browser }}-fullfunctional-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
+                path: ${{ env.browser }}/junit-*.xml
+                retention-days: 90
             - name: Upload log file
               id: upload-log
               uses: actions/upload-artifact@v4.3.3
               with:
-                name: ${{ env.browser }}-FullFunctionalTestPlan-${{ matrix.ios_simulator }}-xcodebuildlog-${{ github.run_number }}
+                name: ${{ env.browser }}-fullfunctional-${{ matrix.ios_simulator }}-xcodebuildlog-${{ github.run_number }}
                 path: ${{ env.browser }}/xcodebuild.log
                 retention-days: 90
             - name: Report to Slack

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -1,9 +1,9 @@
 name: "Firefox UI Tests"
     
 on:
-  workflow_dispatch: {}
-  schedule:
-    - cron: "0 2 * * *"
+    workflow_dispatch: {}
+    schedule:
+      - cron: "0 2 * * *"
 
 env:
     browser: firefox-ios

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -165,7 +165,7 @@ jobs:
           python ../test-fixtures/ci/convert_junit_to_markdown.py --smoke --github --${{ env.browser }} ./combined.xml ./github.md
           cat github.md >> $GITHUB_STEP_SUMMARY
           python ../test-fixtures/ci/convert_junit_to_markdown.py --smoke --slack --${{ env.browser }} ./combined.xml ./slack.json
-          working-directory:  ${{ env.browser }}
+        working-directory:  ${{ env.browser }}
       - name: Upload junit files
         id: upload-junit
         uses: actions/upload-artifact@v4.3.3

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -145,6 +145,10 @@ jobs:
       - name: Determine pass/fail status
         id: passfail
         run: |
+          echo "Smoketest1 status: "${{ steps.run-smoketest1.outcome }}
+          echo "Smoketest2 status: "${{ steps.run-smoketest2.outcome }}
+          echo "Smoketest3 status: "${{ steps.run-smoketest3.outcome }}
+          echo "Smoketest4 status: "${{ steps.run-smoketest4.outcome }}
           if [[ ${{ steps.run-smoketest1.outcome }} != 'success' 
                 || ${{ steps.run-smoketest2.outcome }} != 'success'  
                 || ${{ steps.run-smoketest3.outcome }} != 'success' 

--- a/test-fixtures/ci/convert_junit_to_markdown.py
+++ b/test-fixtures/ci/convert_junit_to_markdown.py
@@ -9,7 +9,6 @@ import xml.etree.ElementTree as ET
 import json
 import re
 from blockkit import Context, Divider, Header, Message, Section
-import re
 
 # Modified from junit_to_markdown
 # https://github.com/stevengoossensB/junit_to_markdown/tree/main
@@ -89,6 +88,10 @@ def count_tests(test_suites, is_smoke=True):
                         tests['failures'] += 1
 
     tests['total_tests'] = tests['passed'] + tests['failures'] + tests['warnings']
+    
+    if not is_smoke:
+        tests['warnings'] = 'N/A'
+
     return tests
 
 def convert_to_slack_markdown(test_suites, is_smoke = True, browser='firefox-ios'):
@@ -114,7 +117,9 @@ def convert_to_slack_markdown(test_suites, is_smoke = True, browser='firefox-ios
             failed_tests_info.append(Section(text=markdown))
     
     # No test failures
-    if len(failed_tests_info) == 0:
+    if tests_info['total_tests'] == 0:
+        failed_tests_info = [ Section(text=':boom: No tests executed :boom:') ]
+    elif len(failed_tests_info) == 0:
         failed_tests_info = [ Section(text=':tada: No test failures :tada:') ]
 
     # Put together the Slack message
@@ -173,7 +178,9 @@ def convert_to_github_markdown(test_suites, is_smoke = True):
             markdown += '## {name}\n\n'.format(name=re.sub('XCUITests?.', '', test_suite.get('name', '')))
             markdown += convert_test_cases_to_github_markdown(test_suite.get('test_cases', []), is_smoke = is_smoke)
     
-    if markdown == '':
+    if tests_info['total_tests'] == 0:
+        markdown += '## :boom: No tests executed :boom:'
+    elif markdown == '':
         markdown += '## :tada: No test failures :tada:'
     else:
         tests_info_markdown = ''


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2909)

## :bulb: Description
Enable all smoke tests to be run alongside with the full functional tests. In addition, the smoke tests and full functional tests are run on a schedule but we can still start them manually.

Test run: https://github.com/mozilla-mobile/firefox-ios/actions/runs/9901369809

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

