### PR TITLE
Bugfix FXIOS-9635 [Microsurvey] Address a11y bugs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1338,7 +1338,11 @@ class BrowserViewController: UIViewController,
     }
 
     private func createMicrosurveyPrompt(with state: MicrosurveyPromptState) {
-        self.microsurvey = MicrosurveyPromptView(state: state, windowUUID: windowUUID)
+        self.microsurvey = MicrosurveyPromptView(
+            state: state,
+            windowUUID: windowUUID,
+            inOverlayMode: overlayManager.inOverlayMode
+        )
         updateMicrosurveyConstraints()
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -72,6 +72,7 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
         label.adjustsFontForContentSizeCategory = true
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
+        label.accessibilityTraits.insert(.header)
     }
 
     private lazy var closeButton: CloseButton = .build { button in

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -112,7 +112,8 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
     init(
         state: MicrosurveyPromptState,
         windowUUID: WindowUUID,
-        notificationCenter: NotificationProtocol = NotificationCenter.default
+        notificationCenter: NotificationProtocol = NotificationCenter.default,
+        inOverlayMode: Bool = false
     ) {
         self.windowUUID = windowUUID
         self.notificationCenter = notificationCenter
@@ -121,6 +122,7 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
                            observing: [.DynamicFontChanged])
         configure(with: state)
         setupView()
+        guard !inOverlayMode else { return }
         UIAccessibility.post(notification: .layoutChanged, argument: titleLabel)
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyTableViewCell.swift
@@ -60,12 +60,16 @@ final class MicrosurveyTableViewCell: UITableViewCell, ReusableCell, ThemeApplic
     }
 
     var optionA11yValue: String {
-        let selectedLabel: String = .Microsurvey.Survey.SelectedRadioButtonAccessibilityLabel
         let unselectedLabel: String = .Microsurvey.Survey.UnselectedRadioButtonAccessibilityLabel
 
-        var a11yValue = checked ? selectedLabel : unselectedLabel
-        if let a11yOptionsOrderValue {
-            a11yValue.append(", \(a11yOptionsOrderValue)")
+        // This check is due to the selected option having a system trait to read out selected
+        // However, there is no system trait for unselected
+        let a11yValue: String
+        let order = a11yOptionsOrderValue ?? ""
+        if checked {
+            a11yValue = order
+        } else {
+            a11yValue = unselectedLabel + ", \(order)"
         }
         return a11yValue
     }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -179,12 +179,16 @@ final class MicrosurveyViewController: UIViewController,
         applyTheme()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        UIAccessibility.post(notification: .screenChanged, argument: String.Microsurvey.Survey.SurveyA11yLabel)
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         store.dispatch(
             MicrosurveyAction(surveyId: model.id, windowUUID: windowUUID, actionType: MicrosurveyActionType.surveyDidAppear)
         )
-        UIAccessibility.post(notification: .screenChanged, argument: nil)
     }
 
     deinit {

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1376,6 +1376,11 @@ extension String {
         }
 
         public struct Survey {
+            public static let SurveyA11yLabel = MZLocalizedString(
+                key: "Microsurvey.Survey.Sheet.AccessibilityLabel.v130",
+                tableName: "Microsurvey",
+                value: "Survey",
+                comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label used to announce that the sheet has appeared.")
             public static let LogoImageA11yLabel = MZLocalizedString(
                 key: "Microsurvey.Survey.LogoImage.AccessibilityLabel.v129",
                 tableName: "Microsurvey",
@@ -1391,11 +1396,6 @@ extension String {
                 tableName: "Microsurvey",
                 value: "Close",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label for close button that dismisses the sheet.")
-            public static let SelectedRadioButtonAccessibilityLabel = MZLocalizedString(
-                key: "Microsurvey.Survey.RadioButton.Selected.AccessibilityLabel.v129",
-                tableName: "Microsurvey",
-                value: "Selected",
-                comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states whether the survey option was selected.")
             public static let UnselectedRadioButtonAccessibilityLabel = MZLocalizedString(
                 key: "Microsurvey.Survey.RadioButton.Unselected.AccessibilityLabel.v129",
                 tableName: "Microsurvey",
@@ -6611,6 +6611,14 @@ extension String {
                 tableName: "EnhancedTrackingProtection",
                 value: "Protections are OFF. We suggest turning it back on.",
                 comment: "A switch to disable enhanced tracking protection inside the menu.")
+        }
+
+        struct v130 {
+            public static let SelectedRadioButtonAccessibilityLabel = MZLocalizedString(
+                key: "Microsurvey.Survey.RadioButton.Selected.AccessibilityLabel.v129",
+                tableName: "Microsurvey",
+                value: "Selected",
+                comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states whether the survey option was selected.")
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -52,6 +52,15 @@ final class MicrosurveyTests: BaseTestCase {
 
         XCTAssertTrue(app.images[AccessibilityIdentifiers.Microsurvey.Survey.firefoxLogo].exists)
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Survey.closeButton].exists)
+        let tablesQuery = app.scrollViews.otherElements.tables
+        let firstOption = tablesQuery.cells.firstMatch
+        firstOption.tap()
+        XCTAssertEqual(firstOption.label, "Very satisfied")
+        XCTAssertEqual(firstOption.value as? String, "1 out of 6")
+
+        let secondOption = tablesQuery.cells["Neutral"]
+        XCTAssertEqual(secondOption.label, "Neutral")
+        XCTAssertEqual(secondOption.value as? String, "Unselected, 3 out of 6")
     }
 
     func testCloseButtonDismissesSurveyAndPrompt() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -55,7 +55,9 @@ final class MicrosurveyTests: BaseTestCase {
         let tablesQuery = app.scrollViews.otherElements.tables
         let firstOption = tablesQuery.cells.firstMatch
         firstOption.tap()
+        mozWaitForElementToExist(firstOption)
         XCTAssertEqual(firstOption.label, "Very satisfied")
+        mozWaitForValueToContains(firstOption, "1 out of 6")
         XCTAssertEqual(firstOption.value as? String, "1 out of 6")
 
         let secondOption = tablesQuery.cells["Neutral"]

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -57,14 +57,12 @@ final class MicrosurveyTests: BaseTestCase {
         firstOption.tap()
         mozWaitForElementToExist(firstOption)
         XCTAssertEqual(firstOption.label, "Very satisfied")
-        mozWaitForValueToContains(firstOption, "1 out of 6")
-        XCTAssertEqual(firstOption.value as? String, "1 out of 6")
+        mozWaitForValueContains(firstOption, value: "1 out of 6")
 
         let secondOption = tablesQuery.cells["Neutral"]
         mozWaitForElementToExist(secondOption)
-        XCTAssertEqual(secondOption.label, "Neutral)
-        mozWaitForValueToContains(secondOption, "Unselected, 3 out of 6")
-        XCTAssertEqual(secondOption.value as? String, "Unselected, 3 out of 6")
+        XCTAssertEqual(secondOption.label, "Neutral")
+        mozWaitForValueContains(secondOption, value: "Unselected, 3 out of 6")
     }
 
     func testCloseButtonDismissesSurveyAndPrompt() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -61,7 +61,9 @@ final class MicrosurveyTests: BaseTestCase {
         XCTAssertEqual(firstOption.value as? String, "1 out of 6")
 
         let secondOption = tablesQuery.cells["Neutral"]
-        XCTAssertEqual(secondOption.label, "Neutral")
+        mozWaitForElementToExist(secondOption)
+        XCTAssertEqual(secondOption.label, "Neutral)
+        mozWaitForValueToContains(secondOption, "Unselected, 3 out of 6")
         XCTAssertEqual(secondOption.value as? String, "Unselected, 3 out of 6")
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Microsurvey is not scrolled into view when it opens](https://mozilla-hub.atlassian.net/browse/FXIOS-9635)
[Microsurvey's sheet is not communicating its group label](https://mozilla-hub.atlassian.net/browse/FXIOS-9622)
[Microsurvey invitation section does not mark its heading programmatically](https://mozilla-hub.atlassian.net/browse/FXIOS-9616)
[Selected radio button in the answer options duplicates `selected` state as a part of its accessible label](https://mozilla-hub.atlassian.net/browse/FXIOS-9634)

[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21233)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21219)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21214)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21231)

## :bulb: Description
Address a11y bugs found with a11y review for microsurvey. Only one blocker, which is FXIOS-9635. Since they were in the same area, I decided to include them in this PR. 
- Avoid announcing layout changed if overlay mode
- Add group label to screen changed announcement
- Add heading trait to the prompt
- Update accessibility value for selected to use system instead of using custom text (also included tests)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)