### PR TITLE
 Bugfix FXIOS-9528 [TabManagerTests] Fix selectTab causing memory leak errors

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -360,12 +360,12 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
 
         preserveTabs()
 
-        Task(priority: .high) {
+        Task(priority: .high) { [weak self] in
             var sessionData: Data?
             if !tab.isFxHomeTab {
-                sessionData = await tabSessionStore.fetchTabSession(tabID: tabUUID)
+                sessionData = await self?.tabSessionStore.fetchTabSession(tabID: tabUUID)
             }
-            await selectTabWithSession(tab: tab,
+            self?.selectTabWithSession(tab: tab,
                                        previous: previous,
                                        sessionData: sessionData)
         }
@@ -436,10 +436,11 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
         store.dispatch(action)
     }
 
-    @MainActor
     private func selectTabWithSession(tab: Tab, previous: Tab?, sessionData: Data?) {
-        selectedTab?.createWebview(with: sessionData)
-        selectedTab?.lastExecutedTime = Date.now()
+        ensureMainThread { [weak self] in
+            self?.selectedTab?.createWebview(with: sessionData)
+            self?.selectedTab?.lastExecutedTime = Date.now()
+        }
     }
 
     // MARK: - Screenshots

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -119,6 +119,20 @@ class TabManagerTests: XCTestCase {
         XCTAssertEqual(subject.tabs.count, 5)
     }
 
+    // MARK: - Select tab
+
+    func test_selectTab_doesNotRetain() {
+        let tabCount = 3
+        let subject = createSubject()
+        addTabs(to: subject, count: tabCount)
+        XCTAssertEqual(subject.selectedIndex, -1) // No tab selected yet
+
+        subject.selectTab(subject.tabs.last)
+
+        XCTAssertEqual(subject.tabs.count, tabCount)
+        XCTAssertEqual(subject.selectedIndex, tabCount - 1)
+    }
+
     // MARK: - Save preview screenshot
 
     func testSaveScreenshotWithNoImage() async throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9528)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21088)

## :bulb: Description
This PR fixes memory leak test failures for the `selectTab` method.

This is a watered down version of #21246 where I do not attempt to make any other test improvements.

The new `test_selectTab_doesNotRetain` test passes at 20,000 iterations without failure for me.

**Test Note:** 
To test really thoroughly, you sometimes need to use xcode right click > run repeatedly option to run individual test and/or TabManagerTests suite upwards of 5,000 times.

@cyndichin This helps, but does not fix, the `addTabsForURLs` I'm afraid.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

