### PR TITLE
Bugfix MTE-3146 ReportSiteTests can be launched

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -86,6 +86,7 @@ class BaseTestCase: XCTestCase {
             app.activate()
         }
         app.launch()
+        mozWaitForElementToExist(app.windows.otherElements.firstMatch)
     }
 
     func setUpLaunchArguments() {
@@ -101,8 +102,6 @@ class BaseTestCase: XCTestCase {
         continueAfterFailure = false
         setUpApp()
         setUpScreenGraph()
-
-        mozWaitForElementToExist(app.windows.otherElements.firstMatch)
     }
 
     override func tearDown() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3146)

## :bulb: Description
Fixed an oversight that `app.launch()` is not called for ReportSiteTests due to `setUpApp()` has been overriden.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

