### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from SearchLoader.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchLoader.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchLoader.swift
@@ -115,49 +115,10 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewModel>, FeatureFlaggable {
                 }
 
                 DispatchQueue.main.async {
-                    let results = queries
-                    defer {
-                        GleanMetrics.Awesomebar.queryTime.stopAndAccumulate(timerid)
-                    }
-
-                    let bookmarksSites = results[safe: 0] ?? []
-                    var combinedSites = bookmarksSites
-                    if !historyHighlightsEnabled {
-                        let historySites = results[safe: 1] ?? []
-                        combinedSites += historySites
-                    }
-
-                    // Load the data in the table view.
-                    self.load(ArrayCursor(data: combinedSites))
-
-                    // If the new search string is not longer than the previous
-                    // we don't need to find an autocomplete suggestion.
-                    guard oldValue.count < self.query.count else { return }
-
-                    // If we should skip the next autocomplete, reset
-                    // the flag and bail out here.
-                    guard !self.skipNextAutocomplete else {
-                        self.skipNextAutocomplete = false
-                        return
-                    }
-
-                    // First, see if the query matches any URLs from the user's search history.
-                    for site in combinedSites {
-                        if let completion = self.completionForURL(site.url) {
-                            self.autocompleteView.setAutocompleteSuggestion(completion)
-                            return
-                        }
-                    }
-
-                    // If there are no search history matches, try matching one of the Alexa top domains.
-                    if let topDomains = self.topDomains {
-                        for domain in topDomains {
-                            if let completion = self.completionForDomain(domain) {
-                                self.autocompleteView.setAutocompleteSuggestion(completion)
-                                return
-                            }
-                        }
-                    }
+                    self.updateUIWithBookmarksAsSitesResults(queries: queries,
+                                                             timerid: timerid,
+                                                             historyHighlightsEnabled: historyHighlightsEnabled,
+                                                             oldValue: oldValue)
                 }
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/SearchLoader.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchLoader.swift
@@ -157,7 +157,7 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewModel>, FeatureFlaggable {
         // First, see if the query matches any URLs from the user's search history.
         for site in combinedSites {
             if let completion = completionForURL(site.url) {
-                urlBar.setAutocompleteSuggestion(completion)
+                autocompleteView.setAutocompleteSuggestion(completion)
                 return
             }
         }
@@ -166,7 +166,7 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewModel>, FeatureFlaggable {
         if let topDomains = topDomains {
             for domain in topDomains {
                 if let completion = completionForDomain(domain) {
-                    urlBar.setAutocompleteSuggestion(completion)
+                    autocompleteView.setAutocompleteSuggestion(completion)
                     return
                 }
             }

--- a/firefox-ios/Client/Frontend/Browser/SearchLoader.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchLoader.swift
@@ -124,10 +124,10 @@ class SearchLoader: Loader<Cursor<Site>, SearchViewModel>, FeatureFlaggable {
         }
     }
 
-    fileprivate func updateUIWithBookmarksAsSitesResults(queries: [[Site]],
-                                                         timerid: TimerId,
-                                                         historyHighlightsEnabled: Bool,
-                                                         oldValue: String) {
+    private func updateUIWithBookmarksAsSitesResults(queries: [[Site]],
+                                                     timerid: TimerId,
+                                                     historyHighlightsEnabled: Bool,
+                                                     oldValue: String) {
         let results = queries
         defer {
             GleanMetrics.Awesomebar.queryTime.stopAndAccumulate(timerid)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `SearchLoader.swift` file. It extracts the UI update logic to a new function.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

