### PR TITLE
Bugfix FXIOS-9654 Country set to Afghanistan after updating any field

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -135,12 +135,12 @@ final class AddressListViewModel: ObservableObject, FeatureFlaggable {
     }
 
     func saveEditButtonTap() {
-        toggleEditMode()
         saveAction? { [weak self] updatedAddress in
             guard let self else { return }
             guard case .edit(let currentAddress) = self.destination else { return }
             self.updateLocal(id: currentAddress.guid, updatedAddress: updatedAddress)
         }
+        toggleEditMode()
     }
 
     private func updateLocal(id: String, updatedAddress: UpdatableAddressFields) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9654)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21256)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Upon closer inspection, I found that the getCurrentFormData() method was saving data as expected. The real issue was that toggling the edit mode interfered with retrieving all the form data. Moving the toggle resolved the problem.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

