### PR TITLE
Fix MTE-3248 - TopTabsTestIphone smoke tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -493,12 +493,6 @@ fileprivate extension BaseTestCase {
 }
 
 class TopTabsTestIphone: IphoneOnlyTestCase {
-    override func setUp() {
-        super.setUp()
-        waitForTabsButton()
-        mozWaitForElementToExist(app.textFields["url"])
-    }
-
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2355535
     // Smoketest
     func testCloseTabFromLongPressTabsButton() {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3248

## :bulb: Description
@clarmso i have noticed recent changes on TopTabsTestIphone tests.
For some reason by adding the override setUp function inside the class is causing these tests to run and fail on iPad.
We already run the setUp method inside IphoneOnlyTestCase. I dont think we need to override it, but let me known if i am missing something.


