### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from AddressAutofillToggle.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -94,6 +94,36 @@ struct AddressAutofillToggle: View {
         }
     }
 
+    fileprivate func mainContent() -> some View {
+        // Horizontal stack containing title, description, and toggle
+        return HStack {
+            // Left-aligned stack for title and description
+            VStack(alignment: .leading) {
+                // Title for the Toggle
+                Text(String.Addresses.Settings.SwitchTitle)
+                    .font(.body)
+                    .foregroundColor(textColor)
+
+                // Description for the Toggle
+                Text(String.Addresses.Settings.SwitchDescription)
+                    .font(.footnote)
+                    .foregroundColor(descriptionTextColor)
+            }
+            .padding(.leading, 16)
+
+            Spacer()
+
+            // Toggle switch
+            Toggle(isOn: $model.isEnabled) {
+                EmptyView()
+            }
+            .padding(.trailing, 16)
+            .labelsHidden()
+            .toggleStyle(SwitchToggleStyle(tint: toggleTintColor))
+            .frame(alignment: .trailing)
+        }
+    }
+
     var traits: AccessibilityTraits {
         if #available(iOS 17.0, *) {
             return [.isButton, .isToggle]

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -37,7 +37,6 @@ struct AddressAutofillToggle: View {
 
     var body: some View {
         VStack {
-            // Divider line to separate content (hidden by default)
             Divider()
                 .frame(height: 0.7)
                 .padding(.leading, 16)

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -75,7 +75,6 @@ struct AddressAutofillToggle: View {
                     .font(.body)
                     .foregroundColor(textColor)
 
-                // Description for the Toggle
                 Text(String.Addresses.Settings.SwitchDescription)
                     .font(.footnote)
                     .foregroundColor(descriptionTextColor)

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -67,7 +67,6 @@ struct AddressAutofillToggle: View {
     }
 
     private func mainContent() -> some View {
-        // Horizontal stack containing title, description, and toggle
         return HStack {
             VStack(alignment: .leading) {
                 Text(String.Addresses.Settings.SwitchTitle)

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -69,7 +69,6 @@ struct AddressAutofillToggle: View {
     private func mainContent() -> some View {
         // Horizontal stack containing title, description, and toggle
         return HStack {
-            // Left-aligned stack for title and description
             VStack(alignment: .leading) {
                 Text(String.Addresses.Settings.SwitchTitle)
                     .font(.body)

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -51,7 +51,6 @@ struct AddressAutofillToggle: View {
                     model.isEnabled = !model.isEnabled
                 }
 
-            // Divider line to separate content
             Divider()
                 .frame(height: 0.7)
                 .padding(.leading, 16)

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -42,7 +42,7 @@ struct AddressAutofillToggle: View {
                 .padding(.leading, 16)
                 .hidden()
 
-            mainContent()
+            main
                 .accessibilityElement()
                 .accessibilityLabel("\(String.Addresses.Settings.SwitchTitle), \(String.Addresses.Settings.SwitchDescription)")
                 .accessibilityValue("\(model.isEnabled ? 1 : 0)")
@@ -65,7 +65,7 @@ struct AddressAutofillToggle: View {
         }
     }
 
-    private func mainContent() -> some View {
+    private var main: some View {
         return HStack {
             VStack(alignment: .leading) {
                 Text(String.Addresses.Settings.SwitchTitle)

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -87,7 +87,6 @@ struct AddressAutofillToggle: View {
 
             Spacer()
 
-            // Toggle switch
             Toggle(isOn: $model.isEnabled) {
                 EmptyView()
             }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -44,13 +44,13 @@ struct AddressAutofillToggle: View {
                 .hidden()
 
             mainContent()
-            .accessibilityElement()
-            .accessibilityLabel("\(String.Addresses.Settings.SwitchTitle), \(String.Addresses.Settings.SwitchDescription)")
-            .accessibilityValue("\(model.isEnabled ? 1 : 0)")
-            .accessibilityAddTraits(traits)
-            .accessibilityAction {
-                model.isEnabled = !model.isEnabled
-            }
+                .accessibilityElement()
+                .accessibilityLabel("\(String.Addresses.Settings.SwitchTitle), \(String.Addresses.Settings.SwitchDescription)")
+                .accessibilityValue("\(model.isEnabled ? 1 : 0)")
+                .accessibilityAddTraits(traits)
+                .accessibilityAction {
+                    model.isEnabled = !model.isEnabled
+                }
 
             // Divider line to separate content
             Divider()

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -57,7 +57,6 @@ struct AddressAutofillToggle: View {
         }
         .background(backgroundColor)
         .onAppear {
-            // Apply theme when the view appears
             applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
         .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -43,33 +43,7 @@ struct AddressAutofillToggle: View {
                 .padding(.leading, 16)
                 .hidden()
 
-            // Horizontal stack containing title, description, and toggle
-            HStack {
-                // Left-aligned stack for title and description
-                VStack(alignment: .leading) {
-                    // Title for the Toggle
-                    Text(String.Addresses.Settings.SwitchTitle)
-                        .font(.body)
-                        .foregroundColor(textColor)
-
-                    // Description for the Toggle
-                    Text(String.Addresses.Settings.SwitchDescription)
-                        .font(.footnote)
-                        .foregroundColor(descriptionTextColor)
-                }
-                .padding(.leading, 16)
-
-                Spacer()
-
-                // Toggle switch
-                Toggle(isOn: $model.isEnabled) {
-                    EmptyView()
-                }
-                .padding(.trailing, 16)
-                .labelsHidden()
-                .toggleStyle(SwitchToggleStyle(tint: toggleTintColor))
-                .frame(alignment: .trailing)
-            }
+            mainContent()
             .accessibilityElement()
             .accessibilityLabel("\(String.Addresses.Settings.SwitchTitle), \(String.Addresses.Settings.SwitchDescription)")
             .accessibilityValue("\(model.isEnabled ? 1 : 0)")

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -71,7 +71,6 @@ struct AddressAutofillToggle: View {
         return HStack {
             // Left-aligned stack for title and description
             VStack(alignment: .leading) {
-                // Title for the Toggle
                 Text(String.Addresses.Settings.SwitchTitle)
                     .font(.body)
                     .foregroundColor(textColor)

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -68,7 +68,7 @@ struct AddressAutofillToggle: View {
         }
     }
 
-    fileprivate func mainContent() -> some View {
+    private func mainContent() -> some View {
         // Horizontal stack containing title, description, and toggle
         return HStack {
             // Left-aligned stack for title and description


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `AddressAutofillToggle.swift ` file. 

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

