### PR TITLE
Bugfix FXIOS-9694 System Find Interactor should always clear between searches (even on the same tab)

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+FindInPage.swift
@@ -22,7 +22,7 @@ extension BrowserViewController {
 
         if isVisible {
             webView.isFindInteractionEnabled = true
-            webView.findInteraction?.searchText = searchText
+            webView.findInteraction?.searchText = searchText ?? ""
             webView.findInteraction?.presentFindNavigator(showingReplace: false)
         } else {
             webView.findInteraction?.dismissFindNavigator()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9694)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21312)

## :bulb: Description
After discussion, the decision with the new iOS 16+ Find Interaction (used for the Find in Page bar) was to disable its default behavior to save the search text after it has been closed and then opened again.

Now, each time the Find in Page bar opens, the text field should be clear.

Find In Page can be opened in 3 ways:
- Go to the menu and select "Find in Page"
- Long press text on a webpage and select "Find in Page" from the menu that appears
- Use the cmd + F keyboard command ('Send keyboard Input to Device' has to be enabled in the sim)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

