### PR TITLE
Bugfix FXIOS-8440 ⁃ Desktop mode view on private mode affects regular mode

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -527,7 +527,7 @@ extension BrowserViewController: WKNavigationDelegate {
         // We always allow this. Additionally, data URIs are also handled just like normal web pages.
         if ["http", "https", "blob", "file"].contains(url.scheme) {
             if navigationAction.targetFrame?.isMainFrame ?? false {
-                tab.changedUserAgent = Tab.ChangeUserAgent.contains(url: url)
+                tab.changedUserAgent = Tab.ChangeUserAgent.contains(url: url, isPrivate: tab.isPrivate)
             }
 
             pendingRequests[url.absoluteString] = navigationAction.request

--- a/firefox-ios/Client/TabManagement/Tab+ChangeUserAgent.swift
+++ b/firefox-ios/Client/TabManagement/Tab+ChangeUserAgent.swift
@@ -28,9 +28,9 @@ extension Tab {
             baseDomainList.removeAll()
         }
 
-        static func contains(url: URL) -> Bool {
+        static func contains(url: URL, isPrivate: Bool) -> Bool {
             guard let baseDomain = url.baseDomain else { return false }
-            return privateModeHostList.contains(baseDomain) || baseDomainList.contains(baseDomain)
+            return isPrivate ? privateModeHostList.contains(baseDomain) : baseDomainList.contains(baseDomain)
         }
 
         static func updateDomainList(forUrl url: URL, isChangedUA: Bool, isPrivate: Bool) {
@@ -44,15 +44,15 @@ extension Tab {
                     ChangeUserAgent.privateModeHostList.remove(baseDomain)
                     // Continue to next section and try remove it from `hostList` also.
                 }
-            }
-
-            if isChangedUA, !baseDomainList.contains(baseDomain) {
-                baseDomainList.insert(baseDomain)
-            } else if !isChangedUA, baseDomainList.contains(baseDomain) {
-                baseDomainList.remove(baseDomain)
             } else {
-                // Don't save to disk, return early
-                return
+                if isChangedUA, !baseDomainList.contains(baseDomain) {
+                    baseDomainList.insert(baseDomain)
+                } else if !isChangedUA, baseDomainList.contains(baseDomain) {
+                    baseDomainList.remove(baseDomain)
+                } else {
+                    // Don't save to disk, return early
+                    return
+                }
             }
 
             // At this point, saving to disk takes place.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/Tab+ChangeUserAgentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/Tab+ChangeUserAgentTests.swift
@@ -42,7 +42,8 @@ class ChangeUserAgentTests: XCTestCase {
             isChangedUA: testMockData.isChangedUA,
             isPrivate: testMockData.isPrivate
         )
-        XCTAssertEqual(Tab.ChangeUserAgent.contains(url: url), testMockData.expectContainsURL)
+        XCTAssertEqual(Tab.ChangeUserAgent.contains(url: url, isPrivate: testMockData.isPrivate),
+                       testMockData.expectContainsURL)
     }
 
     func testUpdateAndContainsDidChangeUAAndPrivate() {
@@ -59,7 +60,8 @@ class ChangeUserAgentTests: XCTestCase {
             isChangedUA: testMockData.isChangedUA,
             isPrivate: testMockData.isPrivate
         )
-        XCTAssertEqual(Tab.ChangeUserAgent.contains(url: url), testMockData.expectContainsURL)
+        XCTAssertEqual(Tab.ChangeUserAgent.contains(url: url, isPrivate: testMockData.isPrivate),
+                       testMockData.expectContainsURL)
     }
 
     func testUpdateAndContainsNoChangeUANotPrivate() {
@@ -77,7 +79,8 @@ class ChangeUserAgentTests: XCTestCase {
             isChangedUA: testMockData.isChangedUA,
             isPrivate: testMockData.isPrivate
         )
-        XCTAssertEqual(Tab.ChangeUserAgent.contains(url: url), testMockData.expectContainsURL)
+        XCTAssertEqual(Tab.ChangeUserAgent.contains(url: url, isPrivate: testMockData.isPrivate),
+                       testMockData.expectContainsURL)
     }
 
     func testUpdateAndContainsNoChangeUAAndPrivate() {
@@ -94,7 +97,8 @@ class ChangeUserAgentTests: XCTestCase {
             isChangedUA: testMockData.isChangedUA,
             isPrivate: testMockData.isPrivate
         )
-        XCTAssertEqual(Tab.ChangeUserAgent.contains(url: url), testMockData.expectContainsURL)
+        XCTAssertEqual(Tab.ChangeUserAgent.contains(url: url, isPrivate: testMockData.isPrivate),
+                       testMockData.expectContainsURL)
     }
 
     func tryAllCasesForUpdateAndContains() {
@@ -130,17 +134,17 @@ class ChangeUserAgentTests: XCTestCase {
                 isChangedUA: testCase.isChangedUA,
                 isPrivate: testCase.isPrivate
             )
-            XCTAssertEqual(Tab.ChangeUserAgent.contains(url: url), testCase.expectContainsURL)
+            XCTAssertEqual(Tab.ChangeUserAgent.contains(url: url, isPrivate: testCase.isPrivate), testCase.expectContainsURL)
         }
     }
 
     func testClear() {
         let url = URL(string: "https://www.google.com")!
         Tab.ChangeUserAgent.updateDomainList(forUrl: url, isChangedUA: true, isPrivate: false)
-        XCTAssert(Tab.ChangeUserAgent.contains(url: url))
+            XCTAssert(Tab.ChangeUserAgent.contains(url: url, isPrivate: false))
 
         Tab.ChangeUserAgent.clear()
-        XCTAssertFalse(Tab.ChangeUserAgent.contains(url: url))
+        XCTAssertFalse(Tab.ChangeUserAgent.contains(url: url, isPrivate: false))
     }
 
     // MARK: removeMobilePrefixFrom tests

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/Tab+ChangeUserAgentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Legacy/Tab+ChangeUserAgentTests.swift
@@ -141,7 +141,7 @@ class ChangeUserAgentTests: XCTestCase {
     func testClear() {
         let url = URL(string: "https://www.google.com")!
         Tab.ChangeUserAgent.updateDomainList(forUrl: url, isChangedUA: true, isPrivate: false)
-            XCTAssert(Tab.ChangeUserAgent.contains(url: url, isPrivate: false))
+      XCTAssert(Tab.ChangeUserAgent.contains(url: url, isPrivate: false))
 
         Tab.ChangeUserAgent.clear()
         XCTAssertFalse(Tab.ChangeUserAgent.contains(url: url, isPrivate: false))

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
@@ -145,9 +145,9 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton])
         app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].tap()
         navigator.goto(BrowserTabMenu)
-        navigator.goto(RequestMobileSite) // toggle off
+        navigator.goto(RequestDesktopSite) // toggle off
         waitUntilPageLoad()
-        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
 
         // is now off in private, mode, confirm it is off in normal mode
 
@@ -155,7 +155,7 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         waitUntilPageLoad()
-        XCTAssert(app.webViews.staticTexts.matching(identifier: "MOBILE_UA").count > 0)
+        XCTAssert(app.webViews.staticTexts.matching(identifier: "DESKTOP_UA").count > 0)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306857


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8440)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18723)

## :bulb: Description
Private mode user agent will no more affect regular mode user agent.
Fixed also some tests.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

