### PR TITLE
Add FXIOS-9741: Data clearance button for address toolbar

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -548,7 +548,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
             let isForwardButtonEnabled = canGoForward
             actions.append(backAction(enabled: isBackButtonEnabled))
             actions.append(forwardAction(enabled: isForwardButtonEnabled))
-            if toolbarState.isPrivateMode && isFeltPrivacyEnabled() {
+            if shouldShowDataClearanceAction(isPrivate: toolbarState.isPrivateMode) {
                 actions.append(dataClearanceAction)
             }
         }
@@ -685,7 +685,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
     }
 
     private func getMiddleButtonAction(url: URL?, isPrivateMode: Bool) -> ToolbarActionState {
-        let shouldShowDataClearanceAction = isPrivateMode && isFeltPrivacyEnabled()
+        let shouldShowDataClearanceAction = shouldShowDataClearanceAction(isPrivate: isPrivateMode)
         guard !shouldShowDataClearanceAction else {
             return dataClearanceAction
         }
@@ -752,10 +752,10 @@ final class ToolbarMiddleware: FeatureFlaggable {
         return manager.shouldDisplayNavigationBorder(toolbarPosition: toolbarPosition)
     }
 
-    private func isFeltPrivacyEnabled() -> Bool {
+    private func shouldShowDataClearanceAction(isPrivate: Bool) -> Bool {
         let isFeltPrivacyUIEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
         let isFeltPrivacyDeletionEnabled = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly)
 
-        return isFeltPrivacyUIEnabled && isFeltPrivacyDeletionEnabled
+        return isPrivate && isFeltPrivacyUIEnabled && isFeltPrivacyDeletionEnabled
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -548,6 +548,9 @@ final class ToolbarMiddleware: FeatureFlaggable {
             let isForwardButtonEnabled = canGoForward
             actions.append(backAction(enabled: isBackButtonEnabled))
             actions.append(forwardAction(enabled: isForwardButtonEnabled))
+            if toolbarState.isPrivateMode && isFeltPrivacyEnabled() {
+                actions.append(dataClearanceAction)
+            }
         }
 
         return actions
@@ -682,10 +685,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
     }
 
     private func getMiddleButtonAction(url: URL?, isPrivateMode: Bool) -> ToolbarActionState {
-        let isFeltPrivacyUIEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
-        let isFeltPrivacyDeletionEnabled = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly)
-        let shouldShowDataClearanceAction = isPrivateMode && isFeltPrivacyUIEnabled &&
-                                            isFeltPrivacyDeletionEnabled
+        let shouldShowDataClearanceAction = isPrivateMode && isFeltPrivacyEnabled()
         guard !shouldShowDataClearanceAction else {
             return dataClearanceAction
         }
@@ -750,5 +750,12 @@ final class ToolbarMiddleware: FeatureFlaggable {
 
     private func shouldDisplayNavigationToolbarBorder(toolbarPosition: AddressToolbarPosition) -> Bool {
         return manager.shouldDisplayNavigationBorder(toolbarPosition: toolbarPosition)
+    }
+
+    private func isFeltPrivacyEnabled() -> Bool {
+        let isFeltPrivacyUIEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
+        let isFeltPrivacyDeletionEnabled = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly)
+
+        return isFeltPrivacyUIEnabled && isFeltPrivacyDeletionEnabled
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9741)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21402)

## :bulb: Description
- Show the data clearance toolbar button in the address toolbar navigation section and perform data clearance when selected when using the refactored toolbar

### Notes:
- Testing this requires enabling the toolbar refactor `enabled` flag, the felt privacy feature `simplified-ui-enabled` flag, and the felt privacy feature `felt-deletion-enabled` flag
- Visible on all iPhones in landscape orientation, and all iPads in portrait and landscape orientations

### Screenshots
![Simulator Screenshot - iPhone 15 Plus - 2024-08-21 at 16 17 13](https://github.com/user-attachments/assets/c42a8fd3-8554-45cf-a715-d6453cd2abe5)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

