### PR TITLE
Refactor FXIOS-9732 Cleanup: remove WindowManager.activeWindow

### DIFF
--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -24,10 +24,6 @@ enum MultiWindowAction {
 /// General window management class that provides some basic coordination and
 /// state management for multiple windows shared across a single running app.
 protocol WindowManager {
-    /// The UUID of the active window (there is always at least 1, except in
-    /// the earliest stages of app startup lifecycle)
-    var activeWindow: WindowUUID { get set }
-
     /// A collection of all open windows and their related metadata.
     var windows: [WindowUUID: AppWindowInfo] { get }
 
@@ -98,14 +94,9 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
     // process of initial configuration.
     private var reservedUUIDs: [WindowUUID] = []
 
-    var activeWindow: WindowUUID {
-        get { return uuidForActiveWindow() }
-        set { _activeWindowUUID = newValue }
-    }
     private let logger: Logger
     private let tabDataStore: TabDataStore
     private let defaults: UserDefaultsInterface
-    private var _activeWindowUUID: WindowUUID?
     private let tabSyncCoordinator = WindowTabsSyncCoordinator()
     private let widgetSimpleTabsCoordinator = WindowSimpleTabsCoordinator()
 
@@ -145,7 +136,7 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         guard let tabManager = window(for: windowUUID)?.tabManager else {
             assertionFailure("Tab Manager unavailable for requested UUID: \(windowUUID). This is a client error.")
             logger.log("No tab manager for window UUID.", level: .fatal, category: .window)
-            return window(for: activeWindow)?.tabManager ?? windows.first!.value.tabManager!
+            return windows.first!.value.tabManager!
         }
 
         return tabManager
@@ -345,38 +336,6 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
 
     private func updateWindow(_ info: AppWindowInfo?, for uuid: WindowUUID) {
         windows[uuid] = info
-        didUpdateWindow(uuid)
-    }
-
-    /// Called internally when a window is updated (or removed).
-    /// - Parameter uuid: the UUID of the window that changed.
-    private func didUpdateWindow(_ uuid: WindowUUID) {
-        // Convenience. If the client has successfully configured
-        // a window and it is the only window in the app, we can
-        // be sure we automatically set it as the active window.
-        if windows.count == 1 {
-            activeWindow = windows.keys.first!
-        }
-    }
-
-    private func uuidForActiveWindow() -> WindowUUID {
-        guard !windows.isEmpty else {
-            // No app windows. Unsupported state; can't recover gracefully.
-            fatalError()
-        }
-
-        guard windows.count > 1 else {
-            // For apps with only 1 window we can always safely return it as the active window.
-            return windows.keys.first!
-        }
-
-        guard let uuid = _activeWindowUUID else {
-            let message = "App has multiple windows but no active window UUID. This is a client error."
-            logger.log(message, level: .fatal, category: .window)
-            assertionFailure(message)
-            return windows.keys.first!
-        }
-        return uuid
     }
 
     private func window(for windowUUID: WindowUUID, createIfNeeded: Bool = false) -> AppWindowInfo? {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -509,10 +509,8 @@ class TabManagerMiddleware {
         let windowManager: WindowManager = AppContainer.shared.resolve()
         guard uuid != .unavailable else {
             assertionFailure()
-            logger.log("Unexpected or unavailable UUID for TabManager. Returning active window tab manager by default.",
-                       level: .warning,
-                       category: .tabs)
-            return windowManager.tabManager(for: windowManager.activeWindow)
+            logger.log("Unexpected or unavailable window UUID for requested TabManager.", level: .fatal, category: .tabs)
+            return windowManager.allWindowTabManagers().first!
         }
 
         return windowManager.tabManager(for: uuid)

--- a/firefox-ios/Client/Frontend/Reader/ReadabilityService.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReadabilityService.swift
@@ -49,7 +49,8 @@ class ReadabilityOperation: Operation {
             // TODO: To resolve profile from DI container
 
             let windowManager: WindowManager = AppContainer.shared.resolve()
-            let tab = Tab(profile: self.profile, configuration: configuration, windowUUID: windowManager.activeWindow)
+            let defaultUUID = windowManager.windows.first?.key ?? .unavailable
+            let tab = Tab(profile: self.profile, configuration: configuration, windowUUID: defaultUUID)
             self.tab = tab
             tab.createWebview()
             tab.navigationDelegate = self

--- a/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
@@ -64,7 +64,8 @@ class DownloadContentScript: TabContentScript {
               let data = Bytes.decodeBase64(base64String)
         else { return }
 
-        let windowUUID = tab?.windowUUID ?? (AppContainer.shared.resolve() as WindowManager).activeWindow
+        let windowManager: WindowManager = AppContainer.shared.resolve()
+        let windowUUID = tab?.windowUUID ?? windowManager.windows.first?.key ?? .unavailable
         defer {
             notificationCenter.post(name: .PendingBlobDownloadAddedToQueue, withObject: nil)
             DownloadContentScript.blobUrlForDownload = nil

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
@@ -18,11 +18,6 @@ final class MockWindowManager: WindowManager {
 
     // MARK: - WindowManager Protocol
 
-    var activeWindow: WindowUUID {
-        get { wrappedManager.activeWindow }
-        set { wrappedManager.activeWindow = newValue }
-    }
-
     var windows: [WindowUUID: AppWindowInfo] {
         wrappedManager.windows
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -26,8 +26,7 @@ class TabManagerTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
         // For this test suite, use a consistent window UUID for all test cases
-        let windowManager: WindowManager = AppContainer.shared.resolve()
-        let uuid = windowManager.activeWindow
+        let uuid: WindowUUID = .XCTestDefaultUUID
         tabWindowUUID = uuid
 
         mockProfile = MockProfile()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -35,7 +35,7 @@ class WindowManagerTests: XCTestCase {
         // Expect 1 app window is now configured
         XCTAssertEqual(1, subject.windows.count)
         // Expect that window is now active window
-        XCTAssertEqual(uuid, subject.activeWindow)
+        // XCTAssertEqual(uuid, subject.activeWindow)
         // Expect our previous tab manager is associated with that window
         XCTAssert(tabManager === subject.tabManager(for: uuid))
         XCTAssertEqual(tabManager.windowUUID, uuid)
@@ -57,27 +57,13 @@ class WindowManagerTests: XCTestCase {
         // Expect 2 app windows are now configured
         XCTAssertEqual(2, subject.windows.count)
         // Expect that our first window is still the active window
-        XCTAssertEqual(firstWindowUUID, subject.activeWindow)
+        // XCTAssertEqual(firstWindowUUID, subject.activeWindow)
 
         // Check for expected tab manager references for each window
         XCTAssert(tabManager === subject.tabManager(for: firstWindowUUID))
         XCTAssertEqual(tabManager.windowUUID, firstWindowUUID)
         XCTAssert(secondTabManager === subject.tabManager(for: secondWindowUUID))
         XCTAssertEqual(secondTabManager.windowUUID, secondWindowUUID)
-    }
-
-    func testChangingActiveWindow() {
-        var subject = createSubject()
-
-        // Configure two app windows
-        let firstWindowUUID = tabManager.windowUUID
-        let secondWindowUUID = secondTabManager.windowUUID
-        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: firstWindowUUID)
-        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: secondTabManager), uuid: secondWindowUUID)
-
-        XCTAssertEqual(subject.activeWindow, firstWindowUUID)
-        subject.activeWindow = secondWindowUUID
-        XCTAssertEqual(subject.activeWindow, secondWindowUUID)
     }
 
     func testOpeningMultipleWindowsAndClosingTheFirstWindow() {
@@ -90,8 +76,8 @@ class WindowManagerTests: XCTestCase {
         subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: secondTabManager), uuid: secondWindowUUID)
 
         // Check that first window is the active window
-        XCTAssertEqual(2, subject.windows.count)
-        XCTAssertEqual(firstWindowUUID, subject.activeWindow)
+        // XCTAssertEqual(2, subject.windows.count)
+        // XCTAssertEqual(firstWindowUUID, subject.activeWindow)
 
         // Close the first window
         subject.windowWillClose(uuid: firstWindowUUID)
@@ -100,7 +86,7 @@ class WindowManagerTests: XCTestCase {
         XCTAssertEqual(1, subject.windows.count)
         XCTAssertEqual(secondWindowUUID, subject.windows.keys.first!)
         // Check that the second window is now automatically our "active" window
-        XCTAssertEqual(secondWindowUUID, subject.activeWindow)
+        // XCTAssertEqual(secondWindowUUID, subject.activeWindow)
     }
 
     func testNextAvailableUUIDWhenNoTabDataIsSaved() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9732)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21379)

## :bulb: Description

Refactor/cleanup; no user-facing changes. We are not meaningfully utilizing `activeWindow` in WindowManager, right now it simply adds to the complexity in that file. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

