### PR TITLE
Bugfix FXIOS-9760 [Toolbar redesign] Prevent URL autocompletion when deleting characters

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -94,7 +94,7 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     }
 
     override func deleteBackward() {
-        lastReplacement = nil
+        lastReplacement = ""
         hideCursor = false
 
         guard markedTextRange == nil else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9760)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21434)

## :bulb: Description
- Backspacing characters in the url bar (`LocationTextField`) can no longer add an autocomplete suggestion to the url

### Notes
- [LocationTextField](https://github.com/mozilla-mobile/firefox-ios/blob/main/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift) is based off of [AutocompleteTextField](https://github.com/mozilla-mobile/firefox-ios/blob/main/firefox-ios/Client/Frontend/Widgets/AutocompleteTextField.swift), and it seems like [this line](https://github.com/mozilla-mobile/firefox-ios/blob/eb617dc64acd0c404705c54f58d9eeb7d82b139e/firefox-ios/Client/Frontend/Widgets/AutocompleteTextField.swift#L374) which sets `lastReplacement` to an empty string got mistranslated. Setting this to an empty string allows for [notifyTextChanged()](https://github.com/mozilla-mobile/firefox-ios/blob/eb617dc64acd0c404705c54f58d9eeb7d82b139e/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift#L177) to run and provide `SearchLoader` with the new search string, which will be shorter than the previous one (because we deleted a character) and prevents the autocomplete suggestion from appearing

### Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/7aba1773-536d-4390-b05b-20728022a3b9

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/18322d24-ee57-486b-969c-9abb3dcbe88a

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

