### PR TITLE
Refactor FXIOS-9854 Replace DefaultChromeSmallSize & DefaultChromeSmallFontBold with FXFontStyles

### DIFF
--- a/firefox-ios/Client/Frontend/UIConstants.swift
+++ b/firefox-ios/Client/Frontend/UIConstants.swift
@@ -14,10 +14,6 @@ public struct UIConstants {
     static var ToolbarPadding: CGFloat = 17
     static let ZoomPageBarHeight: CGFloat = 54
 
-    // Static fonts
-    static let DefaultChromeSmallSize: CGFloat = 11
-    static let DefaultChromeSmallFontBold = UIFont.boldSystemFont(ofSize: DefaultChromeSmallSize)
-
     /// JPEG compression quality for persisted screenshots. Must be between 0-1.
     static let ScreenshotQuality: Float = 1
     static let ActiveScreenshotQuality: CGFloat = 0.5

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetView.swift
@@ -110,7 +110,7 @@ class PhotonActionSheetView: UIView, UIGestureRecognizerDelegate, ThemeApplicabl
     }
 
     private lazy var tabsLabel: UILabel = .build { label in
-        label.font = UIFont.boldSystemFont(ofSize: UIConstants.DefaultChromeSmallSize)
+        label.font = FXFontStyles.Bold.caption2.systemFont()
     }
 
     lazy var bottomBorder: UIView = .build { _ in }

--- a/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
@@ -9,7 +9,7 @@ import Common
 class TabsButton: UIButton, ThemeApplicable {
     struct UX {
         static let cornerRadius: CGFloat = 2
-        static let titleFont: UIFont = UIConstants.DefaultChromeSmallFontBold
+        static let titleFont: UIFont = FXFontStyles.Bold.caption2.systemFont()
         static let insideButtonSize: CGFloat = 24
 
         // Animation constants


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9854)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21633)

## :bulb: Description
Replaces DefaultChromeSmallSize & DefaultChromeSmallFontBold with FXFontStyles.
![Simulator Screenshot - iPhone 15 Pro - 2024-08-27 at 11 23 25](https://github.com/user-attachments/assets/757b8529-a0e7-4378-a58e-69c1e506ea2a)
![Simulator Screenshot - iPhone 15 Pro - 2024-08-27 at 11 15 19](https://github.com/user-attachments/assets/0d082d5a-bafa-4ab9-bd84-07446389438c)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

