### PR TITLE
Bugfix FXIOS-9839 Fix broken navigation when current tab location is homepage

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -358,10 +358,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
 
         preserveTabs()
 
-        var sessionData: Data?
-        if !tab.isFxHomeTab {
-            sessionData = tabSessionStore.fetchTabSession(tabID: tabUUID)
-        }
+        let sessionData = tabSessionStore.fetchTabSession(tabID: tabUUID)
         selectTabWithSession(tab: tab,
                              previous: previous,
                              sessionData: sessionData)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9839)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21602)

## :bulb: Description

Fixes an issue where the back/forward arrows would be disabled incorrectly after launch if the current tab was on the homepage.

### Note

This removes a very old/longstanding logical check that was skipping session data restore if the current tab was on the homepage. I reached out to the team to find out the historical context, as well as if anyone had concerns about this; the feedback I received was that it should be safe to remove. I did a quick round of regression-testing and couldn't identify any issues.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

