### PR TITLE
Bugfix FXIOS-9662 Remove extraneous UUID / window tab files, log error on iPhones

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -24,7 +24,7 @@ public protocol TabDataStore {
     /// preferable when only the UUIDs are needed.
     /// - Returns: a list of UUIDs for any saved WindowData.
     func fetchWindowDataUUIDs() -> [WindowUUID]
-    
+
     /// Erases the on-disk data for tab windows matching the provided UUIDs.
     /// - Parameter forUUIDs: the UUIDs to delete the on-disk tab files for.
     func removeWindowData(forUUIDs: [WindowUUID]) async

--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -23,7 +23,11 @@ public protocol TabDataStore {
     /// saved files in the directory) it is faster than fetchWindowData() and is
     /// preferable when only the UUIDs are needed.
     /// - Returns: a list of UUIDs for any saved WindowData.
-    func fetchWindowDataUUIDs() -> [UUID]
+    func fetchWindowDataUUIDs() -> [WindowUUID]
+    
+    /// Erases the on-disk data for tab windows matching the provided UUIDs.
+    /// - Parameter forUUIDs: the UUIDs to delete the on-disk tab files for.
+    func removeWindowData(forUUIDs: [WindowUUID]) async
 }
 
 public actor DefaultTabDataStore: TabDataStore {
@@ -117,7 +121,7 @@ public actor DefaultTabDataStore: TabDataStore {
         }
     }
 
-    nonisolated public func fetchWindowDataUUIDs() -> [UUID] {
+    nonisolated public func fetchWindowDataUUIDs() -> [WindowUUID] {
         guard let directoryURL = fileManager.windowDataDirectory(isBackup: false) else {
             logger.log("Could not resolve window data directory", level: .warning, category: .tabs)
             return []
@@ -125,12 +129,7 @@ public actor DefaultTabDataStore: TabDataStore {
 
         let fileURLs = fileManager.contentsOfDirectory(at: directoryURL)
 
-        return fileURLs.compactMap {
-            let file = $0.lastPathComponent
-            guard file.hasPrefix(filePrefix) else { return nil }
-            let uuidString = String(file.dropFirst(filePrefix.count))
-            return UUID(uuidString: uuidString)
-        }
+        return fileURLs.compactMap { windowUUID(fromURL: $0) }
     }
 
     private func parseWindowDataFile(fromURL url: URL) -> WindowData? {
@@ -226,11 +225,38 @@ public actor DefaultTabDataStore: TabDataStore {
         fileManager.removeAllFilesAt(directory: backupURL)
     }
 
+    public func removeWindowData(forUUIDs uuids: [WindowUUID]) async {
+        guard let directoryURL = fileManager.windowDataDirectory(isBackup: false) else { return }
+
+        let fileURLs = fileManager.contentsOfDirectory(at: directoryURL)
+
+        for url in fileURLs {
+            guard let uuid = windowUUID(fromURL: url) else { continue }
+            guard uuids.contains(where: { $0 == uuid }) else {
+                logger.log("Will not remove window data for UUID: \(uuid)", level: .info, category: .tabs)
+                continue
+            }
+            logger.log("Removing window data for UUID: \(uuid)", level: .info, category: .tabs)
+            fileManager.removeFileAt(path: url)
+        }
+    }
+
     // MARK: - URL Utils
 
     private func windowURLPath(for windowID: UUID, isBackup: Bool) -> URL? {
         guard let baseURL = fileManager.windowDataDirectory(isBackup: isBackup) else { return nil }
         let baseFilePath = filePrefix + windowID.uuidString
         return baseURL.appendingPathComponent(baseFilePath)
+    }
+
+    /// For a URL that points to a window tab data file, returns the associated UUID
+    /// for that window based on the file name.
+    /// - Parameter url: the URL to parse.
+    /// - Returns: a window UUID or nil if the URL was invalid.
+    private nonisolated func windowUUID(fromURL url: URL) -> WindowUUID? {
+        let file = url.lastPathComponent
+        guard file.hasPrefix(filePrefix) else { return nil }
+        let uuidString = String(file.dropFirst(filePrefix.count))
+        return WindowUUID(uuidString: uuidString)
     }
 }

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -179,6 +179,7 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         guard !AppConstants.isRunningUITests else {
             return ReservedWindowUUID(uuid: WindowUUID.DefaultUITestingUUID, isNew: false)
         }
+        assert(Thread.isMainThread, "Window UUID configuration currently expected on main thread only.")
 
         // • If no saved windows (tab data), we generate a new UUID.
         // • If user has saved windows (tab data), we return the first available UUID
@@ -208,12 +209,25 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         let result: ReservedWindowUUID
         // TODO: [9610] Unit tests should eventually be updated for these changes. Forthcoming.
         if !isIpad && !AppConstants.isRunningUnitTest {
-            // At this point we should always have either a single UUID on disk or
-            // no UUIDs because this is a brand new app install
+            // We should always have either a single UUID on disk or no UUIDs because this is a brand new app install
             if onDiskUUIDs.isEmpty {
                 result = ReservedWindowUUID(uuid: WindowUUID(), isNew: true)
             } else {
                 result = ReservedWindowUUID(uuid: onDiskUUIDs.first!, isNew: false)
+
+                let uuidCount = onDiskUUIDs.count
+                if uuidCount > 1 {
+                    // This is unexpected. Potentially related to incident in v128 (see: FXIOS-9533).
+                    // On iPhone, we should never have more than 1 window tab file. Log an error and
+                    // clean up the UUID(s) that we know won't be used. We expect a certain number of
+                    // these fatal errors to be logged for users previously impacted by the above, and
+                    // then it should fall to zero.
+                    logger.log("Detected multiple window tab files on iPhone (UUID count: \(uuidCount))",
+                               level: .fatal,
+                               category: .window)
+                    let uuidsToDelete = Array(onDiskUUIDs.dropFirst())
+                    Task { await tabDataStore.removeWindowData(forUUIDs: uuidsToDelete) }
+                }
             }
         } else {
             let filteredUUIDs = onDiskUUIDs.filter {

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -217,7 +217,7 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
 
                 let uuidCount = onDiskUUIDs.count
                 if uuidCount > 1 {
-                    // This is unexpected. Potentially related to incident in v128 (see: FXIOS-9533).
+                    // This is unexpected. Potentially related to incident in v128 (see: FXIOS-9516).
                     // On iPhone, we should never have more than 1 window tab file. Log an error and
                     // clean up the UUID(s) that we know won't be used. We expect a certain number of
                     // these fatal errors to be logged for users previously impacted by the above, and

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabDataStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabDataStore.swift
@@ -4,12 +4,15 @@
 
 import Foundation
 import TabDataStore
+import Common
 
 class MockTabDataStore: TabDataStore {
     var fetchWindowDataCalledCount = 0
     var saveWindowDataCalledCount = 0
     var fetchTabWindowData: WindowData?
     var saveWindowData: WindowData?
+    var clearAllWindowsDataCalled = 0
+    var removeWindowDataCalled = 0
     private var persistedTabWindowUUIDs: [UUID] = []
 
     func fetchWindowDataUUIDs() -> [UUID] {
@@ -26,7 +29,13 @@ class MockTabDataStore: TabDataStore {
         saveWindowData = window
     }
 
-    func clearAllWindowsData() async {}
+    func clearAllWindowsData() async {
+        clearAllWindowsDataCalled += 1
+    }
+
+    func removeWindowData(forUUIDs: [WindowUUID]) async {
+        removeWindowDataCalled += 1
+    }
 }
 
 // Utilities for mocking available tab window UUIDs in unit tests.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9662)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21266)

## :bulb: Description

Related to the Sentry log error incident from 7/17. If we detect more than 1 window tab file on iPhone devices, log a new error and clean up the unused window tab files.

### Unit Tests

To keep the diff clean I'm waiting to update some related mocks/unit tests for the protocol addition until PR is approved, but that will be forthcoming soon.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

