### PR TITLE
Bugfix FXIOS-9454 ⁃ Scrolling when in "find in page" mode causes the address bar to open

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
@@ -13,6 +13,7 @@ extension BrowserViewController {
         } else {
             useCustomFindInteraction(isVisible: isVisible, tab: tab)
         }
+        tabManager.selectedTab?.isFindInPageMode = isVisible && isBottomSearchBar
     }
 
     @available(iOS 16, *)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1107,7 +1107,11 @@ class BrowserViewController: UIViewController,
             adjustBottomContentStackView(remake)
         }
 
-        adjustBottomSearchBarForKeyboard()
+        if let tab = tabManager.selectedTab, tab.isFindInPageMode {
+            scrollController.hideToolbars(animated: true, isFindInPageMode: true)
+        } else {
+            adjustBottomSearchBarForKeyboard()
+        }
     }
 
     private func adjustBottomContentStackView(_ remake: ConstraintMaker) {
@@ -3622,6 +3626,11 @@ extension BrowserViewController: KeyboardHelperDelegate {
             })
 
         finishEditionMode()
+    }
+
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidHideWithState state: KeyboardState) {
+        tabManager.selectedTab?.setFindInPage(isBottomSearchBar: isBottomSearchBar,
+                                              doesFindInPageBarExist: findInPageBar != nil)
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillChangeWithState state: KeyboardState) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -529,8 +529,10 @@ class BrowserViewController: UIViewController,
                 self.view.sendSubviewToBack(self.webViewContainerBackdrop)
             })
 
-        // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)
-        scrollController.showToolbars(animated: false)
+        if let tab = tabManager.selectedTab, !tab.isFindInPageMode {
+            // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)
+            scrollController.showToolbars(animated: false)
+        }
 
         browserDidBecomeActive()
     }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -127,6 +127,7 @@ class Tab: NSObject, ThemeApplicable {
     var adsProviderName: String = ""
     var hasHomeScreenshot = false
     var shouldScrollToTop = false
+    var isFindInPageMode = false
 
     private var logger: Logger
 
@@ -769,6 +770,16 @@ class Tab: NSObject, ThemeApplicable {
 
     func expireSnackbars(withClass snackbarClass: String) {
         bars.reversed().filter({ $0.snackbarClassIdentifier == snackbarClass }).forEach({ removeSnackbar($0) })
+    }
+
+    func setFindInPage(isBottomSearchBar: Bool, doesFindInPageBarExist: Bool) {
+        if #available(iOS 16, *) {
+            guard let webView = self.webView,
+                  let findInteraction = webView.findInteraction else { return }
+            isFindInPageMode = findInteraction.isFindNavigatorVisible && isBottomSearchBar
+        } else {
+            isFindInPageMode = doesFindInPageBarExist && isBottomSearchBar
+        }
     }
 
     func setScreenshot(_ screenshot: UIImage?) {

--- a/firefox-ios/Shared/KeyboardHelper.swift
+++ b/firefox-ios/Shared/KeyboardHelper.swift
@@ -46,12 +46,14 @@ public protocol KeyboardHelperDelegate: AnyObject {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState)
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillChangeWithState state: KeyboardState)
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidChangeWithState state: KeyboardState)
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidHideWithState state: KeyboardState)
 }
 
 public extension KeyboardHelperDelegate {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {}
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillChangeWithState state: KeyboardState) {}
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidChangeWithState state: KeyboardState) {}
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidHideWithState state: KeyboardState) {}
 }
 
 /**
@@ -89,6 +91,12 @@ open class KeyboardHelper: NSObject {
             self,
             selector: #selector(keyboardWillHide),
             name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardDidHide),
+            name: UIResponder.keyboardDidHideNotification,
             object: nil
         )
         NotificationCenter.default.addObserver(
@@ -149,6 +157,16 @@ open class KeyboardHelper: NSObject {
             for weakDelegate in delegates {
                 weakDelegate.delegate?.keyboardHelper(self,
                                                       keyboardWillHideWithState: KeyboardState(userInfo))
+            }
+        }
+    }
+
+    @objc
+    private func keyboardDidHide(_ notification: Notification) {
+        if let userInfo = notification.userInfo {
+            for weakDelegate in delegates {
+                weakDelegate.delegate?.keyboardHelper(self,
+                                                      keyboardDidHideWithState: KeyboardState(userInfo))
             }
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9454)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20928)

## :bulb: Description
Hide Address Bar when Find In Page mode is activated but only if the Toolbar position is on the bottom.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

