### PR TITLE
Refactor FXIOS-9053 pre push script to not allow direct pushes for main but for forks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -34,11 +34,6 @@ echo "Restricted remote: $restricted_remote"
 # Special Case: remote being pushed to from the first argument of the pre-push hook
 push_remote_my=$1
 
-if [ "$current_tracked_branch" = "main" ] && [ "$current_tracked_remote" = "$restricted_remote" ]; then
-  echo "Direct pushes to the 'main' branch on this remote are not allowed."
-  exit 1
-fi
-
 if [ "$current_tracked_branch" = "main" ]; then
   # if the tracked remote is the restricted remote
   if [ "$current_tracked_remote" = "$restricted_remote" ]; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -35,12 +35,6 @@ echo "Restricted remote: $restricted_remote"
 push_remote_my=$1
 
 if [ "$current_tracked_branch" = "main" ]; then
-  # if the tracked remote is the restricted remote
-  if [ "$current_tracked_remote" = "$restricted_remote" ]; then
-    echo "Direct pushes to the 'main' branch on the tracked remote are not allowed."
-    exit 1
-  fi
-
   # if the push remote is the restricted remote
   if [ "$push_remote_my" = "$restricted_remote" ]; then
     echo "Direct pushes to the 'main' branch on the specified remote are not allowed."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,18 +1,44 @@
 #!/bin/sh
 
-# Get the current branch
+# current branch
 get_current_branch() {
   current_branch=$(git symbolic-ref --short HEAD)
   echo "$current_branch"
 }
 
-# Save the current branch
+# remote being pushed to
+get_push_remote() {
+  push_remote=$(git for-each-ref --format='%(upstream:remotename)' "$(git symbolic-ref -q HEAD)")
+  echo "$push_remote"
+}
+
+# URL of the remote being pushed to
+get_remote_url() {
+  remote_name=$1
+  remote_url=$(git remote get-url "$remote_name")
+  echo "$remote_url"
+}
+
+# current branch
 current_branch=$(get_current_branch)
 echo "Current branch: $current_branch"
 
-# Check if the current branch is the restricted branch 'main'
-if [ "$current_branch" = "main" ]; then
-  echo "Direct pushes to the 'main' branch are not allowed."
+# remote being pushed to
+push_remote=$(get_push_remote)
+echo "Push remote: $push_remote"
+
+# default to origin
+if [ -z "$push_remote" ]; then
+  push_remote="origin"
+fi
+
+push_remote_url=$(get_remote_url "$push_remote")
+echo "Push remote URL: $push_remote_url"
+
+# Check if the current branch is the restricted branch 'main' and remote URL matches the restricted URL
+restricted_url="https://github.com/mozilla-mobile/firefox-ios.git"
+if [ "$current_branch" = "main" ] && [ "$push_remote_url" = "$restricted_url" ]; then
+  echo "Direct pushes to the 'main' branch on this remote are not allowed."
   exit 1
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,43 +1,37 @@
 #!/bin/sh
 
-# current branch
-get_current_branch() {
-  current_branch=$(git symbolic-ref --short HEAD)
-  echo "$current_branch"
-}
-
-# remote being pushed to
-get_push_remote() {
-  push_remote=$(git for-each-ref --format='%(upstream:remotename)' "$(git symbolic-ref -q HEAD)")
-  echo "$push_remote"
-}
-
-# URL of the remote being pushed to
+# get the URL of a remote
 get_remote_url() {
   remote_name=$1
-  remote_url=$(git remote get-url "$remote_name")
-  echo "$remote_url"
+  git remote get-url "$remote_name"
 }
 
-# current branch
-current_branch=$(get_current_branch)
-echo "Current branch: $current_branch"
+# remote name associated with the restricted URL
+find_remote_name_by_url() {
+  restricted_url="https://github.com/mozilla-mobile/firefox-ios.git"
+  for remote in $(git remote); do
+    remote_url=$(get_remote_url "$remote")
+    if [ "$remote_url" = "$restricted_url" ]; then
+      echo "$remote"
+      return
+    fi
+  done
+  echo ""
+}
 
-# remote being pushed to
-push_remote=$(get_push_remote)
-echo "Push remote: $push_remote"
+# current tracked remote and branch for the current local branch
+upstream=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
+current_tracked_remote=$(echo "$upstream" | cut -d'/' -f1)
+current_tracked_branch=$(echo "$upstream" | cut -d'/' -f2)
 
-# default to origin
-if [ -z "$push_remote" ]; then
-  push_remote="origin"
-fi
+echo "current tracked remote: $current_tracked_remote"
+echo "current tracked branch: $current_tracked_branch"
 
-push_remote_url=$(get_remote_url "$push_remote")
-echo "Push remote URL: $push_remote_url"
+restricted_remote=$(find_remote_name_by_url)
 
-# Check if the current branch is the restricted branch 'main' and remote URL matches the restricted URL
-restricted_url="https://github.com/mozilla-mobile/firefox-ios.git"
-if [ "$current_branch" = "main" ] && [ "$push_remote_url" = "$restricted_url" ]; then
+echo "Restricted remote: $restricted_remote"
+
+if [ "$current_tracked_branch" = "main" ] && [ "$current_tracked_remote" = "$restricted_remote" ]; then
   echo "Direct pushes to the 'main' branch on this remote are not allowed."
   exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -31,9 +31,26 @@ restricted_remote=$(find_remote_name_by_url)
 
 echo "Restricted remote: $restricted_remote"
 
+# Special Case: remote being pushed to from the first argument of the pre-push hook
+push_remote_my=$1
+
 if [ "$current_tracked_branch" = "main" ] && [ "$current_tracked_remote" = "$restricted_remote" ]; then
   echo "Direct pushes to the 'main' branch on this remote are not allowed."
   exit 1
+fi
+
+if [ "$current_tracked_branch" = "main" ]; then
+  # if the tracked remote is the restricted remote
+  if [ "$current_tracked_remote" = "$restricted_remote" ]; then
+    echo "Direct pushes to the 'main' branch on the tracked remote are not allowed."
+    exit 1
+  fi
+
+  # if the push remote is the restricted remote
+  if [ "$push_remote_my" = "$restricted_remote" ]; then
+    echo "Direct pushes to the 'main' branch on the specified remote are not allowed."
+    exit 1
+  fi
 fi
 
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -24,15 +24,15 @@ upstream=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
 current_tracked_remote=$(echo "$upstream" | cut -d'/' -f1)
 current_tracked_branch=$(echo "$upstream" | cut -d'/' -f2)
 
-echo "current tracked remote: $current_tracked_remote"
-echo "current tracked branch: $current_tracked_branch"
+echo "Current tracked remote: $current_tracked_remote"
+echo "Current tracked branch: $current_tracked_branch"
 
 restricted_remote=$(find_remote_name_by_url)
-
 echo "Restricted remote: $restricted_remote"
 
 # Special Case: remote being pushed to from the first argument of the pre-push hook
 push_remote_my=$1
+echo "Push remote: $restricted_remote"
 
 if [ "$current_tracked_branch" = "main" ]; then
   # if the push remote is the restricted remote


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9053)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20023)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

This is slightly modified script to allow for pushes to the remote forks as otherwise forks might not get updated.

Build upon: https://github.com/mozilla-mobile/firefox-ios/pull/20915

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

