### PR TITLE
Bugfix FXIOS-9494 Prevent website data table from collapsing on cell selection

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -46,7 +46,6 @@ class WebsiteDataManagementViewController: UIViewController,
 
     var tableView: UITableView!
     var searchController: UISearchController?
-    var showMoreButtonEnabled = true
 
     private lazy var searchResultsViewController = WebsiteDataSearchResultsViewController(viewModel: viewModel,
                                                                                           windowUUID: windowUUID)
@@ -106,9 +105,10 @@ class WebsiteDataManagementViewController: UIViewController,
             self.loadingView.isHidden = self.viewModel.state != .loading
 
             // Show either 10, 8 or 6 records initially depending on the screen size.
-            let height = max(self.view.frame.width, self.view.frame.height)
-            let numberOfInitialRecords = height > 667 ? 10 : height > 568 ? 8 : 6
-            self.showMoreButtonEnabled = self.viewModel.siteRecords.count > numberOfInitialRecords
+            if self.viewModel.state != .displayAll {
+                let height = max(self.view.frame.width, self.view.frame.height)
+                let numberOfInitialRecords = height > 667 ? 10 : height > 568 ? 8 : 6
+            }
 
             self.searchResultsViewController.reloadData()
             self.tableView.reloadData()
@@ -167,7 +167,7 @@ class WebsiteDataManagementViewController: UIViewController,
         case .showMore:
             let cell = dequeueCellFor(indexPath: indexPath)
             cell.applyTheme(theme: currentTheme())
-            let cellType: ThemedTableViewCellType = showMoreButtonEnabled ? .actionPrimary : .disabled
+            let cellType: ThemedTableViewCellType = viewModel.state != .displayAll ? .actionPrimary : .disabled
             let cellViewModel = ThemedTableViewCellViewModel(
                 theme: currentTheme(),
                 type: cellType
@@ -228,9 +228,9 @@ class WebsiteDataManagementViewController: UIViewController,
             // Show either 10, 8 or 6 records initially depending on the screen size.
             let height = max(self.view.frame.width, self.view.frame.height)
             let numberOfInitialRecords = height > 667 ? 10 : height > 568 ? 8 : 6
-            return showMoreButtonEnabled ? min(numberOfRecords, numberOfInitialRecords) : numberOfRecords
+            return viewModel.state == .displayAll ? numberOfRecords: min(numberOfRecords, numberOfInitialRecords)
         case .showMore:
-            return showMoreButtonEnabled ? 1 : 0
+            return viewModel.state != .displayAll ? 1 : 0
         case .clearButton:
             return 1
         }
@@ -244,7 +244,7 @@ class WebsiteDataManagementViewController: UIViewController,
             viewModel.selectItem(item)
             break
         case .showMore:
-            showMoreButtonEnabled = false
+            viewModel.showMoreButtonPressed()
             tableView.reloadData()
         case .clearButton:
             let generator = UIImpactFeedbackGenerator(style: .heavy)

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewModel.swift
@@ -55,6 +55,10 @@ class WebsiteDataManagementViewModel {
         }
     }
 
+    func showMoreButtonPressed() {
+        state = .displayAll
+    }
+
     private func removeSelectedRecords() {
         let previousState = state
         state = .loading


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9494)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21026)

## :bulb: Description
- Prevent the website data table from collapsing whenever a cell is selected

### Discussion
Previously, any time a cell was selected, the `onViewModelChanged` closure was executed, and if the view model contained more sites than the collapsed state could display, we would always re-show the "Show all" button and collapse the table view. Now, we utilize `State:DisplayAll` to keep track of when we should be displaying the full table view and persist that even after a cell is selected

### Videos

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/bdbde156-878a-4b8f-aa5b-c46faa90cdcf

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/8ff5f33b-e587-4d5d-a2b4-86a305486a30

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

