### PR TITLE
Refactor FXIOS-9850 [Strings] Fix string freeze comments

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3900,7 +3900,7 @@ extension String {
             public static let FindInPage = MZLocalizedString(
                 key: "MainMenu.ToolsSection.FindInPage.Title.v131",
                 tableName: "MainMenu",
-                value: "Find in Page...",
+                value: "Find in Page…",
                 comment: "On the main menu, the title for the action that will bring up the Search menu, so the user can search for a word or a pharse on the current page.")
             public static let Tools = MZLocalizedString(
                 key: "MainMenu.ToolsSection.ToolsSubmenu.Title.v131",
@@ -4039,7 +4039,7 @@ extension String {
                     key: "MainMenu.Submenus.Save.BookmarkThisPage.Title.v131",
                     tableName: "MainMenu",
                     value: "Bookmark This Page",
-                    comment: "On the main menu, in the tools submenu, the title for the menu component that indicates the current zoom level. Placeholder is for the current zoom level percentage. ")
+                    comment: "On the main menu, in the Save submenu, the title for the menu component that allows a user to save a bookmark for this particular page..")
                 public static let BookmarkThisPageSubtitle = MZLocalizedString(
                     key: "MainMenu.Submenus.Save.BookmarkThisPage.Subtitle.v131",
                     tableName: "MainMenu",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9850)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21627)

## :bulb: Description
PR title addressing [string extract](https://github.com/mozilla-l10n/firefoxios-l10n/pull/239)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

