### PR TITLE
Bugfix FXIOS-9631 Conditionally show "Show More" button on website data management table

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -165,7 +165,6 @@ class WebsiteDataManagementViewController: UIViewController,
             return cell
         case .showMore:
             let cell = dequeueCellFor(indexPath: indexPath)
-            cell.applyTheme(theme: currentTheme())
             let cellType: ThemedTableViewCellType = viewModel.state != .displayAll ? .actionPrimary : .disabled
             let cellViewModel = ThemedTableViewCellViewModel(
                 theme: currentTheme(),
@@ -175,6 +174,7 @@ class WebsiteDataManagementViewController: UIViewController,
             cell.accessibilityTraits = UIAccessibilityTraits.button
             cell.accessibilityIdentifier = "ShowMoreWebsiteData"
             cell.configure(viewModel: cellViewModel)
+            cell.applyTheme(theme: currentTheme())
             showMoreButton = cell
             return cell
         case .clearButton:

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -229,16 +229,16 @@ class WebsiteDataManagementViewController: UIViewController,
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         let section = Section(rawValue: section)!
+        let height = max(self.view.frame.width, self.view.frame.height)
+        let numberOfInitialRecords = height > 667 ? 10 : height > 568 ? 8 : 6
+
         switch section {
         case .sites:
             let numberOfRecords = viewModel.siteRecords.count
-
             // Show either 10, 8 or 6 records initially depending on the screen size.
-            let height = max(self.view.frame.width, self.view.frame.height)
-            let numberOfInitialRecords = height > 667 ? 10 : height > 568 ? 8 : 6
             return viewModel.state == .displayAll ? numberOfRecords: min(numberOfRecords, numberOfInitialRecords)
         case .showMore:
-            return viewModel.state != .displayAll ? 1 : 0
+            return (viewModel.state != .displayAll && viewModel.siteRecords.count > numberOfInitialRecords) ? 1 : 0
         case .clearButton:
             return 1
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9631)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21227)

## :bulb: Description
- Prevent the "Show More" button on the website data management table from showing when there are not more sites to show
- Also fixes the color of the "Show More" text which was sometimes incorrect

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

