### PR TITLE
Bugfix FXIOS-9534 Exit edit mode on dismissal in edit address view

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -65,7 +65,9 @@ struct AddressListView: View {
                 Spacer()
             }
         }
-        .sheet(item: $viewModel.destination) { destination in
+        .sheet(item: $viewModel.destination, onDismiss: {
+            viewModel.isEditMode = false
+        }) { destination in
             NavigationView {
                 switch destination {
                 case .add:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9534)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21096)

## :bulb: Description
- Prevent the "Edit address" view from opening in edit mode by ensuring the view model's `isEditMode` property is set to false when the sheet is dismissed via swipe

Note: Even though the "Edit address" view would open in edit mode, all this meant was that the toolbar buttons were in the incorrect state (as if we were currently editing the address), but the form itself remained in view-only mode until the "Cancel" toolbar button was selected (to fix the state mismatch) and the "Edit" toolbar button was pressed again

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

