### PR TITLE
Bugfix MTE-2964 Make "Bitrise Xcode Check and Update" works again

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -758,6 +758,10 @@ workflows:
         - message: "The build run info: $BITRISE_GIT_MESSAGE"
         - webhook_url: "$WEBHOOK_SLACK_TOKEN"
     description: This Workflow is to build the app using latest xcode available in Bitrise
+    meta:
+      bitrise.io:
+        stack: osx-xcode-15.4.x
+        machine_type_id: g2-m1.8core
   L10nBuild:
     steps:
     - activate-ssh-key@4:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -47,15 +47,15 @@ workflows:
     - restore-spm-cache@1:
         is_always_run: true
     - git::https://github.com/DamienBitrise/bitrise-test-plan-sharder.git@master:
-          title: Bitrise Test Plan Sharder
-          inputs:
-            - xcode_project: Client.xcodeproj
-            - target: Client
-            - shards: '4'
-            - scheme: Fennec
-            - debug_mode: 'true'
-            - test_path: ''
-            - file_type: ".swift"
+        title: Bitrise Test Plan Sharder
+        inputs:
+        - xcode_project: Client.xcodeproj
+        - target: Client
+        - shards: '4'
+        - scheme: Fennec
+        - debug_mode: 'true'
+        - test_path: ''
+        - file_type: ".swift"
     - script@1.1:
         title: Build for Testing
         inputs:
@@ -74,8 +74,7 @@ workflows:
         timeout: 600
         inputs:
         - destination: platform=iOS Simulator,name=iPhone 15,OS=17.5
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO"
-            "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
         - xctestrun: "/Users/vagrant/git/DerivedData/Build/Products/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun"
         - maximum_test_repetitions: 2
     - save-spm-cache@1:
@@ -132,7 +131,7 @@ workflows:
 
             echo "bitrise_xcode"
             COUNT_XCUI=$(./test-fixtures/generate-metrics.sh /Users/vagrant/git/xcodebuild_fennec.log all)
-            
+
             envman add --key SHOW_WARNING_IN_SLACK --value Show_Warnings
             envman add --key SHOW_WARNING_COUNT_XCUI --value "$COUNT_XCUI"
 
@@ -174,35 +173,35 @@ workflows:
 
   build_and_test_1_SmokeTest1:
     envs:
-      - opts:
-          is_expand: false
-        SHARD: '1'
+    - opts:
+        is_expand: false
+      SHARD: '1'
     after_run:
-      - _build_and_test
+    - _build_and_test
 
   build_and_test_2_SmokeTest2:
     envs:
-      - opts:
-          is_expand: false
-        SHARD: '2'
+    - opts:
+        is_expand: false
+      SHARD: '2'
     after_run:
-      - _build_and_test
+    - _build_and_test
 
   build_and_test_3_SmokeTest3:
     envs:
-      - opts:
-          is_expand: false
-        SHARD: '3'
+    - opts:
+        is_expand: false
+      SHARD: '3'
     after_run:
-      - _build_and_test
+    - _build_and_test
 
   build_and_test_4_SmokeTest4:
     envs:
-      - opts:
-          is_expand: false
-        SHARD: '4'
+    - opts:
+        is_expand: false
+      SHARD: '4'
     after_run:
-      - _build_and_test
+    - _build_and_test
 
   _build_and_test:
     before_run:
@@ -216,15 +215,12 @@ workflows:
         timeout: 1200
         inputs:
         - destination: platform=iOS Simulator,name=iPhone 15,OS=17.5
-        - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData"
-            "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" 
-            "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+        - xcodebuild_options: '"-derivedDataPath" "/Users/vagrant/git/DerivedData" "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
         - xctestrun: "Users/vagrant/git/DerivedData/Build/Products/Fennec_Smoketest${SHARD}_iphonesimulator17.5-arm64.xctestrun"
     - deploy-to-bitrise-io@2.1.1:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
         inputs:
         - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_${SHARD}_XCRESULT_PATH'
-  
   determine_apps_affected:
     steps:
     - git-clone@6.2: {}
@@ -467,12 +463,12 @@ workflows:
     - script@1:
         inputs:
         - content: |-
-             #!/usr/bin/env bash
-             set -e
-             set -x
-             cd firefox-ios/Client.xcodeproj
-             sed -i '' 's/CODE_SIGN_IDENTITY = "iPhone Developer"/CODE_SIGN_IDENTITY = "iPhone Developer"/' project.pbxproj
-             cd -
+            #!/usr/bin/env bash
+            set -e
+            set -x
+            cd firefox-ios/Client.xcodeproj
+            sed -i '' 's/CODE_SIGN_IDENTITY = "iPhone Developer"/CODE_SIGN_IDENTITY = "iPhone Developer"/' project.pbxproj
+            cd -
         title: Set xcodeproj code_sign_identity to iPhone Developer
     - script@1:
         inputs:
@@ -609,7 +605,7 @@ workflows:
                 envman add --key RUN_UI_TESTS --value Run_UI_Tests
                 exit 0
             fi
-            
+
             # Match on file names in all directories and subdirectories
             #
             # Project Configs
@@ -850,7 +846,8 @@ workflows:
         is_expand: false
       BITRISE_SCHEME: L10nSnapshotTest
     description: >-
-      This Workflow is to run L10n tests in one locale and then share the bundle with the rest of the builds
+      This Workflow is to run L10n tests in one locale and then share the bundle with
+      the rest of the builds
   L10nScreenshotsTests:
     steps:
     - activate-ssh-key@4:
@@ -1227,7 +1224,7 @@ workflows:
         - project_path: firefox-ios/Client.xcodeproj
         - scheme: Fennec
         - destination: platform=iOS Simulator,name=iPhone 15,OS=17.5
-        - test_plan: PerformanceTestPlan   
+        - test_plan: PerformanceTestPlan
     - script@1.1:
         is_always_run: true
         title: Create perfherder data object
@@ -1240,7 +1237,7 @@ workflows:
             set -x
             # get dependency
             cd ./test-fixtures && git clone https://github.com/isabelrios/xcresult_extract.git
-            
+
             echo $BITRISE_XCRESULT_PATH
             ls
             ls $BITRISE_XCRESULT_PATH
@@ -1329,7 +1326,7 @@ workflows:
                 --no-record-video \
                 --client-details=matrixLabel="Bitrise" \
                 --quiet 2>&1)
-            
+
             GCLOUD_EXITCODE=$? # this will get the right-most command from the gcloud subshell
             echo "GCLOUD_EXITCODE: $GCLOUD_EXITCODE"
 
@@ -1646,7 +1643,6 @@ workflows:
         - channel: "#mobile-alerts-ios"
         - message: "The build failed to build"
         - webhook_url: "$SLACK_WEBHOOK"
-  
   focus_ui_test:
     before_run:
     - focus-pull-and-unzip-dependencies
@@ -1698,7 +1694,6 @@ workflows:
         - channel: "#mobile-alerts-ios"
         - message: "The build run the Focus testPlan: $TEST_PLAN_NAME"
         - webhook_url: "$SLACK_WEBHOOK"
-  
   klar_unit_test:
     before_run:
     - focus-pull-and-unzip-dependencies
@@ -1754,7 +1749,7 @@ workflows:
         - channel: "#mobile-alerts-ios"
         - message: "The build run the Focus testPlan: UnitTests"
         - webhook_url: "$SLACK_WEBHOOK"
-  
+
   # # FOCUS UTILITIES WORKFLOWS
   focus-clone-and-build-dependencies:
     description: Clones the repo and builds dependencies
@@ -1771,7 +1766,7 @@ workflows:
         title: ContentBlockerGen
 
   focus-pull-and-unzip-dependencies:
-    description: Pulls and unzip the dependencies from previous stage 
+    description: Pulls and unzip the dependencies from previous stage
     steps:
     - pull-intermediate-files@1:
         inputs:

--- a/test-fixtures/update.py
+++ b/test-fixtures/update.py
@@ -21,10 +21,8 @@ curl ${BITRISE_STACK_INFO} | jq ' . | keys'
 ]
 '''
 pattern = 'osx-xcode-'
-version_name = 'ventura'
-patterns = [pattern, version_name]
+patterns = [pattern]
 BITRISE_YML = 'bitrise.yml'
-WORKFLOW = 'NewXcodeVersions'
 
 
 resp = requests.get(BITRISE_STACK_INFO)
@@ -41,36 +39,26 @@ def parse_semver(raw_str):
         return False
 
 
-def available_stacks():
+def default_stack():
     try:
         resp = requests.get(BITRISE_STACK_INFO)
         resp_json = resp.json()
-        return resp_json['available_stacks']
+        return resp_json['project_types_with_default_stacks']['ios']['default_stack']
     except HTTPError as http_error:
         print('An HTTP error has occurred: {http_error}')
     except Exception as err:
         print('An exception has occurred: {err}')
 
-
-def largest_version():
-    stacks = available_stacks()
-    for item in stacks:
-        # only look at XCode versions that aren't in beta
-        if stacks[item]['beta-tag'] != '': continue
-        # use the first version in the list that matches both platform and version
-        if all([x in item for x in patterns]): 
-            return '{0}.x'.format('.'.join(item.split('.')[0:2]))
-
 if __name__ == '__main__':
     '''
     STEPS
-    1. check bitrise API stack info for latest XCode version
+    1. check bitrise API stack info for the default stack version
     2. compare latest with current bitrise.yml stack version in repo
     3. if same exit, if not, continue
     4. modify bitrise.yml (update stack value)
     '''
 
-    largest_semver = largest_version()
+    largest_semver = default_stack().split(pattern)[1]
     tmp_file = 'tmp.yml'
 
     with open(BITRISE_YML, 'r') as infile:
@@ -83,8 +71,8 @@ if __name__ == '__main__':
 
         y = obj_yaml.load(infile)
 
-        current_semver = y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack']
-
+        current_semver = y['meta']['bitrise.io']['stack']
+        
         # remove pattern prefix from current_semver to compare with largest
         current_semver = current_semver.split(pattern)[1]
 
@@ -94,7 +82,7 @@ if __name__ == '__main__':
             print('New Xcode version available: {0} ... updating bitrise.yml!'.format(largest_semver))
             # add prefix pattern back to be recognizable by bitrise
             # as a valid stack value
-            y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack'] = '{0}{1}'.format(pattern, largest_semver)
+            y['meta']['bitrise.io']['stack'] = '{0}{1}'.format(pattern, largest_semver)
             with open(tmp_file, 'w+') as tmpfile:
                 obj_yaml.dump(y, tmpfile)
                 copyfile(tmp_file, BITRISE_YML)

--- a/test-fixtures/update.py
+++ b/test-fixtures/update.py
@@ -23,7 +23,7 @@ curl ${BITRISE_STACK_INFO} | jq ' . | keys'
 pattern = 'osx-xcode-'
 patterns = [pattern]
 BITRISE_YML = 'bitrise.yml'
-
+WORKFLOW = 'NewXcodeVersions'
 
 resp = requests.get(BITRISE_STACK_INFO)
 resp.raise_for_status()
@@ -71,7 +71,7 @@ if __name__ == '__main__':
 
         y = obj_yaml.load(infile)
 
-        current_semver = y['meta']['bitrise.io']['stack']
+        current_semver = y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack']
         
         # remove pattern prefix from current_semver to compare with largest
         current_semver = current_semver.split(pattern)[1]
@@ -82,7 +82,7 @@ if __name__ == '__main__':
             print('New Xcode version available: {0} ... updating bitrise.yml!'.format(largest_semver))
             # add prefix pattern back to be recognizable by bitrise
             # as a valid stack value
-            y['meta']['bitrise.io']['stack'] = '{0}{1}'.format(pattern, largest_semver)
+            y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack'] = '{0}{1}'.format(pattern, largest_semver)
             with open(tmp_file, 'w+') as tmpfile:
                 obj_yaml.dump(y, tmpfile)
                 copyfile(tmp_file, BITRISE_YML)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2964)

## :bulb: Description
The "Bitrise Xcode Check and Update" is not working because of the following:
* The location of the bitrise stack version has been changed.
* Bitrise's REST API endpoint no longer uses the `beta` field to specify non-stable stacks.

Here are my assumptions:
* The *default stack* for ios development is the latest stable (non-beta) stack.
* Let `ruamel.yaml` library formats the yaml file.

I tested my changes by the following:
* Locally, I modified `bitrise.yml` to use an old stack (say 13.4).
* Run `python ./test-fixtures/update.py`.

Also tested:
Running the Github Action workflow on my fork with `workflow_dispatch` and the changes:
* When there's no changes required: https://github.com/clarmso/firefox-ios/actions/runs/9910711934
* When a change is required: https://github.com/clarmso/firefox-ios/actions/runs/9910734377
* PR created by the Github Action: https://github.com/clarmso/firefox-ios/pull/1

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

