### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from BrowserViewController.swift (2/3)

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2721,10 +2721,10 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    fileprivate func handleAddressField(type: FormAutofillPayloadType?,
-                                        tabWebView: TabWebView,
-                                        webView: WKWebView,
-                                        frame: WKFrameInfo?) {
+    private func handleAddressField(type: FormAutofillPayloadType?,
+                                    tabWebView: TabWebView,
+                                    webView: WKWebView,
+                                    frame: WKFrameInfo?) {
         guard addressAutofillSettingsUserDefaultsIsEnabled(),
               AddressLocaleFeatureValidator.isValidRegion(),
               // FXMO-376: Phase 2 let addressPayload = fieldValues.fieldData as? UnencryptedAddressFields,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2686,9 +2686,9 @@ class BrowserViewController: UIViewController,
             switch fieldValues.fieldValue {
             case .address:
                 handleFoundAddressFieldValue(type: type,
-                                   tabWebView: tabWebView,
-                                   webView: webView,
-                                   frame: frame)
+                                             tabWebView: tabWebView,
+                                             webView: webView,
+                                             frame: frame)
             case .creditCard:
                 guard let creditCardPayload = fieldValues.fieldData as? UnencryptedCreditCardFields,
                       let type = type,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2722,9 +2722,9 @@ class BrowserViewController: UIViewController,
     }
 
     private func handleFoundAddressFieldValue(type: FormAutofillPayloadType?,
-                                    tabWebView: TabWebView,
-                                    webView: WKWebView,
-                                    frame: WKFrameInfo?) {
+                                              tabWebView: TabWebView,
+                                              webView: WKWebView,
+                                              frame: WKFrameInfo?) {
         guard addressAutofillSettingsUserDefaultsIsEnabled(),
               AddressLocaleFeatureValidator.isValidRegion(),
               // FXMO-376: Phase 2 let addressPayload = fieldValues.fieldData as? UnencryptedAddressFields,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2739,6 +2739,34 @@ class BrowserViewController: UIViewController,
         }
     }
 
+    fileprivate func handleAddressField(type: FormAutofillPayloadType?,
+                                        tabWebView: TabWebView,
+                                        webView: WKWebView,
+                                        frame: WKFrameInfo?) {
+        guard addressAutofillSettingsUserDefaultsIsEnabled(),
+              addressAutofillNimbusFeatureFlag(),
+              // FXMO-376: Phase 2 let addressPayload = fieldValues.fieldData as? UnencryptedAddressFields,
+              let type = type else { return }
+
+        // Handle address form filling or capturing
+        switch type {
+        case .fillAddressForm:
+            displayAddressAutofillAccessoryView(tabWebView: tabWebView)
+        case .captureAddressForm:
+            // FXMO-376: No action needed for capturing address form as this is for Phase 2
+            break
+        default:
+            break
+        }
+
+        tabWebView.accessoryView.savedAddressesClosure = {
+            DispatchQueue.main.async { [weak self] in
+                webView.resignFirstResponder()
+                self?.navigationHandler?.showAddressAutofill(frame: frame)
+            }
+        }
+    }
+
     private func displayAutofillCreditCardAccessoryView(tabWebView: TabWebView) {
         profile.autofill.listCreditCards(completion: { cards, error in
             guard let cards = cards, !cards.isEmpty, error == nil else { return }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2685,7 +2685,7 @@ class BrowserViewController: UIViewController,
             // Handle different field types
             switch fieldValues.fieldValue {
             case .address:
-                handleAddressField(type: type,
+                handleFoundAddressFieldValue(type: type,
                                    tabWebView: tabWebView,
                                    webView: webView,
                                    frame: frame)
@@ -2721,7 +2721,7 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    private func handleAddressField(type: FormAutofillPayloadType?,
+    private func handleFoundAddressFieldValue(type: FormAutofillPayloadType?,
                                     tabWebView: TabWebView,
                                     webView: WKWebView,
                                     frame: WKFrameInfo?) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2744,7 +2744,7 @@ class BrowserViewController: UIViewController,
                                         webView: WKWebView,
                                         frame: WKFrameInfo?) {
         guard addressAutofillSettingsUserDefaultsIsEnabled(),
-              addressAutofillNimbusFeatureFlag(),
+              AddressLocaleFeatureValidator.isValidRegion(),
               // FXMO-376: Phase 2 let addressPayload = fieldValues.fieldData as? UnencryptedAddressFields,
               let type = type else { return }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2685,28 +2685,10 @@ class BrowserViewController: UIViewController,
             // Handle different field types
             switch fieldValues.fieldValue {
             case .address:
-                guard addressAutofillSettingsUserDefaultsIsEnabled(),
-                      AddressLocaleFeatureValidator.isValidRegion(),
-                      // FXMO-376: Phase 2 let addressPayload = fieldValues.fieldData as? UnencryptedAddressFields,
-                      let type = type else { return }
-
-                // Handle address form filling or capturing
-                switch type {
-                case .fillAddressForm:
-                    displayAddressAutofillAccessoryView(tabWebView: tabWebView)
-                case .captureAddressForm:
-                    // FXMO-376: No action needed for capturing address form as this is for Phase 2
-                    break
-                default:
-                    break
-                }
-
-                tabWebView.accessoryView.savedAddressesClosure = {
-                    DispatchQueue.main.async { [weak self] in
-                        webView.resignFirstResponder()
-                        self?.navigationHandler?.showAddressAutofill(frame: frame)
-                    }
-                }
+                handleAddressField(type: type,
+                                   tabWebView: tabWebView,
+                                   webView: webView,
+                                   frame: frame)
             case .creditCard:
                 guard let creditCardPayload = fieldValues.fieldData as? UnencryptedCreditCardFields,
                       let type = type,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR remove 1 `closure_body_length` violation from the `BrowserViewController.swift` file. It extracts the address field logic to a new function.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

