### PR TITLE
Fix MTE-3169 - testFindFromLongTap test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -174,19 +174,17 @@ class FindInPageTests: BaseTestCase {
         mozWaitForElementToExist(app.menuItems["Copy"], timeout: 5)
         // Find in page is correctly launched, bar with text pre-filled and
         // the buttons to find next and previous
-        if !iPad() {
-            while !app.menuItems["Find in Page"].exists {
-                if #available(iOS 16, *) {
-                    app.buttons["Forward"].firstMatch.tap()
-                } else {
-                    app.menuItems["show.next.items.menu.button"].tap()
-                }
-                mozWaitForElementToExist(app.menuItems.firstMatch)
-                if #available(iOS 16, *) {
-                    mozWaitForElementToExist(app.buttons["Forward"])
-                } else {
-                    mozWaitForElementToExist(app.menuItems["show.next.items.menu.button"])
-                }
+        while !app.menuItems["Find in Page"].exists {
+            if #available(iOS 16, *) {
+                app.buttons["Forward"].firstMatch.tap()
+            } else {
+                app.menuItems["show.next.items.menu.button"].tap()
+            }
+            mozWaitForElementToExist(app.menuItems.firstMatch)
+            if #available(iOS 16, *) {
+                mozWaitForElementToExist(app.buttons["Forward"])
+            } else {
+                mozWaitForElementToExist(app.menuItems["show.next.items.menu.button"])
             }
         }
         mozWaitForElementToExist(app.menuItems["Find in Page"])


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3169

## :bulb: Description
Test failing for iPad. Removed condition so that  to look for Find in Page menu button regardless of the device.

