### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from SiteImageDownloader.swift

### DIFF
--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
@@ -48,7 +48,7 @@ extension SiteImageDownloader {
         }
     }
 
-    fileprivate func handleImageDownload(url: URL) async throws -> any SiteImageLoadingResult {
+    private func handleImageDownload(url: URL) async throws -> any SiteImageLoadingResult {
         return try await withCheckedThrowingContinuation { continuation in
             // Store a copy of the continuation to act on in the case the sleep finishes first
             self.continuation = continuation

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
@@ -66,7 +66,7 @@ extension SiteImageDownloader {
         }
     }
 
-    fileprivate func handleTimeout() async throws -> any SiteImageLoadingResult {
+    private func handleTimeout() async throws -> any SiteImageLoadingResult {
         try await Task.sleep(nanoseconds: self.timeoutDelay * NSEC_PER_SEC)
         try Task.checkCancellation()
         let error = SiteImageError.unableToDownloadImage("Timeout reached")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `SiteImageDownloader.swift ` file. It extracts two code blocks to new functions: `handleImageDownload` and `handleTimeout`.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

