### PR TITLE
Bugfix FXIOS-9874 [Toolbar redesign] User can get stuck in overlay mode

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarDelegate.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarDelegate.swift
@@ -9,6 +9,7 @@ public protocol AddressToolbarDelegate: AnyObject {
     func searchSuggestions(searchTerm: String)
     func openBrowser(searchTerm: String)
     func openSuggestions(searchTerm: String)
+    func addressToolbarDidBeginEditing(searchTerm: String, shouldShowSuggestions: Bool)
     func addressToolbarAccessibilityActions() -> [UIAccessibilityCustomAction]?
     func configureContextualHint(_ addressToolbar: BrowserAddressToolbar, for button: UIButton)
 }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -263,8 +263,8 @@ public class BrowserAddressToolbar: UIView, AddressToolbar, ThemeApplicable, Loc
         toolbarDelegate?.searchSuggestions(searchTerm: text)
     }
 
-    func locationViewDidBeginEditing(_ text: String) {
-        toolbarDelegate?.openSuggestions(searchTerm: text.lowercased())
+    func locationViewDidBeginEditing(_ text: String, shouldShowSuggestions: Bool) {
+        toolbarDelegate?.addressToolbarDidBeginEditing(searchTerm: text, shouldShowSuggestions: shouldShowSuggestions)
     }
 
     func locationViewDidSubmitText(_ text: String) {

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -277,8 +277,6 @@ public class BrowserAddressToolbar: UIView, AddressToolbar, ThemeApplicable, Loc
         toolbarDelegate?.addressToolbarAccessibilityActions()
     }
 
-    func locationViewDidCancelEditing() {}
-
     // MARK: - ThemeApplicable
     public func applyTheme(theme: Theme) {
         backgroundColor = theme.colors.layer1

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -11,8 +11,6 @@ protocol LocationTextFieldDelegate: AnyObject {
     func locationTextField(_ textField: LocationTextField, didEnterText text: String)
     func locationTextFieldShouldReturn(_ textField: LocationTextField) -> Bool
     func locationTextFieldShouldClear(_ textField: LocationTextField) -> Bool
-    func locationTextFieldDidCancel(_ textField: LocationTextField)
-    func locationPasteAndGo(_ textField: LocationTextField)
     func locationTextFieldDidBeginEditing(_ textField: UITextField)
     func locationTextFieldDidEndEditing(_ textField: UITextField)
 }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -366,13 +366,13 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
 
     func locationTextFieldDidBeginEditing(_ textField: UITextField) {
         updateUIForSearchEngineDisplay()
+        let searchText = searchTerm != nil ? searchTerm : urlAbsolutePath
 
-        DispatchQueue.main.async { [self] in
-            // `attributedText` property is set to nil to remove all formatting and truncation set before.
-            textField.attributedText = nil
-            textField.text = searchTerm != nil ? searchTerm : urlAbsolutePath
-        }
-        delegate?.locationViewDidBeginEditing(textField.text ?? "")
+        // `attributedText` property is set to nil to remove all formatting and truncation set before.
+        textField.attributedText = nil
+        textField.text = searchText
+
+        delegate?.locationViewDidBeginEditing(searchText ?? "", shouldShowSuggestions: searchTerm != nil)
     }
 
     func locationTextFieldDidEndEditing(_ textField: UITextField) {

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -354,16 +354,6 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         return true
     }
 
-    func locationTextFieldDidCancel(_ textField: LocationTextField) {
-        delegate?.locationViewDidCancelEditing()
-    }
-
-    func locationPasteAndGo(_ textField: LocationTextField) {
-        if let pasteboardContents = UIPasteboard.general.string {
-            delegate?.locationViewDidSubmitText(pasteboardContents)
-        }
-    }
-
     func locationTextFieldDidBeginEditing(_ textField: UITextField) {
         updateUIForSearchEngineDisplay()
         let searchText = searchTerm != nil ? searchTerm : urlAbsolutePath

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -258,10 +258,11 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         urlTextField.placeholder = state.urlTextFieldPlaceholder
         urlAbsolutePath = state.url?.absoluteString
 
-        _ = state.isEditing ? becomeFirstResponder() : resignFirstResponder()
+        let shouldShowKeyboard = state.isEditing && !state.isScrollingDuringEdit
+        _ = shouldShowKeyboard ? becomeFirstResponder() : resignFirstResponder()
 
         // Start overlay mode & select text when in edit mode with a search term
-        if state.isEditing, state.shouldSelectSearchTerm {
+        if shouldShowKeyboard, state.shouldSelectSearchTerm {
             DispatchQueue.main.async {
                 self.urlTextField.selectAll(nil)
             }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewDelegate.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewDelegate.swift
@@ -15,8 +15,11 @@ protocol LocationViewDelegate: AnyObject {
 
     /// Called when the user begins editing text in the location view.
     ///
-    /// - Parameter text: The initial text in the location view when the user began editing.
-    func locationViewDidBeginEditing(_ text: String)
+    /// - Parameters:
+    ///   - text: The initial text in the location view when the user began editing.
+    ///   - shouldShowSuggestions: Indicates whether search suggestions should be displayed
+    ///
+    func locationViewDidBeginEditing(_ text: String, shouldShowSuggestions: Bool)
 
     /// Called when the location view should perform a search based on the entered text.
     ///

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewDelegate.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewDelegate.swift
@@ -31,7 +31,4 @@ protocol LocationViewDelegate: AnyObject {
     /// - Returns: An optional array of `UIAccessibilityCustomAction` objects.
     /// Return `nil` if no custom actions are provided.
     func locationViewAccessibilityActions() -> [UIAccessibilityCustomAction]?
-
-    /// Called when the user cancels entering text into the location view.
-    func locationViewDidCancelEditing()
 }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewState.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewState.swift
@@ -20,6 +20,7 @@ public struct LocationViewState {
     public let url: URL?
     public let searchTerm: String?
     public let isEditing: Bool
+    public let isScrollingDuringEdit: Bool
     public let shouldSelectSearchTerm: Bool
     public var onTapLockIcon: (() -> Void)?
     public var onLongPress: (() -> Void)?
@@ -37,6 +38,7 @@ public struct LocationViewState {
         url: URL?,
         searchTerm: String?,
         isEditing: Bool,
+        isScrollingDuringEdit: Bool,
         shouldSelectSearchTerm: Bool,
         onTapLockIcon: (() -> Void)? = nil,
         onLongPress: (() -> Void)? = nil
@@ -53,6 +55,7 @@ public struct LocationViewState {
         self.url = url
         self.searchTerm = searchTerm
         self.isEditing = isEditing
+        self.isScrollingDuringEdit = isScrollingDuringEdit
         self.shouldSelectSearchTerm = shouldSelectSearchTerm
         self.onTapLockIcon = onTapLockIcon
         self.onLongPress = onLongPress

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3041,6 +3041,10 @@ class BrowserViewController: UIViewController,
         configureDataClearanceContextualHint(button)
     }
 
+    func addressToolbarDidBeginEditing(searchTerm: String, shouldShowSuggestions: Bool) {
+        addressToolbarDidEnterOverlayMode(addressToolbarContainer)
+    }
+
     func addressToolbarContainerAccessibilityActions() -> [UIAccessibilityCustomAction]? {
         locationActionsForURLBar().map { $0.accessibilityCustomAction }
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -12,6 +12,7 @@ protocol AddressToolbarContainerDelegate: AnyObject {
     func openBrowser(searchTerm: String)
     func openSuggestions(searchTerm: String)
     func configureContextualHint(for button: UIButton)
+    func addressToolbarDidBeginEditing(searchTerm: String, shouldShowSuggestions: Bool)
     func addressToolbarContainerAccessibilityActions() -> [UIAccessibilityCustomAction]?
     func addressToolbarDidEnterOverlayMode(_ view: UIView)
     func addressToolbar(_ view: UIView, didLeaveOverlayModeForReason: URLBarLeaveOverlayModeReason)
@@ -296,6 +297,20 @@ final class AddressToolbarContainer: UIView,
         let action = ToolbarMiddlewareAction(windowUUID: windowUUID,
                                              actionType: ToolbarMiddlewareActionType.didStartEditingUrl)
         store.dispatch(action)
+    }
+
+    func addressToolbarDidBeginEditing(searchTerm: String, shouldShowSuggestions: Bool) {
+        enterOverlayMode(nil, pasted: false, search: false)
+
+        guard let windowUUID else { return }
+
+        let action = ToolbarMiddlewareAction(windowUUID: windowUUID,
+                                             actionType: ToolbarMiddlewareActionType.didStartEditingUrl)
+        store.dispatch(action)
+
+        if shouldShowSuggestions {
+            delegate?.openSuggestions(searchTerm: searchTerm)
+        }
     }
 
     func addressToolbarAccessibilityActions() -> [UIAccessibilityCustomAction]? {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -18,6 +18,7 @@ class AddressToolbarContainerModel: Equatable {
     let url: URL?
     let searchTerm: String?
     let isEditing: Bool
+    let isScrollingDuringEdit: Bool
     let isPrivateMode: Bool
     let shouldSelectSearchTerm: Bool
     let shouldDisplayCompact: Bool
@@ -40,6 +41,7 @@ class AddressToolbarContainerModel: Equatable {
             url: url,
             searchTerm: term,
             isEditing: isEditing,
+            isScrollingDuringEdit: isScrollingDuringEdit,
             shouldSelectSearchTerm: shouldSelectSearchTerm,
             onTapLockIcon: {
                 let action = ToolbarMiddlewareAction(buttonType: .trackingProtection,
@@ -78,6 +80,7 @@ class AddressToolbarContainerModel: Equatable {
         self.url = state.addressToolbar.url
         self.searchTerm = state.addressToolbar.searchTerm
         self.isEditing = state.addressToolbar.isEditing
+        self.isScrollingDuringEdit = state.addressToolbar.isScrollingDuringEdit
         self.isPrivateMode = state.isPrivateMode
         self.shouldSelectSearchTerm = state.addressToolbar.shouldSelectSearchTerm
         self.shouldDisplayCompact = state.isShowingNavigationToolbar

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -16,6 +16,7 @@ struct AddressBarState: StateType, Equatable {
     var searchTerm: String?
     var lockIconImageName: String?
     var isEditing: Bool
+    var isScrollingDuringEdit: Bool
     var shouldSelectSearchTerm: Bool
     var isLoading: Bool
 
@@ -29,6 +30,7 @@ struct AddressBarState: StateType, Equatable {
                   searchTerm: nil,
                   lockIconImageName: "",
                   isEditing: false,
+                  isScrollingDuringEdit: false,
                   shouldSelectSearchTerm: true,
                   isLoading: false)
     }
@@ -42,6 +44,7 @@ struct AddressBarState: StateType, Equatable {
          searchTerm: String? = nil,
          lockIconImageName: String?,
          isEditing: Bool = false,
+         isScrollingDuringEdit: Bool = false,
          shouldSelectSearchTerm: Bool = true,
          isLoading: Bool = false) {
         self.windowUUID = windowUUID
@@ -53,6 +56,7 @@ struct AddressBarState: StateType, Equatable {
         self.searchTerm = searchTerm
         self.lockIconImageName = lockIconImageName
         self.isEditing = isEditing
+        self.isScrollingDuringEdit = isScrollingDuringEdit
         self.shouldSelectSearchTerm = shouldSelectSearchTerm
         self.isLoading = isLoading
     }
@@ -73,7 +77,8 @@ struct AddressBarState: StateType, Equatable {
                 url: model.url,
                 searchTerm: state.searchTerm,
                 lockIconImageName: model.lockIconImageName ?? state.lockIconImageName,
-                isEditing: state.isEditing
+                isEditing: state.isEditing,
+                isScrollingDuringEdit: state.isScrollingDuringEdit
             )
 
         case ToolbarActionType.numberOfTabsChanged:
@@ -88,7 +93,8 @@ struct AddressBarState: StateType, Equatable {
                 url: state.url,
                 searchTerm: state.searchTerm,
                 lockIconImageName: state.lockIconImageName,
-                isEditing: state.isEditing
+                isEditing: state.isEditing,
+                isScrollingDuringEdit: state.isScrollingDuringEdit
             )
 
         case ToolbarActionType.readerModeStateChanged:
@@ -101,7 +107,8 @@ struct AddressBarState: StateType, Equatable {
                 browserActions: state.browserActions,
                 borderPosition: state.borderPosition,
                 url: addressToolbarModel.url,
-                lockIconImageName: addressToolbarModel.lockIconImageName
+                lockIconImageName: addressToolbarModel.lockIconImageName,
+                isScrollingDuringEdit: state.isScrollingDuringEdit
             )
 
         case ToolbarActionType.addressToolbarActionsDidChange:
@@ -116,7 +123,8 @@ struct AddressBarState: StateType, Equatable {
                 url: state.url,
                 searchTerm: state.searchTerm,
                 lockIconImageName: state.lockIconImageName,
-                isEditing: addressToolbarModel.isEditing ?? state.isEditing
+                isEditing: addressToolbarModel.isEditing ?? state.isEditing,
+                isScrollingDuringEdit: state.isScrollingDuringEdit
             )
 
         case ToolbarActionType.urlDidChange:
@@ -131,7 +139,8 @@ struct AddressBarState: StateType, Equatable {
                 url: addressToolbarModel.url,
                 searchTerm: nil,
                 lockIconImageName: addressToolbarModel.lockIconImageName ?? state.lockIconImageName,
-                isEditing: addressToolbarModel.isEditing ?? state.isEditing
+                isEditing: addressToolbarModel.isEditing ?? state.isEditing,
+                isScrollingDuringEdit: state.isScrollingDuringEdit
             )
 
         case ToolbarActionType.backForwardButtonStatesChanged:
@@ -147,7 +156,8 @@ struct AddressBarState: StateType, Equatable {
                 url: state.url,
                 searchTerm: nil,
                 lockIconImageName: state.lockIconImageName,
-                isEditing: state.isEditing
+                isEditing: state.isEditing,
+                isScrollingDuringEdit: state.isScrollingDuringEdit
             )
 
         case ToolbarActionType.showMenuWarningBadge:
@@ -162,7 +172,8 @@ struct AddressBarState: StateType, Equatable {
                 url: state.url,
                 searchTerm: state.searchTerm,
                 lockIconImageName: state.lockIconImageName,
-                isEditing: state.isEditing
+                isEditing: state.isEditing,
+                isScrollingDuringEdit: state.isScrollingDuringEdit
             )
 
         case ToolbarActionType.scrollOffsetChanged,
@@ -178,7 +189,8 @@ struct AddressBarState: StateType, Equatable {
                 url: state.url,
                 searchTerm: state.searchTerm,
                 lockIconImageName: state.lockIconImageName,
-                isEditing: state.isEditing
+                isEditing: state.isEditing,
+                isScrollingDuringEdit: state.isScrollingDuringEdit
             )
 
         case ToolbarActionType.didPasteSearchTerm:
@@ -194,6 +206,7 @@ struct AddressBarState: StateType, Equatable {
                 searchTerm: toolbarAction.searchTerm,
                 lockIconImageName: state.lockIconImageName,
                 isEditing: true,
+                isScrollingDuringEdit: state.isScrollingDuringEdit,
                 shouldSelectSearchTerm: false
             )
 
@@ -210,6 +223,7 @@ struct AddressBarState: StateType, Equatable {
                 searchTerm: state.searchTerm,
                 lockIconImageName: state.lockIconImageName,
                 isEditing: addressToolbarModel.isEditing ?? state.isEditing,
+                isScrollingDuringEdit: false,
                 shouldSelectSearchTerm: state.shouldSelectSearchTerm
             )
 
@@ -225,7 +239,22 @@ struct AddressBarState: StateType, Equatable {
                 url: state.url,
                 searchTerm: nil,
                 lockIconImageName: state.lockIconImageName,
-                isEditing: addressToolbarModel.isEditing ?? state.isEditing
+                isEditing: addressToolbarModel.isEditing ?? state.isEditing,
+                isScrollingDuringEdit: false
+            )
+
+        case ToolbarActionType.didScrollDuringEdit:
+            return AddressBarState(
+                windowUUID: state.windowUUID,
+                navigationActions: state.navigationActions,
+                pageActions: state.pageActions,
+                browserActions: state.browserActions,
+                borderPosition: state.borderPosition,
+                url: state.url,
+                searchTerm: state.searchTerm,
+                lockIconImageName: state.lockIconImageName,
+                isEditing: state.isEditing,
+                isScrollingDuringEdit: true
             )
 
         default:
@@ -238,7 +267,8 @@ struct AddressBarState: StateType, Equatable {
                 url: state.url,
                 searchTerm: state.searchTerm,
                 lockIconImageName: state.lockIconImageName,
-                isEditing: state.isEditing
+                isEditing: state.isEditing,
+                isScrollingDuringEdit: state.isScrollingDuringEdit
             )
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -68,6 +68,7 @@ enum ToolbarActionType: ActionType {
     case didPasteSearchTerm
     case didStartEditingUrl
     case cancelEdit
+    case didScrollDuringEdit
     case readerModeStateChanged
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -106,7 +106,8 @@ struct ToolbarState: ScreenState, Equatable {
             ToolbarActionType.urlDidChange,
             ToolbarActionType.didPasteSearchTerm,
             ToolbarActionType.didStartEditingUrl,
-            ToolbarActionType.cancelEdit:
+            ToolbarActionType.cancelEdit,
+            ToolbarActionType.didScrollDuringEdit:
             guard let toolbarAction = action as? ToolbarAction else { return state }
             return ToolbarState(
                 windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -193,20 +193,20 @@ struct ToolbarState: ScreenState, Equatable {
 
         case ToolbarActionType.readerModeStateChanged:
             guard let toolbarAction = action as? ToolbarAction else { return state }
-                return ToolbarState(
-                    windowUUID: state.windowUUID,
-                    toolbarPosition: state.toolbarPosition,
-                    isPrivateMode: state.isPrivateMode,
-                    addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
-                    navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
-                    isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-                    isShowingTopTabs: state.isShowingTopTabs,
-                    readerModeState: toolbarAction.readerModeState,
-                    badgeImageName: state.badgeImageName,
-                    maskImageName: state.maskImageName,
-                    canGoBack: state.canGoBack,
-                    canGoForward: state.canGoForward,
-                    numberOfTabs: state.numberOfTabs)
+            return ToolbarState(
+                windowUUID: state.windowUUID,
+                toolbarPosition: state.toolbarPosition,
+                isPrivateMode: state.isPrivateMode,
+                addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
+                navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
+                isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+                isShowingTopTabs: state.isShowingTopTabs,
+                readerModeState: toolbarAction.readerModeState,
+                badgeImageName: state.badgeImageName,
+                maskImageName: state.maskImageName,
+                canGoBack: state.canGoBack,
+                canGoForward: state.canGoForward,
+                numberOfTabs: state.numberOfTabs)
 
         default:
             return ToolbarState(

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -389,9 +389,16 @@ class HomepageViewController:
         if featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly),
            let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID),
            toolbarState.addressToolbar.isEditing {
-            let action = ToolbarMiddlewareAction(windowUUID: windowUUID,
-                                                 actionType: ToolbarMiddlewareActionType.cancelEdit)
-            store.dispatch(action)
+            // When the user scrolls the homepage we cancel edit mode
+            // On a website we just dismiss the keyboard
+            if toolbarState.addressToolbar.url == nil {
+                let action = ToolbarMiddlewareAction(windowUUID: windowUUID,
+                                                     actionType: ToolbarMiddlewareActionType.cancelEdit)
+                store.dispatch(action)
+            } else {
+                let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.didScrollDuringEdit)
+                store.dispatch(action)
+            }
         }
 
         let scrolledToTop = lastContentOffsetY > 0 && scrollView.contentOffset.y <= 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9874)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21663)

## :bulb: Description
Fixes the user being unable to leave overlay mode - now when editing a url the user can scroll the homepage shown in overlay mode and also end edit mode. This PR also shows search suggestions only when a search term is present.
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-08-29 at 16 11 08](https://github.com/user-attachments/assets/729fa74d-4440-47b1-98f9-de83950bb7a7)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

