### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from SearchSuggestClient.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
@@ -81,12 +81,7 @@ class SearchSuggestClient {
             }
 
             guard let suggestions = array?[1] as? [String] else {
-                let error = NSError(
-                    domain: SearchSuggestClientErrorDomain,
-                    code: SearchSuggestClientErrorInvalidResponse,
-                    userInfo: nil
-                )
-                callback(nil, error)
+                self.handleInvalidResponseError(callback: callback)
                 return
             }
 

--- a/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
@@ -54,12 +54,7 @@ class SearchSuggestClient {
             guard let data = data,
                   validatedHTTPResponse(response, statusCode: 200..<300) != nil
             else {
-                let error = NSError(
-                    domain: SearchSuggestClientErrorDomain,
-                    code: SearchSuggestClientErrorInvalidResponse,
-                    userInfo: nil
-                )
-                callback(nil, error as NSError?)
+                self.handleInvalidResponseError(callback: callback)
                 return
             }
 

--- a/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
@@ -95,6 +95,15 @@ class SearchSuggestClient {
         task?.resume()
     }
 
+    fileprivate func handleInvalidResponseError(callback: @escaping (_ response: [String]?, _ error: NSError?) -> Void) {
+        let error = NSError(
+            domain: SearchSuggestClientErrorDomain,
+            code: SearchSuggestClientErrorInvalidResponse,
+            userInfo: nil
+        )
+        callback(nil, error)
+    }
+
     func cancelPendingRequest() {
         task?.cancel()
     }

--- a/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
@@ -71,12 +71,7 @@ class SearchSuggestClient {
             // That is, an array of at least two elements: the search term and an array of suggestions.
 
             if array?.count ?? 0 < 2 {
-                let error = NSError(
-                    domain: SearchSuggestClientErrorDomain,
-                    code: SearchSuggestClientErrorInvalidResponse,
-                    userInfo: nil
-                )
-                callback(nil, error)
+                self.handleInvalidResponseError(callback: callback)
                 return
             }
 

--- a/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
@@ -80,7 +80,7 @@ class SearchSuggestClient {
         task?.resume()
     }
 
-    fileprivate func handleInvalidResponseError(callback: @escaping (_ response: [String]?, _ error: NSError?) -> Void) {
+    private func handleInvalidResponseError(callback: @escaping (_ response: [String]?, _ error: NSError?) -> Void) {
         let error = NSError(
             domain: SearchSuggestClientErrorDomain,
             code: SearchSuggestClientErrorInvalidResponse,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `SearchSuggestClient.swift` file. It extracts the logic to handle error into a new function.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

