### PR TITLE
Add FXIOS-9828 ⁃ Enhanced Tracking Protection certificates details screen strings

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4261,6 +4261,72 @@ extension String {
                 tableName: "EnhancedTrackingProtection",
                 value: "Privacy settings",
                 comment: "The title for the privacy settings button inside the enhanced tracking protection screen.")
+
+            public static let certificatesTitle = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Certificates.Title.v131",
+                tableName: "EnhancedTrackingProtection",
+                value: "Certificate",
+                comment: "The title for the certificates screen inside the certificates screen.")
+
+            public static let certificateSubjectName = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Certificates.SubjectName.v131",
+                tableName: "EnhancedTrackingProtection",
+                value: "Subject Name",
+                comment: "The title for the certificate subject name section inside the certificate screen.")
+
+            public static let certificateCommonName = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Certificates.CommonName.v131",
+                tableName: "EnhancedTrackingProtection",
+                value: "Common Name",
+                comment: "The title for the certificate common name inside the certificate screen.")
+
+            public static let certificateIssuerName = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Certificates.IssuerName.v131",
+                tableName: "EnhancedTrackingProtection",
+                value: "Issuer Name",
+                comment: "The title for the certificate issuer name section inside the certificate screen.")
+
+            public static let certificateIssuerCountry = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Certificates.IssuerCountry.v131",
+                tableName: "EnhancedTrackingProtection",
+                value: "Country",
+                comment: "The title for the certificate issuer country inside the certificate screen.")
+
+            public static let certificateIssuerOrganization = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Certificates.IssuerOrganization.v131",
+                tableName: "EnhancedTrackingProtection",
+                value: "Organization",
+                comment: "The title for the certificate issuer organization inside the certificate screen.")
+
+            public static let certificateValidity = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Certificates.Validity.v131",
+                tableName: "EnhancedTrackingProtection",
+                value: "Validity",
+                comment: "The title for the certificate validity section inside the certificate screen.")
+
+            public static let certificateValidityNotBefore = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Certificates.ValidityNotBefore.v131",
+                tableName: "EnhancedTrackingProtection",
+                value: "Not Before",
+                comment: "The title for the certificate validity not before date inside the certificate screen.")
+
+            public static let certificateValidityNotAfter = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Certificates.ValidityNotAfter.v131",
+                tableName: "EnhancedTrackingProtection",
+                value: "Not After",
+                comment: "The title for the certificate validity not after date inside the certificate screen.")
+
+            public static let certificateSubjectAltNames = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Certificates.SubjectAltNames.v131",
+                tableName: "EnhancedTrackingProtection",
+                value: "Subject Alt Names",
+                comment: "The title for the certificate subject alt names section inside the certificate screen.")
+
+            public static let certificateSubjectAltNamesDNSName = MZLocalizedString(
+                key: "Menu.EnhancedTrackingProtection.Certificates.SubjectAltNamesDNSName.v131",
+                tableName: "EnhancedTrackingProtection",
+                value: "DNS Name",
+                comment: "The title for the certificate subject alt names DNS name inside the certificate screen.")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9828)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21583)

## :bulb: Description
Added strings for certificates screen

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

