### PR TITLE
Bugfix FXIOS-9533 Temporarily disable multi-window, add scene and UUID logging

### DIFF
--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -35,6 +35,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         options connectionOptions: UIScene.ConnectionOptions
     ) {
         guard !AppConstants.isRunningUnitTest else { return }
+        logger.log("SceneDelegate: will connect to session", level: .info, category: .lifecycle)
 
         // Add hooks for the nimbus-cli to test experiments on device or involving deeplinks.
         if let url = connectionOptions.urlContexts.first?.url {
@@ -51,6 +52,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
+        let logUUID = sceneCoordinator?.windowUUID.uuidString ?? "<nil>"
+        logger.log("SceneDelegate: scene did disconnect. UUID: \(logUUID)", level: .info, category: .lifecycle)
         // Handle clean-up here for closing windows on iPad
         guard let sceneCoordinator = (scene.delegate as? SceneDelegate)?.sceneCoordinator else { return }
 
@@ -73,6 +76,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     /// or other activities that need to begin.
     func sceneDidBecomeActive(_ scene: UIScene) {
         guard !AppConstants.isRunningUnitTest else { return }
+        let logUUID = sceneCoordinator?.windowUUID.uuidString ?? "<nil>"
+        logger.log("SceneDelegate: scene did become active. UUID: \(logUUID)", level: .info, category: .lifecycle)
 
         // Resume previously stopped downloads for, and on, THIS scene only.
         if let uuid = sceneCoordinator?.windowUUID {
@@ -87,6 +92,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     /// Use this method to reduce the scene's memory usage, clear claims to resources & dependencies / services.
     /// UIKit takes a snapshot of the scene for the app switcher after this method returns.
     func sceneDidEnterBackground(_ scene: UIScene) {
+        let logUUID = sceneCoordinator?.windowUUID.uuidString ?? "<nil>"
+        logger.log("SceneDelegate: scene did enter background. UUID: \(logUUID)", level: .info, category: .lifecycle)
         if let uuid = sceneCoordinator?.windowUUID {
             downloadQueue.pauseAll(for: uuid)
         }

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -184,11 +184,22 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         // Fetch available window data on disk, and remove any already-opened windows
         // or UUIDs that are already reserved and in the process of opening.
         let openWindowUUIDs = windows.keys
-        let filteredUUIDs = tabDataStore.fetchWindowDataUUIDs().filter {
+        let onDiskUUIDs = tabDataStore.fetchWindowDataUUIDs()
+        let filteredUUIDs = onDiskUUIDs.filter {
             !openWindowUUIDs.contains($0) && !reservedUUIDs.contains($0)
         }
 
+        let onDiskUUIDLog = onDiskUUIDs.map({ $0.uuidString.prefix(8) }).joined(separator: ", ")
+        let reserveLog = reservedUUIDs.map({ $0.uuidString.prefix(8) }).joined(separator: ", ")
+        let openLog = openWindowUUIDs.map({ $0.uuidString.prefix(8) }).joined(separator: ", ")
+        logger.log("WindowManager: reserve next UUID. Disk: \(onDiskUUIDLog). Reserved: \(reserveLog). Open: \(openLog)",
+                   level: .debug,
+                   category: .window)
+
         let result = nextWindowUUIDToOpen(filteredUUIDs)
+        logger.log("WindowManager: reserve next UUID result = \(result.uuid.uuidString) Is new?: \(result.isNew)",
+                   level: .debug,
+                   category: .window)
         let resultUUID = result.uuid
         if result.isNew {
             // Be sure to add any brand-new windows to our ordering preferences

--- a/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -24,7 +24,8 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         // The logic is handled by `reserveNextAvailableWindowUUID`, but this is the point at which a window's UUID
         // is set; this same UUID will be injected throughout several of the window's related components
         // such as its TabManager instance, which also has the window UUID property as a convenience.
-        self.windowUUID = windowManager.reserveNextAvailableWindowUUID()
+        let uuid = windowManager.reserveNextAvailableWindowUUID()
+        self.windowUUID = uuid
         self.window = sceneSetupHelper.configureWindowFor(scene,
                                                           windowUUID: windowUUID,
                                                           screenshotServiceDelegate: screenshotService)
@@ -36,6 +37,7 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         let router = DefaultRouter(navigationController: navigationController)
         super.init(router: router)
 
+        logger.log("SceneCoordinator init completed (UUID: \(uuid))", level: .debug, category: .lifecycle)
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -123,7 +123,7 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
+		<false/>
 		<key>UISceneConfigurations</key>
 		<dict>
 			<key>UIWindowSceneSessionRoleApplication</key>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9533)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21094)

## :bulb: Description

Part of early and ongoing work to test hypothesis for fatal log spike on Sentry (7/17). 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

