### PR TITLE
Bugfix FXIOS-9762 [Unit Tests] Separate testQueryLogins into isolated tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
@@ -61,29 +61,40 @@ class PasswordManagerViewModelTests: XCTestCase {
         waitForExpectations(timeout: 10.0, handler: nil)
     }
 
-    func testQueryLogins() {
-        let expectation = XCTestExpectation()
+    func testQueryLoginsWithEmptyString() {
+        let expectation = XCTestExpectation(description: "Waiting for login query to complete")
         viewModel.queryLogins("") { emptyQueryResult in
             XCTAssertEqual(emptyQueryResult.count, 10)
             expectation.fulfill()
         }
+        wait(for: [expectation], timeout: 1)
+    }
 
+    func testQueryLoginsWithExampleString() {
+        let expectation = XCTestExpectation("Waiting for login query to complete")
         viewModel.queryLogins("example") { exampleQueryResult in
             XCTAssertEqual(exampleQueryResult.count, 10)
             expectation.fulfill()
         }
+        wait(for: [expectation], timeout: 1)
+    }
 
+    func testQueryLoginsWithNumericString() {
+        let expectation = XCTestExpectation("Waiting for login query to complete")
         viewModel.queryLogins("3") { threeQueryResult in
             XCTAssertEqual(threeQueryResult.count, 1)
             expectation.fulfill()
         }
+        wait(for: [expectation], timeout: 1)
+    }
 
+    func testQueryLoginsWithNoResults() {
+        let expectation = XCTestExpectation("Waiting for login query to complete")
         viewModel.queryLogins("yxz") { zQueryResult in
             XCTAssertEqual(zQueryResult.count, 0)
             expectation.fulfill()
         }
-
-        wait(for: [expectation], timeout: 5)
+        wait(for: [expectation], timeout: 1)
     }
 
     func testIsDuringSearchControllerDismiss() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
@@ -26,7 +26,6 @@ class PasswordManagerViewModelTests: XCTestCase {
         )
         self.dataSource = LoginDataSource(viewModel: self.viewModel)
         self.viewModel.setBreachAlertsManager(MockBreachAlertsClient())
-        self.addLogins()
     }
 
     override func tearDown() {
@@ -36,32 +35,35 @@ class PasswordManagerViewModelTests: XCTestCase {
         dataSource = nil
     }
 
-    private func addLogins() {
+    private func setupLogins() {
         _ = self.viewModel.profile.logins.wipeLocalEngine()
-
+        // Create an array to hold all the expectations
+        var expectations: [XCTestExpectation] = []
         for i in (0..<10) {
+            let addExp = XCTestExpectation(description: "Adding login \(i)\(#function)\(#line)")
+            expectations.append(addExp)
+
             let login = LoginEntry(fromJSONDict: [
                 "hostname": "https://example\(i).com",
                 "formSubmitUrl": "https://example.com",
                 "username": "username\(i)",
                 "password": "password\(i)"
             ])
-            let addExp = expectation(description: "\(#function)\(#line)")
-            self.viewModel.profile.logins.addLogin(login: login).upon { addResult in
-                XCTAssertTrue(addResult.isSuccess)
-                XCTAssertNotNil(addResult.successValue)
-                addExp.fulfill()
+            self.viewModel.profile.logins.addLogin(login: login) { result in
+                switch result {
+                case .success(let logins):
+                    XCTAssertEqual(logins?.fields.origin, "https://example\(i).com")
+                    addExp.fulfill()
+                case .failure:
+                    XCTFail("Should not have failed")
+                }
             }
         }
-
-        let logins = self.viewModel.profile.logins.listLogins().value
-        XCTAssertTrue(logins.isSuccess)
-        XCTAssertNotNil(logins.successValue)
-
-        waitForExpectations(timeout: 10.0, handler: nil)
+        wait(for: expectations, timeout: 10.0)
     }
 
     func testQueryLoginsWithEmptyString() {
+        setupLogins()
         let expectation = XCTestExpectation(description: "Waiting for login query to complete")
         viewModel.queryLogins("") { emptyQueryResult in
             XCTAssertEqual(emptyQueryResult.count, 10)
@@ -71,7 +73,8 @@ class PasswordManagerViewModelTests: XCTestCase {
     }
 
     func testQueryLoginsWithExampleString() {
-        let expectation = XCTestExpectation("Waiting for login query to complete")
+        setupLogins()
+        let expectation = XCTestExpectation(description: "Waiting for login query to complete")
         viewModel.queryLogins("example") { exampleQueryResult in
             XCTAssertEqual(exampleQueryResult.count, 10)
             expectation.fulfill()
@@ -80,7 +83,8 @@ class PasswordManagerViewModelTests: XCTestCase {
     }
 
     func testQueryLoginsWithNumericString() {
-        let expectation = XCTestExpectation("Waiting for login query to complete")
+        setupLogins()
+        let expectation = XCTestExpectation(description: "Waiting for login query to complete")
         viewModel.queryLogins("3") { threeQueryResult in
             XCTAssertEqual(threeQueryResult.count, 1)
             expectation.fulfill()
@@ -89,7 +93,8 @@ class PasswordManagerViewModelTests: XCTestCase {
     }
 
     func testQueryLoginsWithNoResults() {
-        let expectation = XCTestExpectation("Waiting for login query to complete")
+        setupLogins()
+        let expectation = XCTestExpectation(description: "Waiting for login query to complete")
         viewModel.queryLogins("yxz") { zQueryResult in
             XCTAssertEqual(zQueryResult.count, 0)
             expectation.fulfill()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
@@ -37,10 +37,10 @@ class PasswordManagerViewModelTests: XCTestCase {
 
     private func setupLogins() {
         _ = self.viewModel.profile.logins.wipeLocalEngine()
-        // Create an array to hold all the expectations
+
         var expectations: [XCTestExpectation] = []
         for i in (0..<10) {
-            let addExp = XCTestExpectation(description: "Adding login \(i)\(#function)\(#line)")
+            let addExp = XCTestExpectation(description: "Adding login \(i) \(#function)\(#line)")
             expectations.append(addExp)
 
             let login = LoginEntry(fromJSONDict: [


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9762)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21437)

## :bulb: Description
These tests were using the same expectation and relying on the same timeout. We should aim to have isolated tests. Although the tests are relying a lot of logic for `RustLogins`, which we would like to avoid, but will require larger refactor. This seems to fix the flakiness locally for the most part. Also, cleaned up how we are setting up logins to avoid using the Deferred method. Ran the whole test class `20,000` and unable to get an error. Before these changes, I was able to get an error within `50` runs. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

