### PR TITLE
Bugfix FXIOS-9825 [Unit Tests] Remove unnecessary glean calls

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -20,7 +20,6 @@ class BrowserViewControllerTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
         TelemetryContextualIdentifier.setupContextId()
         Glean.shared.resetGlean(clearStores: true)
-        Glean.shared.enableTestingMode()
 
         profile = MockProfile()
         tabManager = MockTabManager()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContextMenuHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContextMenuHelperTests.swift
@@ -20,7 +20,6 @@ class ContextMenuHelperTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
 
         Glean.shared.resetGlean(clearStores: true)
-        Glean.shared.enableTestingMode()
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Messaging/GleanPlumbMessageManagerTests.swift
@@ -18,7 +18,6 @@ class GleanPlumbMessageManagerTests: XCTestCase {
         super.setUp()
 
         Glean.shared.resetGlean(clearStores: true)
-        Glean.shared.enableTestingMode()
         messagingStore = MockGleanPlumbMessageStore(messageId: messageId)
         applicationHelper = MockApplicationHelper()
         subject = GleanPlumbMessageManager(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
@@ -12,13 +12,12 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
     override func setUp() {
         super.setUp()
         Glean.shared.resetGlean(clearStores: true)
-        Glean.shared.enableTestingMode()
         DependencyHelperMock().bootstrapDependencies()
     }
 
     override func tearDown() {
-        super.tearDown()
         DependencyHelperMock().reset()
+        super.tearDown()
     }
 
     func testDismissSurveyAction() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
@@ -20,9 +20,8 @@ class OnboardingTelemetryDelegationTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
-        Glean.shared.resetGlean(clearStores: true)
         nimbusUtility = nil
+        super.tearDown()
     }
 
     func testOnboardingCard_viewSendsCardView() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryUtilityTests.swift
@@ -15,11 +15,6 @@ class OnboardingTelemetryUtilityTests: XCTestCase {
         Glean.shared.resetGlean(clearStores: true)
     }
 
-    override func tearDown() {
-        super.tearDown()
-        Glean.shared.resetGlean(clearStores: true)
-    }
-
     // MARK: - Card View telemetry
     func testSendOnboardingCardView_WelcomeCard_Success() {
         let subject = createTelemetryUtility(for: .freshInstall)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
@@ -36,7 +36,6 @@ class PasswordManagerViewModelTests: XCTestCase {
     }
 
     override func tearDown() {
-        Glean.shared.resetGlean(clearStores: true)
         viewModel = nil
         mockLoginProvider = nil
         mockDelegate = nil

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PrivateBrowsingTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PrivateBrowsingTelemetryTests.swift
@@ -11,7 +11,6 @@ final class PrivateBrowsingTelemetryTests: XCTestCase {
     override func setUp() {
         super.setUp()
         Glean.shared.resetGlean(clearStores: true)
-        Glean.shared.enableTestingMode()
     }
 
     func testDataClearanceConfirmed() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SponsoredTileTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SponsoredTileTelemetryTests.swift
@@ -107,7 +107,6 @@ class SponsoredTileTelemetryTests: XCTestCase {
 
     func clearTest() {
         Glean.shared.resetGlean(clearStores: true)
-        Glean.shared.enableTestingMode()
         TelemetryContextualIdentifier.clearUserDefaults()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabsTelemetryTests.swift
@@ -19,7 +19,6 @@ class TabsTelemetryTests: XCTestCase {
         inactiveTabsManager = MockInactiveTabsManager()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         Glean.shared.resetGlean(clearStores: true)
-        Glean.shared.enableTestingMode()
         DependencyHelperMock().bootstrapDependencies()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/HomepageTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/HomepageTelemetryTests.swift
@@ -11,7 +11,6 @@ final class HomepageTelemetryTests: XCTestCase {
     override func setUp() {
         super.setUp()
         Glean.shared.resetGlean(clearStores: true)
-        Glean.shared.enableTestingMode()
     }
 
     func testPrivateModeShortcutToggleTappedInNormalMode() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -19,7 +19,6 @@ class TelemetryWrapperTests: XCTestCase {
     }
 
     override func tearDown() {
-        Glean.shared.resetGlean(clearStores: true)
         Experiments.events.clearEvents()
         DependencyHelperMock().reset()
         super.tearDown()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9825)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21578)

## :bulb: Description
Remove unnecessary methods as clean up which also seems to cause less crash rate. I can still see the crash occasionally, but open a Bugzilla ticket which is attached to the JIRA. 

### Context
On Firefox iOS, some of our glean related unit tests are failing due to a crash. The crash seems to be caused by a UniFFI error through Glean's usage of it.

Quick search for the terms in searchFox, I found the following:
- https://searchfox.org/mozilla-central/rev/e942f7bc56cd103bba86b396ddeba5b1ab04f1a4/third_party/rust/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift#97
- https://searchfox.org/mozilla-central/source/third_party/rust/glean-core/src/dispatcher/mod.rs#162

We are currently resetting the Glean state in our tests with Glean.shared.resetGlean(clearStores: true) at setUp + tearDown. I can run a single test repeatedly (5000x) + see the failure. I seen this error in other tests, but the `test_doesNotHaveMobileBookmarks_GleanIsCalled` case consistently fails.

### Why are we removing these methods?
- `Glean.shared.enableTestingMode()` shouldn't be necessary if you are calling `resetGlean()` since it sets the test mode flag as part of the work it does while resetting. You can see that code being called here: https://github.com/mozilla/glean/blob/41f9487854ec98a8d970ff2157bc3cf65dd6894b/glean-core/ios/Glean/Glean.swift#L517C9-L517C26
- Glean is implemented as a singleton. This has the unfortunate side effect of it not playing nicely with tests when they run in quick succession or concurrently. Resetting Glean can/is expensive and doing it while another test is expecting the underlying glean to be intact is what can lead to this. Resetting state in setup is good enough. Calling it in both setup and teardown causes the crash to occur more often. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Test Steps
Run a single test repeatedly (~5000) and see the error. `test_doesNotHaveMobileBookmarks_GleanIsCalled` case consistently fails, but fails less with this change.

## Screenshots 
| Crash |
| --- |
| ![image](https://github.com/user-attachments/assets/b2fa08a3-f7e3-4c46-9aac-177086af3328)|
