### PR TITLE
Add FXIOS-9841 Show search action in navigation toolbar on private homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -549,7 +549,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
             let isForwardButtonEnabled = canGoForward
             actions.append(backAction(enabled: isBackButtonEnabled))
             actions.append(forwardAction(enabled: isForwardButtonEnabled))
-            if shouldShowDataClearanceAction(isPrivate: toolbarState.isPrivateMode) {
+            if canShowDataClearanceAction(isPrivate: toolbarState.isPrivateMode) {
                 actions.append(dataClearanceAction)
             }
         }
@@ -688,15 +688,13 @@ final class ToolbarMiddleware: FeatureFlaggable {
     }
 
     private func getMiddleButtonAction(url: URL?, isPrivateMode: Bool) -> ToolbarActionState {
-        let shouldShowDataClearanceAction = shouldShowDataClearanceAction(isPrivate: isPrivateMode)
-        guard !shouldShowDataClearanceAction else {
-            return dataClearanceAction
-        }
-
+        let canShowDataClearanceAction = canShowDataClearanceAction(isPrivate: isPrivateMode)
         let isNewTabEnabled = featureFlags.isFeatureEnabled(.toolbarOneTapNewTab, checking: .buildOnly)
-        let middleActionDefault = isNewTabEnabled ? newTabAction : homeAction
-        let middleActionHome = searchAction
-        let middleAction = url == nil ? middleActionHome : middleActionDefault
+        let isToolbarRefactorEnabled = featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
+        let middleActionForWebpage = canShowDataClearanceAction ?
+                                     dataClearanceAction : isNewTabEnabled ? newTabAction : homeAction
+        let middleActionForHomepage = isToolbarRefactorEnabled || !isPrivateMode ? searchAction : dataClearanceAction
+        let middleAction = url == nil ? middleActionForHomepage : middleActionForWebpage
 
         return middleAction
     }
@@ -759,7 +757,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
         return manager.shouldDisplayNavigationBorder(toolbarPosition: toolbarPosition)
     }
 
-    private func shouldShowDataClearanceAction(isPrivate: Bool) -> Bool {
+    private func canShowDataClearanceAction(isPrivate: Bool) -> Bool {
         let isFeltPrivacyUIEnabled = featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly)
         let isFeltPrivacyDeletionEnabled = featureFlags.isFeatureEnabled(.feltPrivacyFeltDeletion, checking: .buildOnly)
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -690,10 +690,9 @@ final class ToolbarMiddleware: FeatureFlaggable {
     private func getMiddleButtonAction(url: URL?, isPrivateMode: Bool) -> ToolbarActionState {
         let canShowDataClearanceAction = canShowDataClearanceAction(isPrivate: isPrivateMode)
         let isNewTabEnabled = featureFlags.isFeatureEnabled(.toolbarOneTapNewTab, checking: .buildOnly)
-        let isToolbarRefactorEnabled = featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
         let middleActionForWebpage = canShowDataClearanceAction ?
                                      dataClearanceAction : isNewTabEnabled ? newTabAction : homeAction
-        let middleActionForHomepage = isToolbarRefactorEnabled || !isPrivateMode ? searchAction : dataClearanceAction
+        let middleActionForHomepage = searchAction
         let middleAction = url == nil ? middleActionForHomepage : middleActionForWebpage
 
         return middleAction


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9841)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21604)

## :bulb: Description
- When the toolbar refactor is enabled, always show the search action in the navigation toolbar on private browsing mode homepage

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

