### PR TITLE
Bugfix FXIOS-9911 ETP menu not showing with toolbar refactor feature enabled

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -18,7 +18,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
     private var urlAbsolutePath: String?
     private var searchTerm: String?
     private var notifyTextChanged: (() -> Void)?
-    private var onTapLockIcon: (() -> Void)?
+    private var onTapLockIcon: ((UIButton) -> Void)?
     private var onLongPress: (() -> Void)?
     private var delegate: LocationViewDelegate?
 
@@ -324,7 +324,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
 
     @objc
     private func didTapLockIcon() {
-        onTapLockIcon?()
+        onTapLockIcon?(lockIconButton)
     }
 
     @objc

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewState.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewState.swift
@@ -22,7 +22,7 @@ public struct LocationViewState {
     public let isEditing: Bool
     public let isScrollingDuringEdit: Bool
     public let shouldSelectSearchTerm: Bool
-    public var onTapLockIcon: (() -> Void)?
+    public var onTapLockIcon: ((UIButton) -> Void)?
     public var onLongPress: (() -> Void)?
 
     public init(
@@ -40,7 +40,7 @@ public struct LocationViewState {
         isEditing: Bool,
         isScrollingDuringEdit: Bool,
         shouldSelectSearchTerm: Bool,
-        onTapLockIcon: (() -> Void)? = nil,
+        onTapLockIcon: ((UIButton) -> Void)? = nil,
         onLongPress: (() -> Void)? = nil
     ) {
         self.searchEngineImageViewA11yId = searchEngineImageViewA11yId

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -263,6 +263,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                     windowUUID: state.windowUUID,
                     browserViewType: state.browserViewType,
                     displayView: .trackingProtectionDetails,
+                    buttonTapped: action.buttonTapped,
                     microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
         case GeneralBrowserActionType.showMenu:
             return BrowserViewControllerState(

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1966,7 +1966,7 @@ class BrowserViewController: UIViewController,
             presentLocationViewActionSheet(from: addressToolbarContainer)
         case .trackingProtectionDetails:
             TelemetryWrapper.recordEvent(category: .action, method: .press, object: .trackingProtectionMenu)
-            navigationHandler?.showEnhancedTrackingProtection(sourceView: view)
+            navigationHandler?.showEnhancedTrackingProtection(sourceView: state.buttonTapped ?? addressToolbarContainer)
         case .menu:
             didTapOnMenu(button: state.buttonTapped)
         case .reloadLongPressAction:

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -43,8 +43,9 @@ class AddressToolbarContainerModel: Equatable {
             isEditing: isEditing,
             isScrollingDuringEdit: isScrollingDuringEdit,
             shouldSelectSearchTerm: shouldSelectSearchTerm,
-            onTapLockIcon: {
+            onTapLockIcon: { button in
                 let action = ToolbarMiddlewareAction(buttonType: .trackingProtection,
+                                                     buttonTapped: button,
                                                      gestureType: .tap,
                                                      windowUUID: self.windowUUID,
                                                      actionType: ToolbarMiddlewareActionType.didTapButton)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -253,7 +253,8 @@ final class ToolbarMiddleware: FeatureFlaggable {
             store.dispatch(action)
 
         case .trackingProtection:
-            let action = GeneralBrowserAction(windowUUID: action.windowUUID,
+            let action = GeneralBrowserAction(buttonTapped: action.buttonTapped,
+                                              windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showTrackingProtectionDetails)
             store.dispatch(action)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9911)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21734)

## :bulb: Description
Bugfix ETP menu not showing due to missing button tapped in `BrowserViewControllerState`, that was originated either by the `LocationView` not passing around its lock button and from the `BrowserViewControllerState.reducer` not passing the action's button tapped property to the state.

To test this the `ToolbarRefactor` feature has to be enabled.

![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-09-02 at 17 25 08](https://github.com/user-attachments/assets/fedcabc2-c737-4c4b-8324-b7cb54c69f2e)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

