### PR TITLE
Fixess MTE-3339 - for credit card tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -206,7 +206,7 @@ class CreditCardsTests: BaseTestCase {
         typeCardName(name: updatedName)
         app.buttons["Save"].tap()
         // The name of the card is saved without issues
-        mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).staticTexts[updatedName])
+        mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons[updatedName])
         // Go to an saved credit card and change the credit card number
         app.tables.cells.element(boundBy: 1).tap()
         app.buttons[creditCardsStaticTexts.ViewCreditCard.edit].tap()
@@ -215,7 +215,7 @@ class CreditCardsTests: BaseTestCase {
         typeCardNr(cardNo: cards[1])
         app.buttons["Save"].tap()
         // The credit card number is saved without issues
-        mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).staticTexts.elementContainingText("1111"))
+        mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons.elementContainingText("1111"))
         // Reach autofill website
         // reachAutofillWebsite() does not work on iOS 15
         if #available(iOS 16, *) {
@@ -249,12 +249,12 @@ class CreditCardsTests: BaseTestCase {
                          ["1111", "Test2", "6/40"],
                          ["9631", "Test3", "7/40"]]
         for i in 1...3 {
-            mozWaitForElementToExist(app.tables.cells.element(boundBy: i).staticTexts.firstMatch)
-            XCTAssertTrue(app.tables.cells.element(boundBy: i).staticTexts.elementContainingText(cardsInfo[i-1][0]).exists,
+            mozWaitForElementToExist(app.tables.cells.element(boundBy: i).buttons.firstMatch)
+            XCTAssertTrue(app.tables.cells.element(boundBy: i).buttons.elementContainingText(cardsInfo[i-1][0]).exists,
                           "\(cardsInfo[i-1][0]) info is not displayed")
-            XCTAssertTrue(app.tables.cells.element(boundBy: i).staticTexts[cardsInfo[i-1][1]].exists,
+            XCTAssertTrue(app.tables.cells.element(boundBy: i).buttons[cardsInfo[i-1][1]].exists,
                           "\(cardsInfo[i-1][1]) info is not displayed")
-            XCTAssertTrue(app.tables.cells.element(boundBy: i).staticTexts[cardsInfo[i-1][2]].exists,
+            XCTAssertTrue(app.tables.cells.element(boundBy: i).buttons[cardsInfo[i-1][2]].exists,
                           "\(cardsInfo[i-1][2]) info is not displayed")
         }
         // reachAutofillWebsite() not working on iOS 15
@@ -338,9 +338,9 @@ class CreditCardsTests: BaseTestCase {
         saveButton.tap()
         // The credit card is saved
         let cardsInfo = ["Test", "5/40"]
-        mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).staticTexts.elementContainingText("1252"))
+        mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons.elementContainingText("1252"))
         for i in cardsInfo {
-            mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).staticTexts[i])
+            mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons[i])
         }
     }
 
@@ -398,10 +398,10 @@ class CreditCardsTests: BaseTestCase {
         unlockLoginsView()
         // The credit card is saved and displayed in the Credit cards section
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.savedCards])
-        mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).staticTexts.elementContainingText("1111"))
+        mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons.elementContainingText("1111"))
         let cardDetails = ["Test", "Expires", "5/40"]
         for i in cardDetails {
-            XCTAssertTrue(app.tables.cells.element(boundBy: 1).staticTexts[i].exists, "\(i) does not exists")
+            XCTAssertTrue(app.tables.cells.element(boundBy: 1).buttons[i].exists, "\(i) does not exists")
         }
     }
 
@@ -479,10 +479,10 @@ class CreditCardsTests: BaseTestCase {
         navigator.goto(CreditCardsSettings)
         unlockLoginsView()
         // Credit cards details changed
-        mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).staticTexts.elementContainingText("1252"))
+        mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons.elementContainingText("1252"))
         cardDetails = ["TestTest2", "Expires", "5/40"]
         for i in cardDetails {
-            mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).staticTexts[i])
+            mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons[i])
         }
     }
 
@@ -505,9 +505,9 @@ class CreditCardsTests: BaseTestCase {
     }
 
     private func selectCreditCardOnFormWebsite() {
-        mozWaitForElementToExist(app.scrollViews.otherElements.tables.staticTexts["Test"])
+        mozWaitForElementToExist(app.scrollViews.otherElements.tables.buttons["Test"])
         var attempts = 4
-        while app.scrollViews.otherElements.tables.staticTexts["Test"].isHittable && attempts > 0 {
+        while app.scrollViews.otherElements.tables.buttons["Test"].isHittable && attempts > 0 {
             app.scrollViews.otherElements.tables.cells.firstMatch.tapOnApp()
             attempts -= 1
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -369,7 +369,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                 // There is no Cancel option in iPad.
                 app.otherElements["PopoverDismissRegion"].tap()
             } else {
-                app.buttons["PhotonMenu.close"].tap()
+                app.buttons["Close"].tap()
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -192,11 +192,7 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         navigator.goto(TrackingProtectionContextMenuDetails)
         mozWaitForElementToExist(app.staticTexts["Secure connection"])
-        if iPad() {
-            app.popovers.scrollViews.buttons.element(boundBy: 2).tap()
-        } else {
-            app.buttons["Close"].tap()
-        }
+        navigator.performAction(Action.CloseTPContextMenu)
         mozWaitForElementToNotExist(app.staticTexts["Secure connection"])
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3339

## :bulb: Description
Fixes for credit card tests. Changed elements.
Also a fix for testLockIconCloseMenu, failing on iPad, added Action.CloseTPContextMenu to include a single line for iPad and iPhone.
