### PR TITLE
Refactor FXIOS-9540 - Change TPAccessoryInfo with Font from design system

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/TPAccessoryInfo.swift
+++ b/firefox-ios/Client/Frontend/Settings/TPAccessoryInfo.swift
@@ -137,11 +137,7 @@ class TPAccessoryInfo: ThemedTableViewController {
         }
         cell.imageView?.tintColor = theme.colors.iconPrimary
         if indexPath.row == 1 {
-            cell.textLabel?.font = DefaultDynamicFontHelper.preferredFont(
-                withTextStyle: .body,
-                size: 13,
-                weight: .regular
-            )
+            cell.textLabel?.font = FXFontStyles.Regular.footnote.scaledFont()
         }
         cell.textLabel?.numberOfLines = 0
         cell.detailTextLabel?.numberOfLines = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9540)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21111)

## :bulb: Description
Refactor `TPAccessoryInfo` with `FXFontStyles` from design system.

`Before:`

<img src="https://github.com/user-attachments/assets/bebdf209-96fb-41d3-97da-48cf0e8fa042" width="300">

`After:`

<img src="https://github.com/user-attachments/assets/06d88f1a-228f-4bce-9f4b-c5fcd3f6592a" width="300">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

