### PR TITLE
Bugfix FXIOS-9811 [Unit Tests] Add mock autofill for CreditCardBottomSheet

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -780,7 +780,6 @@
 		8A8629E2288096C40096DDB1 /* BookmarksFolderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */; };
 		8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E52880B69C0096DDB1 /* BookmarksPanelTests.swift */; };
 		8A86DAD8277298DE00D7BFFF /* ClosedTabsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */; };
-		8A880C442C63CFE200B77F23 /* MockLoginViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A880C432C63CFE200B77F23 /* MockLoginViewModelDelegate.swift */; };
 		8A88815A2B20FFE0009635AE /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A8881592B20FFE0009635AE /* GCDWebServers */; };
 		8A88815C2B2103AD009635AE /* WebEngine in Frameworks */ = {isa = PBXBuildFile; productRef = 8A88815B2B2103AD009635AE /* WebEngine */; };
 		8A88815E2B21071E009635AE /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A88815D2B21071E009635AE /* GCDWebServers */; };
@@ -849,6 +848,10 @@
 		8AB8574627D97CB00075C173 /* HomepageContextMenuProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8574527D97CB00075C173 /* HomepageContextMenuProtocol.swift */; };
 		8AB8574827D97CD40075C173 /* HomePanelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8574727D97CD40075C173 /* HomePanelType.swift */; };
 		8AB8574A27D97CE90075C173 /* HomePanelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8574927D97CE90075C173 /* HomePanelDelegate.swift */; };
+		8AB893A32C73AF5200DAEED7 /* MockCreditCardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB893A22C73AF5200DAEED7 /* MockCreditCardProvider.swift */; };
+		8AB893A62C73AFBA00DAEED7 /* MockLoginProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB893A52C73AFBA00DAEED7 /* MockLoginProvider.swift */; };
+		8AB893A72C73AFCC00DAEED7 /* MockLoginViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A880C432C63CFE200B77F23 /* MockLoginViewModelDelegate.swift */; };
+		8AB893A92C73CBBD00DAEED7 /* CreditCardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB893A82C73CBBD00DAEED7 /* CreditCardProvider.swift */; };
 		8ABA9C8D28931223002C0077 /* MockDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */; };
 		8ABA9C8E28931288002C0077 /* JumpBackInDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA9C8A28931207002C0077 /* JumpBackInDataAdaptorTests.swift */; };
 		8ABC5AEE284532C900FEA552 /* PocketDiscoverCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABC5AED284532C900FEA552 /* PocketDiscoverCell.swift */; };
@@ -6618,6 +6621,9 @@
 		8AB8574527D97CB00075C173 /* HomepageContextMenuProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageContextMenuProtocol.swift; sourceTree = "<group>"; };
 		8AB8574727D97CD40075C173 /* HomePanelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePanelType.swift; sourceTree = "<group>"; };
 		8AB8574927D97CE90075C173 /* HomePanelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePanelDelegate.swift; sourceTree = "<group>"; };
+		8AB893A22C73AF5200DAEED7 /* MockCreditCardProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCreditCardProvider.swift; sourceTree = "<group>"; };
+		8AB893A52C73AFBA00DAEED7 /* MockLoginProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoginProvider.swift; sourceTree = "<group>"; };
+		8AB893A82C73CBBD00DAEED7 /* CreditCardProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardProvider.swift; sourceTree = "<group>"; };
 		8ABA9C8A28931207002C0077 /* JumpBackInDataAdaptorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JumpBackInDataAdaptorTests.swift; sourceTree = "<group>"; };
 		8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDispatchQueue.swift; sourceTree = "<group>"; };
 		8ABC5AED284532C900FEA552 /* PocketDiscoverCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDiscoverCell.swift; sourceTree = "<group>"; };
@@ -10543,6 +10549,15 @@
 			path = LogoHeader;
 			sourceTree = "<group>";
 		};
+		8AB893A12C73AF4500DAEED7 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				8AB893A22C73AF5200DAEED7 /* MockCreditCardProvider.swift */,
+				8AB893A52C73AFBA00DAEED7 /* MockLoginProvider.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		8ABCBE622C485CAA00480A21 /* FeatureFlags */ = {
 			isa = PBXGroup;
 			children = (
@@ -11001,6 +11016,7 @@
 				AB42CC722A1F523F003C9594 /* CreditCardBottomSheetViewController.swift */,
 				AB42CC732A1F5240003C9594 /* CreditCardBottomSheetHeaderView.swift */,
 				ABEF80D42A254185003F52C4 /* CreditCardBottomSheetFooterView.swift */,
+				8AB893A82C73CBBD00DAEED7 /* CreditCardProvider.swift */,
 			);
 			path = CreditCardBottomSheet;
 			sourceTree = "<group>";
@@ -11008,6 +11024,7 @@
 		B23620492B7EAF2C000B1DE7 /* Autofill */ = {
 			isa = PBXGroup;
 			children = (
+				8AB893A12C73AF4500DAEED7 /* Mocks */,
 				439B78172A09721600CAAE37 /* FormAutofillHelperTests.swift */,
 				8CCD74722B90A945008F919B /* LoginListViewModelTests.swift */,
 				8CEDF07D2BFE04B100D2617B /* AddressListViewModelTests.swift */,
@@ -11395,6 +11412,7 @@
 				8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */,
 				965C3C95293431FC006499ED /* MockLaunchSessionProvider.swift */,
 				8AF99B5329EF2AF100108DEC /* MockLogger.swift */,
+				8A880C432C63CFE200B77F23 /* MockLoginViewModelDelegate.swift */,
 				8A93F86629D373AC004159D9 /* MockNavigationController.swift */,
 				5AB4237B28A1947A003BC40C /* MockNotificationCenter.swift */,
 				E18259E229B2A51B00E6BE76 /* MockNotificationManager.swift */,
@@ -11419,7 +11437,6 @@
 				BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */,
 				1D558A562BED7ECB001EF527 /* MockWindowManager.swift */,
 				0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */,
-				8A880C432C63CFE200B77F23 /* MockLoginViewModelDelegate.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -15127,6 +15144,7 @@
 				E13C072B2C2184C80087E404 /* AddressBarState.swift in Sources */,
 				4347B39A298DA5BB0045F677 /* CreditCardInputViewModel.swift in Sources */,
 				6025B10D267B6C5400F59F6B /* LoginRecordExtension.swift in Sources */,
+				8AB893A62C73AFBA00DAEED7 /* MockLoginProvider.swift in Sources */,
 				2F44FCC51A9E85E900FD20CC /* SettingsTableViewController.swift in Sources */,
 				211046C92A7ADE9000A7309F /* BlockPopupSetting.swift in Sources */,
 				8A3233FC286270CF003E1C33 /* FxBookmarkNode.swift in Sources */,
@@ -15206,6 +15224,7 @@
 				AB03032C2AB47AF300DCD8EF /* FakespotOptInCardViewModel.swift in Sources */,
 				1D2F68AB2ACB262900524B92 /* RemoteTabsPanelAction.swift in Sources */,
 				8A5D1CB92A30DBDB005AD35C /* ChinaSyncServiceSetting.swift in Sources */,
+				8AB893A92C73CBBD00DAEED7 /* CreditCardProvider.swift in Sources */,
 				1D8487B42AD0C6C100F7527C /* RemoteTabsPanelMiddleware.swift in Sources */,
 				5AA1D8272BC09ECB00957516 /* TabTrayAnimationQueue.swift in Sources */,
 				C849E46526B9C3DD00260F0B /* SlideoverPresentationController.swift in Sources */,
@@ -15333,6 +15352,7 @@
 				D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */,
 				43D16B8029831DC5009F8279 /* CreditCardInputView.swift in Sources */,
 				21112968289480630082C08B /* HomepageMessageCardViewModel.swift in Sources */,
+				8AB893A32C73AF5200DAEED7 /* MockCreditCardProvider.swift in Sources */,
 				E1CD81BE290C5C7500124B27 /* DevicePickerTableViewHeaderCell.swift in Sources */,
 				B2FEA68B2B460D1D0058E616 /* AddressAutofillSettingsView.swift in Sources */,
 				E12BD0AC28AC37F00029AAF0 /* UIColor+Extension.swift in Sources */,
@@ -15695,7 +15715,6 @@
 				8A95FF672B1E97A800AC303D /* TelemetryContextualIdentifierTests.swift in Sources */,
 				965C3C9829343445006499ED /* MockAppSessionManager.swift in Sources */,
 				8AFCE50929DE136300B1B253 /* MockLaunchFinishedLoadingDelegate.swift in Sources */,
-				8A880C442C63CFE200B77F23 /* MockLoginViewModelDelegate.swift in Sources */,
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* PasswordManagerSelectionHelperTests.swift in Sources */,
 				C8610DA82A0EBD4100B79FF1 /* OnboardingButtonActionTests.swift in Sources */,
@@ -15713,6 +15732,7 @@
 				D525DFB325FBE5E000B18763 /* TabTests.swift in Sources */,
 				C8E78BDD27F4A1E700C48BAA /* HistoryDeletionUtilityTests.swift in Sources */,
 				0AC659272BF35854005C614A /* FxAWebViewModelTests.swift in Sources */,
+				8AB893A72C73AFCC00DAEED7 /* MockLoginViewModelDelegate.swift in Sources */,
 				8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */,
 				5A475E8F29DB89CE009C13FD /* MockTabDataStore.swift in Sources */,
 				8A7A93EE2810ADF2005E7E1B /* ContileProviderTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
@@ -48,7 +48,7 @@ class CredentialAutofillCoordinator: BaseCoordinator {
                                 viewType state: CreditCardBottomSheetState,
                                 frame: WKFrameInfo?,
                                 alertContainer: UIView) {
-        let creditCardControllerViewModel = CreditCardBottomSheetViewModel(profile: profile,
+        let creditCardControllerViewModel = CreditCardBottomSheetViewModel(creditCardProvider: profile.autofill,
                                                                            creditCard: creditCard,
                                                                            decryptedCreditCard: decryptedCard,
                                                                            state: state)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
@@ -62,8 +62,7 @@ enum CreditCardBottomSheetState: String, Equatable, CaseIterable {
 
 class CreditCardBottomSheetViewModel {
     private var logger: Logger
-    let profile: Profile
-    let autofill: RustAutofill
+    let autofill: CreditCardProvider
     var creditCard: CreditCard? {
         didSet {
             didUpdateCreditCard?()
@@ -81,13 +80,12 @@ class CreditCardBottomSheetViewModel {
     var storedCreditCards = [CreditCard]()
     var state: CreditCardBottomSheetState
 
-    init(profile: Profile,
+    init(creditCardProvider: CreditCardProvider,
          creditCard: CreditCard?,
          decryptedCreditCard: UnencryptedCreditCardFields?,
          logger: Logger = DefaultLogger.shared,
          state: CreditCardBottomSheetState) {
-        self.profile = profile
-        self.autofill = profile.autofill
+        self.autofill = creditCardProvider
         self.state = state
         self.logger = logger
         creditCards = [CreditCard]()

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardProvider.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardProvider.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Storage
+import struct MozillaAppServices.CreditCard
+
+protocol CreditCardProvider {
+    func addCreditCard(
+        creditCard: UnencryptedCreditCardFields,
+        completion: @escaping (CreditCard?, Error?) -> Void
+    )
+    func decryptCreditCardNumber(encryptedCCNum: String?) -> String?
+    func listCreditCards(completion: @escaping ([CreditCard]?, Error?) -> Void)
+    func updateCreditCard(
+        id: String,
+        creditCard: UnencryptedCreditCardFields,
+        completion: @escaping (Bool?, Error?) -> Void
+    )
+}
+
+extension RustAutofill: CreditCardProvider {}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockCreditCardProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockCreditCardProvider.swift
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import MozillaAppServices
+import Storage
+
+class MockCreditCardProvider: CreditCardProvider {
+    var addCreditCardCalledCount = 0
+    var updateCreditCardCalledCount = 0
+    var listCreditCardsCalledCount = 0
+
+    private var exampleCreditCard = CreditCard(
+        guid: "1",
+        ccName: "Allen Burges",
+        ccNumberEnc: "4111111111111111",
+        ccNumberLast4: "1111",
+        ccExpMonth: 3,
+        ccExpYear: 2043,
+        ccType: "VISA",
+        timeCreated: 1234678,
+        timeLastUsed: nil,
+        timeLastModified: 123123,
+        timesUsed: 123123
+    )
+
+    func addCreditCard(
+        creditCard: UnencryptedCreditCardFields,
+        completion: @escaping (CreditCard?, Error?) -> Void
+    ) {
+        addCreditCardCalledCount += 1
+        completion(exampleCreditCard, nil)
+    }
+    func decryptCreditCardNumber(encryptedCCNum: String?) -> String? { return "testCCNum" }
+    func listCreditCards(completion: @escaping ([CreditCard]?, Error?) -> Void) {
+        listCreditCardsCalledCount += 1
+        completion([exampleCreditCard], nil)
+    }
+    func updateCreditCard(
+        id: String,
+        creditCard: UnencryptedCreditCardFields,
+        completion: @escaping (Bool?, Error?) -> Void
+    ) {
+        updateCreditCardCalledCount += 1
+        completion(nil, nil)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockLoginProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockLoginProvider.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import MozillaAppServices
+
+class MockLoginProvider: LoginProvider {
+    var searchLoginsWithQueryCalledCount = 0
+    var addLoginCalledCount = 0
+    func searchLoginsWithQuery(
+        _ query: String?,
+        completionHandler: @escaping (
+            Result<
+                [MozillaAppServices.EncryptedLogin],
+            any Error
+            >
+        ) -> Void
+    ) {
+        searchLoginsWithQueryCalledCount += 1
+        completionHandler(.success([]))
+    }
+
+    func addLogin(
+        login: MozillaAppServices.LoginEntry,
+        completionHandler: @escaping (
+            Result<
+            MozillaAppServices.EncryptedLogin?,
+            any Error
+            >
+        ) -> Void
+    ) {
+        addLoginCalledCount += 1
+        completionHandler(.success(nil))
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
@@ -13,9 +13,7 @@ import XCTest
 class CreditCardBottomSheetViewModelTests: XCTestCase {
     private var profile: MockProfile!
     private var viewModel: CreditCardBottomSheetViewModel!
-    private var files: FileAccessor!
-    private var autofill: RustAutofill!
-    private var encryptionKey: String!
+    private var mockAutofill: MockCreditCardProvider!
     private var samplePlainTextCard = UnencryptedCreditCardFields(ccName: "Allen Burges",
                                                                   ccNumber: "4111111111111111",
                                                                   ccNumberLast4: "1111",
@@ -41,105 +39,49 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
                                               timeLastModified: 123123,
                                               timesUsed: 123123)
 
-    private var invalidSampleCreditCard = CreditCard(guid: "1",
-                                                     ccName: "Allen Burges",
-                                                     ccNumberEnc: "",
-                                                     ccNumberLast4: "",
-                                                     ccExpMonth: 1,
-                                                     ccExpYear: 0,
-                                                     ccType: "",
-                                                     timeCreated: 0,
-                                                     timeLastUsed: nil,
-                                                     timeLastModified: 2,
-                                                     timesUsed: 0)
-
     override func setUp() {
         super.setUp()
-        files = MockFiles()
-
-        if let rootDirectory = try? files.getAndEnsureDirectory() {
-            let databasePath = URL(fileURLWithPath: rootDirectory, isDirectory: true)
-                .appendingPathComponent("testAutofill.db").path
-            try? files.remove("testAutofill.db")
-
-            if let key = try? createAutofillKey() {
-                encryptionKey = key
-            } else {
-                XCTFail("Encryption key wasn't created")
-            }
-
-            autofill = RustAutofill(databasePath: databasePath)
-            _ = autofill.reopenIfClosed()
-        } else {
-            XCTFail("Could not retrieve root directory")
-        }
-
-        profile = MockProfile()
-        _ = profile.autofill.reopenIfClosed()
-
-        viewModel = CreditCardBottomSheetViewModel(profile: profile,
-                                                   creditCard: nil,
-                                                   decryptedCreditCard: samplePlainTextCard,
-                                                   state: .save)
+        mockAutofill = MockCreditCardProvider()
+        viewModel = CreditCardBottomSheetViewModel(
+            creditCardProvider: mockAutofill,
+            creditCard: nil,
+            decryptedCreditCard: samplePlainTextCard,
+            state: .save
+        )
     }
 
     override func tearDown() {
-        super.tearDown()
-        profile.shutdown()
-        profile = nil
-        autofill = nil
-        files = nil
+        mockAutofill = nil
         viewModel = nil
+        super.tearDown()
     }
 
     // MARK: - Test Cases
-    func testSavingCard() {
-        viewModel.creditCard = sampleCreditCard
+    func test_saveCreditCard_callsAddCreditCard() {
         let expectation = expectation(description: "wait for credit card fields to be saved")
         let decryptedCreditCard = viewModel.getPlainCreditCardValues(bottomSheetState: .save)
         // Make sure the year saved is a 4 digit year and not 2 digit
         // 2000 because that is our current period
         XCTAssertTrue(decryptedCreditCard!.ccExpYear > 2000)
         viewModel.saveCreditCard(with: decryptedCreditCard) { creditCard, error in
-            guard error == nil, let creditCard = creditCard else {
-                XCTFail()
-                return
-            }
-            XCTAssertEqual(creditCard.ccName, self.viewModel.creditCard?.ccName)
-            // Note: the number for credit card is encrypted so that part
-            // will get added later and for now we will check the name only
+            XCTAssertEqual(self.mockAutofill.addCreditCardCalledCount, 1)
             expectation.fulfill()
         }
         waitForExpectations(timeout: 1.0)
     }
 
-    func testUpdatingCard() {
+    func test_saveAndUpdateCreditCard_callsProperAutofillMethods() {
         viewModel.state = .save
-        viewModel.decryptedCreditCard = samplePlainTextCard
         let expectationSave = expectation(description: "wait for credit card fields to be saved")
         let expectationUpdate = expectation(description: "wait for credit card fields to be updated")
 
         viewModel.saveCreditCard(with: samplePlainTextCard) { creditCard, error in
-            guard error == nil, let creditCard = creditCard else {
-                XCTFail()
-                return
-            }
+            XCTAssertEqual(self.mockAutofill.addCreditCardCalledCount, 1)
             expectationSave.fulfill()
-            XCTAssertEqual(creditCard.ccName, self.viewModel.decryptedCreditCard?.ccName)
-            // Note: the number for credit card is encrypted so that part
-            // will get added later and for now we will check the name only
-
-            self.samplePlainTextCard.ccExpYear = 2045
-            self.samplePlainTextCard.ccName = "Test"
             self.viewModel.state = .update
-
-            self.viewModel.updateCreditCard(for: creditCard.guid,
+            self.viewModel.updateCreditCard(for: creditCard?.guid,
                                             with: self.samplePlainTextCard) { didUpdate, error in
-                XCTAssertNotNil(didUpdate)
-                if let updated = didUpdate {
-                    XCTAssert(updated)
-                }
-                XCTAssertNil(error)
+                XCTAssertEqual(self.mockAutofill.updateCreditCardCalledCount, 1)
                 expectationUpdate.fulfill()
             }
         }
@@ -338,54 +280,58 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         XCTAssertEqual(value!.ccNumber, sampleCreditCardVal.ccNumberEnc)
     }
 
-    func test_didTapMainButton() {
+    func test_didTapMainButton_withSaveState_callsAddCreditCard() {
         viewModel.state = .save
         viewModel.decryptedCreditCard = samplePlainTextCard
         let expectation = expectation(description: "wait for credit card fields to be saved")
 
-        viewModel.didTapMainButton { error in
-            XCTAssertNil(error)
+        viewModel.didTapMainButton { _ in
+            XCTAssertEqual(self.mockAutofill.addCreditCardCalledCount, 1)
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: 1.0)
     }
 
-    func test_invalidCreditCardUpdateDidTapMainButton() {
+    func test_didTapMainButton_withUpdateState_callsAddCreditCard() {
         viewModel.state = .update
-        viewModel.creditCard = invalidSampleCreditCard
         viewModel.decryptedCreditCard = samplePlainTextCard
         let expectation = expectation(description: "wait for credit card fields to be updated")
 
-        viewModel.didTapMainButton { error in
-            XCTAssertNotNil(error)
+        viewModel.didTapMainButton { _ in
+            XCTAssertEqual(self.mockAutofill.updateCreditCardCalledCount, 1)
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: 1.0)
     }
 
-    func test_updateCreditCardList() {
+    func test_updateCreditCardList_callsListCreditCards() {
         let expectation = expectation(description: "wait for credit card to be added")
         viewModel.creditCard = nil
         viewModel.decryptedCreditCard = nil
-        // Add a sample card to the storage
-        viewModel.saveCreditCard(with: samplePlainTextCard) { creditCard, error in
-            guard error == nil, creditCard != nil else {
-                XCTFail()
-                return
-            }
-            // Make the view model state selected card
-            self.viewModel.state = .selectSavedCard
-            // Perform update
-            self.viewModel.updateCreditCardList({ cards in
-                // Check if the view model updated the list
-                let cards = self.viewModel.creditCards
-                XCTAssertNotNil(cards)
-                XCTAssert(!cards!.isEmpty)
-                expectation.fulfill()
-            })
-        }
-        waitForExpectations(timeout: 3.0)
+        viewModel.state = .selectSavedCard
+
+        viewModel.updateCreditCardList({ cards in
+            XCTAssertEqual(self.viewModel.creditCards, cards)
+            XCTAssertEqual(cards?.count, 1)
+            XCTAssertEqual(cards?.first?.guid, "1")
+            XCTAssertEqual(cards?.first?.ccName, "Allen Burges")
+            XCTAssertEqual(self.mockAutofill.listCreditCardsCalledCount, 1)
+            expectation.fulfill()
+        })
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func test_updateCreditCardList_withoutSelectedSavedCardState_doesNotCallListCreditCards() {
+        let expectation = expectation(description: "wait for credit card to be added")
+        expectation.isInverted = true
+        viewModel.creditCard = nil
+        viewModel.decryptedCreditCard = nil
+
+        viewModel.updateCreditCardList({ cards in
+            expectation.fulfill()
+        })
+        waitForExpectations(timeout: 1.0)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLoginViewModelDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockLoginViewModelDelegate.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import MozillaAppServices
 @testable import Client
 
 class MockLoginViewModelDelegate: LoginViewModelDelegate {
@@ -15,35 +14,5 @@ class MockLoginViewModelDelegate: LoginViewModelDelegate {
 
     func breachPathDidUpdate() {
         breachPathDidUpdateCalledCount += 1
-    }
-}
-
-class MockLoginProvider: LoginProvider {
-    var searchLoginsWithQueryCalledCount = 0
-    var addLoginCalledCount = 0
-    func searchLoginsWithQuery(
-        _ query: String?,
-        completionHandler: @escaping (
-            Result<
-                [MozillaAppServices.EncryptedLogin],
-            any Error
-            >
-        ) -> Void
-    ) {
-        searchLoginsWithQueryCalledCount += 1
-        completionHandler(.success([]))
-    }
-
-    func addLogin(
-        login: MozillaAppServices.LoginEntry,
-        completionHandler: @escaping (
-            Result<
-            MozillaAppServices.EncryptedLogin?,
-            any Error
-            >
-        ) -> Void
-    ) {
-        addLoginCalledCount += 1
-        completionHandler(.success(nil))
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9811)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21551)

## :bulb: Description
Similar to this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/21482), we want to mock out the Rust dependencies if we want to unit test the specific functionality for the `CreditCardBottomSheetViewModel`. Similar to creating the `AddressProvider`, `LoginProvider`, I have created the `CreditCardProvider` and clean up some of the tests. A lot of the current tests were using the db, which makes it less reliable and more integration versus unit tests. Some of the logic should be in the `RustAutofillTests` instead. By creating the mock, I simplified some of the tests to check for calls instead.

Open to any suggestions, but this seems to lean towards more reliable tests.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

