### PR TITLE
Bugfix FXIOS-9500 [Microsurvey] Fix iPad bugs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1391,6 +1391,7 @@ class BrowserViewController: UIViewController,
         if UIDevice.current.userInterfaceIdiom == .pad {
             topTabsViewController?.refreshTabs()
         }
+        setupMicrosurvey()
     }
 
     func showLibrary(panel: LibraryPanelType) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9500)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9499)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9498)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21035)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21034)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21032)

## :bulb: Description
PR to address three bugs [here](https://github.com/mozilla-mobile/firefox-ios/issues?q=is%3Aissue+is%3Aopen+21035+21034+21032+21031). See JIRA and Issues tagged above.

The issue was that on iPad we were not calling `setupMicrosurvey` earlier enough, so added it here as another check to determine if we should show the microsurvey when there has been an update in the content.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

