### PR TITLE
Add FXIOS-9195 #20363 ⁃ Enhanced Tracking Protection screen status enabled design

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4127,7 +4127,7 @@ extension String {
                 comment: "Text to let users know how many trackers were blocked on the current website. Placeholder for the number of trackers blocked")
 
             public static let noTrackersLabel = MZLocalizedString(
-                key: "Menu.EnhancedTrackingProtection.Details.Trackers.v128",
+                key: "Menu.EnhancedTrackingProtection.Details.NoTrackers.v131",
                 tableName: "EnhancedTrackingProtection",
                 value: "No trackers found",
                 comment: "Text to let users know that no trackers were found on the current website.")

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -737,11 +737,15 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
 
         siteDomainLabel.text = viewModel.websiteTitle
         siteDisplayTitleLabel.text = viewModel.displayTitle
-        let totalTrackerBlocked = String(viewModel.contentBlockerStats?.total ?? 0)
-        let trackersText = String(format: .Menu.EnhancedTrackingProtection.trackersBlockedLabel, totalTrackerBlocked)
-        trackersLabel.text = trackersText
+        if let trackersNumber = viewModel.contentBlockerStats?.total, trackersNumber > 0 {
+            trackersLabel.text = String(format: .Menu.EnhancedTrackingProtection.trackersBlockedLabel,
+                                        String(trackersNumber))
+        } else {
+            trackersLabel.text = .Menu.EnhancedTrackingProtection.noTrackersLabel
+        }
         shieldImage.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.shield)
             .withRenderingMode(.alwaysTemplate)
+        connectionStatusImage.image = viewModel.getConnectionStatusImage(themeType: currentTheme().type)
         connectionStatusLabel.text = viewModel.connectionStatusString
         toggleSwitch.isOn = viewModel.isSiteETPEnabled
         viewModel.isProtectionEnabled = toggleSwitch.isOn

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -737,12 +737,7 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
 
         siteDomainLabel.text = viewModel.websiteTitle
         siteDisplayTitleLabel.text = viewModel.displayTitle
-        if let trackersNumber = viewModel.contentBlockerStats?.total, trackersNumber > 0 {
-            trackersLabel.text = String(format: .Menu.EnhancedTrackingProtection.trackersBlockedLabel,
-                                        String(trackersNumber))
-        } else {
-            trackersLabel.text = .Menu.EnhancedTrackingProtection.noTrackersLabel
-        }
+        trackersLabel.text = getTrackerString()
         shieldImage.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.shield)
             .withRenderingMode(.alwaysTemplate)
         connectionStatusImage.image = viewModel.getConnectionStatusImage(themeType: currentTheme().type)
@@ -755,6 +750,15 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
         connectionDetailsTitleLabel.text = viewModel.connectionDetailsTitle
         connectionDetailsStatusLabel.text = viewModel.connectionDetailsHeader
         foxStatusImage.image = viewModel.connectionDetailsImage
+    }
+
+    private func getTrackerString() -> String {
+        if let trackersNumber = viewModel.contentBlockerStats?.total, trackersNumber > 0 {
+            return String(format: .Menu.EnhancedTrackingProtection.trackersBlockedLabel,
+                          String(trackersNumber))
+        } else {
+            return .Menu.EnhancedTrackingProtection.noTrackersLabel
+        }
     }
 
     private func setupViewActions() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9195)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20363)

## :bulb: Description
Changed UI state when protection is ON

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

