### PR TITLE
Bugfix FXIOS-9490 [Microsurvey] add padding to throttle count

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -94,7 +94,7 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
     weak var delegate: HomepageViewModelDelegate?
     private var wallpaperManager: WallpaperManager
     private var logger: Logger
-    private let viewWillAppearEventThrottler = Throttler(seconds: 0.1)
+    private let viewWillAppearEventThrottler = Throttler(seconds: 0.5)
 
     // Child View models
     private var childViewModels: [HomepageViewModelProtocol]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9490)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21016)

## :bulb: Description
Although I tested the delay locally and it seems to work fine, QA reported they still see the issue so the delay is most likely too short on nightly on iPad. In this case added some extra buffering.

Previous PR: https://github.com/mozilla-mobile/firefox-ios/pull/20874

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

