### PR TITLE
Add FXIOS-9832 - Password Generator Feature Flag

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -29,6 +29,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case microsurvey
     case nativeErrorPage
     case nightMode
+    case passwordGenerator
     case preferSwitchToOpenTabOverDuplicate
     case reduxSearchSettings
     case closeRemoteTabs
@@ -91,6 +92,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .menuRefactor,
                 .nativeErrorPage,
                 .nightMode,
+                .passwordGenerator,
                 .preferSwitchToOpenTabOverDuplicate,
                 .reduxSearchSettings,
                 .reportSiteIssue,

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -251,8 +251,7 @@ final class NimbusFeatureFlagLayer {
     }
 
     private func checkPasswordGeneratorFeature(from nimbus: FxNimbus) -> Bool {
-        let config = nimbus.features.passwordGeneratorFeature.value()
-        return config.status
+        return nimbus.features.passwordGeneratorFeature.value().enabled
     }
 
     private func checkProductBackInStockFakespotFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -64,6 +64,9 @@ final class NimbusFeatureFlagLayer {
         case .nightMode:
             return checkNightModeFeature(from: nimbus)
 
+        case .passwordGenerator:
+            return checkPasswordGeneratorFeature(from: nimbus)
+
         case .preferSwitchToOpenTabOverDuplicate:
             return checkPreferSwitchToOpenTabOverDuplicate(from: nimbus)
 
@@ -245,6 +248,11 @@ final class NimbusFeatureFlagLayer {
         let config = nimbus.features.shopping2023.value()
 
         return config.productAds
+    }
+
+    private func checkPasswordGeneratorFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.passwordGeneratorFeature.value()
+        return config.status
     }
 
     private func checkProductBackInStockFakespotFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/nimbus-features/passwordGeneratorFeature.yaml
+++ b/firefox-ios/nimbus-features/passwordGeneratorFeature.yaml
@@ -1,0 +1,17 @@
+# The configuration for the passwordGeneratorFeature feature
+features:
+  password-generator-feature:
+    description: Password Generator Feature
+    variables:
+      status:
+        description: If true, the password generator feature is enabled
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          status: false
+      - channel: developer
+        value:
+          status: false
+

--- a/firefox-ios/nimbus-features/passwordGeneratorFeature.yaml
+++ b/firefox-ios/nimbus-features/passwordGeneratorFeature.yaml
@@ -3,15 +3,15 @@ features:
   password-generator-feature:
     description: Password Generator Feature
     variables:
-      status:
+      enabled:
         description: If true, the password generator feature is enabled
         type: Boolean
         default: false
     defaults:
       - channel: beta
         value:
-          status: false
+          enabled: false
       - channel: developer
         value:
-          status: false
+          enabled: false
 

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -29,6 +29,7 @@ include:
   - nimbus-features/nativeErrorPageFeature.yaml
   - nimbus-features/nightModeFeature.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml
+  - nimbus-features/passwordGeneratorFeature.yaml
   - nimbus-features/reduxSearchSettingsFeature.yaml
   - nimbus-features/remoteTabManagement.yaml
   - nimbus-features/searchFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9832)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21589)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Addition of a feature flag for development of the password generator feature
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

