### PR TITLE
Bugfix FXIOS-9444: Maintain private tabs after revisiting onboarding

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -31,8 +31,6 @@ class BrowserCoordinator: BaseCoordinator,
     var homepageViewController: HomepageViewController?
     var privateViewController: PrivateHomepageViewController?
 
-    override var isDismissable: Bool { false }
-
     private var profile: Profile
     private let tabManager: TabManager
     private let themeManager: ThemeManager
@@ -42,6 +40,8 @@ class BrowserCoordinator: BaseCoordinator,
     private let applicationHelper: ApplicationHelper
     private var browserIsReady = false
     private var windowUUID: WindowUUID { return tabManager.windowUUID }
+
+    override var isDismissable: Bool { false }
 
     init(router: Router,
          screenshotService: ScreenshotService,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -31,6 +31,8 @@ class BrowserCoordinator: BaseCoordinator,
     var homepageViewController: HomepageViewController?
     var privateViewController: PrivateHomepageViewController?
 
+    override var isDismissable: Bool { false }
+
     private var profile: Profile
     private let tabManager: TabManager
     private let themeManager: ThemeManager


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9444)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20898)

## :bulb: Description
- Persist current browsing mode and private tab data after re-showing `IntroViewController` (onboarding) via Settings -> Show Tour

### Discussion
- This was achieved by overriding `Coordinator`'s `isDismissable` property inside `BrowserCoordinator` so that it cannot be dismissed, in this case, when a route is handled by it's parent coordinator (ie `SceneCoordinator`). `BrowserCoordinator` is also core to the application, and there is really never a case where we would want to de/reinitialize it aside from killing the entire application or a scene/window.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

