### PR TITLE
Fixes MTE-3229 - for private and home page tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -259,7 +259,7 @@ class BaseTestCase: XCTestCase {
             .otherElements
             .otherElements
             .count
-        let numberOfExpectedRecentlyVisitedBookmarks = 3
+        let numberOfExpectedRecentlyVisitedBookmarks = 2
         XCTAssertEqual(numberOfRecentlyVisitedBookmarks, numberOfExpectedRecentlyVisitedBookmarks)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -770,7 +770,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         }
 
         screenState.gesture(forAction: Action.ToggleRecentlySaved) { userState in
-            app.tables.cells.switches["Recently Saved"].tap()
+            app.tables.cells.switches["Bookmarks"].tap()
         }
 
         screenState.backAction = navigationControllerBackAction

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -266,7 +266,7 @@ class HomePageSettingsUITests: BaseTestCase {
         bookmarkPages()
         addContentToReaderView()
         navigator.performAction(Action.GoToHomePage)
-        mozWaitForElementToExist(app.staticTexts["Recently Saved"])
+        mozWaitForElementToExist(app.staticTexts["Bookmarks"])
         navigator.performAction(Action.ToggleRecentlySaved)
         // On iPad we have the homepage button always present,
         // on iPhone we have the search button instead when we're on a new tab page

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -108,14 +108,10 @@ class PrivateBrowsingTest: BaseTestCase {
         app.cells.staticTexts["Homepage"].tap()
         navigator.nowAt(NewTabScreen)
 
-        // Go back to private browsing and check that the tab has not been closed
+        // Go back to private browsing and check that the tab has been closed
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         mozWaitForElementToExist(app.otherElements["Tabs Tray"])
-        XCTAssertNotNil(
-            app.otherElements["Tabs Tray"].collectionViews.cells.staticTexts
-                .element(boundBy: 0).label
-                .range(of: url2Label)
-        )
+        mozWaitForElementToExist(app.staticTexts["Private Browsing"])
         checkOpenTabsBeforeClosingPrivateMode()
     }
 
@@ -269,18 +265,8 @@ fileprivate extension BaseTestCase {
         let numPrivTabs = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(
             numPrivTabs,
-            1,
-            "The number of tabs is not correct, the private tab should not have been closed"
-        )
-    }
-
-    func checkOpenTabsAfterClosingPrivateMode() {
-        // The private tab is not loger closed after "Close Private Tabs" has been removed
-        let numPrivTabsAfterClosing = app.otherElements["Tabs Tray"].cells.count
-        XCTAssertEqual(
-            numPrivTabsAfterClosing,
-            1,
-            "The number of tabs is not correct"
+            0,
+            "The private tab should have been closed"
         )
     }
 
@@ -337,12 +323,11 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
         navigator.openURL(url2)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: TIMEOUT)
 
-        // FXIOS-8672: "Close Private Tabs" has been removed from the settings.
         // Leave PM by tapping on PM shourt cut
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarHomePanel)
         waitForTabsButton()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-        checkOpenTabsAfterClosingPrivateMode()
+        checkOpenTabsBeforeClosingPrivateMode()
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307009


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3229

## :bulb: Description
Close private tab toggle has been added and it is on by default.
When closing the private mode the tabs are closing.
Updates are required on automation tests:
testClosePrivateTabsOptionClosesPrivateTabs
testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad

Also updated testRecentlySaved by updating recently saved section with bookmarks.
