### PR TITLE
Fix MTE-3249 - testLockIconSecureConnection test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -160,7 +160,7 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.goto(TrackingProtectionContextMenuDetails)
         // A page displaying the connection is secure
         mozWaitForElementToExist(app.staticTexts["mozilla.org"])
-        mozWaitForElementToExist(app.staticTexts["Connection is secure"])
+        mozWaitForElementToExist(app.staticTexts["Secure connection"])
         XCTAssertEqual(
             app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
             "Secure connection"


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3249

## :bulb: Description
Small static text update for testLockIconSecureConnection test

