### PR TITLE
Refactor FXIOS-9382 - Update Fonts related to Wallpaper to use FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -36,7 +36,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
     }
 
     private lazy var instructionLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.font = FXFontStyles.Regular.caption1.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.text = .Onboarding.Wallpaper.SelectorDescription
         label.textAlignment = .center

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -27,8 +27,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
     private var collectionViewHeightConstraint: NSLayoutConstraint!
 
     private lazy var headerLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .headline,
-                                                            size: 17)
+        label.font = FXFontStyles.Regular.headline.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.text = .Onboarding.Wallpaper.SelectorTitle
         label.textAlignment = .center
@@ -37,8 +36,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
     }
 
     private lazy var instructionLabel: UILabel = .build { label in
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body,
-                                                            size: 12)
+        label.font = FXFontStyles.Regular.body.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.text = .Onboarding.Wallpaper.SelectorDescription
         label.textAlignment = .center


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9382)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20770)

## :bulb: Description
This PR replaces the usage of DefaultDynamicFontHelper with FXFontStyles for `WallpaperSelectorViewController`.

Before:
<img src="https://github.com/user-attachments/assets/40605296-1161-483c-b50a-932717c84c10" width="300">

After:
<img src="https://github.com/user-attachments/assets/9d3ae35f-c33b-4b65-ad77-1a5ad2ded586" width="300">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

