### PR TITLE
Refactor FXIOS-9539 - Update fonts related to RemoveAddressButton to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/RemoveAddressButton.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/RemoveAddressButton.swift
@@ -11,11 +11,7 @@ class RemoveAddressButton: UIButton, ThemeApplicable {
 
     init() {
         super.init(frame: .zero)
-        self.titleLabel?.font = DefaultDynamicFontHelper.preferredFont(
-            withTextStyle: .body,
-            size: 17,
-            weight: .regular
-        )
+        self.titleLabel?.font = FXFontStyles.Regular.body.scaledFont()
 
         addSubview(topSeparator)
         addSubview(bottomSeparator)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/9539)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21110)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- This PR updates the font in RemoveAddressButton to FXFontStyles instead of the DefaultDynamicFontHelper in order to standardize the fonts and align with the design system.

| Before - Light | After - Light |
| -------------- | ------------- |
| <img src="https://github.com/user-attachments/assets/f1f3b3d5-56e2-4900-bbc2-9b1bd5bd27cf" width="450"/> | <img src="https://github.com/user-attachments/assets/d1bae19d-be96-4a05-8e36-bf705596a37a" width="450"/> |

| Before - Dark | After - Dark |
| -------------- | ------------- |
| <img src="https://github.com/user-attachments/assets/070cd673-f79a-4f2a-bad5-662d4fc9c4d0" width="450"/> | <img src="https://github.com/user-attachments/assets/68809f9f-35e2-4d9f-bd40-967ed2163be8" width="450"/> |

Note: The change is only for the "Remove Address" button.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

