### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from BrowserViewController.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -656,7 +656,7 @@ class BrowserViewController: UIViewController,
         show(toast: toast)
     }
 
-    fileprivate func handleMicrosurvey(state: BrowserViewControllerState) {
+    private func handleMicrosurvey(state: BrowserViewControllerState) {
         if !state.microsurveyState.showPrompt {
             guard microsurvey != nil else { return }
             removeMicrosurveyPrompt()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -636,20 +636,7 @@ class BrowserViewController: UIViewController,
 
             executeToolbarActions()
 
-            // Microsurveys
-            if !state.microsurveyState.showPrompt {
-                guard microsurvey != nil else { return }
-                removeMicrosurveyPrompt()
-            } else if state.microsurveyState.showSurvey {
-                guard let model = state.microsurveyState.model else {
-                    logger.log("Microsurvey model should not be nil", level: .warning, category: .redux)
-                    return
-                }
-                navigationHandler?.showMicrosurvey(model: model)
-            } else if state.microsurveyState.showPrompt {
-                guard microsurvey == nil else { return }
-                createMicrosurveyPrompt(with: state.microsurveyState)
-            }
+            handleMicrosurvey(state: state)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -669,6 +669,22 @@ class BrowserViewController: UIViewController,
         show(toast: toast)
     }
 
+    fileprivate func handleMicrosurvey(state: BrowserViewControllerState) {
+        if !state.microsurveyState.showPrompt {
+            guard microsurvey != nil else { return }
+            removeMicrosurveyPrompt()
+        } else if state.microsurveyState.showSurvey {
+            guard let model = state.microsurveyState.model else {
+                logger.log("Microsurvey model should not be nil", level: .warning, category: .redux)
+                return
+            }
+            navigationHandler?.showMicrosurvey(model: model)
+        } else if state.microsurveyState.showPrompt {
+            guard microsurvey == nil else { return }
+            createMicrosurveyPrompt(with: state.microsurveyState)
+        }
+    }
+
     // MARK: - Lifecycle
 
     override func viewDidLoad() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR remove 1 `closure_body_length` violation from the `BrowserViewController.swift` file. 

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

