### PR TITLE
Refactor FXIOS-7301 - Remove 3 closure_body_length violations from ContentBlocker.swift

### DIFF
--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -339,27 +339,7 @@ extension ContentBlocker {
                         forIdentifier: filename,
                         encodedContentRuleList: str
                     ) { rule, error in
-                        defer {
-                            dispatchGroup.leave()
-                        }
-                        guard error == nil else {
-                            self.logger.log(
-                                "Content blocker errored with: \(String(describing: error))",
-                                level: .warning,
-                                category: .webview
-                            )
-                            assert(error == nil)
-                            return
-                        }
-                        guard rule != nil else {
-                            self.logger.log(
-                                "We came across a nil rule set for BlockList.",
-                                level: .warning,
-                                category: .webview
-                            )
-                            assert(rule != nil)
-                            return
-                        }
+                        self.compileContentRuleListCompletion(dispatchGroup: dispatchGroup, rule: rule, error: error)
                     }
                 }
             }

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -350,7 +350,7 @@ extension ContentBlocker {
         }
     }
 
-    fileprivate func compileContentRuleListCompletion(dispatchGroup: DispatchGroup,
+    private func compileContentRuleListCompletion(dispatchGroup: DispatchGroup,
                                                       rule: WKContentRuleList?,
                                                       error: (any Error)?) {
         defer {

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -369,4 +369,30 @@ extension ContentBlocker {
             completion()
         }
     }
+
+    fileprivate func compileContentRuleListCompletion(dispatchGroup: DispatchGroup,
+                                                      rule: WKContentRuleList?,
+                                                      error: (any Error)?) {
+        defer {
+            dispatchGroup.leave()
+        }
+        guard error == nil else {
+            self.logger.log(
+                "Content blocker errored with: \(String(describing: error))",
+                level: .warning,
+                category: .webview
+            )
+            assert(error == nil)
+            return
+        }
+        guard rule != nil else {
+            self.logger.log(
+                "We came across a nil rule set for BlockList.",
+                level: .warning,
+                category: .webview
+            )
+            assert(rule != nil)
+            return
+        }
+    }
 }

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -351,8 +351,8 @@ extension ContentBlocker {
     }
 
     private func compileContentRuleListCompletion(dispatchGroup: DispatchGroup,
-                                                      rule: WKContentRuleList?,
-                                                      error: (any Error)?) {
+                                                  rule: WKContentRuleList?,
+                                                  error: (any Error)?) {
         defer {
             dispatchGroup.leave()
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 3 `closure_body_length` violations from the `ContentBlocker.swift ` file, extracting a big function. 

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

