### PR TITLE
Bugfix FXIOS-9482 Reselect correct tab when undo close all tabs

### DIFF
--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -647,7 +647,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
                                                 isSelected: selectedTab?.tabUUID == tab.tabUUID)
         }
         backupCloseTabs = tabs
-        
+
         for tab in currentModeTabs {
             await self.removeTab(tab.tabUUID) // updates selected tab...
         }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -649,7 +649,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         backupCloseTabs = tabs
 
         for tab in currentModeTabs {
-            await self.removeTab(tab.tabUUID) // updates selected tab...
+            await self.removeTab(tab.tabUUID)
         }
 
         // Save the tab state that existed prior to removals (preserves original selected tab)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -206,66 +206,6 @@ class TabManagerTests: XCTestCase {
         XCTAssertEqual(subject.tabs.first?.isPrivate, true)
     }
 
-    // MARK: - Remove all tabs
-
-    func test_removeAllTabs_hasOneHomeTabAfter() async throws {
-        let numTabs = 3
-        let subject = createSubject()
-        let addedTabs: [Tab]
-
-        // Setup the tab manager with 3 starting tabs and select the first one
-        addTabs(to: subject, count: numTabs)
-        addedTabs = subject.tabs
-
-        // Check preconditions
-        XCTAssertEqual(addedTabs.count, numTabs)
-
-        // Test
-        await subject.removeAllTabs(isPrivateMode: false)
-
-        // Wait for async save closures to complete so subject would trigger the memory leak check
-        try await Task.sleep(nanoseconds: 2 * sleepTime)
-
-        // Check results
-        XCTAssertEqual(subject.tabs.count, 1)
-        guard let homeTab = subject.tabs.first else {
-            XCTFail("After closing all tabs, there should be one home tab")
-            return
-        }
-        XCTAssertEqual(homeTab.url?.absoluteString, "internal://local/about/home#panel=0")
-        XCTAssertFalse(addedTabs.contains(where: { $0.tabUUID == homeTab.tabUUID }), "Tabs should have been removed")
-    }
-
-    func test_removeAllTabs_savesCorrectBackupCloseTab() async throws {
-        let numTabs = 3
-        let subject = createSubject()
-        let addedTabs: [Tab]
-        let selectedTabUUID: TabUUID?
-
-        // Setup the tab manager with 3 starting tabs and select the first one
-        addTabs(to: subject, count: numTabs)
-        addedTabs = subject.tabs
-        subject.selectTab(addedTabs.first)
-        selectedTabUUID = subject.selectedTab?.tabUUID
-
-        // Check preconditions
-        XCTAssertEqual(addedTabs.count, numTabs)
-        XCTAssertEqual(subject.selectedIndex, 0, "First tab should be selected")
-        XCTAssertNotNil(selectedTabUUID, "Tab UUID must not be nil after adding tabs")
-
-        // Test
-        await subject.removeAllTabs(isPrivateMode: false)
-
-        // Wait for async save closures to complete so subject would trigger the memory leak check
-        try await Task.sleep(nanoseconds: 2 * sleepTime)
-
-        XCTAssertEqual(
-            subject.backupCloseTab?.tab.tabUUID,
-            selectedTabUUID,
-            "The backup tab should be the previously selected tab"
-        )
-    }
-
     // MARK: - Helper methods
 
     private func createSubject() -> TabManagerImplementation {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -222,7 +222,7 @@ class TabManagerTests: XCTestCase {
 
         // Test
         await subject.removeAllTabs(isPrivateMode: false)
-        
+
         // Wait for async save closures to complete so subject would trigger the memory leak check
         try await Task.sleep(nanoseconds: 2 * sleepTime)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -206,6 +206,66 @@ class TabManagerTests: XCTestCase {
         XCTAssertEqual(subject.tabs.first?.isPrivate, true)
     }
 
+    // MARK: - Remove all tabs
+
+    func test_removeAllTabs_hasOneHomeTabAfter() async throws {
+        let numTabs = 3
+        let subject = createSubject()
+        let addedTabs: [Tab]
+
+        // Setup the tab manager with 3 starting tabs and select the first one
+        addTabs(to: subject, count: numTabs)
+        addedTabs = subject.tabs
+
+        // Check preconditions
+        XCTAssertEqual(addedTabs.count, numTabs)
+
+        // Test
+        await subject.removeAllTabs(isPrivateMode: false)
+
+        // Check results
+        XCTAssertEqual(subject.tabs.count, 1)
+        guard let homeTab = subject.tabs.first else {
+            XCTFail("After closing all tabs, there should be one home tab")
+            return
+        }
+        XCTAssertEqual(homeTab.url?.absoluteString, "internal://local/about/home#panel=0")
+        XCTAssertFalse(addedTabs.contains(where: { $0.tabUUID == homeTab.tabUUID }), "Tabs should have been removed")
+
+        // Wait for async save closures to complete so subject would trigger the memory leak check
+        try await Task.sleep(nanoseconds: sleepTime)
+    }
+
+    func test_removeAllTabs_savesCorrectBackupCloseTab() async throws {
+        let numTabs = 3
+        let subject = createSubject()
+        let addedTabs: [Tab]
+        let selectedTabUUID: TabUUID?
+
+        // Setup the tab manager with 3 starting tabs and select the first one
+        addTabs(to: subject, count: numTabs)
+        addedTabs = subject.tabs
+        subject.selectTab(addedTabs.first)
+        selectedTabUUID = subject.selectedTab?.tabUUID
+
+        // Check preconditions
+        XCTAssertEqual(addedTabs.count, numTabs)
+        XCTAssertEqual(subject.selectedIndex, 0, "First tab should be selected")
+        XCTAssertNotNil(selectedTabUUID, "Tab UUID must not be nil after adding tabs")
+
+        // Test
+        await subject.removeAllTabs(isPrivateMode: false)
+
+        XCTAssertEqual(
+            subject.backupCloseTab?.tab.tabUUID,
+            selectedTabUUID,
+            "The backup tab should be the previously selected tab"
+        )
+
+        // Wait for async save closures to complete so subject would trigger the memory leak check
+        try await Task.sleep(nanoseconds: sleepTime)
+    }
+
     // MARK: - Helper methods
 
     private func createSubject() -> TabManagerImplementation {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -222,6 +222,9 @@ class TabManagerTests: XCTestCase {
 
         // Test
         await subject.removeAllTabs(isPrivateMode: false)
+        
+        // Wait for async save closures to complete so subject would trigger the memory leak check
+        try await Task.sleep(nanoseconds: 2 * sleepTime)
 
         // Check results
         XCTAssertEqual(subject.tabs.count, 1)
@@ -231,9 +234,6 @@ class TabManagerTests: XCTestCase {
         }
         XCTAssertEqual(homeTab.url?.absoluteString, "internal://local/about/home#panel=0")
         XCTAssertFalse(addedTabs.contains(where: { $0.tabUUID == homeTab.tabUUID }), "Tabs should have been removed")
-
-        // Wait for async save closures to complete so subject would trigger the memory leak check
-        try await Task.sleep(nanoseconds: sleepTime)
     }
 
     func test_removeAllTabs_savesCorrectBackupCloseTab() async throws {
@@ -256,14 +256,14 @@ class TabManagerTests: XCTestCase {
         // Test
         await subject.removeAllTabs(isPrivateMode: false)
 
+        // Wait for async save closures to complete so subject would trigger the memory leak check
+        try await Task.sleep(nanoseconds: 2 * sleepTime)
+
         XCTAssertEqual(
             subject.backupCloseTab?.tab.tabUUID,
             selectedTabUUID,
             "The backup tab should be the previously selected tab"
         )
-
-        // Wait for async save closures to complete so subject would trigger the memory leak check
-        try await Task.sleep(nanoseconds: sleepTime)
     }
 
     // MARK: - Helper methods


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9482)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20984)

## :bulb: Description
Each call to `removeTab()` updates the `backupCloseTab`. This PR saves the selected tab state prior to closing all tabs, then reassigns it to the `backupCloseTab` after the calls to `removeTab()` have been made.

Fix Demo:

https://github.com/user-attachments/assets/ae0cd1b0-fd05-4452-9165-3b9c56958bf0


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

