### PR TITLE
Fix MTE-3129 microsurvey tests on iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -52,15 +52,22 @@ final class MicrosurveyTests: BaseTestCase {
     }
 
     private func generateTriggerForMicrosurvey() {
-        let homepageToggleButton = app
-            .collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView]
-            .buttons[AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton]
-        homepageToggleButton.tap()
-        let privateHomepageToggleButton = app
-            .scrollViews
-            .otherElements
-            .buttons[AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton]
-        privateHomepageToggleButton.tap()
-        mozWaitForElementToExist(app.collectionViews["FxCollectionView"])
+        let homepageToggleButtonIphone =
+        app.buttons[AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton]
+        let homepageToggleButtonIpad = app.buttons[AccessibilityIdentifiers.Browser.TopTabs.privateModeButton]
+        if !iPad() {
+            homepageToggleButtonIphone.tap()
+            mozWaitForElementToExist(app.staticTexts[AccessibilityIdentifiers.PrivateMode.Homepage.link])
+        } else {
+            homepageToggleButtonIpad.tap()
+            mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.Browser.TopTabs.collectionView])
+        }
+        if !iPad() {
+            homepageToggleButtonIphone.tap()
+            mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView])
+        } else {
+            homepageToggleButtonIpad.tap()
+            mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.Browser.TopTabs.collectionView])
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3129

## :bulb: Description
Not sure why we need to toggle the app from regular mode to private mode on the microsurvey tests, but i am fixing the tests to pass on Ipad also. A deeper investigation on the valid scenarios to be validated will be done after the test cases will be eligible to be automated. 
