### PR TITLE
Bugfix FXIOS-9633 Sign in Mozilla Accounts button

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -510,6 +510,7 @@ public struct AccessibilityIdentifiers {
             static let fxaSignInButton = "EmailSignIn.button"
             static let qrButton = "QRCodeSignIn.button"
             static let qrScanFailedAlertOkButton = "qrCodeAlert.okButton"
+            static let signInButton = "Sign in"
         }
 
         struct Search {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -688,7 +688,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton].tap()
         }
         screenState.gesture(forAction: Action.FxATapOnSignInButton) { userState in
-            app.webViews.buttons.element(boundBy: 0).tap()
+            app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.signInButton].tap()
         }
         screenState.tap(app.webViews.links["Create an account"].firstMatch, to: FxCreateAccount)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9633)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21229)

## :bulb: Description
When we debugged the Mozilla Accounts sign-in page, we saw that a button ("Sign in") now has a label. Without the label, XCUITest can't tap on on the button.

I have run the sync integration tests locally to ensure that the change works for the Mozilla Accounts sign-in page.

Let's continue to monitor any crashes from Sync Integration Tests.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

