### PR TITLE
Bugfix FXIOS-9720 background color of search engine image view

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -400,7 +400,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         urlTextFieldColor = colors.textPrimary
         urlTextFieldSubdomainColor = colors.textSecondary
         gradientLayer.colors = colors.layerGradientURL.cgColors.reversed()
-        searchEngineImageView.backgroundColor = colors.layer1
+        searchEngineImageView.backgroundColor = colors.layer2
         lockIconButton.tintColor = colors.iconPrimary
         lockIconButton.backgroundColor = colors.layerSearch
         urlTextField.applyTheme(theme: theme)

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -400,7 +400,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         urlTextFieldColor = colors.textPrimary
         urlTextFieldSubdomainColor = colors.textSecondary
         gradientLayer.colors = colors.layerGradientURL.cgColors.reversed()
-        searchEngineImageView.backgroundColor = colors.iconPrimary
+        searchEngineImageView.backgroundColor = colors.layer1
         lockIconButton.tintColor = colors.iconPrimary
         lockIconButton.backgroundColor = colors.layerSearch
         urlTextField.applyTheme(theme: theme)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9720)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21363)

## :bulb: Description
Changed the background color of the search engine fav icon to approriate one.

## Screenshots
![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-09-03 at 11 48 31](https://github.com/user-attachments/assets/d4ace99a-866e-4d83-b7ff-bdae1218d859)

![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-09-03 at 11 48 45](https://github.com/user-attachments/assets/f61e193a-1efd-4c39-98bf-623be62aadb9)

![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-09-03 at 11 49 08](https://github.com/user-attachments/assets/9e9f55e4-705a-4615-8387-f4258ce6a529)

![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-09-03 at 11 49 20](https://github.com/user-attachments/assets/4a602e2d-87ad-4983-9d36-60e6389bea06)



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

