### PR TITLE
Bugfix FXIOS-9320 ⁃ Copy option is missing from share menu

### DIFF
--- a/firefox-ios/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -18,8 +18,7 @@ class ShareExtensionHelper: NSObject, FeatureFlaggable {
     private let pocketActionExtension = "com.ideashower.ReadItLaterPro.Action-Extension"
 
     private var excludingActivities: [UIActivity.ActivityType] {
-        return [UIActivity.ActivityType.addToReadingList,
-                 UIActivity.ActivityType.copyToPasteboard]
+        return [UIActivity.ActivityType.addToReadingList]
     }
 
     // Can be a file:// or http(s):// url

--- a/firefox-ios/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -103,8 +103,6 @@ class ShareExtensionHelper: NSObject, FeatureFlaggable {
 
     private func getApplicationActivities() -> [UIActivity] {
         var appActivities = [UIActivity]()
-        let copyLinkActivity = CopyLinkActivity(activityType: .copyLink, url: url)
-        appActivities.append(copyLinkActivity)
 
         let sendToDeviceActivity = SendToDeviceActivity(activityType: .sendToDevice, url: url)
         appActivities.append(sendToDeviceActivity)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9320)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20649)

## :bulb: Description
Added back Copy option to the share menu

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

