### PR TITLE
Refactor - ImageProvider SiteImageView extension is now also MainActor

### DIFF
--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/HeroImageFetcher/ImageProvider.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/HeroImageFetcher/ImageProvider.swift
@@ -13,6 +13,7 @@ protocol ImageProvider {
 }
 
 extension NSItemProvider: ImageProvider {
+    @MainActor
     func loadObject(ofClass aClass: NSItemProviderReading.Type) async throws -> UIImage {
         return try await withCheckedThrowingContinuation { continuation in
             loadObject(ofClass: aClass) { image, error in


### PR DESCRIPTION
## :scroll: Tickets
No tickets

## :bulb: Description
Warning was `Passing argument of non-sendable type 'NSItemProvider' outside of main actor-isolated context may introduce data races`.

<img width="1371" alt="Screenshot 2024-08-16 at 5 45 58 AM" src="https://github.com/user-attachments/assets/93bf1a64-e3ab-472c-9d7f-d017a41f424c">

I figured we could put the `extension NSItemProvider: ImageProvider` extension as `@MainActor` as well to avoid this issue (?). That extension is under the `SiteImageView` package and so it's not used anywhere else that there.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

