### PR TITLE
Refactor FXIOS-9778 Add Multipath TCP (MPTCP) support

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/HTMLDataRequest.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/HTMLDataRequest.swift
@@ -21,6 +21,7 @@ struct DefaultHTMLDataRequest: HTMLDataRequest {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.httpAdditionalHeaders = ["User-Agent": RequestConstants.userAgent]
         configuration.timeoutIntervalForRequest = RequestConstants.timeout
+        configuration.multipathServiceType = .handover
 
         let urlSession = URLSession(configuration: configuration)
 

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */; };
 		158241282820698B00956B39 /* RustRemoteTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158241272820698B00956B39 /* RustRemoteTabsTests.swift */; };
 		15DE98FD27FCED4F00F1ECDB /* RustRemoteTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DE98FC27FCED4F00F1ECDB /* RustRemoteTabs.swift */; };
+		1BE7A4902C636AC800460798 /* URLSession+sharedMPTCP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE7A48F2C636AC800460798 /* URLSession+sharedMPTCP.swift */; };
+		1BE7A4922C636AEA00460798 /* URLSessionConfiguration+defaultMPTCP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE7A4912C636AEA00460798 /* URLSessionConfiguration+defaultMPTCP.swift */; };
 		1D06AE6624FEE4D5000B092B /* TopSitesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D06AE6524FEE4D5000B092B /* TopSitesProvider.swift */; };
 		1D06AE6A24FEE8D6000B092B /* TabProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D06AE6924FEE8D6000B092B /* TabProvider.swift */; };
 		1D0BA05C24F46A0400D731B5 /* TopSitesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0BA05B24F46A0400D731B5 /* TopSitesProvider.swift */; };
@@ -2364,6 +2366,8 @@
 		1BA8499F9CDB2D9FC59EC547 /* sat-Olck */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sat-Olck"; path = "sat-Olck.lproj/HistoryPanel.strings"; sourceTree = "<group>"; };
 		1BCB46B98C7EF0844081BADE /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		1BE04EA5B4E6654288CBB928 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
+		1BE7A48F2C636AC800460798 /* URLSession+sharedMPTCP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+sharedMPTCP.swift"; sourceTree = "<group>"; };
+		1BE7A4912C636AEA00460798 /* URLSessionConfiguration+defaultMPTCP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionConfiguration+defaultMPTCP.swift"; sourceTree = "<group>"; };
 		1BF1480584A7191A7FA97050 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Today.strings; sourceTree = "<group>"; };
 		1C0D49279DC88F974E4BE1CB /* gd */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gd; path = gd.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		1C284BDCAF7741956A35582A /* kk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kk; path = kk.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
@@ -9643,6 +9647,8 @@
 				E1442FC7294782D7003680B0 /* UIViewController+Extension.swift */,
 				C81A8F2426D3ED1900EBA539 /* UIWindow+Extension.swift */,
 				E1442FC9294782D8003680B0 /* URL+Mail.swift */,
+				1BE7A48F2C636AC800460798 /* URLSession+sharedMPTCP.swift */,
+				1BE7A4912C636AEA00460798 /* URLSessionConfiguration+defaultMPTCP.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -15847,6 +15853,7 @@
 				8AB8571F27D931B40075C173 /* EmptyTopSiteCell.swift in Sources */,
 				CAC458F1249429C20042561A /* PasswordManagerSelectionHelper.swift in Sources */,
 				C8656D75270F834600E199EA /* FlaggableFeatureOptions.swift in Sources */,
+				1BE7A4922C636AEA00460798 /* URLSessionConfiguration+defaultMPTCP.swift in Sources */,
 				C8CD80D82A1E31C20097C3AE /* NimbusOnboardingTestingConfigUtility.swift in Sources */,
 				81E1914D2BB8578600543D78 /* OnboardingMultipleChoiceSelectionDelegate.swift in Sources */,
 				8AB8573727D951640075C173 /* HomeLogoHeaderViewModel.swift in Sources */,
@@ -15897,6 +15904,7 @@
 				8A9AC46B276D11280047F5B0 /* PocketViewModel.swift in Sources */,
 				8A7653BF28A2C92600924ABF /* PocketStandardCellViewModel.swift in Sources */,
 				8A5D1CAE2A30D71A005AD35C /* ThemeSetting.swift in Sources */,
+				1BE7A4902C636AC800460798 /* URLSession+sharedMPTCP.swift in Sources */,
 				C82F4C2B29AE2DF1005BD116 /* NotificationsSettingsViewController.swift in Sources */,
 				59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */,
 				C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */,

--- a/firefox-ios/Client/Entitlements/FennecApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FennecApplication.entitlements
@@ -6,6 +6,8 @@
 	<string>development</string>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>
+	<key>com.apple.developer.networking.multipath</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.Fennec</string>

--- a/firefox-ios/Client/Entitlements/FennecEnterpriseApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FennecEnterpriseApplication.entitlements
@@ -6,6 +6,8 @@
 	<string>development</string>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>
+	<key>com.apple.developer.networking.multipath</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.Fennec.enterprise</string>

--- a/firefox-ios/Client/Entitlements/FirefoxApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FirefoxApplication.entitlements
@@ -2,16 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>production</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>
 	</array>
-    <key>com.apple.developer.authentication-services.autofill-credential-provider</key>
-    <true/>
-    <key>com.apple.developer.web-browser</key>
-    <true/>
-	<key>aps-environment</key>
-	<string>production</string>
+	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
+	<true/>
+	<key>com.apple.developer.networking.multipath</key>
+	<true/>
+	<key>com.apple.developer.web-browser</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.Firefox</string>

--- a/firefox-ios/Client/Entitlements/FirefoxBetaApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FirefoxBetaApplication.entitlements
@@ -2,12 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>production</string>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
+	<true/>
+	<key>com.apple.developer.networking.multipath</key>
 	<true/>
 	<key>com.apple.developer.web-browser</key>
 	<true/>
-	<key>aps-environment</key>
-	<string>production</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.mozilla.ios.FirefoxBeta</string>

--- a/firefox-ios/Client/Extensions/URLSession+sharedMPTCP.swift
+++ b/firefox-ios/Client/Extensions/URLSession+sharedMPTCP.swift
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+extension URLSession{
+    static let sharedMPTCP: URLSession = URLSession(configuration: URLSessionConfiguration.defaultMPTCP)
+}

--- a/firefox-ios/Client/Extensions/URLSession+sharedMPTCP.swift
+++ b/firefox-ios/Client/Extensions/URLSession+sharedMPTCP.swift
@@ -4,6 +4,6 @@
 
 import Foundation
 
-extension URLSession{
-    static let sharedMPTCP: URLSession = URLSession(configuration: URLSessionConfiguration.defaultMPTCP)
+extension URLSession {
+    static let sharedMPTCP = URLSession(configuration: URLSessionConfiguration.defaultMPTCP)
 }

--- a/firefox-ios/Client/Extensions/URLSessionConfiguration+defaultMPTCP.swift
+++ b/firefox-ios/Client/Extensions/URLSessionConfiguration+defaultMPTCP.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+extension URLSessionConfiguration{
+    static var defaultMPTCP: URLSessionConfiguration{
+        var conf = Self.default
+        #if os(iOS)
+            // multipath is only available on iOS, enable it only in this case
+            conf.multipathServiceType = .handover
+        #endif
+        // if we aren't building for iOS, defaultMPTCP == default, thus fall back to TCP
+        return conf
+    }
+    
+    static var ephemeralMPTCP: URLSessionConfiguration{
+        var conf = Self.ephemeral
+        #if os(iOS)
+            // multipath is only available on iOS, enable it only in this case
+            conf.multipathServiceType = .handover
+        #endif
+        // if we aren't building for iOS, defaultMPTCP == default, thus fall back to TCP
+        return conf
+    }
+}

--- a/firefox-ios/Client/Extensions/URLSessionConfiguration+defaultMPTCP.swift
+++ b/firefox-ios/Client/Extensions/URLSessionConfiguration+defaultMPTCP.swift
@@ -6,7 +6,7 @@ import Foundation
 
 extension URLSessionConfiguration {
     static var defaultMPTCP: URLSessionConfiguration {
-        var conf = self.default
+        let conf = self.default
         #if os(iOS)
             // multipath is only available on iOS, enable it only in this case
             conf.multipathServiceType = .handover
@@ -16,7 +16,7 @@ extension URLSessionConfiguration {
     }
 
     static var ephemeralMPTCP: URLSessionConfiguration {
-        var conf = self.ephemeral
+        let conf = self.ephemeral
         #if os(iOS)
             // multipath is only available on iOS, enable it only in this case
             conf.multipathServiceType = .handover

--- a/firefox-ios/Client/Extensions/URLSessionConfiguration+defaultMPTCP.swift
+++ b/firefox-ios/Client/Extensions/URLSessionConfiguration+defaultMPTCP.swift
@@ -4,8 +4,8 @@
 
 import Foundation
 
-extension URLSessionConfiguration{
-    static var defaultMPTCP: URLSessionConfiguration{
+extension URLSessionConfiguration {
+    static var defaultMPTCP: URLSessionConfiguration {
         var conf = self.default
         #if os(iOS)
             // multipath is only available on iOS, enable it only in this case
@@ -14,8 +14,8 @@ extension URLSessionConfiguration{
         // if we aren't building for iOS, defaultMPTCP == default, thus fall back to TCP
         return conf
     }
-    
-    static var ephemeralMPTCP: URLSessionConfiguration{
+
+    static var ephemeralMPTCP: URLSessionConfiguration {
         var conf = self.ephemeral
         #if os(iOS)
             // multipath is only available on iOS, enable it only in this case

--- a/firefox-ios/Client/Extensions/URLSessionConfiguration+defaultMPTCP.swift
+++ b/firefox-ios/Client/Extensions/URLSessionConfiguration+defaultMPTCP.swift
@@ -6,7 +6,7 @@ import Foundation
 
 extension URLSessionConfiguration{
     static var defaultMPTCP: URLSessionConfiguration{
-        var conf = Self.default
+        var conf = self.default
         #if os(iOS)
             // multipath is only available on iOS, enable it only in this case
             conf.multipathServiceType = .handover
@@ -16,12 +16,12 @@ extension URLSessionConfiguration{
     }
     
     static var ephemeralMPTCP: URLSessionConfiguration{
-        var conf = Self.ephemeral
+        var conf = self.ephemeral
         #if os(iOS)
             // multipath is only available on iOS, enable it only in this case
             conf.multipathServiceType = .handover
         #endif
-        // if we aren't building for iOS, defaultMPTCP == default, thus fall back to TCP
+        // If we aren't building for iOS, ephemeralMPTCP == ephemeral, thus fallback to TCP
         return conf
     }
 }

--- a/firefox-ios/Client/Extensions/URLSessionConfiguration+defaultMPTCP.swift
+++ b/firefox-ios/Client/Extensions/URLSessionConfiguration+defaultMPTCP.swift
@@ -7,21 +7,13 @@ import Foundation
 extension URLSessionConfiguration {
     static var defaultMPTCP: URLSessionConfiguration {
         let conf = self.default
-        #if os(iOS)
-            // multipath is only available on iOS, enable it only in this case
-            conf.multipathServiceType = .handover
-        #endif
-        // if we aren't building for iOS, defaultMPTCP == default, thus fall back to TCP
+        conf.multipathServiceType = .handover
         return conf
     }
 
     static var ephemeralMPTCP: URLSessionConfiguration {
         let conf = self.ephemeral
-        #if os(iOS)
-            // multipath is only available on iOS, enable it only in this case
-            conf.multipathServiceType = .handover
-        #endif
-        // If we aren't building for iOS, ephemeralMPTCP == ephemeral, thus fallback to TCP
+        conf.multipathServiceType = .handover
         return conf
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
@@ -164,7 +164,7 @@ class ActionProviderBuilder {
 
             makeURLSession(
                 userAgent: UserAgent.fxaUserAgent,
-                configuration: URLSessionConfiguration.default
+                configuration: URLSessionConfiguration.defaultMPTCP
             ).dataTask(with: url) { (data, response, error) in
                 guard validatedHTTPResponse(response, statusCode: 200..<300) != nil else {
                     application.endBackgroundTask(taskId)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3856,7 +3856,7 @@ extension BrowserViewController {
     func getImageData(_ url: URL, success: @escaping (Data) -> Void) {
         makeURLSession(
             userAgent: UserAgent.fxaUserAgent,
-            configuration: URLSessionConfiguration.default).dataTask(with: url
+            configuration: URLSessionConfiguration.defaultMPTCP).dataTask(with: url
             ) { (data, response, error) in
             if validatedHTTPResponse(response, statusCode: 200..<300) != nil,
                let data = data {

--- a/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadQueue.swift
@@ -131,7 +131,7 @@ class HTTPDownload: Download {
             self.hasContentEncoding = false
         }
 
-        self.session = URLSession(configuration: .ephemeral, delegate: self, delegateQueue: .main)
+        self.session = URLSession(configuration: .ephemeralMPTCP, delegate: self, delegateQueue: .main)
         self.task = session?.downloadTask(with: self.request)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/OpenInHelper/OpenPassBookHelper.swift
@@ -30,7 +30,7 @@ class OpenPassBookHelper {
     private let presenter: Presenter
     private let cookieStore: WKHTTPCookieStore
     private lazy var session = makeURLSession(userAgent: UserAgent.fxaUserAgent,
-                                              configuration: .ephemeral)
+                                              configuration: .ephemeralMPTCP)
     private let logger: Logger
 
     init(response: URLResponse,

--- a/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchSuggestClient.swift
@@ -22,7 +22,7 @@ class SearchSuggestClient {
 
     fileprivate lazy var urlSession: URLSession = makeURLSession(
         userAgent: self.userAgent,
-        configuration: URLSessionConfiguration.ephemeral
+        configuration: URLSessionConfiguration.ephemeralMPTCP
     )
 
     init(searchEngine: OpenSearchEngine, userAgent: String) {

--- a/firefox-ios/Client/Frontend/Browser/TemporaryDocument.swift
+++ b/firefox-ios/Client/Frontend/Browser/TemporaryDocument.swift
@@ -23,7 +23,7 @@ class TemporaryDocument: NSObject {
         super.init()
 
         self.session = URLSession(
-            configuration: .default,
+            configuration: .defaultMPTCP,
             delegate: nil,
             delegateQueue: temporaryDocumentOperationQueue
         )

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/ContileProvider.swift
@@ -35,7 +35,7 @@ class ContileProvider: ContileProviderInterface, URLCaching, FeatureFlaggable {
     init(
         networking: ContileNetworking = DefaultContileNetwork(
             with: makeURLSession(userAgent: UserAgent.mobileUserAgent(),
-                                 configuration: URLSessionConfiguration.default)),
+                                 configuration: URLSessionConfiguration.defaultMPTCP)),
         urlCache: URLCache = URLCache.shared,
         logger: Logger = DefaultLogger.shared
     ) {

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/NetworkServices/WallpaperNetworkModule.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/NetworkServices/WallpaperNetworkModule.swift
@@ -8,7 +8,7 @@ import Shared
 class WallpaperNetworkingModule: WallpaperNetworking {
     private var urlSession: URLSessionProtocol
 
-    init(with urlSession: URLSessionProtocol = URLSession.shared) {
+    init(with urlSession: URLSessionProtocol = URLSession.sharedMPTCP) {
         self.urlSession = urlSession
     }
 

--- a/firefox-ios/Client/Frontend/PasswordManagement/BreachAlertsClient.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/BreachAlertsClient.swift
@@ -39,7 +39,7 @@ public class BreachAlertsClient: BreachAlertsClientProtocol {
         request.httpMethod = "HEAD"
 
         dataTask?.cancel()
-        dataTask = URLSession.shared.dataTask(with: request) { _, response, _ in
+        dataTask = URLSession.sharedMPTCP.dataTask(with: request) { _, response, _ in
             guard let response = response as? HTTPURLResponse else { return }
             guard response.statusCode < 400 else {
                 completion(nil)
@@ -62,7 +62,7 @@ public class BreachAlertsClient: BreachAlertsClientProtocol {
         guard let url = URL(string: endpoint.rawValue, invalidCharacters: false) else { return }
 
         dataTask?.cancel()
-        dataTask = URLSession.shared.dataTask(with: url) { data, response, error in
+        dataTask = URLSession.sharedMPTCP.dataTask(with: url) { data, response, error in
             guard let response = response as? HTTPURLResponse else { return }
             guard response.statusCode < 400 else {
                 return

--- a/firefox-ios/Providers/Pocket/PocketProvider.swift
+++ b/firefox-ios/Providers/Pocket/PocketProvider.swift
@@ -58,7 +58,7 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
 
     private lazy var urlSession = makeURLSession(
         userAgent: UserAgent.defaultClientUserAgent,
-        configuration: URLSessionConfiguration.default
+        configuration: URLSessionConfiguration.defaultMPTCP
     )
 
     private lazy var pocketKey: String? = {

--- a/firefox-ios/Shared/NetworkUtils.swift
+++ b/firefox-ios/Shared/NetworkUtils.swift
@@ -11,6 +11,7 @@ public func makeURLSession(
     timeout: TimeInterval? = nil
 ) -> URLSession {
     configuration.httpAdditionalHeaders = ["User-Agent": userAgent]
+    configuration.multipathServiceType = .handover
     if let t = timeout {
         configuration.timeoutIntervalForRequest = t
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/GeneralizedImageFetcherTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/GeneralizedImageFetcherTests.swift
@@ -112,7 +112,7 @@ extension GeneralizedImageFetcherTests {
     }
 
     func getGeneralizedImageFetcher(file: StaticString = #filePath, line: UInt = #line) -> GeneralizedImageFetcher {
-        let configuration = URLSessionConfiguration.ephemeral
+        let configuration = URLSessionConfiguration.ephemeralMPTCP
         configuration.protocolClasses = [URLProtocolStub.self]
         let session = URLSession(configuration: configuration)
         let cache = URLCache(memoryCapacity: 100000, diskCapacity: 1000, directory: URL(string: "/dev/null"))


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21470)
[Jira](https://mozilla-hub.atlassian.net/browse/FXIOS-9778)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

MPTCP is a TCP extension allowing to improve network reliabilty by using mutiple network interface for the same TCP connection. Check https://www.mptcp.dev and https://developer.apple.com/documentation/foundation/urlsessionconfiguration/improving_network_reliability_using_multipath_tcp for details. Changes to this repository includes introducing new configurations (defaultMPTCP/ephemeralMPTCP), replacing uses of default/ephemeral by these new configurations, introducing a sharedMPTCP property on URLSession and modifying the makeURL function to enable the handover mode by default

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [X] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

