### PR TITLE
Bugfix MTE-3146 Fix junit xml file name

### DIFF
--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -232,8 +232,6 @@ jobs:
         - name: Run tests
           id: run-tests
           run: |
-            xcrun simctl shutdown all
-            xcrun simctl erase all
             xcrun simctl boot '${{ matrix.ios_simulator }}'
             xcodebuild \
               test-without-building \

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -168,7 +168,7 @@ jobs:
           python ../test-fixtures/ci/convert_junit_to_markdown.py --smoke --github --${{ env.browser }} ./combined.xml ./github.md
           cat github.md >> $GITHUB_STEP_SUMMARY
           python ../test-fixtures/ci/convert_junit_to_markdown.py --smoke --slack --${{ env.browser }} ./combined.xml ./slack.json
-          mv ./combined junit-smoketests-${{ matrix.ios_simulator }}-`date +"%Y-%m-%d"`.xml
+          mv ./combined "junit-smoketests-${{ matrix.ios_simulator }}-`date +"%Y-%m-%d"`.xml"
         working-directory:  ${{ env.browser }}
       - name: Upload junit files
         id: upload-junit
@@ -243,6 +243,7 @@ jobs:
               -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
               -testPlan FullFunctionalTestPlan \
               -resultBundlePath ${{ env.test_results_directory }}/results \
+              -only-testing:XCUITests/ActivityStreamTest \
               | tee xcodebuild.log | xcpretty -r junit && exit ${PIPESTATUS[0]}
           working-directory:  ${{ env.browser }}
           continue-on-error: true
@@ -252,7 +253,7 @@ jobs:
             python ../test-fixtures/ci/convert_junit_to_markdown.py --github --${{ env.browser }} ./build/reports/junit.xml ./github.md
             cat github.md >> $GITHUB_STEP_SUMMARY
             python ../test-fixtures/ci/convert_junit_to_markdown.py --slack --${{ env.browser }} ./build/reports/junit.xml ./slack.json
-            mv ./build/reports/junit.xml junit-fullfunctional-${{ matrix.ios_simulator }}-`date +"%Y-%m-%d"`.xml
+            mv ./build/reports/junit.xml "junit-fullfunctional-${{ matrix.ios_simulator }}-`date +"%Y-%m-%d"`.xml"
           working-directory:  ${{ env.browser }}
         - name: Upload junit files
           id: upload-junit

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -168,7 +168,7 @@ jobs:
           python ../test-fixtures/ci/convert_junit_to_markdown.py --smoke --github --${{ env.browser }} ./combined.xml ./github.md
           cat github.md >> $GITHUB_STEP_SUMMARY
           python ../test-fixtures/ci/convert_junit_to_markdown.py --smoke --slack --${{ env.browser }} ./combined.xml ./slack.json
-          mv ./combined "junit-smoketests-${{ matrix.ios_simulator }}-`date +"%Y-%m-%d"`.xml"
+          mv ./combined.xml "junit-smoketests-${{ matrix.ios_simulator }}-`date +"%Y-%m-%d"`.xml"
         working-directory:  ${{ env.browser }}
       - name: Upload junit files
         id: upload-junit

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -241,7 +241,6 @@ jobs:
               -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
               -testPlan FullFunctionalTestPlan \
               -resultBundlePath ${{ env.test_results_directory }}/results \
-              -only-testing:XCUITests/ActivityStreamTest \
               | tee xcodebuild.log | xcpretty -r junit && exit ${PIPESTATUS[0]}
           working-directory:  ${{ env.browser }}
           continue-on-error: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3146)

## :bulb: Description
The filename with the device name and the timestamp was not working because of the spaces. Let me put quotation marks so that the device name and the timestamp can be included in the filename.

Sample test run (with only one full functional tests): https://github.com/mozilla-mobile/firefox-ios/actions/runs/10204615272/job/28233965461

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

