### PR TITLE
Bugfix FXIOS-9495 Prevent unexpected cell text highlight in website data table

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -46,6 +46,7 @@ class WebsiteDataManagementViewController: UIViewController,
 
     var tableView: UITableView!
     var searchController: UISearchController?
+    var showMoreButtonEnabled = true
 
     private lazy var searchResultsViewController = WebsiteDataSearchResultsViewController(viewModel: viewModel,
                                                                                           windowUUID: windowUUID)
@@ -107,10 +108,9 @@ class WebsiteDataManagementViewController: UIViewController,
             self.loadingView.isHidden = self.viewModel.state != .loading
 
             // Show either 10, 8 or 6 records initially depending on the screen size.
-            if self.viewModel.state != .displayAll {
-                let height = max(self.view.frame.width, self.view.frame.height)
-                let numberOfInitialRecords = height > 667 ? 10 : height > 568 ? 8 : 6
-            }
+            let height = max(self.view.frame.width, self.view.frame.height)
+            let numberOfInitialRecords = height > 667 ? 10 : height > 568 ? 8 : 6
+            self.showMoreButtonEnabled = self.viewModel.siteRecords.count > numberOfInitialRecords
 
             self.searchResultsViewController.reloadData()
             self.tableView.reloadData()
@@ -169,7 +169,7 @@ class WebsiteDataManagementViewController: UIViewController,
         case .showMore:
             let cell = dequeueCellFor(indexPath: indexPath)
             cell.applyTheme(theme: currentTheme())
-            let cellType: ThemedTableViewCellType = viewModel.state != .displayAll ? .actionPrimary : .disabled
+            let cellType: ThemedTableViewCellType = showMoreButtonEnabled ? .actionPrimary : .disabled
             let cellViewModel = ThemedTableViewCellViewModel(
                 theme: currentTheme(),
                 type: cellType
@@ -239,9 +239,9 @@ class WebsiteDataManagementViewController: UIViewController,
             // Show either 10, 8 or 6 records initially depending on the screen size.
             let height = max(self.view.frame.width, self.view.frame.height)
             let numberOfInitialRecords = height > 667 ? 10 : height > 568 ? 8 : 6
-            return viewModel.state == .displayAll ? numberOfRecords: min(numberOfRecords, numberOfInitialRecords)
+            return showMoreButtonEnabled ? min(numberOfRecords, numberOfInitialRecords) : numberOfRecords
         case .showMore:
-            return viewModel.state != .displayAll ? 1 : 0
+            return showMoreButtonEnabled ? 1 : 0
         case .clearButton:
             return 1
         }
@@ -255,7 +255,7 @@ class WebsiteDataManagementViewController: UIViewController,
             viewModel.selectItem(item)
             break
         case .showMore:
-            viewModel.showMoreButtonPressed()
+            showMoreButtonEnabled = false
             tableView.reloadData()
         case .clearButton:
             let generator = UIImpactFeedbackGenerator(style: .heavy)

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -16,6 +16,7 @@ class WebsiteDataManagementViewController: UIViewController,
     var notificationCenter: NotificationProtocol
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
+    private static let showMoreCellReuseIdentifier = "showMoreCell"
 
     private enum Section: Int {
         case sites = 0
@@ -69,7 +70,7 @@ class WebsiteDataManagementViewController: UIViewController,
         tableView.allowsMultipleSelectionDuringEditing = true
         tableView.allowsSelectionDuringEditing = true
         tableView.register(ThemedTableViewCell.self, forCellReuseIdentifier: ThemedTableViewCell.cellIdentifier)
-        tableView.register(ThemedTableViewCell.self, forCellReuseIdentifier: "showMoreCell")
+        tableView.register(ThemedTableViewCell.self, forCellReuseIdentifier: WebsiteDataManagementViewController.showMoreCellReuseIdentifier)
         tableView.register(cellType: ThemedTableViewCell.self)
         tableView.register(cellType: ThemedCenteredTableViewCell.self)
         tableView.register(
@@ -207,7 +208,7 @@ class WebsiteDataManagementViewController: UIViewController,
             return cell
         case .showMore:
             guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: "showMoreCell",
+                withIdentifier: WebsiteDataManagementViewController.showMoreCellReuseIdentifier,
                 for: indexPath
             ) as? ThemedTableViewCell
             else {

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -46,7 +46,6 @@ class WebsiteDataManagementViewController: UIViewController,
 
     var tableView: UITableView!
     var searchController: UISearchController?
-    var showMoreButtonEnabled = true
 
     private lazy var searchResultsViewController = WebsiteDataSearchResultsViewController(viewModel: viewModel,
                                                                                           windowUUID: windowUUID)
@@ -106,9 +105,10 @@ class WebsiteDataManagementViewController: UIViewController,
             self.loadingView.isHidden = self.viewModel.state != .loading
 
             // Show either 10, 8 or 6 records initially depending on the screen size.
-            let height = max(self.view.frame.width, self.view.frame.height)
-            let numberOfInitialRecords = height > 667 ? 10 : height > 568 ? 8 : 6
-            self.showMoreButtonEnabled = self.viewModel.siteRecords.count > numberOfInitialRecords
+            if self.viewModel.state != .displayAll {
+                let height = max(self.view.frame.width, self.view.frame.height)
+                let numberOfInitialRecords = height > 667 ? 10 : height > 568 ? 8 : 6
+            }
 
             self.searchResultsViewController.reloadData()
             self.tableView.reloadData()
@@ -167,7 +167,7 @@ class WebsiteDataManagementViewController: UIViewController,
         case .showMore:
             let cell = dequeueCellFor(indexPath: indexPath)
             cell.applyTheme(theme: currentTheme())
-            let cellType: ThemedTableViewCellType = showMoreButtonEnabled ? .actionPrimary : .disabled
+            let cellType: ThemedTableViewCellType = viewModel.state != .displayAll ? .actionPrimary : .disabled
             let cellViewModel = ThemedTableViewCellViewModel(
                 theme: currentTheme(),
                 type: cellType
@@ -228,9 +228,9 @@ class WebsiteDataManagementViewController: UIViewController,
             // Show either 10, 8 or 6 records initially depending on the screen size.
             let height = max(self.view.frame.width, self.view.frame.height)
             let numberOfInitialRecords = height > 667 ? 10 : height > 568 ? 8 : 6
-            return showMoreButtonEnabled ? min(numberOfRecords, numberOfInitialRecords) : numberOfRecords
+            return viewModel.state == .displayAll ? numberOfRecords: min(numberOfRecords, numberOfInitialRecords)
         case .showMore:
-            return showMoreButtonEnabled ? 1 : 0
+            return viewModel.state != .displayAll ? 1 : 0
         case .clearButton:
             return 1
         }
@@ -244,7 +244,7 @@ class WebsiteDataManagementViewController: UIViewController,
             viewModel.selectItem(item)
             break
         case .showMore:
-            showMoreButtonEnabled = false
+            viewModel.showMoreButtonPressed()
             tableView.reloadData()
         case .clearButton:
             let generator = UIImpactFeedbackGenerator(style: .heavy)

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -67,6 +67,8 @@ class WebsiteDataManagementViewController: UIViewController,
         tableView.isEditing = true
         tableView.allowsMultipleSelectionDuringEditing = true
         tableView.allowsSelectionDuringEditing = true
+        tableView.register(ThemedTableViewCell.self, forCellReuseIdentifier: ThemedTableViewCell.cellIdentifier)
+        tableView.register(ThemedTableViewCell.self, forCellReuseIdentifier: "showMoreCell")
         tableView.register(cellType: ThemedTableViewCell.self)
         tableView.register(cellType: ThemedCenteredTableViewCell.self)
         tableView.register(
@@ -194,9 +196,18 @@ class WebsiteDataManagementViewController: UIViewController,
             return ThemedTableViewCell()
         }
         switch section {
-        case .sites, .showMore:
+        case .sites:
             guard let cell = tableView.dequeueReusableCell(
                 withIdentifier: ThemedTableViewCell.cellIdentifier,
+                for: indexPath
+            ) as? ThemedTableViewCell
+            else {
+                return ThemedTableViewCell()
+            }
+            return cell
+        case .showMore:
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: "showMoreCell",
                 for: indexPath
             ) as? ThemedTableViewCell
             else {

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -70,7 +70,10 @@ class WebsiteDataManagementViewController: UIViewController,
         tableView.allowsMultipleSelectionDuringEditing = true
         tableView.allowsSelectionDuringEditing = true
         tableView.register(ThemedTableViewCell.self, forCellReuseIdentifier: ThemedTableViewCell.cellIdentifier)
-        tableView.register(ThemedTableViewCell.self, forCellReuseIdentifier: WebsiteDataManagementViewController.showMoreCellReuseIdentifier)
+        tableView.register(
+            ThemedTableViewCell.self,
+            forCellReuseIdentifier: WebsiteDataManagementViewController.showMoreCellReuseIdentifier
+        )
         tableView.register(cellType: ThemedTableViewCell.self)
         tableView.register(cellType: ThemedCenteredTableViewCell.self)
         tableView.register(

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewModel.swift
@@ -55,6 +55,10 @@ class WebsiteDataManagementViewModel {
         }
     }
 
+    func showMoreButtonPressed() {
+        state = .displayAll
+    }
+
     private func removeSelectedRecords() {
         let previousState = state
         state = .loading

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewModel.swift
@@ -55,10 +55,6 @@ class WebsiteDataManagementViewModel {
         }
     }
 
-    func showMoreButtonPressed() {
-        state = .displayAll
-    }
-
     private func removeSelectedRecords() {
         let previousState = state
         state = .loading


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9495)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21027)

## :bulb: Description
- All cell's text color in the `sites` section of the website data table should now always be the same

### Discussion
The `.sites' and `.showMore` sections of the UITableView were utilizing the same cell/cell identifier, causing issues with cell reuse between sections. 

### Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/271b62f3-e8b6-4e69-a929-fa70acd95fad

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/f14b27bd-83e7-4080-820e-410f7953d991

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

