### PR TITLE
Bugfix FXIOS-9771 [Unit Tests] Fix flaky TelemetryWrapperTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -13,14 +13,16 @@ class TelemetryWrapperTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
         Glean.shared.resetGlean(clearStores: true)
         Experiments.events.clearEvents()
     }
 
     override func tearDown() {
-        super.tearDown()
         Glean.shared.resetGlean(clearStores: true)
         Experiments.events.clearEvents()
+        DependencyHelperMock().reset()
+        super.tearDown()
     }
 
     // MARK: - Bookmarks
@@ -770,6 +772,7 @@ class TelemetryWrapperTests: XCTestCase {
 
     func test_backgroundWallpaperMetric_themedWallpaperIsSent() {
         let profile = MockProfile()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         TelemetryWrapper.shared.setup(profile: profile)
 
         let themedWallpaper = Wallpaper(id: "amethyst",
@@ -1446,7 +1449,7 @@ class TelemetryWrapperTests: XCTestCase {
         )
     }
 
-    func test_syncLogin_NimbusIsCalled() throws {
+    func test_syncLogin_NimbusIsCalled() {
         XCTAssertFalse(
             try Experiments.createJexlHelper()!.evalJexl(
                 expression: "'sync.login_completed_view'|eventSum('Days', 1, 0) > 0"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9771)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21447)

## :bulb: Description
Running these tests locally, I was getting an error where the AppContainer was failing to resolve the dependencies. I notice that we weren't using our dependency mocks and resetting it after each test. By doing so, I no longer see the error in the screenshot below. Also insure our `featureflagsmanager` was using the `mockProfile` in one test as well as clean up a test that was using an unnecessary throw. We also are calling the super class teardown too earlier, its best practice to call it after clean up. 

I ran these tests 100 times, so will keep monitoring if these are still flakey. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots 
| Error | 
| --- | 
| ![image](https://github.com/user-attachments/assets/7abc2ecd-6c59-4a3a-814f-91809a1484d0)| 
