### PR TITLE
Bugfix FXIOS-9461 [Tab Tray Refactor] Fix weird behavior after closing and restoring inactive tabs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -431,7 +431,7 @@ class TabManagerMiddleware {
                                                          actionType: TabPanelMiddlewareActionType.refreshInactiveTabs)
             store.dispatch(refreshAction)
 
-            let toastAction = TabPanelMiddlewareAction(toastType: .closedAllTabs(count: tabsState.inactiveTabs.count),
+            let toastAction = TabPanelMiddlewareAction(toastType: .closedAllInactiveTabs(count: tabsState.inactiveTabs.count),
                                                        windowUUID: uuid,
                                                        actionType: TabPanelMiddlewareActionType.showToast)
             store.dispatch(toastAction)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -431,7 +431,8 @@ class TabManagerMiddleware {
                                                          actionType: TabPanelMiddlewareActionType.refreshInactiveTabs)
             store.dispatch(refreshAction)
 
-            let toastAction = TabPanelMiddlewareAction(toastType: .closedAllInactiveTabs(count: tabsState.inactiveTabs.count),
+            let inactiveTabsCount = tabsState.inactiveTabs.count
+            let toastAction = TabPanelMiddlewareAction(toastType: .closedAllInactiveTabs(count: inactiveTabsCount),
                                                        windowUUID: uuid,
                                                        actionType: TabPanelMiddlewareActionType.showToast)
             store.dispatch(toastAction)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9461)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20948)

## :bulb: Description
Previously we were setting the incorrect middleware action when setting up the toast - `closedAllTabs`. Now we are using the correct one `closedAllInactiveTabs` and so the toast triggers the correct middleware action when we tap undo.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

