### PR TITLE
 Refactor - Fix rust storage warning

### DIFF
--- a/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggest.swift
@@ -59,7 +59,7 @@ public class RustFirefoxSuggest: RustFirefoxSuggestProtocol {
         try await withCheckedThrowingContinuation { continuation in
             writerQueue.async(qos: .utility) {
                 do {
-                    try self.store.ingest(constraints: SuggestIngestionConstraints())
+                    _ = try self.store.ingest(constraints: SuggestIngestionConstraints())
                     continuation.resume()
                 } catch {
                     continuation.resume(throwing: error)


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
Fix rust storage warning. @linabutler tagging you since you worked in that area! The warning was that the return was not used, so just want to make sure this is expected 👀 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

