### PR TITLE
Refactor MTE-3341 Support iOS 18 for Focus XCUITest

### DIFF
--- a/focus-ios/focus-ios-tests/XCUITest/BrowsingTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/BrowsingTest.swift
@@ -31,10 +31,14 @@ class BrowsingTest: BaseTestCase {
 
         // Launch external app
         let RemindersApp: XCUIElement
-        if iPad() {
-            RemindersApp = app.collectionViews.scrollViews.cells.element(boundBy: 0)
+        if #available(iOS 17, *) {
+            RemindersApp = app.collectionViews.scrollViews.cells["Reminders"]
         } else {
-            RemindersApp = app.collectionViews.scrollViews.cells.element(boundBy: 1)
+            if iPad() {
+                RemindersApp = app.collectionViews.scrollViews.cells.element(boundBy: 0)
+            } else {
+                RemindersApp = app.collectionViews.scrollViews.cells.element(boundBy: 1)
+            }
         }
         waitForExistence(RemindersApp)
         waitForHittable(RemindersApp)

--- a/focus-ios/focus-ios-tests/XCUITest/SettingTest.swift
+++ b/focus-ios/focus-ios-tests/XCUITest/SettingTest.swift
@@ -254,28 +254,30 @@ class SettingTest: BaseTestCase {
         XCTAssertEqual(app.switches["BlockerToggle.Safari"].value! as! String, "0")
 
         iOS_Settings.activate()
-        waitForExistence(iOS_Settings.cells["Safari"])
-        iOS_Settings.cells["Safari"].tap()
-        iOS_Settings.cells["AutoFill"].swipeUp()
-        if #available(iOS 15.0, *) {
-            iOS_Settings.cells.staticTexts["Extensions"].tap()
-        } else {
-            iOS_Settings.cells.staticTexts["CONTENT_BLOCKERS"].tap()
+        if #unavailable(iOS 18) {
+            waitForExistence(iOS_Settings.cells["Safari"])
+            iOS_Settings.cells["Safari"].tap()
+            iOS_Settings.cells["AutoFill"].swipeUp()
+            if #available(iOS 15.0, *) {
+                iOS_Settings.cells.staticTexts["Extensions"].tap()
+            } else {
+                iOS_Settings.cells.staticTexts["CONTENT_BLOCKERS"].tap()
+            }
+            iOS_Settings.tables.cells.staticTexts["Firefox Focus"].tap()
+            iOS_Settings.tables.cells.switches.element(boundBy: 0).tap()
+            iOS_Settings.terminate()
+
+            XCUIDevice.shared.press(.home)
+            // Let's be sure the app is backgrounded
+            _ = app.wait(for: XCUIApplication.State.runningBackground, timeout: 45)
+            let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+            waitForExistence(springboard.icons["XCUITest-Runner"], timeout: 15)
+
+            // Go back to the app to verify that the toggle has changed its value
+            app.activate()
+            waitForExistence(app.navigationBars["Settings"], timeout: 15)
+            XCTAssertEqual(app.switches["BlockerToggle.Safari"].value! as! String, "1")
         }
-        iOS_Settings.tables.cells.staticTexts["Firefox Focus"].tap()
-        iOS_Settings.tables.cells.switches.element(boundBy: 0).tap()
-        iOS_Settings.terminate()
-
-        XCUIDevice.shared.press(.home)
-        // Let's be sure the app is backgrounded
-        _ = app.wait(for: XCUIApplication.State.runningBackground, timeout: 45)
-        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        waitForExistence(springboard.icons["XCUITest-Runner"], timeout: 15)
-
-        // Go back to the app to verify that the toggle has changed its value
-        app.activate()
-        waitForExistence(app.navigationBars["Settings"], timeout: 15)
-        XCTAssertEqual(app.switches["BlockerToggle.Safari"].value! as! String, "1")
     }
 
     func setUrlAutoCompleteTo(desiredAutoCompleteState: String) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3341)

## :bulb: Description
Focus v130 should support iOS 18. I updated the Focus smoke and full functional tests to ensure that they work on iOS 18 (as well as 17, 16 and 15).

This PR needs to be backported to `release/v130` branch.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

