### PR TITLE
Bugfix FXIOS-9529 Fix Sentry errors for newly-created iPad windows

### DIFF
--- a/BrowserKit/Sources/Common/WindowUUID+Extensions.swift
+++ b/BrowserKit/Sources/Common/WindowUUID+Extensions.swift
@@ -10,6 +10,20 @@ import Foundation
 /// can be run side-by-side on iPad (once multi-window is enabled). [FXIOS-7349]
 public typealias WindowUUID = UUID
 
+/// Describes a UUID available for use in a window on either iPhone or iPad.
+public struct ReservedWindowUUID {
+    /// The UUID of the window.
+    public let uuid: WindowUUID
+
+    /// True if the UUID is for a newly-created window (with no tabs on disk)
+    public let isNew: Bool
+
+    public init(uuid: WindowUUID, isNew: Bool) {
+        self.uuid = uuid
+        self.isNew = isNew
+    }
+}
+
 public extension WindowUUID {
     /// Sentinel UUID value for use when a window is unavailable or unknown.
     ///

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -8,6 +8,15 @@ import Shared
 import TabDataStore
 import WidgetKit
 
+/// Describes a UUID available for use in a window on either iPhone or iPad.
+struct ReservedWindowUUID {
+    /// The UUID of the window.
+    let uuid: WindowUUID
+
+    /// True if the UUID is for a newly-created window (with no tabs on disk)
+    let isNew: Bool
+}
+
 /// Defines various actions in the app which are performed for all open iPad
 /// windows. These can be routed through the WindowManager 
 enum MultiWindowAction {
@@ -60,7 +69,7 @@ protocol WindowManager {
     /// windows are being restored concurrently, we never supply the same UUID
     /// to more than one window.
     /// - Returns: a UUID for the next window to be opened.
-    func reserveNextAvailableWindowUUID() -> WindowUUID
+    func reserveNextAvailableWindowUUID() -> ReservedWindowUUID
 
     /// Signals the WindowManager that a window event has occurred. Window events
     /// are communicated to any interested Coordinators for _all_ windows, but
@@ -168,9 +177,11 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         windowOrderingPriority = prefs
     }
 
-    func reserveNextAvailableWindowUUID() -> WindowUUID {
+    func reserveNextAvailableWindowUUID() -> ReservedWindowUUID {
         // Continue to provide the expected hardcoded UUID for UI tests.
-        guard !AppConstants.isRunningUITests else { return WindowUUID.DefaultUITestingUUID }
+        guard !AppConstants.isRunningUITests else {
+            return ReservedWindowUUID(uuid: WindowUUID.DefaultUITestingUUID, isNew: false)
+        }
 
         // • If no saved windows (tab data), we generate a new UUID.
         // • If user has saved windows (tab data), we return the first available UUID
@@ -210,7 +221,7 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
 
         // Reserve the UUID until the Client finishes the window configuration process
         reservedUUIDs.append(resultUUID)
-        return resultUUID
+        return result
     }
 
     func postWindowEvent(event: WindowEvent, windowUUID: WindowUUID) {
@@ -268,17 +279,17 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
     /// already open or reserved (this is important - these UUIDs should be pre-
     /// filtered).
     /// - Returns: the UUID for the next window that will be opened on iPad.
-    private func nextWindowUUIDToOpen(_ onDiskUUIDs: [WindowUUID]) -> (uuid: WindowUUID, isNew: Bool) {
-        func nextUUIDUsingFallbackSorting() -> (uuid: WindowUUID, isNew: Bool) {
+    private func nextWindowUUIDToOpen(_ onDiskUUIDs: [WindowUUID]) -> ReservedWindowUUID {
+        func nextUUIDUsingFallbackSorting() -> ReservedWindowUUID {
             let sortedUUIDs = onDiskUUIDs.sorted(by: { return $0.uuidString > $1.uuidString })
             if let resultUUID = sortedUUIDs.first {
-                return (uuid: resultUUID, isNew: false)
+                return ReservedWindowUUID(uuid: resultUUID, isNew: false)
             }
-            return (uuid: WindowUUID(), isNew: true)
+            return ReservedWindowUUID(uuid: WindowUUID(), isNew: true)
         }
 
         guard !onDiskUUIDs.isEmpty else {
-            return (uuid: WindowUUID(), isNew: true)
+            return ReservedWindowUUID(uuid: WindowUUID(), isNew: true)
         }
 
         // Get the ordering preference
@@ -292,7 +303,7 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         // Iterate and return the first UUID that is available within our on-disk UUIDs
         // (which excludes windows already open or reserved).
         for uuid in priorityPreference where onDiskUUIDs.contains(uuid) {
-            return (uuid: uuid, isNew: false)
+            return ReservedWindowUUID(uuid: uuid, isNew: false)
         }
 
         return nextUUIDUsingFallbackSorting()

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -8,15 +8,6 @@ import Shared
 import TabDataStore
 import WidgetKit
 
-/// Describes a UUID available for use in a window on either iPhone or iPad.
-struct ReservedWindowUUID {
-    /// The UUID of the window.
-    let uuid: WindowUUID
-
-    /// True if the UUID is for a newly-created window (with no tabs on disk)
-    let isNew: Bool
-}
-
 /// Defines various actions in the app which are performed for all open iPad
 /// windows. These can be routed through the WindowManager 
 enum MultiWindowAction {

--- a/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -10,10 +10,11 @@ import Storage
 /// Each scene has it's own scene coordinator, which is the root coordinator for a scene.
 class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinishedLoadingDelegate {
     var window: UIWindow?
-    let windowUUID: WindowUUID
+    var windowUUID: WindowUUID { reservedWindowUUID.uuid }
     private let screenshotService: ScreenshotService
     private let sceneContainer: SceneContainer
     private let windowManager: WindowManager
+    private let reservedWindowUUID: ReservedWindowUUID
 
     init(scene: UIScene,
          sceneSetupHelper: SceneSetupHelper = SceneSetupHelper(),
@@ -24,10 +25,10 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         // The logic is handled by `reserveNextAvailableWindowUUID`, but this is the point at which a window's UUID
         // is set; this same UUID will be injected throughout several of the window's related components
         // such as its TabManager instance, which also has the window UUID property as a convenience.
-        let uuid = windowManager.reserveNextAvailableWindowUUID()
-        self.windowUUID = uuid
+        let reserved = windowManager.reserveNextAvailableWindowUUID()
+        self.reservedWindowUUID = reserved
         self.window = sceneSetupHelper.configureWindowFor(scene,
-                                                          windowUUID: windowUUID,
+                                                          windowUUID: reserved.uuid,
                                                           screenshotServiceDelegate: screenshotService)
         self.screenshotService = screenshotService
         self.sceneContainer = sceneContainer
@@ -37,7 +38,7 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         let router = DefaultRouter(navigationController: navigationController)
         super.init(router: router)
 
-        logger.log("SceneCoordinator init completed (UUID: \(uuid))", level: .debug, category: .lifecycle)
+        logger.log("SceneCoordinator init completed (UUID: \(reserved.uuid))", level: .debug, category: .lifecycle)
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }
@@ -119,7 +120,7 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
                    category: .coordinator)
 
         let tabManager = TabManagerImplementation(profile: AppContainer.shared.resolve(),
-                                                  uuid: windowUUID)
+                                                  uuid: reservedWindowUUID)
         let browserCoordinator = BrowserCoordinator(router: router,
                                                     screenshotService: screenshotService,
                                                     tabManager: tabManager)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -859,6 +859,8 @@ class BrowserViewController: UIViewController,
             displayedRestoreTabsAlert = true
             showRestoreTabsAlert()
         } else {
+            // Tab restoration is triggered here for new installs, cold launches, or any BVC appearance.
+            // Note: `restoreTabs()` returns early if `tabs` is not-empty; repeated calls should have no effect.
             tabManager.restoreTabs()
         }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -130,7 +130,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
               tabs.isEmpty
         else {
             // Always make sure there is a single normal tab
-            // MR here is where the first empty tab for a new window is generated
+            // Note: this is where the first tab in a newly-created browser window will be added
             await generateEmptyTab()
             logger.log("There was no tabs restored, creating a normal tab",
                        level: .debug,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -30,7 +30,7 @@ class DependencyHelperMock {
         let windowManager: WindowManager = MockWindowManager(wrappedManager: WindowManagerImplementation())
         let tabManager: TabManager =
         injectedTabManager ?? TabManagerImplementation(profile: profile,
-                                                       uuid: windowUUID,
+                                                       uuid: ReservedWindowUUID(uuid: windowUUID, isNew: false),
                                                        windowManager: windowManager)
 
         let appSessionProvider: AppSessionProvider = AppSessionManager()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -19,7 +19,8 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
+        tabManager = TabManagerImplementation(profile: profile,
+                                              uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
         subject = BrowserViewController(profile: profile, tabManager: tabManager)
         tabManagerDelegate = TabManagerNavDelegate()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/HomepageViewControllerTests.swift
@@ -25,7 +25,8 @@ class HomepageViewControllerTests: XCTestCase {
     }
 
     func testHomepageViewController_simpleCreation_hasNoLeaks() {
-        let tabManager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
+        let tabManager = TabManagerImplementation(profile: profile,
+                                                  uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
         let urlBar = URLBarView(profile: profile, windowUUID: .XCTestDefaultUUID)
         let overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)
@@ -40,7 +41,8 @@ class HomepageViewControllerTests: XCTestCase {
 
     func testHomepage_viewWillAppear_sendsBehavioralTargetingEvent() {
         Experiments.events.clearEvents()
-        let tabManager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
+        let tabManager = TabManagerImplementation(profile: profile,
+                                                  uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
         let urlBar = URLBarView(profile: profile, windowUUID: .XCTestDefaultUUID)
         let overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -30,7 +30,8 @@ class JumpBackInViewModelTests: XCTestCase {
         mockTabManager = MockTabManager()
         stubBrowserViewController = BrowserViewController(
             profile: mockProfile,
-            tabManager: TabManagerImplementation(profile: mockProfile, uuid: .XCTestDefaultUUID)
+            tabManager: TabManagerImplementation(profile: mockProfile,
+                                                 uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
         )
 
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/GridTabViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/GridTabViewControllerTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 @testable import Client
 
 final class LegacyGridTabViewControllerTests: XCTestCase {
@@ -13,7 +14,8 @@ final class LegacyGridTabViewControllerTests: XCTestCase {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        manager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
+        manager = TabManagerImplementation(profile: profile,
+                                           uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/HistoryHighlights/HistoryHighlightsManagerTests.swift
@@ -5,6 +5,7 @@
 import MozillaAppServices
 import Shared
 import XCTest
+import Common
 
 @testable import Client
 @testable import Storage
@@ -24,7 +25,8 @@ class HistoryHighlightsTests: XCTestCase {
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         DependencyHelperMock().bootstrapDependencies()
         profile.reopen()
-        let tabManager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
+        let tabManager = TabManagerImplementation(profile: profile,
+                                                  uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
         entryProvider = HistoryHighlightsTestEntryProvider(with: profile, and: tabManager)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
@@ -47,7 +47,7 @@ final class MockWindowManager: WindowManager {
         wrappedManager.windowWillClose(uuid: uuid)
     }
 
-    func reserveNextAvailableWindowUUID() -> WindowUUID {
+    func reserveNextAvailableWindowUUID() -> ReservedWindowUUID {
         wrappedManager.reserveNextAvailableWindowUUID()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 @testable import Client
 
 class AppSettingsTableViewControllerTests: XCTestCase {
@@ -17,7 +18,8 @@ class AppSettingsTableViewControllerTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
         self.profile = MockProfile()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
-        self.tabManager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
+        self.tabManager = TabManagerImplementation(profile: profile,
+                                                   uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
         self.appAuthenticator = MockAppAuthenticator()
         self.delegate = MockSettingsFlowDelegate()
         self.applicationHelper = MockApplicationHelper()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
@@ -18,7 +18,8 @@ class StartAtHomeHelperTests: XCTestCase {
 
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
+        tabManager = TabManagerImplementation(profile: profile,
+                                              uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
 
         DependencyHelperMock().bootstrapDependencies()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsTelemetryTests.swift
@@ -31,7 +31,7 @@ class TabsTelemetryTests: XCTestCase {
 
     func testTrackTabsQuantity_withNormalTab_gleanIsCalled() {
         let tabManager = TabManagerImplementation(profile: profile,
-                                                  uuid: .XCTestDefaultUUID,
+                                                  uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false),
                                                   inactiveTabsManager: inactiveTabsManager)
 
         let tab = tabManager.addTab()
@@ -50,7 +50,8 @@ class TabsTelemetryTests: XCTestCase {
     }
 
     func testTrackTabsQuantity_withPrivateTab_gleanIsCalled() {
-        let tabManager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
+        let tabManager = TabManagerImplementation(profile: profile,
+                                                  uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
         tabManager.addTab(isPrivate: true)
 
         TabsTelemetry.trackTabsQuantity(tabManager: tabManager)
@@ -66,7 +67,7 @@ class TabsTelemetryTests: XCTestCase {
 
     func testTrackTabsQuantity_ensureNoInactiveTabs_gleanIsCalled() {
         let tabManager = TabManagerImplementation(profile: profile,
-                                                  uuid: .XCTestDefaultUUID,
+                                                  uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false),
                                                   inactiveTabsManager: inactiveTabsManager)
         let tab = tabManager.addTab()
         inactiveTabsManager.activeTabs = [tab]

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -211,7 +211,7 @@ class TabManagerTests: XCTestCase {
     private func createSubject() -> TabManagerImplementation {
         let subject = TabManagerImplementation(profile: mockProfile,
                                                imageStore: mockDiskImageStore,
-                                               uuid: tabWindowUUID,
+                                               uuid: ReservedWindowUUID(uuid: tabWindowUUID, isNew: false),
                                                tabDataStore: mockTabStore,
                                                tabSessionStore: mockSessionStore)
         trackForMemoryLeaks(subject)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -123,7 +123,8 @@ class MockTabToolbar: TabToolbarProtocol {
 
     init() {
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
+        tabManager = TabManagerImplementation(profile: profile,
+                                              uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         _tabToolBarDelegate = BrowserViewController(profile: profile, tabManager: tabManager)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/LegacyTabTrayViewControllerTests.swift
@@ -23,7 +23,8 @@ final class LegacyTabTrayViewControllerTests: XCTestCase {
 
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        manager = TabManagerImplementation(profile: profile, uuid: .XCTestDefaultUUID)
+        manager = TabManagerImplementation(profile: profile,
+                                           uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
         urlBar = MockURLBarView()
         overlayManager = MockOverlayModeManager()
         overlayManager.setURLBar(urlBarView: urlBar)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -112,7 +112,7 @@ class WindowManagerTests: XCTestCase {
         // generated UUIDs but it is astronomically small (1 out of 2^122).
         let uuid1 = subject.reserveNextAvailableWindowUUID()
         let uuid2 = subject.reserveNextAvailableWindowUUID()
-        XCTAssertNotEqual(uuid1, uuid2)
+        XCTAssertNotEqual(uuid1.uuid, uuid2.uuid)
     }
 
     func testNextAvailableUUIDWhenOnlyOneWindowSaved() {
@@ -123,11 +123,11 @@ class WindowManagerTests: XCTestCase {
         mockTabDataStore.injectMockTabWindowUUID(savedUUID)
 
         // Check that asking for first UUID returns the expected UUID
-        XCTAssertEqual(savedUUID, subject.reserveNextAvailableWindowUUID())
+        XCTAssertEqual(savedUUID, subject.reserveNextAvailableWindowUUID().uuid)
         // Open a window using this UUID
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: savedUUID)
         // Check that asking for another UUID returns a new, random UUID
-        XCTAssertNotEqual(savedUUID, subject.reserveNextAvailableWindowUUID())
+        XCTAssertNotEqual(savedUUID, subject.reserveNextAvailableWindowUUID().uuid)
     }
 
     func testNextAvailableUUIDWhenMultipleWindowsSaved() {
@@ -141,9 +141,9 @@ class WindowManagerTests: XCTestCase {
         mockTabDataStore.injectMockTabWindowUUID(uuid2)
 
         // Ask for UUIDs for two windows, which we open and configure
-        let result1 = subject.reserveNextAvailableWindowUUID()
+        let result1 = subject.reserveNextAvailableWindowUUID().uuid
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: result1)
-        let result2 = subject.reserveNextAvailableWindowUUID()
+        let result2 = subject.reserveNextAvailableWindowUUID().uuid
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: result2)
 
         // Check that our UUIDs are the ones we expected
@@ -153,7 +153,7 @@ class WindowManagerTests: XCTestCase {
         XCTAssertEqual(expectedUUIDs.count, 2)
 
         // Check that asking for a 3rd UUID returns a new, random UUID
-        let result3 = subject.reserveNextAvailableWindowUUID()
+        let result3 = subject.reserveNextAvailableWindowUUID().uuid
         XCTAssertFalse(expectedUUIDs.contains(result3))
         XCTAssertNotEqual(result1, result3)
         XCTAssertNotEqual(result2, result3)
@@ -166,9 +166,9 @@ class WindowManagerTests: XCTestCase {
         let tabManager2 = MockTabManager()
 
         // Create two separate windows with associated Tab Managers
-        let uuid1 = subject.reserveNextAvailableWindowUUID()
+        let uuid1 = subject.reserveNextAvailableWindowUUID().uuid
         subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager1), uuid: uuid1)
-        let uuid2 = subject.reserveNextAvailableWindowUUID()
+        let uuid2 = subject.reserveNextAvailableWindowUUID().uuid
         subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager2), uuid: uuid2)
 
         // Check that allWindowTabManagers returns both expected instances
@@ -193,11 +193,11 @@ class WindowManagerTests: XCTestCase {
 
         // Request a UUID. We expect it to be the first persisted WindowData
         // UUID, which will also be reserved for use.
-        let requestedUUID1 = subject.reserveNextAvailableWindowUUID()
+        let requestedUUID1 = subject.reserveNextAvailableWindowUUID().uuid
         XCTAssertEqual(requestedUUID1, savedUUID)
 
         // Request a 2nd UUID. We expect it to be a different UUID.
-        let requestedUUID2 = subject.reserveNextAvailableWindowUUID()
+        let requestedUUID2 = subject.reserveNextAvailableWindowUUID().uuid
         XCTAssertNotEqual(requestedUUID2, savedUUID)
     }
 
@@ -221,8 +221,8 @@ class WindowManagerTests: XCTestCase {
 
         // Now attempt to re-open two windows in order. We expect window
         // 1 to open, then window 2
-        let result1 = subject.reserveNextAvailableWindowUUID()
-        let result2 = subject.reserveNextAvailableWindowUUID()
+        let result1 = subject.reserveNextAvailableWindowUUID().uuid
+        let result2 = subject.reserveNextAvailableWindowUUID().uuid
         XCTAssertEqual(result1, uuid1)
         XCTAssertEqual(result2, uuid2)
 
@@ -234,8 +234,8 @@ class WindowManagerTests: XCTestCase {
         subject.windowWillClose(uuid: uuid2)
 
         // Check that the next time we open the windows the order is now reversed
-        let result2_1 = subject.reserveNextAvailableWindowUUID()
-        let result2_2 = subject.reserveNextAvailableWindowUUID()
+        let result2_1 = subject.reserveNextAvailableWindowUUID().uuid
+        let result2_2 = subject.reserveNextAvailableWindowUUID().uuid
         XCTAssertEqual(result2_1, uuid2)
         XCTAssertEqual(result2_2, uuid1)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9529)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21089)

## :bulb: Description

The client didn't previously have a notion of a new window (with 0 tabs) vs. a window being restored (also with 0 tabs, but with serialized tabs on-disk). This led to incorrect errors logged to Sentry when creating brand-new iPad windows. Summary:

- On a fresh install of iPad or iPhone, `restoreTabs` is not run; instead `migrateAndRestore()` is called which does not lead to the incorrect log error from `fetchWindowData`
- In all other scenarios (cold launch, or BVC appearance), `restoreTabs()` is called; this includes newly-created windows on iPad
- When a new window is created, the WindowManager knows whether it's new or not but this information wasn't available at the tab manager level and so the tab manager would try to restore tabs anyway even though a brand new window will never have tabs on disk
- The proposed fix is to inject enough information from the WindowManager (which is responsible for providing the UUIDs) down to the tab manager so that it can reason properly about whether it can safely skip `fetchWindowData`

### Notes

The `windowIsNew` state remains `true` during the app lifecycle when the window was created. This shouldn't cause any problems, because AFAICS (and I corroborated this in chat) we only perform one `restoreTabs()`, and once the `tabs` array is populated subsequent calls do nothing (and `tabs` should never go empty). However, if there is some scenario in which we needed to re-restore the window's tabs again in the same lifecycle that it was first created, then `windowIsNew` would need to be set to false at some point otherwise follow-up tab restoration won't do anything. But again, based on everything I can see so far this is not a scenario that should ever occur. So having this state/flag on the window's tab manager should be fine based on all of the information I have.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

