### PR TITLE
Bugfix FXIOS-9815 cookie issue

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "c7e239b5c1492ffc3ebd7fbcc7a92548ce4e78f0",
-        "version" : "1.1.0"
+        "revision" : "df5d2fcd22e3f480e3ef85bf23e277a4a0ef524d",
+        "version" : "1.2.0"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "f0525da24dc3c6cbb2b6b338b65042bc91cbc4bb",
-        "version" : "3.3.0"
+        "revision" : "a53a7e8f858902659d4784322bede34f4e49097e",
+        "version" : "3.6.1"
       }
     },
     {

--- a/firefox-ios/Client/Frontend/Reader/ReadabilityService.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReadabilityService.swift
@@ -46,13 +46,11 @@ class ReadabilityOperation: Operation {
 
         DispatchQueue.main.async(execute: { () in
             let configuration = WKWebViewConfiguration()
-            // TODO: To resolve profile from DI container
-
             let windowManager: WindowManager = AppContainer.shared.resolve()
             let defaultUUID = windowManager.windows.first?.key ?? .unavailable
-            let tab = Tab(profile: self.profile, configuration: configuration, windowUUID: defaultUUID)
+            let tab = Tab(profile: self.profile, windowUUID: defaultUUID)
             self.tab = tab
-            tab.createWebview()
+            tab.createWebview(configuration: configuration)
             tab.navigationDelegate = self
 
             let readerMode = ReaderMode(tab: tab)

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -446,9 +446,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
                                  isRestoring: !tabRestoreHasFinished)
         }
 
-//        if !zombie {
-//            tab.createWebview()
-//        }
         tab.navigationDelegate = self.navDelegate
 
         if let request = request {

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -206,7 +206,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
 
     // MARK: - Webview configuration
     // A WKWebViewConfiguration used for normal tabs
-    private lazy var configuration: WKWebViewConfiguration = {
+    lazy var configuration: WKWebViewConfiguration = {
         return LegacyTabManager.makeWebViewConfig(isPrivate: false, prefs: profile.prefs)
     }()
 
@@ -344,7 +344,6 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     // MARK: - Add tabs
     func addTab(_ request: URLRequest?, afterTab: Tab?, isPrivate: Bool) -> Tab {
         return addTab(request,
-                      configuration: nil,
                       afterTab: afterTab,
                       flushToDisk: true,
                       zombie: false,
@@ -353,13 +352,11 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
 
     @discardableResult
     func addTab(_ request: URLRequest! = nil,
-                configuration: WKWebViewConfiguration! = nil,
                 afterTab: Tab? = nil,
                 zombie: Bool = false,
                 isPrivate: Bool = false
     ) -> Tab {
         return addTab(request,
-                      configuration: configuration,
                       afterTab: afterTab,
                       flushToDisk: true,
                       zombie: zombie,
@@ -389,23 +386,18 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     func addTab(_ request: URLRequest? = nil,
-                configuration: WKWebViewConfiguration? = nil,
                 afterTab: Tab? = nil,
                 flushToDisk: Bool,
                 zombie: Bool,
                 isPrivate: Bool = false
     ) -> Tab {
-        // Take the given configuration. Or if it was nil, take our default configuration for the current browsing mode.
-        let configuration: WKWebViewConfiguration = configuration ?? (isPrivate ? privateConfiguration : self.configuration)
-
-        let tab = Tab(profile: profile, configuration: configuration, isPrivate: isPrivate, windowUUID: windowUUID)
+        let tab = Tab(profile: profile, isPrivate: isPrivate, windowUUID: windowUUID)
         configureTab(tab, request: request, afterTab: afterTab, flushToDisk: flushToDisk, zombie: zombie)
         return tab
     }
 
     func addPopupForParentTab(profile: Profile, parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab {
         let popup = Tab(profile: profile,
-                        configuration: configuration,
                         isPrivate: parentTab.isPrivate,
                         windowUUID: windowUUID)
         configureTab(popup, request: nil, afterTab: parentTab, flushToDisk: true, zombie: false, isPopup: true)
@@ -454,9 +446,9 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
                                  isRestoring: !tabRestoreHasFinished)
         }
 
-        if !zombie {
-            tab.createWebview()
-        }
+//        if !zombie {
+//            tab.createWebview()
+//        }
         tab.navigationDelegate = self.navDelegate
 
         if let request = request {

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -446,6 +446,10 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
                                  isRestoring: !tabRestoreHasFinished)
         }
 
+        if !zombie {
+            let configuration = tab.isPrivate ? self.privateConfiguration : self.configuration
+            tab.createWebview(configuration: configuration)
+        }
         tab.navigationDelegate = self.navDelegate
 
         if let request = request {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -391,23 +391,21 @@ class Tab: NSObject, ThemeApplicable {
     // If this tab has been opened from another, its parent will point to the tab from which it was opened
     weak var parent: Tab?
 
-    fileprivate var contentScriptManager = TabContentScriptManager()
+    private var contentScriptManager = TabContentScriptManager()
 
-    fileprivate let configuration: WKWebViewConfiguration
+    private var configuration: WKWebViewConfiguration?
 
     /// Any time a tab tries to make requests to display a Javascript Alert and we are not the active
     /// tab instance, queue it for later until we become foregrounded.
-    fileprivate var alertQueue = [JSAlertInfo]()
+    private var alertQueue = [JSAlertInfo]()
 
     var profile: Profile
 
     init(profile: Profile,
-         configuration: WKWebViewConfiguration,
          isPrivate: Bool = false,
          windowUUID: WindowUUID,
          faviconHelper: SiteImageHandler = DefaultSiteImageHandler.factory(),
          logger: Logger = DefaultLogger.shared) {
-        self.configuration = configuration
         self.nightMode = false
         self.windowUUID = windowUUID
         self.noImageMode = false
@@ -460,7 +458,8 @@ class Tab: NSObject, ThemeApplicable {
         }
     }
 
-    func createWebview(with restoreSessionData: Data? = nil) {
+    func createWebview(with restoreSessionData: Data? = nil, configuration: WKWebViewConfiguration) {
+        self.configuration = configuration
         if webView == nil {
             configuration.userContentController = WKUserContentController()
             configuration.allowsInlineMediaPlayback = true

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -62,7 +62,6 @@ protocol TabManager: AnyObject {
 
     @discardableResult
     func addTab(_ request: URLRequest!,
-                configuration: WKWebViewConfiguration!,
                 afterTab: Tab?,
                 zombie: Bool,
                 isPrivate: Bool) -> Tab

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -130,13 +130,11 @@ extension TabManager {
 
     @discardableResult
     func addTab(_ request: URLRequest! = nil,
-                configuration: WKWebViewConfiguration! = nil,
                 afterTab: Tab? = nil,
                 zombie: Bool = false,
                 isPrivate: Bool = false
     ) -> Tab {
         addTab(request,
-               configuration: configuration,
                afterTab: afterTab,
                zombie: zombie,
                isPrivate: isPrivate)

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -7,6 +7,7 @@ import TabDataStore
 import Storage
 import Common
 import Shared
+import WebKit
 
 // This class subclasses the legacy tab manager temporarily so we can
 // gradually migrate to the new system
@@ -432,7 +433,9 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
 
     private func selectTabWithSession(tab: Tab, previous: Tab?, sessionData: Data?) {
         assert(Thread.isMainThread, "Currently expected to be called only on main thread.")
-        selectedTab?.createWebview(with: sessionData)
+        let configuration: WKWebViewConfiguration = tab.isPrivate ? self.privateConfiguration : self.configuration
+
+        selectedTab?.createWebview(with: sessionData, configuration: configuration)
         selectedTab?.lastExecutedTime = Date.now()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/FormAutofillHelperTests.swift
@@ -51,7 +51,7 @@ class FormAutofillHelperTests: XCTestCase {
         profile = MockProfile()
         DependencyHelperMock().bootstrapDependencies()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
-        tab = Tab(profile: profile, configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+        tab = Tab(profile: profile, windowUUID: windowUUID)
         formAutofillHelper = FormAutofillHelper(tab: tab)
         secureWebviewMock = WKWebViewMock(URL(string: "https://foo.com")!)
         secureFrameMock = WKFrameInfoMock(webView: secureWebviewMock, frameURL: URL(string: "https://foo.com")!)
@@ -281,10 +281,10 @@ class FormAutofillHelperTests: XCTestCase {
     }
 
     func test_formAutofillHelper_foundFieldValuesClosure_doesntLeak() {
-        let tab = Tab(profile: profile, configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+        let tab = Tab(profile: profile, windowUUID: windowUUID)
         let subject = FormAutofillHelper(tab: tab)
         trackForMemoryLeaks(subject)
-        tab.createWebview()
+        tab.createWebview(configuration: .init())
         tab.addContentScript(subject, name: FormAutofillHelper.name())
 
         subject.foundFieldValues = { fieldValues, type, frame in

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -286,9 +286,9 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
     }
 
     func testShowBackForwardList_presentsBackForwardListViewController() {
-        let mockTab = Tab(profile: profile, configuration: .init(), windowUUID: windowUUID)
+        let mockTab = Tab(profile: profile, windowUUID: windowUUID)
         mockTab.url = URL(string: "https://www.google.com")
-        mockTab.createWebview()
+        mockTab.createWebview(configuration: .init())
         tabManager.selectedTab = mockTab
 
         let subject = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollControllerTests.swift
@@ -22,7 +22,7 @@ final class TabScrollControllerTests: XCTestCase {
 
         self.mockProfile = MockProfile()
         self.subject = TabScrollingController(windowUUID: windowUUID)
-        self.tab = Tab(profile: mockProfile, configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+        self.tab = Tab(profile: mockProfile, windowUUID: windowUUID)
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
         mockGesture = UIPanGestureRecognizerMock()
         DependencyHelperMock().bootstrapDependencies()
@@ -92,7 +92,7 @@ final class TabScrollControllerTests: XCTestCase {
     }
 
     private func setupTabScroll() {
-        tab.createWebview()
+        tab.createWebview(configuration: .init())
         tab.webView?.scrollView.contentSize = CGSize(width: 200, height: 2000)
         tab.webView?.scrollView.delegate = subject
         subject.tab = tab

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInDataAdaptorTests.swift
@@ -12,7 +12,6 @@ final class JumpBackInDataAdaptorTests: XCTestCase {
     var mockTabManager: MockTabManager!
     var mockProfile: MockProfile!
     let sleepTime: UInt64 = 100_000_000
-    let webViewConfig = WKWebViewConfiguration()
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
     override func setUp() {
@@ -149,7 +148,7 @@ extension JumpBackInDataAdaptorTests {
 
     func createTab(profile: MockProfile,
                    urlString: String? = "www.website.com") -> Tab {
-        let tab = Tab(profile: profile, configuration: webViewConfig, windowUUID: windowUUID)
+        let tab = Tab(profile: profile, windowUUID: windowUUID)
 
         if let urlString = urlString {
             tab.url = URL(string: urlString)!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/JumpBackIn/JumpBackInViewModelTests.swift
@@ -586,9 +586,8 @@ extension JumpBackInViewModelTests {
     }
 
     func createTab(profile: MockProfile,
-                   configuration: WKWebViewConfiguration = WKWebViewConfiguration(),
                    urlString: String? = "www.website.com") -> Tab {
-        let tab = Tab(profile: profile, configuration: configuration, windowUUID: windowUUID)
+        let tab = Tab(profile: profile, windowUUID: windowUUID)
 
         if let urlString = urlString {
             tab.url = URL(string: urlString)!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
@@ -79,9 +79,8 @@ class AccountSyncHandlerTests: XCTestCase {
 // MARK: - Helper methods
 private extension AccountSyncHandlerTests {
     func createTab(profile: MockProfile,
-                   configuration: WKWebViewConfiguration = WKWebViewConfiguration(),
                    urlString: String? = "www.website.com") -> Tab {
-        let tab = Tab(profile: profile, configuration: configuration, windowUUID: windowUUID)
+        let tab = Tab(profile: profile, windowUUID: windowUUID)
 
         if let urlString = urlString {
             tab.url = URL(string: urlString)!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -95,7 +95,7 @@ class MockBrowserViewController: BrowserViewController {
         openURLInNewTabURL = url
         openURLInNewTabIsPrivate = isPrivate
         openURLInNewTabCount += 1
-        return Tab(profile: MockProfile(), configuration: .init(), windowUUID: windowUUID)
+        return Tab(profile: MockProfile(), windowUUID: windowUUID)
     }
 
     override func handleQRCode() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -62,9 +62,8 @@ class MockTabManager: TabManager {
     }
 
     func addTab(_ request: URLRequest?, afterTab: Tab?, isPrivate: Bool) -> Tab {
-        let configuration = WKWebViewConfiguration()
         let profile = MockProfile()
-        let tab = Tab(profile: profile, configuration: configuration, isPrivate: isPrivate, windowUUID: windowUUID)
+        let tab = Tab(profile: profile, isPrivate: isPrivate, windowUUID: windowUUID)
         tabs.append(tab)
         return tab
     }
@@ -137,7 +136,7 @@ class MockTabManager: TabManager {
     }
 
     func addPopupForParentTab(profile: Profile, parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab {
-        return Tab(profile: MockProfile(), configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+        return Tab(profile: MockProfile(), windowUUID: windowUUID)
     }
 
     func makeToastFromRecentlyClosedUrls(_ recentlyClosedTabs: [Tab],
@@ -148,12 +147,11 @@ class MockTabManager: TabManager {
 
     @discardableResult
     func addTab(_ request: URLRequest!,
-                configuration: WKWebViewConfiguration!,
                 afterTab: Tab?,
                 zombie: Bool,
                 isPrivate: Bool
     ) -> Tab {
-        return Tab(profile: MockProfile(), configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+        return Tab(profile: MockProfile(), windowUUID: windowUUID)
     }
 
     func backgroundRemoveAllTabs(isPrivate: Bool,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabEventHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/TabEventHandlerTests.swift
@@ -14,7 +14,6 @@ class TabEventHandlerTests: XCTestCase {
     let windowUUID: WindowUUID = .XCTestDefaultUUID
     func testEventDelivery() {
         let tab = Tab(profile: MockProfile(),
-                      configuration: WKWebViewConfiguration(),
                       windowUUID: windowUUID)
         let handler = DummyHandler()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -16,7 +16,6 @@ class TabManagerTests: XCTestCase {
     var mockSessionStore: MockTabSessionStore!
     var mockProfile: MockProfile!
     var mockDiskImageStore: MockDiskImageStore!
-    let webViewConfig = WKWebViewConfiguration()
     let sleepTime: UInt64 = 1 * NSEC_PER_SEC
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
@@ -219,7 +218,7 @@ class TabManagerTests: XCTestCase {
 
     private func addTabs(to subject: TabManagerImplementation, count: Int) {
         for _ in 0..<count {
-            let tab = Tab(profile: mockProfile, configuration: webViewConfig, windowUUID: windowUUID)
+            let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
             tab.url = URL(string: "https://mozilla.com")!
             subject.tabs.append(tab)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -34,14 +34,14 @@ class TabTests: XCTestCase {
 
     func testDisplayTitle_ForHomepageURL() {
         let url = URL(string: "internal://local/about/home")!
-        let tab = Tab(profile: MockProfile(), configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
         tab.url = url
         let expectedDisplayTitle = String.AppMenu.AppMenuOpenHomePageTitleString
         XCTAssertEqual(tab.displayTitle, expectedDisplayTitle)
     }
 
     func testTabDoesntLeak() {
-        let tab = Tab(profile: MockProfile(), configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
         tab.tabDelegate = tabDelegate
         trackForMemoryLeaks(tab)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/InactiveTabsManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/InactiveTabsManagerTests.swift
@@ -72,17 +72,17 @@ final class InactiveTabsManagerTests: XCTestCase {
                             amountOfInactiveTabs: Int = 0) -> [Tab] {
         var tabs = [Tab]()
         for _ in  0..<amountOfRegularTabs {
-            let tab = Tab(profile: profile, configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+            let tab = Tab(profile: profile, windowUUID: windowUUID)
             tabs.append(tab)
         }
 
         for _ in  0..<amountOfPrivateTabs {
-            let tab = Tab(profile: profile, configuration: WKWebViewConfiguration(), isPrivate: true, windowUUID: windowUUID)
+            let tab = Tab(profile: profile, isPrivate: true, windowUUID: windowUUID)
             tabs.append(tab)
         }
 
         for _ in 0..<amountOfInactiveTabs {
-            let tab = Tab(profile: profile, configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+            let tab = Tab(profile: profile, windowUUID: windowUUID)
             let lastExecutedDate = Calendar.current.add(numberOfDays: -15, to: Date())
             tab.lastExecutedTime = lastExecutedDate?.toTimestamp()
             tabs.append(tab)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabWebViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabWebViewTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import WebKit
 
 class TabWebViewTests: XCTestCaseRootViewController, UIGestureRecognizerDelegate {
-    private var configuration: WKWebViewConfiguration!
+    private var configuration = WKWebViewConfiguration()
     private var navigationDelegate: MockNavigationDelegate!
     private var tabWebViewDelegate: MockTabWebViewDelegate!
     private let sleepTime: UInt64 = 1 * NSEC_PER_SEC
@@ -18,7 +18,6 @@ class TabWebViewTests: XCTestCaseRootViewController, UIGestureRecognizerDelegate
 
     override func setUp() {
         super.setUp()
-        configuration = WKWebViewConfiguration()
         navigationDelegate = MockNavigationDelegate()
         tabWebViewDelegate = MockTabWebViewDelegate()
         DependencyHelperMock().bootstrapDependencies()
@@ -27,65 +26,63 @@ class TabWebViewTests: XCTestCaseRootViewController, UIGestureRecognizerDelegate
 
     override func tearDown() {
         super.tearDown()
-        configuration = nil
         navigationDelegate = nil
         tabWebViewDelegate = nil
         DependencyHelperMock().reset()
     }
 
     func testBasicTabWebView_doesntLeak() async throws {
-        _ = try await createSubject(configuration: configuration)
+        _ = try await createSubject()
     }
 
     func testSavedCardsClosure_doesntLeak() async throws {
-        let subject = try await createSubject(configuration: configuration)
+        let subject = try await createSubject()
         subject.accessoryView.savedCardsClosure = {}
     }
 
     func testTabWebView_doesntLeak() {
-        let tab = Tab(profile: MockProfile(), configuration: configuration, windowUUID: windowUUID)
-        tab.createWebview()
+        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
+        tab.createWebview(configuration: configuration)
 
         trackForMemoryLeaks(tab)
     }
 
     func testTabWebView_load_doesntLeak() {
-        let tab = Tab(profile: MockProfile(), configuration: configuration, windowUUID: windowUUID)
-        tab.createWebview()
+        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
+        tab.createWebview(configuration: configuration)
         tab.loadRequest(URLRequest(url: URL(string: "https://www.mozilla.com")!))
 
         trackForMemoryLeaks(tab)
     }
 
     func testTabWebView_withLegacySessionData_doesntLeak() {
-        let tab = Tab(profile: MockProfile(), configuration: configuration, windowUUID: windowUUID)
+        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
         tab.url = URL(string: "http://yahoo.com/")!
-        tab.createWebview()
+        tab.createWebview(configuration: configuration)
 
         trackForMemoryLeaks(tab)
     }
 
     func testTabWebView_withSessionData_doesntLeak() {
-        let tab = Tab(profile: MockProfile(), configuration: configuration, windowUUID: windowUUID)
-        tab.createWebview(with: Data())
+        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
+        tab.createWebview(with: Data(), configuration: configuration)
 
         trackForMemoryLeaks(tab)
     }
 
     func testTabWebView_withURL_doesntLeak() {
-        let tab = Tab(profile: MockProfile(), configuration: configuration, windowUUID: windowUUID)
+        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
         tab.url = URL(string: "https://www.mozilla.com")!
-        tab.createWebview()
+        tab.createWebview(configuration: configuration)
 
         trackForMemoryLeaks(tab)
     }
 
     // MARK: - Helper methods
 
-    func createSubject(configuration: WKWebViewConfiguration,
-                       file: StaticString = #file,
+    func createSubject(file: StaticString = #file,
                        line: UInt = #line) async throws -> TabWebView {
-        let subject = TabWebView(frame: .zero, configuration: configuration, windowUUID: windowUUID)
+        let subject = TabWebView(frame: .zero, windowUUID: windowUUID)
         try await Task.sleep(nanoseconds: sleepTime)
         subject.configure(delegate: tabWebViewDelegate, navigationDelegate: navigationDelegate)
         trackForMemoryLeaks(subject)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabWebViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabWebViewTests.swift
@@ -82,7 +82,7 @@ class TabWebViewTests: XCTestCaseRootViewController, UIGestureRecognizerDelegate
 
     func createSubject(file: StaticString = #file,
                        line: UInt = #line) async throws -> TabWebView {
-        let subject = TabWebView(frame: .zero, windowUUID: windowUUID)
+        let subject = TabWebView(frame: .zero, configuration: .init(), windowUUID: windowUUID)
         try await Task.sleep(nanoseconds: sleepTime)
         subject.configure(delegate: tabWebViewDelegate, navigationDelegate: navigationDelegate)
         trackForMemoryLeaks(subject)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/SponsoredContentFilterUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/SponsoredContentFilterUtilityTests.swift
@@ -150,18 +150,18 @@ extension SponsoredContentFilterUtilityTests {
                     sponsoredTabsCount: Int) -> [Tab] {
         var tabs = [Tab]()
         (0..<normalTabsCount).forEach { index in
-            let tab = Tab(profile: profile, configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+            let tab = Tab(profile: profile, windowUUID: windowUUID)
             tab.url = URL(string: normalURL)
             tabs.append(tab)
         }
 
         (0..<emptyURLTabsCount).forEach { index in
-            let tab = Tab(profile: profile, configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+            let tab = Tab(profile: profile, windowUUID: windowUUID)
             tabs.append(tab)
         }
 
         (0..<sponsoredTabsCount).forEach { index in
-            let tab = Tab(profile: profile, configuration: WKWebViewConfiguration(), windowUUID: windowUUID)
+            let tab = Tab(profile: profile, windowUUID: windowUUID)
             tab.url = URL(string: SponsoredContentFilterUtilityTests.sponsoredStandardURL)
             tabs.append(tab)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9815)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21560)

## :bulb: Description
Move the webview config setting down a level so it's only accessed as it's needed. This avoids the possibility of the non persistent store being accessed prior to a private tab being selected.
Also moved the web view creation so that it only occurs as needed. 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

