### PR TITLE
Refactor FXIOS-7301 [Swiftlint] Remove 1 closure_body_length violation from Authenticator.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -145,6 +145,13 @@ class Authenticator {
         }
     }
 
+    fileprivate static func filterHttpAuthLogins(logins: [EncryptedLogin]) -> [EncryptedLogin] {
+        return logins.compactMap {
+            // HTTP Auth must have nil formSubmitUrl and a non-nil httpRealm.
+            return $0.formSubmitUrl == nil && $0.httpRealm != nil ? $0 : nil
+        }
+    }
+
     fileprivate static func handleDuplicatedEntries(logins: [EncryptedLogin],
                                                     challenge: URLAuthenticationChallenge,
                                                     loginsProvider: RustLogins) -> URLCredential? {

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -171,6 +171,23 @@ class Authenticator {
         return credentials
     }
 
+    fileprivate static func handleUnmatchedSchemes(logins: [EncryptedLogin],
+                                                   challenge: URLAuthenticationChallenge,
+                                                   loginsProvider: RustLogins,
+                                                   completionHandler: @escaping (Result<URLCredential?, Error>) -> Void) {
+        let login = logins[0]
+        let credentials = login.credentials
+        let new = LoginEntry(credentials: login.credentials, protectionSpace: challenge.protectionSpace)
+        loginsProvider.updateLogin(id: login.id, login: new) { result in
+            switch result {
+            case .success:
+                completionHandler(.success(credentials))
+            case .failure(let error):
+                completionHandler(.failure(error))
+            }
+        }
+    }
+
     fileprivate static func promptForUsernamePassword(
         _ viewController: UIViewController,
         credentials: URLCredential?,

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -121,17 +121,10 @@ class Authenticator {
                 // saved in a previous iteration of the app so we need to migrate it. We only care about the
                 // the username/password so we can rewrite the scheme to be correct.
                 else if logins.count == 1 && logins[0].protectionSpace.`protocol` != challenge.protectionSpace.`protocol` {
-                    let login = logins[0]
-                    credentials = login.credentials
-                    let new = LoginEntry(credentials: login.credentials, protectionSpace: challenge.protectionSpace)
-                    loginsProvider.updateLogin(id: login.id, login: new) { result in
-                        switch result {
-                        case .success:
-                            completionHandler(.success(credentials))
-                        case .failure(let error):
-                            completionHandler(.failure(error))
-                        }
-                    }
+                    handleUnmatchedSchemes(logins: logins,
+                                           challenge: challenge,
+                                           loginsProvider: loginsProvider,
+                                           completionHandler: completionHandler)
                     return
                 }
 

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -112,18 +112,9 @@ class Authenticator {
                 // It is possible that we might have duplicate entries since we match against host and scheme://host.
                 // This is a side effect of https://bugzilla.mozilla.org/show_bug.cgi?id=1238103.
                 if logins.count > 1 {
-                    credentials = (logins.first(where: { login in
-                        (login.protectionSpace.`protocol` == challenge.protectionSpace.`protocol`)
-                        && !login.hasMalformedHostname
-                    }))?.credentials
-
-                    let malformedGUIDs: [GUID] = logins.compactMap { login in
-                        if login.hasMalformedHostname {
-                            return login.id
-                        }
-                        return nil
-                    }
-                    loginsProvider.deleteLogins(ids: malformedGUIDs) { _ in }
+                    credentials = handleDuplicatedEntries(logins: logins,
+                                                          challenge: challenge,
+                                                          loginsProvider: loginsProvider)
                 }
 
                 // Found a single entry but the schemes don't match. This is a result of a schemeless entry that we

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -141,7 +141,7 @@ class Authenticator {
         }
     }
 
-    fileprivate static func filterHttpAuthLogins(logins: [EncryptedLogin]) -> [EncryptedLogin] {
+    private static func filterHttpAuthLogins(logins: [EncryptedLogin]) -> [EncryptedLogin] {
         return logins.compactMap {
             // HTTP Auth must have nil formSubmitUrl and a non-nil httpRealm.
             return $0.formSubmitUrl == nil && $0.httpRealm != nil ? $0 : nil

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -167,10 +167,10 @@ class Authenticator {
         return credentials
     }
 
-    fileprivate static func handleUnmatchedSchemes(logins: [EncryptedLogin],
-                                                   challenge: URLAuthenticationChallenge,
-                                                   loginsProvider: RustLogins,
-                                                   completionHandler: @escaping (Result<URLCredential?, Error>) -> Void) {
+    private static func handleUnmatchedSchemes(logins: [EncryptedLogin],
+                                               challenge: URLAuthenticationChallenge,
+                                               loginsProvider: RustLogins,
+                                               completionHandler: @escaping (Result<URLCredential?, Error>) -> Void) {
         let login = logins[0]
         let credentials = login.credentials
         let new = LoginEntry(credentials: login.credentials, protectionSpace: challenge.protectionSpace)

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -8,6 +8,7 @@ import Storage
 import Common
 
 import struct MozillaAppServices.LoginEntry
+import struct MozillaAppServices.EncryptedLogin
 
 class Authenticator {
     fileprivate static let MaxAuthenticationAttempts = 3

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -148,9 +148,9 @@ class Authenticator {
         }
     }
 
-    fileprivate static func handleDuplicatedEntries(logins: [EncryptedLogin],
-                                                    challenge: URLAuthenticationChallenge,
-                                                    loginsProvider: RustLogins) -> URLCredential? {
+    private static func handleDuplicatedEntries(logins: [EncryptedLogin],
+                                                challenge: URLAuthenticationChallenge,
+                                                loginsProvider: RustLogins) -> URLCredential? {
         let credentials = (logins.first(where: { login in
             (login.protectionSpace.`protocol` == challenge.protectionSpace.`protocol`)
             && !login.hasMalformedHostname

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -129,9 +129,7 @@ class Authenticator {
                 else if logins.count == 1 {
                     credentials = logins[0].credentials
                 } else {
-                    logger.log("No logins found for Authenticator",
-                               level: .info,
-                               category: .webview)
+                    logger.log("No logins found for Authenticator", level: .info, category: .webview)
                 }
 
                 completionHandler(.success(credentials))

--- a/firefox-ios/Client/Frontend/Browser/Authenticator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Authenticator.swift
@@ -103,10 +103,7 @@ class Authenticator {
                     return
                 }
 
-                let logins = logins.compactMap {
-                    // HTTP Auth must have nil formSubmitUrl and a non-nil httpRealm.
-                    return $0.formSubmitUrl == nil && $0.httpRealm != nil ? $0 : nil
-                }
+                let logins = filterHttpAuthLogins(logins: logins)
                 var credentials: URLCredential?
 
                 // It is possible that we might have duplicate entries since we match against host and scheme://host.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `Authenticator.swift` file. 

To do this, I extracted the following logics to new functions:
- filter HTTP auth logins
- handle duplicated entries
- handle unmatched schemes

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

