### PR TITLE
Bugfix FXIOS-9910 UILargeContentViewerInteraction to BrowserNavigationToolbar and BrowserAddressToolbar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -176,6 +176,12 @@ public class BrowserAddressToolbar: UIView, AddressToolbar, ThemeApplicable, Loc
         ])
 
         updateActionSpacing()
+
+        setupAccessibility()
+    }
+
+    private func setupAccessibility() {
+        addInteraction(UILargeContentViewerInteraction())
     }
 
     internal func updateActions(state: AddressToolbarState) {

--- a/BrowserKit/Sources/ToolbarKit/NavigationToolbar/BrowserNavigationToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/NavigationToolbar/BrowserNavigationToolbar.swift
@@ -61,6 +61,12 @@ public class BrowserNavigationToolbar: UIView, NavigationToolbar, ThemeApplicabl
             actionStack.bottomAnchor.constraint(equalTo: bottomAnchor),
             actionStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.horizontalEdgeSpace),
         ])
+
+        setupAccessibility()
+    }
+
+    private func setupAccessibility() {
+        addInteraction(UILargeContentViewerInteraction())
     }
 
     private func updateActionStack(toolbarElements: [ToolbarElement]) {


### PR DESCRIPTION
Added `UILargeContentViewerInteraction` to `BrowserNavigationToolbar` and `BrowserAddressToolbar` in order to have the desired large content view effect for large font sizes.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9910)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21729)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

