### PR TITLE
Bugfix FXIOS-9818 [Unit Tests] Resolve flaky PocketDataAdaptorTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Pocket/PocketDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Pocket/PocketDataAdaptorTests.swift
@@ -28,7 +28,7 @@ class PocketDataAdaptorTests: XCTestCase {
         XCTAssertEqual(data.count, 0, "Data should be null")
     }
 
-    func testGetPocketData() {
+    func testGetPocketData() async {
         let stories: [PocketFeedStory] = [
             .make(title: "feed1"),
             .make(title: "feed2"),
@@ -36,7 +36,10 @@ class PocketDataAdaptorTests: XCTestCase {
         ]
         mockPocketAPI = MockPocketAPI(result: .success(stories))
         let subject = createSubject()
-        let data = subject.getPocketData()
+        let task = Task {
+            subject.getPocketData()
+        }
+        let data = await task.value
         XCTAssertEqual(data.count, 3, "Data should contain three pocket stories")
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9818)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
In draft, would like to discuss with team how to test this particular code, since it leads to flakiness. There are some workarounds, or should be writing our async / await code differently.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

