### PR TITLE
Refactor FXIOS-7301 - Help to remove 1 closure_body_length violation from UITestAppDelegate.swift (2/3)

### DIFF
--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -38,42 +38,7 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
             }
 
             if arg.starts(with: LaunchArguments.LoadDatabasePrefix) {
-                if launchArguments.contains(LaunchArguments.ClearProfile) {
-                    fatalError("Clearing profile and loading a test database is not a supported combination.")
-                }
-
-                // Grab the name of file in the bundle's test-fixtures dir, and copy it to the runtime app dir.
-                let filename = arg.replacingOccurrences(of: LaunchArguments.LoadDatabasePrefix, with: "")
-                let input = URL(
-                    fileURLWithPath: Bundle(for: UITestAppDelegate.self).path(
-                        forResource: filename,
-                        ofType: nil,
-                        inDirectory: "test-fixtures"
-                    )!
-                )
-                try? FileManager.default.createDirectory(
-                    atPath: dirForTestProfile,
-                    withIntermediateDirectories: false,
-                    attributes: nil
-                )
-                let output = URL(fileURLWithPath: "\(dirForTestProfile)/places.db")
-
-                let enumerator = FileManager.default.enumerator(atPath: dirForTestProfile)
-                let filePaths = enumerator?.allObjects as! [String]
-                filePaths.filter { $0.contains(".db") }.forEach { item in
-                    try? FileManager.default.removeItem(
-                        at: URL(fileURLWithPath: "\(dirForTestProfile)/\(item)")
-                    )
-                }
-
-                do {
-                    try FileManager.default.copyItem(at: input, to: output)
-                } catch {
-                    fatalError("Could not copy items from \(input) to \(output): \(error)")
-                }
-
-                // Tests currently load a browserdb history, we make sure we migrate it everytime
-                UserDefaults.standard.setValue(false, forKey: PrefsKeys.PlacesHistoryMigrationSucceeded)
+                configureDatabase(arg, launchArguments: launchArguments)
             }
 
             if arg.starts(with: LaunchArguments.LoadTabsStateArchive) {

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -169,7 +169,7 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
         }
     }
 
-    fileprivate func configureDatabase(_ arg: String, launchArguments: [String]) {
+    private func configureDatabase(_ arg: String, launchArguments: [String]) {
         if launchArguments.contains(LaunchArguments.ClearProfile) {
             fatalError("Clearing profile and loading a test database is not a supported combination.")
         }

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -30,7 +30,6 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
 
         var profile: BrowserProfile
         let launchArguments = ProcessInfo.processInfo.arguments
-        let dirForTestProfile = self.dirForTestProfile
 
         launchArguments.forEach { arg in
             if arg.starts(with: LaunchArguments.ServerPort) {

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -204,6 +204,45 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
         }
     }
 
+    fileprivate func configureDatabase(_ arg: String, launchArguments: [String]) {
+        if launchArguments.contains(LaunchArguments.ClearProfile) {
+            fatalError("Clearing profile and loading a test database is not a supported combination.")
+        }
+
+        // Grab the name of file in the bundle's test-fixtures dir, and copy it to the runtime app dir.
+        let filename = arg.replacingOccurrences(of: LaunchArguments.LoadDatabasePrefix, with: "")
+        let input = URL(
+            fileURLWithPath: Bundle(for: UITestAppDelegate.self).path(
+                forResource: filename,
+                ofType: nil,
+                inDirectory: "test-fixtures"
+            )!
+        )
+        try? FileManager.default.createDirectory(
+            atPath: dirForTestProfile,
+            withIntermediateDirectories: false,
+            attributes: nil
+        )
+        let output = URL(fileURLWithPath: "\(dirForTestProfile)/places.db")
+
+        let enumerator = FileManager.default.enumerator(atPath: dirForTestProfile)
+        let filePaths = enumerator?.allObjects as! [String]
+        filePaths.filter { $0.contains(".db") }.forEach { item in
+            try? FileManager.default.removeItem(
+                at: URL(fileURLWithPath: "\(dirForTestProfile)/\(item)")
+            )
+        }
+
+        do {
+            try FileManager.default.copyItem(at: input, to: output)
+        } catch {
+            fatalError("Could not copy items from \(input) to \(output): \(error)")
+        }
+
+        // Tests currently load a browserdb history, we make sure we migrate it everytime
+        UserDefaults.standard.setValue(false, forKey: PrefsKeys.PlacesHistoryMigrationSucceeded)
+    }
+
     override func application(
         _ application: UIApplication,
         willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR help to remove 1 `closure_body_length` violation from the `UITestAppDelegate.swift` file. It is the first of three parts, and in this one I've extracted the database configuration into a new function.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

