### PR TITLE
Refactor [Strings] Update alphabetical order and move menu strings

### DIFF
--- a/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
@@ -78,7 +78,7 @@ class ShareExtensionCoordinator: BaseCoordinator,
             showSendToDevice(url: url)
         case CustomActivityAction.copyLink.actionType:
             SimpleToast().showAlertWithText(
-                .AppMenu.AppMenuCopyURLConfirmMessage,
+                .OldStrings.v130.AppMenu.AppMenuCopyURLConfirmMessage,
                 bottomContainer: alertContainer,
                 theme: themeManager.getCurrentTheme(for: windowUUID))
             dequeueNotShownJSAlert()
@@ -163,7 +163,7 @@ class ShareExtensionCoordinator: BaseCoordinator,
             self.router.dismiss()
             self.parentCoordinator?.didFinish(from: self)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                SimpleToast().showAlertWithText(.AppMenu.AppMenuTabSentConfirmMessage,
+                SimpleToast().showAlertWithText(.OldStrings.v130.AppMenu.AppMenuTabSentConfirmMessage,
                                                 bottomContainer: self.alertContainer,
                                                 theme: self.themeManager.getCurrentTheme(for: self.windowUUID))
             }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -329,7 +329,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate, UIDocumentPickerDele
 
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         if !urls.isEmpty {
-            showToast(message: .AppMenu.AppMenuDownloadPDFConfirmMessage, toastAction: .downloadPDF)
+            showToast(message: .OldStrings.v130.AppMenu.AppMenuDownloadPDFConfirmMessage, toastAction: .downloadPDF)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1507,9 +1507,9 @@ class BrowserViewController: UIViewController,
     private func showBookmarkToast(bookmarkURL: URL? = nil, title: String? = nil, action: BookmarkAction) {
         switch action {
         case .add:
-            self.showToast(message: .AppMenu.AddBookmarkConfirmMessage, toastAction: .bookmarkPage)
+            self.showToast(message: .OldStrings.v130.AppMenu.AddBookmarkConfirmMessage, toastAction: .bookmarkPage)
         case .remove:
-            self.showToast(bookmarkURL, title, message: .AppMenu.RemoveBookmarkConfirmMessage, toastAction: .removeBookmark)
+            self.showToast(bookmarkURL, title, message: .OldStrings.v130.AppMenu.RemoveBookmarkConfirmMessage, toastAction: .removeBookmark)
         }
     }
 
@@ -3667,7 +3667,7 @@ extension BrowserViewController: DevicePickerViewControllerDelegate, Instruction
         profile.sendItem(shareItem, toDevices: devices).uponQueue(.main) { _ in
             self.popToBVC()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                SimpleToast().showAlertWithText(.AppMenu.AppMenuTabSentConfirmMessage,
+                SimpleToast().showAlertWithText(.OldStrings.v130.AppMenu.AppMenuTabSentConfirmMessage,
                                                 bottomContainer: self.contentContainer,
                                                 theme: self.currentTheme())
             }

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -309,7 +309,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     private func getNewTabAction() -> PhotonRowActions? {
         guard let tab = selectedTab else { return nil }
-        return SingleActionViewModel(title: tab.isPrivate ? .AppMenu.NewPrivateTab : .AppMenu.NewTab,
+        return SingleActionViewModel(title: tab.isPrivate ? .OldStrings.v130.AppMenu.NewPrivateTab : .OldStrings.v130.AppMenu.NewTab,
                                      iconString: StandardImageIdentifiers.Large.plus) { _ in
             let shouldFocusLocationField = NewTabAccessors.getNewTabPage(self.profile.prefs) != .homePage
             self.delegate?.openNewTabFromMenu(focusLocationField: shouldFocusLocationField, isPrivate: tab.isPrivate)
@@ -318,7 +318,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getHistoryLibraryAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.AppMenuHistory,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.AppMenuHistory,
                                      iconString: StandardImageIdentifiers.Large.history) { _ in
             self.delegate?.showLibrary(panel: .history)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .viewHistoryPanel)
@@ -326,7 +326,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getDownloadsLibraryAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.AppMenuDownloads,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.AppMenuDownloads,
                                      iconString: StandardImageIdentifiers.Large.download) { _ in
             self.delegate?.showLibrary(panel: .downloads)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .viewDownloadsPanel)
@@ -338,7 +338,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getZoomAction() -> PhotonRowActions? {
         guard let tab = selectedTab else { return nil }
         let zoomLevel = NumberFormatter.localizedString(from: NSNumber(value: tab.pageZoom), number: .percent)
-        let title = String(format: .AppMenu.ZoomPageTitle, zoomLevel)
+        let title = String(format: .OldStrings.v130.AppMenu.ZoomPageTitle, zoomLevel)
         let zoomAction = SingleActionViewModel(title: title,
                                                iconString: StandardImageIdentifiers.Large.pageZoom) { _ in
             self.delegate?.showZoomPage(tab: tab)
@@ -347,7 +347,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getFindInPageAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.AppMenuFindInPageTitleString,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.AppMenuFindInPageTitleString,
                                      iconString: StandardImageIdentifiers.Large.search) { _ in
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .findInPage)
             self.delegate?.showFindInPage()
@@ -363,11 +363,11 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         let siteTypeTelemetryObject: TelemetryWrapper.EventObject
         // swiftlint:disable line_length
         if defaultUAisDesktop {
-            toggleActionTitle = tab.changedUserAgent ? .AppMenu.AppMenuViewDesktopSiteTitleString : .AppMenu.AppMenuViewMobileSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .OldStrings.v130.AppMenu.AppMenuViewDesktopSiteTitleString : .OldStrings.v130.AppMenu.AppMenuViewMobileSiteTitleString
             toggleActionIcon = tab.changedUserAgent ? StandardImageIdentifiers.Large.deviceDesktop : StandardImageIdentifiers.Large.deviceMobile
             siteTypeTelemetryObject = .requestDesktopSite
         } else {
-            toggleActionTitle = tab.changedUserAgent ? .AppMenu.AppMenuViewMobileSiteTitleString : .AppMenu.AppMenuViewDesktopSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .OldStrings.v130.AppMenu.AppMenuViewMobileSiteTitleString : .OldStrings.v130.AppMenu.AppMenuViewDesktopSiteTitleString
             toggleActionIcon = tab.changedUserAgent ? StandardImageIdentifiers.Large.deviceMobile : StandardImageIdentifiers.Large.deviceDesktop
             siteTypeTelemetryObject = .requestMobileSite
         }
@@ -388,19 +388,19 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getCopyAction() -> PhotonRowActions? {
-        return SingleActionViewModel(title: .AppMenu.AppMenuCopyLinkTitleString,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.AppMenuCopyLinkTitleString,
                                      iconString: StandardImageIdentifiers.Large.link) { _ in
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .copyAddress)
             if let url = self.selectedTab?.canonicalURL?.displayURL {
                 UIPasteboard.general.url = url
-                self.delegate?.showToast(message: .AppMenu.AppMenuCopyURLConfirmMessage, toastAction: .copyUrl)
+                self.delegate?.showToast(message: .OldStrings.v130.AppMenu.AppMenuCopyURLConfirmMessage, toastAction: .copyUrl)
             }
         }.items
     }
 
     private func getSendToDevice() -> PhotonRowActions {
         let uuid = windowUUID
-        return SingleActionViewModel(title: .AppMenu.TouchActions.SendLinkToDeviceTitle,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.TouchActions.SendLinkToDeviceTitle,
                                      iconString: StandardImageIdentifiers.Large.deviceDesktopSend) { _ in
             guard let delegate = self.sendToDeviceDelegate,
                   let selectedTab = self.selectedTab,
@@ -427,7 +427,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getReportSiteIssueAction() -> PhotonRowActions? {
         guard featureFlags.isFeatureEnabled(.reportSiteIssue, checking: .buildOnly) else { return nil }
 
-        return SingleActionViewModel(title: .AppMenu.AppMenuReportSiteIssueTitleString,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.AppMenuReportSiteIssueTitleString,
                                      iconString: StandardImageIdentifiers.Large.lightbulb) { _ in
             guard let tabURL = self.selectedTab?.url?.absoluteString else { return }
             self.delegate?.openURLInNewTab(SupportUtils.URLForReportSiteIssue(tabURL), isPrivate: false)
@@ -436,7 +436,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getHelpAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.Help,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.Help,
                                      iconString: StandardImageIdentifiers.Large.helpCircle) { _ in
             if let url = URL(string: "https://support.mozilla.org/products/ios") {
                 self.delegate?.openURLInNewTab(url, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false)
@@ -446,7 +446,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getCustomizeHomePageAction() -> PhotonRowActions? {
-        return SingleActionViewModel(title: .AppMenu.CustomizeHomePage,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.CustomizeHomePage,
                                      iconString: StandardImageIdentifiers.Large.edit) { _ in
             self.delegate?.showCustomizeHomePage()
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .customizeHomePage)
@@ -454,7 +454,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getSettingsAction() -> PhotonRowActions {
-        let openSettings = SingleActionViewModel(title: .AppMenu.AppMenuSettingsTitleString,
+        let openSettings = SingleActionViewModel(title: .OldStrings.v130.AppMenu.AppMenuSettingsTitleString,
                                                  iconString: StandardImageIdentifiers.Large.settings) { _ in
             TelemetryWrapper.recordEvent(category: .action, method: .open, object: .settings)
 
@@ -470,7 +470,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         var items: [PhotonRowActions] = []
 
         let nightModeEnabled = NightModeHelper.isActivated()
-        let nightModeTitle: String = nightModeEnabled ? .AppMenu.AppMenuTurnOffNightMode : .AppMenu.AppMenuTurnOnNightMode
+        let nightModeTitle: String = nightModeEnabled ? .OldStrings.v130.AppMenu.AppMenuTurnOffNightMode : .OldStrings.v130.AppMenu.AppMenuTurnOnNightMode
         let nightMode = SingleActionViewModel(
             title: nightModeTitle,
             iconString: StandardImageIdentifiers.Large.nightMode,
@@ -505,7 +505,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         let needsReAuth = rustAccount.accountNeedsReauth()
 
         guard let userProfile = rustAccount.userProfile else {
-            return SingleActionViewModel(title: .AppMenu.SyncAndSaveData,
+            return SingleActionViewModel(title: .OldStrings.v130.AppMenu.SyncAndSaveData,
                                          iconString: StandardImageIdentifiers.Large.sync,
                                          tapHandler: action).items
         }
@@ -549,7 +549,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             delegate?.updateToolbarState()
         }
 
-        whatsNewAction = SingleActionViewModel(title: .AppMenu.WhatsNewString,
+        whatsNewAction = SingleActionViewModel(title: .OldStrings.v130.AppMenu.WhatsNewString,
                                                iconString: StandardImageIdentifiers.Large.whatsNew,
                                                isEnabled: showBadgeForWhatsNew) { _ in
             if let whatsNewURL = SupportUtils.URLForWhatsNew {
@@ -567,7 +567,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     // MARK: Share
 
     private func getShareFileAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.AppMenuSharePageTitleString,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.AppMenuSharePageTitleString,
                                      iconString: StandardImageIdentifiers.Large.shareApple) { _ in
             guard let tab = self.selectedTab,
                   let url = tab.url
@@ -578,7 +578,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getShareAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.Share,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.Share,
                                      iconString: StandardImageIdentifiers.Large.shareApple) { _ in
             guard let tab = self.selectedTab, let url = tab.canonicalURL?.displayURL else { return }
 
@@ -613,7 +613,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getDownloadPDFAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .AppMenu.AppMenuDownloadPDF,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.AppMenuDownloadPDF,
                                      iconString: StandardImageIdentifiers.Large.folder) { _ in
             guard let tab = self.selectedTab, let temporaryDocument = tab.temporaryDocument else { return }
                 temporaryDocument.getURL { fileURL in
@@ -652,7 +652,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getReadingListLibraryAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.ReadingList,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.ReadingList,
                                      iconString: StandardImageIdentifiers.Large.readingList) { _ in
             self.delegate?.showLibrary(panel: .readingList)
         }
@@ -663,7 +663,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getAddReadingListAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.AddReadingList,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.AddReadingList,
                                      iconString: StandardImageIdentifiers.Large.readingListAdd) { _ in
             guard let tab = self.selectedTab,
                   let url = self.tabUrl?.displayURL
@@ -680,19 +680,19 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                 object: .readingListItem,
                 value: .pageActionMenu
             )
-            self.delegate?.showToast(message: .AppMenu.AddToReadingListConfirmMessage, toastAction: .addToReadingList)
+            self.delegate?.showToast(message: .OldStrings.v130.AppMenu.AddToReadingListConfirmMessage, toastAction: .addToReadingList)
         }
     }
 
     private func getRemoveReadingListAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.RemoveReadingList,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.RemoveReadingList,
                                      iconString: StandardImageIdentifiers.Large.delete) { _ in
             guard let url = self.tabUrl?.displayURL?.absoluteString,
                   let record = self.profile.readingList.getRecordWithURL(url).value.successValue
             else { return }
 
             self.profile.readingList.deleteRecord(record, completion: nil)
-            self.delegate?.showToast(message: .AppMenu.RemoveFromReadingListConfirmMessage,
+            self.delegate?.showToast(message: .OldStrings.v130.AppMenu.RemoveFromReadingListConfirmMessage,
                                      toastAction: .removeFromReadingList)
             TelemetryWrapper.recordEvent(category: .action,
                                          method: .delete,
@@ -716,7 +716,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getBookmarkLibraryAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.Bookmarks,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.Bookmarks,
                                      iconString: StandardImageIdentifiers.Large.bookmarkTrayFill) { _ in
             self.delegate?.showLibrary(panel: .bookmarks)
         }
@@ -727,7 +727,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getAddBookmarkAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.AddBookmark,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.AddBookmark,
                                      iconString: StandardImageIdentifiers.Large.bookmark) { _ in
             guard let tab = self.selectedTab,
                   let url = tab.canonicalURL?.displayURL
@@ -745,14 +745,14 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getRemoveBookmarkAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.RemoveBookmark,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.RemoveBookmark,
                                      iconString: StandardImageIdentifiers.Large.bookmarkSlash) { _ in
             guard let url = self.tabUrl?.displayURL else { return }
 
             self.profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
                 guard result.isSuccess else { return }
                 self.delegate?.showToast(
-                    message: .AppMenu.RemoveBookmarkConfirmMessage,
+                    message: .OldStrings.v130.AppMenu.RemoveBookmarkConfirmMessage,
                     toastAction: .removeBookmark
                 )
                 self.removeBookmarkShortcut()
@@ -781,7 +781,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             let site = Site(url: url.absoluteString, title: title)
             self.profile.pinnedSites.addPinnedTopSite(site).uponQueue(.main) { result in
                 guard result.isSuccess else { return }
-                self.delegate?.showToast(message: .AppMenu.AddPinToShortcutsConfirmMessage, toastAction: .pinPage)
+                self.delegate?.showToast(message: .OldStrings.v130.AppMenu.AddPinToShortcutsConfirmMessage, toastAction: .pinPage)
             }
 
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .pinToTopSites)
@@ -789,7 +789,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     private func getRemoveShortcutAction() -> SingleActionViewModel {
-        return SingleActionViewModel(title: .AppMenu.RemoveFromShortcuts,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.RemoveFromShortcuts,
                                      iconString: StandardImageIdentifiers.Large.pinSlash) { _ in
             guard let url = self.selectedTab?.url?.displayURL,
                   let title = self.selectedTab?.displayTitle else { return }
@@ -797,7 +797,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             self.profile.pinnedSites.removeFromPinnedTopSites(site).uponQueue(.main) { result in
                 if result.isSuccess {
                     self.delegate?.showToast(
-                        message: .AppMenu.RemovePinFromShortcutsConfirmMessage,
+                        message: .OldStrings.v130.AppMenu.RemovePinFromShortcutsConfirmMessage,
                         toastAction: .removePinPage
                     )
                 }
@@ -811,7 +811,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getPasswordAction(navigationController: UINavigationController?) -> PhotonRowActions? {
         guard PasswordManagerListViewController.shouldShowAppMenuShortcut(forPrefs: profile.prefs) else { return nil }
         TelemetryWrapper.recordEvent(category: .action, method: .open, object: .logins)
-        return SingleActionViewModel(title: .AppMenu.AppMenuPasswords,
+        return SingleActionViewModel(title: .OldStrings.v130.AppMenu.AppMenuPasswords,
                                      iconString: StandardImageIdentifiers.Large.login,
                                      iconType: .Image,
                                      iconAlignment: .left) { _ in

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -628,7 +628,7 @@ extension LegacyGridTabViewController: LegacyTabPeekDelegate {
     }
 
     func tabPeekDidCopyUrl() {
-        SimpleToast().showAlertWithText(.AppMenu.AppMenuCopyURLConfirmMessage,
+        SimpleToast().showAlertWithText(.OldStrings.v130.AppMenu.AppMenuCopyURLConfirmMessage,
                                         bottomContainer: view,
                                         theme: currentTheme(),
                                         bottomConstraintPadding: -toolbarHeight)
@@ -701,7 +701,7 @@ extension LegacyGridTabViewController {
         guard !tabDisplayManager.isDragging else { return }
 
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.addAction(UIAlertAction(title: .AppMenu.AppMenuCloseAllTabsTitleString,
+        controller.addAction(UIAlertAction(title: .OldStrings.v130.AppMenu.AppMenuCloseAllTabsTitleString,
                                            style: .default,
                                            handler: { _ in self.closeTabsTrayBackground() }),
                              accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -51,7 +51,7 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
             }
             if self.hasRemoteClients {
                 actions.append(UIPreviewAction(
-                    title: .AppMenu.TouchActions.SendToDeviceTitle,
+                    title: .OldStrings.v130.AppMenu.TouchActions.SendToDeviceTitle,
                     style: .default
                 ) { [weak self] previewAction, viewController in
                     guard let wself = self, let clientPicker = wself.fxaDevicePicker else { return }
@@ -99,7 +99,7 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
             }
             if self.hasRemoteClients {
                 actions.append(UIAction(
-                    title: .AppMenu.TouchActions.SendToDeviceTitle,
+                    title: .OldStrings.v130.AppMenu.TouchActions.SendToDeviceTitle,
                     image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.shareApple),
                     identifier: nil
                 ) { [weak self] _ in

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabTrayViewController.swift
@@ -53,7 +53,7 @@ class LegacyTabTrayViewController: UIViewController, Themeable, TabTrayControlle
         return createButtonItem(imageName: StandardImageIdentifiers.Large.delete,
                                 action: #selector(didTapDeleteTabs(_:)),
                                 a11yId: AccessibilityIdentifiers.TabTray.closeAllTabsButton,
-                                a11yLabel: .AppMenu.Toolbar.TabTrayDeleteMenuButtonAccessibilityLabel)
+                                a11yLabel: .OldStrings.v130.AppMenu.Toolbar.TabTrayDeleteMenuButtonAccessibilityLabel)
     }()
 
     private lazy var newTabButtonIpad: UIBarButtonItem = {
@@ -67,7 +67,7 @@ class LegacyTabTrayViewController: UIViewController, Themeable, TabTrayControlle
         return createButtonItem(imageName: StandardImageIdentifiers.Large.delete,
                                 action: #selector(didTapDeleteTabs(_:)),
                                 a11yId: AccessibilityIdentifiers.TabTray.closeAllTabsButton,
-                                a11yLabel: .AppMenu.Toolbar.TabTrayDeleteMenuButtonAccessibilityLabel)
+                                a11yLabel: .OldStrings.v130.AppMenu.Toolbar.TabTrayDeleteMenuButtonAccessibilityLabel)
     }()
 
     private lazy var newTabButtonIphone: UIBarButtonItem = {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
@@ -17,7 +17,7 @@ enum TabTrayPanelType: Int, CaseIterable {
         case .privateTabs:
             return .TabTrayPrivateBrowsingTitle
         case .syncedTabs:
-            return .AppMenu.AppMenuSyncedTabsTitleString
+            return .OldStrings.v130.AppMenu.AppMenuSyncedTabsTitleString
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -108,7 +108,7 @@ class TabTrayViewController: UIViewController,
         return createButtonItem(imageName: StandardImageIdentifiers.Large.delete,
                                 action: #selector(deleteTabsButtonTapped),
                                 a11yId: AccessibilityIdentifiers.TabTray.closeAllTabsButton,
-                                a11yLabel: .AppMenu.Toolbar.TabTrayDeleteMenuButtonAccessibilityLabel)
+                                a11yLabel: .OldStrings.v130.AppMenu.Toolbar.TabTrayDeleteMenuButtonAccessibilityLabel)
     }()
 
     private lazy var newTabButton: UIBarButtonItem = {
@@ -481,7 +481,7 @@ class TabTrayViewController: UIViewController,
 
     private func showCloseAllConfirmation() {
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.addAction(UIAlertAction(title: .AppMenu.AppMenuCloseAllTabsTitleString,
+        controller.addAction(UIAlertAction(title: .OldStrings.v130.AppMenu.AppMenuCloseAllTabsTitleString,
                                            style: .default,
                                            handler: { _ in self.confirmCloseAll() }),
                              accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)

--- a/firefox-ios/Client/Frontend/Browser/ToastType.swift
+++ b/firefox-ios/Client/Frontend/Browser/ToastType.swift
@@ -23,9 +23,9 @@ enum ToastType: Equatable {
                 .TabsTray.CloseTabsToast.Title,
                 tabsCount)
         case .copyURL:
-            return .AppMenu.AppMenuCopyURLConfirmMessage
+            return .OldStrings.v130.AppMenu.AppMenuCopyURLConfirmMessage
         case .addBookmark:
-            return .AppMenu.AddBookmarkConfirmMessage
+            return .OldStrings.v130.AppMenu.AddBookmarkConfirmMessage
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -60,7 +60,7 @@ class ToolbarMiddleware: FeatureFlaggable {
         actionType: .menu,
         iconName: StandardImageIdentifiers.Large.appMenu,
         isEnabled: true,
-        a11yLabel: .AppMenu.Toolbar.MenuButtonAccessibilityLabel,
+        a11yLabel: .OldStrings.v130.AppMenu.Toolbar.MenuButtonAccessibilityLabel,
         a11yId: AccessibilityIdentifiers.Toolbar.settingsMenuButton)
 
     lazy var tabsAction = ToolbarActionState(

--- a/firefox-ios/Client/Frontend/Browser/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/ZoomPageBar.swift
@@ -65,7 +65,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     private lazy var zoomOutButton: UIButton = .build { button in
         self.configureButton(button,
                              image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.subtract),
-                             accessibilityLabel: .AppMenu.ZoomPageDecreaseZoomAccessibilityLabel,
+                             accessibilityLabel: .OldStrings.v130.AppMenu.ZoomPageDecreaseZoomAccessibilityLabel,
                              accessibilityIdentifier: AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomOutButton)
         button.setContentHuggingPriority(.required, for: .horizontal)
         button.configuration = .plain()
@@ -83,7 +83,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     private lazy var zoomInButton: UIButton = .build { button in
         self.configureButton(button,
                              image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus),
-                             accessibilityLabel: .AppMenu.ZoomPageIncreaseZoomAccessibilityLabel,
+                             accessibilityLabel: .OldStrings.v130.AppMenu.ZoomPageIncreaseZoomAccessibilityLabel,
                              accessibilityIdentifier: AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomInButton)
         button.setContentHuggingPriority(.required, for: .horizontal)
         button.configuration = .plain()
@@ -93,7 +93,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     private lazy var closeButton: UIButton = .build { button in
         self.configureButton(button,
                              image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
-                             accessibilityLabel: .AppMenu.ZoomPageCloseAccessibilityLabel,
+                             accessibilityLabel: .OldStrings.v130.AppMenu.ZoomPageCloseAccessibilityLabel,
                              accessibilityIdentifier: AccessibilityIdentifiers.FindInPage.findInPageCloseButton)
     }
 
@@ -219,7 +219,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         zoomLevel.text = NumberFormatter.localizedString(from: NSNumber(value: tab.pageZoom), number: .percent)
         zoomLevel.isEnabled = tab.pageZoom == 1.0 ? false : true
         gestureRecognizer.isEnabled = !(tab.pageZoom == 1.0)
-        zoomLevel.accessibilityLabel = String(format: .AppMenu.ZoomPageCurrentZoomLevelAccessibilityLabel,
+        zoomLevel.accessibilityLabel = String(format: .OldStrings.v130.AppMenu.ZoomPageCurrentZoomLevelAccessibilityLabel,
                                               zoomLevel.text ?? "")
     }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -526,7 +526,7 @@ extension BookmarksPanel: LibraryPanelContextMenu {
                                                tapHandler: { _ in
             self.profile.pinnedSites.addPinnedTopSite(site).uponQueue(.main) { result in
                 if result.isSuccess {
-                    SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage,
+                    SimpleToast().showAlertWithText(.OldStrings.v130.AppMenu.AddPinToShortcutsConfirmMessage,
                                                     bottomContainer: self.view,
                                                     theme: self.currentTheme())
                 } else {

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -884,7 +884,7 @@ extension HistoryPanel {
     func pinToTopSites(_ site: Site) {
         profile.pinnedSites.addPinnedTopSite(site).uponQueue(.main) { result in
             if result.isSuccess {
-                SimpleToast().showAlertWithText(.AppMenu.AddPinToShortcutsConfirmMessage,
+                SimpleToast().showAlertWithText(.OldStrings.v130.AppMenu.AddPinToShortcutsConfirmMessage,
                                                 bottomContainer: self.view,
                                                 theme: self.currentTheme())
             }

--- a/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryPanelHelper.swift
@@ -56,13 +56,13 @@ enum LibraryPanelType: Int, CaseIterable {
     var title: String {
         switch self {
         case .bookmarks:
-            return .AppMenu.AppMenuBookmarksTitleString
+            return .OldStrings.v130.AppMenu.AppMenuBookmarksTitleString
         case .history:
-            return .AppMenu.AppMenuHistoryTitleString
+            return .OldStrings.v130.AppMenu.AppMenuHistoryTitleString
         case .downloads:
-            return .AppMenu.AppMenuDownloadsTitleString
+            return .OldStrings.v130.AppMenu.AppMenuDownloadsTitleString
         case .readingList:
-            return .AppMenu.AppMenuReadingListTitleString
+            return .OldStrings.v130.AppMenu.AppMenuReadingListTitleString
         }
     }
 

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -54,194 +54,6 @@ private func MZLocalizedString(
 // Note that strings shouldn't be reused in multiple places in the application. Depending
 // on the Locale we can't guarantee one string will be translated the same even if its value is the same.
 
-// MARK: - Alerts
-extension String {
-    public struct Alerts {
-        public struct RestoreTabs {
-            public static let Title = MZLocalizedString(
-                key: "Alerts.RestoreTabs.Title.v109.v2",
-                tableName: "Alerts",
-                value: "%@ crashed. Restore your tabs?",
-                comment: "The title of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed. The placeholder will be the Firefox name.")
-            public static let Message = MZLocalizedString(
-                key: "Alerts.RestoreTabs.Message.v109",
-                tableName: "Alerts",
-                value: "Sorry about that. Restore tabs to pick up where you left off.",
-                comment: "The body of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed.")
-            public static let ButtonNo = MZLocalizedString(
-                key: "Alerts.RestoreTabs.Button.No.v109",
-                tableName: "Alerts",
-                value: "No",
-                comment: "The title for the negative action of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed, and will reject the action of restoring tabs.")
-            public static let ButtonYes = MZLocalizedString(
-                key: "Alerts.RestoreTabs.Button.Yes.v109",
-                tableName: "Alerts",
-                value: "Restore tabs",
-                comment: "The title for the affirmative action of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed, and will restore existing tabs.")
-        }
-
-        public struct FeltDeletion {
-            public static let Title = MZLocalizedString(
-                key: "Alerts.FeltDeletion.Title.v122",
-                tableName: "Alerts",
-                value: "End your private session?",
-                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the title for the alert.")
-            public static let Body = MZLocalizedString(
-                key: "Alerts.FeltDeletion.Body.v122",
-                tableName: "Alerts",
-                value: "Close all private tabs and delete history, cookies, and all other site data.",
-                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the body text for the alert.")
-            public static let ConfirmButton = MZLocalizedString(
-                key: "Alerts.FeltDeletion.Button.Confirm.v122",
-                tableName: "Alerts",
-                value: "Delete session data",
-                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the affirmative action for the alert, confirming that you do want to do that.")
-            public static let CancelButton = MZLocalizedString(
-                key: "Alerts.FeltDeletion.Button.Cancel.v122",
-                tableName: "Alerts",
-                value: "Cancel",
-                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the cancel action for the alert, cancelling ending your session.")
-        }
-    }
-}
-
-// MARK: - Biometric Authentication
-extension String {
-    public struct Biometry {
-        public struct Screen {
-            public static let UniversalAuthenticationReason = MZLocalizedString(
-                key: "Biometry.Screen.UniversalAuthenticationReason.v115",
-                tableName: "BiometricAuthentication",
-                value: "Authenticate to access passwords.",
-                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")
-            public static let UniversalAuthenticationReasonV2 = MZLocalizedString(
-                key: "Biometry.Screen.UniversalAuthenticationReason.v122",
-                tableName: "BiometricAuthentication",
-                value: "Authenticate to access your saved passwords and payment methods.",
-                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen for logins and encrypted cards.")
-        }
-    }
-}
-
-// MARK: - Bookmarks Menu
-extension String {
-    public struct Bookmarks {
-        public struct Menu {
-            public static let DesktopBookmarks = MZLocalizedString(
-                key: "Bookmarks.Menu.DesktopBookmarks",
-                tableName: nil,
-                value: "Desktop Bookmarks",
-                comment: "A label indicating all bookmarks grouped under the category 'Desktop Bookmarks'.")
-        }
-    }
-}
-
-// MARK: - Contextual Hints
-extension String {
-    public struct ContextualHints {
-        public static let ContextualHintsCloseAccessibility = MZLocalizedString(
-            key: "ContextualHintsCloseButtonAccessibility.v105",
-            tableName: nil,
-            value: "Close",
-            comment: "Accessibility label for action denoting closing contextual hint.")
-
-        public struct FirefoxHomepage {
-            public struct JumpBackIn {
-                public static let PersonalizedHome = MZLocalizedString(
-                    key: "ContextualHints.FirefoxHomepage.JumpBackIn.PersonalizedHome",
-                    tableName: "JumpBackIn",
-                    value: "Meet your personalized homepage. Recent tabs, bookmarks, and search results will appear here.",
-                    comment: "Contextual hints are little popups that appear for the users informing them of new features. This one talks about additions to the Firefox homepage regarding a more personalized experience.")
-                public static let SyncedTab = MZLocalizedString(
-                    key: "ContextualHints.FirefoxHomepage.JumpBackIn.SyncedTab.v106",
-                    tableName: "JumpBackIn",
-                    value: "Your tabs are syncing! Pick up where you left off on your other device.",
-                    comment: "Contextual hints are little popups that appear for the users informing them of new features. When a user is logged in and has a tab synced from desktop, this popup indicates which tab that is within the Jump Back In section.")
-            }
-        }
-
-        public struct TabsTray {
-            public struct InactiveTabs {
-                public static let Action = MZLocalizedString(
-                    key: "ContextualHints.TabTray.InactiveTabs.CallToAction",
-                    tableName: nil,
-                    value: "Turn off in settings",
-                    comment: "Contextual hints are little popups that appear for the users informing them of new features. This one is the call to action for the inactive tabs contextual popup.")
-                public static let Body = MZLocalizedString(
-                    key: "ContextualHints.TabTray.InactiveTabs",
-                    tableName: nil,
-                    value: "Tabs you haven’t viewed for two weeks get moved here.",
-                    comment: "Contextual hints are little popups that appear for the users informing them of new features. This one talks about the inactive tabs feature.")
-            }
-        }
-
-        public struct Toolbar {
-            public static let SearchBarPlacementButtonText = MZLocalizedString(
-                key: "ContextualHints.SearchBarPlacement.CallToAction",
-                tableName: nil,
-                value: "Toolbar Settings",
-                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one is a call to action for the popup describing search bar placement. It indicates a user can navigate to the settings page that allows them to customize the placement of the search bar.")
-            public static let SearchBarTopPlacement = MZLocalizedString(
-                key: "ContextualHints.Toolbar.Top.Description.v107",
-                tableName: "ToolbarLocation",
-                value: "Move the toolbar to the bottom if that’s more your style.",
-                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one indicates a user can navigate to the Settings page to move the search bar to the bottom.")
-            public static let SearchBarBottomPlacement = MZLocalizedString(
-                key: "ContextualHints.Toolbar.Bottom.Description.v107",
-                tableName: "ToolbarLocation",
-                value: "Move the toolbar to the top if that’s more your style.",
-                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one indicates a user can navigate to the Settings page to move the search bar to the top.")
-        }
-
-        public struct Shopping {
-            public static let NotOptedInBody = MZLocalizedString(
-                key: "ContextualHints.Shopping.NotOptedIn.v120",
-                tableName: "Shopping",
-                value: "Find out if you can trust this product’s reviews — before you buy.",
-                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one indicates that a user can tap on the shopping button to start using the Shopping feature.")
-            public static let NotOptedInAction = MZLocalizedString(
-                key: "ContextualHints.Shopping.NotOptedInAction.v120",
-                tableName: "Shopping",
-                value: "Try Review Checker",
-                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one is a call to action for the popup describing the Shopping feature. It indicates that a user can go directly to the Shopping feature by tapping the text of the action.")
-            public static let OptedInBody = MZLocalizedString(
-                key: "ContextualHints.Shopping.OptedInBody.v120",
-                tableName: "Shopping",
-                value: "Are these reviews reliable? Check now to see an adjusted rating.",
-                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one appears after the user has opted in and informs him if he wants use the review checker by tapping the Shopping button.")
-            public static let OptedInAction = MZLocalizedString(
-                key: "ContextualHints.Shopping.OptedInAction.v120",
-                tableName: "Shopping",
-                value: "Open Review Checker",
-                comment: "Contextual hints are little popups that appear for the users informing them of new features. This is a call to action for the popup that appears after the user has opted in for the Shopping feature. It indicates that a user can directly open the review checker by tapping the text of the action.")
-        }
-
-        public struct FeltDeletion {
-            public static let Body = MZLocalizedString(
-                key: "ContextualHints.FeltDeletion.Body.v122",
-                tableName: "ContextualHints",
-                value: "Tap here to start a fresh private session. Delete your history, cookies — everything.",
-                comment: "Contextual hints are little popups that appear for the users informing them of new features. This is a call to action for the popup that appears to educate users about what the fire button in the toolbar does, when in private mode.")
-        }
-    }
-}
-
-// MARK: - Keyboard Accessory View
-extension String {
-    public struct KeyboardAccessory {
-        public static let NextButtonA11yLabel = MZLocalizedString(
-            key: "KeyboardAccessory.NextButton.Accessibility.Label.v124",
-            tableName: "KeyboardAccessory",
-            value: "Next form field",
-            comment: "Accessibility label for next button that is displayed above the keyboard when a form field on a website was tapped.")
-        public static let PreviousButtonA11yLabel = MZLocalizedString(
-            key: "KeyboardAccessory.PreviousButton.Accessibility.Label.v124",
-            tableName: "KeyboardAccessory",
-            value: "Previous form field",
-            comment: "Accessibility label for previous button that is displayed above the keyboard when a form field on a website was tapped.")
-    }
-}
-
 // MARK: - Address Autofill
 extension String {
     public struct Addresses {
@@ -572,6 +384,178 @@ extension String {
                 tableName: "BottomSheet",
                 value: "Use a saved address?",
                 comment: "When a user is in the process of entering an address, a screen pops up prompting the user if they want to use a saved address. This string is used as the title label of the screen.")
+        }
+    }
+}
+
+// MARK: - Alerts
+extension String {
+    public struct Alerts {
+        public struct RestoreTabs {
+            public static let Title = MZLocalizedString(
+                key: "Alerts.RestoreTabs.Title.v109.v2",
+                tableName: "Alerts",
+                value: "%@ crashed. Restore your tabs?",
+                comment: "The title of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed. The placeholder will be the Firefox name.")
+            public static let Message = MZLocalizedString(
+                key: "Alerts.RestoreTabs.Message.v109",
+                tableName: "Alerts",
+                value: "Sorry about that. Restore tabs to pick up where you left off.",
+                comment: "The body of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed.")
+            public static let ButtonNo = MZLocalizedString(
+                key: "Alerts.RestoreTabs.Button.No.v109",
+                tableName: "Alerts",
+                value: "No",
+                comment: "The title for the negative action of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed, and will reject the action of restoring tabs.")
+            public static let ButtonYes = MZLocalizedString(
+                key: "Alerts.RestoreTabs.Button.Yes.v109",
+                tableName: "Alerts",
+                value: "Restore tabs",
+                comment: "The title for the affirmative action of the restore tabs pop-up alert. This alert shows when opening up Firefox after it crashed, and will restore existing tabs.")
+        }
+
+        public struct FeltDeletion {
+            public static let Title = MZLocalizedString(
+                key: "Alerts.FeltDeletion.Title.v122",
+                tableName: "Alerts",
+                value: "End your private session?",
+                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the title for the alert.")
+            public static let Body = MZLocalizedString(
+                key: "Alerts.FeltDeletion.Body.v122",
+                tableName: "Alerts",
+                value: "Close all private tabs and delete history, cookies, and all other site data.",
+                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the body text for the alert.")
+            public static let ConfirmButton = MZLocalizedString(
+                key: "Alerts.FeltDeletion.Button.Confirm.v122",
+                tableName: "Alerts",
+                value: "Delete session data",
+                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the affirmative action for the alert, confirming that you do want to do that.")
+            public static let CancelButton = MZLocalizedString(
+                key: "Alerts.FeltDeletion.Button.Cancel.v122",
+                tableName: "Alerts",
+                value: "Cancel",
+                comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the cancel action for the alert, cancelling ending your session.")
+        }
+    }
+}
+
+// MARK: - Biometric Authentication
+extension String {
+    public struct Biometry {
+        public struct Screen {
+            public static let UniversalAuthenticationReason = MZLocalizedString(
+                key: "Biometry.Screen.UniversalAuthenticationReason.v115",
+                tableName: "BiometricAuthentication",
+                value: "Authenticate to access passwords.",
+                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen.")
+            public static let UniversalAuthenticationReasonV2 = MZLocalizedString(
+                key: "Biometry.Screen.UniversalAuthenticationReason.v122",
+                tableName: "BiometricAuthentication",
+                value: "Authenticate to access your saved passwords and payment methods.",
+                comment: "Biometric authentication is when the system prompts users for Face ID or fingerprint before accessing protected information. This string asks the user to enter their device passcode to access the protected screen for logins and encrypted cards.")
+        }
+    }
+}
+
+// MARK: - Bookmarks Menu
+extension String {
+    public struct Bookmarks {
+        public struct Menu {
+            public static let DesktopBookmarks = MZLocalizedString(
+                key: "Bookmarks.Menu.DesktopBookmarks",
+                tableName: nil,
+                value: "Desktop Bookmarks",
+                comment: "A label indicating all bookmarks grouped under the category 'Desktop Bookmarks'.")
+        }
+    }
+}
+
+// MARK: - Contextual Hints
+extension String {
+    public struct ContextualHints {
+        public static let ContextualHintsCloseAccessibility = MZLocalizedString(
+            key: "ContextualHintsCloseButtonAccessibility.v105",
+            tableName: nil,
+            value: "Close",
+            comment: "Accessibility label for action denoting closing contextual hint.")
+
+        public struct FirefoxHomepage {
+            public struct JumpBackIn {
+                public static let PersonalizedHome = MZLocalizedString(
+                    key: "ContextualHints.FirefoxHomepage.JumpBackIn.PersonalizedHome",
+                    tableName: "JumpBackIn",
+                    value: "Meet your personalized homepage. Recent tabs, bookmarks, and search results will appear here.",
+                    comment: "Contextual hints are little popups that appear for the users informing them of new features. This one talks about additions to the Firefox homepage regarding a more personalized experience.")
+                public static let SyncedTab = MZLocalizedString(
+                    key: "ContextualHints.FirefoxHomepage.JumpBackIn.SyncedTab.v106",
+                    tableName: "JumpBackIn",
+                    value: "Your tabs are syncing! Pick up where you left off on your other device.",
+                    comment: "Contextual hints are little popups that appear for the users informing them of new features. When a user is logged in and has a tab synced from desktop, this popup indicates which tab that is within the Jump Back In section.")
+            }
+        }
+
+        public struct TabsTray {
+            public struct InactiveTabs {
+                public static let Action = MZLocalizedString(
+                    key: "ContextualHints.TabTray.InactiveTabs.CallToAction",
+                    tableName: nil,
+                    value: "Turn off in settings",
+                    comment: "Contextual hints are little popups that appear for the users informing them of new features. This one is the call to action for the inactive tabs contextual popup.")
+                public static let Body = MZLocalizedString(
+                    key: "ContextualHints.TabTray.InactiveTabs",
+                    tableName: nil,
+                    value: "Tabs you haven’t viewed for two weeks get moved here.",
+                    comment: "Contextual hints are little popups that appear for the users informing them of new features. This one talks about the inactive tabs feature.")
+            }
+        }
+
+        public struct Toolbar {
+            public static let SearchBarPlacementButtonText = MZLocalizedString(
+                key: "ContextualHints.SearchBarPlacement.CallToAction",
+                tableName: nil,
+                value: "Toolbar Settings",
+                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one is a call to action for the popup describing search bar placement. It indicates a user can navigate to the settings page that allows them to customize the placement of the search bar.")
+            public static let SearchBarTopPlacement = MZLocalizedString(
+                key: "ContextualHints.Toolbar.Top.Description.v107",
+                tableName: "ToolbarLocation",
+                value: "Move the toolbar to the bottom if that’s more your style.",
+                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one indicates a user can navigate to the Settings page to move the search bar to the bottom.")
+            public static let SearchBarBottomPlacement = MZLocalizedString(
+                key: "ContextualHints.Toolbar.Bottom.Description.v107",
+                tableName: "ToolbarLocation",
+                value: "Move the toolbar to the top if that’s more your style.",
+                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one indicates a user can navigate to the Settings page to move the search bar to the top.")
+        }
+
+        public struct Shopping {
+            public static let NotOptedInBody = MZLocalizedString(
+                key: "ContextualHints.Shopping.NotOptedIn.v120",
+                tableName: "Shopping",
+                value: "Find out if you can trust this product’s reviews — before you buy.",
+                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one indicates that a user can tap on the shopping button to start using the Shopping feature.")
+            public static let NotOptedInAction = MZLocalizedString(
+                key: "ContextualHints.Shopping.NotOptedInAction.v120",
+                tableName: "Shopping",
+                value: "Try Review Checker",
+                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one is a call to action for the popup describing the Shopping feature. It indicates that a user can go directly to the Shopping feature by tapping the text of the action.")
+            public static let OptedInBody = MZLocalizedString(
+                key: "ContextualHints.Shopping.OptedInBody.v120",
+                tableName: "Shopping",
+                value: "Are these reviews reliable? Check now to see an adjusted rating.",
+                comment: "Contextual hints are little popups that appear for the users informing them of new features. This one appears after the user has opted in and informs him if he wants use the review checker by tapping the Shopping button.")
+            public static let OptedInAction = MZLocalizedString(
+                key: "ContextualHints.Shopping.OptedInAction.v120",
+                tableName: "Shopping",
+                value: "Open Review Checker",
+                comment: "Contextual hints are little popups that appear for the users informing them of new features. This is a call to action for the popup that appears after the user has opted in for the Shopping feature. It indicates that a user can directly open the review checker by tapping the text of the action.")
+        }
+
+        public struct FeltDeletion {
+            public static let Body = MZLocalizedString(
+                key: "ContextualHints.FeltDeletion.Body.v122",
+                tableName: "ContextualHints",
+                value: "Tap here to start a fresh private session. Delete your history, cookies — everything.",
+                comment: "Contextual hints are little popups that appear for the users informing them of new features. This is a call to action for the popup that appears to educate users about what the fire button in the toolbar does, when in private mode.")
         }
     }
 }
@@ -1081,6 +1065,22 @@ extension String {
     }
 }
 
+// MARK: - Keyboard Accessory View
+extension String {
+    public struct KeyboardAccessory {
+        public static let NextButtonA11yLabel = MZLocalizedString(
+            key: "KeyboardAccessory.NextButton.Accessibility.Label.v124",
+            tableName: "KeyboardAccessory",
+            value: "Next form field",
+            comment: "Accessibility label for next button that is displayed above the keyboard when a form field on a website was tapped.")
+        public static let PreviousButtonA11yLabel = MZLocalizedString(
+            key: "KeyboardAccessory.PreviousButton.Accessibility.Label.v124",
+            tableName: "KeyboardAccessory",
+            value: "Previous form field",
+            comment: "Accessibility label for previous button that is displayed above the keyboard when a form field on a website was tapped.")
+    }
+}
+
 // MARK: - Keyboard shortcuts/"hotkeys"
 extension String {
     /// Identifiers of all new strings should begin with `Keyboard.Shortcuts.`
@@ -1348,6 +1348,304 @@ extension String {
         public struct Downloads { }
     }
 }
+
+// MARK: - Main Menu
+extension String {
+    public struct AppMenu {
+        public static let AppMenuReportSiteIssueTitleString = MZLocalizedString(
+            key: "Menu.ReportSiteIssueAction.Title",
+            tableName: "Menu",
+            value: "Report Site Issue",
+            comment: "Label for the button, displayed in the menu, used to report a compatibility issue with the current page.")
+        public static let AppMenuSharePageTitleString = MZLocalizedString(
+            key: "Menu.SharePageAction.Title",
+            tableName: "Menu",
+            value: "Share Page With…",
+            comment: "Label for the button, displayed in the menu, used to open the share dialog.")
+        public static let AppMenuCopyLinkTitleString = MZLocalizedString(
+            key: "Menu.CopyLink.Title",
+            tableName: "Menu",
+            value: "Copy Link",
+            comment: "Label for the button, displayed in the menu, used to copy the current page link to the clipboard.")
+        public static let AppMenuFindInPageTitleString = MZLocalizedString(
+            key: "Menu.FindInPageAction.Title",
+            tableName: "Menu",
+            value: "Find in Page",
+            comment: "Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page.")
+        public static let AppMenuViewDesktopSiteTitleString = MZLocalizedString(
+            key: "Menu.ViewDekstopSiteAction.Title",
+            tableName: "Menu",
+            value: "Request Desktop Site",
+            comment: "Label for the button, displayed in the menu, used to request the desktop version of the current website.")
+        public static let AppMenuViewMobileSiteTitleString = MZLocalizedString(
+            key: "Menu.ViewMobileSiteAction.Title",
+            tableName: "Menu",
+            value: "Request Mobile Site",
+            comment: "Label for the button, displayed in the menu, used to request the mobile version of the current website.")
+        public static let AppMenuSettingsTitleString = MZLocalizedString(
+            key: "Menu.OpenSettingsAction.Title",
+            tableName: "Menu",
+            value: "Settings",
+            comment: "Label for the button, displayed in the menu, used to open the Settings menu.")
+        public static let AppMenuCloseAllTabsTitleString = MZLocalizedString(
+            key: "Menu.CloseAllTabsAction.Title",
+            tableName: "Menu",
+            value: "Close All Tabs",
+            comment: "Label for the button, displayed in the menu, used to close all tabs currently open.")
+        public static let AppMenuOpenHomePageTitleString = MZLocalizedString(
+            key: "SettingsMenu.OpenHomePageAction.Title",
+            tableName: "Menu",
+            value: "Homepage",
+            comment: "Label for the button, displayed in the menu, used to navigate to the home page.")
+        public static let AppMenuBookmarksTitleString = MZLocalizedString(
+            key: "Menu.OpenBookmarksAction.AccessibilityLabel.v2",
+            tableName: "Menu",
+            value: "Bookmarks",
+            comment: "Accessibility label for the button, displayed in the menu, used to open the Bookmarks home panel. Please keep as short as possible, <15 chars of space available.")
+        public static let AppMenuReadingListTitleString = MZLocalizedString(
+            key: "Menu.OpenReadingListAction.AccessibilityLabel.v2",
+            tableName: "Menu",
+            value: "Reading List",
+            comment: "Accessibility label for the button, displayed in the menu, used to open the Reading list home panel. Please keep as short as possible, <15 chars of space available.")
+        public static let AppMenuHistoryTitleString = MZLocalizedString(
+            key: "Menu.OpenHistoryAction.AccessibilityLabel.v2",
+            tableName: "Menu",
+            value: "History",
+            comment: "Accessibility label for the button, displayed in the menu, used to open the History home panel. Please keep as short as possible, <15 chars of space available.")
+        public static let AppMenuDownloadsTitleString = MZLocalizedString(
+            key: "Menu.OpenDownloadsAction.AccessibilityLabel.v2",
+            tableName: "Menu",
+            value: "Downloads",
+            comment: "Accessibility label for the button, displayed in the menu, used to open the Downloads home panel. Please keep as short as possible, <15 chars of space available.")
+        public static let AppMenuSyncedTabsTitleString = MZLocalizedString(
+            key: "Menu.OpenSyncedTabsAction.AccessibilityLabel.v2",
+            tableName: "Menu",
+            value: "Synced Tabs",
+            comment: "Accessibility label for the button, displayed in the menu, used to open the Synced Tabs home panel. Please keep as short as possible, <15 chars of space available.")
+        public static let AppMenuTurnOnNightMode = MZLocalizedString(
+            key: "Menu.NightModeTurnOn.Label2",
+            tableName: nil,
+            value: "Turn on Night Mode",
+            comment: "Label for the button, displayed in the menu, turns on night mode.")
+        public static let AppMenuTurnOffNightMode = MZLocalizedString(
+            key: "Menu.NightModeTurnOff.Label2",
+            tableName: nil,
+            value: "Turn off Night Mode",
+            comment: "Label for the button, displayed in the menu, turns off night mode.")
+        public static let AppMenuHistory = MZLocalizedString(
+            key: "Menu.History.Label",
+            tableName: nil,
+            value: "History",
+            comment: "Label for the button, displayed in the menu, takes you to History screen when pressed.")
+        public static let AppMenuDownloads = MZLocalizedString(
+            key: "Menu.Downloads.Label",
+            tableName: nil,
+            value: "Downloads",
+            comment: "Label for the button, displayed in the menu, takes you to Downloads screen when pressed.")
+        public static let AppMenuDownloadPDF = MZLocalizedString(
+            key: "Menu.DownloadPDF.Label.v129",
+            tableName: "Menu",
+            value: "Download PDF",
+            comment: "Label for the button, displayed in the menu, downloads a pdf when pressed.")
+        public static let AppMenuDownloadPDFConfirmMessage = MZLocalizedString(
+            key: "Menu.DownloadPDF.Confirm.v129",
+            tableName: "Menu",
+            value: "Successfully Downloaded PDF",
+            comment: "Toast displayed to user after downlaod pdf was pressed.")
+        public static let AppMenuPasswords = MZLocalizedString(
+            key: "Menu.Passwords.Label",
+            tableName: nil,
+            value: "Passwords",
+            comment: "Label for the button, displayed in the menu, takes you to passwords screen when pressed.")
+        public static let AppMenuCopyURLConfirmMessage = MZLocalizedString(
+            key: "Menu.CopyURL.Confirm",
+            tableName: nil,
+            value: "URL Copied To Clipboard",
+            comment: "Toast displayed to user after copy url pressed.")
+        public static let AppMenuTabSentConfirmMessage = MZLocalizedString(
+            key: "Menu.TabSent.Confirm",
+            tableName: nil,
+            value: "Tab Sent",
+            comment: "Toast displayed to the user after a tab has been sent successfully.")
+        public static let WhatsNewString = MZLocalizedString(
+            key: "Menu.WhatsNew.Title",
+            tableName: nil,
+            value: "What’s New",
+            comment: "The title for the option to view the What's new page.")
+        public static let CustomizeHomePage = MZLocalizedString(
+            key: "Menu.CustomizeHomePage.v99",
+            tableName: nil,
+            value: "Customize Homepage",
+            comment: "Label for the customize homepage button in the menu page. Pressing this button takes users to the settings options, where they can customize the Firefox Home page")
+        public static let NewTab = MZLocalizedString(
+            key: "Menu.NewTab.v99",
+            tableName: nil,
+            value: "New Tab",
+            comment: "Label for the new tab button in the menu page. Pressing this button opens a new tab.")
+        public static let NewPrivateTab = MZLocalizedString(
+            key: "Menu.NewPrivateTab.Label",
+            tableName: nil,
+            value: "New Private Tab",
+            comment: "Label for the new private tab button in the menu page. Pressing this button opens a new private tab.")
+        public static let Help = MZLocalizedString(
+            key: "Menu.Help.v99",
+            tableName: nil,
+            value: "Help",
+            comment: "Label for the help button in the menu page. Pressing this button opens the support page https://support.mozilla.org/en-US/products/ios")
+        public static let Share = MZLocalizedString(
+            key: "Menu.Share.v99",
+            tableName: nil,
+            value: "Share",
+            comment: "Label for the share button in the menu page. Pressing this button open the share menu to share the current website.")
+        public static let SyncAndSaveData = MZLocalizedString(
+            key: "Menu.SyncAndSaveData.v103",
+            tableName: nil,
+            value: "Sync and Save Data",
+            comment: "Label for the Firefox Sync button in the menu page. Pressing this button open the sign in to Firefox page service to sync and save data.")
+
+        // Shortcuts
+        public static let AddToShortcuts = MZLocalizedString(
+            key: "Menu.AddToShortcuts.v99",
+            tableName: nil,
+            value: "Add to Shortcuts",
+            comment: "Label for the add to shortcuts button in the menu. Pressing this button pins the current website as a shortcut on the home page.")
+        public static let RemoveFromShortcuts = MZLocalizedString(
+            key: "Menu.RemovedFromShortcuts.v99",
+            tableName: nil,
+            value: "Remove from Shortcuts",
+            comment: "Label for the remove from shortcuts button in the menu. Pressing this button removes the current website from the shortcut pins on the home page.")
+        public static let AddPinToShortcutsConfirmMessage = MZLocalizedString(
+            key: "Menu.AddPin.Confirm2",
+            tableName: nil,
+            value: "Added to Shortcuts",
+            comment: "Toast displayed to the user after adding the item to the Shortcuts.")
+        public static let RemovePinFromShortcutsConfirmMessage = MZLocalizedString(
+            key: "Menu.RemovePin.Confirm2.v99",
+            tableName: nil,
+            value: "Removed from Shortcuts",
+            comment: "Toast displayed to the user after removing the item to the Shortcuts.")
+
+        // Bookmarks
+        public static let Bookmarks = MZLocalizedString(
+            key: "Menu.Bookmarks.Label",
+            tableName: nil,
+            value: "Bookmarks",
+            comment: "Label for the button, displayed in the menu, takes you to bookmarks screen when pressed.")
+        public static let AddBookmark = MZLocalizedString(
+            key: "Menu.AddBookmark.Label.v99",
+            tableName: nil,
+            value: "Add",
+            comment: "Label for the add bookmark button in the menu. Pressing this button bookmarks the current page. Please keep the text as short as possible for this label.")
+        public static let AddBookmarkConfirmMessage = MZLocalizedString(
+            key: "Menu.AddBookmark.Confirm",
+            tableName: nil,
+            value: "Bookmark Added",
+            comment: "Toast displayed to the user after a bookmark has been added.")
+        public static let RemoveBookmark = MZLocalizedString(
+            key: "Menu.RemoveBookmark.Label.v99",
+            tableName: nil,
+            value: "Remove",
+            comment: "Label for the remove bookmark button in the menu. Pressing this button remove the current page from the bookmarks. Please keep the text as short as possible for this label.")
+        public static let RemoveBookmarkConfirmMessage = MZLocalizedString(
+            key: "Menu.RemoveBookmark.Confirm",
+            tableName: nil,
+            value: "Bookmark Removed",
+            comment: "Toast displayed to the user after a bookmark has been removed.")
+
+        // Reading list
+        public static let ReadingList = MZLocalizedString(
+            key: "Menu.ReadingList.Label",
+            tableName: nil,
+            value: "Reading List",
+            comment: "Label for the button, displayed in the menu, takes you to Reading List screen when pressed.")
+        public static let AddReadingList = MZLocalizedString(
+            key: "Menu.AddReadingList.Label.v99",
+            tableName: nil,
+            value: "Add",
+            comment: "Label for the add to reading list button in the menu. Pressing this button adds the current page to the reading list. Please keep the text as short as possible for this label.")
+        public static let AddToReadingListConfirmMessage = MZLocalizedString(
+            key: "Menu.AddToReadingList.Confirm",
+            tableName: nil,
+            value: "Added To Reading List",
+            comment: "Toast displayed to the user after adding the item to their reading list.")
+        public static let RemoveReadingList = MZLocalizedString(
+            key: "Menu.RemoveReadingList.Label.v99",
+            tableName: nil,
+            value: "Remove",
+            comment: "Label for the remove from reading list button in the menu. Pressing this button removes the current page from the reading list. Please keep the text as short as possible for this label.")
+        public static let RemoveFromReadingListConfirmMessage = MZLocalizedString(
+            key: "Menu.RemoveReadingList.Confirm.v99",
+            tableName: nil,
+            value: "Removed from Reading List",
+            comment: "Toast displayed to confirm to the user that his reading list item was correctly removed.")
+
+        // ZoomPageBar
+        public static let ZoomPageTitle = MZLocalizedString(
+            key: "Menu.ZoomPage.Title.v113",
+            tableName: nil,
+            value: "Zoom (%@)",
+            comment: "Label for the zoom page button in the menu, used to show the Zoom Page bar. The placeholder shows the current zoom level in percent.")
+        public static let ZoomPageCloseAccessibilityLabel = MZLocalizedString(
+            key: "Menu.ZoomPage.Close.AccessibilityLabel.v113",
+            tableName: "ZoomPageBar",
+            value: "Close Zoom Panel",
+            comment: "Accessibility label for closing the zoom panel in Zoom Page Bar")
+        public static let ZoomPageIncreaseZoomAccessibilityLabel = MZLocalizedString(
+            key: "Menu.ZoomPage.IncreaseZoom.AccessibilityLabel.v113",
+            tableName: "ZoomPageBar",
+            value: "Increase Zoom Level",
+            comment: "Accessibility label for increasing the zoom level in Zoom Page Bar")
+        public static let ZoomPageDecreaseZoomAccessibilityLabel = MZLocalizedString(
+            key: "Menu.ZoomPage.DecreaseZoom.AccessibilityLabel.v113",
+            tableName: "ZoomPageBar",
+            value: "Decrease Zoom Level",
+            comment: "Accessibility label for decreasing the zoom level in Zoom Page Bar")
+        public static let ZoomPageCurrentZoomLevelAccessibilityLabel = MZLocalizedString(
+            key: "Menu.ZoomPage.CurrentZoomLevel.AccessibilityLabel.v113",
+            tableName: "ZoomPageBar",
+            value: "Current Zoom Level: %@",
+            comment: "Accessibility label for current zoom level in Zoom Page Bar. The placeholder represents the zoom level")
+
+        // Toolbar
+        public struct Toolbar {
+            public static let MenuButtonAccessibilityLabel = MZLocalizedString(
+                key: "Toolbar.Menu.AccessibilityLabel",
+                tableName: nil,
+                value: "Menu",
+                comment: "Accessibility label for the Menu button.")
+            public static let HomeMenuButtonAccessibilityLabel = MZLocalizedString(
+                key: "Menu.Toolbar.Home.AccessibilityLabel.v99",
+                tableName: nil,
+                value: "Home",
+                comment: "Accessibility label for the Home button on the toolbar. Pressing this button brings the user to the home page.")
+            public static let BookmarksButtonAccessibilityLabel = MZLocalizedString(
+                key: "Menu.Toolbar.Bookmarks.AccessibilityLabel.v99",
+                tableName: nil,
+                value: "Bookmarks",
+                comment: "Accessibility label for the Bookmark button on the toolbar. Pressing this button opens the bookmarks menu")
+            public static let TabTrayDeleteMenuButtonAccessibilityLabel = MZLocalizedString(
+                key: "Toolbar.Menu.CloseAllTabs",
+                tableName: nil,
+                value: "Close All Tabs",
+                comment: "Accessibility label for the Close All Tabs menu button.")
+        }
+
+        // 3D TouchActions
+        public struct TouchActions {
+            public static let SendToDeviceTitle = MZLocalizedString(
+                key: "Send to Device",
+                tableName: "3DTouchActions",
+                value: nil,
+                comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
+            public static let SendLinkToDeviceTitle = MZLocalizedString(
+                key: "Menu.SendLinkToDevice",
+                tableName: "3DTouchActions",
+                value: "Send Link to Device",
+                comment: "Label for preview action on Tab Tray Tab to send the current link to another device")
+        }
+    }
+}
+
 
 // MARK: - Micro survey
 extension String {
@@ -3759,304 +4057,6 @@ extension String {
             tableName: "QRCode",
             value: "Scan QR code",
             comment: "Accessibility label of the QR code button in the toolbar")
-    }
-}
-
-// MARK: - App menu
-extension String {
-    /// Identifiers of all new strings should begin with `Menu.`
-    public struct AppMenu {
-        public static let AppMenuReportSiteIssueTitleString = MZLocalizedString(
-            key: "Menu.ReportSiteIssueAction.Title",
-            tableName: "Menu",
-            value: "Report Site Issue",
-            comment: "Label for the button, displayed in the menu, used to report a compatibility issue with the current page.")
-        public static let AppMenuSharePageTitleString = MZLocalizedString(
-            key: "Menu.SharePageAction.Title",
-            tableName: "Menu",
-            value: "Share Page With…",
-            comment: "Label for the button, displayed in the menu, used to open the share dialog.")
-        public static let AppMenuCopyLinkTitleString = MZLocalizedString(
-            key: "Menu.CopyLink.Title",
-            tableName: "Menu",
-            value: "Copy Link",
-            comment: "Label for the button, displayed in the menu, used to copy the current page link to the clipboard.")
-        public static let AppMenuFindInPageTitleString = MZLocalizedString(
-            key: "Menu.FindInPageAction.Title",
-            tableName: "Menu",
-            value: "Find in Page",
-            comment: "Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page.")
-        public static let AppMenuViewDesktopSiteTitleString = MZLocalizedString(
-            key: "Menu.ViewDekstopSiteAction.Title",
-            tableName: "Menu",
-            value: "Request Desktop Site",
-            comment: "Label for the button, displayed in the menu, used to request the desktop version of the current website.")
-        public static let AppMenuViewMobileSiteTitleString = MZLocalizedString(
-            key: "Menu.ViewMobileSiteAction.Title",
-            tableName: "Menu",
-            value: "Request Mobile Site",
-            comment: "Label for the button, displayed in the menu, used to request the mobile version of the current website.")
-        public static let AppMenuSettingsTitleString = MZLocalizedString(
-            key: "Menu.OpenSettingsAction.Title",
-            tableName: "Menu",
-            value: "Settings",
-            comment: "Label for the button, displayed in the menu, used to open the Settings menu.")
-        public static let AppMenuCloseAllTabsTitleString = MZLocalizedString(
-            key: "Menu.CloseAllTabsAction.Title",
-            tableName: "Menu",
-            value: "Close All Tabs",
-            comment: "Label for the button, displayed in the menu, used to close all tabs currently open.")
-        public static let AppMenuOpenHomePageTitleString = MZLocalizedString(
-            key: "SettingsMenu.OpenHomePageAction.Title",
-            tableName: "Menu",
-            value: "Homepage",
-            comment: "Label for the button, displayed in the menu, used to navigate to the home page.")
-        public static let AppMenuBookmarksTitleString = MZLocalizedString(
-            key: "Menu.OpenBookmarksAction.AccessibilityLabel.v2",
-            tableName: "Menu",
-            value: "Bookmarks",
-            comment: "Accessibility label for the button, displayed in the menu, used to open the Bookmarks home panel. Please keep as short as possible, <15 chars of space available.")
-        public static let AppMenuReadingListTitleString = MZLocalizedString(
-            key: "Menu.OpenReadingListAction.AccessibilityLabel.v2",
-            tableName: "Menu",
-            value: "Reading List",
-            comment: "Accessibility label for the button, displayed in the menu, used to open the Reading list home panel. Please keep as short as possible, <15 chars of space available.")
-        public static let AppMenuHistoryTitleString = MZLocalizedString(
-            key: "Menu.OpenHistoryAction.AccessibilityLabel.v2",
-            tableName: "Menu",
-            value: "History",
-            comment: "Accessibility label for the button, displayed in the menu, used to open the History home panel. Please keep as short as possible, <15 chars of space available.")
-        public static let AppMenuDownloadsTitleString = MZLocalizedString(
-            key: "Menu.OpenDownloadsAction.AccessibilityLabel.v2",
-            tableName: "Menu",
-            value: "Downloads",
-            comment: "Accessibility label for the button, displayed in the menu, used to open the Downloads home panel. Please keep as short as possible, <15 chars of space available.")
-        public static let AppMenuSyncedTabsTitleString = MZLocalizedString(
-            key: "Menu.OpenSyncedTabsAction.AccessibilityLabel.v2",
-            tableName: "Menu",
-            value: "Synced Tabs",
-            comment: "Accessibility label for the button, displayed in the menu, used to open the Synced Tabs home panel. Please keep as short as possible, <15 chars of space available.")
-        public static let AppMenuTurnOnNightMode = MZLocalizedString(
-            key: "Menu.NightModeTurnOn.Label2",
-            tableName: nil,
-            value: "Turn on Night Mode",
-            comment: "Label for the button, displayed in the menu, turns on night mode.")
-        public static let AppMenuTurnOffNightMode = MZLocalizedString(
-            key: "Menu.NightModeTurnOff.Label2",
-            tableName: nil,
-            value: "Turn off Night Mode",
-            comment: "Label for the button, displayed in the menu, turns off night mode.")
-        public static let AppMenuHistory = MZLocalizedString(
-            key: "Menu.History.Label",
-            tableName: nil,
-            value: "History",
-            comment: "Label for the button, displayed in the menu, takes you to History screen when pressed.")
-        public static let AppMenuDownloads = MZLocalizedString(
-            key: "Menu.Downloads.Label",
-            tableName: nil,
-            value: "Downloads",
-            comment: "Label for the button, displayed in the menu, takes you to Downloads screen when pressed.")
-        public static let AppMenuDownloadPDF = MZLocalizedString(
-            key: "Menu.DownloadPDF.Label.v129",
-            tableName: "Menu",
-            value: "Download PDF",
-            comment: "Label for the button, displayed in the menu, downloads a pdf when pressed.")
-        public static let AppMenuDownloadPDFConfirmMessage = MZLocalizedString(
-            key: "Menu.DownloadPDF.Confirm.v129",
-            tableName: "Menu",
-            value: "Successfully Downloaded PDF",
-            comment: "Toast displayed to user after downlaod pdf was pressed.")
-        public static let AppMenuPasswords = MZLocalizedString(
-            key: "Menu.Passwords.Label",
-            tableName: nil,
-            value: "Passwords",
-            comment: "Label for the button, displayed in the menu, takes you to passwords screen when pressed.")
-        public static let AppMenuCopyURLConfirmMessage = MZLocalizedString(
-            key: "Menu.CopyURL.Confirm",
-            tableName: nil,
-            value: "URL Copied To Clipboard",
-            comment: "Toast displayed to user after copy url pressed.")
-        public static let AppMenuTabSentConfirmMessage = MZLocalizedString(
-            key: "Menu.TabSent.Confirm",
-            tableName: nil,
-            value: "Tab Sent",
-            comment: "Toast displayed to the user after a tab has been sent successfully.")
-        public static let WhatsNewString = MZLocalizedString(
-            key: "Menu.WhatsNew.Title",
-            tableName: nil,
-            value: "What’s New",
-            comment: "The title for the option to view the What's new page.")
-        public static let CustomizeHomePage = MZLocalizedString(
-            key: "Menu.CustomizeHomePage.v99",
-            tableName: nil,
-            value: "Customize Homepage",
-            comment: "Label for the customize homepage button in the menu page. Pressing this button takes users to the settings options, where they can customize the Firefox Home page")
-        public static let NewTab = MZLocalizedString(
-            key: "Menu.NewTab.v99",
-            tableName: nil,
-            value: "New Tab",
-            comment: "Label for the new tab button in the menu page. Pressing this button opens a new tab.")
-        public static let NewPrivateTab = MZLocalizedString(
-            key: "Menu.NewPrivateTab.Label",
-            tableName: nil,
-            value: "New Private Tab",
-            comment: "Label for the new private tab button in the menu page. Pressing this button opens a new private tab.")
-        public static let Help = MZLocalizedString(
-            key: "Menu.Help.v99",
-            tableName: nil,
-            value: "Help",
-            comment: "Label for the help button in the menu page. Pressing this button opens the support page https://support.mozilla.org/en-US/products/ios")
-        public static let Share = MZLocalizedString(
-            key: "Menu.Share.v99",
-            tableName: nil,
-            value: "Share",
-            comment: "Label for the share button in the menu page. Pressing this button open the share menu to share the current website.")
-        public static let SyncAndSaveData = MZLocalizedString(
-            key: "Menu.SyncAndSaveData.v103",
-            tableName: nil,
-            value: "Sync and Save Data",
-            comment: "Label for the Firefox Sync button in the menu page. Pressing this button open the sign in to Firefox page service to sync and save data.")
-
-        // Shortcuts
-        public static let AddToShortcuts = MZLocalizedString(
-            key: "Menu.AddToShortcuts.v99",
-            tableName: nil,
-            value: "Add to Shortcuts",
-            comment: "Label for the add to shortcuts button in the menu. Pressing this button pins the current website as a shortcut on the home page.")
-        public static let RemoveFromShortcuts = MZLocalizedString(
-            key: "Menu.RemovedFromShortcuts.v99",
-            tableName: nil,
-            value: "Remove from Shortcuts",
-            comment: "Label for the remove from shortcuts button in the menu. Pressing this button removes the current website from the shortcut pins on the home page.")
-        public static let AddPinToShortcutsConfirmMessage = MZLocalizedString(
-            key: "Menu.AddPin.Confirm2",
-            tableName: nil,
-            value: "Added to Shortcuts",
-            comment: "Toast displayed to the user after adding the item to the Shortcuts.")
-        public static let RemovePinFromShortcutsConfirmMessage = MZLocalizedString(
-            key: "Menu.RemovePin.Confirm2.v99",
-            tableName: nil,
-            value: "Removed from Shortcuts",
-            comment: "Toast displayed to the user after removing the item to the Shortcuts.")
-
-        // Bookmarks
-        public static let Bookmarks = MZLocalizedString(
-            key: "Menu.Bookmarks.Label",
-            tableName: nil,
-            value: "Bookmarks",
-            comment: "Label for the button, displayed in the menu, takes you to bookmarks screen when pressed.")
-        public static let AddBookmark = MZLocalizedString(
-            key: "Menu.AddBookmark.Label.v99",
-            tableName: nil,
-            value: "Add",
-            comment: "Label for the add bookmark button in the menu. Pressing this button bookmarks the current page. Please keep the text as short as possible for this label.")
-        public static let AddBookmarkConfirmMessage = MZLocalizedString(
-            key: "Menu.AddBookmark.Confirm",
-            tableName: nil,
-            value: "Bookmark Added",
-            comment: "Toast displayed to the user after a bookmark has been added.")
-        public static let RemoveBookmark = MZLocalizedString(
-            key: "Menu.RemoveBookmark.Label.v99",
-            tableName: nil,
-            value: "Remove",
-            comment: "Label for the remove bookmark button in the menu. Pressing this button remove the current page from the bookmarks. Please keep the text as short as possible for this label.")
-        public static let RemoveBookmarkConfirmMessage = MZLocalizedString(
-            key: "Menu.RemoveBookmark.Confirm",
-            tableName: nil,
-            value: "Bookmark Removed",
-            comment: "Toast displayed to the user after a bookmark has been removed.")
-
-        // Reading list
-        public static let ReadingList = MZLocalizedString(
-            key: "Menu.ReadingList.Label",
-            tableName: nil,
-            value: "Reading List",
-            comment: "Label for the button, displayed in the menu, takes you to Reading List screen when pressed.")
-        public static let AddReadingList = MZLocalizedString(
-            key: "Menu.AddReadingList.Label.v99",
-            tableName: nil,
-            value: "Add",
-            comment: "Label for the add to reading list button in the menu. Pressing this button adds the current page to the reading list. Please keep the text as short as possible for this label.")
-        public static let AddToReadingListConfirmMessage = MZLocalizedString(
-            key: "Menu.AddToReadingList.Confirm",
-            tableName: nil,
-            value: "Added To Reading List",
-            comment: "Toast displayed to the user after adding the item to their reading list.")
-        public static let RemoveReadingList = MZLocalizedString(
-            key: "Menu.RemoveReadingList.Label.v99",
-            tableName: nil,
-            value: "Remove",
-            comment: "Label for the remove from reading list button in the menu. Pressing this button removes the current page from the reading list. Please keep the text as short as possible for this label.")
-        public static let RemoveFromReadingListConfirmMessage = MZLocalizedString(
-            key: "Menu.RemoveReadingList.Confirm.v99",
-            tableName: nil,
-            value: "Removed from Reading List",
-            comment: "Toast displayed to confirm to the user that his reading list item was correctly removed.")
-
-        // ZoomPageBar
-        public static let ZoomPageTitle = MZLocalizedString(
-            key: "Menu.ZoomPage.Title.v113",
-            tableName: nil,
-            value: "Zoom (%@)",
-            comment: "Label for the zoom page button in the menu, used to show the Zoom Page bar. The placeholder shows the current zoom level in percent.")
-        public static let ZoomPageCloseAccessibilityLabel = MZLocalizedString(
-            key: "Menu.ZoomPage.Close.AccessibilityLabel.v113",
-            tableName: "ZoomPageBar",
-            value: "Close Zoom Panel",
-            comment: "Accessibility label for closing the zoom panel in Zoom Page Bar")
-        public static let ZoomPageIncreaseZoomAccessibilityLabel = MZLocalizedString(
-            key: "Menu.ZoomPage.IncreaseZoom.AccessibilityLabel.v113",
-            tableName: "ZoomPageBar",
-            value: "Increase Zoom Level",
-            comment: "Accessibility label for increasing the zoom level in Zoom Page Bar")
-        public static let ZoomPageDecreaseZoomAccessibilityLabel = MZLocalizedString(
-            key: "Menu.ZoomPage.DecreaseZoom.AccessibilityLabel.v113",
-            tableName: "ZoomPageBar",
-            value: "Decrease Zoom Level",
-            comment: "Accessibility label for decreasing the zoom level in Zoom Page Bar")
-        public static let ZoomPageCurrentZoomLevelAccessibilityLabel = MZLocalizedString(
-            key: "Menu.ZoomPage.CurrentZoomLevel.AccessibilityLabel.v113",
-            tableName: "ZoomPageBar",
-            value: "Current Zoom Level: %@",
-            comment: "Accessibility label for current zoom level in Zoom Page Bar. The placeholder represents the zoom level")
-
-        // Toolbar
-        public struct Toolbar {
-            public static let MenuButtonAccessibilityLabel = MZLocalizedString(
-                key: "Toolbar.Menu.AccessibilityLabel",
-                tableName: nil,
-                value: "Menu",
-                comment: "Accessibility label for the Menu button.")
-            public static let HomeMenuButtonAccessibilityLabel = MZLocalizedString(
-                key: "Menu.Toolbar.Home.AccessibilityLabel.v99",
-                tableName: nil,
-                value: "Home",
-                comment: "Accessibility label for the Home button on the toolbar. Pressing this button brings the user to the home page.")
-            public static let BookmarksButtonAccessibilityLabel = MZLocalizedString(
-                key: "Menu.Toolbar.Bookmarks.AccessibilityLabel.v99",
-                tableName: nil,
-                value: "Bookmarks",
-                comment: "Accessibility label for the Bookmark button on the toolbar. Pressing this button opens the bookmarks menu")
-            public static let TabTrayDeleteMenuButtonAccessibilityLabel = MZLocalizedString(
-                key: "Toolbar.Menu.CloseAllTabs",
-                tableName: nil,
-                value: "Close All Tabs",
-                comment: "Accessibility label for the Close All Tabs menu button.")
-        }
-
-        // 3D TouchActions
-        public struct TouchActions {
-            public static let SendToDeviceTitle = MZLocalizedString(
-                key: "Send to Device",
-                tableName: "3DTouchActions",
-                value: nil,
-                comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
-            public static let SendLinkToDeviceTitle = MZLocalizedString(
-                key: "Menu.SendLinkToDevice",
-                tableName: "3DTouchActions",
-                value: "Send Link to Device",
-                comment: "Label for preview action on Tab Tray Tab to send the current link to another device")
-        }
     }
 }
 

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1351,7 +1351,37 @@ extension String {
 
 // MARK: - Main Menu
 extension String {
-    public struct AppMenu {
+    public struct MainMenu {
+        public struct Account {
+
+        }
+
+        public struct TabsSection {
+
+        }
+
+        public struct ToolSection {
+
+        }
+
+        public struct LibraryPanelSection {
+
+        }
+
+        public struct SettingsSection {
+
+        }
+
+        public struct Submenus {
+            public struct Tools {
+
+            }
+
+            public struct Save {
+
+            }
+        }
+
         public static let AppMenuReportSiteIssueTitleString = MZLocalizedString(
             key: "Menu.ReportSiteIssueAction.Title",
             tableName: "Menu",
@@ -1644,6 +1674,7 @@ extension String {
                 comment: "Label for preview action on Tab Tray Tab to send the current link to another device")
         }
     }
+
 }
 
 
@@ -4514,7 +4545,7 @@ extension String {
         tableName: nil,
         value: "Available devices:",
         comment: "Header for the list of devices table")
-    public static let ShareSendToDevice = String.AppMenu.TouchActions.SendToDeviceTitle
+    public static let ShareSendToDevice = String.OldStrings.v130.AppMenu.TouchActions.SendToDeviceTitle
 
     // The above items are re-used strings from the old extension. New strings below.
 
@@ -6603,6 +6634,302 @@ extension String {
                 tableName: "EnhancedTrackingProtection",
                 value: "Protections are OFF. We suggest turning it back on.",
                 comment: "A switch to disable enhanced tracking protection inside the menu.")
+        }
+
+        struct v130 {
+            public struct AppMenu {
+                public static let AppMenuReportSiteIssueTitleString = MZLocalizedString(
+                    key: "Menu.ReportSiteIssueAction.Title",
+                    tableName: "Menu",
+                    value: "Report Site Issue",
+                    comment: "Label for the button, displayed in the menu, used to report a compatibility issue with the current page.")
+                public static let AppMenuSharePageTitleString = MZLocalizedString(
+                    key: "Menu.SharePageAction.Title",
+                    tableName: "Menu",
+                    value: "Share Page With…",
+                    comment: "Label for the button, displayed in the menu, used to open the share dialog.")
+                public static let AppMenuCopyLinkTitleString = MZLocalizedString(
+                    key: "Menu.CopyLink.Title",
+                    tableName: "Menu",
+                    value: "Copy Link",
+                    comment: "Label for the button, displayed in the menu, used to copy the current page link to the clipboard.")
+                public static let AppMenuFindInPageTitleString = MZLocalizedString(
+                    key: "Menu.FindInPageAction.Title",
+                    tableName: "Menu",
+                    value: "Find in Page",
+                    comment: "Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page.")
+                public static let AppMenuViewDesktopSiteTitleString = MZLocalizedString(
+                    key: "Menu.ViewDekstopSiteAction.Title",
+                    tableName: "Menu",
+                    value: "Request Desktop Site",
+                    comment: "Label for the button, displayed in the menu, used to request the desktop version of the current website.")
+                public static let AppMenuViewMobileSiteTitleString = MZLocalizedString(
+                    key: "Menu.ViewMobileSiteAction.Title",
+                    tableName: "Menu",
+                    value: "Request Mobile Site",
+                    comment: "Label for the button, displayed in the menu, used to request the mobile version of the current website.")
+                public static let AppMenuSettingsTitleString = MZLocalizedString(
+                    key: "Menu.OpenSettingsAction.Title",
+                    tableName: "Menu",
+                    value: "Settings",
+                    comment: "Label for the button, displayed in the menu, used to open the Settings menu.")
+                public static let AppMenuCloseAllTabsTitleString = MZLocalizedString(
+                    key: "Menu.CloseAllTabsAction.Title",
+                    tableName: "Menu",
+                    value: "Close All Tabs",
+                    comment: "Label for the button, displayed in the menu, used to close all tabs currently open.")
+                public static let AppMenuOpenHomePageTitleString = MZLocalizedString(
+                    key: "SettingsMenu.OpenHomePageAction.Title",
+                    tableName: "Menu",
+                    value: "Homepage",
+                    comment: "Label for the button, displayed in the menu, used to navigate to the home page.")
+                public static let AppMenuBookmarksTitleString = MZLocalizedString(
+                    key: "Menu.OpenBookmarksAction.AccessibilityLabel.v2",
+                    tableName: "Menu",
+                    value: "Bookmarks",
+                    comment: "Accessibility label for the button, displayed in the menu, used to open the Bookmarks home panel. Please keep as short as possible, <15 chars of space available.")
+                public static let AppMenuReadingListTitleString = MZLocalizedString(
+                    key: "Menu.OpenReadingListAction.AccessibilityLabel.v2",
+                    tableName: "Menu",
+                    value: "Reading List",
+                    comment: "Accessibility label for the button, displayed in the menu, used to open the Reading list home panel. Please keep as short as possible, <15 chars of space available.")
+                public static let AppMenuHistoryTitleString = MZLocalizedString(
+                    key: "Menu.OpenHistoryAction.AccessibilityLabel.v2",
+                    tableName: "Menu",
+                    value: "History",
+                    comment: "Accessibility label for the button, displayed in the menu, used to open the History home panel. Please keep as short as possible, <15 chars of space available.")
+                public static let AppMenuDownloadsTitleString = MZLocalizedString(
+                    key: "Menu.OpenDownloadsAction.AccessibilityLabel.v2",
+                    tableName: "Menu",
+                    value: "Downloads",
+                    comment: "Accessibility label for the button, displayed in the menu, used to open the Downloads home panel. Please keep as short as possible, <15 chars of space available.")
+                public static let AppMenuSyncedTabsTitleString = MZLocalizedString(
+                    key: "Menu.OpenSyncedTabsAction.AccessibilityLabel.v2",
+                    tableName: "Menu",
+                    value: "Synced Tabs",
+                    comment: "Accessibility label for the button, displayed in the menu, used to open the Synced Tabs home panel. Please keep as short as possible, <15 chars of space available.")
+                public static let AppMenuTurnOnNightMode = MZLocalizedString(
+                    key: "Menu.NightModeTurnOn.Label2",
+                    tableName: nil,
+                    value: "Turn on Night Mode",
+                    comment: "Label for the button, displayed in the menu, turns on night mode.")
+                public static let AppMenuTurnOffNightMode = MZLocalizedString(
+                    key: "Menu.NightModeTurnOff.Label2",
+                    tableName: nil,
+                    value: "Turn off Night Mode",
+                    comment: "Label for the button, displayed in the menu, turns off night mode.")
+                public static let AppMenuHistory = MZLocalizedString(
+                    key: "Menu.History.Label",
+                    tableName: nil,
+                    value: "History",
+                    comment: "Label for the button, displayed in the menu, takes you to History screen when pressed.")
+                public static let AppMenuDownloads = MZLocalizedString(
+                    key: "Menu.Downloads.Label",
+                    tableName: nil,
+                    value: "Downloads",
+                    comment: "Label for the button, displayed in the menu, takes you to Downloads screen when pressed.")
+                public static let AppMenuDownloadPDF = MZLocalizedString(
+                    key: "Menu.DownloadPDF.Label.v129",
+                    tableName: "Menu",
+                    value: "Download PDF",
+                    comment: "Label for the button, displayed in the menu, downloads a pdf when pressed.")
+                public static let AppMenuDownloadPDFConfirmMessage = MZLocalizedString(
+                    key: "Menu.DownloadPDF.Confirm.v129",
+                    tableName: "Menu",
+                    value: "Successfully Downloaded PDF",
+                    comment: "Toast displayed to user after downlaod pdf was pressed.")
+                public static let AppMenuPasswords = MZLocalizedString(
+                    key: "Menu.Passwords.Label",
+                    tableName: nil,
+                    value: "Passwords",
+                    comment: "Label for the button, displayed in the menu, takes you to passwords screen when pressed.")
+                public static let AppMenuCopyURLConfirmMessage = MZLocalizedString(
+                    key: "Menu.CopyURL.Confirm",
+                    tableName: nil,
+                    value: "URL Copied To Clipboard",
+                    comment: "Toast displayed to user after copy url pressed.")
+                public static let AppMenuTabSentConfirmMessage = MZLocalizedString(
+                    key: "Menu.TabSent.Confirm",
+                    tableName: nil,
+                    value: "Tab Sent",
+                    comment: "Toast displayed to the user after a tab has been sent successfully.")
+                public static let WhatsNewString = MZLocalizedString(
+                    key: "Menu.WhatsNew.Title",
+                    tableName: nil,
+                    value: "What’s New",
+                    comment: "The title for the option to view the What's new page.")
+                public static let CustomizeHomePage = MZLocalizedString(
+                    key: "Menu.CustomizeHomePage.v99",
+                    tableName: nil,
+                    value: "Customize Homepage",
+                    comment: "Label for the customize homepage button in the menu page. Pressing this button takes users to the settings options, where they can customize the Firefox Home page")
+                public static let NewTab = MZLocalizedString(
+                    key: "Menu.NewTab.v99",
+                    tableName: nil,
+                    value: "New Tab",
+                    comment: "Label for the new tab button in the menu page. Pressing this button opens a new tab.")
+                public static let NewPrivateTab = MZLocalizedString(
+                    key: "Menu.NewPrivateTab.Label",
+                    tableName: nil,
+                    value: "New Private Tab",
+                    comment: "Label for the new private tab button in the menu page. Pressing this button opens a new private tab.")
+                public static let Help = MZLocalizedString(
+                    key: "Menu.Help.v99",
+                    tableName: nil,
+                    value: "Help",
+                    comment: "Label for the help button in the menu page. Pressing this button opens the support page https://support.mozilla.org/en-US/products/ios")
+                public static let Share = MZLocalizedString(
+                    key: "Menu.Share.v99",
+                    tableName: nil,
+                    value: "Share",
+                    comment: "Label for the share button in the menu page. Pressing this button open the share menu to share the current website.")
+                public static let SyncAndSaveData = MZLocalizedString(
+                    key: "Menu.SyncAndSaveData.v103",
+                    tableName: nil,
+                    value: "Sync and Save Data",
+                    comment: "Label for the Firefox Sync button in the menu page. Pressing this button open the sign in to Firefox page service to sync and save data.")
+
+                // Shortcuts
+                public static let AddToShortcuts = MZLocalizedString(
+                    key: "Menu.AddToShortcuts.v99",
+                    tableName: nil,
+                    value: "Add to Shortcuts",
+                    comment: "Label for the add to shortcuts button in the menu. Pressing this button pins the current website as a shortcut on the home page.")
+                public static let RemoveFromShortcuts = MZLocalizedString(
+                    key: "Menu.RemovedFromShortcuts.v99",
+                    tableName: nil,
+                    value: "Remove from Shortcuts",
+                    comment: "Label for the remove from shortcuts button in the menu. Pressing this button removes the current website from the shortcut pins on the home page.")
+                public static let AddPinToShortcutsConfirmMessage = MZLocalizedString(
+                    key: "Menu.AddPin.Confirm2",
+                    tableName: nil,
+                    value: "Added to Shortcuts",
+                    comment: "Toast displayed to the user after adding the item to the Shortcuts.")
+                public static let RemovePinFromShortcutsConfirmMessage = MZLocalizedString(
+                    key: "Menu.RemovePin.Confirm2.v99",
+                    tableName: nil,
+                    value: "Removed from Shortcuts",
+                    comment: "Toast displayed to the user after removing the item to the Shortcuts.")
+
+                // Bookmarks
+                public static let Bookmarks = MZLocalizedString(
+                    key: "Menu.Bookmarks.Label",
+                    tableName: nil,
+                    value: "Bookmarks",
+                    comment: "Label for the button, displayed in the menu, takes you to bookmarks screen when pressed.")
+                public static let AddBookmark = MZLocalizedString(
+                    key: "Menu.AddBookmark.Label.v99",
+                    tableName: nil,
+                    value: "Add",
+                    comment: "Label for the add bookmark button in the menu. Pressing this button bookmarks the current page. Please keep the text as short as possible for this label.")
+                public static let AddBookmarkConfirmMessage = MZLocalizedString(
+                    key: "Menu.AddBookmark.Confirm",
+                    tableName: nil,
+                    value: "Bookmark Added",
+                    comment: "Toast displayed to the user after a bookmark has been added.")
+                public static let RemoveBookmark = MZLocalizedString(
+                    key: "Menu.RemoveBookmark.Label.v99",
+                    tableName: nil,
+                    value: "Remove",
+                    comment: "Label for the remove bookmark button in the menu. Pressing this button remove the current page from the bookmarks. Please keep the text as short as possible for this label.")
+                public static let RemoveBookmarkConfirmMessage = MZLocalizedString(
+                    key: "Menu.RemoveBookmark.Confirm",
+                    tableName: nil,
+                    value: "Bookmark Removed",
+                    comment: "Toast displayed to the user after a bookmark has been removed.")
+
+                // Reading list
+                public static let ReadingList = MZLocalizedString(
+                    key: "Menu.ReadingList.Label",
+                    tableName: nil,
+                    value: "Reading List",
+                    comment: "Label for the button, displayed in the menu, takes you to Reading List screen when pressed.")
+                public static let AddReadingList = MZLocalizedString(
+                    key: "Menu.AddReadingList.Label.v99",
+                    tableName: nil,
+                    value: "Add",
+                    comment: "Label for the add to reading list button in the menu. Pressing this button adds the current page to the reading list. Please keep the text as short as possible for this label.")
+                public static let AddToReadingListConfirmMessage = MZLocalizedString(
+                    key: "Menu.AddToReadingList.Confirm",
+                    tableName: nil,
+                    value: "Added To Reading List",
+                    comment: "Toast displayed to the user after adding the item to their reading list.")
+                public static let RemoveReadingList = MZLocalizedString(
+                    key: "Menu.RemoveReadingList.Label.v99",
+                    tableName: nil,
+                    value: "Remove",
+                    comment: "Label for the remove from reading list button in the menu. Pressing this button removes the current page from the reading list. Please keep the text as short as possible for this label.")
+                public static let RemoveFromReadingListConfirmMessage = MZLocalizedString(
+                    key: "Menu.RemoveReadingList.Confirm.v99",
+                    tableName: nil,
+                    value: "Removed from Reading List",
+                    comment: "Toast displayed to confirm to the user that his reading list item was correctly removed.")
+
+                // ZoomPageBar
+                public static let ZoomPageTitle = MZLocalizedString(
+                    key: "Menu.ZoomPage.Title.v113",
+                    tableName: nil,
+                    value: "Zoom (%@)",
+                    comment: "Label for the zoom page button in the menu, used to show the Zoom Page bar. The placeholder shows the current zoom level in percent.")
+                public static let ZoomPageCloseAccessibilityLabel = MZLocalizedString(
+                    key: "Menu.ZoomPage.Close.AccessibilityLabel.v113",
+                    tableName: "ZoomPageBar",
+                    value: "Close Zoom Panel",
+                    comment: "Accessibility label for closing the zoom panel in Zoom Page Bar")
+                public static let ZoomPageIncreaseZoomAccessibilityLabel = MZLocalizedString(
+                    key: "Menu.ZoomPage.IncreaseZoom.AccessibilityLabel.v113",
+                    tableName: "ZoomPageBar",
+                    value: "Increase Zoom Level",
+                    comment: "Accessibility label for increasing the zoom level in Zoom Page Bar")
+                public static let ZoomPageDecreaseZoomAccessibilityLabel = MZLocalizedString(
+                    key: "Menu.ZoomPage.DecreaseZoom.AccessibilityLabel.v113",
+                    tableName: "ZoomPageBar",
+                    value: "Decrease Zoom Level",
+                    comment: "Accessibility label for decreasing the zoom level in Zoom Page Bar")
+                public static let ZoomPageCurrentZoomLevelAccessibilityLabel = MZLocalizedString(
+                    key: "Menu.ZoomPage.CurrentZoomLevel.AccessibilityLabel.v113",
+                    tableName: "ZoomPageBar",
+                    value: "Current Zoom Level: %@",
+                    comment: "Accessibility label for current zoom level in Zoom Page Bar. The placeholder represents the zoom level")
+
+                // Toolbar
+                public struct Toolbar {
+                    public static let MenuButtonAccessibilityLabel = MZLocalizedString(
+                        key: "Toolbar.Menu.AccessibilityLabel",
+                        tableName: nil,
+                        value: "Menu",
+                        comment: "Accessibility label for the Menu button.")
+                    public static let HomeMenuButtonAccessibilityLabel = MZLocalizedString(
+                        key: "Menu.Toolbar.Home.AccessibilityLabel.v99",
+                        tableName: nil,
+                        value: "Home",
+                        comment: "Accessibility label for the Home button on the toolbar. Pressing this button brings the user to the home page.")
+                    public static let BookmarksButtonAccessibilityLabel = MZLocalizedString(
+                        key: "Menu.Toolbar.Bookmarks.AccessibilityLabel.v99",
+                        tableName: nil,
+                        value: "Bookmarks",
+                        comment: "Accessibility label for the Bookmark button on the toolbar. Pressing this button opens the bookmarks menu")
+                    public static let TabTrayDeleteMenuButtonAccessibilityLabel = MZLocalizedString(
+                        key: "Toolbar.Menu.CloseAllTabs",
+                        tableName: nil,
+                        value: "Close All Tabs",
+                        comment: "Accessibility label for the Close All Tabs menu button.")
+                }
+
+                // 3D TouchActions
+                public struct TouchActions {
+                    public static let SendToDeviceTitle = MZLocalizedString(
+                        key: "Send to Device",
+                        tableName: "3DTouchActions",
+                        value: nil,
+                        comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
+                    public static let SendLinkToDeviceTitle = MZLocalizedString(
+                        key: "Menu.SendLinkToDevice",
+                        tableName: "3DTouchActions",
+                        value: "Send Link to Device",
+                        comment: "Label for preview action on Tab Tray Tab to send the current link to another device")
+                }
+            }
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -153,19 +153,19 @@ open class TabToolbarHelper: NSObject {
         let appMenuImage = UIImage.templateImageNamed(StandardImageIdentifiers.Large.appMenu)
         toolbar.appMenuButton.contentMode = .center
         toolbar.appMenuButton.showsLargeContentViewer = true
-        toolbar.appMenuButton.largeContentTitle = .AppMenu.Toolbar.MenuButtonAccessibilityLabel
+        toolbar.appMenuButton.largeContentTitle = .OldStrings.v130.AppMenu.Toolbar.MenuButtonAccessibilityLabel
         toolbar.appMenuButton.largeContentImage = appMenuImage
         toolbar.appMenuButton.setImage(appMenuImage, for: .normal)
-        toolbar.appMenuButton.accessibilityLabel = .AppMenu.Toolbar.MenuButtonAccessibilityLabel
+        toolbar.appMenuButton.accessibilityLabel = .OldStrings.v130.AppMenu.Toolbar.MenuButtonAccessibilityLabel
         toolbar.appMenuButton.addTarget(self, action: #selector(didClickMenu), for: .touchUpInside)
         toolbar.appMenuButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.settingsMenuButton
 
         toolbar.bookmarksButton.contentMode = .center
         toolbar.bookmarksButton.showsLargeContentViewer = true
         toolbar.bookmarksButton.largeContentImage = ImageBookmark
-        toolbar.bookmarksButton.largeContentTitle = .AppMenu.Toolbar.BookmarksButtonAccessibilityLabel
+        toolbar.bookmarksButton.largeContentTitle = .OldStrings.v130.AppMenu.Toolbar.BookmarksButtonAccessibilityLabel
         toolbar.bookmarksButton.setImage(ImageBookmark, for: .normal)
-        toolbar.bookmarksButton.accessibilityLabel = .AppMenu.Toolbar.BookmarksButtonAccessibilityLabel
+        toolbar.bookmarksButton.accessibilityLabel = .OldStrings.v130.AppMenu.Toolbar.BookmarksButtonAccessibilityLabel
         toolbar.bookmarksButton.addTarget(self, action: #selector(didClickLibrary), for: .touchUpInside)
         toolbar.bookmarksButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.bookmarksButton
 

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -67,7 +67,7 @@ extension PhotonActionSheetProtocol {
                                                       iconString: StandardImageIdentifiers.Large.link) { _ in
             if let url = tabManager.selectedTab?.canonicalURL?.displayURL ?? urlBar.currentURL {
                 UIPasteboard.general.url = url
-                SimpleToast().showAlertWithText(.AppMenu.AppMenuCopyURLConfirmMessage,
+                SimpleToast().showAlertWithText(.OldStrings.v130.AppMenu.AppMenuCopyURLConfirmMessage,
                                                 bottomContainer: alertContainer,
                                                 theme: themeManager.getCurrentTheme(for: tabManager.windowUUID))
             }
@@ -89,9 +89,9 @@ extension PhotonActionSheetProtocol {
         let toggleActionTitle: String
         // swiftlint:disable line_length
         if defaultUAisDesktop {
-            toggleActionTitle = tab.changedUserAgent ? .AppMenu.AppMenuViewDesktopSiteTitleString : .AppMenu.AppMenuViewMobileSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .OldStrings.v130.AppMenu.AppMenuViewDesktopSiteTitleString : .OldStrings.v130.AppMenu.AppMenuViewMobileSiteTitleString
         } else {
-            toggleActionTitle = tab.changedUserAgent ? .AppMenu.AppMenuViewMobileSiteTitleString : .AppMenu.AppMenuViewDesktopSiteTitleString
+            toggleActionTitle = tab.changedUserAgent ? .OldStrings.v130.AppMenu.AppMenuViewMobileSiteTitleString : .OldStrings.v130.AppMenu.AppMenuViewDesktopSiteTitleString
         }
         // swiftlint:enable line_length
         let toggleDesktopSite = SingleActionViewModel(title: toggleActionTitle,

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -194,7 +194,7 @@ class Tab: NSObject, ThemeApplicable {
     /// or not, it will resort to other displayable titles.
     var displayTitle: String {
         if self.isFxHomeTab {
-            return .AppMenu.AppMenuOpenHomePageTitleString
+            return .OldStrings.v130.AppMenu.AppMenuOpenHomePageTitleString
         }
 
         if let lastTitle = lastTitle, !lastTitle.isEmpty {
@@ -226,7 +226,7 @@ class Tab: NSObject, ThemeApplicable {
         var backUpName: String = "" // In case display title is empty
 
         if let baseDomain = baseDomain {
-            backUpName = baseDomain.contains("local") ? .AppMenu.AppMenuOpenHomePageTitleString : baseDomain
+            backUpName = baseDomain.contains("local") ? .OldStrings.v130.AppMenu.AppMenuOpenHomePageTitleString : baseDomain
         } else if let url = url, let about = InternalURL(url)?.aboutComponent {
             backUpName = about
         }

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -1676,33 +1676,33 @@ extension TelemetryWrapper {
             }
         // MARK: App menu
         case (.action, .tap, .homePageMenu, _, _):
-            GleanMetrics.AppMenu.homepageMenu.add()
+            GleanMetrics.OldStrings.v130.AppMenu.homepageMenu.add()
         case (.action, .tap, .siteMenu, _, _):
-            GleanMetrics.AppMenu.siteMenu.add()
+            GleanMetrics.OldStrings.v130.AppMenu.siteMenu.add()
         case (.action, .tap, .logins, _, _):
-            GleanMetrics.AppMenu.logins.add()
+            GleanMetrics.OldStrings.v130.AppMenu.logins.add()
         case (.action, .tap, .signIntoSync, _, _):
-            GleanMetrics.AppMenu.signIntoSync.add()
+            GleanMetrics.OldStrings.v130.AppMenu.signIntoSync.add()
         case (.action, .tap, .home, _, _):
-            GleanMetrics.AppMenu.home.add()
+            GleanMetrics.OldStrings.v130.AppMenu.home.add()
         case (.action, .tap, .blockImagesEnabled, _, _):
-            GleanMetrics.AppMenu.blockImagesEnabled.add()
+            GleanMetrics.OldStrings.v130.AppMenu.blockImagesEnabled.add()
         case (.action, .tap, .blockImagesDisabled, _, _):
-            GleanMetrics.AppMenu.blockImagesDisabled.add()
+            GleanMetrics.OldStrings.v130.AppMenu.blockImagesDisabled.add()
         case (.action, .tap, .nightModeEnabled, _, _):
-            GleanMetrics.AppMenu.nightModeEnabled.add()
+            GleanMetrics.OldStrings.v130.AppMenu.nightModeEnabled.add()
         case (.action, .tap, .nightModeDisabled, _, _):
-            GleanMetrics.AppMenu.nightModeDisabled.add()
+            GleanMetrics.OldStrings.v130.AppMenu.nightModeDisabled.add()
         case (.action, .open, .whatsNew, _, _):
-            GleanMetrics.AppMenu.whatsNew.add()
+            GleanMetrics.OldStrings.v130.AppMenu.whatsNew.add()
         case (.action, .tap, .help, _, _):
-            GleanMetrics.AppMenu.help.add()
+            GleanMetrics.OldStrings.v130.AppMenu.help.add()
         case (.action, .tap, .customizeHomePage, _, _):
-            GleanMetrics.AppMenu.customizeHomepage.add()
+            GleanMetrics.OldStrings.v130.AppMenu.customizeHomepage.add()
         case (.action, .open, .settings, _, _):
-            GleanMetrics.AppMenu.settings.add()
+            GleanMetrics.OldStrings.v130.AppMenu.settings.add()
         case(.action, .open, .logins, _, _):
-            GleanMetrics.AppMenu.passwords.record()
+            GleanMetrics.OldStrings.v130.AppMenu.passwords.record()
 
         // MARK: Page Menu
         case (.action, .tap, .sharePageWith, _, _):

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/LibraryViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/LibraryViewModelTests.swift
@@ -40,13 +40,13 @@ class LibraryViewModelTests: XCTestCase {
         for panel in subject.panelDescriptors {
             switch panel.panelType {
             case .bookmarks:
-                XCTAssertEqual(panel.panelType.title, .AppMenu.AppMenuBookmarksTitleString)
+                XCTAssertEqual(panel.panelType.title, .OldStrings.v130.AppMenu.AppMenuBookmarksTitleString)
             case .history:
-                XCTAssertEqual(panel.panelType.title, .AppMenu.AppMenuHistoryTitleString)
+                XCTAssertEqual(panel.panelType.title, .OldStrings.v130.AppMenu.AppMenuHistoryTitleString)
             case .downloads:
-                XCTAssertEqual(panel.panelType.title, .AppMenu.AppMenuDownloadsTitleString)
+                XCTAssertEqual(panel.panelType.title, .OldStrings.v130.AppMenu.AppMenuDownloadsTitleString)
             case .readingList:
-                XCTAssertEqual(panel.panelType.title, .AppMenu.AppMenuReadingListTitleString)
+                XCTAssertEqual(panel.panelType.title, .OldStrings.v130.AppMenu.AppMenuReadingListTitleString)
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -36,7 +36,7 @@ class TabTests: XCTestCase {
         let url = URL(string: "internal://local/about/home")!
         let tab = Tab(profile: MockProfile(), configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
         tab.url = url
-        let expectedDisplayTitle = String.AppMenu.AppMenuOpenHomePageTitleString
+        let expectedDisplayTitle = String.OldStrings.v130.AppMenu.AppMenuOpenHomePageTitleString
         XCTAssertEqual(tab.displayTitle, expectedDisplayTitle)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -54,7 +54,7 @@ class TabToolbarHelperTests: XCTestCase {
 
     func testTelemetryForSiteMenu() {
         mockToolbar.tabToolbarDelegate?.tabToolbarDidPressMenu(mockToolbar, button: mockToolbar.appMenuButton)
-        testCounterMetricRecordingSuccess(metric: GleanMetrics.AppMenu.siteMenu)
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.OldStrings.v130.AppMenu.siteMenu)
     }
 
     func test_tabToolBarHelper_basicCreation_doesntLeak() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -1123,7 +1123,7 @@ class TelemetryWrapperTests: XCTestCase {
     func test_signIntoSync_GleanIsCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .signIntoSync)
 
-        testCounterMetricRecordingSuccess(metric: GleanMetrics.AppMenu.signIntoSync)
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.OldStrings.v130.AppMenu.signIntoSync)
     }
 
     func test_settingsMenuSync_GleanIsCalled() {
@@ -1133,7 +1133,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_appMenuLoginsAndPasswordsTapped_GleanIsCalled() {
         TelemetryWrapper.recordEvent(category: .action, method: .open, object: .logins)
-        testEventMetricRecordingSuccess(metric: GleanMetrics.AppMenu.passwords)
+        testEventMetricRecordingSuccess(metric: GleanMetrics.OldStrings.v130.AppMenu.passwords)
     }
 
     // MARK: Logins and Passwords


### PR DESCRIPTION
## :scroll: Tickets
Minor work, there's no ticket for this.

## :bulb: Description
A bunch of files have been updated, but the main changes are in `Strings.swift` where I fixed some alphabetical things, added a new `MainMenu` string struct which will have the new strings, and moved the old `AppMenu` struct to oldStrings (which is where we currently 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

