### PR TITLE
Bugfix FXIOS-9490 [Microsurvey] Using default action causes issues opening survey

### DIFF
--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbMessage.swift
@@ -41,7 +41,7 @@ struct GleanPlumbMessage {
     /// The action URL as resolved by the Nimbus Messaging component.
     ///
     /// Embedding apps should not read from this directly.
-    let action: String
+    let action: String?
 
     /// The conditions that need to be satisfied for a message to be considered eligible to present.
     ///

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
@@ -240,6 +240,19 @@ class GleanPlumbMessageManagerTests: XCTestCase {
         XCTAssertEqual(hardcodedNimbusFeatures.getExposureCount(featureId: "messaging"), 2)
     }
 
+    func testManagerGetMessages_happyPath_withNoAction() throws {
+        let expectedId = "infoCard"
+        let messages = [
+            createMessage(messageId: "infoCard-notyet", action: nil, surface: .newTabCard, trigger: ["true", "false"]),
+            createMessage(messageId: expectedId, action: nil, surface: .newTabCard, trigger: ["true", "true"])
+        ]
+        guard let observed = subject.getNextMessage(for: .newTabCard, from: messages) else {
+            XCTFail("Expected to retrieve message")
+            return
+        }
+        XCTAssertEqual(observed.id, expectedId)
+    }
+
     func testManagerOnMessageDisplayed() {
         let message = createMessage(messageId: messageId)
         subject.onMessageDisplayed(message)
@@ -357,6 +370,16 @@ class GleanPlumbMessageManagerTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.Messaging.malformed)
     }
 
+    func testManagerOnMessagePressed_withNoAction() {
+        let message = createMessage(messageId: messageId, action: nil)
+        subject.onMessagePressed(message, window: nil)
+        let messageMetadata = messagingStore.getMessageMetadata(messageId: messageId)
+        XCTAssertTrue(messageMetadata.isExpired)
+        XCTAssertEqual(applicationHelper.openURLCalled, 0)
+        XCTAssertNil(applicationHelper.lastOpenURL)
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Messaging.clicked)
+    }
+
     func testManagerOnMessageDismissed() {
         let message = createMessage(messageId: messageId)
         subject.onMessageDismissed(message)
@@ -369,7 +392,7 @@ class GleanPlumbMessageManagerTests: XCTestCase {
     // MARK: - Helper function
 
     private func createMessage(messageId: String,
-                               action: String = "MAKE_DEFAULT_BROWSER",
+                               action: String? = "MAKE_DEFAULT_BROWSER",
                                actionParams: [String: String] = [:],
                                surface: MessageSurfaceId = .newTabCard,
                                trigger: [String] = ["true"],

--- a/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging.fml.yaml
@@ -103,11 +103,10 @@ objects:
       action:
         # We would like this to be of ActionName type, but it accepts https:// URLs
         # so changing this would be a breaking change.
-        type: ActionName
+        type: Option<ActionName>
         description: >
           The name of a deeplink URL to be opened if the button is clicked.
-        # This should never be defaulted.
-        default: OPEN_URL
+        default: null
       action-params:
         type: Map<String, String>
         description: Query parameters appended to the deeplink action URL


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9490)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21016)

## :bulb: Description
**Context**
There was an issue that if a user tries to open the survey from the prompt in a specific way, it would immediately close the screen. This issue can be discovered on nightly build by performing the following:
`Navigating to tab tray -> open a new tab -> dismiss keyboard -> press continue on microsurvey prompt` 

**Problem**
The issue was that we had an action attached to the microsurvey mobile messaging system, which triggered `findAndHandle` that caused the survey to dismiss itself. 

**Resolution**
As part of this PR, I decided to change the default to null instead of OPEN_URL. By doing so, I had to make the appropriate changes in `createMessage` and `onMessagePressed` to allow for null actions. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
