### PR TITLE
Add MTE-2912 Focus iOS tests for iOS 15 and 16

### DIFF
--- a/.github/workflows/firefox-ios-ui-tests-old.yml
+++ b/.github/workflows/firefox-ios-ui-tests-old.yml
@@ -1,0 +1,82 @@
+name: Focus iOS 16 tests
+on:
+  workflow_dispatch:
+
+env:
+    browser: focus-ios
+    xcode_version: 15.4
+    ios_simulator_default: iPhone 14
+    xcodebuild_scheme: Focus
+    xcodebuild_target: XCUITest
+    test_results_directory: /Users/runner/tmp
+
+jobs:
+  Focus:
+    name: Focus
+    runs-on: macos-14
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4.1.7
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install packages
+        run: |
+          brew update
+          brew install blacktop/tap/ipsw
+          pip3 install virtualenv pipenv
+      - name: Setup Xcode
+        id: xcode
+        run: |
+          sudo rm -rf /Applications/Xcode.app
+          sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app/Contents/Developer
+          xcodebuild -version
+          ./checkout.sh
+          ./bootstrap.sh --force
+      - name: Create iOS 16 simulator
+        id: setup-simulator
+        run: |
+          brew install blacktop/tap/ipsw
+          echo "iOS 16.4 Simulator" | ipsw download xcode --sim
+          dmg_file=$(ls *.dmg)
+          curl https://gist.githubusercontent.com/testableapple/3688bbf7c0e475aa915bd34b7cf7876e/raw/db91bbbc5ace3835de34db5030c6b04e519847e5/install_runtime.sh > install_runtime.sh
+          chmod u+x install_runtime.sh
+          sh install_runtime.sh "${dmg_file}"
+          xcrun simctl list runtimes
+      - name: Build Focus
+        id: compile
+        run: |
+          xcodebuild build-for-testing \
+            -project Blockzilla.xcodeproj -scheme Focus \
+            -testPlan SmokeTest -configuration FocusDebug\
+            CODE_SIGNING_ALLOWED=NO -destination \
+            'platform=iOS Simulator,name=iPhone 14 Pro Max,OS=16.4'
+        working-directory: focus-ios
+      - name: Run unit tests
+        run: |
+          xcodebuild test-without-building \
+            -scheme Focus \
+            -project Blockzilla.xcodeproj -configuration FocusDebug \
+            CODE_SIGNING_ALLOWED=NO \
+            -destination 'platform=iOS Simulator,name=iPhone 14 Pro Max,OS=16.4' \
+            -testPlan UnitTests
+        working-directory: focus-ios
+      - name: Run smoke tests
+        run: |
+          xcodebuild test-without-building \
+            -scheme Focus \
+            -project Blockzilla.xcodeproj -configuration FocusDebug \
+            CODE_SIGNING_ALLOWED=NO \
+            -destination 'platform=iOS Simulator,name=iPhone 14 Pro Max,OS=16.4' \
+            -testPlan SmokeTest
+        working-directory: focus-ios
+      - name: Run full functional tests
+        run: |
+          xcodebuild test-without-building \
+            -scheme Focus \
+            -project Blockzilla.xcodeproj -configuration FocusDebug \
+            CODE_SIGNING_ALLOWED=NO \
+            -destination 'platform=iOS Simulator,name=iPhone 14 Pro Max,OS=16.4' \
+            -testPlan FullFunctionalTests
+        working-directory: focus-ios

--- a/.github/workflows/firefox-ios-ui-tests-old.yml
+++ b/.github/workflows/firefox-ios-ui-tests-old.yml
@@ -1,22 +1,29 @@
-name: Focus iOS 16 tests
+name: Focus iOS 15 & 16 tests
 on:
   workflow_dispatch:
 
 env:
     browser: focus-ios
     xcode_version: 15.4
-    ios_simulator_default: iPhone 14
-    xcodebuild_scheme: Focus
-    xcodebuild_target: XCUITest
     test_results_directory: /Users/runner/tmp
 
 jobs:
-  Focus:
-    name: Focus
+  Focus-iOS-Tests:
+    name: Focus iOS
     runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ios_version: 16.4
+            ios_simulator: iPhone 14
+          - ios_version: 15.5
+            ios_simulator: iPhone 13
     steps:
       - name: Check out source code
         uses: actions/checkout@v4.1.7
+        with:
+          repository: mozilla-mobile/firefox-ios
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -34,11 +41,11 @@ jobs:
           xcodebuild -version
           ./checkout.sh
           ./bootstrap.sh --force
-      - name: Create iOS 16 simulator
+      - name: Create iOS ${{ matrix.ios_version }} simulator
         id: setup-simulator
         run: |
           brew install blacktop/tap/ipsw
-          echo "iOS 16.4 Simulator" | ipsw download xcode --sim
+          echo "iOS ${{ matrix.ios_version }} Simulator" | ipsw download xcode --sim
           dmg_file=$(ls *.dmg)
           curl https://gist.githubusercontent.com/testableapple/3688bbf7c0e475aa915bd34b7cf7876e/raw/db91bbbc5ace3835de34db5030c6b04e519847e5/install_runtime.sh > install_runtime.sh
           chmod u+x install_runtime.sh
@@ -49,34 +56,37 @@ jobs:
         run: |
           xcodebuild build-for-testing \
             -project Blockzilla.xcodeproj -scheme Focus \
-            -testPlan SmokeTest -configuration FocusDebug\
+            -configuration FocusDebug \
             CODE_SIGNING_ALLOWED=NO -destination \
-            'platform=iOS Simulator,name=iPhone 14 Pro Max,OS=16.4'
+            'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}'
         working-directory: focus-ios
       - name: Run unit tests
         run: |
           xcodebuild test-without-building \
-            -scheme Focus \
-            -project Blockzilla.xcodeproj -configuration FocusDebug \
+            -project Blockzilla.xcodeproj -scheme Focus \
+            -configuration FocusDebug \
             CODE_SIGNING_ALLOWED=NO \
-            -destination 'platform=iOS Simulator,name=iPhone 14 Pro Max,OS=16.4' \
+            -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan UnitTests
-        working-directory: focus-ios
+        working-directory: ${{ env.browser }}
+        continue-on-error: true
       - name: Run smoke tests
         run: |
           xcodebuild test-without-building \
-            -scheme Focus \
-            -project Blockzilla.xcodeproj -configuration FocusDebug \
+            -project Blockzilla.xcodeproj -scheme Focus \
+            -configuration FocusDebug \
             CODE_SIGNING_ALLOWED=NO \
-            -destination 'platform=iOS Simulator,name=iPhone 14 Pro Max,OS=16.4' \
+            -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan SmokeTest
-        working-directory: focus-ios
+        working-directory: ${{ env.browser }}
+        continue-on-error: true
       - name: Run full functional tests
         run: |
           xcodebuild test-without-building \
-            -scheme Focus \
-            -project Blockzilla.xcodeproj -configuration FocusDebug \
+            -project Blockzilla.xcodeproj -scheme Focus \
+            -configuration FocusDebug \
             CODE_SIGNING_ALLOWED=NO \
-            -destination 'platform=iOS Simulator,name=iPhone 14 Pro Max,OS=16.4' \
+            -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan FullFunctionalTests
-        working-directory: focus-ios
+        working-directory: ${{ env.browser }}
+        continue-on-error: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2912)

## :bulb: Description
Let's put Focus iOS tests on Github Actions. Here are the tests being run:
* UnitTests
* Smoketest
* FullFunctionalTestPlan

The following iOS and simulators are used:
* iPhone 14 iOS 16.4
* iPhone 13 iOS 15.5

Sample test run: https://github.com/clarmso/metrics-firefox-ios/actions/runs/10231046658/job/28306535600

Here are the outstanding tasks for this work:
* Report to slack
* Output test failures info to Github Action job
* Dispatch the job automatically on a regular basis.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

