### PR TITLE
Refactor FXIOS-9761 Verify text color of location text field

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/DarkTheme.swift
@@ -47,7 +47,7 @@ private struct DarkColourPalette: ThemeColourPalette {
     var layerConfirmation: UIColor = FXColors.Green80
     var layerWarning: UIColor = FXColors.Yellow70.withAlphaComponent(0.77)
     var layerError: UIColor = FXColors.Pink80
-    var layerSelectedText: UIColor = FXColors.DarkGrey05.withAlphaComponent(0.34)
+    var layerSelectedText: UIColor = FXColors.LightGrey05.withAlphaComponent(0.34)
     var layerSearch: UIColor = FXColors.DarkGrey80
     var layerGradientURL = Gradient(colors: [
         FXColors.DarkGrey80.withAlphaComponent(0),

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -159,7 +159,7 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
         if isEditing {
             textColor = colors.textPrimary
         }
-        
+
         tintClearButton()
     }
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -50,6 +50,7 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
         autocorrectionType = .no
         autocapitalizationType = .none
         returnKeyType = .go
+        tintAdjustmentMode = .normal
         delegate = self
 
         // Disable dragging urls on iPhones because it conflicts with editing the text
@@ -87,18 +88,8 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        guard let image = UIImage(named: StandardImageIdentifiers.Large.crossCircleFill) else { return }
         if tintedClearImage == nil {
-            if let clearButtonTintColor {
-                tintedClearImage = image.withTintColor(clearButtonTintColor)
-            }
-        }
-
-        // Since we're unable to change the tint color of the clear image, we need to iterate through the
-        // subviews, find the clear button, and tint it ourselves.
-        // https://stackoverflow.com/questions/55046917/clear-button-on-text-field-not-accessible-with-voice-over-swift
-        if let clearButton = value(forKey: "_clearButton") as? UIButton {
-            clearButton.setImage(tintedClearImage, for: [])
+            tintClearButton()
         }
     }
 
@@ -163,6 +154,7 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
         let colors = theme.colors
         clearButtonTintColor = colors.iconPrimary
         markedTextStyle = [NSAttributedString.Key.backgroundColor: colors.layerSelectedText]
+        tintClearButton()
     }
 
     // MARK: - Private
@@ -233,6 +225,19 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     private func forceResetCursor() {
         selectedTextRange = nil
         selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
+    }
+
+    private func tintClearButton() {
+        // Since we're unable to change the tint color of the clear image, we need to use KVO to
+        // find the clear button, and tint it ourselves.
+        // https://stackoverflow.com/questions/27944781/how-to-change-the-tint-color-of-the-clear-button-on-a-uitextfield
+        guard let image = UIImage(named: StandardImageIdentifiers.Large.crossCircleFill),
+              let clearButtonTintColor,
+              let clearButton = value(forKey: "_clearButton") as? UIButton
+        else { return }
+
+        tintedClearImage = image.withTintColor(clearButtonTintColor)
+        clearButton.setImage(tintedClearImage, for: [])
     }
 
     // MARK: - UITextFieldDelegate

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -152,8 +152,14 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     // MARK: - ThemeApplicable
     func applyTheme(theme: Theme) {
         let colors = theme.colors
+        tintColor = colors.layerSelectedText
         clearButtonTintColor = colors.iconPrimary
         markedTextStyle = [NSAttributedString.Key.backgroundColor: colors.layerSelectedText]
+
+        if isEditing {
+            textColor = colors.textPrimary
+        }
+        
         tintClearButton()
     }
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -43,6 +43,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         return CGFloat(width)
     }
 
+    private lazy var urlTextFieldColor: UIColor = .black
     private lazy var urlTextFieldSubdomainColor: UIColor = .clear
     private lazy var gradientLayer = CAGradientLayer()
     private lazy var gradientView: UIView = .build()
@@ -276,7 +277,9 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         let urlString = urlAbsolutePath ?? ""
         let (subdomain, normalizedHost) = URL.getSubdomainAndHost(from: urlString)
 
-        let attributedString = NSMutableAttributedString(string: normalizedHost)
+        let attributedString = NSMutableAttributedString(
+            string: normalizedHost,
+            attributes: [.foregroundColor : urlTextFieldColor])
 
         if let subdomain {
             let range = NSRange(location: 0, length: subdomain.count)
@@ -403,6 +406,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
     // MARK: - ThemeApplicable
     func applyTheme(theme: Theme) {
         let colors = theme.colors
+        urlTextFieldColor = colors.textPrimary
         urlTextFieldSubdomainColor = colors.textSecondary
         gradientLayer.colors = colors.layerGradientURL.cgColors.reversed()
         searchEngineImageView.backgroundColor = colors.iconPrimary

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -279,7 +279,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
 
         let attributedString = NSMutableAttributedString(
             string: normalizedHost,
-            attributes: [.foregroundColor : urlTextFieldColor])
+            attributes: [.foregroundColor: urlTextFieldColor])
 
         if let subdomain {
             let range = NSRange(location: 0, length: subdomain.count)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9761)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21435)

## :bulb: Description
Sets the tint color for the text field. Uses the text color in edit mode (in non-edit mode the url gets formatted). Updates the selected text color for the dark theme. And updates the tint of the clear button when changing themes.

![Simulator Screen Recording - iPhone 15 Pro Max - 2024-08-16 at 17 24 42](https://github.com/user-attachments/assets/f0587a9f-ab03-455e-96b9-5b9ef89c0338)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

