### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from LegacyTabPeekViewController.swift

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 		787EDD852943EE75002B93AE /* JumpBackInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787EDD832943EE75002B93AE /* JumpBackInTests.swift */; };
 		78FE1E892B040E7000338465 /* FirefoxSuggestTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78FE1E872B040E7000338465 /* FirefoxSuggestTest.swift */; };
 		7ADC1D192C27D35B003ED924 /* ActionProviderBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADC1D182C27D35B003ED924 /* ActionProviderBuilder.swift */; };
+		7A6DF9EB2BFECC3C00A0C608 /* LegacyTabPeekPreviewActionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6DF9EA2BFECC3C00A0C608 /* LegacyTabPeekPreviewActionBuilder.swift */; };
 		7B10AA9F1E3A15020002DD08 /* DataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B10AA9E1E3A15020002DD08 /* DataExtensions.swift */; };
 		7B10AABB1E3A1F650002DD08 /* URLRequestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B10AABA1E3A1F650002DD08 /* URLRequestExtensions.swift */; };
 		7B2142FE1E5E055000CDD3FC /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7B2142FC1E5E055000CDD3FC /* InfoPlist.strings */; };
@@ -6084,6 +6085,7 @@
 		797548C8B7F6A801A090D219 /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		79B14B7CBAE86AEB3730EB33 /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		7A0C4AEAA9CB35000E35A5BB /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
+		7A6DF9EA2BFECC3C00A0C608 /* LegacyTabPeekPreviewActionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabPeekPreviewActionBuilder.swift; sourceTree = "<group>"; };
 		7A704C668511CA18CA660BAA /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		7A7741BB976626FBB10E5BDC /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		7A7F476EBF03E15BDE5A3C43 /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
@@ -8768,6 +8770,7 @@
 				C81AC6B526160091007800C5 /* LegacyTabTrayViewModel.swift */,
 				968BD7EA27DFF0F8003148B3 /* ASGroup.swift */,
 				216C133D29DCA8FF0097533B /* LegacyTabLayoutDelegate.swift */,
+				7A6DF9EA2BFECC3C00A0C608 /* LegacyTabPeekPreviewActionBuilder.swift */,
 			);
 			path = Legacy;
 			sourceTree = "<group>";
@@ -14547,6 +14550,7 @@
 				D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */,
 				E17496382991A2720096900A /* AdaptiveStack.swift in Sources */,
 				E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */,
+				7A6DF9EB2BFECC3C00A0C608 /* LegacyTabPeekPreviewActionBuilder.swift in Sources */,
 				E177989C2BD7D48500F6F0EB /* ToolbarAction.swift in Sources */,
 				F8A0B08229AD61FA0091C75B /* RustSyncManager.swift in Sources */,
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -564,8 +564,9 @@
 		782B0A362AB41DFC0049EE1A /* FakespotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782B0A352AB41DFC0049EE1A /* FakespotTests.swift */; };
 		787EDD852943EE75002B93AE /* JumpBackInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787EDD832943EE75002B93AE /* JumpBackInTests.swift */; };
 		78FE1E892B040E7000338465 /* FirefoxSuggestTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78FE1E872B040E7000338465 /* FirefoxSuggestTest.swift */; };
-		7ADC1D192C27D35B003ED924 /* ActionProviderBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADC1D182C27D35B003ED924 /* ActionProviderBuilder.swift */; };
+		7A352B772C4F196B00359D51 /* LegacyTabPeekPreviewActionBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A352B762C4F196B00359D51 /* LegacyTabPeekPreviewActionBuilderTests.swift */; };
 		7A6DF9EB2BFECC3C00A0C608 /* LegacyTabPeekPreviewActionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6DF9EA2BFECC3C00A0C608 /* LegacyTabPeekPreviewActionBuilder.swift */; };
+		7ADC1D192C27D35B003ED924 /* ActionProviderBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADC1D182C27D35B003ED924 /* ActionProviderBuilder.swift */; };
 		7B10AA9F1E3A15020002DD08 /* DataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B10AA9E1E3A15020002DD08 /* DataExtensions.swift */; };
 		7B10AABB1E3A1F650002DD08 /* URLRequestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B10AABA1E3A1F650002DD08 /* URLRequestExtensions.swift */; };
 		7B2142FE1E5E055000CDD3FC /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7B2142FC1E5E055000CDD3FC /* InfoPlist.strings */; };
@@ -6085,6 +6086,7 @@
 		797548C8B7F6A801A090D219 /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		79B14B7CBAE86AEB3730EB33 /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		7A0C4AEAA9CB35000E35A5BB /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/PrivateBrowsing.strings"; sourceTree = "<group>"; };
+		7A352B762C4F196B00359D51 /* LegacyTabPeekPreviewActionBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabPeekPreviewActionBuilderTests.swift; sourceTree = "<group>"; };
 		7A6DF9EA2BFECC3C00A0C608 /* LegacyTabPeekPreviewActionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabPeekPreviewActionBuilder.swift; sourceTree = "<group>"; };
 		7A704C668511CA18CA660BAA /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		7A7741BB976626FBB10E5BDC /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
@@ -9729,6 +9731,22 @@
 			path = Generated;
 			sourceTree = "<group>";
 		};
+		7A352B722C4F190F00359D51 /* Tabs */ = {
+			isa = PBXGroup;
+			children = (
+				7A352B732C4F191500359D51 /* Legacy */,
+			);
+			path = Tabs;
+			sourceTree = "<group>";
+		};
+		7A352B732C4F191500359D51 /* Legacy */ = {
+			isa = PBXGroup;
+			children = (
+				7A352B762C4F196B00359D51 /* LegacyTabPeekPreviewActionBuilderTests.swift */,
+			);
+			path = Legacy;
+			sourceTree = "<group>";
+		};
 		7B0B1B9C1C1B69F500DF4AB5 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -11969,6 +11987,7 @@
 		E1AEC173286E0CF500062E29 /* Browser */ = {
 			isa = PBXGroup;
 			children = (
+				7A352B722C4F190F00359D51 /* Tabs */,
 				21B337BA29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift */,
 				F98CB66B2A4123B5005F38E9 /* EnhancedTrackingProtection */,
 				8A1E3BE828CBC57E003388C4 /* SearchEngines */,
@@ -15552,6 +15571,7 @@
 				8AFE4C2127480D0C00B97C65 /* LegacyTabTrayViewControllerTests.swift in Sources */,
 				E1312FD129D237EE008DDA85 /* NotificationSurfaceManagerTests.swift in Sources */,
 				21371FA228A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift in Sources */,
+				7A352B772C4F196B00359D51 /* LegacyTabPeekPreviewActionBuilderTests.swift in Sources */,
 				5AE371842A4DD6F50092A760 /* PasswordManagerListViewControllerSpy.swift in Sources */,
 				8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */,
 				ABEF80D92A2F283E003F52C4 /* CreditCardBottomSheetViewModelTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilder.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+class LegacyTabPeekPreviewActionBuilder {
+    private var actions = [UIPreviewActionItem]()
+
+    var count: Int {
+        return actions.count
+    }
+
+    func addBookmark(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
+        actions.append(UIPreviewAction(
+            title: .TabPeekAddToBookmarks,
+            style: .default,
+            handler: handler
+        ))
+    }
+
+    func addSendToDeviceTitle(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
+        actions.append(UIPreviewAction(
+            title: .AppMenu.TouchActions.SendToDeviceTitle,
+            style: .default,
+            handler: handler
+        ))
+    }
+
+    func addCopyUrl(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
+        actions.append(UIPreviewAction(
+            title: .TabPeekCopyUrl,
+            style: .default,
+            handler: handler
+        ))
+    }
+
+    func addCloseTab(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
+        actions.append(UIPreviewAction(
+            title: .TabPeekCloseTab,
+            style: .destructive,
+            handler: handler
+        ))
+    }
+
+    func build() -> [UIPreviewActionItem] {
+        return actions
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -27,6 +27,14 @@ class PreviewActionBuilder {
             handler: handler
         ))
     }
+
+    func addSendToDeviceTitle(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
+        actions.append(UIPreviewAction(
+            title: .AppMenu.TouchActions.SendToDeviceTitle,
+            style: .default,
+            handler: handler
+        ))
+    }
 }
 
 class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -19,6 +19,14 @@ protocol LegacyTabPeekDelegate: AnyObject {
 
 class PreviewActionBuilder {
     private var actions = [UIPreviewActionItem]()
+
+    func addBookmark(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
+        actions.append(UIPreviewAction(
+            title: .TabPeekAddToBookmarks,
+            style: .default,
+            handler: handler
+        ))
+    }
 }
 
 class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -88,13 +88,10 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
                 }
             }
             if self.hasRemoteClients {
-                actions.append(UIPreviewAction(
-                    title: .AppMenu.TouchActions.SendToDeviceTitle,
-                    style: .default
-                ) { [weak self] previewAction, viewController in
+                actionsBuilder.addSendToDeviceTitle { [weak self] previewAction, viewController in
                     guard let wself = self, let clientPicker = wself.fxaDevicePicker else { return }
                     wself.delegate?.tabPeekRequestsPresentationOf(clientPicker)
-                })
+                }
             }
             // only add the copy URL action if we don't already have 3 items in our list
             // as we are only allowed 4 in total and we always want to display close tab

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -17,7 +17,7 @@ protocol LegacyTabPeekDelegate: AnyObject {
     func tabPeekDidCopyUrl()
 }
 
-class PreviewActionBuilder {
+class LegacyTabPeekPreviewActionBuilder {
     private var actions = [UIPreviewActionItem]()
 
     var count: Int {
@@ -79,7 +79,7 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
     override var previewActionItems: [UIPreviewActionItem] { return previewActions }
 
     lazy var previewActions: [UIPreviewActionItem] = {
-        let actionsBuilder = PreviewActionBuilder()
+        let actionsBuilder = LegacyTabPeekPreviewActionBuilder()
 
         let urlIsTooLongToSave = self.tab?.urlIsTooLong ?? false
         let isHomeTab = self.tab?.isFxHomeTab ?? false

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -104,13 +104,10 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
                 }
             }
         }
-        actions.append(UIPreviewAction(
-            title: .TabPeekCloseTab,
-            style: .destructive
-        ) { [weak self] previewAction, viewController in
+        actionsBuilder.addCloseTab { [weak self] previewAction, viewController in
             guard let wself = self, let tab = wself.tab else { return }
             wself.delegate?.tabPeekDidCloseTab(tab)
-        })
+        }
 
         return actions
     }()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -17,50 +17,6 @@ protocol LegacyTabPeekDelegate: AnyObject {
     func tabPeekDidCopyUrl()
 }
 
-class LegacyTabPeekPreviewActionBuilder {
-    private var actions = [UIPreviewActionItem]()
-
-    var count: Int {
-        return actions.count
-    }
-
-    func addBookmark(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
-        actions.append(UIPreviewAction(
-            title: .TabPeekAddToBookmarks,
-            style: .default,
-            handler: handler
-        ))
-    }
-
-    func addSendToDeviceTitle(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
-        actions.append(UIPreviewAction(
-            title: .AppMenu.TouchActions.SendToDeviceTitle,
-            style: .default,
-            handler: handler
-        ))
-    }
-
-    func addCopyUrl(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
-        actions.append(UIPreviewAction(
-            title: .TabPeekCopyUrl,
-            style: .default,
-            handler: handler
-        ))
-    }
-
-    func addCloseTab(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
-        actions.append(UIPreviewAction(
-            title: .TabPeekCloseTab,
-            style: .destructive,
-            handler: handler
-        ))
-    }
-
-    func build() -> [UIPreviewActionItem] {
-        return actions
-    }
-}
-
 class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
     weak var tab: Tab?
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -82,13 +82,10 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
         let isHomeTab = self.tab?.isFxHomeTab ?? false
         if !self.ignoreURL && !urlIsTooLongToSave {
             if !self.isBookmarked && !isHomeTab {
-                actions.append(UIPreviewAction(
-                    title: .TabPeekAddToBookmarks,
-                    style: .default
-                ) { [weak self] previewAction, viewController in
+                actionsBuilder.addBookmark { [weak self] previewAction, viewController in
                     guard let wself = self, let tab = wself.tab else { return }
                     wself.delegate?.tabPeekDidAddBookmark(tab)
-                })
+                }
             }
             if self.hasRemoteClients {
                 actions.append(UIPreviewAction(

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -20,6 +20,10 @@ protocol LegacyTabPeekDelegate: AnyObject {
 class PreviewActionBuilder {
     private var actions = [UIPreviewActionItem]()
 
+    var count: Int {
+        return actions.count
+    }
+
     func addBookmark(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
         actions.append(UIPreviewAction(
             title: .TabPeekAddToBookmarks,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -51,6 +51,10 @@ class PreviewActionBuilder {
             handler: handler
         ))
     }
+
+    func build() -> [UIPreviewActionItem] {
+        return actions
+    }
 }
 
 class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -109,7 +109,7 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
             wself.delegate?.tabPeekDidCloseTab(tab)
         }
 
-        return actions
+        return actionsBuilder.build()
     }()
 
     func contextActions(defaultActions: [UIMenuElement]) -> UIMenu {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -17,6 +17,9 @@ protocol LegacyTabPeekDelegate: AnyObject {
     func tabPeekDidCopyUrl()
 }
 
+class PreviewActionBuilder {
+}
+
 class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
     weak var tab: Tab?
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -75,6 +75,7 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
     override var previewActionItems: [UIPreviewActionItem] { return previewActions }
 
     lazy var previewActions: [UIPreviewActionItem] = {
+        let actionsBuilder = PreviewActionBuilder()
         var actions = [UIPreviewActionItem]()
 
         let urlIsTooLongToSave = self.tab?.urlIsTooLong ?? false

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -96,15 +96,12 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
             // only add the copy URL action if we don't already have 3 items in our list
             // as we are only allowed 4 in total and we always want to display close tab
             if actions.count < 3 {
-                actions.append(UIPreviewAction(
-                    title: .TabPeekCopyUrl,
-                    style: .default
-                ) { [weak self] previewAction, viewController in
+                actionsBuilder.addCopyUrl { [weak self] previewAction, viewController in
                     guard let wself = self, let url = wself.tab?.canonicalURL else { return }
 
                     UIPasteboard.general.url = url
                     wself.delegate?.tabPeekDidCopyUrl()
-                })
+                }
             }
         }
         actions.append(UIPreviewAction(

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -99,7 +99,7 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
             }
             // only add the copy URL action if we don't already have 3 items in our list
             // as we are only allowed 4 in total and we always want to display close tab
-            if actions.count < 3 {
+            if actionsBuilder.count < 3 {
                 actionsBuilder.addCopyUrl { [weak self] previewAction, viewController in
                     guard let wself = self, let url = wself.tab?.canonicalURL else { return }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -35,6 +35,14 @@ class PreviewActionBuilder {
             handler: handler
         ))
     }
+
+    func addCopyUrl(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
+        actions.append(UIPreviewAction(
+            title: .TabPeekCopyUrl,
+            style: .default,
+            handler: handler
+        ))
+    }
 }
 
 class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -43,6 +43,14 @@ class PreviewActionBuilder {
             handler: handler
         ))
     }
+
+    func addCloseTab(handler: @escaping (UIPreviewAction, UIViewController) -> Void) {
+        actions.append(UIPreviewAction(
+            title: .TabPeekCloseTab,
+            style: .destructive,
+            handler: handler
+        ))
+    }
 }
 
 class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -18,6 +18,7 @@ protocol LegacyTabPeekDelegate: AnyObject {
 }
 
 class PreviewActionBuilder {
+    private var actions = [UIPreviewActionItem]()
 }
 
 class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabPeekViewController.swift
@@ -80,7 +80,6 @@ class LegacyTabPeekViewController: UIViewController, WKNavigationDelegate {
 
     lazy var previewActions: [UIPreviewActionItem] = {
         let actionsBuilder = PreviewActionBuilder()
-        var actions = [UIPreviewActionItem]()
 
         let urlIsTooLongToSave = self.tab?.urlIsTooLong ?? false
         let isHomeTab = self.tab?.isFxHomeTab ?? false

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+final class LegacyTabPeekPreviewActionBuilderTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
@@ -51,4 +51,15 @@ final class LegacyTabPeekPreviewActionBuilderTests: XCTestCase {
         let action = builder.build().first ?? UIPreviewAction()
         XCTAssertEqual(action.title, String.TabPeekCloseTab)
     }
+
+    func test_build_afterAddedAllActions_shouldContains4Actions() {
+        builder.addBookmark { _, __ in }
+        builder.addSendToDeviceTitle { _, __ in }
+        builder.addCopyUrl { _, __ in }
+        builder.addCloseTab { _, __ in }
+
+        let actions = builder.build()
+
+        XCTAssertEqual(actions.count, 4)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
@@ -37,4 +37,11 @@ final class LegacyTabPeekPreviewActionBuilderTests: XCTestCase {
         let action = builder.build().first ?? UIPreviewAction()
         XCTAssertEqual(action.title, String.AppMenu.TouchActions.SendToDeviceTitle)
     }
+
+    func test_addCopyUrl_afterAdded_shouldContainsInActions() {
+        builder.addCopyUrl { _, __ in }
+
+        let action = builder.build().first ?? UIPreviewAction()
+        XCTAssertEqual(action.title, String.TabPeekCopyUrl)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
@@ -3,15 +3,18 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+@testable import Client
 
 final class LegacyTabPeekPreviewActionBuilderTests: XCTestCase {
+    var builder: LegacyTabPeekPreviewActionBuilder!
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    override func setUp() {
+        super.setUp()
+        builder = LegacyTabPeekPreviewActionBuilder()
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    override func tearDown() {
+        super.tearDown()
+        builder = nil
     }
-
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
@@ -44,4 +44,11 @@ final class LegacyTabPeekPreviewActionBuilderTests: XCTestCase {
         let action = builder.build().first ?? UIPreviewAction()
         XCTAssertEqual(action.title, String.TabPeekCopyUrl)
     }
+
+    func test_addCloseTab_afterAdded_shouldContainsInActions() {
+        builder.addCloseTab { _, __ in }
+
+        let action = builder.build().first ?? UIPreviewAction()
+        XCTAssertEqual(action.title, String.TabPeekCloseTab)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
@@ -23,4 +23,11 @@ final class LegacyTabPeekPreviewActionBuilderTests: XCTestCase {
 
         XCTAssertEqual(result, 0)
     }
+
+    func test_addBookmark_afterAdded_shouldContainsInActions() {
+        builder.addBookmark { _, __ in }
+
+        let action = builder.build().first ?? UIPreviewAction()
+        XCTAssertEqual(action.title, String.TabPeekAddToBookmarks)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
@@ -14,19 +14,4 @@ final class LegacyTabPeekPreviewActionBuilderTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
@@ -30,4 +30,11 @@ final class LegacyTabPeekPreviewActionBuilderTests: XCTestCase {
         let action = builder.build().first ?? UIPreviewAction()
         XCTAssertEqual(action.title, String.TabPeekAddToBookmarks)
     }
+
+    func test_addSendToDeviceTitle_afterAdded_shouldContainsInActions() {
+        builder.addSendToDeviceTitle { _, __ in }
+
+        let action = builder.build().first ?? UIPreviewAction()
+        XCTAssertEqual(action.title, String.AppMenu.TouchActions.SendToDeviceTitle)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Tabs/Legacy/LegacyTabPeekPreviewActionBuilderTests.swift
@@ -17,4 +17,10 @@ final class LegacyTabPeekPreviewActionBuilderTests: XCTestCase {
         super.tearDown()
         builder = nil
     }
+
+    func test_count_afterBuilderIsInstantiated_shouldBeZero() {
+        let result = builder.count
+
+        XCTAssertEqual(result, 0)
+    }
 }

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -5,7 +5,7 @@ set -e
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
 THRESHOLD_UNIT_TEST=9
-THRESHOLD_XCUITEST=18
+THRESHOLD_XCUITEST=21
 
 WARNING_COUNT=$(grep -E -v "SourcePackages/checkouts" "$BUILD_LOG_FILE" | grep -E "(^|:)[0-9]+:[0-9]+:|warning:|ld: warning:|<unknown>:0: warning:|fatal|===" | uniq | wc -l)
 

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -5,7 +5,7 @@ set -e
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
 THRESHOLD_UNIT_TEST=9
-THRESHOLD_XCUITEST=14
+THRESHOLD_XCUITEST=18
 
 WARNING_COUNT=$(grep -E -v "SourcePackages/checkouts" "$BUILD_LOG_FILE" | grep -E "(^|:)[0-9]+:[0-9]+:|warning:|ld: warning:|<unknown>:0: warning:|fatal|===" | uniq | wc -l)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `LegacyTabPeekViewController.swift` file. 

I've created a builder to build the actions inside the view controller, and simple unit tests for it.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

