### PR TITLE
Bugfix FXIOS-7328 Sec Bugzilla 1843467 SSL Lock Spoof

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -840,6 +840,10 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        if let url = webView.url, !isToolbarRefactorEnabled {
+            urlBar.locationView.hasSecureContent = webView.hasOnlySecureContent
+            urlBar.locationView.showTrackingProtectionButton(for: url)
+        }
         webviewTelemetry.stop()
 
         if let tab = tabManager[webView],

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3569,11 +3569,15 @@ extension BrowserViewController: TabManagerDelegate {
                 // If the webView is loading, we hide the lock
                 // icon and wait for did finish to get the lasted secure content status
             } else if webView.isLoading {
-                self.urlBar.locationView.hideTrackingProtectionButton()
+                if !isToolbarRefactorEnabled {
+                    self.urlBar.locationView.hideTrackingProtectionButton()
+                }
                 // If not, we show the lock icon with the secure content status of the webView
             } else {
-                self.urlBar.locationView.hasSecureContent = webView.hasOnlySecureContent
-                self.urlBar.locationView.showTrackingProtectionButton(for: webView.url)
+                if !isToolbarRefactorEnabled {
+                    self.urlBar.locationView.hasSecureContent = webView.hasOnlySecureContent
+                    self.urlBar.locationView.showTrackingProtectionButton(for: webView.url)
+                }
             }
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3566,7 +3566,8 @@ extension BrowserViewController: TabManagerDelegate {
                 // The webView can go gray if it was zombified due to memory pressure.
                 // When this happens, the URL is nil, so try restoring the page upon selection.
                 selectedTab.reload()
-                // If the webView is loading, we hide the lock icon and wait for did finish to get the lasted secure content status
+                // If the webView is loading, we hide the lock
+                // icon and wait for did finish to get the lasted secure content status
             } else if webView.isLoading {
                 self.urlBar.locationView.hideTrackingProtectionButton()
                 // If not, we show the lock icon with the secure content status of the webView

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1784,10 +1784,7 @@ class BrowserViewController: UIViewController,
                 navigationToolbar.updateForwardStatus(canGoForward)
             }
         case .hasOnlySecureContent:
-            if !isToolbarRefactorEnabled {
-                urlBar.locationView.hasSecureContent = webView.hasOnlySecureContent
-                urlBar.locationView.showTrackingProtectionButton(for: webView.url)
-            }
+            break
         default:
             assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
         }
@@ -3569,6 +3566,13 @@ extension BrowserViewController: TabManagerDelegate {
                 // The webView can go gray if it was zombified due to memory pressure.
                 // When this happens, the URL is nil, so try restoring the page upon selection.
                 selectedTab.reload()
+                // If the webView is loading, we hide the lock icon and wait for did finish to get the lasted secure content status
+            } else if webView.isLoading {
+                self.urlBar.locationView.hideTrackingProtectionButton()
+                // If not, we show the lock icon with the secure content status of the webView
+            } else {
+                self.urlBar.locationView.hasSecureContent = webView.hasOnlySecureContent
+                self.urlBar.locationView.showTrackingProtectionButton(for: webView.url)
             }
         }
 

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -66,7 +66,6 @@ class TabLocationView: UIView, FeatureFlaggable {
             hideButtons()
             updateTextWithURL()
             setNeedsUpdateConstraints()
-            showTrackingProtectionButton(for: url)
         }
     }
 
@@ -368,10 +367,12 @@ class TabLocationView: UIView, FeatureFlaggable {
     }
 
     func showTrackingProtectionButton(for url: URL?) {
+        guard let url else { return }
+        setTrackingProtection(theme: currentTheme())
         ensureMainThread {
             let isValidHttpUrlProtocol = self.isValidHttpUrlProtocol(url)
-            let isReaderModeURL = url?.isReaderModeURL ?? false
-            let isFxHomeUrl = url?.isFxHomeUrl ?? false
+            let isReaderModeURL = url.isReaderModeURL
+            let isFxHomeUrl = url.isFxHomeUrl
             if !isFxHomeUrl, !isReaderModeURL, isValidHttpUrlProtocol, self.trackingProtectionButton.isHidden {
                 self.trackingProtectionButton.transform = UX.trackingProtectionxOffset
                 self.trackingProtectionButton.alpha = 0
@@ -541,16 +542,6 @@ extension TabLocationView: TabEventHandler {
         guard let blocker = tab.contentBlocker else { return }
 
         ensureMainThread { [self] in
-            self.blockerStatus = blocker.status
-        }
-    }
-
-    func tabDidGainFocus(_ tab: Tab) {
-        guard let blocker = tab.contentBlocker else { return }
-
-        ensureMainThread { [self] in
-            self.showTrackingProtectionButton(for: tab.webView?.url)
-            self.hasSecureContent = (tab.webView?.hasOnlySecureContent ?? false)
             self.blockerStatus = blocker.status
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7328)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
We are to eager in setting the security lock icon on url bar. That information is available later after the webview in fully loaded. This PR changes when the security status is updated and when the lock is shown and fixed a security spoofing issue.
The video below shows multiple cases where the lock icon is set. First opening a website from an existing tab, switching tabs with different security status and loading a website in a new tab.
https://github.com/user-attachments/assets/57be4b10-35b2-4a30-9b6d-40303c05e617

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

