### PR TITLE
Bugfix FXIOS-9780 The site info sheet can no longer be dismissed

### DIFF
--- a/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
@@ -48,8 +48,9 @@ class EnhancedTrackingProtectionCoordinator: BaseCoordinator,
                 contentBlockerStats: contentBlockerStats
             )
 
-            self.enhancedTrackingProtectionMenuVC = TrackingProtectionViewController(viewModel: etpViewModel,
-                                                                                     windowUUID: tabManager.windowUUID)
+            enhancedTrackingProtectionMenuVC = TrackingProtectionViewController(viewModel: etpViewModel,
+                                                                                windowUUID: tabManager.windowUUID)
+            enhancedTrackingProtectionMenuVC?.enhancedTrackingProtectionMenuDelegate = self
         } else {
             let oldEtpViewModel = EnhancedTrackingProtectionMenuVM(
                 url: url,
@@ -59,10 +60,10 @@ class EnhancedTrackingProtectionCoordinator: BaseCoordinator,
                 contentBlockerStatus: contentBlockerStatus
             )
 
-            self.legacyEnhancedTrackingProtectionMenuVC = EnhancedTrackingProtectionMenuVC(viewModel: oldEtpViewModel,
-                                                                                           windowUUID: tabManager.windowUUID)
+            legacyEnhancedTrackingProtectionMenuVC = EnhancedTrackingProtectionMenuVC(viewModel: oldEtpViewModel,
+                                                                                      windowUUID: tabManager.windowUUID)
+            legacyEnhancedTrackingProtectionMenuVC?.enhancedTrackingProtectionMenuDelegate = self
         }
-        enhancedTrackingProtectionMenuVC?.enhancedTrackingProtectionMenuDelegate = self
     }
 
     func start(sourceView: UIView) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9780)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21472)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The legacy controller delegate was not connected anymore so the delegate methods were not being called which made the close button stop working
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

