### PR TITLE
Refactor MTE-3342 Firefox XCUITests for iOS 18.0

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -84,9 +84,11 @@ final class MicrosurveyTests: BaseTestCase {
         app.buttons[AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton]
         let homepageToggleButtonIpad = app.buttons[AccessibilityIdentifiers.Browser.TopTabs.privateModeButton]
         if !iPad() {
+            mozWaitForElementToExist(homepageToggleButtonIphone)
             homepageToggleButtonIphone.tap()
             mozWaitForElementToExist(app.staticTexts[AccessibilityIdentifiers.PrivateMode.Homepage.link])
         } else {
+            mozWaitForElementToExist(homepageToggleButtonIpad)
             homepageToggleButtonIpad.tap()
             mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.Browser.TopTabs.collectionView])
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3342)

## :bulb: Description
The `MicrosurveyTests` fails intermittently on iOS 18.0. I'd like to harden a step that caused some intermittent failures.

This change should be backported to `release/v130`.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

