### PR TITLE
Bugfix FXIOS-9804 - Page action for homepage tab is displayed for url tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -542,11 +542,13 @@ final class ToolbarMiddleware: FeatureFlaggable {
     ) -> [ToolbarActionState] {
         var actions = [ToolbarActionState]()
 
+        let isUrlChangeAction = action.actionType as? ToolbarMiddlewareActionType == .urlDidChange
         let isReaderModeAction = action.actionType as? ToolbarMiddlewareActionType == .readerModeStateChanged
         let readerModeState = isReaderModeAction ? action.readerModeState : toolbarState.readerModeState
+        let url = (isUrlChangeAction || isReaderModeAction) ? action.url : toolbarState.addressToolbar.url
         readerModeAction.shouldDisplayAsHighlighted = readerModeState == .active
 
-        guard action.url != nil, !isEditing else {
+        guard url != nil, !isEditing else {
             // On homepage we only show the QR code button
             return [qrCodeScanAction]
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9804)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21525)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

