### PR TITLE
Bugfix FXIOS-9039 Hide incorrect downloaded bytes when downloading encoded (e.g. gzip) files

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -45,6 +45,7 @@ extension BrowserViewController: DownloadQueueDelegate {
         combinedTotalBytesExpected: Int64?
     ) {
         downloadToast?.combinedBytesDownloaded = combinedBytesDownloaded
+        downloadToast?.combinedTotalBytesExpected = combinedTotalBytesExpected
     }
 
     func downloadQueue(_ downloadQueue: DownloadQueue, download: Download, didFinishDownloadingTo location: URL) {}

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -45,7 +45,6 @@ extension BrowserViewController: DownloadQueueDelegate {
         combinedTotalBytesExpected: Int64?
     ) {
         downloadToast?.combinedBytesDownloaded = combinedBytesDownloaded
-        downloadToast?.combinedTotalBytesExpected = combinedTotalBytesExpected
     }
 
     func downloadQueue(_ downloadQueue: DownloadQueue, download: Download, didFinishDownloadingTo location: URL) {}

--- a/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
@@ -119,7 +119,8 @@ class HTTPDownload: Download {
         }
 
         self.totalBytesExpected = preflightResponse.expectedContentLength > 0 ? preflightResponse.expectedContentLength : nil
-        if let contentEncodingHeader = (preflightResponse as? HTTPURLResponse)?.allHeaderFields["Content-Encoding"] as? String,
+        if let contentEncodingHeader = (preflightResponse as? HTTPURLResponse)?
+                                       .allHeaderFields["Content-Encoding"] as? String,
            !contentEncodingHeader.isEmpty {
             // If this header is present, some encoding has been applied to the payload (likely gzip compression), so the
             // above `preflightResponse.expectedContentLength` reflects the size of the encoded content, not the actual file

--- a/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
@@ -24,7 +24,7 @@ class Download: NSObject {
 
     fileprivate(set) var totalBytesExpected: Int64?
     fileprivate(set) var bytesDownloaded: Int64
-    // Whether the server has indicated it will send encoded data (via response `Content-Encoding` header)
+    // Whether the server has indicated it will send encoded data (via response `Content-Encoding` header) (FXIOS-9039)
     fileprivate(set) var hasContentEncoding: Bool?
 
     init(originWindow: WindowUUID) {
@@ -125,6 +125,7 @@ class HTTPDownload: Download {
             // If this header is present, some encoding has been applied to the payload (likely gzip compression), so the
             // above `preflightResponse.expectedContentLength` reflects the size of the encoded content, not the actual file
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
+            // FXIOS-9039
             self.hasContentEncoding = true
         } else {
             self.hasContentEncoding = false

--- a/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
@@ -63,9 +63,10 @@ class DownloadToast: Toast {
                 self.descriptionLabel.text = self.descriptionText
 
                 if let percent = self.percent {
+                    self.progressView.isHidden = false
                     self.progressWidthConstraint?.constant = self.toastView.frame.width * percent
                 } else {
-                    self.progressWidthConstraint?.constant = 0
+                    self.progressView.isHidden = true
                 }
 
                 self.layoutIfNeeded()

--- a/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
@@ -49,11 +49,25 @@ class DownloadToast: Toast {
 
     var downloads: [Download] = []
 
-    var percent: CGFloat = 0.0 {
+    // Returns true if one or more downloads have encoded data (indicated via response `Content-Encoding` header).
+    // If at least one download has encoded data, we cannot get a correct total estimate for all the downloads.
+    // In that case, we do not show descriptive text. This will be improved in a later rework of the download manager.
+    // FXIOS-9039
+    var hasContentEncoding: Bool {
+        return downloads.contains(where: { $0.hasContentEncoding ?? false })
+    }
+
+    var percent: CGFloat? = 0.0 {
         didSet {
             UIView.animate(withDuration: 0.05) {
                 self.descriptionLabel.text = self.descriptionText
-                self.progressWidthConstraint?.constant = self.toastView.frame.width * self.percent
+
+                if let percent = self.percent {
+                    self.progressWidthConstraint?.constant = self.toastView.frame.width * percent
+                } else {
+                    self.progressWidthConstraint?.constant = 0
+                }
+                
                 self.layoutIfNeeded()
             }
         }
@@ -72,6 +86,11 @@ class DownloadToast: Toast {
     }
 
     var descriptionText: String {
+        guard !hasContentEncoding else {
+            // We cannot get a correct estimate of encoded downloaded bytes (FXIOS-9039)
+            return String()
+        }
+
         let downloadedSize = ByteCountFormatter.string(
             fromByteCount: combinedBytesDownloaded,
             countStyle: .file
@@ -144,6 +163,12 @@ class DownloadToast: Toast {
 
     func updatePercent() {
         DispatchQueue.main.async {
+            guard !self.hasContentEncoding else {
+                // We cannot get a correct estimate of encoded downloaded bytes (FXIOS-9039)
+                self.percent = nil
+                return
+            }
+
             guard let combinedTotalBytesExpected = self.combinedTotalBytesExpected else {
                 self.percent = 0.0
                 return

--- a/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
@@ -67,7 +67,7 @@ class DownloadToast: Toast {
                 } else {
                     self.progressWidthConstraint?.constant = 0
                 }
-                
+
                 self.layoutIfNeeded()
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
@@ -120,8 +120,7 @@ class DownloadHelper: NSObject {
         var modelText = host
 
         // This size reflects the (possibly compressed) download size of the file, not necessarily its true size.
-        // e.g. In the case of gzip content
-        // TODO Do we want some indication in the UI that this file will be larger once uncompressed?
+        // e.g. In the case of gzip content (FXIOS-9039)
         if let expectedSize = expectedSize {
             modelText = "\(expectedSize) — \(host)"
         }

--- a/firefox-ios/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenInHelper/DownloadHelper.swift
@@ -119,6 +119,9 @@ class DownloadHelper: NSObject {
         var filenameItem: SingleActionViewModel
         var modelText = host
 
+        // This size reflects the (possibly compressed) download size of the file, not necessarily its true size.
+        // e.g. In the case of gzip content
+        // TODO Do we want some indication in the UI that this file will be larger once uncompressed?
         if let expectedSize = expectedSize {
             modelText = "\(expectedSize) — \(host)"
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9039)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR removes download details from the DownloadToast when downloading files delivered with encoded content (e.g. gzip from GitHub).

Normal download:

<img height="400" alt="Screenshot 2024-08-22 at 12 13 37 PM" src="https://github.com/user-attachments/assets/f35f4582-2be4-4d98-93e4-e08818822d36">

Encoded file download (details removed and no animation):
<img height="400" alt="Screenshot 2024-08-22 at 12 09 52 PM" src="https://github.com/user-attachments/assets/7f8c7233-4a85-40bd-88b0-e4af3b49302f">

Normal multiple downloads:
<img height="400" alt="Screenshot 2024-08-22 at 12 18 41 PM" src="https://github.com/user-attachments/assets/f862d041-f334-4c53-922d-2f594d2b7c69">

Multiple file downloads where at least 1 file is encoded:
<img height="400" alt="Screenshot 2024-08-22 at 12 26 54 PM" src="https://github.com/user-attachments/assets/241ab1a1-a2a0-4406-84a9-68a6e6c43014">
^ This will be improved in a later download manager rework (approved by Andy).

### Testing Hints

- Test downloading multiple larger files: https://huggingface.co/runwayml/stable-diffusion-v1-5/tree/main
- Test downloading gzip encoded content: https://github.com/matthewreagan/WebstersEnglishDictionary/blob/master/dictionary.json (long press tap and try to save the raw content of the file)
- Turn on the Network Link Conditioner in Mac settings to slow down the downloads for testing.

## OLD CONTEXT (previous solution that has been removed + discussion):
Prior to downloading encoded content (e.g. gzip), we can do a quick HEAD request to the server to check the uncompressed file size. Otherwise, the download progress bar will will appear to exceed the `totalBytesExpected`.

This is because `totalBytesExpected` comes from the response `Content-Length` header and reflects the compressed size of a file sent by a server capable of serving gzip/compress encoded content. However, `NSURLSession` automatically decodes the gzip/compress encoded content and reports the _decoded_ (inflated) bytes to the delegate methods. As a result, the received file appears larger than what was expected.

Please check the ticket for my comment if you want more background detail about the issue.

Here is some additional background on the [Accept-Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding) header. Also note that the [iOS documentation states](https://developer.apple.com/documentation/foundation/nsurlresponse/1413507-expectedcontentlength) _"Some [NSURLResponse] protocol implementations report the content length as part of the response, but not all protocols guarantee to deliver that amount of data. Your app should be prepared to deal with more or less data."_

To test downloading an encoded file, try long tap downloading @mattreaganmozilla's [file here (the view raw link)](https://github.com/matthewreagan/WebstersEnglishDictionary/blob/master/dictionary.json). The encoded size when the server sends gzip is ~9 MB. The real file size (uncompressed) is ~23 MB.

## Before (Bug Case)

The download progress bar appears to continue off the screen.

https://github.com/user-attachments/assets/80034e9f-34b4-4439-8951-6f9850c2f049

## After (One possible fix)

https://github.com/user-attachments/assets/0c363724-b9d7-4793-a986-634bdbaa9503

## Discussion

In the demo, you'll notice that the download bar appears to jump. That's because there is latency in the background HEAD check (the download is not held up until the check returns). The total size is reevaluated as the bar is already increasing. I'm not sure if this is ideal. 🤔 

Here are some other ideas I've had:
- Disable the automatic decoding done by URLSession, which would allow us to show the total progress on the encoded size instead of the decoded size. Unfortunately, I could not find any valid APIs for this. I saw rumour that there were some deprecated APIs or some hacky ways of overriding this default behaviour, but I don't think we want to go down that route.
    - If anyone has more insight into this though, I feel like this would be the best case, because then we could report the progress on the downloaded _encoded_ bytes rather than the downloaded _decoded_ bytes!
- Set Accept-Encoding to `identity` (i.e. no server compression) on all downloads. But this would increase network bandwidth just for a UI optimization.
- When we detect a file is encoded by the server, we could force the HEAD check to complete _before_ the download starts (thus no jump in the bar if there's a delay). But that's extra time for the user to wait.
- Do no extra requests and instead simply show an indeterminate loading bar for encoded downloads. But this gives the user no feedback on the progress.
- Change the UI so we do not show numbers when downloading encoded content. For example, Safari does not appear to show details of the downloaded bytes (see screenshot below, check the blue circle slowly filling to the left of the bottom address bar).
<img width="517" alt="Screenshot 2024-07-12 at 9 52 54 AM" src="https://github.com/user-attachments/assets/5aa8cc9a-641d-4829-9b10-1bcdedd28239">

If we are leaning toward a more sophisticated solution, maybe we can add some logging to see how common it is for users to download encoded content first to guide how much energy we should put into this?

### Download Preview?

There's also one more case to consider... when we show the download preview, do we want to indicate in the UI that the download is a compressed size? Because once the bar shows, for example, this 9 MB file we're downloading is progressing from 0 to 23 MB, the user is probably going to be confused.

<img width="517" alt="Screenshot 2024-07-12 at 9 48 19 AM" src="https://github.com/user-attachments/assets/cf41e6c7-2078-433d-98f1-1031e9160159">
<img width="517" alt="Screenshot 2024-07-12 at 9 48 22 AM" src="https://github.com/user-attachments/assets/e8f0709a-707b-4ec5-8268-eed3f0ca4682">

## Thank you for coming to my TED talk! 😛 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

