### PR TITLE
Bugfix FXIOS-8080 Favicon flicker on home

### DIFF
--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -449,15 +449,22 @@ extension JumpBackInViewModel: HomepageSectionHandler {
 extension JumpBackInViewModel: JumpBackInDelegate {
     func didLoadNewData() {
         Task { @MainActor in
-            self.recentTabs = await self.jumpBackInDataAdaptor.getRecentTabData()
-            self.recentSyncedTab = await self.jumpBackInDataAdaptor.getSyncedTabData()
-            self.isSyncTabFeatureEnabled = await self.jumpBackInDataAdaptor.hasSyncedTabFeatureEnabled()
+            await self.updateJumpBackInData()
             logger.log("JumpBack didLoadNewData and section shouldShow \(self.shouldShow)",
                        level: .debug,
                        category: .homepage)
-            guard self.isEnabled else { return }
-
-            self.delegate?.reloadView()
+            reloadView()
         }
+    }
+
+    private func updateJumpBackInData() async {
+        self.recentTabs = await self.jumpBackInDataAdaptor.getRecentTabData()
+        self.recentSyncedTab = await self.jumpBackInDataAdaptor.getSyncedTabData()
+        self.isSyncTabFeatureEnabled = await self.jumpBackInDataAdaptor.hasSyncedTabFeatureEnabled()
+    }
+
+    private func reloadView() {
+        guard self.isEnabled else { return }
+        self.delegate?.reloadView()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
@@ -8,11 +8,7 @@ import XCTest
 import WebKit
 import Common
 
-// NOTE:
-// Tab groups not tested at the moment since it depends on RustPlaces concrete object.
-// Need protocol to be able to fix this
-
-class JumpBackInDataAdaptorTests: XCTestCase {
+final class JumpBackInDataAdaptorTests: XCTestCase {
     var mockTabManager: MockTabManager!
     var mockProfile: MockProfile!
     let sleepTime: UInt64 = 100_000_000
@@ -33,7 +29,7 @@ class JumpBackInDataAdaptorTests: XCTestCase {
         mockTabManager = nil
     }
 
-    func testEmptyData_tabTrayGroupsDisabled() async {
+    func testEmptyData() async {
         let subject = createSubject()
         try? await Task.sleep(nanoseconds: sleepTime)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -628,15 +628,6 @@ actor JumpBackInDataAdaptorMock: JumpBackInDataAdaptor {
         return recentTabs
     }
 
-    var recentGroups: [ASGroup<Tab>]?
-    func setRecentGroups(recentGroups: [ASGroup<Tab>]?) {
-        self.recentGroups = recentGroups
-    }
-
-    func getGroupsData() -> [ASGroup<Tab>]? {
-        return recentGroups
-    }
-
     var mockHasSyncedTabFeatureEnabled = true
     func setMockHasSyncedTabFeatureEnabled(enabled: Bool) {
         mockHasSyncedTabFeatureEnabled = enabled


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8080)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17992)

## :bulb: Description
This is a bandaid fix in terms of the favicon flickering. It seems that we were reloading the view multiple times for jump back in when unnecessary. Move the method for reloading view until all tab related data for jump back in completes. Although I suspect there were still be flickering, hoping that this will alleviate the issue a bit. 

I tested jump back in with at least 3 tabs and testing with sync as well. Only issue I see is there is a delay in fetching the images for the cells in the jump back in section, but this is on main as well.

We seem to have a lot of of tests covered here 🔥 , however, I noticed that we are using a lot of `Task.sleep` which I'm not sure is the route we want to go with writing the async / await code. I'll bring this up during team meeting to discuss on best path forward. With that, I left tests as is. 

Note: Also cleaned up some code that doesn't seem to be used. Looks like we were using tab groups before.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

