### PR TITLE
Refactor FXIOS-7301 - Remove 3 closure_body_length violations from CreditCardInputView.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -90,6 +90,34 @@ struct CreditCardInputView: View {
         }
     }
 
+    fileprivate func mainContent() -> some View {
+        return VStack(spacing: 0) {
+            Divider()
+                .frame(height: 0.7)
+                .foregroundColor(borderColor)
+
+            nameContent()
+                .background(textFieldBackgroundColor)
+
+            numberContent()
+                .background(textFieldBackgroundColor)
+
+            expirationContent()
+                .background(textFieldBackgroundColor)
+
+            Spacer()
+                .frame(height: 4)
+
+            if viewModel.state == .edit {
+                RemoveCardButton(windowUUID: windowUUID,
+                                 alertDetails: viewModel.removeButtonDetails)
+                .padding(.top, 28)
+            }
+
+            Spacer()
+        }
+    }
+
     fileprivate func nameContent() -> some View {
         return Group {
             CreditCardInputField(windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -51,7 +51,7 @@ struct CreditCardInputView: View {
     private var main: some View {
         return ZStack {
             backgroundColor.ignoresSafeArea()
-            formContent()
+            form
                 .navigationBarTitle(viewModel.state.title,
                                     displayMode: .inline)
                 .toolbar {
@@ -70,7 +70,7 @@ struct CreditCardInputView: View {
         }
     }
 
-    private func formContent() -> some View {
+    private var form: some View {
         return VStack(spacing: 0) {
             Divider()
                 .frame(height: 0.7)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -28,7 +28,7 @@ struct CreditCardInputView: View {
         NavigationView {
             ZStack {
                 backgroundColor.ignoresSafeArea()
-                mainContent()
+                formContent()
                     .navigationBarTitle(viewModel.state.title,
                                         displayMode: .inline)
                     .toolbar {
@@ -66,7 +66,7 @@ struct CreditCardInputView: View {
         }
     }
 
-    fileprivate func mainContent() -> some View {
+    fileprivate func formContent() -> some View {
         return VStack(spacing: 0) {
             Divider()
                 .frame(height: 0.7)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -82,7 +82,7 @@ struct CreditCardInputView: View {
             number
                 .background(textFieldBackgroundColor)
 
-            expirationContent()
+            expiration
                 .background(textFieldBackgroundColor)
 
             Spacer()
@@ -128,7 +128,7 @@ struct CreditCardInputView: View {
         }
     }
 
-    private func expirationContent() -> some View {
+    private var expiration: some View {
         return Group {
             CreditCardInputField(windowUUID: windowUUID,
                                  inputType: .expiration,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -39,19 +39,8 @@ struct CreditCardInputView: View {
                     numberContent()
                         .background(textFieldBackgroundColor)
 
-                    Group {
-                        CreditCardInputField(windowUUID: windowUUID,
-                                             inputType: .expiration,
-                                             showError: viewModel.showExpirationError,
-                                             inputViewModel: viewModel)
-                        .padding(.top, 11)
-
-                        Divider()
-                            .frame(height: 0.7)
-                            .foregroundColor(borderColor)
-                            .padding(.top, 1)
-                    }
-                    .background(textFieldBackgroundColor)
+                    expirationContent()
+                        .background(textFieldBackgroundColor)
 
                     Spacer()
                         .frame(height: 4)
@@ -135,7 +124,7 @@ struct CreditCardInputView: View {
         return Group {
             CreditCardInputField(windowUUID: windowUUID,
                                  inputType: .expiration,
-                                 showError: !viewModel.expirationIsValid,
+                                 showError: viewModel.showExpirationError,
                                  inputViewModel: viewModel)
             .padding(.top, 11)
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -26,43 +26,25 @@ struct CreditCardInputView: View {
 
     var body: some View {
         NavigationView {
-            ZStack {
-                backgroundColor.ignoresSafeArea()
-                formContent()
-                    .navigationBarTitle(viewModel.state.title,
-                                        displayMode: .inline)
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarTrailing) {
-                            rightBarButton()
-                                .disabled(!viewModel.isRightBarButtonEnabled)
-                                .foregroundColor(barButtonColor)
-                        }
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            leftBarButton()
-                                .foregroundColor(barButtonColor)
-                        }
-                    }
-                    .padding(.top, 0)
-                    .background(backgroundColor.edgesIgnoringSafeArea(.bottom))
-            }
-            .blur(radius: isBlurred ? 10 : 0)
-            .onAppear {
-                applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-                guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-                applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
-            }
-            .onReceive(NotificationCenter.default.publisher(
-                for: UIApplication.willResignActiveNotification)
-            ) { _ in
-                isBlurred = true
-            }
-            .onReceive(NotificationCenter.default.publisher(
-                for: UIApplication.didBecomeActiveNotification)
-            ) { _ in
-                isBlurred = false
-            }
+            mainContent()
+                .blur(radius: isBlurred ? 10 : 0)
+                .onAppear {
+                    applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
+                    guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
+                    applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+                }
+                .onReceive(NotificationCenter.default.publisher(
+                    for: UIApplication.willResignActiveNotification)
+                ) { _ in
+                    isBlurred = true
+                }
+                .onReceive(NotificationCenter.default.publisher(
+                    for: UIApplication.didBecomeActiveNotification)
+                ) { _ in
+                    isBlurred = false
+                }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -128,7 +128,7 @@ struct CreditCardInputView: View {
         }
     }
 
-    fileprivate func expirationContent() -> some View {
+    private func expirationContent() -> some View {
         return Group {
             CreditCardInputField(windowUUID: windowUUID,
                                  inputType: .expiration,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -79,7 +79,7 @@ struct CreditCardInputView: View {
             name
                 .background(textFieldBackgroundColor)
 
-            numberContent()
+            number
                 .background(textFieldBackgroundColor)
 
             expirationContent()
@@ -113,7 +113,7 @@ struct CreditCardInputView: View {
         }
     }
 
-    private func numberContent() -> some View {
+    private var number: some View {
         return Group {
             CreditCardInputField(windowUUID: windowUUID,
                                  inputType: .number,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -48,7 +48,7 @@ struct CreditCardInputView: View {
         }
     }
 
-    fileprivate func mainContent() -> some View {
+    private func mainContent() -> some View {
         return ZStack {
             backgroundColor.ignoresSafeArea()
             formContent()

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -113,7 +113,7 @@ struct CreditCardInputView: View {
         }
     }
 
-    fileprivate func numberContent() -> some View {
+    private func numberContent() -> some View {
         return Group {
             CreditCardInputField(windowUUID: windowUUID,
                                  inputType: .number,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -33,19 +33,8 @@ struct CreditCardInputView: View {
                         .frame(height: 0.7)
                         .foregroundColor(borderColor)
 
-                    Group {
-                        CreditCardInputField(windowUUID: windowUUID,
-                                             inputType: .name,
-                                             showError: !viewModel.nameIsValid,
-                                             inputViewModel: viewModel)
-                        .padding(.top, 11)
-
-                        Divider()
-                            .frame(height: 0.7)
-                            .foregroundColor(borderColor)
-                            .padding(.top, 1)
-                    }
-                    .background(textFieldBackgroundColor)
+                    nameContent()
+                        .background(textFieldBackgroundColor)
 
                     Group {
                         CreditCardInputField(windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -153,6 +153,21 @@ struct CreditCardInputView: View {
         }
     }
 
+    fileprivate func expirationContent() -> some View {
+        return Group {
+            CreditCardInputField(windowUUID: windowUUID,
+                                 inputType: .expiration,
+                                 showError: !viewModel.expirationIsValid,
+                                 inputViewModel: viewModel)
+            .padding(.top, 11)
+
+            Divider()
+                .frame(height: 0.7)
+                .foregroundColor(borderColor)
+                .padding(.top, 1)
+        }
+    }
+
     func applyTheme(theme: Theme) {
         let color = theme.colors
         backgroundColor = Color(color.layer1)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -28,46 +28,22 @@ struct CreditCardInputView: View {
         NavigationView {
             ZStack {
                 backgroundColor.ignoresSafeArea()
-                VStack(spacing: 0) {
-                    Divider()
-                        .frame(height: 0.7)
-                        .foregroundColor(borderColor)
-
-                    nameContent()
-                        .background(textFieldBackgroundColor)
-
-                    numberContent()
-                        .background(textFieldBackgroundColor)
-
-                    expirationContent()
-                        .background(textFieldBackgroundColor)
-
-                    Spacer()
-                        .frame(height: 4)
-
-                    if viewModel.state == .edit {
-                        RemoveCardButton(windowUUID: windowUUID,
-                                         alertDetails: viewModel.removeButtonDetails)
-                        .padding(.top, 28)
+                mainContent()
+                    .navigationBarTitle(viewModel.state.title,
+                                        displayMode: .inline)
+                    .toolbar {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            rightBarButton()
+                                .disabled(!viewModel.isRightBarButtonEnabled)
+                                .foregroundColor(barButtonColor)
+                        }
+                        ToolbarItem(placement: .navigationBarLeading) {
+                            leftBarButton()
+                                .foregroundColor(barButtonColor)
+                        }
                     }
-
-                    Spacer()
-                }
-                .navigationBarTitle(viewModel.state.title,
-                                    displayMode: .inline)
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        rightBarButton()
-                            .disabled(!viewModel.isRightBarButtonEnabled)
-                            .foregroundColor(barButtonColor)
-                    }
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        leftBarButton()
-                            .foregroundColor(barButtonColor)
-                    }
-                }
-                .padding(.top, 0)
-                .background(backgroundColor.edgesIgnoringSafeArea(.bottom))
+                    .padding(.top, 0)
+                    .background(backgroundColor.edgesIgnoringSafeArea(.bottom))
             }
             .blur(radius: isBlurred ? 10 : 0)
             .onAppear {

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -66,6 +66,28 @@ struct CreditCardInputView: View {
         }
     }
 
+    fileprivate func mainContent() -> some View {
+        return ZStack {
+            backgroundColor.ignoresSafeArea()
+            formContent()
+                .navigationBarTitle(viewModel.state.title,
+                                    displayMode: .inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        rightBarButton()
+                            .disabled(!viewModel.isRightBarButtonEnabled)
+                            .foregroundColor(barButtonColor)
+                    }
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        leftBarButton()
+                            .foregroundColor(barButtonColor)
+                    }
+                }
+                .padding(.top, 0)
+                .background(backgroundColor.edgesIgnoringSafeArea(.bottom))
+        }
+    }
+
     fileprivate func formContent() -> some View {
         return VStack(spacing: 0) {
             Divider()

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -138,6 +138,21 @@ struct CreditCardInputView: View {
         }
     }
 
+    fileprivate func numberContent() -> some View {
+        return Group {
+            CreditCardInputField(windowUUID: windowUUID,
+                                 inputType: .number,
+                                 showError: !viewModel.numberIsValid,
+                                 inputViewModel: viewModel)
+            .padding(.top, 11)
+
+            Divider()
+                .frame(height: 0.7)
+                .foregroundColor(borderColor)
+                .padding(.top, 1)
+        }
+    }
+
     func applyTheme(theme: Theme) {
         let color = theme.colors
         backgroundColor = Color(color.layer1)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -26,7 +26,7 @@ struct CreditCardInputView: View {
 
     var body: some View {
         NavigationView {
-            mainContent()
+            main
                 .blur(radius: isBlurred ? 10 : 0)
                 .onAppear {
                     applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
@@ -48,7 +48,7 @@ struct CreditCardInputView: View {
         }
     }
 
-    private func mainContent() -> some View {
+    private var main: some View {
         return ZStack {
             backgroundColor.ignoresSafeArea()
             formContent()

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -36,19 +36,8 @@ struct CreditCardInputView: View {
                     nameContent()
                         .background(textFieldBackgroundColor)
 
-                    Group {
-                        CreditCardInputField(windowUUID: windowUUID,
-                                             inputType: .number,
-                                             showError: !viewModel.numberIsValid,
-                                             inputViewModel: viewModel)
-                        .padding(.top, 11)
-
-                        Divider()
-                            .frame(height: 0.7)
-                            .foregroundColor(borderColor)
-                            .padding(.top, 1)
-                    }
-                    .background(textFieldBackgroundColor)
+                    numberContent()
+                        .background(textFieldBackgroundColor)
 
                     Group {
                         CreditCardInputField(windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -98,7 +98,7 @@ struct CreditCardInputView: View {
         }
     }
 
-    fileprivate func nameContent() -> some View {
+    private func nameContent() -> some View {
         return Group {
             CreditCardInputField(windowUUID: windowUUID,
                                  inputType: .name,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -70,7 +70,7 @@ struct CreditCardInputView: View {
         }
     }
 
-    fileprivate func formContent() -> some View {
+    private func formContent() -> some View {
         return VStack(spacing: 0) {
             Divider()
                 .frame(height: 0.7)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -123,6 +123,21 @@ struct CreditCardInputView: View {
         }
     }
 
+    fileprivate func nameContent() -> some View {
+        return Group {
+            CreditCardInputField(windowUUID: windowUUID,
+                                 inputType: .name,
+                                 showError: !viewModel.nameIsValid,
+                                 inputViewModel: viewModel)
+            .padding(.top, 11)
+
+            Divider()
+                .frame(height: 0.7)
+                .foregroundColor(borderColor)
+                .padding(.top, 1)
+        }
+    }
+
     func applyTheme(theme: Theme) {
         let color = theme.colors
         backgroundColor = Color(color.layer1)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -76,7 +76,7 @@ struct CreditCardInputView: View {
                 .frame(height: 0.7)
                 .foregroundColor(borderColor)
 
-            nameContent()
+            name
                 .background(textFieldBackgroundColor)
 
             numberContent()
@@ -98,7 +98,7 @@ struct CreditCardInputView: View {
         }
     }
 
-    private func nameContent() -> some View {
+    private var name: some View {
         return Group {
             CreditCardInputField(windowUUID: windowUUID,
                                  inputType: .name,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 3 `closure_body_length` violations from the `CreditCardInputView.swift ` file. 

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

