### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from Experiments.swift (3/3)

### DIFF
--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -203,6 +203,28 @@ enum Experiments {
         return isReviewCheckerEnabled
     }
 
+    fileprivate static func buildNimbus(dbPath: String,
+                                        errorReporter: @escaping NimbusErrorReporter,
+                                        initialExperiments: URL?,
+                                        isFirstRun: Bool) -> NimbusInterface {
+        let bundles = [
+            Bundle.main,
+            Strings.bundle,
+            Strings.bundle.fallbackTranslationBundle(language: "en-US")
+        ].compactMap { $0 }
+
+        return NimbusBuilder(dbPath: dbPath)
+            .with(url: remoteSettingsURL)
+            .using(previewCollection: usePreviewCollection())
+            .with(errorReporter: errorReporter)
+            .with(initialExperiments: initialExperiments)
+            .isFirstRun(isFirstRun)
+            .with(bundles: bundles)
+            .with(featureManifest: FxNimbus.shared)
+            .with(commandLineArgs: CommandLine.arguments)
+            .build(appInfo: getAppSettings(isFirstRun: isFirstRun))
+    }
+
     /// A convenience method to initialize the `NimbusApi` object at startup.
     ///
     /// This includes opening the database, connecting to the Remote Settings server, and downloading

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -191,10 +191,10 @@ enum Experiments {
         return isReviewCheckerEnabled
     }
 
-    fileprivate static func buildNimbus(dbPath: String,
-                                        errorReporter: @escaping NimbusErrorReporter,
-                                        initialExperiments: URL?,
-                                        isFirstRun: Bool) -> NimbusInterface {
+    private static func buildNimbus(dbPath: String,
+                                    errorReporter: @escaping NimbusErrorReporter,
+                                    initialExperiments: URL?,
+                                    isFirstRun: Bool) -> NimbusInterface {
         let bundles = [
             Bundle.main,
             Strings.bundle,

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -157,22 +157,10 @@ enum Experiments {
             return NimbusDisabled.shared
         }
 
-        let bundles = [
-            Bundle.main,
-            Strings.bundle,
-            Strings.bundle.fallbackTranslationBundle(language: "en-US")
-        ].compactMap { $0 }
-
-        return NimbusBuilder(dbPath: dbPath)
-            .with(url: remoteSettingsURL)
-            .using(previewCollection: usePreviewCollection())
-            .with(errorReporter: errorReporter)
-            .with(initialExperiments: initialExperiments)
-            .isFirstRun(isFirstRun)
-            .with(bundles: bundles)
-            .with(featureManifest: FxNimbus.shared)
-            .with(commandLineArgs: CommandLine.arguments)
-            .build(appInfo: getAppSettings(isFirstRun: isFirstRun))
+        return buildNimbus(dbPath: dbPath,
+                           errorReporter: errorReporter,
+                           initialExperiments: initialExperiments,
+                           isFirstRun: isFirstRun)
     }()
 
     private static func getAppSettings(isFirstRun: Bool) -> NimbusAppSettings {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `Experiments.swift` file. It extracts the Nimbus builder logic to a new function.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

