### PR TITLE
Bugfix MTE-3146 Remove override for setUp()

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -408,8 +408,6 @@ class IpadOnlyTestCase: BaseTestCase {
         specificForPlatform = .pad
         if iPad() {
             super.setUp()
-            waitForTabsButton()
-            mozWaitForElementToExist(app.textFields["url"])
         }
     }
 }
@@ -419,8 +417,6 @@ class IphoneOnlyTestCase: BaseTestCase {
         specificForPlatform = .phone
         if !iPad() {
             super.setUp()
-            waitForTabsButton()
-            mozWaitForElementToExist(app.textFields["url"])
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -30,8 +30,6 @@ class JumpBackInTests: BaseTestCase {
         XCTAssertEqual(app.switches["Jump Back In"].value as! String, "1")
 
         navigator.goto(NewTabScreen)
-        waitForTabsButton()
-        mozWaitForElementToExist(app.textFields["url"])
     }
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2306922

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
@@ -6,12 +6,6 @@ import XCTest
 
 let websiteUrl = "www.mozilla.org"
 class NewTabSettingsTest: BaseTestCase {
-    override func setUp() {
-        super.setUp()
-        waitForTabsButton()
-        mozWaitForElementToExist(app.textFields["url"])
-    }
-
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307026
     // Smoketest
     func testCheckNewTabSettingsByDefault() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
@@ -4,12 +4,6 @@
 
 import Foundation
 class OpeningScreenTests: BaseTestCase {
-    override func setUp() {
-        super.setUp()
-        waitForTabsButton()
-        mozWaitForElementToExist(app.textFields["url"])
-    }
-
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307039
     func testLastOpenedTab() {
         // Open a web page

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -313,12 +313,6 @@ class PrivateBrowsingTestIphone: IphoneOnlyTestCase {
 class PrivateBrowsingTestIpad: IpadOnlyTestCase {
     typealias HistoryPanelA11y = AccessibilityIdentifiers.LibraryPanels.HistoryPanel
 
-    override func setUp() {
-        super.setUp()
-        waitForTabsButton()
-        mozWaitForElementToExist(app.textFields["url"])
-    }
-
     // This test is only enabled for iPad. Shortcut does not exists on iPhone
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307008
     func testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
@@ -6,12 +6,6 @@ import Common
 import XCTest
 
 class TabCounterTests: BaseTestCase {
-    override func setUp() {
-        super.setUp()
-        waitForTabsButton()
-        mozWaitForElementToExist(app.textFields["url"])
-    }
-
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2359077
     func testTabIncrement() throws {
         navigator.nowAt(NewTabScreen)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -603,12 +603,6 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
 // Tests to check if Tab Counter is updating correctly after opening three tabs by tapping on '+' button
 // and closing the tabs by tapping 'x' button
 class TopTabsTestIpad: IpadOnlyTestCase {
-    override func setUp() {
-        super.setUp()
-        waitForTabsButton()
-        mozWaitForElementToExist(app.textFields["url"])
-    }
-
     // https://testrail.stage.mozaws.net/index.php?/cases/view/2307023
     func testUpdateTabCounter() {
         if skipPlatform { return }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3146)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Let me remove the override to the default `setUp()` step for now. I thought they would help, but they don't. 😞 

@dragosb01 I hope I caught all the instances.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

