### PR TITLE
remove unnecessary support for `releases` branches in taskcluster.yml

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -108,7 +108,7 @@ tasks:
             $if: >
               tasks_for in ["action", "cron"]
               || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
-              || (tasks_for == "github-push" && (short_head_branch == "main" || short_head_branch[:8] == "releases"))
+              || (tasks_for == "github-push" && short_head_branch == "main")
               || (tasks_for == "github-release" && releaseAction == "published")
             then:
                 taskId: 


### PR DESCRIPTION
As far as I can tell, there's never been any branches starting with `releases`. It's possible that this was meant to be `release` (of which there are many branches...), but seeing as it hasn't been needed, we can probably just remove it?

This is being done partly in support of https://bugzilla.mozilla.org/show_bug.cgi?id=1907217, where we're becoming more explicit about which branches we grant scopes to in Github repositories.