### PR TITLE
Bugfix FXIOS-9406 Fix intermittent blank homepage 

### DIFF
--- a/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabSessionStore.swift
@@ -10,21 +10,22 @@ public protocol TabSessionStore {
     /// - Parameters:
     ///   - tabID: an ID that uniquely identifies the tab
     ///   - sessionData: the data associated with a session, encoded as a Data object
-    func saveTabSession(tabID: UUID, sessionData: Data) async
+    func saveTabSession(tabID: UUID, sessionData: Data)
 
     /// Fetches the session data associated with a tab
     /// - Parameter tabID: an ID that uniquely identifies the tab
     /// - Returns: the data associated with a session, encoded as a Data object
-    func fetchTabSession(tabID: UUID) async -> Data?
+    func fetchTabSession(tabID: UUID) -> Data?
 
     /// Cleans up any tab session data files for tabs that are no longer open.
     func deleteUnusedTabSessionData(keeping: [UUID]) async
 }
 
-public actor DefaultTabSessionStore: TabSessionStore {
+public class DefaultTabSessionStore: TabSessionStore {
     let fileManager: TabFileManager
     let logger: Logger
     let filePrefix = "tab-"
+    private let lock = NSRecursiveLock()
 
     public init(fileManager: TabFileManager = DefaultTabFileManager(),
                 logger: Logger = DefaultLogger.shared) {
@@ -32,7 +33,7 @@ public actor DefaultTabSessionStore: TabSessionStore {
         self.logger = logger
     }
 
-    public func saveTabSession(tabID: UUID, sessionData: Data) async {
+    public func saveTabSession(tabID: UUID, sessionData: Data) {
         guard let directory = fileManager.tabSessionDataDirectory() else { return }
 
         if !fileManager.fileExists(atPath: directory) {
@@ -41,6 +42,8 @@ public actor DefaultTabSessionStore: TabSessionStore {
 
         let path = directory.appendingPathComponent(filePrefix + tabID.uuidString)
         do {
+            lock.lock()
+            defer { lock.unlock() }
             try sessionData.write(to: path, options: .atomicWrite)
         } catch {
             logger.log("Failed to save session data with error: \(error.localizedDescription)",
@@ -49,11 +52,13 @@ public actor DefaultTabSessionStore: TabSessionStore {
         }
     }
 
-    public func fetchTabSession(tabID: UUID) async -> Data? {
+    public func fetchTabSession(tabID: UUID) -> Data? {
         guard let path = fileManager.tabSessionDataDirectory()?.appendingPathComponent(filePrefix + tabID.uuidString)
         else { return nil }
 
         do {
+            lock.lock()
+            defer { lock.unlock() }
             return try Data(contentsOf: path)
         } catch {
             logger.log("Failed to decode session data with error: \(error.localizedDescription)",

--- a/BrowserKit/Tests/TabDataStoreTests/TabSessionStoreTests.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/TabSessionStoreTests.swift
@@ -21,24 +21,24 @@ final class TabSessionStoreTests: XCTestCase {
 
     // MARK: Save
 
-    func testSaveWithoutDirectory() async {
+    func testSaveWithoutDirectory() {
         let subject = createSubject()
         let uuid = UUID()
         let dataFile = Data(count: 100)
-        await subject.saveTabSession(tabID: uuid, sessionData: dataFile)
+        subject.saveTabSession(tabID: uuid, sessionData: dataFile)
 
         XCTAssertEqual(mockFileManager.tabSessionDataDirectoryCalledCount, 1)
         XCTAssertEqual(mockFileManager.fileExistsCalledCount, 0)
         XCTAssertEqual(mockFileManager.createDirectoryAtPathCalledCount, 0)
     }
 
-    func testSaveTabSession() async {
+    func testSaveTabSession() {
         let subject = createSubject()
         let uuid = UUID()
         let dataFile = Data(count: 100)
         mockFileManager.primaryDirectoryURL = URL(string: "some/directory")
         mockFileManager.fileExists = false
-        await subject.saveTabSession(tabID: uuid, sessionData: dataFile)
+        subject.saveTabSession(tabID: uuid, sessionData: dataFile)
 
         XCTAssertEqual(mockFileManager.tabSessionDataDirectoryCalledCount, 1)
         XCTAssertEqual(mockFileManager.fileExistsCalledCount, 1)
@@ -47,21 +47,21 @@ final class TabSessionStoreTests: XCTestCase {
 
     // MARK: Fetch
 
-    func testFetchTabSessionWithoutDirectory() async {
+    func testFetchTabSessionWithoutDirectory() {
         let subject = createSubject()
         let uuid = UUID()
 
-        _ = await subject.fetchTabSession(tabID: uuid)
+        _ = subject.fetchTabSession(tabID: uuid)
 
         XCTAssertEqual(mockFileManager.tabSessionDataDirectoryCalledCount, 1)
     }
 
-    func testFetchTabSession() async {
+    func testFetchTabSession() {
         let subject = createSubject()
         let uuid = UUID()
         mockFileManager.primaryDirectoryURL = URL(string: "some/directory")
 
-        _ = await subject.fetchTabSession(tabID: uuid)
+        _ = subject.fetchTabSession(tabID: uuid)
 
         XCTAssertEqual(mockFileManager.tabSessionDataDirectoryCalledCount, 1)
     }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -360,15 +360,13 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
 
         preserveTabs()
 
-        Task(priority: .high) {
-            var sessionData: Data?
-            if !tab.isFxHomeTab {
-                sessionData = await tabSessionStore.fetchTabSession(tabID: tabUUID)
-            }
-            await selectTabWithSession(tab: tab,
-                                       previous: previous,
-                                       sessionData: sessionData)
+        var sessionData: Data?
+        if !tab.isFxHomeTab {
+            sessionData = tabSessionStore.fetchTabSession(tabID: tabUUID)
         }
+        selectTabWithSession(tab: tab,
+                             previous: previous,
+                             sessionData: sessionData)
 
         // Default to false if the feature flag is not enabled
         var isPrivate = false
@@ -436,8 +434,8 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
         store.dispatch(action)
     }
 
-    @MainActor
     private func selectTabWithSession(tab: Tab, previous: Tab?, sessionData: Data?) {
+        assert(Thread.isMainThread, "Currently expected to be called only on main thread.")
         selectedTab?.createWebview(with: sessionData)
         selectedTab?.lastExecutedTime = Date.now()
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -436,22 +436,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
         assert(Thread.isMainThread, "Currently expected to be called only on main thread.")
         selectedTab?.createWebview(with: sessionData)
         selectedTab?.lastExecutedTime = Date.now()
-
-        // [FXIOS-9785 Note 1] Workaround to resolve Aug 7, 2024 incident (PR #21486)
-        //   NOTE: This needs more work because the change from PR #21328 fixed another issue,
-        //         and thus couldn't be completely rolled back.
-        //         However, now we are repeating this delegate notification which is less than ideal and may have unexpected
-        //         consequences.
-        //         See ticket for more information.
-        // Broadcast updates for any listeners
-        delegates.forEach {
-            $0.get()?.tabManager(
-                self,
-                didSelectedTabChange: tab,
-                previous: previous,
-                isRestoring: !tabRestoreHasFinished
-            )
-        }
     }
 
     // MARK: - Screenshots

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -308,9 +308,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
               let tabID = UUID(uuidString: tab.tabUUID)
         else { return }
 
-        Task {
-            await self.tabSessionStore.saveTabSession(tabID: tabID, sessionData: tabSession)
-        }
+        self.tabSessionStore.saveTabSession(tabID: tabID, sessionData: tabSession)
     }
 
     private func saveAllTabData() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabSessionStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabSessionStore.swift
@@ -10,17 +10,17 @@ class MockTabSessionStore: TabSessionStore {
     var tabID: UUID?
     var sessionData: Data?
 
-    func saveTabSession(tabID: UUID, sessionData: Data) async {
+    func saveTabSession(tabID: UUID, sessionData: Data) {
         saveTabSessionCallCount += 1
         self.tabID = tabID
         self.sessionData = sessionData
     }
 
-    func fetchTabSession(tabID: UUID) async -> Data? {
+    func fetchTabSession(tabID: UUID) -> Data? {
         return Data()
     }
 
-    func clearAllData() async {}
+    func clearAllData() {}
 
-    func deleteUnusedTabSessionData(keeping: [UUID]) async {}
+    func deleteUnusedTabSessionData(keeping: [UUID]) {}
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9406)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20831)

## :bulb: Description

I believe our use of `actor` for TabSessionStore is incorrect for a few reasons, and also problematic because it forces us to use an async `Task` in our `selectTab` function which should effectively be synchronous.

The change in this PR is to remove the use of `actor` and instead leverage a simple mutex to ensure atomicity of the on-disk files. Offhand I don't believe this lock is actually necessary 🤔 , however for now it will ensure that any concerns around concurrent reads/writes to the files are alleviated, and the lock should be extremely fast and contention should generally be minimal (or non-existent).

In practice, removing this use of `Task` appears to fix the blank homepage issue for me reliably. I also can't observe any issues with the back navigation button as we observed for the 8/7 incident. (This general area of the codebase still needs further evaluation and updates, we may for example be able to remove the workaround we originally added for the back button now that this removal of the actor is in place.)

## Unit Tests

To keep the PR diff readable, I haven't yet updated unit tests etc. for this refactor. Still forthcoming.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

