### PR TITLE
Refactor MTE-3341 Firefox iOS XCUITests for iOS 18.0

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -115,7 +115,6 @@ class BrowsingPDFTests: BaseTestCase {
         navigator.openURL(PDF_website["url"]!)
         waitUntilPageLoad()
         navigator.performAction(Action.BookmarkThreeDots)
-        waitUntilPageLoad()
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Bookmarks)
         mozWaitForElementToExist(app.tables["Bookmarks List"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DatabaseFixtureTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DatabaseFixtureTest.swift
@@ -64,8 +64,12 @@ class DatabaseFixtureTest: BaseTestCase {
        do {
            let snapshot = try app.tables["History List"].snapshot()
            let historyList = snapshot.children.count
-
-           XCTAssertEqual(historyList, 103, "There should be 103 entries in the history list")
+           if #available(iOS 18, *) {
+               XCTAssertEqual(historyList, 105, "There should be 105 entries in the history list")
+           } else {
+               // For iOS 18, the scrollbars (vertical and horizontal) are included in the table
+               XCTAssertEqual(historyList, 103, "There should be 103 entries in the history list")
+           }
        } catch {
            XCTFail("Failed to take snapshot: \(error)")
        }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -166,7 +166,6 @@ class FindInPageTests: BaseTestCase {
         let textToFind = "from"
 
         // Long press on the word to be found
-        waitUntilPageLoad()
         mozWaitForElementToExist(app.webViews.staticTexts[textToFind])
         let stringToFind = app.webViews.staticTexts.matching(identifier: textToFind)
         let firstStringToFind = stringToFind.element(boundBy: 0)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -295,8 +295,10 @@ class NavigationTest: BaseTestCase {
         } else {
             mozWaitForElementToExist(app.buttons["Copy"])
         }
-        if !iPad() {
-            mozWaitForElementToExist(app.scrollViews.staticTexts["Messages"])
+        if #unavailable(iOS 18) {
+            if !iPad() {
+                mozWaitForElementToExist(app.scrollViews.staticTexts["Messages"])
+            }
         }
         if #unavailable(iOS 17) {
             mozWaitForElementToExist(app.scrollViews.cells["XCElementSnapshotPrivilegedValuePlaceholder"])
@@ -315,8 +317,10 @@ class NavigationTest: BaseTestCase {
         } else {
             mozWaitForElementToExist(app.buttons["Copy"])
         }
-        if !iPad() {
-            mozWaitForElementToExist(app.scrollViews.staticTexts["Messages"])
+        if #unavailable(iOS 18) {
+            if !iPad() {
+                mozWaitForElementToExist(app.scrollViews.staticTexts["Messages"])
+            }
         }
         if #unavailable(iOS 17) {
             mozWaitForElementToExist(app.scrollViews.cells["XCElementSnapshotPrivilegedValuePlaceholder"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
@@ -235,7 +235,10 @@ class ReadingListTests: BaseTestCase {
         savedToReadingList.tap()
         // The article is displayed in Reader View
         mozWaitForElementToExist(app.buttons["Reader View"])
-        XCTAssertTrue(app.buttons["Reader View"].isSelected)
+        // iOS 18 only: Reader View icon is enabled but is not selected.
+        if #unavailable(iOS 18) {
+            XCTAssertTrue(app.buttons["Reader View"].isSelected)
+        }
         XCTAssertTrue(app.buttons["Reader View"].isEnabled)
         app.buttons[AccessibilityIdentifiers.Toolbar.homeButton].tap()
         navigator.nowAt(NewTabScreen)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3341)

## :bulb: Description
I would like to make the XCUITest to compatible with iOS 18 so that the team is prepared for the upcoming iOS release.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

