### PR TITLE
Refactor [FXIOS-9789] Refactor the TabManagerDelegate and add asserts for incident related preconditions

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3467,104 +3467,104 @@ extension BrowserViewController: SearchViewControllerDelegate {
 }
 
 extension BrowserViewController: TabManagerDelegate {
-    func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool) {
+    func tabManager(_ tabManager: TabManager, didSelectedTabChange selectedTab: Tab, previousTab: Tab?, isRestoring: Bool) {
+        // Failing to have a non-nil webView by this point will cause the toolbar scrolling behaviour to regress, back/foward
+        // buttons never to become enabled, etc. on tab restore after launch. [FXIOS-9785, FXIOS-9781]
+        assert(selectedTab.webView != nil, "Setup will fail if the webView is not initialized for selectedTab")
+
         // Remove the old accessibilityLabel. Since this webview shouldn't be visible, it doesn't need it
         // and having multiple views with the same label confuses tests.
-        if let webView = previous?.webView {
-            webView.endEditing(true)
-            webView.accessibilityLabel = nil
-            webView.accessibilityElementsHidden = true
-            webView.accessibilityIdentifier = nil
-            webView.removeFromSuperview()
+        if let previousWebView = previousTab?.webView {
+            previousWebView.endEditing(true)
+            previousWebView.accessibilityLabel = nil
+            previousWebView.accessibilityElementsHidden = true
+            previousWebView.accessibilityIdentifier = nil
+            previousWebView.removeFromSuperview()
         }
 
-        if let tab = selected, previous == nil || tab.isPrivate != previous?.isPrivate {
+        if previousTab == nil || selectedTab.isPrivate != previousTab?.isPrivate {
             applyTheme()
 
             if !isToolbarRefactorEnabled {
                 let ui: [PrivateModeUI?] = [toolbar, topTabsViewController, urlBar]
-                ui.forEach { $0?.applyUIMode(isPrivate: tab.isPrivate, theme: currentTheme()) }
+                ui.forEach { $0?.applyUIMode(isPrivate: selectedTab.isPrivate, theme: currentTheme()) }
             }
         } else {
             // Theme is applied to the tab and webView in the else case
             // because in the if block is applied already to all the tabs and web views
-            selected?.applyTheme(theme: currentTheme())
-            selected?.webView?.applyTheme(theme: currentTheme())
+            selectedTab.applyTheme(theme: currentTheme())
+            selectedTab.webView?.applyTheme(theme: currentTheme())
         }
 
-        if let tab = selected {
-            updateURLBarDisplayURL(tab)
-            if isToolbarRefactorEnabled, addressToolbarContainer.inOverlayMode, tab.url?.displayURL != nil {
-                addressToolbarContainer.leaveOverlayMode(reason: .finished, shouldCancelLoading: false)
-            } else if !isToolbarRefactorEnabled, urlBar.inOverlayMode, tab.url?.displayURL != nil {
-                urlBar.leaveOverlayMode(reason: .finished, shouldCancelLoading: false)
-            }
-
-            readerModeCache = tab.isPrivate ? MemoryReaderModeCache.sharedInstance : DiskReaderModeCache.sharedInstance
-            if let privateModeButton = topTabsViewController?.privateModeButton,
-               previous != nil && previous?.isPrivate != tab.isPrivate {
-                privateModeButton.setSelected(tab.isPrivate, animated: true)
-            }
-            ReaderModeHandlers.readerModeCache = readerModeCache
-
-            scrollController.tab = tab
-
-            if let webView = tab.webView {
-                webView.accessibilityLabel = .WebViewAccessibilityLabel
-                webView.accessibilityIdentifier = "contentView"
-                webView.accessibilityElementsHidden = false
-
-                browserDelegate?.show(webView: webView)
-
-                if webView.url == nil {
-                    // The web view can go gray if it was zombified due to memory pressure.
-                    // When this happens, the URL is nil, so try restoring the page upon selection.
-                    tab.reload()
-                }
-            }
-
-            // Update Fakespot sidebar if necessary
-            updateFakespot(tab: tab)
+        updateURLBarDisplayURL(selectedTab)
+        if isToolbarRefactorEnabled, addressToolbarContainer.inOverlayMode, selectedTab.url?.displayURL != nil {
+            addressToolbarContainer.leaveOverlayMode(reason: .finished, shouldCancelLoading: false)
+        } else if !isToolbarRefactorEnabled, urlBar.inOverlayMode, selectedTab.url?.displayURL != nil {
+            urlBar.leaveOverlayMode(reason: .finished, shouldCancelLoading: false)
         }
+
+        if let privateModeButton = topTabsViewController?.privateModeButton,
+           previousTab != nil && previousTab?.isPrivate != selectedTab.isPrivate {
+            privateModeButton.setSelected(selectedTab.isPrivate, animated: true)
+        }
+        readerModeCache = selectedTab.isPrivate ? MemoryReaderModeCache.sharedInstance : DiskReaderModeCache.sharedInstance
+        ReaderModeHandlers.readerModeCache = readerModeCache
+
+        scrollController.tab = selectedTab
+
+        if let webView = selectedTab.webView {
+            webView.accessibilityLabel = .WebViewAccessibilityLabel
+            webView.accessibilityIdentifier = "contentView"
+            webView.accessibilityElementsHidden = false
+
+            browserDelegate?.show(webView: webView)
+
+            if webView.url == nil {
+                // The webView can go gray if it was zombified due to memory pressure.
+                // When this happens, the URL is nil, so try restoring the page upon selection.
+                selectedTab.reload()
+            }
+        }
+
+        // Update Fakespot sidebar if necessary
+        updateFakespot(tab: selectedTab)
 
         updateTabCountUsingTabManager(tabManager)
 
         bottomContentStackView.removeAllArrangedViews()
-        if let bars = selected?.bars {
-            bars.forEach { bar in
-                bottomContentStackView.addArrangedViewToBottom(bar, completion: { self.view.layoutIfNeeded() })
-            }
+
+        selectedTab.bars.forEach { bar in
+            bottomContentStackView.addArrangedViewToBottom(bar, completion: { self.view.layoutIfNeeded() })
         }
 
-        updateFindInPageVisibility(isVisible: false, tab: previous)
-        setupMiddleButtonStatus(isLoading: selected?.loading ?? false)
+        updateFindInPageVisibility(isVisible: false, tab: previousTab)
+        setupMiddleButtonStatus(isLoading: selectedTab.loading)
 
-        // [FXIOS-9785 Note #2] Back button can't be enabled unless the webView is already initialized
         if isToolbarRefactorEnabled {
-            dispatchBackForwardToolbarAction(selected?.canGoBack, windowUUID, .backButtonStateChanged)
-            dispatchBackForwardToolbarAction(selected?.canGoForward, windowUUID, .forwardButtonStateChanged)
+            dispatchBackForwardToolbarAction(selectedTab.canGoBack, windowUUID, .backButtonStateChanged)
+            dispatchBackForwardToolbarAction(selectedTab.canGoForward, windowUUID, .forwardButtonStateChanged)
         } else {
-            navigationToolbar.updateBackStatus(selected?.canGoBack ?? false)
-            navigationToolbar.updateForwardStatus(selected?.canGoForward ?? false)
+            navigationToolbar.updateBackStatus(selectedTab.canGoBack)
+            navigationToolbar.updateForwardStatus(selectedTab.canGoForward)
         }
 
-        if let url = selected?.webView?.url, !InternalURL.isValid(url: url) {
+        if let url = selectedTab.webView?.url, !InternalURL.isValid(url: url) {
             if isToolbarRefactorEnabled {
-                addressToolbarContainer.updateProgressBar(progress: selected?.estimatedProgress ?? 0)
+                addressToolbarContainer.updateProgressBar(progress: selectedTab.estimatedProgress)
             } else {
-                urlBar.updateProgressBar(Float(selected?.estimatedProgress ?? 0))
+                urlBar.updateProgressBar(Float(selectedTab.estimatedProgress))
             }
         }
 
-        if let readerMode = selected?.getContentScript(name: ReaderMode.name()) as? ReaderMode {
-            updateReaderModeState(for: selected, readerModeState: readerMode.state)
+        if let readerMode = selectedTab.getContentScript(name: ReaderMode.name()) as? ReaderMode {
+            updateReaderModeState(for: selectedTab, readerModeState: readerMode.state)
             if readerMode.state == .active {
                 showReaderModeBar(animated: false)
             } else {
                 hideReaderModeBar(animated: false)
             }
         } else {
-            updateReaderModeState(for: selected, readerModeState: .unavailable)
+            updateReaderModeState(for: selectedTab, readerModeState: .unavailable)
         }
 
         if topTabsVisible {
@@ -3572,8 +3572,8 @@ extension BrowserViewController: TabManagerDelegate {
         }
 
        /// If the selectedTab is showing an error page trigger a reload
-        if let url = selected?.url, let internalUrl = InternalURL(url), internalUrl.isErrorPage {
-            selected?.reloadPage()
+        if let url = selectedTab.url, let internalUrl = InternalURL(url), internalUrl.isErrorPage {
+            selectedTab.reloadPage()
             return
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
@@ -937,19 +937,12 @@ extension LegacyTabDisplayManager: TabEventHandler {
 
 // MARK: - TabManagerDelegate
 extension LegacyTabDisplayManager: TabManagerDelegate {
-    func tabManager(
-        _ tabManager: TabManager,
-        didSelectedTabChange selected: Tab?,
-        previous: Tab?,
-        isRestoring: Bool
-    ) {
+    func tabManager(_ tabManager: TabManager, didSelectedTabChange selectedTab: Tab, previousTab: Tab?, isRestoring: Bool) {
         cancelDragAndGestures()
 
-        if let selected = selected {
-            // A tab can be re-selected during deletion
-            let changed = selected != previous
-            updateCellFor(tab: selected, selectedTabChanged: changed)
-        }
+        // A tab can be re-selected during deletion
+        let changedTab = selectedTab != previousTab
+        updateCellFor(tab: selectedTab, selectedTabChanged: changedTab)
 
         // Rather than using 'previous' Tab to deselect, just check if the selected tab
         // is different, and update the required cells. The refreshStore() cancels

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -31,8 +31,9 @@ class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvi
         }
 
         didSet {
+            // FXIOS-9781 This could result in scrolling not closing the toolbar
+            assert(scrollView != nil, "Can't set the scrollView delegate if the webView.scrollView is nil")
             self.scrollView?.addGestureRecognizer(panGesture)
-            // [FXIOS-9785 Note #3] Toolbar delegate can't be set unless the webView is already initialized
             scrollView?.delegate = self
             scrollView?.keyboardDismissMode = .onDrag
             configureRefreshControl(isEnabled: true)

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -10,7 +10,8 @@ import Shared
 
 // MARK: - TabManagerDelegate
 protocol TabManagerDelegate: AnyObject {
-    func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool)
+    // Must be called on the main thread
+    func tabManager(_ tabManager: TabManager, didSelectedTabChange selectedTab: Tab, previousTab: Tab?, isRestoring: Bool)
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, placeNextToParentTab: Bool, isRestoring: Bool)
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool)
 
@@ -21,7 +22,7 @@ protocol TabManagerDelegate: AnyObject {
 }
 
 extension TabManagerDelegate {
-    func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?, isRestoring: Bool) {}
+    func tabManager(_ tabManager: TabManager, didSelectedTabChange selectedTab: Tab, previousTab: Tab?, isRestoring: Bool) {}
     func tabManager(_ tabManager: TabManager, didAddTab tab: Tab, placeNextToParentTab: Bool, isRestoring: Bool) {}
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {}
 

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -236,10 +236,16 @@ class Tab: NSObject, ThemeApplicable {
     }
 
     var canGoBack: Bool {
+        // FXIOS-9785 This could result in the back button never being enabled for restored tabs
+        assert(webView != nil, "We should not be trying to enable or disable the back button before the webView is set")
+
         return webView?.canGoBack ?? false
     }
 
     var canGoForward: Bool {
+        // FXIOS-9785 This could result in the forward button never being enabled for restored tabs
+        assert(webView != nil, "We should not be trying to enable or disable the forward button before the webView is set")
+
         return webView?.canGoForward ?? false
     }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -385,7 +385,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
             $0.get()?.tabManager(
                 self,
                 didSelectedTabChange: tab,
-                previous: previous,
+                previousTab: previous,
                 isRestoring: !tabRestoreHasFinished
             )
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9789)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21499)

## :bulb: Description

This PR is largely refactoring and should cause no change in behaviour. However, new asserts during development will help protect against a future release regressing in the same way as the Aug 8, 2024 incident (FXIOS-9785).

- No calls to `didSelectedTabChange` ever had a `nil` `selectedTab`, so refactored the `TabManagerDelegate` method definition to not accept an optional and cleaned up implementations with unnecessary `??` fallbacks and optional unwrapping
- Refactored param naming for clarity in long method implementations
- Added asserts to critical codepaths related to the Aug 8, 2024 incident (on tab restore after hard kill, regressed closing toolbar, lost back/forward buttons being enabled). These issues were both caused by the `selectedTab`'s `webView` being `nil` (not yet initialized). @mattreaganmozilla 's PR https://github.com/mozilla-mobile/firefox-ios/pull/21496 fixed one of the related issues so saving a tab's `webView`'s `interactionState` (i.e. `sessionState`) is no longer asynchronous. Thus, the `webView` should always be initialized in the `TabManagerDelegate` `didSelectedTabChange` call.
- Cleaned up incident related notes from `FXIOS-9785`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

