### PR TITLE
Refactor FXIOS-7301 - Help to remove 1 closure_body_length violation from UITestAppDelegate.swift (1/3)

### DIFF
--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -195,7 +195,7 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
         return profile
     }
 
-    fileprivate func configureWebserverPort(_ arg: String) {
+    private func configureWebserverPort(_ arg: String) {
         let portString = arg.replacingOccurrences(of: LaunchArguments.ServerPort, with: "")
         if let port = Int(portString) {
             AppInfo.webserverPort = port

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -34,12 +34,7 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
 
         launchArguments.forEach { arg in
             if arg.starts(with: LaunchArguments.ServerPort) {
-                let portString = arg.replacingOccurrences(of: LaunchArguments.ServerPort, with: "")
-                if let port = Int(portString) {
-                    AppInfo.webserverPort = port
-                } else {
-                    fatalError("Failed to set web server port override.")
-                }
+                configureWebserverPort(arg)
             }
 
             if arg.starts(with: LaunchArguments.LoadDatabasePrefix) {

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -200,6 +200,15 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
         return profile
     }
 
+    fileprivate func configureWebserverPort(_ arg: String) {
+        let portString = arg.replacingOccurrences(of: LaunchArguments.ServerPort, with: "")
+        if let port = Int(portString) {
+            AppInfo.webserverPort = port
+        } else {
+            fatalError("Failed to set web server port override.")
+        }
+    }
+
     override func application(
         _ application: UIApplication,
         willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR help to remove 1 `closure_body_length` violation from the `UITestAppDelegate.swift` file. It is the first of three parts, and in this one I've extracted the web server port config into a new function.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

