### PR TITLE
Refactor FXIOS-7301 - Help to remove 1 closure_body_length violation from FakespotState.swift (1/3)

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -76,14 +76,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleHighlights(action: action, state: state)
 
         case FakespotActionType.tabDidChange:
-            guard let tabUUID = action.tabUUID else { return state }
-            var state = state
-            if state.telemetryState[tabUUID] == nil {
-                state.telemetryState[tabUUID] = TelemetryState()
-            }
-            state.currentTabUUID = tabUUID
-
-            return state
+            return handleTabDidChange(action: action, state: state)
 
         case FakespotActionType.tabDidReload:
             guard let tabUUID = action.tabUUID,

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -159,7 +159,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handleHighlights(action: FakespotAction, state: FakespotState) -> FakespotState {
+    private static func handleHighlights(action: FakespotAction, state: FakespotState) -> FakespotState {
         let isExpanded = action.isExpanded ?? state.isHighlightsSectionExpanded
         var state = state
         state.expandState[state.currentTabUUID, default: ExpandState()].isHighlightsSectionExpanded = isExpanded

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -73,10 +73,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleReviewQuality(action: action, state: state)
 
         case FakespotActionType.highlightsDidChange:
-            let isExpanded = action.isExpanded ?? state.isHighlightsSectionExpanded
-            var state = state
-            state.expandState[state.currentTabUUID, default: ExpandState()].isHighlightsSectionExpanded = isExpanded
-            return state
+            return handleHighlights(action: action, state: state)
 
         case FakespotActionType.tabDidChange:
             guard let tabUUID = action.tabUUID else { return state }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -166,7 +166,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handleTabDidChange(action: FakespotAction, state: FakespotState) -> FakespotState {
+    private static func handleTabDidChange(action: FakespotAction, state: FakespotState) -> FakespotState {
         guard let tabUUID = action.tabUUID else { return state }
         var state = state
         if state.telemetryState[tabUUID] == nil {

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -168,4 +168,11 @@ struct FakespotState: ScreenState, Equatable {
         state.expandState[state.currentTabUUID, default: ExpandState()].isReviewQualityExpanded = isExpanded
         return state
     }
+
+    fileprivate static func handleHighlights(action: FakespotAction, state: FakespotState) -> FakespotState {
+        let isExpanded = action.isExpanded ?? state.isHighlightsSectionExpanded
+        var state = state
+        state.expandState[state.currentTabUUID, default: ExpandState()].isHighlightsSectionExpanded = isExpanded
+        return state
+    }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -152,7 +152,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handleReviewQuality(action: FakespotAction, state: FakespotState) -> FakespotState {
+    private static func handleReviewQuality(action: FakespotAction, state: FakespotState) -> FakespotState {
         let isExpanded = action.isExpanded ?? state.isReviewQualityExpanded
         var state = state
         state.expandState[state.currentTabUUID, default: ExpandState()].isReviewQualityExpanded = isExpanded

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -67,7 +67,7 @@ struct FakespotState: ScreenState, Equatable {
 
         switch action.actionType {
         case FakespotActionType.settingsStateDidChange:
-            return handleSettingsStateDidChange(action: action, state: state)
+            return handleSettings(action: action, state: state)
 
         case FakespotActionType.reviewQualityDidChange:
             return handleReviewQuality(action: action, state: state)
@@ -145,7 +145,7 @@ struct FakespotState: ScreenState, Equatable {
         }
     }
 
-    fileprivate static func handleSettingsStateDidChange(action: FakespotAction, state: FakespotState) -> FakespotState {
+    fileprivate static func handleSettings(action: FakespotAction, state: FakespotState) -> FakespotState {
         let isExpanded = action.isExpanded ?? state.isSettingsExpanded
         var state = state
         state.expandState[state.currentTabUUID, default: ExpandState()].isSettingsExpanded = isExpanded

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -145,7 +145,7 @@ struct FakespotState: ScreenState, Equatable {
         }
     }
 
-    fileprivate static func handleSettings(action: FakespotAction, state: FakespotState) -> FakespotState {
+    private static func handleSettings(action: FakespotAction, state: FakespotState) -> FakespotState {
         let isExpanded = action.isExpanded ?? state.isSettingsExpanded
         var state = state
         state.expandState[state.currentTabUUID, default: ExpandState()].isSettingsExpanded = isExpanded

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -172,4 +172,15 @@ struct FakespotState: ScreenState, Equatable {
         state.expandState[state.currentTabUUID, default: ExpandState()].isHighlightsSectionExpanded = isExpanded
         return state
     }
+
+    fileprivate static func handleTabDidChange(action: FakespotAction, state: FakespotState) -> FakespotState {
+        guard let tabUUID = action.tabUUID else { return state }
+        var state = state
+        if state.telemetryState[tabUUID] == nil {
+            state.telemetryState[tabUUID] = TelemetryState()
+        }
+        state.currentTabUUID = tabUUID
+
+        return state
+    }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -67,10 +67,7 @@ struct FakespotState: ScreenState, Equatable {
 
         switch action.actionType {
         case FakespotActionType.settingsStateDidChange:
-            let isExpanded = action.isExpanded ?? state.isSettingsExpanded
-            var state = state
-            state.expandState[state.currentTabUUID, default: ExpandState()].isSettingsExpanded = isExpanded
-            return state
+            return handleSettingsStateDidChange(action: action, state: state)
 
         case FakespotActionType.reviewQualityDidChange:
             let isExpanded = action.isExpanded ?? state.isReviewQualityExpanded

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -70,10 +70,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleSettingsStateDidChange(action: action, state: state)
 
         case FakespotActionType.reviewQualityDidChange:
-            let isExpanded = action.isExpanded ?? state.isReviewQualityExpanded
-            var state = state
-            state.expandState[state.currentTabUUID, default: ExpandState()].isReviewQualityExpanded = isExpanded
-            return state
+            return handleReviewQuality(action: action, state: state)
 
         case FakespotActionType.highlightsDidChange:
             let isExpanded = action.isExpanded ?? state.isHighlightsSectionExpanded

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -160,4 +160,11 @@ struct FakespotState: ScreenState, Equatable {
             return state
         }
     }
+
+    fileprivate static func handleSettingsStateDidChange(action: FakespotAction, state: FakespotState) -> FakespotState {
+        let isExpanded = action.isExpanded ?? state.isSettingsExpanded
+        var state = state
+        state.expandState[state.currentTabUUID, default: ExpandState()].isSettingsExpanded = isExpanded
+        return state
+    }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -164,4 +164,11 @@ struct FakespotState: ScreenState, Equatable {
         state.expandState[state.currentTabUUID, default: ExpandState()].isSettingsExpanded = isExpanded
         return state
     }
+
+    fileprivate static func handleReviewQuality(action: FakespotAction, state: FakespotState) -> FakespotState {
+        let isExpanded = action.isExpanded ?? state.isReviewQualityExpanded
+        var state = state
+        state.expandState[state.currentTabUUID, default: ExpandState()].isReviewQualityExpanded = isExpanded
+        return state
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR help to remove 1 `closure_body_length` violation from the `FakespotState.swift` file. It extracts to new functions the logic to:
- handle settings
- handle review quality
- handle highlights
- handle tab did change

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

