### PR TITLE
Refactor FXIOS-7301 - Help to remove 1 closure_body_length violation from Experiments.swift (1/3)

### DIFF
--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -143,16 +143,11 @@ enum Experiments {
 
         let isPhone = UIDevice.current.userInterfaceIdiom == .phone
 
-        var isReviewCheckerEnabled = false
-        if let prefs = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier) {
-            isReviewCheckerEnabled = prefs.bool(forKey: "profile." + PrefsKeys.Shopping2023OptIn)
-        }
-
         let customTargetingAttributes: [String: Any] =  [
             "isFirstRun": "\(isFirstRun)",
             "is_first_run": isFirstRun,
             "is_phone": isPhone,
-            "is_review_checker_enabled": isReviewCheckerEnabled
+            "is_review_checker_enabled": isReviewCheckerEnabled()
         ]
 
         // App settings, to allow experiments to target the app name and the

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -198,6 +198,14 @@ enum Experiments {
             .build(appInfo: appSettings)
     }()
 
+    private static func isReviewCheckerEnabled() -> Bool {
+        var isReviewCheckerEnabled = false
+        if let prefs = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier) {
+            isReviewCheckerEnabled = prefs.bool(forKey: "profile." + PrefsKeys.Shopping2023OptIn)
+        }
+        return isReviewCheckerEnabled
+    }
+
     /// A convenience method to initialize the `NimbusApi` object at startup.
     ///
     /// This includes opening the database, connecting to the Remote Settings server, and downloading


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR help to remove 1 `closure_body_length` violation from the `Experiments.swift`. I preferred to split it in three separated PRs to turn easy the review. This first one just breaks the `isReviewCheckerEnabled` logic to a new function.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

