### PR TITLE
Bugfix FXIOS-9518 Fix for random reload

### DIFF
--- a/firefox-ios/Client/Frontend/Components/ContentContainer.swift
+++ b/firefox-ios/Client/Frontend/Components/ContentContainer.swift
@@ -65,6 +65,8 @@ class ContentContainer: UIView {
     ///
     /// - Parameter content: The content to update
     func update(content: ContentContainable) {
+        // If the content type is the same as the current then return early
+        guard content != type else { return }
         removePreviousContent()
         saveContentType(content: content)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9518)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21069)

## :bulb: Description
This issue is difficult to reproduce but I believe this change should at least address the symptom. If a request to embed the webview is triggered it will be ignored if the webview is already embedded. I don't know what is triggering the random request in the first place tho.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

