### PR TITLE
Add FXIOS-9628 [Native Error Page] Feature flag for error page setup

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -27,6 +27,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case loginAutofill
     case menuRefactor
     case microsurvey
+    case nativeErrorPage
     case nightMode
     case preferSwitchToOpenTabOverDuplicate
     case reduxSearchSettings
@@ -88,6 +89,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .loginAutofill,
                 .microsurvey,
                 .menuRefactor,
+                .nativeErrorPage,
                 .nightMode,
                 .preferSwitchToOpenTabOverDuplicate,
                 .reduxSearchSettings,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1374,8 +1374,6 @@ class BrowserViewController: UIViewController,
 
     private func setupNativeErrorPage() {
         guard featureFlags.isFeatureEnabled(.nativeErrorPage, checking: .buildOnly) else { return }
-
-        print("native error page feature enabled")
     }
 
     // MARK: - Update content

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1369,6 +1369,15 @@ class BrowserViewController: UIViewController,
         updateBarBordersForMicrosurvey()
         updateViewConstraints()
     }
+
+    // MARK: - Native Error Page
+
+    private func setupNativeErrorPage() {
+        guard featureFlags.isFeatureEnabled(.nativeErrorPage, checking: .buildOnly) else { return }
+
+        print("native error page feature enabled")
+    }
+
     // MARK: - Update content
 
     func updateContentInHomePanel(_ browserViewType: BrowserViewType) {

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -302,8 +302,6 @@ final class NimbusFeatureFlagLayer {
     }
 
     private func checkNativeErrorPageFeature(from nimbus: FxNimbus) -> Bool {
-        let config = nimbus.features.nativeErrorPageFeature.value()
-
-        return config.enabled
+        return nimbus.features.nativeErrorPageFeature.value().enabled
     }
 }

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -58,6 +58,9 @@ final class NimbusFeatureFlagLayer {
         case .microsurvey:
             return checkMicrosurveyFeature(from: nimbus)
 
+        case .nativeErrorPage:
+            return checkNativeErrorPageFeature(from: nimbus)
+
         case .nightMode:
             return checkNightModeFeature(from: nimbus)
 
@@ -296,5 +299,11 @@ final class NimbusFeatureFlagLayer {
     private func checkCloseRemoteTabsFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.remoteTabManagement.value()
         return config.closeTabsEnabled
+    }
+
+    private func checkNativeErrorPageFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.nativeErrorPageFeature.value()
+
+        return config.enabled
     }
 }

--- a/firefox-ios/nimbus-features/nativeErrorPageFeature.yaml
+++ b/firefox-ios/nimbus-features/nativeErrorPageFeature.yaml
@@ -1,0 +1,19 @@
+# The configuration for the nativeErrorPageFeature feature
+features:
+  nativeErrorPage-feature:
+    description: >
+      This feature is for managing the roll out of the native error page feature
+    variables:
+      enabled:
+        description: >
+          If true, the feature is active.
+        type: Boolean
+        default: false
+
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: false

--- a/firefox-ios/nimbus-features/nativeErrorPageFeature.yaml
+++ b/firefox-ios/nimbus-features/nativeErrorPageFeature.yaml
@@ -1,6 +1,6 @@
 # The configuration for the nativeErrorPageFeature feature
 features:
-  nativeErrorPage-feature:
+  native-error-page-feature:
     description: >
       This feature is for managing the roll out of the native error page feature
     variables:

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -26,6 +26,7 @@ include:
   - nimbus-features/menuRefactorFeature.yaml
   - nimbus-features/messagingFeature.yaml
   - nimbus-features/microsurveyFeature.yaml
+  - nimbus-features/nativeErrorPageFeature.yaml
   - nimbus-features/nightModeFeature.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml
   - nimbus-features/reduxSearchSettingsFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9628)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21221)

## :bulb: Description
Added feature flag for native error page setup.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

