### PR TITLE
Removed MTE-3123 - workaround for all private tabs test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -8,7 +8,7 @@ import Common
 let PDF_website = [
     "url": "https://storage.googleapis.com/mobile_test_assets/public/pdf-test.pdf",
     "pdfValue": "storage.googleapis.com/mobile_test_assets/public/pdf-test.pdf",
-    "urlValue": "yukon.ca/en/educat",
+    "urlValue": "yukon.ca/en/education-and-schools",
     "bookmarkLabel": "https://storage.googleapis.com/mobile_test_assets/public/pdf-test.pdf",
     "longUrlValue": "http://www.education.gov.yk.ca/"
 ]

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -1236,13 +1236,9 @@ extension MMNavigator where T == FxUserState {
     }
 
     // Add a new Tab from the New Tab option in Browser Tab Menu
-    func createNewTab(isPrivate: Bool = false) {
+    func createNewTab() {
         let app = XCUIApplication()
         self.goto(TabTray)
-        // Workaround for issue https://github.com/mozilla-mobile/firefox-ios/issues/18743
-        if isPrivate {
-            self.performAction(Action.TogglePrivateMode)
-        }
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
         app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].tap()
         self.nowAt(NewTabScreen)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -200,8 +200,9 @@ class PrivateBrowsingTest: BaseTestCase {
     func testAllPrivateTabsRestore() {
         // Several tabs opened in private tabs tray. Tap on the trashcan 
         navigator.nowAt(NewTabScreen)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         for _ in 1...4 {
-            navigator.createNewTab(isPrivate: true)
+            navigator.createNewTab()
             if app.keyboards.element.isVisible() && !iPad() {
                 mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT)
                 navigator.performAction(Action.CloseURLBarOpen)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
@@ -141,7 +141,17 @@ class ThirdPartySearchTest: BaseTestCase {
         UIPasteboard.general.string = searchUrl
         customengineurlTextView.tap()
         customengineurlTextView.press(forDuration: 2.0)
-        app.staticTexts["Paste"].tap()
+        let pasteOption = app.menuItems["Paste"]
+        if pasteOption.exists {
+            pasteOption.tap()
+        } else {
+            var nrOfTaps = 3
+            while !pasteOption.exists && nrOfTaps > 0 {
+                customengineurlTextView.press(forDuration: 2.0)
+                nrOfTaps -= 1
+            }
+            pasteOption.tap()
+        }
 
         mozWaitForElementToExist(app.buttons["customEngineSaveButton"], timeout: 3)
         app.buttons["customEngineSaveButton"].tap()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3123

## :bulb: Description
Removed workaround for opening  private tabs
Improved testCustomEngineFromIncorrectTemplate test making sure paste menu option is visible.
<img width="631" alt="Screenshot 2024-07-12 at 09 25 27" src="https://github.com/user-attachments/assets/2c83eb36-a8cb-416f-9e15-d1d21623d650">
