### PR TITLE
Refactor FXIOS-7301 - Help to remove 1 closure_body_length violation from Experiments.swift (2/3)

### DIFF
--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -193,6 +193,26 @@ enum Experiments {
             .build(appInfo: appSettings)
     }()
 
+    fileprivate static func getAppSettings(isFirstRun: Bool) -> NimbusAppSettings {
+        let isPhone = UIDevice.current.userInterfaceIdiom == .phone
+
+        let customTargetingAttributes: [String: Any] =  [
+            "isFirstRun": "\(isFirstRun)",
+            "is_first_run": isFirstRun,
+            "is_phone": isPhone,
+            "is_review_checker_enabled": isReviewCheckerEnabled()
+        ]
+
+        // App settings, to allow experiments to target the app name and the
+        // channel. The values given here should match what `Experimenter`
+        // thinks it is.
+        return NimbusAppSettings(
+            appName: nimbusAppName,
+            channel: AppConstants.buildChannel.nimbusString,
+            customTargetingAttributes: customTargetingAttributes
+        )
+    }
+
     private static func isReviewCheckerEnabled() -> Bool {
         var isReviewCheckerEnabled = false
         if let prefs = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier) {

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -141,24 +141,6 @@ enum Experiments {
             defaults.set(false, forKey: NIMBUS_IS_FIRST_RUN_KEY)
         }
 
-        let isPhone = UIDevice.current.userInterfaceIdiom == .phone
-
-        let customTargetingAttributes: [String: Any] =  [
-            "isFirstRun": "\(isFirstRun)",
-            "is_first_run": isFirstRun,
-            "is_phone": isPhone,
-            "is_review_checker_enabled": isReviewCheckerEnabled()
-        ]
-
-        // App settings, to allow experiments to target the app name and the
-        // channel. The values given here should match what `Experimenter`
-        // thinks it is.
-        let appSettings = NimbusAppSettings(
-            appName: nimbusAppName,
-            channel: AppConstants.buildChannel.nimbusString,
-            customTargetingAttributes: customTargetingAttributes
-        )
-
         let errorReporter: NimbusErrorReporter = { err in
             DefaultLogger.shared.log("Error in Nimbus SDK",
                                      level: .warning,
@@ -190,7 +172,7 @@ enum Experiments {
             .with(bundles: bundles)
             .with(featureManifest: FxNimbus.shared)
             .with(commandLineArgs: CommandLine.arguments)
-            .build(appInfo: appSettings)
+            .build(appInfo: getAppSettings(isFirstRun: isFirstRun))
     }()
 
     fileprivate static func getAppSettings(isFirstRun: Bool) -> NimbusAppSettings {

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -175,7 +175,7 @@ enum Experiments {
             .build(appInfo: getAppSettings(isFirstRun: isFirstRun))
     }()
 
-    fileprivate static func getAppSettings(isFirstRun: Bool) -> NimbusAppSettings {
+    private static func getAppSettings(isFirstRun: Bool) -> NimbusAppSettings {
         let isPhone = UIDevice.current.userInterfaceIdiom == .phone
 
         let customTargetingAttributes: [String: Any] =  [


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR help to remove 1 `closure_body_length` violation from the `Experiments.swift` file. It breaks the `appSettings` logic to a new function.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

