### PR TITLE
Bugfix MTE-3145 Stablize Focus tests on Github Actions

### DIFF
--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -253,7 +253,7 @@ jobs:
               uses: actions/upload-artifact@v4.3.3
               with:
                 name: ${{ env.browser }}-fullfunctional-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
-                path: ${{ env.browser }}/build/reports/junit.xml
+                path: ${{ env.browser }}/junit-*.xml
                 retention-days: 90
             - name: Upload log file
               id: upload-log

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -253,7 +253,7 @@ jobs:
               uses: actions/upload-artifact@v4.3.3
               with:
                 name: ${{ env.browser }}-fullfunctional-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
-                path: ${{ env.browser }}/junit-*.xml
+                path: ${{ env.browser }}/build/reports/junit.xml
                 retention-days: 90
             - name: Upload log file
               id: upload-log

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -112,6 +112,13 @@ jobs:
                 name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-xcodebuildlog-${{ github.run_number }}
                 path: ${{ env.browser }}/xcodebuild.log
                 retention-days: 90
+            - name: Upload junit files
+              id: upload-junit
+              uses: actions/upload-artifact@v4.3.3
+              with:
+                name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
+                path: ${{ env.browser }}/junit-*.xml
+                retention-days: 90
             - name: Report to Slack
               id: slack
               uses: slackapi/slack-github-action@v1.26.0

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -66,6 +66,10 @@ jobs:
               run: |
                 gem install xcpretty -v 0.3.0
                 pip install blockkit==1.9.1
+                # Reduce network flakiness
+                sudo sysctl -w net.link.generic.system.hwcksum_tx=0
+                sudo sysctl -w net.link.generic.system.hwcksum_rx=0
+
             - name: Setup Xcode
               id: xcode
               run: |

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -117,7 +117,7 @@ jobs:
               uses: actions/upload-artifact@v4.3.3
               with:
                 name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
-                path: ${{ env.browser }}/junit-*.xml
+                path: ${{ env.browser }}/build/reports/junit.xml
                 retention-days: 90
             - name: Report to Slack
               id: slack

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -66,9 +66,6 @@ jobs:
               run: |
                 gem install xcpretty -v 0.3.0
                 pip install blockkit==1.9.1
-                # Reduce network flakiness
-                sudo sysctl -w net.link.generic.system.hwcksum_tx=0
-                sudo sysctl -w net.link.generic.system.hwcksum_rx=0
 
             - name: Setup Xcode
               id: xcode

--- a/focus-ios/focus-ios-tests/FullFunctionalTests.xctestplan
+++ b/focus-ios/focus-ios-tests/FullFunctionalTests.xctestplan
@@ -28,6 +28,7 @@
         "BrowsingTest\/testActivityMenuRequestDesktopItem()",
         "CopyPasteTest\/testClipboard()",
         "CopyPasteTest\/testPastenGo()",
+        "DragAndDropTest",
         "FindInPageTest\/testActivityMenuFindInPageAction()",
         "OnboardingTest",
         "PastenGoTest\/testPastenGo()",

--- a/focus-ios/focus-ios-tests/XCUITest/BaseTestCase.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/BaseTestCase.swift
@@ -51,27 +51,27 @@ class BaseTestCase: XCTestCase {
         return false
     }
 
-    func waitForEnable(_ element: XCUIElement, timeout: TimeInterval = 5.0, file: String = #file, line: UInt = #line) {
-        waitFor(element, with: "exists == enable", timeout: timeout, file: file, line: line)
+    func waitForEnable(_ element: XCUIElement, timeout: TimeInterval = 30.0, file: String = #file, line: UInt = #line) {
+        waitFor(element, with: "enabled == true", timeout: timeout, file: file, line: line)
     }
 
-    func waitForExistence(_ element: XCUIElement, timeout: TimeInterval = 5.0, file: String = #file, line: UInt = #line) {
+    func waitForExistence(_ element: XCUIElement, timeout: TimeInterval = 30.0, file: String = #file, line: UInt = #line) {
             waitFor(element, with: "exists == true", timeout: timeout, file: file, line: line)
     }
 
-    func waitForHittable(_ element: XCUIElement, timeout: TimeInterval = 5.0, file: String = #file, line: UInt = #line) {
+    func waitForHittable(_ element: XCUIElement, timeout: TimeInterval = 30.0, file: String = #file, line: UInt = #line) {
             waitFor(element, with: "isHittable == true", timeout: timeout, file: file, line: line)
     }
 
-    func waitForNoExistence(_ element: XCUIElement, timeoutValue: TimeInterval = 5.0, file: String = #file, line: UInt = #line) {
-           waitFor(element, with: "exists != true", timeout: timeoutValue, file: file, line: line)
+    func waitForNoExistence(_ element: XCUIElement, timeout: TimeInterval = 30.0, file: String = #file, line: UInt = #line) {
+           waitFor(element, with: "exists != true", timeout: timeout, file: file, line: line)
     }
 
-    func waitForValueContains(_ element: XCUIElement, value: String, file: String = #file, line: UInt = #line) {
-            waitFor(element, with: "value CONTAINS '\(value)'", file: file, line: line)
+    func waitForValueContains(_ element: XCUIElement, timeout: TimeInterval = 30.0, value: String, file: String = #file, line: UInt = #line) {
+            waitFor(element, with: "value CONTAINS '\(value)'", timeout: timeout, file: file, line: line)
     }
 
-    private func waitFor(_ element: XCUIElement, with predicateString: String, description: String? = nil, timeout: TimeInterval = 5.0, file: String, line: UInt) {
+    private func waitFor(_ element: XCUIElement, with predicateString: String, description: String? = nil, timeout: TimeInterval = 30, file: String, line: UInt) {
             let predicate = NSPredicate(format: predicateString)
             let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
             let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
@@ -115,9 +115,11 @@ class BaseTestCase: XCTestCase {
     }
 
     func loadWebPage(_ url: String, waitForLoadToFinish: Bool = true) {
-        waitForExistence(app.textFields["URLBar.urlText"], timeout: 3)
+        waitForExistence(app.textFields["URLBar.urlText"])
         app.textFields["URLBar.urlText"].tap()
-        app.textFields["URLBar.urlText"].clearAndEnterText(text: url+"\n")
+        app.textFields["URLBar.urlText"].clearAndEnterText(text: url)
+        waitForValueContains(app.textFields["URLBar.urlText"], value: url)
+        app.textFields["URLBar.urlText"].typeText("\n")
 
 //        if waitForLoadToFinish {
 //            let finishLoadingTimeout: TimeInterval = 30
@@ -129,7 +131,7 @@ class BaseTestCase: XCTestCase {
 //        }
     }
 
-    private func waitFor(_ element: XCUIElement, with predicateString: String, description: String? = nil, timeout: TimeInterval = 5.0) {
+    private func waitFor(_ element: XCUIElement, with predicateString: String, description: String? = nil, timeout: TimeInterval = 30) {
         let predicate = NSPredicate(format: predicateString)
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
         let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
@@ -145,7 +147,7 @@ class BaseTestCase: XCTestCase {
 
     func waitForWebPageLoad () {
         let app = XCUIApplication()
-        let finishLoadingTimeout: TimeInterval = 30
+        let finishLoadingTimeout: TimeInterval = 60
         let progressIndicator = app.progressIndicators.element(boundBy: 0)
 
         expectation(for: NSPredicate(format: "exists != true"), evaluatedWith: progressIndicator, handler: nil)

--- a/focus-ios/focus-ios-tests/XCUITest/BrowsingTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/BrowsingTest.swift
@@ -26,6 +26,7 @@ class BrowsingTest: BaseTestCase {
             shareButton = app.cells["Share Page With..."]
         }
         waitForExistence(shareButton)
+        waitForHittable(shareButton)
         shareButton.tap()
 
         // Launch external app
@@ -35,10 +36,10 @@ class BrowsingTest: BaseTestCase {
         } else {
             RemindersApp = app.collectionViews.scrollViews.cells.element(boundBy: 1)
         }
-        waitForExistence(RemindersApp, timeout: 5)
+        waitForExistence(RemindersApp)
+        waitForHittable(RemindersApp)
         RemindersApp.tap()
-        waitForExistence(app.buttons["Add"], timeout: 10)
-        XCTAssertTrue(app.buttons["Add"].exists)
+        waitForExistence(app.buttons["Add"])
     }
 
     // Smoketest
@@ -79,8 +80,6 @@ class BrowsingTest: BaseTestCase {
     // Smoketest
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2587661
     func testActivityMenuRequestDesktopItem() {
-        let urlBarTextField = app.textFields["URLBar.urlText"]
-
         // Wait for existence rather than hittable because the textfield is technically disabled
         loadWebPage("facebook.com")
 
@@ -129,14 +128,13 @@ class BrowsingTest: BaseTestCase {
             let collapsedTruncatedurltextTextView = app.textViews["Collapsed.truncatedUrlText"]
             waitForExistence(collapsedTruncatedurltextTextView)
 
-            XCTAssertTrue(collapsedTruncatedurltextTextView.isHittable)
+            waitForHittable(collapsedTruncatedurltextTextView)
             XCTAssertEqual(collapsedTruncatedurltextTextView.value as? String, "news.ycombinator.com")
 
             // After swiping down, the collapsed URL should not be displayed
             app.swipeDown()
             app.swipeDown()
             waitForNoExistence(collapsedTruncatedurltextTextView)
-            XCTAssertFalse(collapsedTruncatedurltextTextView.exists)
         }
     }
 }

--- a/focus-ios/focus-ios-tests/XCUITest/CopyPasteTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/CopyPasteTest.swift
@@ -50,6 +50,7 @@ class CopyPasteTest: BaseTestCase {
         // Check clipboard suggestion is shown
         waitForValueContains(searchOrEnterAddressTextField, value: "mozilla.org/")
         waitForExistence(app.buttons["Search for mozilla"])
+        waitForHittable(app.buttons["Search for mozilla"])
         app.typeText("\n")
 
         // Check the correct site is reached
@@ -95,7 +96,7 @@ class CopyPasteTest: BaseTestCase {
         let searchOrEnterAddressTextField = app.textFields["URLBar.urlText"]
         waitForExistence(searchOrEnterAddressTextField, timeout: 30)
         searchOrEnterAddressTextField.tap()
-        waitForExistence(app.menuItems["Paste"], timeout: 10)
+        waitForExistence(app.menuItems["Paste"])
         XCTAssertTrue(app.menuItems["Paste & Go"].isEnabled)
 
         // Note: I can't click through "XCUITest-Runner would like to paste from Firefox Focus"

--- a/focus-ios/focus-ios-tests/XCUITest/DragAndDropTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/DragAndDropTest.swift
@@ -22,7 +22,7 @@ class DragAndDropTest: BaseTestCase {
             // DragAndDrop the url for only one second so that the TP menu is not shown and the search box is not covered
             urlBarTextField.firstMatch.press(forDuration: 1, thenDragTo: app.webViews.otherElements["search"].firstMatch)
             // Verify that the text in the search field is the same as the text in the url text field
-            XCTAssertEqual(app.webViews.textFields[websiteWithSearchField["urlSearchField"]!].firstMatch.value as? String, websiteWithSearchField["url"]!)
+            waitForValueContains(app.webViews.textFields[websiteWithSearchField["urlSearchField"]!].firstMatch, value: websiteWithSearchField["url"]!)
         }
     }
 }

--- a/focus-ios/focus-ios-tests/XCUITest/OnboardingTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/OnboardingTest.swift
@@ -4,9 +4,7 @@
 
 import XCTest
 
-class OnboardingTest: XCTestCase {
-    let app = XCUIApplication()
-
+class OnboardingTest: BaseTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
@@ -19,49 +17,31 @@ class OnboardingTest: XCTestCase {
         app.terminate()
     }
 
-    // Copied from BaseTestCase
-    private func waitForExistence(_ element: XCUIElement, timeout: TimeInterval = 5.0, file: String = #file, line: UInt = #line) {
-        waitFor(element, with: "exists == true", timeout: timeout, file: file, line: line)
-    }
-
-    private func waitFor(_ element: XCUIElement, with predicateString: String, description: String? = nil, timeout: TimeInterval = 5.0, file: String, line: UInt) {
-           let predicate = NSPredicate(format: predicateString)
-           let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
-           let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
-           if result != .completed {
-               let message = description ?? "Expect predicate \(predicateString) for \(element.description)"
-               var issue = XCTIssue(type: .assertionFailure, compactDescription: message)
-               let location = XCTSourceCodeLocation(filePath: file, lineNumber: Int(line))
-               issue.sourceCodeContext = XCTSourceCodeContext(location: location)
-               self.record(issue)
-           }
-       }
-
     // Smoketest
     // https://testrail.stage.mozaws.net/index.php?/cases/view/394959
     func testPressingDots() throws {
         let pageIndicatorButton = app.pageIndicators.firstMatch
         XCTAssertEqual(pageIndicatorButton.value as? String, "page 1 of 2")
 
-        waitForExistence(app.staticTexts["Welcome to Firefox Focus!"], timeout: 15)
+        waitForExistence(app.staticTexts["Welcome to Firefox Focus!"])
         XCTAssert(app.images["icon_background"].exists)
         XCTAssert(app.buttons["Get Started"].isEnabled)
         XCTAssert(app.buttons["icon_close"].isEnabled)
         pageIndicatorButton.tap()
 
         XCTAssertEqual(pageIndicatorButton.value as? String, "page 2 of 2")
-        waitForExistence(app.staticTexts["Focus isn’t like other browsers"], timeout: 15)
-        XCTAssert(app.images["icon_hugging_focus"].exists)
-        XCTAssert(app.buttons["Set as Default Browser"].isEnabled)
-        XCTAssert(app.buttons["Skip"].isEnabled)
-        XCTAssert(app.buttons["icon_close"].isEnabled)
+        waitForExistence(app.staticTexts["Focus isn’t like other browsers"])
+        waitForExistence(app.images["icon_hugging_focus"])
+        waitForEnable(app.buttons["Set as Default Browser"])
+        waitForEnable(app.buttons["Skip"])
+        waitForEnable(app.buttons["icon_close"])
         pageIndicatorButton.tap()
 
         XCTAssertEqual(pageIndicatorButton.value as? String, "page 1 of 2")
-        waitForExistence(app.staticTexts["Welcome to Firefox Focus!"], timeout: 15)
+        waitForExistence(app.staticTexts["Welcome to Firefox Focus!"])
         pageIndicatorButton.tap()
 
         XCTAssertEqual(pageIndicatorButton.value as? String, "page 2 of 2")
-        waitForExistence(app.staticTexts["Focus isn’t like other browsers"], timeout: 15)
+        waitForExistence(app.staticTexts["Focus isn’t like other browsers"])
     }
 }

--- a/focus-ios/focus-ios-tests/XCUITest/PageActionMenuTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/PageActionMenuTest.swift
@@ -16,7 +16,7 @@ class PageActionMenuTest: BaseTestCase {
         app.textFields["Search or enter address"].typeText("domain")
 
         // Try all functions of find in page bar
-        waitForExistence(app.buttons["FindInPageBar.button"], timeout: 5)
+        waitForExistence(app.buttons["FindInPageBar.button"])
         app.buttons["FindInPageBar.button"].tap()
 
         waitForHittable(app.buttons["FindInPage.find_previous"])
@@ -43,7 +43,7 @@ class PageActionMenuTest: BaseTestCase {
         app.buttons["HomeView.settingsButton"].tap()
 
         let findInPageButton = app.findInPageButton
-        waitForExistence(findInPageButton, timeout: 10)
+        waitForExistence(findInPageButton)
         findInPageButton.tap()
 
         // Activate find in page activity item and search for a keyword

--- a/focus-ios/focus-ios-tests/XCUITest/PageShortcutsTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/PageShortcutsTest.swift
@@ -19,14 +19,13 @@ class PageShortcutsTest: BaseTestCase {
         app.eraseButton.tap()
 
         // Verify the shortcut is created
-        XCTAssertTrue(app.otherElements.staticTexts["Mozilla"].exists)
+        waitForExistence(app.otherElements.staticTexts["Mozilla"])
 
         // Remove created shortcut
         app.otherElements["outerView"].press(forDuration: 2)
         waitForExistence(app.collectionViews.cells.buttons["Remove from Shortcuts"])
         app.collectionViews.cells.buttons["Remove from Shortcuts"].tap()
         waitForNoExistence(app.otherElements.staticTexts["Mozilla"])
-        XCTAssertFalse(app.otherElements.staticTexts["Mozilla"].exists)
     }
 
     // Smoketest
@@ -38,7 +37,7 @@ class PageShortcutsTest: BaseTestCase {
         app.eraseButton.tap()
 
         // Verify the shortcut is created
-        XCTAssertTrue(app.otherElements.staticTexts["Mozilla"].exists)
+        waitForExistence(app.otherElements.staticTexts["Mozilla"])
 
         // Rename shortcut
         app.otherElements["outerView"].press(forDuration: 2)
@@ -49,7 +48,6 @@ class PageShortcutsTest: BaseTestCase {
         app.alerts.buttons["Save"].tap()
 
         waitForExistence(app.otherElements.staticTexts["Cheese"])
-        XCTAssertTrue(app.otherElements.staticTexts["Cheese"].exists)
     }
 
     // Smoketest
@@ -69,7 +67,7 @@ class PageShortcutsTest: BaseTestCase {
         waitForWebPageLoad()
 
         // Tap on shortcuts settings menu option
-        waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 15)
+        waitForExistence(app.buttons["HomeView.settingsButton"])
         app.buttons["HomeView.settingsButton"].tap()
         if iPad() {
             waitForExistence(app.collectionViews.cells.element(boundBy: 0))

--- a/focus-ios/focus-ios-tests/XCUITest/SearchProviderTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/SearchProviderTest.swift
@@ -38,10 +38,10 @@ class SearchProviderTest: BaseTestCase {
         doSearch(searchWord: "mozilla", provider: provider)
         waitForWebPageLoad()
 
-        waitForExistence(app.buttons["URLBar.deleteButton"], timeout: 5)
+        waitForExistence(app.buttons["URLBar.deleteButton"])
         app.buttons["URLBar.deleteButton"].tap()
         if !iPad() {
-            waitForExistence(app.buttons["URLBar.cancelButton"], timeout: 5)
+            waitForExistence(app.buttons["URLBar.cancelButton"])
             app.buttons["URLBar.cancelButton"].tap()
         }
         checkForHomeScreen()
@@ -68,12 +68,12 @@ class SearchProviderTest: BaseTestCase {
     // https://testrail.stage.mozaws.net/index.php?/cases/view/1707744
     func testAddRemoveCustomSearchProvider() {
         dismissURLBarFocused()
-        waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 10)
+        waitForExistence(app.buttons["HomeView.settingsButton"])
         // Set search engine to Google
         app.buttons["HomeView.settingsButton"].tap()
 
         let settingsButton = app.settingsButton
-        waitForExistence(settingsButton, timeout: 10)
+        waitForExistence(settingsButton)
         settingsButton.tap()
 
         waitForExistence(app.tables.cells["SettingsViewController.searchCell"])
@@ -113,13 +113,13 @@ class SearchProviderTest: BaseTestCase {
     // https://testrail.stage.mozaws.net/index.php?/cases/view/1707745
     func testPreventionOfRemovingDefaultSearchProvider() {
         dismissURLBarFocused()
-        waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 10)
+        waitForExistence(app.buttons["HomeView.settingsButton"])
         // Set search engine to Google
         app.buttons["HomeView.settingsButton"].tap()
         let settingsButton = app.settingsButton
-        waitForExistence(settingsButton, timeout: 10)
+        waitForExistence(settingsButton)
         settingsButton.tap()
-        waitForExistence(app.tables.cells["SettingsViewController.searchCell"], timeout: 5)
+        waitForExistence(app.tables.cells["SettingsViewController.searchCell"])
         let defaultEngineName = app.tables.cells["SettingsViewController.searchCell"].staticTexts.element(boundBy: 1).label
         app.tables.cells["SettingsViewController.searchCell"].tap()
 
@@ -133,16 +133,16 @@ class SearchProviderTest: BaseTestCase {
     }
 
     private func changeSearchProvider(provider: String) {
-        waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 10)
+        waitForExistence(app.buttons["HomeView.settingsButton"])
         // Set search engine to Google
         app.buttons["HomeView.settingsButton"].tap()
 
         let settingsButton = app.settingsButton
-        waitForExistence(settingsButton, timeout: 10)
+        waitForExistence(settingsButton)
         settingsButton.tap()
-        waitForExistence(app.tables.cells["SettingsViewController.searchCell"], timeout: 5)
+        waitForExistence(app.tables.cells["SettingsViewController.searchCell"])
         app.tables.cells["SettingsViewController.searchCell"].tap()
-        waitForExistence(app.tables.staticTexts[provider], timeout: 5)
+        waitForExistence(app.tables.staticTexts[provider])
         app.tables.staticTexts[provider].tap()
         app.buttons["Done"].tap()
     }

--- a/focus-ios/focus-ios-tests/XCUITest/SearchSuggestionsTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/SearchSuggestionsTest.swift
@@ -36,11 +36,11 @@ class SearchSuggestionsPromptTest: BaseTestCase {
 
     func checkToggleStartsOff() {
         dismissURLBarFocused()
-        waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 10)
+        waitForExistence(app.buttons["HomeView.settingsButton"])
         // Set search engine to Google
         app.buttons["HomeView.settingsButton"].tap()
         let settingsButton = app.settingsButton
-        waitForExistence(settingsButton, timeout: 10)
+        waitForExistence(settingsButton)
         settingsButton.tap()
         waitForExistence(app.tables.cells["SettingsViewController.searchCell"])
         checkToggle(isOn: false)
@@ -74,7 +74,7 @@ class SearchSuggestionsPromptTest: BaseTestCase {
         waitForHittable(app.buttons["HomeView.settingsButton"])
         app.buttons["HomeView.settingsButton"].tap()
         let settingsButton = app.settingsButton
-        waitForExistence(settingsButton, timeout: 10)
+        waitForExistence(settingsButton)
         settingsButton.tap()
         waitForExistence(app.tables.cells["SettingsViewController.searchCell"])
         checkToggle(isOn: true)
@@ -111,7 +111,7 @@ class SearchSuggestionsPromptTest: BaseTestCase {
         waitForHittable(app.buttons["HomeView.settingsButton"])
         app.buttons["HomeView.settingsButton"].tap()
         let settingsButton = app.settingsButton
-        waitForExistence(settingsButton, timeout: 10)
+        waitForExistence(settingsButton)
         settingsButton.tap()
         waitForExistence(app.tables.cells["SettingsViewController.searchCell"])
         checkToggle(isOn: false)
@@ -123,7 +123,7 @@ class SearchSuggestionsPromptTest: BaseTestCase {
         checkToggleStartsOff()
 
         // Turn toggle ON
-        waitForExistence(app.tables.switches["BlockerToggle.enableSearchSuggestions"], timeout: 5)
+        waitForExistence(app.tables.switches["BlockerToggle.enableSearchSuggestions"])
 
         app.tables.cells.switches["BlockerToggle.enableSearchSuggestions"].tap()
 
@@ -134,7 +134,7 @@ class SearchSuggestionsPromptTest: BaseTestCase {
         // Adding a delay in case of slow network
         sleep(4)
 
-        waitForNoExistence(app.otherElements["SearchSuggestionsPromptView"], timeoutValue: 5)
+        waitForNoExistence(app.otherElements["SearchSuggestionsPromptView"])
 
         // Ensure search suggestions are shown
         checkSuggestions()
@@ -168,7 +168,7 @@ class SearchSuggestionsPromptTest: BaseTestCase {
         waitForExistence(app.buttons["HomeView.settingsButton"])
         app.buttons["HomeView.settingsButton"].tap()
         let settingsButton = app.settingsButton
-        waitForExistence(settingsButton, timeout: 10)
+        waitForExistence(settingsButton)
         settingsButton.tap()
         waitForExistence(app.tables.cells["SettingsViewController.searchCell"])
         app.tables.switches["BlockerToggle.enableSearchSuggestions"].tap()

--- a/focus-ios/focus-ios-tests/XCUITest/SettingTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/SettingTest.swift
@@ -14,17 +14,17 @@ class SettingTest: BaseTestCase {
         dismissURLBarFocused()
 
         // Navigate to Settings
-        waitForExistence(app.buttons["Settings"], timeout: 5)
+        waitForExistence(app.buttons["Settings"])
         app.buttons["Settings"].tap()
 
         let settingsButton = app.settingsButton
-        waitForExistence(settingsButton, timeout: 10)
+        waitForExistence(settingsButton)
         settingsButton.tap()
 
         // Check About page
         app.tables.firstMatch.swipeUp()
         let aboutCell = app.cells["settingsViewController.about"]
-        waitForExistence(aboutCell, timeout: 10)
+        waitForExistence(aboutCell)
         aboutCell.tap()
 
         let tablesQuery = app.tables
@@ -43,13 +43,13 @@ class SettingTest: BaseTestCase {
 
         // Check the initial state of the switch values
         let safariSwitch = app.tables.switches["Safari"]
-        waitForExistence(app.tables.switches["Safari"], timeout: 5)
+        waitForExistence(app.tables.switches["Safari"])
 
         XCTAssertEqual(safariSwitch.value as! String, "0")
         safariSwitch.tap()
 
         // Check the information page
-        waitForExistence(app.staticTexts["Open device settings"], timeout: 5)
+        waitForExistence(app.staticTexts["Open device settings"])
         XCTAssert(app.staticTexts["Open device settings"].exists)
         XCTAssert(app.staticTexts["Select Safari, then select Extensions"].exists)
         if app.label == "Firefox Focus" {
@@ -79,7 +79,7 @@ class SettingTest: BaseTestCase {
         XCTAssertEqual(app.tables.switches["BlockerToggle.BlockAnalytics"].value as! String, "1")
         XCTAssertEqual(app.tables.switches["BlockerToggle.BlockSocial"].value as! String, "1")
         let otherContentSwitch = app.tables.switches["BlockerToggle.BlockOther"]
-        waitForExistence(app.tables.switches["BlockerToggle.BlockOther"], timeout: 5)
+        waitForExistence(app.tables.switches["BlockerToggle.BlockOther"])
         XCTAssertEqual(otherContentSwitch.value as! String, "0")
 
         otherContentSwitch.tap()
@@ -108,7 +108,7 @@ class SettingTest: BaseTestCase {
             swipes = swipes - 1
         }
         reviewCell.tap()
-        waitForExistence(safariApp, timeout: 10)
+        waitForExistence(safariApp)
         XCTAssert(safariApp.state == .runningForeground)
 
         safariApp.terminate()
@@ -116,9 +116,9 @@ class SettingTest: BaseTestCase {
 
         // Let's be sure the app is backgrounded
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        waitForExistence(springboard.icons["XCUITest-Runner"], timeout: 15)
+        waitForExistence(springboard.icons["XCUITest-Runner"])
         app.activate()
-        waitForExistence(app.navigationBars["Settings"], timeout: 10)
+        waitForExistence(app.navigationBars["Settings"])
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2574974
@@ -160,7 +160,7 @@ class SettingTest: BaseTestCase {
         app.buttons["HomeView.settingsButton"].tap()
 
         let settingsButton = app.settingsButton
-        waitForExistence(settingsButton, timeout: 10)
+        waitForExistence(settingsButton)
         settingsButton.tap()
 
         // Navigate to Autocomplete Settings
@@ -188,7 +188,7 @@ class SettingTest: BaseTestCase {
         app.buttons["Settings"].tap()
 
         let settingsButton = app.settingsButton
-        waitForExistence(settingsButton, timeout: 10)
+        waitForExistence(settingsButton)
         settingsButton.tap()
 
         // Navigate to Autocomplete Settings
@@ -246,16 +246,16 @@ class SettingTest: BaseTestCase {
         let settingsButton = app.settingsButton
         waitForExistence(settingsButton, timeout: 10)
         settingsButton.tap()
-        waitForExistence(app.tables.cells["settingsViewController.themeCell"], timeout: 10)
+        waitForExistence(app.tables.cells["settingsViewController.themeCell"])
         app.tables.cells["settingsViewController.themeCell"].swipeUp()
 
         // Check that Safari toggle is off, swipe to get to Safari Integration menu
-        waitForExistence(app.otherElements["SIRI SHORTCUTS"], timeout: 10)
+        waitForExistence(app.otherElements["SIRI SHORTCUTS"])
         app.otherElements["SIRI SHORTCUTS"].swipeUp()
         XCTAssertEqual(app.switches["BlockerToggle.Safari"].value! as! String, "0")
 
         iOS_Settings.activate()
-        waitForExistence(iOS_Settings.cells["Safari"], timeout: 10)
+        waitForExistence(iOS_Settings.cells["Safari"])
         iOS_Settings.cells["Safari"].tap()
         iOS_Settings.cells["AutoFill"].swipeUp()
         if #available(iOS 15.0, *) {
@@ -404,7 +404,7 @@ class SettingTest: BaseTestCase {
             app.buttons["URLBar.cancelButton"].tap()
         }
         app.buttons["Settings"].tap()
-        waitForExistence(settingsButton, timeout: 10)
+        waitForExistence(settingsButton)
         settingsButton.tap()
         waitForExistence(app.tables.cells["SettingsViewController.autocompleteCell"])
         app.tables.cells["SettingsViewController.autocompleteCell"].tap()

--- a/focus-ios/focus-ios-tests/XCUITest/TrackingProtectionTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/TrackingProtectionTest.swift
@@ -10,14 +10,14 @@ class TrackingProtectionTest: BaseTestCase {
         // Go to in-app settings
         // Check the new options in TP Settings menu
         dismissURLBarFocused()
-        waitForExistence(app.buttons["HomeView.settingsButton"], timeout: 10)
+        waitForExistence(app.buttons["HomeView.settingsButton"])
         // Set search engine to Google
         app.buttons["HomeView.settingsButton"].tap()
         let settingsButton = app.settingsButton
         waitForExistence(settingsButton, timeout: 10)
         settingsButton.tap()
 
-        waitForExistence(app.tables.cells["settingsViewController.trackingCell"], timeout: 10)
+        waitForExistence(app.tables.cells["settingsViewController.trackingCell"])
         app.tables.cells["settingsViewController.trackingCell"].tap()
 
         waitForExistence(app.navigationBars["Tracking Protection"])
@@ -98,7 +98,7 @@ class TrackingProtectionTest: BaseTestCase {
         }
         waitForExistence(app.buttons["HomeView.settingsButton"])
         app.buttons["HomeView.settingsButton"].tap()
-        waitForExistence(app.collectionViews.buttons["Settings"], timeout: 5)
+        waitForExistence(app.collectionViews.buttons["Settings"])
         app.collectionViews.buttons["Settings"].tap()
         waitForExistence(app.cells["settingsViewController.trackingCell"])
         app.cells["settingsViewController.trackingCell"].tap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3145)

## :bulb: Description
Focus tests don't all pass consistently. All of the tests suppose to pass (according to MacStadium).

Here are some reasons from Github Action's end:
* Network could be slow
* Runners are not as powerful as the MacStadium counterpart
* `XCTAssert` command does not wait for update

Here are some highlights:
* Increase default timeout for `waitFor` commands to 30 seconds
* Use default `waitFor` timeout unless a longer timeout is required
* Change `XCTAssert` commands to `waitFor` ones
* Increased timeout for `waitForWebPageLoad ()`
* Alleviate network slowness: https://github.com/actions/runner-images/issues/1187
* `DragAndDropTests` may be disabled 😢 - It fails consistently on Github Actions but passes for me

Sample run of the job: https://github.com/mozilla-mobile/firefox-ios/actions/runs/9967948360

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

