### PR TITLE
Bugfix FXIOS-9717 - Add missing Learn More url to Redux action

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -206,6 +206,7 @@ class TabDisplayPanel: UIViewController,
 
     func didTapLearnMore(urlRequest: URLRequest) {
         let action = TabPanelViewAction(panelType: panelType,
+                                        urlRequest: urlRequest,
                                         windowUUID: windowUUID,
                                         actionType: TabPanelViewActionType.learnMorePrivateMode)
         store.dispatch(action)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9717)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21356)

## :bulb: Description
The Redux action was missing the url parameter.

I fixed that.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

