### PR TITLE
Bugfix FXIOS-9842 [Toolbar redesign] Tapping outside the URL bar is not completely closing the keyboard

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -273,8 +273,6 @@ public class BrowserAddressToolbar: UIView, AddressToolbar, ThemeApplicable, Loc
         toolbarDelegate?.addressToolbarAccessibilityActions()
     }
 
-    func locationViewDidCancelEditing() {}
-
     // MARK: - ThemeApplicable
     public func applyTheme(theme: Theme) {
         backgroundColor = theme.colors.layer1

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -11,7 +11,6 @@ protocol LocationTextFieldDelegate: AnyObject {
     func locationTextField(_ textField: LocationTextField, didEnterText text: String)
     func locationTextFieldShouldReturn(_ textField: LocationTextField) -> Bool
     func locationTextFieldShouldClear(_ textField: LocationTextField) -> Bool
-    func locationTextFieldDidCancel(_ textField: LocationTextField)
     func locationPasteAndGo(_ textField: LocationTextField)
     func locationTextFieldDidBeginEditing(_ textField: UITextField)
     func locationTextFieldDidEndEditing(_ textField: UITextField)

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -354,10 +354,6 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         return true
     }
 
-    func locationTextFieldDidCancel(_ textField: LocationTextField) {
-        delegate?.locationViewDidCancelEditing()
-    }
-
     func locationPasteAndGo(_ textField: LocationTextField) {
         if let pasteboardContents = UIPasteboard.general.string {
             delegate?.locationViewDidSubmitText(pasteboardContents)

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewDelegate.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewDelegate.swift
@@ -28,7 +28,4 @@ protocol LocationViewDelegate: AnyObject {
     /// - Returns: An optional array of `UIAccessibilityCustomAction` objects.
     /// Return `nil` if no custom actions are provided.
     func locationViewAccessibilityActions() -> [UIAccessibilityCustomAction]?
-
-    /// Called when the user cancels entering text into the location view.
-    func locationViewDidCancelEditing()
 }

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -385,6 +385,15 @@ class HomepageViewController:
                                                          theme: theme)
         }
 
+        // Only dispatch action when user is in edit mode to avoid having the toolbar re-displayed
+        if featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly),
+           let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID),
+           toolbarState.addressToolbar.isEditing {
+            let action = ToolbarMiddlewareAction(windowUUID: windowUUID,
+                                                 actionType: ToolbarMiddlewareActionType.cancelEdit)
+            store.dispatch(action)
+        }
+
         let scrolledToTop = lastContentOffsetY > 0 && scrollView.contentOffset.y <= 0
         let scrolledDown = lastContentOffsetY == 0 && scrollView.contentOffset.y > 0
 

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -365,6 +365,10 @@ class HomepageViewController:
     private func dismissKeyboard() {
         if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
             overlayManager.cancelEditing(shouldCancelLoading: false)
+
+            let action = ToolbarMiddlewareAction(windowUUID: windowUUID,
+                                                 actionType: ToolbarMiddlewareActionType.cancelEdit)
+            store.dispatch(action)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9842)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21605)

## :bulb: Description
Ends the edit mode in the address toolbar when the keyboard gets dismissed. Also cleans up unused code.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

