### PR TITLE
Bugfix FXIOS-8953 - App crashes when tapping reader view button

### DIFF
--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -109,12 +109,7 @@ enum ReaderModeFontSize: Int {
     }
 
     static var defaultSize: ReaderModeFontSize {
-        var contentSizeCategory: UIContentSizeCategory?
-        ensureMainThread {
-            contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
-        }
-
-        switch contentSizeCategory {
+        switch UIApplication.shared.preferredContentSizeCategory {
         case .extraSmall:
             return .size1
         case .small:
@@ -195,7 +190,7 @@ struct ReaderModeStyle {
         self.theme = ReaderModeTheme.preferredTheme(for: self.theme, window: windowUUID)
     }
 
-    static func defaultStyle(for window: WindowUUID?) -> ReaderModeStyle {
+    static func defaultStyle(for window: WindowUUID? = nil) -> ReaderModeStyle {
         return ReaderModeStyle(
             windowUUID: window,
             theme: .light,

--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -109,7 +109,16 @@ enum ReaderModeFontSize: Int {
     }
 
     static var defaultSize: ReaderModeFontSize {
-        switch UIApplication.shared.preferredContentSizeCategory {
+        var contentSizeCategory: UIContentSizeCategory?
+        if Thread.isMainThread {
+            contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        } else {
+            DispatchQueue.main.sync {
+                contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+            }
+        }
+
+        switch contentSizeCategory {
         case .extraSmall:
             return .size1
         case .small:

--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -110,12 +110,8 @@ enum ReaderModeFontSize: Int {
 
     static var defaultSize: ReaderModeFontSize {
         var contentSizeCategory: UIContentSizeCategory?
-        if Thread.isMainThread {
+        ensureMainThread {
             contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
-        } else {
-            DispatchQueue.main.sync {
-                contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
-            }
         }
 
         switch contentSizeCategory {

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -62,16 +62,19 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
                         // profile and then generate HTML from the Readability results.
                         if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle),
                            let style = ReaderModeStyle(windowUUID: nil, dict: dict) {
-                                readerModeStyle = style
-                            } else {
-                                readerModeStyle.theme = ReaderModeTheme.preferredTheme(window: nil)
-                            }
+                            readerModeStyle = style
+                        } else {
+                            readerModeStyle.theme = ReaderModeTheme.preferredTheme(window: nil)
+                        }
 
-                            guard let html = ReaderModeUtils.generateReaderContent(readabilityResult, initialStyle: readerModeStyle),
-                                  let response = GCDWebServerDataResponse(html: html) else { return nil }
-                            response.setValue("default-src 'none'; img-src *; style-src http://localhost:* '\(ReaderModeStyleHash)'; font-src http://localhost:*",
-                                              forAdditionalHeader: "Content-Security-Policy")
-                            return response
+                        guard let html = ReaderModeUtils.generateReaderContent(
+                            readabilityResult,
+                            initialStyle: readerModeStyle
+                        ),
+                              let response = GCDWebServerDataResponse(html: html) else { return nil }
+                        response.setValue("default-src 'none'; img-src *; style-src http://localhost:* '\(ReaderModeStyleHash)'; font-src http://localhost:*",
+                                          forAdditionalHeader: "Content-Security-Policy")
+                        return response
                     } catch {
                         // This page has not been converted to reader mode yet. This happens when you for example add an
                         // item via the app extension and the application has not yet had a change to readerize that

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -72,6 +72,8 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
                             initialStyle: readerModeStyle
                         ),
                               let response = GCDWebServerDataResponse(html: html) else { return nil }
+                        // Apply a Content Security Policy that disallows everything except images from
+                        // anywhere and fonts and css from our internal server
                         response.setValue("default-src 'none'; img-src *; style-src http://localhost:* '\(ReaderModeStyleHash)'; font-src http://localhost:*",
                                           forAdditionalHeader: "Content-Security-Policy")
                         return response


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8953)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19783)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Our application encountered a crash caused by accessing a UIKit property, `UIApplication.shared.preferredContentSizeCategory`, from a background thread. 


- The crash occurred within the `defaultSize` computed property of `ReaderModeFontSize`, where `UIApplication.shared.preferredContentSizeCategory` was accessed to determine the default font size based on the user's preferred text size settings. This property access was not restricted to the main thread, leading to the crash when `defaultSize` was invoked from a background thread.

To address this issue I did 2 things:

1. Thread Check: Determine if the current execution thread is the main thread using `Thread.isMainThread`.
2. Safe Access on Main Thread:
    * If the current thread is the main thread, directly access `UIApplication.shared.preferredContentSizeCategory`.
    * If the current thread is a background thread, use `DispatchQueue.main.sync` to synchronously dispatch a block to the main thread, where the property is safely accessed.

This approach ensures that `UIApplication.shared.preferredContentSizeCategory` is always accessed on the main thread, thus preventing the crash.

https://github.com/user-attachments/assets/d3f8fcfc-2cab-47f1-b633-3640c6cd7ed9


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

