### PR TITLE
Refactor FXIOS-9917 - Add missing `AutofillFormFactory` module

### DIFF
--- a/firefox-ios/Client/Assets/CC_Script/CC_Python_Update.py
+++ b/firefox-ios/Client/Assets/CC_Script/CC_Python_Update.py
@@ -12,6 +12,7 @@ FILES_TO_DOWNLOAD = [
     "browser/extensions/formautofill/content/addressFormLayout.mjs",
     "toolkit/components/formautofill/Constants.ios.mjs",
     "toolkit/modules/CreditCard.sys.mjs",
+    "toolkit/components/formautofill/shared/AutofillFormFactory.sys.mjs",
     "toolkit/components/formautofill/shared/CreditCardRuleset.sys.mjs",
     "toolkit/components/formautofill/shared/CreditCardRecord.sys.mjs",
     "toolkit/components/formautofill/shared/FieldScanner.sys.mjs",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9917)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21749)

## :bulb: Description
This PR:
- Adds `AutofillFormFactory.sys.mjs` to list of pulled files.
- Blocks https://github.com/mozilla-mobile/firefox-ios/pull/21747

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)~
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~Wrote unit tests and/or ensured the tests suite is passing~
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed, I updated documentation / comments for complex code and public methods~
- [ ] ~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~
