### PR TITLE
Bugfix FXIOS-9883 [Toolbar redesign] Highlight text when url bar is focused

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -214,7 +214,6 @@ final class AddressToolbarContainer: UIView,
                                      leadingSpace: leadingToolbarSpace,
                                      trailingSpace: trailingToolbarSpace)
 
-
             // Dismiss overlay mode when not editing to fix overlay mode staying open
             // on iPad when switching tabs using top tabs
             if !toolbarState.addressToolbar.isEditing {
@@ -240,17 +239,13 @@ final class AddressToolbarContainer: UIView,
 
     private func setupLayout() {
         addSubview(progressBar)
-        addSubview(toolbar)
 
         NSLayoutConstraint.activate([
             progressBar.leadingAnchor.constraint(equalTo: leadingAnchor),
             progressBar.trailingAnchor.constraint(equalTo: trailingAnchor),
-
-            toolbar.topAnchor.constraint(equalTo: topAnchor),
-            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
-            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor),
-            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
+
+        setupToolbarConstraints()
     }
 
     private func switchToolbars() {
@@ -260,6 +255,10 @@ final class AddressToolbarContainer: UIView,
             regularToolbar.removeFromSuperview()
         }
 
+        setupToolbarConstraints()
+    }
+
+    private func setupToolbarConstraints() {
         addSubview(toolbar)
 
         NSLayoutConstraint.activate([

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -200,42 +200,45 @@ final class AddressToolbarContainer: UIView,
 
     private func updateModel(toolbarState: ToolbarState) {
         guard let windowUUID, let profile else { return }
-        let model = AddressToolbarContainerModel(state: toolbarState,
-                                                 profile: profile,
-                                                 windowUUID: windowUUID)
-        if self.model != model {
-            self.model = model
-
-        	updateProgressBarPosition(toolbarState.toolbarPosition)
-            compactToolbar.configure(state: model.addressToolbarState,
+        let newModel = AddressToolbarContainerModel(state: toolbarState,
+                                                    profile: profile,
+                                                    windowUUID: windowUUID)
+        if self.model != newModel {
+            updateProgressBarPosition(toolbarState.toolbarPosition)
+            compactToolbar.configure(state: newModel.addressToolbarState,
                                      toolbarDelegate: self,
                                      leadingSpace: leadingToolbarSpace,
                                      trailingSpace: trailingToolbarSpace)
-            regularToolbar.configure(state: model.addressToolbarState,
+            regularToolbar.configure(state: newModel.addressToolbarState,
                                      toolbarDelegate: self,
                                      leadingSpace: leadingToolbarSpace,
                                      trailingSpace: trailingToolbarSpace)
 
-            // the layout (compact/regular) that should be displayed is driven by the state
-            adjustLayout()
 
             // Dismiss overlay mode when not editing to fix overlay mode staying open
             // on iPad when switching tabs using top tabs
             if !toolbarState.addressToolbar.isEditing {
                 leaveOverlayMode(reason: .cancelled, shouldCancelLoading: false)
             }
+
+            // the layout (compact/regular) that should be displayed is driven by the state
+            // but we only need to switch toolbars if shouldDisplayCompact changes
+            // otherwise we needlessly add/remove toolbars from the view hierarchy,
+            // which messes with the LocationTextField first responder status (see FXIOS-9883)
+            let shouldSwitchToolbars = newModel.shouldDisplayCompact != self.model?.shouldDisplayCompact
+
+            // Replace the old model after we are done using it for comparison
+            // All functionality that depends on the new model should come after this
+            self.model = newModel
+
+            if shouldSwitchToolbars {
+                switchToolbars()
+            }
         }
     }
 
     private func setupLayout() {
         addSubview(progressBar)
-        adjustLayout()
-    }
-
-    private func adjustLayout() {
-        compactToolbar.removeFromSuperview()
-        regularToolbar.removeFromSuperview()
-
         addSubview(toolbar)
 
         NSLayoutConstraint.activate([
@@ -245,7 +248,24 @@ final class AddressToolbarContainer: UIView,
             toolbar.topAnchor.constraint(equalTo: topAnchor),
             toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
             toolbar.bottomAnchor.constraint(equalTo: bottomAnchor),
-            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+
+    private func switchToolbars() {
+        if compactToolbar.isDescendant(of: self) {
+            compactToolbar.removeFromSuperview()
+        } else {
+            regularToolbar.removeFromSuperview()
+        }
+
+        addSubview(toolbar)
+
+        NSLayoutConstraint.activate([
+            toolbar.topAnchor.constraint(equalTo: topAnchor),
+            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            toolbar.bottomAnchor.constraint(equalTo: bottomAnchor),
+            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -224,7 +224,8 @@ final class AddressToolbarContainer: UIView,
             // the layout (compact/regular) that should be displayed is driven by the state
             // but we only need to switch toolbars if shouldDisplayCompact changes
             // otherwise we needlessly add/remove toolbars from the view hierarchy,
-            // which messes with the LocationTextField first responder status (see FXIOS-9883)
+            // which messes with the LocationTextField first responder status
+            // (see https://github.com/mozilla-mobile/firefox-ios/issues/21676)
             let shouldSwitchToolbars = newModel.shouldDisplayCompact != self.model?.shouldDisplayCompact
 
             // Replace the old model after we are done using it for comparison


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9883)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21676)

## :bulb: Description
- Fixes the issue where the url/search text would not be highlighted when pressing the url bar and the textfield becomes focused

### Background
- Only one of two different types of address toolbars can be displayed in `AddressToolbarContainer` at a time depending on the `ToolbarState`: `CompactBrowserAddressToolbar` or `RegularBrowserAddressToolbar`. After commit 63894d26f0b32dfcda1932b6252358c95d5d35b4, every time the `ToolbarState` changed, the currently displayed toolbar would be removed from the view hierarchy, and either replaced with itself or the other toolbar, ultimately depending on the state of `ToolbarState.isShowingNavigationToolbar` (instead of only changing when the devices trait collection changed). This caused issues when the `LocationTextField` (the textfield responsible for the url / search query) gained focus, because it would become first responder, get removed from the view hierarchy (which removed it's first responder status), get readded to the view hierarchy, and then attempt to have all the text selected (which doesn't work unless the textfield has first responder status).
- Commit 63894d26f0b32dfcda1932b6252358c95d5d35b4 

### Solution
- Only remove the current address toolbar from the view hierarchy if `shouldDisplayCompact` changes, and there is an actual need to switch address toolbars.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

