### PR TITLE
Refactor FXIOS-9547 Enforce singular window UUID on iPhone devices

### DIFF
--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -205,7 +205,7 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         // are >1 windows we've encountered some type of unexpected state.
         let isIpad = (UIDevice.current.userInterfaceIdiom == .pad)
 
-        let result: (uuid: WindowUUID, isNew: Bool)
+        let result: ReservedWindowUUID
         if !isIpad {
             // if onDiskUUIDs.count > 1 { ... }
             // TODO: [FXIOS-9544] If >1 tab session files, clean up & merge
@@ -213,9 +213,9 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
             // At this point we should always have either a single UUID on disk or
             // no UUIDs because this is a brand new app install
             if onDiskUUIDs.isEmpty {
-                result = (uuid: WindowUUID(), isNew: true)
+                result = ReservedWindowUUID(uuid: WindowUUID(), isNew: true)
             } else {
-                result = (uuid: onDiskUUIDs.first!, isNew: false)
+                result = ReservedWindowUUID(uuid: onDiskUUIDs.first!, isNew: false)
             }
         } else {
             let filteredUUIDs = onDiskUUIDs.filter {

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -91,7 +91,13 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
     }
 
     private(set) var windows: [WindowUUID: AppWindowInfo] = [:]
+
+    // A list of UUIDs that have already been reserved for windows which are being actively configured.
+    // Because so much of our early launch configuration occurs async, it's possible to request more than
+    // one window UUID before previous windows have completed, this tracks reserved UUIDs still in the
+    // process of initial configuration.
     private var reservedUUIDs: [WindowUUID] = []
+
     var activeWindow: WindowUUID {
         get { return uuidForActiveWindow() }
         set { _activeWindowUUID = newValue }
@@ -187,9 +193,6 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         // or UUIDs that are already reserved and in the process of opening.
         let openWindowUUIDs = windows.keys
         let onDiskUUIDs = tabDataStore.fetchWindowDataUUIDs()
-        let filteredUUIDs = onDiskUUIDs.filter {
-            !openWindowUUIDs.contains($0) && !reservedUUIDs.contains($0)
-        }
 
         let onDiskUUIDLog = onDiskUUIDs.map({ $0.uuidString.prefix(8) }).joined(separator: ", ")
         let reserveLog = reservedUUIDs.map({ $0.uuidString.prefix(8) }).joined(separator: ", ")
@@ -198,10 +201,33 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
                    level: .debug,
                    category: .window)
 
-        let result = nextWindowUUIDToOpen(filteredUUIDs)
-        logger.log("WindowManager: reserve next UUID result = \(result.uuid.uuidString) Is new?: \(result.isNew)",
-                   level: .debug,
-                   category: .window)
+        // On iPhone devices, we expect there only to ever be a single window. If there
+        // are >1 windows we've encountered some type of unexpected state.
+        let isIpad = (UIDevice.current.userInterfaceIdiom == .pad)
+
+        let result: (uuid: WindowUUID, isNew: Bool)
+        if !isIpad {
+            // if onDiskUUIDs.count > 1 { ... }
+            // TODO: [FXIOS-9544] If >1 tab session files, clean up & merge
+
+            // At this point we should always have either a single UUID on disk or
+            // no UUIDs because this is a brand new app install
+            if onDiskUUIDs.isEmpty {
+                result = (uuid: WindowUUID(), isNew: true)
+            } else {
+                result = (uuid: onDiskUUIDs.first!, isNew: false)
+            }
+        } else {
+            let filteredUUIDs = onDiskUUIDs.filter {
+                !openWindowUUIDs.contains($0) && !reservedUUIDs.contains($0)
+            }
+
+            result = nextWindowUUIDToOpen(filteredUUIDs)
+            logger.log("WindowManager: reserve next UUID result = \(result.uuid.uuidString) Is new?: \(result.isNew)",
+                       level: .debug,
+                       category: .window)
+        }
+
         let resultUUID = result.uuid
         if result.isNew {
             // Be sure to add any brand-new windows to our ordering preferences

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -223,11 +223,11 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
             }
 
             result = nextWindowUUIDToOpen(filteredUUIDs)
-            logger.log("WindowManager: reserve next UUID result = \(result.uuid.uuidString) Is new?: \(result.isNew)",
-                       level: .debug,
-                       category: .window)
         }
 
+        logger.log("WindowManager: reserve next UUID result = \(result.uuid.uuidString) Is new?: \(result.isNew)",
+                   level: .debug,
+                   category: .window)
         let resultUUID = result.uuid
         if result.isNew {
             // Be sure to add any brand-new windows to our ordering preferences

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -206,7 +206,8 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         let isIpad = (UIDevice.current.userInterfaceIdiom == .pad)
 
         let result: ReservedWindowUUID
-        if !isIpad {
+        // TODO: [9610] Unit tests should eventually be updated for these changes. Forthcoming.
+        if !isIpad && !AppConstants.isRunningUnitTest {
             // if onDiskUUIDs.count > 1 { ... }
             // TODO: [FXIOS-9544] If >1 tab session files, clean up & merge
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9547)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21124)

## Merge Conflict

Note: this will require a merge conflict resolution with the changes from https://github.com/mozilla-mobile/firefox-ios/pull/21115. 

## :bulb: Description

This forces the use of a singular UUID on iPhone devices. Since we never expect to support or allow >1 window on non-iPad devices, it provides a safety mechanism to guard against unexpected states which could arise from bugs that would introduce more than one UUID and/or tab data file.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

