### PR TITLE
Bugfix FXIOS-9763 [Unit Tests] Fix flaky TabToolbarHelperTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -10,9 +10,6 @@ import Common
 import Shared
 
 class TabToolbarHelperTests: XCTestCase {
-    var subject: TabToolbarHelper!
-    var mockToolbar: MockTabToolbar!
-
     let backButtonImage = UIImage.templateImageNamed(StandardImageIdentifiers.Large.back)?
         .imageFlippedForRightToLeftLayoutDirection()
     let forwardButtonImage = UIImage.templateImageNamed(StandardImageIdentifiers.Large.forward)?
@@ -25,36 +22,41 @@ class TabToolbarHelperTests: XCTestCase {
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
-        mockToolbar = MockTabToolbar()
-        subject = TabToolbarHelper(toolbar: mockToolbar)
-        Glean.shared.resetGlean(clearStores: true)
     }
 
     override func tearDown() {
+        DependencyHelperMock().reset()
         super.tearDown()
-        AppContainer.shared.reset()
-        mockToolbar = nil
-        subject = nil
     }
 
     func testSetsInitialImages() {
+        let mockToolbar = MockTabToolbar()
+        _ = TabToolbarHelper(toolbar: mockToolbar)
         XCTAssertEqual(mockToolbar.backButton.image(for: .normal), backButtonImage)
         XCTAssertEqual(mockToolbar.forwardButton.image(for: .normal), forwardButtonImage)
     }
 
     func testSearchStateImages() {
+        let mockToolbar = MockTabToolbar()
+        let subject = TabToolbarHelper(toolbar: mockToolbar)
         subject.setMiddleButtonState(.search)
         XCTAssertEqual(mockToolbar.multiStateButton.image(for: .normal), searchButtonImage)
     }
 
     func testTapHome() {
+        let mockToolbar = MockTabToolbar()
+        let subject = TabToolbarHelper(toolbar: mockToolbar)
         subject.setMiddleButtonState(.home)
         XCTAssertEqual(mockToolbar.multiStateButton.image(for: .normal), imageHome)
     }
 
     func testTelemetryForSiteMenu() {
+        Glean.shared.resetGlean(clearStores: true)
+        let mockToolbar = MockTabToolbar()
+        _ = TabToolbarHelper(toolbar: mockToolbar)
         mockToolbar.tabToolbarDelegate?.tabToolbarDidPressMenu(mockToolbar, button: mockToolbar.appMenuButton)
         testCounterMetricRecordingSuccess(metric: GleanMetrics.AppMenu.siteMenu)
+        Glean.shared.resetGlean(clearStores: true)
     }
 
     func test_tabToolBarHelper_basicCreation_doesntLeak() {
@@ -123,8 +125,7 @@ class MockTabToolbar: TabToolbarProtocol {
 
     init() {
         profile = MockProfile()
-        tabManager = TabManagerImplementation(profile: profile,
-                                              uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
+        tabManager = MockTabManager()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         _tabToolBarDelegate = BrowserViewController(profile: profile, tabManager: tabManager)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9763)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21438)

## :bulb: Description
This test was failing due to this error:
![image](https://github.com/user-attachments/assets/fdd5e27f-a079-4408-82cc-36b3df9eef25)
- Move some setup and teardown code to each individual tests since not all of the tests are using it and we only care to add it to the tests that are relying on it
- Ran tests 1000 times and unable to trigger the same errors

Not too sure why this fixes the error that I saw previously. Discussed with @mattreaganmozilla that there may be conversations to rethink how we handle our dependencies and whether we want to even use AppContainer. Based on this, decided to go with this fix and not spend additional effort to investigate exactly why this fixes the error above.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

