### PR TITLE
Add FXIOS-9712 Data clearance button for toolbar refactor

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -30,7 +30,6 @@ public struct AccessibilityIdentifiers {
         static let addNewTabButton = "TabToolbar.addNewTabButton"
         static let searchButton = "TabToolbar.searchButton"
         static let stopButton = "TabToolbar.stopButton"
-        static let dataClearanceButton = "TabToolbar.dataClearanceButton"
         static let bookmarksButton = "TabToolbar.libraryButton"
         static let shoppingButton = "TabLocationView.shoppingButton"
     }

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -30,6 +30,7 @@ public struct AccessibilityIdentifiers {
         static let addNewTabButton = "TabToolbar.addNewTabButton"
         static let searchButton = "TabToolbar.searchButton"
         static let stopButton = "TabToolbar.stopButton"
+        static let dataClearanceButton = "TabToolbar.dataClearanceButton"
         static let bookmarksButton = "TabToolbar.libraryButton"
         static let shoppingButton = "TabLocationView.shoppingButton"
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -50,6 +50,7 @@ enum GeneralBrowserActionType: ActionType {
     case showShare
     case addNewTab
     case showNewTabLongPressActions
+    case clearData
 }
 
 class GeneralBrowserMiddlewareAction: Action {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -43,6 +43,10 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
     // Presents alert to clear users private session data
     func tabToolbarDidPressFire(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
+        didTapOnFire()
+    }
+
+    func didTapOnFire() {
         let alert = UIAlertController(
             title: .Alerts.FeltDeletion.Title,
             message: .Alerts.FeltDeletion.Body,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -42,11 +42,11 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     }
 
     // Presents alert to clear users private session data
-    func tabToolbarDidPressFire(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        didTapOnFire()
+    func tabToolbarDidPressDataClearance(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
+        didTapOnDataClearance()
     }
 
-    func didTapOnFire() {
+    func didTapOnDataClearance() {
         let alert = UIAlertController(
             title: .Alerts.FeltDeletion.Title,
             message: .Alerts.FeltDeletion.Body,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -28,6 +28,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         case tabTray
         case share
         case newTabLongPressActions
+        case dataClearance
     }
 
     let windowUUID: WindowUUID
@@ -373,6 +374,15 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 windowUUID: state.windowUUID,
                 browserViewType: state.browserViewType,
                 displayView: .newTabLongPressActions,
+                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
+        case GeneralBrowserActionType.clearData:
+            return BrowserViewControllerState(
+                searchScreenState: state.searchScreenState,
+                showDataClearanceFlow: state.showDataClearanceFlow,
+                fakespotState: state.fakespotState,
+                windowUUID: state.windowUUID,
+                browserViewType: state.browserViewType,
+                displayView: .dataClearance,
                 microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
         default:
             return state

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1927,7 +1927,7 @@ class BrowserViewController: UIViewController,
         case .newTabLongPressActions:
             presentNewTabLongPressActionSheet(from: view)
         case .dataClearance:
-            didTapOnFire()
+            didTapOnDataClearance()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1926,6 +1926,8 @@ class BrowserViewController: UIViewController,
             didTapOnShare(from: button)
         case .newTabLongPressActions:
             presentNewTabLongPressActionSheet(from: view)
+        case .dataClearance:
+            didTapOnFire()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -615,9 +615,8 @@ class ToolbarMiddleware: FeatureFlaggable {
     private func getMiddleButtonAction(url: URL?, isPrivateMode: Bool) -> ToolbarActionState {
         let isFeltPrivacyUIEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
         let isFeltPrivacyDeletionEnabled = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly)
-        let isToolbarRefactorEnabled = featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
         let shouldShowDataClearanceAction = isPrivateMode && isFeltPrivacyUIEnabled &&
-                                            isFeltPrivacyDeletionEnabled && isToolbarRefactorEnabled
+                                            isFeltPrivacyDeletionEnabled
         if shouldShowDataClearanceAction {
             return dataClearanceAction
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -617,7 +617,7 @@ class ToolbarMiddleware: FeatureFlaggable {
         let isFeltPrivacyDeletionEnabled = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly)
         let shouldShowDataClearanceAction = isPrivateMode && isFeltPrivacyUIEnabled &&
                                             isFeltPrivacyDeletionEnabled
-        if shouldShowDataClearanceAction {
+        guard !shouldShowDataClearanceAction else {
             return dataClearanceAction
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -613,7 +613,12 @@ class ToolbarMiddleware: FeatureFlaggable {
     }
 
     private func getMiddleButtonAction(url: URL?, isPrivateMode: Bool) -> ToolbarActionState {
-        guard !isPrivateMode else {
+        let isFeltPrivacyUIEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
+        let isFeltPrivacyDeletionEnabled = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly)
+        let isToolbarRefactorEnabled = featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
+        let shouldShowDataClearanceAction = isPrivateMode && isFeltPrivacyUIEnabled &&
+                                            isFeltPrivacyDeletionEnabled && isToolbarRefactorEnabled
+        if shouldShowDataClearanceAction {
             return dataClearanceAction
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -90,7 +90,7 @@ class ToolbarMiddleware: FeatureFlaggable {
         iconName: StandardImageIdentifiers.Large.dataClearance,
         isEnabled: true,
         a11yLabel: .TabToolbarDataClearanceAccessibilityLabel,
-        a11yId: AccessibilityIdentifiers.Toolbar.dataClearanceButton)
+        a11yId: AccessibilityIdentifiers.Toolbar.fireButton)
 
     private func resolveGeneralBrowserMiddlewareActions(action: GeneralBrowserMiddlewareAction, state: AppState) {
         let uuid = action.windowUUID

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -85,6 +85,13 @@ class ToolbarMiddleware: FeatureFlaggable {
         a11yLabel: .TabToolbarSearchAccessibilityLabel,
         a11yId: AccessibilityIdentifiers.Toolbar.searchButton)
 
+    lazy var dataClearanceAction = ToolbarActionState(
+        actionType: .dataClearance,
+        iconName: StandardImageIdentifiers.Large.dataClearance,
+        isEnabled: true,
+        a11yLabel: .TabToolbarDataClearanceAccessibilityLabel,
+        a11yId: AccessibilityIdentifiers.Toolbar.dataClearanceButton)
+
     private func resolveGeneralBrowserMiddlewareActions(action: GeneralBrowserMiddlewareAction, state: AppState) {
         let uuid = action.windowUUID
 
@@ -247,6 +254,10 @@ class ToolbarMiddleware: FeatureFlaggable {
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .startSearchButton)
             updateAddressToolbarNavigationActions(action: action, state: state, isEditing: true)
 
+        case .dataClearance:
+            let action = GeneralBrowserAction(windowUUID: action.windowUUID,
+                                              actionType: GeneralBrowserActionType.clearData)
+            store.dispatch(action)
         default:
             break
         }
@@ -574,10 +585,7 @@ class ToolbarMiddleware: FeatureFlaggable {
         let isUrlChangeAction = action.actionType as? ToolbarMiddlewareActionType == .urlDidChange
         let url = isUrlChangeAction ? action.url : toolbarState.addressToolbar.url
 
-        let isNewTabEnabled = featureFlags.isFeatureEnabled(.toolbarOneTapNewTab, checking: .buildOnly)
-        let middleActionDefault = isNewTabEnabled ? newTabAction : homeAction
-        let middleActionHome = searchAction
-        let middleAction = url == nil ? middleActionHome : middleActionDefault
+        let middleAction = getMiddleButtonAction(url: url, isPrivateMode: toolbarState.isPrivateMode)
 
         let isShowingTopTabs = action.isShowingTopTabs ?? false
 
@@ -602,6 +610,19 @@ class ToolbarMiddleware: FeatureFlaggable {
             actions: actions,
             displayBorder: displayBorder)
         return navToolbarModel
+    }
+
+    private func getMiddleButtonAction(url: URL?, isPrivateMode: Bool) -> ToolbarActionState {
+        guard !isPrivateMode else {
+            return dataClearanceAction
+        }
+
+        let isNewTabEnabled = featureFlags.isFeatureEnabled(.toolbarOneTapNewTab, checking: .buildOnly)
+        let middleActionDefault = isNewTabEnabled ? newTabAction : homeAction
+        let middleActionHome = searchAction
+        let middleAction = url == nil ? middleActionHome : middleActionDefault
+
+        return middleAction
     }
 
     // MARK: - Helper

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -35,7 +35,7 @@ protocol TabToolbarDelegate: AnyObject {
     func tabToolbarDidLongPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressForward(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressHome(_ tabToolbar: TabToolbarProtocol, button: UIButton)
-    func tabToolbarDidPressFire(_ tabToolbar: TabToolbarProtocol, button: UIButton)
+    func tabToolbarDidPressDataClearance(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressMenu(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressBookmarks(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton)
@@ -246,7 +246,7 @@ open class TabToolbarHelper: NSObject {
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .startSearchButton)
             toolbar.tabToolbarDelegate?.tabToolbarDidPressSearch(toolbar, button: toolbar.multiStateButton)
         case .fire:
-            toolbar.tabToolbarDelegate?.tabToolbarDidPressFire(toolbar, button: toolbar.multiStateButton)
+            toolbar.tabToolbarDelegate?.tabToolbarDidPressDataClearance(toolbar, button: toolbar.multiStateButton)
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -42,6 +42,18 @@ final class BrowserViewControllerStateTests: XCTestCase {
         XCTAssertEqual(newState.displayView, .newTabLongPressActions)
     }
 
+    func testClearDataAction() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.displayView)
+
+        let action = getAction(for: .clearData)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.displayView, .dataClearance)
+    }
+
     // MARK: - Private
     private func createSubject() -> BrowserViewControllerState {
         return BrowserViewControllerState(windowUUID: .XCTestDefaultUUID)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9712)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21350)

## :bulb: Description
- Show the data clearance toolbar button and perform data clearance when selected when using the refactored toolbar
- Testing this requires enabling the toolbar refactor `enabled` flag, the felt privacy feature `simplified-ui-enabled` flag, and the felt privacy feature `felt-deletion-enabled` flag.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

