### PR TITLE
Add FXIOS-9716 [Native Error Page] Strings for No internet Connection and Generic Error

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1469,28 +1469,35 @@ extension String {
 // MARK: - Native Error Page
 extension String {
     struct NativeErrorPage {
-        struct GenericError {
-            public static let NoInternetConnectionTitleLabel = MZLocalizedString(
-                key: "NativeErrorPage.GenericError.NoInternetConnection.TitleLabel.v136",
+        struct NoInternetConnection {
+            public static let TitleLabel = MZLocalizedString(
+                key: "NativeErrorPage.NoInternetConnection.TitleLabel.v131",
                 tableName: "NativeErrorPage",
                 value: "Looks like there’s a problem with your internet connection.",
                 comment: "On error page, this is the title for no internet connection")
-            public static let NoInternetConnectionDescription = MZLocalizedString(
-                key: "NativeErrorPage.GenericError.NoInternetConnection.Description.v136",
+            public static let Description = MZLocalizedString(
+                key: "NativeErrorPage.NoInternetConnection.Description.v131",
                 tableName: "NativeErrorPage",
                 value: "Try connecting on a different device. Check your modem or router. Disconnect and reconnect to Wi-Fi.",
                 comment: "On error page, this is the description for no internet connection.")
-            public static let NoErrorCodeTitleLabel = MZLocalizedString(
-                key: "NativeErrorPage.GenericError.NoErrorCode.TitleLabel.v136",
+        }
+        struct GenericError {
+            public static let TitleLabel = MZLocalizedString(
+                key: "NativeErrorPage.GenericError.TitleLabel.v131",
                 tableName: "NativeErrorPage",
                 value: "Be careful. Something doesn’t look right.",
-                comment: "On error page, this is the title for generic error with no error code.")
-            public static let PageReload = MZLocalizedString(
-                key: "NativeErrorPage.GenericError.PageReload.v136",
+                comment: "On error page, this is the title for generic error.")
+            public static let Description = MZLocalizedString(
+                key: "NativeErrorPage.GenericError.Description.v131",
                 tableName: "NativeErrorPage",
-                value: "Reload",
-                comment: "On error page, this is shown on a button that will try to load the page again.")
+                value: "An SSL error has occurred and a secure connection to the server cannot be made.",
+                comment: "On error page, this is the description for generic error.")
         }
+        public static let ButtonLabel = MZLocalizedString(
+            key: "NativeErrorPage.ButtonLabel.v131",
+            tableName: "NativeErrorPage",
+            value: "Reload",
+            comment: "On error page, this is the text on a button that will try to load the page again.")
     }
 }
 

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1466,6 +1466,34 @@ extension String {
     }
 }
 
+// MARK: - Native Error Page
+extension String {
+    struct NativeErrorPage {
+        struct GenericError {
+            public static let NoInternetConnectionTitleLabel = MZLocalizedString(
+                key: "NativeErrorPage.GenericError.NoInternetConnection.TitleLabel.v136",
+                tableName: "NativeErrorPage",
+                value: "Looks like there’s a problem with your internet connection.",
+                comment: "On error page, this is the title for no internet connection")
+            public static let NoInternetConnectionDescription = MZLocalizedString(
+                key: "NativeErrorPage.GenericError.NoInternetConnection.Description.v136",
+                tableName: "NativeErrorPage",
+                value: "Try connecting on a different device. Check your modem or router. Disconnect and reconnect to Wi-Fi.",
+                comment: "On error page, this is the description for no internet connection.")
+            public static let NoErrorCodeTitleLabel = MZLocalizedString(
+                key: "NativeErrorPage.GenericError.NoErrorCode.TitleLabel.v136",
+                tableName: "NativeErrorPage",
+                value: "Be careful. Something doesn’t look right.",
+                comment: "On error page, this is the title for generic error with no error code.")
+            public static let PageReload = MZLocalizedString(
+                key: "NativeErrorPage.GenericError.PageReload.v136",
+                tableName: "NativeErrorPage",
+                value: "Reload",
+                comment: "On error page, this is shown on a button that will try to load the page again.")
+        }
+    }
+}
+
 // MARK: - Onboarding screens
 extension String {
     public struct Onboarding {

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1469,6 +1469,11 @@ extension String {
 // MARK: - Native Error Page
 extension String {
     struct NativeErrorPage {
+        public static let ButtonLabel = MZLocalizedString(
+            key: "NativeErrorPage.ButtonLabel.v131",
+            tableName: "NativeErrorPage",
+            value: "Reload",
+            comment: "On error page, this is the text on a button that will try to load the page again.")
         struct NoInternetConnection {
             public static let TitleLabel = MZLocalizedString(
                 key: "NativeErrorPage.NoInternetConnection.TitleLabel.v131",
@@ -1493,11 +1498,6 @@ extension String {
                 value: "An SSL error has occurred and a secure connection to the server cannot be made.",
                 comment: "On error page, this is the description for generic error.")
         }
-        public static let ButtonLabel = MZLocalizedString(
-            key: "NativeErrorPage.ButtonLabel.v131",
-            tableName: "NativeErrorPage",
-            value: "Reload",
-            comment: "On error page, this is the text on a button that will try to load the page again.")
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9716)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21354)

## :bulb: Description
Added strings for no internet connection and generic error page.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

