### PR TITLE
Remove FXIOS-9706 - Remove the `awesomebar.{engagement, abandonment}` events.

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3303,13 +3303,11 @@ extension BrowserViewController: SearchViewControllerDelegate {
         case .engaged:
             let visibleSuggestionsTelemetryInfo = searchViewController.visibleSuggestionsTelemetryInfo
             visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0) }
-            TelemetryWrapper.gleanRecordEvent(category: .action, method: .engagement, object: .locationBar)
             searchViewController.searchTelemetry?.recordURLBarSearchEngagementTelemetryEvent()
         case .abandoned:
             searchViewController.searchTelemetry?.engagementType = .dismiss
             let visibleSuggestionsTelemetryInfo = searchViewController.visibleSuggestionsTelemetryInfo
             visibleSuggestionsTelemetryInfo.forEach { trackVisibleSuggestion(telemetryInfo: $0) }
-            TelemetryWrapper.gleanRecordEvent(category: .action, method: .abandonment, object: .locationBar)
             searchViewController.searchTelemetry?.recordURLBarSearchAbandonmentTelemetryEvent()
         default:
             break

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -312,8 +312,6 @@ extension TelemetryWrapper {
         case switchControl = "switch-control"
         case dynamicTextSize = "dynamic-text-size"
         case error = "error"
-        case engagement = "engagement"
-        case abandonment = "abandonment"
     }
 
     public enum EventObject: String {
@@ -1927,10 +1925,6 @@ extension TelemetryWrapper {
             GleanMetrics.Awesomebar.shareButtonTapped.record()
         case (.action, .drag, .locationBar, _, _):
             GleanMetrics.Awesomebar.dragLocationBar.record()
-        case (.action, .engagement, .locationBar, _, _):
-            GleanMetrics.Awesomebar.engagement.record()
-        case (.action, .abandonment, .locationBar, _, _):
-            GleanMetrics.Awesomebar.abandonment.record()
         // MARK: - GleanPlumb Messaging
         case (.information, .view, .messaging, .messageImpression, let extras):
             guard let messageSurface = extras?[EventExtraKey.messageSurface.rawValue] as? String,

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -4620,38 +4620,6 @@ awesomebar:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-01-01"
-  engagement:
-    type: event
-    description: |
-      Recorded when the user completes their search session by
-      tapping a search result, or entering a URL or a search term.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-8326
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-8550
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/18452
-      - https://github.com/mozilla-mobile/firefox-ios/pull/19009
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    data_sensitivity:
-      - interaction
-    expires: "2025-01-01"
-  abandonment:
-    type: event
-    description: |
-      Recorded when the user dismisses the awesomebar without completing their
-      search.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-8326
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-8550
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/18452
-      - https://github.com/mozilla-mobile/firefox-ios/pull/19009
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    data_sensitivity:
-      - interaction
-    expires: "2025-01-01"
 
 # Share sheet specific metrics
 


### PR DESCRIPTION
The counts for the `urlbar` versions of these events now agree with the `awesomebar` events, so the `awesomebar` events are redundant.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9706)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21337)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

