### PR TITLE
Add FXIOS-9503 [Microsurvey] Hide border requirement

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -16,6 +16,7 @@ public struct AccessibilityIdentifiers {
     /// Used for toolbar/URL bar buttons since our classes are built that buttons can live in one or the other
     /// Using only those a11y identifiers for both ensures we have standard way to refer to buttons from iPad to iPhone
     struct Toolbar {
+        static let urlBarBorder = "TabToolbar.urlBarBorder"
         static let settingsMenuButton = "TabToolbar.menuButton"
         static let homeButton = "TabToolbar.homeButton"
         static let trackingProtection = "TabLocationView.trackingProtectionButton"

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1277,6 +1277,14 @@ class BrowserViewController: UIViewController,
     }
 
     // MARK: - Microsurvey
+    private var isToolbarPositionBottom: Bool {
+        let toolbarState = store.state.screenState(ToolbarState.self,
+                                                   for: .toolbar,
+                                                   window: windowUUID)
+        let isBottomToolbar = toolbarState?.toolbarPosition == .bottom
+        return isToolbarRefactorEnabled ? isBottomToolbar : urlBar.isBottomSearchBar
+    }
+
     private func setupMicrosurvey() {
         guard featureFlags.isFeatureEnabled(.microsurvey, checking: .buildOnly), microsurvey == nil else { return }
 
@@ -1291,13 +1299,7 @@ class BrowserViewController: UIViewController,
         microsurvey.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(microsurvey)
 
-        let toolbarState = store.state.screenState(ToolbarState.self,
-                                                   for: .toolbar,
-                                                   window: windowUUID)
-        let isBottomToolbar = toolbarState?.toolbarPosition == .bottom
-        let isBottomSearch = isToolbarRefactorEnabled ? isBottomToolbar : urlBar.isBottomSearchBar
-
-        if isBottomSearch {
+        if isToolbarPositionBottom {
             overKeyboardContainer.addArrangedViewToTop(microsurvey, animated: false, completion: {
                 self.view.layoutIfNeeded()
             })
@@ -1309,7 +1311,23 @@ class BrowserViewController: UIViewController,
 
         microsurvey.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
 
+        updateBarBordersForMicrosurvey()
         updateViewConstraints()
+    }
+
+    // Update border to hide when microsurvey is shown so that
+    // it appears to belong the app and harder to spoof
+    private func updateBarBordersForMicrosurvey() {
+        // TODO: FXIOS-9503 Update for Toolbar Redesign
+        guard !shouldUseiPadSetup(), !isToolbarRefactorEnabled else { return }
+        let hasMicrosurvery = microsurvey != nil
+
+        if let urlBar, isToolbarPositionBottom {
+            urlBar.isMicrosurveyShown = hasMicrosurvery
+            urlBar.updateTopBorderDisplay()
+        }
+        toolbar.isMicrosurveyShown = hasMicrosurvery
+        toolbar.setNeedsDisplay()
     }
 
     private func createMicrosurveyPrompt(with state: MicrosurveyPromptState) {
@@ -1320,19 +1338,14 @@ class BrowserViewController: UIViewController,
     private func removeMicrosurveyPrompt() {
         guard let microsurvey else { return }
 
-        let toolbarState = store.state.screenState(ToolbarState.self,
-                                                   for: .toolbar,
-                                                   window: windowUUID)
-        let isBottomToolbar = toolbarState?.toolbarPosition == .bottom
-        let isBottomSearch = isToolbarRefactorEnabled ? isBottomToolbar : urlBar.isBottomSearchBar
-
-        if isBottomSearch {
+        if isToolbarPositionBottom {
             overKeyboardContainer.removeArrangedView(microsurvey)
         } else {
             bottomContainer.removeArrangedView(microsurvey)
         }
 
         self.microsurvey = nil
+        updateBarBordersForMicrosurvey()
         updateViewConstraints()
     }
     // MARK: - Update content

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -27,6 +27,7 @@ class TabToolbar: UIView, SearchBarLocationProvider {
                                                      imageMask: ImageIdentifiers.menuWarningMask)
 
     var helper: TabToolbarHelper?
+    var isMicrosurveyShown = false
     private let contentView = UIStackView()
 
     // MARK: - Initializers
@@ -81,8 +82,9 @@ class TabToolbar: UIView, SearchBarLocationProvider {
     }
 
     override func draw(_ rect: CGRect) {
-        // No line when the search bar is on top of the toolbar
-        guard !isBottomSearchBar else { return }
+        // No line when the search bar or microsurvey is on top of the toolbar
+        // In terms of the microsurvey, by not having the border, it makes it difficult for websites to replicate the prompt.
+        guard !isBottomSearchBar && !isMicrosurveyShown else { return }
 
         if let context = UIGraphicsGetCurrentContext() {
             drawLine(context, start: .zero, end: CGPoint(x: frame.width, y: 0))

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -100,6 +100,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     var toolbarIsShowing = false
     var topTabsIsShowing = false
+    var isMicrosurveyShown = false
 
     var locationTextField: ToolbarTextField?
     private var isActivatingLocationTextField = false
@@ -123,7 +124,9 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         return locationContainer
     }()
 
-    private let line = UIView()
+    private let line: UIView = .build { view in
+        view.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.urlBarBorder
+    }
 
     lazy var tabsButton: TabsButton = {
         let tabsButton = TabsButton()
@@ -520,6 +523,10 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     func hideProgressBar() {
         progressBar.isHidden = true
         progressBar.setProgress(0, animated: false)
+    }
+
+    func updateTopBorderDisplay() {
+        line.isHidden = isBottomSearchBar && isMicrosurveyShown
     }
 
     func updateReaderModeState(_ state: ReaderModeState) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -20,7 +20,7 @@ final class MicrosurveyTests: BaseTestCase {
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists)
     }
 
-    func testURLBorderHidden_whenMicrosurveyPromptShownAndAppearsWhenClosed() throws {
+    func testURLBorderHiddenWhenMicrosurveyPromptShown() throws {
         guard !iPad() else {
             throw XCTSkip("Toolbar option not available for iPad")
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -20,6 +20,23 @@ final class MicrosurveyTests: BaseTestCase {
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists)
     }
 
+    func testURLBorderHidden_whenMicrosurveyPromptShownAndAppearsWhenClosed() throws {
+        guard !iPad() else {
+            throw XCTSkip("Toolbar option not available for iPad")
+        }
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(ToolbarSettings)
+        navigator.performAction(Action.SelectToolbarBottom)
+        navigator.goto(HomePanelsScreen)
+        generateTriggerForMicrosurvey()
+        XCTAssertFalse(app.otherElements[AccessibilityIdentifiers.Toolbar.urlBarBorder].exists)
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton].exists)
+        XCTAssertTrue(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo].exists)
+        XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists)
+        app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].tap()
+        XCTAssertFalse(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists)
+    }
+
     func testCloseButtonDismissesMicrosurveyPrompt() {
         generateTriggerForMicrosurvey()
         app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].tap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9503)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21038)

## :bulb: Description
Add border requirement for microsurvey
- When survey is shown, hide border in between survey and toolbar
- When survey is shown and search bar is at bottom, hide border between search and survey
- When survey is dismissed, show border as normal

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots 
| Bottom | Top |
| --- | --- |
| ![simulator_screenshot_FB5DFCFF-F6A0-4DFA-A440-D7BD0316B808](https://github.com/user-attachments/assets/5d02e1a2-e103-4faf-a944-c9f1e33dfb3c) | ![simulator_screenshot_FB90981E-37D1-44BB-B39A-2571D46E9DA9](https://github.com/user-attachments/assets/3cd28c01-61ba-4556-bec1-137ae646dd37) |
