### PR TITLE
Refactor FXIOS-9392  Update colors for tab strip on iPad

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -764,7 +764,7 @@ extension LegacyTabDisplayManager: UICollectionViewDropDelegate {
         let previewParams = UIDragPreviewParameters()
 
         let path = UIBezierPath(
-            roundedRect: cell.selectedBackground.frame,
+            roundedRect: cell.cellBackground.frame,
             cornerRadius: TopTabsUX.TabCornerRadius
         )
         previewParams.visiblePath = path

--- a/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabCell.swift
@@ -36,7 +36,7 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, LegacyTabTrayCell, Reus
     weak var delegate: TopTabCellDelegate?
 
     // MARK: - UI Elements
-    let selectedBackground: UIView = .build { view in
+    let cellBackground: UIView = .build { view in
         view.clipsToBounds = false
         view.layer.cornerRadius = UX.tabCornerRadius
         view.layer.shadowRadius = UX.shadowRadius
@@ -124,9 +124,9 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, LegacyTabTrayCell, Reus
 
         let isToolbarRefactorEnabled = featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
         let backgroundColor = isToolbarRefactorEnabled ? colors.actionTabActive : colors.layer2
-        selectedBackground.backgroundColor = backgroundColor
-        selectedBackground.layer.shadowColor = colors.shadowDefault.cgColor
-        selectedBackground.isHidden = false
+        cellBackground.backgroundColor = backgroundColor
+        cellBackground.layer.shadowColor = colors.shadowDefault.cgColor
+        cellBackground.isHidden = false
     }
 
     func applyUnselectedStyle(theme: Theme) {
@@ -136,10 +136,9 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, LegacyTabTrayCell, Reus
         closeButton.tintColor = colors.textPrimary
 
         let isToolbarRefactorEnabled = featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
-        let backgroundColor = isToolbarRefactorEnabled ? colors.actionTabInactive : .clear
-        selectedBackground.backgroundColor = backgroundColor
-        selectedBackground.layer.shadowColor = UIColor.clear.cgColor
-        selectedBackground.isHidden = isToolbarRefactorEnabled ? false : true
+        cellBackground.backgroundColor = isToolbarRefactorEnabled ? colors.actionTabInactive : .clear
+        cellBackground.layer.shadowColor = UIColor.clear.cgColor
+        cellBackground.isHidden = isToolbarRefactorEnabled ? false : true
     }
 
     func applyTheme(theme: Theme) {
@@ -151,17 +150,17 @@ class TopTabCell: UICollectionViewCell, ThemeApplicable, LegacyTabTrayCell, Reus
     }
 
     private func setupLayout() {
-        addSubviews(selectedBackground, titleText, closeButton, favicon)
+        addSubviews(cellBackground, titleText, closeButton, favicon)
 
         NSLayoutConstraint.activate(
             [
-                selectedBackground.widthAnchor.constraint(equalTo: widthAnchor),
-                selectedBackground.heightAnchor.constraint(
+                cellBackground.widthAnchor.constraint(equalTo: widthAnchor),
+                cellBackground.heightAnchor.constraint(
                     equalTo: heightAnchor,
                     multiplier: UX.backgroundHeightMultiplier
                 ),
-                selectedBackground.centerXAnchor.constraint(equalTo: centerXAnchor),
-                selectedBackground.centerYAnchor.constraint(equalTo: centerYAnchor),
+                cellBackground.centerXAnchor.constraint(equalTo: centerXAnchor),
+                cellBackground.centerYAnchor.constraint(equalTo: centerYAnchor),
 
                 favicon.centerYAnchor.constraint(equalTo: centerYAnchor, constant: UX.tabNudge),
                 favicon.widthAnchor.constraint(equalToConstant: UX.faviconSize),

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -185,8 +185,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
         let currentTheme = themeManager.getCurrentTheme(for: windowUUID)
         let colors = currentTheme.colors
 
-        let isToolbarRefactorEnabled = featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
-        view.backgroundColor = isToolbarRefactorEnabled ? colors.layer1 : colors.layer3
+        view.backgroundColor = colors.layer3
         tabsButton.applyTheme(theme: currentTheme)
         privateModeButton.applyTheme(theme: currentTheme)
         newTab.tintColor = colors.iconPrimary

--- a/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
@@ -71,7 +71,6 @@ class StatusBarOverlay: UIView,
     // MARK: - ThemeApplicable
 
     func applyTheme(theme: Theme) {
-        let isToolbarRefactorEnabled = featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
         savedBackgroundColor = hasTopTabs ? theme.colors.layer3 : theme.colors.layer1
         backgroundColor = savedBackgroundColor?.withAlphaComponent(scrollOffset)
     }

--- a/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
@@ -72,8 +72,7 @@ class StatusBarOverlay: UIView,
 
     func applyTheme(theme: Theme) {
         let isToolbarRefactorEnabled = featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
-        let topTabsColor = isToolbarRefactorEnabled ? theme.colors.layer1 : theme.colors.layer3
-        savedBackgroundColor = hasTopTabs ? topTabsColor : theme.colors.layer1
+        savedBackgroundColor = hasTopTabs ? theme.colors.layer3 : theme.colors.layer1
         backgroundColor = savedBackgroundColor?.withAlphaComponent(scrollOffset)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9392)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20799)

## :bulb: Description
This PR updates the color of the selected/unselected tabs on iPad as well as the tab strip and status bar overlay.

![New Enabled](https://github.com/user-attachments/assets/6ff2890a-969f-4272-92d9-416b5ab65df6)

![simulator_screenshot_0B1F1DF7-D75F-447A-A8DB-2C78A1ABC012](https://github.com/user-attachments/assets/0c9a3fbf-beaf-490a-869c-c831c2bd5bd5)

![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-07-25 at 17 07 04](https://github.com/user-attachments/assets/3fe36188-8a4c-493b-9dc8-dd195eeb7f80)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

