### PR TITLE
Add FXIOS-9648 & FXIOS-9656 - Password Generator UI + Copy password button complete

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF0DB931A8545800039F300 /* URLBarView.swift */; };
 		0BF1B7E31AC60DEA00A7B407 /* InsetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */; };
 		0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */; };
+		0E456F152C541CB300EE93BF /* PasswordGeneratorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E456F142C541CB300EE93BF /* PasswordGeneratorViewController.swift */; };
 		158241282820698B00956B39 /* RustRemoteTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158241272820698B00956B39 /* RustRemoteTabsTests.swift */; };
 		15DE98FD27FCED4F00F1ECDB /* RustRemoteTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DE98FC27FCED4F00F1ECDB /* RustRemoteTabs.swift */; };
 		1D06AE6624FEE4D5000B092B /* TopSitesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D06AE6524FEE4D5000B092B /* TopSitesProvider.swift */; };
@@ -2220,6 +2221,7 @@
 		0E134A0087CE6D183E5DA1D4 /* jv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = jv; path = jv.lproj/Search.strings; sourceTree = "<group>"; };
 		0E2440E3AD220D7C5EB7BB50 /* ia */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ia; path = ia.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		0E2D4E0FA5490EF048AEE106 /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
+		0E456F142C541CB300EE93BF /* PasswordGeneratorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorViewController.swift; sourceTree = "<group>"; };
 		0E4E4A54808AB93E32297350 /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		0E524676A2657BD8147C072A /* gd */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gd; path = gd.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		0E854FF68376A644D3C0FA95 /* te */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = te; path = te.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
@@ -8925,6 +8927,14 @@
 			path = SearchQuickLinksMedium;
 			sourceTree = "<group>";
 		};
+		0E456F132C541C8F00EE93BF /* PasswordGenerator */ = {
+			isa = PBXGroup;
+			children = (
+				0E456F142C541CB300EE93BF /* PasswordGeneratorViewController.swift */,
+			);
+			path = PasswordGenerator;
+			sourceTree = "<group>";
+		};
 		1D7B78952ADF324E0011E9F2 /* Event Queue */ = {
 			isa = PBXGroup;
 			children = (
@@ -12945,6 +12955,7 @@
 		F84B21F11A0910F600AAB793 /* Frontend */ = {
 			isa = PBXGroup;
 			children = (
+				0E456F132C541C8F00EE93BF /* PasswordGenerator */,
 				8A1A93572B757C7B0069C190 /* LottieFiles */,
 				392ED7D51D0AEEEE009D9B62 /* Accessors */,
 				E692E3271C46E62D009D1240 /* AuthenticationManager */,
@@ -15298,6 +15309,7 @@
 				8A2D593E27DC0AA100713EC9 /* TopSite.swift in Sources */,
 				8A0A1BA32B22030100E8706F /* PrivateMessageCardCell.swift in Sources */,
 				AB9CBC022C53B64C00102610 /* TrackingProtectionAction.swift in Sources */,
+				0E456F152C541CB300EE93BF /* PasswordGeneratorViewController.swift in Sources */,
 				213BF7532AC21D1B00C53A64 /* TabDisplayPanel.swift in Sources */,
 				434E733725EED32E006D3BDE /* BrowserViewController+URLBarDelegate.swift in Sources */,
 				C88E7A5B2A0553510072E638 /* OnboardingLinkInfoModel.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -752,5 +752,12 @@ public struct AccessibilityIdentifiers {
         static let creditCardCloseButton = "Autofill.creditCardCloseButton"
         static let loginCloseButton = "Autofill.loginCloseButton"
     }
+
+    enum PasswordGenerator {
+        static let bottomSheet = "PasswordGenerator.bottomSheet"
+        static let bottomSheetHeader = "PasswordGenerator.bottomSheetHeader"
+        static let bottomSheetUsePasswordButton = "PasswordGenerator.bottomSheetUsePasswordButton"
+        static let bottomSheetRefreshStrongPasswordButton = "PasswordGenerator.bottomSheetRefreshStrongPasswordButton"
+    }
 }
 // swiftlint:enable line_length

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -5,6 +5,7 @@
 import Common
 import Shared
 import UIKit
+import ComponentLibrary
 
 extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     // MARK: Data Clearance CFR / Contextual Hint
@@ -362,6 +363,20 @@ extension BrowserViewController: ToolBarActionMenuDelegate, UIDocumentPickerDele
         presentSignInViewController(fxaParameters.launchParameters,
                                     flowType: fxaParameters.flowType,
                                     referringPage: fxaParameters.referringPage)
+    }
+    func showPasswordGeneratorBottomSheet() {
+        let passwordGeneratorVC = PasswordGeneratorViewController(windowUUID: windowUUID)
+
+        var bottomSheetVM = BottomSheetViewModel(
+            closeButtonA11yLabel: .PasswordGenerator.CloseButtonA11yLabel,
+            closeButtonA11yIdentifier: AccessibilityIdentifiers.PasswordGenerator.bottomSheet)
+        bottomSheetVM.shouldDismissForTapOutside = true
+        let bottomSheetVC = BottomSheetViewController(
+            viewModel: bottomSheetVM,
+            childViewController: passwordGeneratorVC,
+            usingDimmedBackground: true,
+            windowUUID: windowUUID)
+        showViewController(viewController: bottomSheetVC)
     }
 
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -27,6 +27,7 @@ protocol ToolBarActionMenuDelegate: AnyObject {
     func showCreditCardSettings()
     func showSignInView(fxaParameters: FxASignInViewParameters)
     func showFilePicker(fileURL: URL)
+    func showPasswordGeneratorBottomSheet()
 }
 
 extension ToolBarActionMenuDelegate {
@@ -252,6 +253,12 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             append(to: &section, action: reportSiteIssueAction)
         }
 
+        // TODO: FXIOS-9659 [TEMPORARY] Remove password generator prompt menu button after this ticket has been implemented
+        if featureFlags.isFeatureEnabled(.passwordGenerator, checking: .buildOnly) {
+            let showPasswordGeneratorPromptAction = getShowPasswordGeneratorPromptAction()
+            append(to: &section, action: showPasswordGeneratorPromptAction)
+        }
+
         return section
     }
 
@@ -432,6 +439,17 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             guard let tabURL = self.selectedTab?.url?.absoluteString else { return }
             self.delegate?.openURLInNewTab(SupportUtils.URLForReportSiteIssue(tabURL), isPrivate: false)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .reportSiteIssue)
+        }.items
+    }
+
+    // TODO: FXIOS-9659 [TEMPORARY] Remove password generator prompt menu button after this ticket has been implemented
+    private func getShowPasswordGeneratorPromptAction() -> PhotonRowActions? {
+        guard featureFlags.isFeatureEnabled(.passwordGenerator, checking: .buildOnly) else { return nil }
+
+        // This method will be removed so the title not being localized doesn't matter
+        return SingleActionViewModel(title: "Show Password Generator Prompt",
+                                     iconString: StandardImageIdentifiers.Large.lock) { _ in
+            self.delegate?.showPasswordGeneratorBottomSheet()
         }.items
     }
 

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -1,0 +1,237 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import Shared
+import UIKit
+
+class PasswordGeneratorViewController: UIViewController, Themeable {
+    private enum UX {
+        static let containerPadding: CGFloat = 20
+        static let containerElementsVerticalPadding: CGFloat = 16
+
+        static let passwordFieldBorderWidth: CGFloat = 1
+        static let passwordFieldCornerRadius: CGFloat = 4
+        static let passwordFieldHorizontalPadding: CGFloat = 16
+        static let passwordLabelAndButtonSpacing: CGFloat = 10
+        static let passwordFieldVerticalPadding: CGFloat = 10
+
+        static let headerIconLabelSpacing: CGFloat = 10
+        static let headerVerticalPadding: CGFloat = 8
+    }
+    // MARK: - Properties
+
+    private lazy var contentView: UIView = .build()
+    private lazy var headerLabel: UILabel = .build { label in
+        label.numberOfLines = 0
+        label.font = FXFontStyles.Bold.body.scaledFont()
+        label.text = .PasswordGenerator.UseStrongPassword
+        label.accessibilityIdentifier = AccessibilityIdentifiers.PasswordGenerator.bottomSheetHeader
+        label.accessibilityTraits = .header
+    }
+    private lazy var headerImageView: UIImageView = .build { imageView in
+        imageView.image = UIImage(named: StandardImageIdentifiers.Large.login)?.withRenderingMode(.alwaysTemplate)
+    }
+    private lazy var captionLabel: UILabel = .build { label in
+        label.numberOfLines = 0
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
+        label.text = .PasswordGenerator.PasswordGeneratorInformation
+    }
+
+    private lazy var header: UIView = .build()
+
+    private lazy var passwordField: UIView = .build { field in
+        field.layer.borderWidth = UX.passwordFieldBorderWidth
+        field.layer.cornerRadius = UX.passwordFieldCornerRadius
+
+        field.isUserInteractionEnabled = true
+
+        let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(self.handleLongPress(_:)))
+        field.addGestureRecognizer(longPressGesture)
+    }
+
+    private lazy var passwordLabel: UILabel = .build { label in
+        label.numberOfLines = 0
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.text = "X3yusk3~^V+bc7z"
+        var text = NSMutableAttributedString(string: .PasswordGenerator.passwordReadoutPrefaceA11y)
+        text.append(NSMutableAttributedString(string: label.text!, attributes: [.accessibilitySpeechSpellOut: true]))
+        label.accessibilityAttributedLabel = text
+    }
+
+    private lazy var passwordRefreshButton: UIButton = .build { button in
+        button.setImage(
+            UIImage(named: StandardImageIdentifiers.Large.arrowClockwise)?.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.accessibilityLabel = .PasswordGenerator.refreshStrongPasswordButtonA11yLabel
+        button.accessibilityIdentifier = AccessibilityIdentifiers.PasswordGenerator.bottomSheetRefreshStrongPasswordButton
+    }
+
+    private lazy var usePasswordButton: PrimaryRoundedButton = .build { button in
+        let usePasswordButtonVM = PrimaryRoundedButtonViewModel(
+            title: .PasswordGenerator.UsePassword,
+            a11yIdentifier: AccessibilityIdentifiers.PasswordGenerator.bottomSheetUsePasswordButton)
+        button.configure(viewModel: usePasswordButtonVM)
+    }
+
+    var themeManager: ThemeManager
+    var themeObserver: NSObjectProtocol?
+    var notificationCenter: NotificationProtocol
+    let windowUUID: WindowUUID
+    var currentWindowUUID: UUID? { windowUUID }
+    private var contentViewHeightConstraint: NSLayoutConstraint!
+
+    // MARK: - Initializers
+
+    init(windowUUID: WindowUUID,
+         themeManager: ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: NotificationProtocol = NotificationCenter.default) {
+        self.windowUUID = windowUUID
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        listenForThemeChange(view)
+        setupView()
+        applyTheme()
+        UIAccessibility.post(notification: .screenChanged, argument: String.PasswordGenerator.PasswordGenerator)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        applyTheme()
+    }
+
+    private func setupView() {
+        // Adding Subviews
+        view.addSubview(contentView)
+        contentView.addSubviews(header, captionLabel, passwordField, usePasswordButton)
+        header.addSubviews(headerImageView, headerLabel)
+        passwordField.addSubviews(passwordLabel, passwordRefreshButton)
+
+        // Content View Constraints
+        NSLayoutConstraint.activate([
+            contentView.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+                constant: UX.containerPadding),
+            contentView.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                constant: -UX.containerPadding),
+            contentView.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
+                constant: UX.containerPadding),
+            contentView.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -UX.containerPadding),
+        ])
+
+        // Header elements layout
+        NSLayoutConstraint.activate([
+            headerImageView.bottomAnchor.constraint(equalTo: header.bottomAnchor),
+            headerImageView.leadingAnchor.constraint(equalTo: header.leadingAnchor),
+            headerImageView.topAnchor.constraint(
+                greaterThanOrEqualTo: header.topAnchor,
+                constant: UX.headerVerticalPadding),
+            headerLabel.topAnchor.constraint(
+                equalTo: header.topAnchor,
+                constant: UX.headerVerticalPadding),
+            headerLabel.bottomAnchor.constraint(equalTo: header.bottomAnchor),
+            headerLabel.leadingAnchor.constraint(
+                equalTo: headerImageView.trailingAnchor,
+                constant: UX.headerIconLabelSpacing),
+            headerLabel.trailingAnchor.constraint(equalTo: header.trailingAnchor)
+        ])
+
+        // Password Field Elements Layout
+        NSLayoutConstraint.activate([
+            passwordLabel.topAnchor.constraint(
+                equalTo: passwordField.topAnchor,
+                constant: UX.passwordFieldVerticalPadding),
+            passwordLabel.leadingAnchor.constraint(
+                equalTo: passwordField.leadingAnchor,
+                constant: UX.passwordFieldHorizontalPadding),
+            passwordLabel.bottomAnchor.constraint(
+                equalTo: passwordField.bottomAnchor,
+                constant: -UX.passwordFieldVerticalPadding),
+            passwordRefreshButton.topAnchor.constraint(
+                equalTo: passwordField.topAnchor,
+                constant: UX.passwordFieldVerticalPadding),
+            passwordRefreshButton.leadingAnchor.constraint(
+                greaterThanOrEqualTo: passwordLabel.trailingAnchor,
+                constant: UX.passwordLabelAndButtonSpacing),
+            passwordRefreshButton.trailingAnchor.constraint(
+                equalTo: passwordField.trailingAnchor,
+                constant: -UX.passwordFieldHorizontalPadding),
+            passwordRefreshButton.bottomAnchor.constraint(
+                equalTo: passwordField.bottomAnchor,
+                constant: -UX.passwordFieldVerticalPadding)
+        ])
+
+        // Content View Elements Layout
+        NSLayoutConstraint.activate([
+            header.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            header.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor,
+                constant: -45),
+            header.topAnchor.constraint(equalTo: contentView.topAnchor),
+            captionLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            captionLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            captionLabel.topAnchor.constraint(
+                equalTo: header.bottomAnchor,
+                constant: UX.containerElementsVerticalPadding),
+            passwordField.leadingAnchor.constraint(equalTo: captionLabel.leadingAnchor),
+            passwordField.trailingAnchor.constraint(equalTo: captionLabel.trailingAnchor),
+            passwordField.topAnchor.constraint(
+                equalTo: captionLabel.bottomAnchor,
+                constant: UX.containerElementsVerticalPadding),
+            usePasswordButton.leadingAnchor.constraint(equalTo: passwordField.leadingAnchor),
+            usePasswordButton.trailingAnchor.constraint(
+                equalTo: passwordField.trailingAnchor),
+            usePasswordButton.topAnchor.constraint(
+                equalTo: passwordField.bottomAnchor,
+                constant: UX.containerElementsVerticalPadding),
+            usePasswordButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+
+    // MARK: - Themable
+    func applyTheme() {
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        view.backgroundColor = theme.colors.layer1
+        headerImageView.tintColor = theme.colors.iconPrimary
+        headerLabel.textColor = theme.colors.textPrimary
+        captionLabel.textColor = theme.colors.textSecondary
+        passwordField.backgroundColor = theme.colors.layer2
+        passwordField.layer.borderColor = theme.colors.borderPrimary.cgColor
+        passwordLabel.textColor = theme.colors.textPrimary
+        passwordRefreshButton.tintColor = theme.colors.iconPrimary
+        usePasswordButton.applyTheme(theme: theme)
+    }
+
+    @objc
+    func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+        let menuController = UIMenuController.shared
+        let copyItem = UIMenuItem(title: .PasswordGenerator.copyStrongPassword, action: #selector(copyText(_:)))
+        menuController.menuItems = [copyItem]
+        menuController.showMenu(from: passwordLabel, rect: passwordLabel.bounds)
+    }
+
+    @objc
+    func copyText(_ sender: Any?) {
+        UIPasteboard.general.string = passwordLabel.text
+    }
+}
+
+extension PasswordGeneratorViewController: BottomSheetChild {
+    func willDismiss() { }
+}

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -6888,6 +6888,52 @@ extension String {
     }
 }
 
+// MARK: - Password generator
+extension String {
+    public struct PasswordGenerator {
+        public static let UseStrongPassword = MZLocalizedString(
+            key: "PasswordGenerator.UseStrongPassword.v133",
+            tableName: "PasswordGenerator",
+            value: "Use a strong password?",
+            comment: "Header Text displayed when a user interacts with the password field in a signup form, as part of a popup. A random password has been generated for the user and clicking a button fills in the password of the signup form with this password.")
+        public static let PasswordGeneratorInformation = MZLocalizedString(
+            key: "PasswordGenerator.PasswordGeneratorInformation.v133",
+            tableName: "PasswordGenerator",
+            value: "Firefox can generate random, secure passwords for you when you're creating an account. It’ll be saved into your account for future use.",
+            comment: "Text displayed when a user interacts with the password field in a signup form, as part of a popup. This popup allows the user to generate a password that they have the option to save for use in the future.")
+        public static let UsePassword = MZLocalizedString(
+            key: "PasswordGenerator.UsePassword.v133",
+            tableName: "PasswordGenerator",
+            value: "Use Password",
+            comment: "Button displayed when a user interacts with the password field in a signup form, as part of a popup. A random password has been generated for the user and clicking this button fills in the password of the signup form with this password.")
+        public static let PasswordGenerator = MZLocalizedString(
+            key: "PasswordGenerator.PasswordGenerator.v133",
+            tableName: "PasswordGenerator",
+            value: "Password Generator",
+            comment: "Accessibility label describing a feature that generates a password when a signup form is interacted with.")
+        public static let CloseButtonA11yLabel = MZLocalizedString(
+            key: "PasswordGenerator.CloseButtonA11ylabel.v133",
+            tableName: "PasswordGenerator",
+            value: "Close",
+            comment: "Accessibility label describing the close button for the popup related to a feature that generates a password when a signup form is interacted with.")
+        public static let refreshStrongPasswordButtonA11yLabel = MZLocalizedString(
+            key: "PasswordGenerator.refreshStrongPasswordButtonA11yLabel.v133",
+            tableName: "PasswordGenerator",
+            value: "Generate new strong password",
+            comment: "Accessibility label describing the refresh password button for the popup related to a feature that generates a password when a signup form is interacted with.")
+        public static let passwordReadoutPrefaceA11y = MZLocalizedString(
+            key: "PasswordGenerator.passwordReadoutPrefaceA11y.v133",
+            tableName: "PasswordGenerator",
+            value: "Generated password: ",
+            comment: "Preface such that an accesibility user is alerted to the fact that the strong password is going to be announced following this string")
+        public static let copyStrongPassword = MZLocalizedString(
+            key: "PasswordGenerator.copyStrongPassword.v133",
+            tableName: "PasswordGenerator",
+            value: "Copy",
+            comment: "When a user creates an account the have the option to generate a strong password to use for this new account. The user is capable of copying this password by long pressing the generated value displayed to a user in a popup")
+    }
+}
+
 // MARK: - v35 Strings
 extension String {
     public static let FirefoxHomeJumpBackInSectionTitle = MZLocalizedString(

--- a/firefox-ios/nimbus-features/passwordGeneratorFeature.yaml
+++ b/firefox-ios/nimbus-features/passwordGeneratorFeature.yaml
@@ -13,5 +13,5 @@ features:
           enabled: false
       - channel: developer
         value:
-          enabled: false
+          enabled: true
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket 1](https://mozilla-hub.atlassian.net/browse/FXIOS-9648)
[Github issue 1](https://github.com/mozilla-mobile/firefox-ios/issues/21250)
[Jira ticket 2](https://mozilla-hub.atlassian.net/browse/FXIOS-9656)
[Github issue 2](https://github.com/mozilla-mobile/firefox-ios/issues/21259)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added the UI for the password generator feature. This includes the ability to copy the generated password. Please note this is only the UI and the buttons are not yet properly set up.
The password generator prompt can be opened via the "Show Password Generator Prompt" button in the main hamburger menu
<img width="300" alt="Screenshot 2024-08-29 at 1 57 43 PM" src="https://github.com/user-attachments/assets/8e5b2772-fff7-47fe-9c83-f1f6db976f10">
Also note that this button is temporary and will be removed once I've had the chance to work alongside the credential management team to have the prompt show up automatically when a user interacts with a password field on a signup form.
TO-DO: 
- Update the version numbers on strings
- Delete the "Show Password Generator Prompt" Button

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

