### PR TITLE
Add FXIOS-9457 Add feature flag for One Tap New Tab in ToolbarRefactorFeature

### DIFF
--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -9,11 +9,19 @@ features:
           Enables the feature
         type: Boolean
         default: false
+      one_tap_new_tab:
+        description: >
+          If true, enables the one tap new tab feature for users.
+        type: Boolean
+        default: false
+        
     defaults:
       - channel: beta
         value:
           enabled: false
+          one_tap_new_tab: false
       - channel: developer
         value:
           enabled: false
+          one_tap_new_tab: false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9457)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20941)

## :bulb: Description
Adds feature flag for One Tap New Tab in ToolbarRefactorFeature.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

