### PR TITLE
Bump - Update SPM to rust-components 131.0.0

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -23343,7 +23343,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 132.0.20240831050348;
+				version = 131.0.0;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "003a732adbaeb9c009a7f0f2a91832a584a143a0",
-        "version" : "132.0.20240831050348"
+        "revision" : "c1881f70eef739e1973ba5d72ddc2fe55f2670bf",
+        "version" : "131.0.0"
       }
     },
     {

--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -7159,7 +7159,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 132.0.20240831050348;
+				version = 131.0.0;
 			};
 		};
 		8A0E7F2C2BA0F0E0006BC6B6 /* XCRemoteSwiftPackageReference "Fuzi" */ = {

--- a/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift",
         "state": {
           "branch": null,
-          "revision": "003a732adbaeb9c009a7f0f2a91832a584a143a0",
-          "version": "132.0.20240831050348"
+          "revision": "c1881f70eef739e1973ba5d72ddc2fe55f2670bf",
+          "version": "131.0.0"
         }
       },
       {


### PR DESCRIPTION
Note that rust-components was incorrectly set to 132.0.x because the new 131 applications services branch was cut last Friday instead of today (because of the public holiday today for the team) and it was automatically imported to `main` before I cut the 131 branch (https://github.com/mozilla-mobile/firefox-ios/commit/da32d1f5757a236cb33bfaba941a19ec47e57dd0)