### PR TITLE
Add MTE-3284 - back arrow navigation test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -75,6 +75,7 @@
         "LoginTest",
         "MicrosurveyTests",
         "MultiWindowTests",
+        "NavigationTest",
         "NightModeTests",
         "OpeningScreenTests",
         "PerformanceTests",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
@@ -94,6 +94,7 @@
         "LoginTest",
         "MicrosurveyTests",
         "MultiWindowTests",
+        "NavigationTest\/testBackArrowNavigation()",
         "NavigationTest\/testBookmarkLink()",
         "NavigationTest\/testCopyLink()",
         "NavigationTest\/testCopyLinkPrivateMode()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
@@ -84,6 +84,7 @@
         "LoginTest\/testSearchLogin()",
         "MicrosurveyTests",
         "MultiWindowTests",
+        "NavigationTest\/testBackArrowNavigation()",
         "NavigationTest\/testBookmarkLink()",
         "NavigationTest\/testCopyLink()",
         "NavigationTest\/testCopyLinkPrivateMode()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -482,6 +482,29 @@ class NavigationTest: BaseTestCase {
         mozWaitForElementToExist(app.tables["Bookmarks List"].staticTexts[website_2["link"]!])
     }
 
+    // https://mozilla.testrail.io/index.php?/cases/view/2695828
+    func testBackArrowNavigation() {
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
+        navigator.nowAt(NewTabScreen)
+        closeFromAppSwitcherAndRelaunch()
+        navigator.openURL(path(forTestPage: "test-example.html"))
+        waitUntilPageLoad()
+        app.links[website_2["link"]!].tap()
+        waitUntilPageLoad()
+        let backButton = app.buttons[AccessibilityIdentifiers.Toolbar.backButton]
+        mozWaitForElementToExist(backButton)
+        XCTAssertTrue(backButton.isHittable, "Back button is not hittable")
+        XCTAssertTrue(backButton.isEnabled, "Back button is disabled")
+        backButton.tap()
+        waitUntilPageLoad()
+        mozWaitForValueContains(app.textFields["url"], value: "test-example.html")
+        XCTAssertTrue(backButton.isHittable, "Back button is not hittable")
+        XCTAssertTrue(backButton.isEnabled, "Back button is disabled")
+        backButton.tap()
+        waitUntilPageLoad()
+        mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
+    }
+
     private func openContextMenuForArticleLink() {
         navigator.openURL(path(forTestPage: "test-example.html"))
         mozWaitForElementToExist(app.webViews.links[website_2["link"]!], timeout: TIMEOUT_LONG)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3284

## :bulb: Description

https://mozilla-hub.atlassian.net/browse/FXIOS-9785

<img width="616" alt="Screenshot 2024-08-09 at 15 42 40" src="https://github.com/user-attachments/assets/4f18f703-02ce-4e96-9cc0-fcecb2a5f625">
