### PR TITLE
Bugfix FXIOS-9852 ⁃ Ensure deep links open in corresponding mode based on current browsing mode (Private or Normal)

### DIFF
--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -42,10 +42,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             Experiments.shared.initializeTooling(url: url)
         }
 
+        // By default if no bool value is set we close the private tabs and open app in normal mode
+        let isClosePrivateTabsEnabled = profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs) ?? true
         routeBuilder.configure(
-            isPrivate: UserDefaults.standard.bool(
-                forKey: PrefsKeys.LastSessionWasPrivate
-            ),
+            isPrivate: UserDefaults.standard.bool(forKey: PrefsKeys.LastSessionWasPrivate) && !isClosePrivateTabsEnabled,
             prefs: profile.prefs
         )
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9852)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21631)

## :bulb: Description
Reopen the app (by deeplinks) in private mode only if **Close Private Tabs** option, from menu, is disabled.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

