### PR TITLE
Add FXIOS-9523 v130 string for toolbar refactor

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -5766,6 +5766,14 @@ extension String {
             tableName: "Toolbar",
             value: "New Tab",
             comment: "Accessibility label for the new tab button that can be displayed in the navigation or address toolbar.")
+        public struct TabToolbarLongPressActionsMenu {
+            public static let CloseThisTabButton = MZLocalizedString(
+                key: "Toolbar.Tab.CloseThisTab.Button.v130",
+                tableName: "Toolbar",
+                value: "Close This Tab",
+                comment: "Label for button on action sheet, accessed via long pressing tab toolbar button, that closes the current tab when pressed"
+            )
+        }
     }
 
     public struct AddressToolbar {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9523)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21080)

## :bulb: Description
- Added "Close This Tab" string for v130 used in long press action sheet of the tab tray button as part of the toolbar redesign. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

