### PR TITLE
Add FXIOS-9516 Add merge window data function

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -251,7 +251,7 @@ public actor DefaultTabDataStore: TabDataStore {
               let primaryWindow = await fetchWindowData(uuid: primaryID)
         else { return }
 
-        var newTabData = primaryWindow.tabData
+        var newTabData = [TabData]()
 
         for uuid in windowIDs {
             if let nextWindow = await fetchWindowData(uuid: uuid) {

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -76,7 +76,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .preLaunchDependenciesComplete,
             .postLaunchDependenciesComplete,
             .accountManagerInitialized,
-            .browserIsReady
+            .browserIsReady,
+            .windowUUIDEstablished
         ])
 
         // Then setup dependency container as it's needed for everything else

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -214,6 +214,8 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
                     await tabDataStore.mergeWindowsData()
                     AppEventQueue.signal(event: .windowUUIDEstablished)
                 }
+            } else {
+                AppEventQueue.signal(event: .windowUUIDEstablished)
             }
 
             // At this point we should always have either a single UUID on disk or
@@ -229,6 +231,7 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
             }
 
             result = nextWindowUUIDToOpen(filteredUUIDs)
+            AppEventQueue.signal(event: .windowUUIDEstablished)
         }
 
         logger.log("WindowManager: reserve next UUID result = \(result.uuid.uuidString) Is new?: \(result.isNew)",

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -208,8 +208,13 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         let result: ReservedWindowUUID
         // TODO: [9610] Unit tests should eventually be updated for these changes. Forthcoming.
         if !isIpad && !AppConstants.isRunningUnitTest {
-            // if onDiskUUIDs.count > 1 { ... }
-            // TODO: [FXIOS-9544] If >1 tab session files, clean up & merge
+            // An iPhone should never have more than 1 window UUID, if this occurs merge the data and clean up
+            if onDiskUUIDs.count > 1 {
+                Task {
+                    await tabDataStore.mergeWindowsData()
+                    AppEventQueue.signal(event: .windowUUIDEstablished)
+                }
+            }
 
             // At this point we should always have either a single UUID on disk or
             // no UUIDs because this is a brand new app install

--- a/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -21,6 +21,7 @@ public enum AppEvent: AppEventType {
     case postLaunchDependenciesComplete
     case accountManagerInitialized
     case browserIsReady
+    case windowUUIDEstablished
 
     // Activities: Profile Syncing
     case profileSyncing

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabDataStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabDataStore.swift
@@ -27,6 +27,8 @@ class MockTabDataStore: TabDataStore {
     }
 
     func clearAllWindowsData() async {}
+
+    func mergeWindowsData() async {}
 }
 
 // Utilities for mocking available tab window UUIDs in unit tests.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9544)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21120)

## :bulb: Description
Adds a method to tab data store to merge window data files.

This is just a draft for quick feedback. Still todo, add tests and actually call the method once Matt's PR is merged. 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

