### PR TITLE
Bugfix FXIOS-9762 [Unit Tests] Add more checks for PasswordManagerViewModelTests

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -780,6 +780,7 @@
 		8A8629E2288096C40096DDB1 /* BookmarksFolderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */; };
 		8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E52880B69C0096DDB1 /* BookmarksPanelTests.swift */; };
 		8A86DAD8277298DE00D7BFFF /* ClosedTabsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */; };
+		8A880C442C63CFE200B77F23 /* MockLoginViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A880C432C63CFE200B77F23 /* MockLoginViewModelDelegate.swift */; };
 		8A88815A2B20FFE0009635AE /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A8881592B20FFE0009635AE /* GCDWebServers */; };
 		8A88815C2B2103AD009635AE /* WebEngine in Frameworks */ = {isa = PBXBuildFile; productRef = 8A88815B2B2103AD009635AE /* WebEngine */; };
 		8A88815E2B21071E009635AE /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A88815D2B21071E009635AE /* GCDWebServers */; };
@@ -6540,6 +6541,7 @@
 		8A8629E52880B69C0096DDB1 /* BookmarksPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPanelTests.swift; sourceTree = "<group>"; };
 		8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabsStoreTests.swift; sourceTree = "<group>"; };
 		8A87AEE02C1B4D17007428B2 /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
+		8A880C432C63CFE200B77F23 /* MockLoginViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoginViewModelDelegate.swift; sourceTree = "<group>"; };
 		8A8917682B57283B008B01EA /* HomepageHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageHeaderCell.swift; sourceTree = "<group>"; };
 		8A8BAE152B2119E600D774EB /* InternalURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalURL.swift; sourceTree = "<group>"; };
 		8A8DDEBE276259A900E7B97A /* RatingPromptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManager.swift; sourceTree = "<group>"; };
@@ -11405,6 +11407,7 @@
 				BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */,
 				1D558A562BED7ECB001EF527 /* MockWindowManager.swift */,
 				0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */,
+				8A880C432C63CFE200B77F23 /* MockLoginViewModelDelegate.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -15678,6 +15681,7 @@
 				8A95FF672B1E97A800AC303D /* TelemetryContextualIdentifierTests.swift in Sources */,
 				965C3C9829343445006499ED /* MockAppSessionManager.swift in Sources */,
 				8AFCE50929DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift in Sources */,
+				8A880C442C63CFE200B77F23 /* MockLoginViewModelDelegate.swift in Sources */,
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* PasswordManagerSelectionHelperTests.swift in Sources */,
 				C8610DA82A0EBD4100B79FF1 /* OnboardingButtonActionTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -821,6 +821,7 @@
 		8AAAB0592C1B7240008830B3 /* MockRustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAAB0582C1B723F008830B3 /* MockRustFirefoxSuggest.swift */; };
 		8AAAB05B2C1B7268008830B3 /* ClientTabsSearchWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAAB05A2C1B7268008830B3 /* ClientTabsSearchWrapper.swift */; };
 		8AAAB05F2C1B72C9008830B3 /* SearchHighlightItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAAB05E2C1B72C9008830B3 /* SearchHighlightItem.swift */; };
+		8AABB92D2C64F77000F1FE51 /* LoginProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABB92C2C64F77000F1FE51 /* LoginProvider.swift */; };
 		8AABBCFC2A0010900089941E /* GleanWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBCFB2A0010900089941E /* GleanWrapper.swift */; };
 		8AABBCFF2A0017960089941E /* MockGleanWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */; };
 		8AABBD012A001ADF0089941E /* ApplicationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABBD002A001ADF0089941E /* ApplicationHelper.swift */; };
@@ -6581,6 +6582,7 @@
 		8AAAB0582C1B723F008830B3 /* MockRustFirefoxSuggest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockRustFirefoxSuggest.swift; sourceTree = "<group>"; };
 		8AAAB05A2C1B7268008830B3 /* ClientTabsSearchWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientTabsSearchWrapper.swift; sourceTree = "<group>"; };
 		8AAAB05E2C1B72C9008830B3 /* SearchHighlightItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHighlightItem.swift; sourceTree = "<group>"; };
+		8AABB92C2C64F77000F1FE51 /* LoginProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProvider.swift; sourceTree = "<group>"; };
 		8AABBCFB2A0010900089941E /* GleanWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanWrapper.swift; sourceTree = "<group>"; };
 		8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGleanWrapper.swift; sourceTree = "<group>"; };
 		8AABBD002A001ADF0089941E /* ApplicationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationHelper.swift; sourceTree = "<group>"; };
@@ -12372,6 +12374,7 @@
 				E1E5BE242A28F7BE00248F77 /* PasswordDetailViewControllerModel.swift */,
 				CAA3B7E52497DCB60094E3C1 /* LoginDataSource.swift */,
 				CA520E7924913C1B00CCAB48 /* PasswordManagerViewModel.swift */,
+				8AABB92C2C64F77000F1FE51 /* LoginProvider.swift */,
 				CA7FC7D224A6A9B70012F347 /* PasswordManagerDataSourceHelper.swift */,
 				CA90753724929B22005B794D /* NoLoginsView.swift */,
 				CAC458F0249429C20042561A /* PasswordManagerSelectionHelper.swift */,
@@ -15092,6 +15095,7 @@
 				EBB89507219398E500EB91A0 /* ContentBlocker.swift in Sources */,
 				216A0D792A40E85A008077BA /* ThemeSettingsState.swift in Sources */,
 				5A3A2A0D287F742C00B79EAC /* BackgroundSyncUtility.swift in Sources */,
+				8AABB92D2C64F77000F1FE51 /* LoginProvider.swift in Sources */,
 				21AFCFEE2AE80B700027E9CE /* TabsCoordinator.swift in Sources */,
 				8A1CBB952BE017D3008BE4D4 /* MicrosurveyPromptAction.swift in Sources */,
 				23ED80FF25C89C9800D0E9D5 /* DefaultBrowserOnboardingViewController.swift in Sources */,

--- a/firefox-ios/Client/Frontend/PasswordManagement/LoginProvider.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/LoginProvider.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import MozillaAppServices
+import Storage
+
+protocol LoginProvider: AnyObject {
+    func searchLoginsWithQuery(
+        _ query: String?,
+        completionHandler: @escaping (Result<[EncryptedLogin], Error>) -> Void)
+    func addLogin(login: LoginEntry, completionHandler: @escaping (Result<EncryptedLogin?, Error>) -> Void)
+}
+
+extension RustLogins: LoginProvider {}

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -47,7 +47,8 @@ class PasswordManagerListViewController: SensitiveViewController, Themeable {
         self.viewModel = PasswordManagerViewModel(
             profile: profile,
             searchController: searchController,
-            theme: themeManager.getCurrentTheme(for: windowUUID)
+            theme: themeManager.getCurrentTheme(for: windowUUID),
+            loginProvider: profile.logins
         )
         self.loginDataSource = LoginDataSource(viewModel: viewModel)
         self.themeManager = themeManager

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerViewModel.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerViewModel.swift
@@ -6,7 +6,6 @@ import Common
 import Foundation
 import Storage
 import Shared
-import AuthenticationServices
 
 import struct MozillaAppServices.EncryptedLogin
 import struct MozillaAppServices.LoginEntry
@@ -22,6 +21,7 @@ final class PasswordManagerViewModel {
     private(set) var isDuringSearchControllerDismiss = false
     private(set) var count = 0
     private(set) var hasData = false
+    private let loginProvider: LoginProvider
     weak var searchController: UISearchController?
     weak var delegate: LoginViewModelDelegate?
     private(set) var titles = [Character]()
@@ -46,10 +46,11 @@ final class PasswordManagerViewModel {
     var hasLoadedBreaches = false
     var theme: Theme
 
-    init(profile: Profile, searchController: UISearchController, theme: Theme) {
+    init(profile: Profile, searchController: UISearchController, theme: Theme, loginProvider: LoginProvider) {
         self.profile = profile
         self.searchController = searchController
         self.theme = theme
+        self.loginProvider = loginProvider
     }
 
     func loadLogins(_ query: String? = nil, loginDataSource: LoginDataSource) {
@@ -78,7 +79,7 @@ final class PasswordManagerViewModel {
     /// Searches SQLite database for logins that match query.
     /// Wraps the SQLiteLogins method to allow us to cancel it from our end.
     func queryLogins(_ query: String, completion: @escaping ([EncryptedLogin]) -> Void) {
-        profile.logins.searchLoginsWithQuery(query) { result in
+        loginProvider.searchLoginsWithQuery(query) { result in
             ensureMainThread {
                 switch result {
                 case .success(let logins):
@@ -155,7 +156,7 @@ final class PasswordManagerViewModel {
     }
 
     public func save(loginRecord: LoginEntry, completion: @escaping ((String?) -> Void)) {
-        profile.logins.addLogin(login: loginRecord, completionHandler: { result in
+        loginProvider.addLogin(login: loginRecord, completionHandler: { result in
             switch result {
             case .success(let encryptedLogin):
                 self.sendLoginsSavedTelemetry()

--- a/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
@@ -41,7 +41,8 @@ final class AppStartupTelemetry {
         let loginsViewModel = PasswordManagerViewModel(
             profile: profile,
             searchController: searchController,
-            theme: LightTheme()
+            theme: LightTheme(),
+            loginProvider: profile.logins
         )
         let dataSource = LoginDataSource(viewModel: loginsViewModel)
         loginsViewModel.loadLogins(loginDataSource: dataSource)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLoginViewModelDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLoginViewModelDelegate.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import Client
+
+class MockLoginViewModelDelegate: LoginViewModelDelegate {
+    var loginSectionsDidUpdateCalledCount = 0
+    var breachPathDidUpdateCalledCount = 0
+    func loginSectionsDidUpdate() {
+        loginSectionsDidUpdateCalledCount += 1
+    }
+
+    func breachPathDidUpdate() {
+        breachPathDidUpdateCalledCount += 1
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLoginViewModelDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLoginViewModelDelegate.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import MozillaAppServices
 @testable import Client
 
 class MockLoginViewModelDelegate: LoginViewModelDelegate {
@@ -14,5 +15,35 @@ class MockLoginViewModelDelegate: LoginViewModelDelegate {
 
     func breachPathDidUpdate() {
         breachPathDidUpdateCalledCount += 1
+    }
+}
+
+class MockLoginProvider: LoginProvider {
+    var searchLoginsWithQueryCalledCount = 0
+    var addLoginCalledCount = 0
+    func searchLoginsWithQuery(
+        _ query: String?,
+        completionHandler: @escaping (
+            Result<
+                [MozillaAppServices.EncryptedLogin],
+            any Error
+            >
+        ) -> Void
+    ) {
+        searchLoginsWithQueryCalledCount += 1
+        completionHandler(.success([]))
+    }
+
+    func addLogin(
+        login: MozillaAppServices.LoginEntry,
+        completionHandler: @escaping (
+            Result<
+            MozillaAppServices.EncryptedLogin?,
+            any Error
+            >
+        ) -> Void
+    ) {
+        addLoginCalledCount += 1
+        completionHandler(.success(nil))
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
@@ -7,6 +7,7 @@ import MozillaAppServices
 import Shared
 import Storage
 import XCTest
+import Glean
 
 @testable import Client
 
@@ -31,9 +32,11 @@ class PasswordManagerViewModelTests: XCTestCase {
         self.mockDelegate = MockLoginViewModelDelegate()
         self.viewModel.delegate = mockDelegate
         self.viewModel.setBreachAlertsManager(MockBreachAlertsClient())
+        Glean.shared.resetGlean(clearStores: true)
     }
 
     override func tearDown() {
+        Glean.shared.resetGlean(clearStores: true)
         viewModel = nil
         mockLoginProvider = nil
         mockDelegate = nil
@@ -54,6 +57,7 @@ class PasswordManagerViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.Logins.saved)
     }
 
     func testaddLoginWithString() {
@@ -69,6 +73,7 @@ class PasswordManagerViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.Logins.saved)
     }
 
     func testQueryLoginsWithEmptyString() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9762)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21437)

## :bulb: Description
Discussed with Razvan and decided to refactor these tests so are avoiding using the db to write these tests. Instead these tests should be testing the methods specifically in the `PasswordManagerViewModel` and decided to inject the logins in the initializer so that it can be mocked. I followed how it was used in `AddressProvider.swift` written by @razvanlitianu.  The tests have been rewritten to check for calls from the login provider. The actual testing of saving and querying login data should live in RustLoginsTests and not necessarily in these tests.

Ran these tests 1000 times.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

