### PR TITLE
Bugfix FXIOS-9336 & FXIOS-9448 Fixed Continue Button Scaling Password Manager Onboarding

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -37,7 +37,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         button.configure(viewModel: buttonViewModel)
         button.addTarget(self, action: #selector(self.proceedButtonTapped), for: .touchUpInside)
     }
-    
+
     private lazy var contentView: UIView = .build { view in
         view.translatesAutoresizingMaskIntoConstraints = false
     }
@@ -64,7 +64,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         super.viewDidLoad()
 
         self.title = .Settings.Passwords.Title
-        
+
         setupLayout()
     }
 
@@ -79,12 +79,12 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     func proceedButtonTapped(_ sender: UIButton) {
         continueFromOnboarding()
     }
-    
+
     private func setupLayout() {
         view.addSubviews(scrollView)
         scrollView.addSubview(contentView)
         contentView.addSubviews(onboardingMessageLabel, learnMoreButton, continueButton)
-        
+
         NSLayoutConstraint.activate(
             [
                 scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -38,12 +38,11 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         button.addTarget(self, action: #selector(self.proceedButtonTapped), for: .touchUpInside)
     }
 
-    private lazy var contentView: UIView = .build { view in
-        view.translatesAutoresizingMaskIntoConstraints = false
-    }
-    private lazy var scrollView: UIScrollView = .build { scrollView in
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-    }
+    private lazy var contentView: UIView = .build()
+
+    private lazy var scrollView: UIScrollView = .build()
+
+    private lazy var infoContainer: UIView = .build()
 
     weak var coordinator: PasswordManagerFlowDelegate?
     private var appAuthenticator: AppAuthenticationProtocol
@@ -82,8 +81,10 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
 
     private func setupLayout() {
         view.addSubviews(scrollView)
+
         scrollView.addSubview(contentView)
-        contentView.addSubviews(onboardingMessageLabel, learnMoreButton, continueButton)
+        infoContainer.addSubviews(onboardingMessageLabel, learnMoreButton)
+        contentView.addSubviews(infoContainer, continueButton)
 
         NSLayoutConstraint.activate(
             [
@@ -91,47 +92,59 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
                 scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
                 scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
                 scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
                 contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
                 contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
                 contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
                 contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
                 contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+                contentView.heightAnchor.constraint(greaterThanOrEqualTo: scrollView.frameLayoutGuide.heightAnchor),
+
+                infoContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                infoContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                infoContainer.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor),
+                infoContainer.centerYAnchor.constraint(
+                    equalTo: contentView.centerYAnchor,
+                    constant: -continueButton.frame.height - UX.standardSpacing,
+                    priority: .defaultLow
+                ),
+
                 onboardingMessageLabel.leadingAnchor.constraint(
-                    equalTo: contentView.leadingAnchor,
+                    equalTo: infoContainer.leadingAnchor,
                     constant: UX.standardSpacing
                 ),
                 onboardingMessageLabel.trailingAnchor.constraint(
-                    equalTo: contentView.trailingAnchor,
+                    equalTo: infoContainer.trailingAnchor,
                     constant: -UX.standardSpacing
                 ),
-                onboardingMessageLabel.centerXAnchor.constraint(
-                    equalTo: contentView.centerXAnchor
-                ),
                 onboardingMessageLabel.topAnchor.constraint(
-                    equalTo: contentView.topAnchor,
+                    equalTo: infoContainer.topAnchor,
                     constant: UX.standardSpacing
                 ),
+
                 learnMoreButton.centerXAnchor.constraint(
-                    equalTo: contentView.centerXAnchor
+                    equalTo: infoContainer.centerXAnchor
                 ),
                 learnMoreButton.topAnchor.constraint(
                     equalTo: onboardingMessageLabel.bottomAnchor,
                     constant: UX.standardSpacing
                 ),
                 learnMoreButton.leadingAnchor.constraint(
-                    greaterThanOrEqualTo: contentView.leadingAnchor,
+                    greaterThanOrEqualTo: infoContainer.leadingAnchor,
                     constant: UX.buttonHorizontalPadding
                 ),
+                learnMoreButton.bottomAnchor.constraint(equalTo: infoContainer.bottomAnchor),
                 learnMoreButton.trailingAnchor.constraint(
-                    lessThanOrEqualTo: contentView.trailingAnchor,
+                    lessThanOrEqualTo: infoContainer.trailingAnchor,
                     constant: -UX.buttonHorizontalPadding
                 ),
+
                 continueButton.leadingAnchor.constraint(
-                    greaterThanOrEqualTo: contentView.leadingAnchor,
+                    equalTo: contentView.leadingAnchor,
                     constant: UX.buttonHorizontalPadding
                 ),
                 continueButton.trailingAnchor.constraint(
-                    lessThanOrEqualTo: contentView.trailingAnchor,
+                    equalTo: contentView.trailingAnchor,
                     constant: -UX.buttonHorizontalPadding
                 ),
                 continueButton.centerXAnchor.constraint(
@@ -140,13 +153,13 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
                 continueButton.widthAnchor.constraint(
                     lessThanOrEqualToConstant: UX.continueButtonMaxWidth
                 ),
-                continueButton.topAnchor.constraint(
-                    greaterThanOrEqualTo: learnMoreButton.bottomAnchor,
-                    constant: UX.standardSpacing
-                ),
                 continueButton.bottomAnchor.constraint(
-                    equalTo: contentView.bottomAnchor,
-                    constant: -UX.standardSpacing
+                     equalTo: contentView.bottomAnchor,
+                     constant: -UX.standardSpacing
+                ),
+                continueButton.topAnchor.constraint(
+                    greaterThanOrEqualTo: infoContainer.bottomAnchor,
+                    constant: UX.standardSpacing
                 ),
             ])
     }

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -10,9 +10,7 @@ import ComponentLibrary
 class PasswordManagerOnboardingViewController: SettingsViewController {
     private struct UX {
         static let maxLabelLines: Int = 0
-        static let buttonCornerRadius: CGFloat = 8
         static let standardSpacing: CGFloat = 20
-        static let continueButtonHeight: CGFloat = 44
         static let buttonHorizontalPadding: CGFloat = 35
         static let continueButtonMaxWidth: CGFloat = 360
     }
@@ -39,6 +37,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
         button.configure(viewModel: buttonViewModel)
         button.addTarget(self, action: #selector(self.proceedButtonTapped), for: .touchUpInside)
     }
+    
     private lazy var contentView: UIView = .build { view in
         view.translatesAutoresizingMaskIntoConstraints = false
     }
@@ -62,27 +61,11 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     }
 
     override func viewDidLoad() {
-            super.viewDidLoad()
+        super.viewDidLoad()
 
-            self.title = .Settings.Passwords.Title
-
-            self.view.addSubviews(scrollView)
-
-            NSLayoutConstraint.activate([
-                scrollView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
-                scrollView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
-                scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-                scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
-            ])
-            scrollView.addSubview(contentView)
-            NSLayoutConstraint.activate([
-                contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
-                contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-                contentView.bottomAnchor.constraint(greaterThanOrEqualTo: scrollView.bottomAnchor),
-                contentView.heightAnchor.constraint(greaterThanOrEqualTo: scrollView.heightAnchor)
-            ])
-            contentView.addSubviews(onboardingMessageLabel, learnMoreButton, continueButton)
-            configureContentViewChildConstraints()
+        self.title = .Settings.Passwords.Title
+        
+        setupLayout()
     }
 
     @objc
@@ -96,44 +79,63 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     func proceedButtonTapped(_ sender: UIButton) {
         continueFromOnboarding()
     }
-
-    private func configureContentViewChildConstraints() {
+    
+    private func setupLayout() {
+        view.addSubviews(scrollView)
+        scrollView.addSubview(contentView)
+        contentView.addSubviews(onboardingMessageLabel, learnMoreButton, continueButton)
+        
         NSLayoutConstraint.activate(
             [
+                scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+                scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+                contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+                contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+                contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+                contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+                contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
                 onboardingMessageLabel.leadingAnchor.constraint(
-                    equalTo: contentView.safeAreaLayoutGuide.leadingAnchor,
+                    equalTo: contentView.leadingAnchor,
                     constant: UX.standardSpacing
                 ),
                 onboardingMessageLabel.trailingAnchor.constraint(
-                    equalTo: contentView.safeAreaLayoutGuide.trailingAnchor,
+                    equalTo: contentView.trailingAnchor,
                     constant: -UX.standardSpacing
                 ),
                 onboardingMessageLabel.centerXAnchor.constraint(
-                    equalTo: contentView.safeAreaLayoutGuide.centerXAnchor
+                    equalTo: contentView.centerXAnchor
                 ),
                 onboardingMessageLabel.topAnchor.constraint(
-                    equalTo: contentView.safeAreaLayoutGuide.topAnchor,
+                    equalTo: contentView.topAnchor,
                     constant: UX.standardSpacing
                 ),
                 learnMoreButton.centerXAnchor.constraint(
-                    equalTo: contentView.safeAreaLayoutGuide.centerXAnchor
+                    equalTo: contentView.centerXAnchor
                 ),
                 learnMoreButton.topAnchor.constraint(
                     equalTo: onboardingMessageLabel.bottomAnchor,
                     constant: UX.standardSpacing
                 ),
+                learnMoreButton.leadingAnchor.constraint(
+                    greaterThanOrEqualTo: contentView.leadingAnchor,
+                    constant: UX.buttonHorizontalPadding
+                ),
+                learnMoreButton.trailingAnchor.constraint(
+                    lessThanOrEqualTo: contentView.trailingAnchor,
+                    constant: -UX.buttonHorizontalPadding
+                ),
                 continueButton.leadingAnchor.constraint(
-                    equalTo: contentView.safeAreaLayoutGuide.leadingAnchor,
-                    constant: UX.buttonHorizontalPadding,
-                    priority: .defaultHigh
+                    greaterThanOrEqualTo: contentView.leadingAnchor,
+                    constant: UX.buttonHorizontalPadding
                 ),
                 continueButton.trailingAnchor.constraint(
-                    equalTo: contentView.safeAreaLayoutGuide.trailingAnchor,
-                    constant: -UX.buttonHorizontalPadding,
-                    priority: .defaultHigh
+                    lessThanOrEqualTo: contentView.trailingAnchor,
+                    constant: -UX.buttonHorizontalPadding
                 ),
                 continueButton.centerXAnchor.constraint(
-                    equalTo: contentView.safeAreaLayoutGuide.centerXAnchor
+                    equalTo: contentView.centerXAnchor
                 ),
                 continueButton.widthAnchor.constraint(
                     lessThanOrEqualToConstant: UX.continueButtonMaxWidth
@@ -143,7 +145,7 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
                     constant: UX.standardSpacing
                 ),
                 continueButton.bottomAnchor.constraint(
-                    equalTo: contentView.safeAreaLayoutGuide.bottomAnchor,
+                    equalTo: contentView.bottomAnchor,
                     constant: -UX.standardSpacing
                 ),
             ])

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerOnboardingViewController.swift
@@ -33,11 +33,17 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     }
 
     private lazy var continueButton: PrimaryRoundedButton = .build { button in
-        button.layer.cornerRadius = UX.buttonCornerRadius
-        button.setTitle(.LoginsOnboardingContinueButtonTitle, for: .normal)
-        button.accessibilityIdentifier = AccessibilityIdentifiers.Settings.Passwords.onboardingContinue
-        button.configuration?.titleAlignment = .center
+        let buttonViewModel = PrimaryRoundedButtonViewModel(
+            title: .LoginsOnboardingContinueButtonTitle,
+            a11yIdentifier: AccessibilityIdentifiers.Settings.Passwords.onboardingContinue)
+        button.configure(viewModel: buttonViewModel)
         button.addTarget(self, action: #selector(self.proceedButtonTapped), for: .touchUpInside)
+    }
+    private lazy var contentView: UIView = .build { view in
+        view.translatesAutoresizingMaskIntoConstraints = false
+    }
+    private lazy var scrollView: UIScrollView = .build { scrollView in
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
     }
 
     weak var coordinator: PasswordManagerFlowDelegate?
@@ -56,50 +62,27 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     }
 
     override func viewDidLoad() {
-        super.viewDidLoad()
+            super.viewDidLoad()
 
-        self.title = .Settings.Passwords.Title
+            self.title = .Settings.Passwords.Title
 
-        self.view.addSubviews(onboardingMessageLabel, learnMoreButton, continueButton)
+            self.view.addSubviews(scrollView)
 
-        NSLayoutConstraint.activate(
-            [
-                onboardingMessageLabel.leadingAnchor.constraint(
-                    equalTo: self.view.safeAreaLayoutGuide.leadingAnchor,
-                    constant: UX.standardSpacing
-                ),
-                onboardingMessageLabel.trailingAnchor.constraint(
-                    equalTo: self.view.safeAreaLayoutGuide.trailingAnchor,
-                    constant: -UX.standardSpacing
-                ),
-                onboardingMessageLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-                onboardingMessageLabel.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
-
-                learnMoreButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-                learnMoreButton.topAnchor.constraint(
-                    equalTo: onboardingMessageLabel.safeAreaLayoutGuide.bottomAnchor,
-                    constant: UX.standardSpacing
-                ),
-
-                continueButton.bottomAnchor.constraint(
-                    equalTo: self.view.layoutMarginsGuide.bottomAnchor,
-                    constant: -UX.standardSpacing
-                ),
-                continueButton.heightAnchor.constraint(equalToConstant: UX.continueButtonHeight),
-                continueButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-                continueButton.leadingAnchor.constraint(
-                    equalTo: self.view.safeAreaLayoutGuide.leadingAnchor,
-                    constant: UX.buttonHorizontalPadding,
-                    priority: .defaultHigh
-                ),
-                continueButton.trailingAnchor.constraint(
-                    equalTo: self.view.safeAreaLayoutGuide.trailingAnchor,
-                    constant: -UX.buttonHorizontalPadding,
-                    priority: .defaultHigh
-                ),
-                continueButton.widthAnchor.constraint(lessThanOrEqualToConstant: UX.continueButtonMaxWidth)
-            ]
-        )
+            NSLayoutConstraint.activate([
+                scrollView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
+                scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+                scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+            ])
+            scrollView.addSubview(contentView)
+            NSLayoutConstraint.activate([
+                contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+                contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+                contentView.bottomAnchor.constraint(greaterThanOrEqualTo: scrollView.bottomAnchor),
+                contentView.heightAnchor.constraint(greaterThanOrEqualTo: scrollView.heightAnchor)
+            ])
+            contentView.addSubviews(onboardingMessageLabel, learnMoreButton, continueButton)
+            configureContentViewChildConstraints()
     }
 
     @objc
@@ -112,6 +95,58 @@ class PasswordManagerOnboardingViewController: SettingsViewController {
     @objc
     func proceedButtonTapped(_ sender: UIButton) {
         continueFromOnboarding()
+    }
+
+    private func configureContentViewChildConstraints() {
+        NSLayoutConstraint.activate(
+            [
+                onboardingMessageLabel.leadingAnchor.constraint(
+                    equalTo: contentView.safeAreaLayoutGuide.leadingAnchor,
+                    constant: UX.standardSpacing
+                ),
+                onboardingMessageLabel.trailingAnchor.constraint(
+                    equalTo: contentView.safeAreaLayoutGuide.trailingAnchor,
+                    constant: -UX.standardSpacing
+                ),
+                onboardingMessageLabel.centerXAnchor.constraint(
+                    equalTo: contentView.safeAreaLayoutGuide.centerXAnchor
+                ),
+                onboardingMessageLabel.topAnchor.constraint(
+                    equalTo: contentView.safeAreaLayoutGuide.topAnchor,
+                    constant: UX.standardSpacing
+                ),
+                learnMoreButton.centerXAnchor.constraint(
+                    equalTo: contentView.safeAreaLayoutGuide.centerXAnchor
+                ),
+                learnMoreButton.topAnchor.constraint(
+                    equalTo: onboardingMessageLabel.bottomAnchor,
+                    constant: UX.standardSpacing
+                ),
+                continueButton.leadingAnchor.constraint(
+                    equalTo: contentView.safeAreaLayoutGuide.leadingAnchor,
+                    constant: UX.buttonHorizontalPadding,
+                    priority: .defaultHigh
+                ),
+                continueButton.trailingAnchor.constraint(
+                    equalTo: contentView.safeAreaLayoutGuide.trailingAnchor,
+                    constant: -UX.buttonHorizontalPadding,
+                    priority: .defaultHigh
+                ),
+                continueButton.centerXAnchor.constraint(
+                    equalTo: contentView.safeAreaLayoutGuide.centerXAnchor
+                ),
+                continueButton.widthAnchor.constraint(
+                    lessThanOrEqualToConstant: UX.continueButtonMaxWidth
+                ),
+                continueButton.topAnchor.constraint(
+                    greaterThanOrEqualTo: learnMoreButton.bottomAnchor,
+                    constant: UX.standardSpacing
+                ),
+                continueButton.bottomAnchor.constraint(
+                    equalTo: contentView.safeAreaLayoutGuide.bottomAnchor,
+                    constant: -UX.standardSpacing
+                ),
+            ])
     }
 
     private func continueFromOnboarding() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9336)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20671)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added a scroll view to the password manager onboarding, along with updated constraints for the continue button to make for a better accessibility experience
Before: 
<img src="https://github.com/user-attachments/assets/77dbb2ee-e9da-46b5-bfc0-ab8ac91d3364" width="300">

After:

https://github.com/user-attachments/assets/28edbc1e-9ce5-4898-afb9-8670a9bf42d7



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

