### PR TITLE
Refactor FXIOS-9737 Add badge to tabs icon when in private mode

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -512,7 +512,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
         let menuBadgeImageName = isShowMenuWarningAction ? action.badgeImageName : toolbarState.badgeImageName
         let maskImageName = isShowMenuWarningAction ? action.maskImageName : toolbarState.maskImageName
 
-        actions.append(contentsOf: [tabsAction(numberOfTabs: numberOfTabs),
+        actions.append(contentsOf: [tabsAction(numberOfTabs: numberOfTabs, isPrivateMode: toolbarState.isPrivateMode),
                                     menuAction(badgeImageName: menuBadgeImageName, maskImageName: maskImageName)])
 
         return actions
@@ -669,7 +669,9 @@ final class ToolbarMiddleware: FeatureFlaggable {
             backAction(enabled: canGoBack),
             forwardAction(enabled: canGoForward),
             middleAction,
-            tabsAction(numberOfTabs: numberOfTabs, isShowingTopTabs: isShowingTopTabs),
+            tabsAction(numberOfTabs: numberOfTabs,
+                       isPrivateMode: toolbarState.isPrivateMode,
+                       isShowingTopTabs: isShowingTopTabs),
             menuAction(badgeImageName: menuBadgeImageName, maskImageName: maskImageName)
         ]
 
@@ -720,10 +722,14 @@ final class ToolbarMiddleware: FeatureFlaggable {
             a11yId: AccessibilityIdentifiers.Toolbar.forwardButton)
     }
 
-    private func tabsAction(numberOfTabs: Int = 1, isShowingTopTabs: Bool = false) -> ToolbarActionState {
+    private func tabsAction(numberOfTabs: Int = 1,
+                            isPrivateMode: Bool = false,
+                            isShowingTopTabs: Bool = false) -> ToolbarActionState {
         return ToolbarActionState(
             actionType: .tabs,
             iconName: StandardImageIdentifiers.Large.tab,
+            badgeImageName: isPrivateMode ? StandardImageIdentifiers.Medium.privateModeCircleFillPurple : nil,
+            maskImageName: isPrivateMode ? ImageIdentifiers.badgeMask : nil,
             numberOfTabs: numberOfTabs,
             isShowingTopTabs: isShowingTopTabs,
             isEnabled: true,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9737)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21396)

## :bulb: Description
Show private mode badge on tab button in address and navigation toolbar when user is in private mode.

![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-23 at 10 46 44](https://github.com/user-attachments/assets/f8c979cc-29c3-4ab8-9ab5-9409fb194126)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-23 at 10 46 47](https://github.com/user-attachments/assets/095b2850-6665-49de-b631-817972959ed0)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

