### PR TITLE
Bugfix FXIOS-9772 [Unit Tests] Update AccountSync tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
@@ -45,24 +45,21 @@ class AccountSyncHandlerTests: XCTestCase {
         XCTAssertEqual(syncManager.syncNamedCollectionsCalled, 1)
     }
 
-    func testTabDidGainFocus_highThrottleTime_doesntSync() {
-        let subject = AccountSyncHandler(with: profile, throttleTime: 1000, queue: DispatchQueue.global())
+    func testTabDidGainFocus_highThrottleTime_executedAtMostOnce() {
+        let threshold: Double = 1000
+        let stepWaitTime = 2.0
+        let subject = AccountSyncHandler(with: profile, throttleTime: threshold, queue: DispatchQueue.global())
         let tab = createTab(profile: profile)
-        subject.tabDidGainFocus(tab)
 
-        XCTAssertEqual(syncManager.syncNamedCollectionsCalled, 0)
-    }
-
-    func testTabDidGainFocus_multipleThrottle_withoutWaitdoesntSync() {
-        let subject = AccountSyncHandler(with: profile, throttleTime: 0.2, queue: DispatchQueue.global())
-        let tab = createTab(profile: profile)
-        subject.tabDidGainFocus(tab)
-        subject.tabDidGainFocus(tab)
-        subject.tabDidGainFocus(tab)
         subject.tabDidGainFocus(tab)
         subject.tabDidGainFocus(tab)
 
-        XCTAssertEqual(syncManager.syncNamedCollectionsCalled, 0)
+        let expectation = XCTestExpectation(description: "SyncNamedCollectionsCalled value expectation")
+        DispatchQueue.main.asyncAfter(deadline: .now() + stepWaitTime) {
+            XCTAssertEqual(self.syncManager.syncNamedCollectionsCalled, 1)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: stepWaitTime * 2)
     }
 
     func testTabDidGainFocus_multipleThrottle_withWaitSyncOnce() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9772)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21448)

## :bulb: Description
Two tests were flakey in the `AccountSyncHandlerTests`:
- `testTabDidGainFocus_multipleThrottle_withoutWaitdoesntSync`
- `testTabDidGainFocus_highThrottleTime_doesntSync`

The tests were originally testing that with multiple throttles or high throttle time, we wouldn't call sync at all. However, looking at our throttle code and `ThrottlerTests` it seems that we trigger at least one call. Based on this, I have removed the `testTabDidGainFocus_multipleThrottle_withoutWaitdoesntSync` since we are already covering the case of one execution call with `testTabDidGainFocus_multipleThrottle_withWaitSyncOnce`. I updated `testTabDidGainFocus_highThrottleTime_doesntSync` to follow suit in checking that at most one call is executed.

This may cause a larger issue in that there could have been a change with the throttle code that cause these tests to fail, but given that the changes have been in prod, it doesn't seem too much of a concern and that we just haven't updated the tests. Overall, I have updated the tests to follow that of `ThrottleTests` in that we execute at most once (instead of none).

These tests were ran 1000 times and passed without throwing errors. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
| Test Results 
| --- |
| ![image](https://github.com/user-attachments/assets/798947de-e3e1-4e0d-a411-0ddd6472eecf) |
