### PR TITLE
Bugfix FXIOS-9755 Update the url bar even if there is no webview

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3400,8 +3400,9 @@ extension BrowserViewController: TabManagerDelegate {
             selected?.webView?.applyTheme(theme: currentTheme())
         }
 
-        if let tab = selected, let webView = tab.webView {
+        if let tab = selected {
             updateURLBarDisplayURL(tab)
+
             if !isToolbarRefactorEnabled, urlBar.inOverlayMode, tab.url?.displayURL != nil {
                 urlBar.leaveOverlayMode(reason: .finished, shouldCancelLoading: false)
             }
@@ -3415,16 +3416,18 @@ extension BrowserViewController: TabManagerDelegate {
 
             scrollController.tab = tab
 
-            webView.accessibilityLabel = .WebViewAccessibilityLabel
-            webView.accessibilityIdentifier = "contentView"
-            webView.accessibilityElementsHidden = false
+            if let webView = tab.webView {
+                webView.accessibilityLabel = .WebViewAccessibilityLabel
+                webView.accessibilityIdentifier = "contentView"
+                webView.accessibilityElementsHidden = false
 
-            browserDelegate?.show(webView: webView)
+                browserDelegate?.show(webView: webView)
 
-            if webView.url == nil {
-                // The web view can go gray if it was zombified due to memory pressure.
-                // When this happens, the URL is nil, so try restoring the page upon selection.
-                tab.reload()
+                if webView.url == nil {
+                    // The web view can go gray if it was zombified due to memory pressure.
+                    // When this happens, the URL is nil, so try restoring the page upon selection.
+                    tab.reload()
+                }
             }
 
             // Update Fakespot sidebar if necessary


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9755)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21425)

## :bulb: Description
Break the update block into sections so only the webview stuff is gated on their being an existing webview

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

