### PR TITLE
Temporary workaround for FXIOS-9785 fix (PR 21328 partial revert).

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3532,6 +3532,7 @@ extension BrowserViewController: TabManagerDelegate {
         updateFindInPageVisibility(isVisible: false, tab: previous)
         setupMiddleButtonStatus(isLoading: selected?.loading ?? false)
 
+        // [FXIOS-9785 Note #2] Back button can't be enabled unless the webView is already initialized
         if isToolbarRefactorEnabled {
             dispatchBackForwardToolbarAction(selected?.canGoBack, windowUUID, .backButtonStateChanged)
             dispatchBackForwardToolbarAction(selected?.canGoForward, windowUUID, .forwardButtonStateChanged)

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -32,6 +32,7 @@ class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvi
 
         didSet {
             self.scrollView?.addGestureRecognizer(panGesture)
+            // [FXIOS-9785 Note #3] Toolbar delegate can't be set unless the webView is already initialized
             scrollView?.delegate = self
             scrollView?.keyboardDismissMode = .onDrag
             configureRefreshControl(isEnabled: true)

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -440,6 +440,16 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
     private func selectTabWithSession(tab: Tab, previous: Tab?, sessionData: Data?) {
         selectedTab?.createWebview(with: sessionData)
         selectedTab?.lastExecutedTime = Date.now()
+
+        // Broadcast updates for any listeners
+        delegates.forEach {
+            $0.get()?.tabManager(
+                self,
+                didSelectedTabChange: tab,
+                previous: previous,
+                isRestoring: !tabRestoreHasFinished
+            )
+        }
     }
 
     // MARK: - Screenshots

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -441,6 +441,12 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
         selectedTab?.createWebview(with: sessionData)
         selectedTab?.lastExecutedTime = Date.now()
 
+        // [FXIOS-9785 Note 1] Workaround to resolve Aug 7, 2024 incident (PR #21486)
+        //   NOTE: This needs more work because the change from PR #21328 fixed another issue,
+        //         and thus couldn't be completely rolled back.
+        //         However, now we are repeating this delegate notification which is less than ideal and may have unexpected
+        //         consequences.
+        //         See ticket for more information.
         // Broadcast updates for any listeners
         delegates.forEach {
             $0.get()?.tabManager(


### PR DESCRIPTION
## :scroll: Tickets
Fixes 2 regressions (stopgap measure)
[Jira ticket #1](https://mozilla-hub.atlassian.net/browse/FXIOS-9785)
[Jira ticket #2](https://mozilla-hub.atlassian.net/browse/FXIOS-9781)

## :bulb: Description
Partially reverts change from [PR 21328](https://github.com/mozilla-mobile/firefox-ios/pull/21328/files).

Workaround for Aug 7, 2024 incident.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

