### PR TITLE
Improve MTE-3192 smoke tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -168,7 +168,7 @@ class CreditCardsTests: BaseTestCase {
             waitForExistence(app.buttons["Done"])
             app.buttons["Done"].tap()
             app.swipeUp()
-            mozWaitForElementToExist(app.webViews["contentView"].webViews.staticTexts["Explore Checkout"])
+            mozWaitForElementToExist(app.webViews["contentView"].webViews.staticTexts["Explore Checkout"], timeout: TIMEOUT)
             mozWaitForElementToExist(cardNumber)
             cardNumber.tapOnApp()
             // The autofill option (Use saved card prompt) is displayed

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -373,8 +373,7 @@ class NavigationTest: BaseTestCase {
 
         mozWaitForElementToExist(app.links["Visit site anyway"])
         app.links["Visit site anyway"].tap()
-        mozWaitForElementToExist(app.webViews.otherElements["expired.badssl.com"], timeout: TIMEOUT)
-        XCTAssertTrue(app.webViews.otherElements["expired.badssl.com"].exists)
+        mozWaitForElementToExist(app.webViews.otherElements["expired.badssl.com"], timeout: TIMEOUT_LONG)
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307022


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3192

## :bulb: Description
Attempt to improve testAutofillCreditCardsToggleOnOoff and testSSL smoke tests that are failing occasionally on our bitrise runs
