### PR TITLE
Refactor FXIOS-9726 - Refactor/Split TrackingProtectionViewController URefactor/Split TrackingProtectionViewController UI into more custom views

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -17,6 +17,11 @@
 		047F9B4224E1FF4000CD7DF7 /* ImageButtonWithLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047F9B3C24E1FF4000CD7DF7 /* ImageButtonWithLabel.swift */; };
 		0A49784A2C53E63200B1E82A /* TrackingProtectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4978492C53E63200B1E82A /* TrackingProtectionViewController.swift */; };
 		0A7693612C7DD19600103A6D /* CertificatesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7693602C7DD19500103A6D /* CertificatesViewModelTests.swift */; };
+		0A7693692C81F2A300103A6D /* TrackingProtectionConnectionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7693682C81F2A200103A6D /* TrackingProtectionConnectionDetailsView.swift */; };
+		0A76936B2C82018700103A6D /* TrackingProtectionBlockedTrackersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A76936A2C82018700103A6D /* TrackingProtectionBlockedTrackersView.swift */; };
+		0A93C8A82C85FFA600BEA143 /* TrackingProtectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A93C8A72C85FFA600BEA143 /* TrackingProtectionHeaderView.swift */; };
+		0A93C8AA2C87070300BEA143 /* TrackingProtectionConnectionStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A93C8A92C87070300BEA143 /* TrackingProtectionConnectionStatusView.swift */; };
+		0A93C8AC2C870E7100BEA143 /* TrackingProtectionToggleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A93C8AB2C870E7100BEA143 /* TrackingProtectionToggleView.swift */; };
 		0AC659272BF35854005C614A /* FxAWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC659262BF35854005C614A /* FxAWebViewModelTests.swift */; };
 		0AC659292BF493CE005C614A /* MockFxAWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */; };
 		0AD3EEAC2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD3EEAB2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift */; };
@@ -1056,7 +1061,6 @@
 		AB9CBC082C53B7CD00102610 /* TrackingProtectionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9CBC062C53B76400102610 /* TrackingProtectionStateTests.swift */; };
 		ABB507CF2A136FB2009CAA67 /* UserConversionMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB507CD2A136FB2009CAA67 /* UserConversionMetricsTests.swift */; };
 		ABE4393E2AC432040074FFE1 /* PartnerWebsites.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE4393D2AC432040074FFE1 /* PartnerWebsites.swift */; };
-		ABE856AB2C74F23200C56F47 /* TrackingProtectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE856AA2C74F23200C56F47 /* TrackingProtectionHeaderView.swift */; };
 		ABE856AD2C75029F00C56F47 /* TrackingProtectionStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE856AC2C75029F00C56F47 /* TrackingProtectionStatusView.swift */; };
 		ABEF80D12A24D2BE003F52C4 /* CreditCardBottomSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABEF80D02A24D2BE003F52C4 /* CreditCardBottomSheetViewModel.swift */; };
 		ABEF80D52A254185003F52C4 /* CreditCardBottomSheetFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABEF80D42A254185003F52C4 /* CreditCardBottomSheetFooterView.swift */; };
@@ -2172,7 +2176,12 @@
 		0A5B4CE9B0996AE804491134 /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/Shared.strings; sourceTree = "<group>"; };
 		0A734328A164466314ECE4BE /* ia */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ia; path = ia.lproj/Menu.strings; sourceTree = "<group>"; };
 		0A7693602C7DD19500103A6D /* CertificatesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatesViewModelTests.swift; sourceTree = "<group>"; };
+		0A7693682C81F2A200103A6D /* TrackingProtectionConnectionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionConnectionDetailsView.swift; sourceTree = "<group>"; };
+		0A76936A2C82018700103A6D /* TrackingProtectionBlockedTrackersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionBlockedTrackersView.swift; sourceTree = "<group>"; };
 		0A7D41DB98DDB127A2B8C544 /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/Menu.strings; sourceTree = "<group>"; };
+		0A93C8A72C85FFA600BEA143 /* TrackingProtectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionHeaderView.swift; sourceTree = "<group>"; };
+		0A93C8A92C87070300BEA143 /* TrackingProtectionConnectionStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionConnectionStatusView.swift; sourceTree = "<group>"; };
+		0A93C8AB2C870E7100BEA143 /* TrackingProtectionToggleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionToggleView.swift; sourceTree = "<group>"; };
 		0AC659262BF35854005C614A /* FxAWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAWebViewModelTests.swift; sourceTree = "<group>"; };
 		0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFxAWebViewModel.swift; sourceTree = "<group>"; };
 		0AD3EEAB2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedCenteredTableViewCell.swift; sourceTree = "<group>"; };
@@ -7278,7 +7287,6 @@
 		AB9CBC062C53B76400102610 /* TrackingProtectionStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackingProtectionStateTests.swift; sourceTree = "<group>"; };
 		ABB507CD2A136FB2009CAA67 /* UserConversionMetricsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserConversionMetricsTests.swift; sourceTree = "<group>"; };
 		ABE4393D2AC432040074FFE1 /* PartnerWebsites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartnerWebsites.swift; sourceTree = "<group>"; };
-		ABE856AA2C74F23200C56F47 /* TrackingProtectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionHeaderView.swift; sourceTree = "<group>"; };
 		ABE856AC2C75029F00C56F47 /* TrackingProtectionStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionStatusView.swift; sourceTree = "<group>"; };
 		ABEF80D02A24D2BE003F52C4 /* CreditCardBottomSheetViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreditCardBottomSheetViewModel.swift; sourceTree = "<group>"; };
 		ABEF80D42A254185003F52C4 /* CreditCardBottomSheetFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardBottomSheetFooterView.swift; sourceTree = "<group>"; };
@@ -11224,17 +11232,21 @@
 				0AFF7F692C7C7BB800265214 /* CertificatesCell.swift */,
 				0AFF7F6A2C7C7BB900265214 /* CertificatesViewController.swift */,
 				0AFF7F6B2C7C7BB900265214 /* CertificatesViewModel.swift */,
+				AB2AC6652BD15E6300022AAB /* CertificatesHandler.swift */,
 				AB9CBBFE2C53B64B00102610 /* TrackingProtectionAction.swift */,
 				AB9CBBFF2C53B64B00102610 /* TrackingProtectionMiddleware.swift */,
 				AB9CBC002C53B64B00102610 /* TrackingProtectionModel.swift */,
 				AB9CBC012C53B64B00102610 /* TrackingProtectionState.swift */,
-				AB2AC6652BD15E6300022AAB /* CertificatesHandler.swift */,
 				AB936A682C05F2B100600F82 /* TrackingProtectionButton.swift */,
 				0A4978492C53E63200B1E82A /* TrackingProtectionViewController.swift */,
 				AB9A0C002C6CBC9100BFA22A /* TrackingProtectionDetailsViewController.swift */,
-				ABE856AA2C74F23200C56F47 /* TrackingProtectionHeaderView.swift */,
 				ABE856AC2C75029F00C56F47 /* TrackingProtectionStatusView.swift */,
 				AB8EE2D22C750E6100BD0A6B /* TrackingProtectionVerifiedByView.swift */,
+				0A93C8A72C85FFA600BEA143 /* TrackingProtectionHeaderView.swift */,
+				0A7693682C81F2A200103A6D /* TrackingProtectionConnectionDetailsView.swift */,
+				0A76936A2C82018700103A6D /* TrackingProtectionBlockedTrackersView.swift */,
+				0A93C8A92C87070300BEA143 /* TrackingProtectionConnectionStatusView.swift */,
+				0A93C8AB2C870E7100BEA143 /* TrackingProtectionToggleView.swift */,
 			);
 			path = TrackingProtection;
 			sourceTree = "<group>";
@@ -14971,6 +14983,7 @@
 				C23889DF2A4EFCE500429673 /* ShareExtensionCoordinator.swift in Sources */,
 				8AE80BBE2891C21A00BC12EA /* JumpBackInSyncedTab.swift in Sources */,
 				8C6F94652A972EB300415FF6 /* FakespotAdjustRatingView.swift in Sources */,
+				0A93C8AC2C870E7100BEA143 /* TrackingProtectionToggleView.swift in Sources */,
 				8A3EF7FD2A2FCFAC00796E3A /* AppReviewPromptSetting.swift in Sources */,
 				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
 				E1FE133329C22782002A65FF /* BackgroundNotificationSurfaceUtility.swift in Sources */,
@@ -15157,7 +15170,6 @@
 				E19B38B328A42D5E00D8C541 /* WallpaperCollectionViewCell.swift in Sources */,
 				0BB5B30B1AC0AD1F0052877D /* LoginsHelper.swift in Sources */,
 				8A3EF8092A2FD02B00796E3A /* ExperimentsSettings.swift in Sources */,
-				ABE856AB2C74F23200C56F47 /* TrackingProtectionHeaderView.swift in Sources */,
 				C87DF9DB267247190097E707 /* UIConstants+BottomInset.swift in Sources */,
 				8AD08D1527E9198E00B8E907 /* TabsTelemetry.swift in Sources */,
 				74B420C92A1D0D7A00370E53 /* OnboardingInstructionsPopupInfoModel.swift in Sources */,
@@ -15387,6 +15399,7 @@
 				BD1C89CA2A1E3CE7000A4201 /* PocketFooterView.swift in Sources */,
 				81020C942BB5B026007B8481 /* OnboardingMultipleChoiceButtonViewModel.swift in Sources */,
 				E12BD0AE28AC38480029AAF0 /* UIImage+Extension.swift in Sources */,
+				0A7693692C81F2A300103A6D /* TrackingProtectionConnectionDetailsView.swift in Sources */,
 				F886218C270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift in Sources */,
 				D83822001FC7961D00303C12 /* DispatchQueueHelper.swift in Sources */,
 				EBC486992195F46B00CDA48D /* InternalSchemeHandler.swift in Sources */,
@@ -15535,6 +15548,7 @@
 				E1ADE23C2B0649F200FD17AA /* FakespotState.swift in Sources */,
 				2816F0001B33E05400522243 /* UIConstants.swift in Sources */,
 				21E78A7228F9A93100F8D687 /* UIDeviceInterface.swift in Sources */,
+				0A93C8A82C85FFA600BEA143 /* TrackingProtectionHeaderView.swift in Sources */,
 				EBB89508219398E500EB91A0 /* ContentBlocker+Safelist.swift in Sources */,
 				437A9B6A2681257F00FB41C1 /* LegacyInactiveTabViewModel.swift in Sources */,
 				C838FD5E289981240068F60B /* WallpaperURLProvider.swift in Sources */,
@@ -15674,6 +15688,7 @@
 				C29B64EE2AD937D500F3244B /* QRCodeNavigationHandler.swift in Sources */,
 				8A19ACB42A3290D9001C2147 /* ContentBlockerSetting.swift in Sources */,
 				219935E72B05447C00E5966F /* TabDisplayModel.swift in Sources */,
+				0A76936B2C82018700103A6D /* TrackingProtectionBlockedTrackersView.swift in Sources */,
 				E1463D022981DA190074E16E /* NotificationManager.swift in Sources */,
 				219A0FD92ACC8C0F009A6D1A /* InactiveTabsFooterView.swift in Sources */,
 				884CA7492344A301002E4711 /* TextContentDetector.swift in Sources */,
@@ -15714,6 +15729,7 @@
 				21357F2F294237D8004BF9FD /* RemoteTabsClientAndTabsDataSource.swift in Sources */,
 				E13C07292C217D700087E404 /* NavigationBarState.swift in Sources */,
 				59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */,
+				0A93C8AA2C87070300BEA143 /* TrackingProtectionConnectionStatusView.swift in Sources */,
 				C849E46126B9C39B00260F0B /* EnhancedTrackingProtectionVC.swift in Sources */,
 				E40FAB0C1A7ABB77009CB80D /* WebServer.swift in Sources */,
 				59A68D66379CFA85C4EAF00B /* TwoLineImageOverlayCell.swift in Sources */,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionBlockedTrackersView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionBlockedTrackersView.swift
@@ -1,0 +1,162 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+final class TrackingProtectionBlockedTrackersView: UIView, ThemeApplicable {
+    private struct UX {
+        static let trackersLabelConstraintConstant = 16.0
+    }
+
+    var trackersButtonCallback: (() -> Void)?
+
+    private let shieldImage: UIImageView = .build { image in
+        image.contentMode = .scaleAspectFit
+        image.clipsToBounds = true
+        image.layer.masksToBounds = true
+        image.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.shield)
+            .withRenderingMode(.alwaysTemplate)
+    }
+
+    private let trackersLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    private let trackersDetailArrow: UIImageView = .build { image in
+        image.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.chevronLeft)
+            .withRenderingMode(.alwaysTemplate)
+            .imageFlippedForRightToLeftLayoutDirection()
+        image.transform = CGAffineTransform(rotationAngle: .pi)
+    }
+
+    private let trackersHorizontalLine: UIView = .build()
+    private let trackersButton: UIButton = .build()
+
+    private var shieldImageHeightConstraint: NSLayoutConstraint?
+    private var trackersArrowHeightConstraint: NSLayoutConstraint?
+    private var trackersLabelTopConstraint: NSLayoutConstraint?
+    private var trackersLabelBottomConstraint: NSLayoutConstraint?
+
+    init() {
+        super.init(frame: .zero)
+        setupLayout()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        self.addSubviews(shieldImage, trackersLabel, trackersDetailArrow, trackersButton, trackersHorizontalLine)
+        shieldImageHeightConstraint = shieldImage.heightAnchor.constraint(equalToConstant: TPMenuUX.UX.iconSize)
+        trackersArrowHeightConstraint = trackersDetailArrow.heightAnchor.constraint(
+            equalToConstant: TPMenuUX.UX.iconSize
+        )
+
+        trackersLabelTopConstraint = trackersLabel.topAnchor.constraint(
+            equalTo: self.topAnchor,
+            constant: UX.trackersLabelConstraintConstant)
+        trackersLabelBottomConstraint = trackersLabel.bottomAnchor.constraint(
+            equalTo: self.bottomAnchor,
+            constant: -UX.trackersLabelConstraintConstant)
+
+        NSLayoutConstraint.activate([
+            shieldImage.leadingAnchor.constraint(
+                equalTo: self.leadingAnchor,
+                constant: TPMenuUX.UX.horizontalMargin
+            ),
+            shieldImage.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            shieldImage.heightAnchor.constraint(equalTo: shieldImage.widthAnchor),
+            shieldImageHeightConstraint!,
+            trackersLabel.leadingAnchor.constraint(
+                equalTo: shieldImage.trailingAnchor,
+                constant: TPMenuUX.UX.horizontalMargin
+            ),
+            trackersLabel.trailingAnchor.constraint(
+                equalTo: trackersDetailArrow.leadingAnchor,
+                constant: TPMenuUX.UX.horizontalMargin
+            ),
+            trackersLabelTopConstraint ?? NSLayoutConstraint(),
+            trackersLabelBottomConstraint ?? NSLayoutConstraint(),
+
+            trackersDetailArrow.trailingAnchor.constraint(
+                equalTo: self.trailingAnchor,
+                constant: -TPMenuUX.UX.horizontalMargin
+            ),
+            trackersDetailArrow.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            trackersArrowHeightConstraint!,
+            trackersDetailArrow.widthAnchor.constraint(equalTo: trackersDetailArrow.heightAnchor),
+
+            trackersButton.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            trackersButton.topAnchor.constraint(equalTo: self.topAnchor),
+            trackersButton.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            trackersButton.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+
+            trackersHorizontalLine.leadingAnchor.constraint(equalTo: trackersLabel.leadingAnchor),
+            trackersHorizontalLine.trailingAnchor.constraint(equalTo: self.trailingAnchor,
+                                                             constant: -TPMenuUX.UX.connectionDetailsHeaderMargins),
+            trackersHorizontalLine.heightAnchor.constraint(equalToConstant: TPMenuUX.UX.Line.height),
+            self.bottomAnchor.constraint(equalTo: trackersHorizontalLine.bottomAnchor)
+        ])
+    }
+
+    func setupDetails(for trackersBlocked: Int?) {
+        trackersLabel.text = getTrackerString(for: trackersBlocked)
+        shieldImage.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.shield)
+            .withRenderingMode(.alwaysTemplate)
+    }
+
+    func setupAccessibilityIdentifiers(arrowImageA11yId: String,
+                                       trackersBlockedLabelA11yId: String,
+                                       shieldImageA11yId: String) {
+        trackersDetailArrow.accessibilityIdentifier = arrowImageA11yId
+        trackersLabel.accessibilityIdentifier = trackersBlockedLabelA11yId
+        shieldImage.accessibilityIdentifier = shieldImageA11yId
+    }
+
+    func adjustLayout() {
+        let iconSize = TPMenuUX.UX.iconSize
+        shieldImageHeightConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: iconSize), 2 * iconSize)
+        trackersArrowHeightConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: iconSize), 2 * iconSize)
+    }
+
+    func setVisibility(isHidden: Bool) {
+        self.isHidden = isHidden
+        if isHidden {
+            trackersLabelTopConstraint?.constant = 0
+            trackersLabelBottomConstraint?.constant = 0
+        } else {
+            trackersLabelTopConstraint?.constant = UX.trackersLabelConstraintConstant
+            trackersLabelBottomConstraint?.constant = -UX.trackersLabelConstraintConstant
+        }
+    }
+
+    func setupActions() {
+        trackersButton.addTarget(self, action: #selector(blockedTrackersTapped), for: .touchUpInside)
+    }
+
+    @objc
+    func blockedTrackersTapped() {
+        trackersButtonCallback?()
+    }
+
+    private func getTrackerString(for trackersBlocked: Int?) -> String {
+        if let trackersBlocked, trackersBlocked > 0 {
+            return String(format: .Menu.EnhancedTrackingProtection.trackersBlockedLabel,
+                          String(trackersBlocked))
+        } else {
+            return .Menu.EnhancedTrackingProtection.noTrackersLabel
+        }
+    }
+
+    func applyTheme(theme: Theme) {
+        self.backgroundColor = theme.colors.layer2
+        trackersDetailArrow.tintColor = theme.colors.iconSecondary
+        shieldImage.tintColor = theme.colors.iconPrimary
+        trackersHorizontalLine.backgroundColor = theme.colors.borderPrimary
+    }
+}

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionConnectionDetailsView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionConnectionDetailsView.swift
@@ -1,0 +1,119 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+final class TrackingProtectionConnectionDetailsView: UIView {
+    private struct UX {
+        static let foxImageSize: CGFloat = 100
+        static let connectionDetailsLabelsVerticalSpacing: CGFloat = 12
+        static let connectionDetailsLabelBottomSpacing: CGFloat = 28
+        static let connectionDetailsStackSpacing = 15.0
+    }
+
+    private let connectionDetailsContentView: UIView = .build { view in
+        view.layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
+        view.layer.masksToBounds = true
+    }
+
+    private let foxStatusImage: UIImageView = .build { image in
+        image.contentMode = .scaleAspectFit
+        image.clipsToBounds = true
+    }
+
+    private var connectionDetailsLabelsContainer: UIStackView = .build { stack in
+        stack.backgroundColor = .clear
+        stack.distribution = .fillProportionally
+        stack.alignment = .leading
+        stack.axis = .vertical
+        stack.spacing = UX.connectionDetailsStackSpacing
+    }
+
+    private var connectionDetailsTitleLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Bold.subheadline.scaledFont()
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    private let connectionDetailsStatusLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    init() {
+        super.init(frame: .zero)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        self.layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
+        self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        self.layer.masksToBounds = true
+
+        connectionDetailsLabelsContainer.addArrangedSubview(connectionDetailsTitleLabel)
+        connectionDetailsLabelsContainer.addArrangedSubview(connectionDetailsStatusLabel)
+        connectionDetailsContentView.addSubviews(foxStatusImage, connectionDetailsLabelsContainer)
+        self.addSubview(connectionDetailsContentView)
+        NSLayoutConstraint.activate([
+            // Content
+            connectionDetailsContentView.leadingAnchor.constraint(
+                equalTo: self.leadingAnchor,
+                constant: TPMenuUX.UX.connectionDetailsHeaderMargins
+            ),
+            connectionDetailsContentView.trailingAnchor.constraint(
+                equalTo: self.trailingAnchor,
+                constant: -TPMenuUX.UX.connectionDetailsHeaderMargins
+            ),
+            connectionDetailsContentView.topAnchor.constraint(equalTo: self.topAnchor,
+                                                              constant: TPMenuUX.UX.connectionDetailsHeaderMargins),
+            connectionDetailsContentView.bottomAnchor.constraint(equalTo: self.bottomAnchor,
+                                                                 constant: -TPMenuUX.UX.connectionDetailsHeaderMargins / 2),
+            // Image
+            foxStatusImage.leadingAnchor.constraint(
+                equalTo: connectionDetailsContentView.leadingAnchor,
+                constant: TPMenuUX.UX.horizontalMargin
+            ),
+            foxStatusImage.topAnchor.constraint(
+                equalTo: connectionDetailsContentView.topAnchor,
+                constant: TPMenuUX.UX.horizontalMargin
+            ),
+            foxStatusImage.heightAnchor.constraint(equalToConstant: UX.foxImageSize),
+            foxStatusImage.widthAnchor.constraint(equalToConstant: UX.foxImageSize),
+
+            // Labels
+            connectionDetailsLabelsContainer.topAnchor.constraint(
+                equalTo: connectionDetailsContentView.topAnchor,
+                constant: TPMenuUX.UX.horizontalMargin
+            ),
+            connectionDetailsLabelsContainer.bottomAnchor.constraint(
+                equalTo: connectionDetailsContentView.bottomAnchor,
+                constant: -UX.connectionDetailsLabelBottomSpacing / 2
+            ),
+            connectionDetailsLabelsContainer.leadingAnchor.constraint(
+                equalTo: foxStatusImage.trailingAnchor,
+                constant: UX.connectionDetailsLabelsVerticalSpacing),
+            connectionDetailsLabelsContainer.trailingAnchor.constraint(equalTo:
+                                                                        connectionDetailsContentView.trailingAnchor,
+                                                                       constant: -TPMenuUX.UX.horizontalMargin),
+            connectionDetailsLabelsContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.foxImageSize)
+        ])
+    }
+
+    func setupDetails(color: UIColor? = nil, title: String, status: String, image: UIImage?) {
+        connectionDetailsContentView.backgroundColor = color
+        connectionDetailsTitleLabel.text = title
+        connectionDetailsStatusLabel.text = status
+        foxStatusImage.image = image
+    }
+
+    func setupAccessibilityIdentifiers(foxImageA11yId: String) {
+        foxStatusImage.accessibilityIdentifier = foxImageA11yId
+    }
+}

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionConnectionStatusView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionConnectionStatusView.swift
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
+    private struct UX {
+        static let connectionStatusLabelConstraintConstant = 16.0
+        static let toggleLabelsContainerConstraintConstant = 16.0
+    }
+
+    var connectionStatusButtonCallback: (() -> Void)?
+
+    private let connectionStatusImage: UIImageView = .build { image in
+        image.contentMode = .scaleAspectFit
+        image.clipsToBounds = true
+        image.layer.masksToBounds = true
+    }
+
+    private let connectionStatusLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    private let connectionDetailArrow: UIImageView = .build { image in
+        image.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.chevronLeft)
+            .withRenderingMode(.alwaysTemplate)
+            .imageFlippedForRightToLeftLayoutDirection()
+        image.transform = CGAffineTransform(rotationAngle: .pi)
+    }
+
+    private let connectionButton: UIButton = .build()
+
+    private var lockImageHeightConstraint: NSLayoutConstraint?
+    private var connectionArrowHeightConstraint: NSLayoutConstraint?
+
+    init() {
+        super.init(frame: .zero)
+        setupLayout()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        self.addSubviews(connectionStatusImage, connectionStatusLabel, connectionDetailArrow)
+        self.addSubviews(connectionButton)
+
+        lockImageHeightConstraint = connectionStatusImage.widthAnchor.constraint(
+            equalToConstant: TPMenuUX.UX.iconSize
+        )
+        connectionArrowHeightConstraint = connectionDetailArrow.heightAnchor.constraint(
+            equalToConstant: TPMenuUX.UX.iconSize
+        )
+
+        NSLayoutConstraint.activate([
+            connectionStatusImage.leadingAnchor.constraint(
+                equalTo: self.leadingAnchor,
+                constant: TPMenuUX.UX.horizontalMargin
+            ),
+            connectionStatusImage.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            lockImageHeightConstraint ?? NSLayoutConstraint(),
+            connectionStatusImage.heightAnchor.constraint(equalTo: self.widthAnchor),
+
+            connectionStatusLabel.leadingAnchor.constraint(
+                equalTo: connectionStatusImage.trailingAnchor,
+                constant: TPMenuUX.UX.horizontalMargin
+            ),
+            connectionStatusLabel.topAnchor.constraint(equalTo: self.topAnchor,
+                                                       constant: UX.connectionStatusLabelConstraintConstant),
+            connectionStatusLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor,
+                                                          constant: -UX.connectionStatusLabelConstraintConstant),
+            connectionStatusLabel.trailingAnchor.constraint(
+                equalTo: connectionDetailArrow.leadingAnchor,
+                constant: TPMenuUX.UX.horizontalMargin
+            ),
+
+            connectionDetailArrow.trailingAnchor.constraint(
+                equalTo: self.trailingAnchor,
+                constant: -TPMenuUX.UX.horizontalMargin
+            ),
+            connectionDetailArrow.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            connectionArrowHeightConstraint!,
+            connectionDetailArrow.widthAnchor.constraint(equalTo: connectionDetailArrow.heightAnchor),
+
+            connectionButton.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            connectionButton.topAnchor.constraint(equalTo: self.topAnchor),
+            connectionButton.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            connectionButton.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+        ])
+    }
+
+    func setupDetails(image: UIImage, text: String) {
+        connectionStatusImage.image = image
+        connectionStatusLabel.text = text
+    }
+
+    func setupAccessibilityIdentifiers(arrowImageA11yId: String, securityStatusLabelA11yId: String) {
+        connectionDetailArrow.accessibilityIdentifier = arrowImageA11yId
+        connectionStatusLabel.accessibilityIdentifier = securityStatusLabelA11yId
+    }
+
+    func adjustLayout() {
+        let iconSize = TPMenuUX.UX.iconSize
+        lockImageHeightConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: iconSize), 2 * iconSize)
+        connectionArrowHeightConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: iconSize), 2 * iconSize)
+    }
+
+    func setupActions() {
+        connectionButton.addTarget(self, action: #selector(connectionDetailsTapped), for: .touchUpInside)
+    }
+
+    @objc
+    func connectionDetailsTapped() {
+        connectionStatusButtonCallback?()
+    }
+
+    func applyTheme(theme: Theme) {
+        self.backgroundColor = theme.colors.layer2
+        connectionDetailArrow.tintColor = theme.colors.iconSecondary
+    }
+
+    func setConnectionStatusImage(image: UIImage, isConnectionSecure: Bool, theme: Theme) {
+        connectionStatusImage.image = image
+        if isConnectionSecure {
+            connectionStatusImage.tintColor = theme.colors.iconPrimary
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionDetailsViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionDetailsViewController.swift
@@ -21,6 +21,13 @@ struct TrackingProtectionDetailsModel {
 }
 
 class TrackingProtectionDetailsViewController: UIViewController, Themeable {
+    private struct UX {
+        static let baseCellHeight: CGFloat = 44
+        static let baseDistance: CGFloat = 20
+        static let bottomDistance: CGFloat = 350
+        static let viewCertButtonTopDistance: CGFloat = 8.0
+    }
+
     // MARK: - UI
     private let scrollView: UIScrollView = .build { scrollView in }
     private let baseView: UIStackView = .build { stackView in
@@ -107,13 +114,13 @@ class TrackingProtectionDetailsViewController: UIViewController, Themeable {
             scrollView.topAnchor.constraint(equalTo: headerView.bottomAnchor),
             scrollView.bottomAnchor.constraint(
                 equalTo: view.bottomAnchor,
-                constant: -TPMenuUX.UX.TrackingDetails.bottomDistance
+                constant: -UX.bottomDistance
             ),
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             baseView.topAnchor.constraint(
                 equalTo: scrollView.topAnchor,
-                constant: TPMenuUX.UX.TrackingDetails.baseDistance
+                constant: UX.baseDistance
             ),
             baseView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
             baseView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
@@ -141,7 +148,7 @@ class TrackingProtectionDetailsViewController: UIViewController, Themeable {
                 equalTo: view.safeAreaLayoutGuide.leadingAnchor,
                 constant: TPMenuUX.UX.horizontalMargin
             ),
-            headerView.heightAnchor.constraint(greaterThanOrEqualToConstant: TPMenuUX.UX.baseCellHeight)
+            headerView.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.baseCellHeight)
         ]
 
         constraints.append(contentsOf: headerViewContraints)
@@ -151,7 +158,7 @@ class TrackingProtectionDetailsViewController: UIViewController, Themeable {
     private func setupConnectionStatusView() {
         baseView.addArrangedSubview(connectionView)
         let connectionViewContraints = [
-            connectionView.heightAnchor.constraint(greaterThanOrEqualToConstant: TPMenuUX.UX.baseCellHeight),
+            connectionView.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.baseCellHeight),
         ]
 
         constraints.append(contentsOf: connectionViewContraints)
@@ -161,7 +168,7 @@ class TrackingProtectionDetailsViewController: UIViewController, Themeable {
     private func setupVerifiedByView() {
         baseView.addArrangedSubview(verifiedByView)
         let verifiedByViewContraints = [
-            verifiedByView.heightAnchor.constraint(greaterThanOrEqualToConstant: TPMenuUX.UX.baseCellHeight)
+            verifiedByView.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.baseCellHeight)
         ]
 
         constraints.append(contentsOf: verifiedByViewContraints)
@@ -177,7 +184,7 @@ class TrackingProtectionDetailsViewController: UIViewController, Themeable {
         viewCertificatesButton.configure(viewModel: certificatesButtonViewModel)
         baseView.addArrangedSubview(viewCertificatesButton)
         baseView.setCustomSpacing(
-            TPMenuUX.UX.TrackingDetails.viewCertButtonTopDistance,
+            UX.viewCertButtonTopDistance,
             after: verifiedByView
         )
     }
@@ -211,7 +218,7 @@ class TrackingProtectionDetailsViewController: UIViewController, Themeable {
     }
 
     private func updateViewDetails() {
-        headerView.siteTitleLabel.text = model.topLevelDomain
+        headerView.setTitle(with: model.topLevelDomain)
         connectionView.connectionStatusLabel.text = model.connectionStatusMessage
         let certificateVerifier =  String(format: .Menu.EnhancedTrackingProtection.connectionVerifiedByLabel,
                                           model.topLevelDomain) // to be updated with the certificate verifier

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionStatusView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionStatusView.swift
@@ -9,6 +9,11 @@ import Shared
 import ComponentLibrary
 
 class TrackingProtectionStatusView: UIView {
+    private struct UX {
+        static let imageMargins: CGFloat = 10
+        static let connectionStatusLabelConstraintConstant = 16.0
+    }
+
     let connectionImage: UIImageView = .build { image in
         image.contentMode = .scaleAspectFit
         image.clipsToBounds = true
@@ -56,7 +61,7 @@ class TrackingProtectionStatusView: UIView {
 
             connectionStatusLabel.leadingAnchor.constraint(
                 equalTo: connectionImage.trailingAnchor,
-                constant: TPMenuUX.UX.TrackingDetails.imageMargins
+                constant: UX.imageMargins
             ),
             connectionStatusLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
             connectionStatusLabel.centerYAnchor.constraint(equalTo: centerYAnchor),

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionToggleView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionToggleView.swift
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+
+final class TrackingProtectionToggleView: UIView, ThemeApplicable {
+    private struct UX {
+        static let toggleLabelsContainerConstraintConstant = 16.0
+    }
+
+    var toggleSwitchedCallback: (() -> Void)?
+
+    private let toggleLabelsContainer: UIStackView = .build { stack in
+        stack.backgroundColor = .clear
+        stack.distribution = .fill
+        stack.alignment = .leading
+        stack.axis = .vertical
+        stack.spacing = TPMenuUX.UX.headerLabelDistance
+    }
+
+    private let toggleLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    private let toggleSwitch: UISwitch = .build { toggleSwitch in
+        toggleSwitch.isEnabled = true
+    }
+
+    private let toggleStatusLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.caption1.scaledFont()
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    var toggleIsOn: Bool {
+        toggleSwitch.isOn
+    }
+
+    init() {
+        super.init(frame: .zero)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        self.layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
+        self.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        self.backgroundColor = .clear
+        self.translatesAutoresizingMaskIntoConstraints = false
+
+        toggleLabelsContainer.addArrangedSubview(toggleLabel)
+        toggleLabelsContainer.addArrangedSubview(toggleStatusLabel)
+        self.addSubviews(toggleLabelsContainer, toggleSwitch)
+
+        NSLayoutConstraint.activate([
+            toggleLabelsContainer.leadingAnchor.constraint(
+                equalTo: self.leadingAnchor,
+                constant: TPMenuUX.UX.horizontalMargin
+            ),
+            toggleLabelsContainer.trailingAnchor.constraint(
+                equalTo: toggleSwitch.leadingAnchor,
+                constant: -TPMenuUX.UX.horizontalMargin
+            ),
+            toggleLabelsContainer.topAnchor.constraint(
+                equalTo: self.topAnchor,
+                constant: UX.toggleLabelsContainerConstraintConstant
+            ),
+            toggleLabelsContainer.bottomAnchor.constraint(
+                equalTo: self.bottomAnchor,
+                constant: -UX.toggleLabelsContainerConstraintConstant
+            ),
+
+            toggleSwitch.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            toggleSwitch.trailingAnchor.constraint(
+                equalTo: self.trailingAnchor,
+                constant: -TPMenuUX.UX.horizontalMargin
+            )
+        ])
+    }
+
+    func setStatusLabelText(with text: String) {
+        toggleStatusLabel.text = text
+    }
+
+    func setupDetails(isOn: Bool) {
+        toggleSwitch.isOn = isOn
+        toggleLabel.text = .Menu.EnhancedTrackingProtection.switchTitle
+        toggleStatusLabel.text = toggleIsOn ?
+            .Menu.EnhancedTrackingProtection.switchOnText : .Menu.EnhancedTrackingProtection.switchOffText
+    }
+
+    func setupAccessibilityIdentifiers(toggleViewTitleLabelA11yId: String, toggleViewBodyLabelA11yId: String) {
+        toggleLabel.accessibilityIdentifier = toggleViewTitleLabelA11yId
+        toggleStatusLabel.accessibilityIdentifier = toggleViewBodyLabelA11yId
+    }
+
+    func setupActions() {
+        toggleSwitch.addTarget(self, action: #selector(trackingProtectionToggleTapped), for: .valueChanged)
+    }
+
+    @objc
+    func trackingProtectionToggleTapped() {
+        toggleSwitchedCallback?()
+    }
+
+    func applyTheme(theme: Theme) {
+        self.backgroundColor = theme.colors.layer2
+        toggleSwitch.tintColor = theme.colors.actionPrimary
+        toggleSwitch.onTintColor = theme.colors.actionPrimary
+        toggleStatusLabel.textColor = theme.colors.textSecondary
+    }
+}

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -9,52 +9,20 @@ import ComponentLibrary
 import SiteImageView
 
 struct TPMenuUX {
-    struct Fonts {
-        static let websiteTitle: TextStyling = FXFontStyles.Regular.headline
-        static let viewTitleLabels: TextStyling = FXFontStyles.Regular.body
-        static let detailsLabel: TextStyling = FXFontStyles.Regular.caption1
-        static let minorInfoLabel: TextStyling = FXFontStyles.Regular.subheadline
-    }
-
     struct UX {
-        static let baseCellHeight: CGFloat = 44
         static let popoverTopDistance: CGFloat = 16
         static let horizontalMargin: CGFloat = 16
         static let viewCornerRadius: CGFloat = 8
         static let headerLabelDistance: CGFloat = 2.0
-        static let headerLinesLimit: Int = 2
-        static let foxImageSize: CGFloat = 100
         static let iconSize: CGFloat = 24
-        static let protectionViewBottomSpacing: CGFloat = 70
-        static let siteDomainLabelsVerticalSpacing: CGFloat = 12
-        static let connectionDetailsLabelBottomSpacing: CGFloat = 28
         static let connectionDetailsHeaderMargins: CGFloat = 8
-        static let faviconImageSize: CGFloat = 40
-        static let closeButtonSize: CGFloat = 30
         static let faviconCornerRadius: CGFloat = 5
-        static let scrollContentHorizontalPadding: CGFloat = 16
-
-        static let trackersLabelConstraintConstant = 16.0
-        static let connectionStatusLabelConstraintConstant = 16.0
-        static let toggleLabelsContainerConstraintConstant = 16.0
-
         static let clearDataButtonCornerRadius: CGFloat = 12
         static let clearDataButtonBorderWidth: CGFloat = 1
         static let settingsLinkButtonBottomSpacing: CGFloat = 32
-        static let connectionDetailsStackSpacing = 15.0
-
         static let modalMenuCornerRadius: CGFloat = 12
         struct Line {
             static let height: CGFloat = 1
-        }
-        struct TrackingDetails {
-            static let baseDistance: CGFloat = 20
-            static let imageMargins: CGFloat = 10
-            static let bottomDistance: CGFloat = 350
-            static let viewCertButtonTopDistance: CGFloat = 8.0
-        }
-        struct BlockedTrackers {
-            static let headerDistance: CGFloat = 8
         }
     }
 }
@@ -64,8 +32,7 @@ protocol TrackingProtectionMenuDelegate: AnyObject {
     func didFinish()
 }
 
-// TODO: FXIOS-9726 #21369 - Refactor/Split TrackingProtectionViewController UI into more custom views
-class TrackingProtectionViewController: UIViewController, Themeable, Notifiable, UIScrollViewDelegate, BottomSheetChild {
+class TrackingProtectionViewController: UIViewController, Themeable, Notifiable, UIScrollViewDelegate {
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
@@ -74,98 +41,22 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
 
     weak var enhancedTrackingProtectionMenuDelegate: TrackingProtectionMenuDelegate?
 
-    private var faviconHeightConstraint: NSLayoutConstraint?
-    private var faviconWidthConstraint: NSLayoutConstraint?
     private var foxImageHeightConstraint: NSLayoutConstraint?
-    private var shieldImageHeightConstraint: NSLayoutConstraint?
-    private var lockImageHeightConstraint: NSLayoutConstraint?
-    private var trackersLabelTopConstraint: NSLayoutConstraint?
-    private var trackersLabelBottomConstraint: NSLayoutConstraint?
-
-    private var trackersArrowHeightConstraint: NSLayoutConstraint?
-    private var connectionArrowHeightConstraint: NSLayoutConstraint?
 
     private lazy var scrollView: UIScrollView = .build { scrollView in
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.showsVerticalScrollIndicator = false
     }
 
-    private let baseView: UIView = .build { view in
-        view.translatesAutoresizingMaskIntoConstraints = false
-    }
+    private let baseView: UIView = .build()
 
     // MARK: UI components Header View
-    private let headerContainer: UIView = .build { view in
-        view.backgroundColor = .clear
-    }
-
-    private lazy var headerLabelsContainer: UIStackView = .build { stack in
-        stack.backgroundColor = .clear
-        stack.alignment = .leading
-        stack.axis = .vertical
-        stack.spacing = TPMenuUX.UX.headerLabelDistance
-    }
-
-    private var favicon: FaviconImageView = .build { favicon in
-        favicon.manuallySetImage(
-            UIImage(named: StandardImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysTemplate) ?? UIImage())
-    }
-
-    private let siteDisplayTitleLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.headline.scaledFont()
-        label.numberOfLines = TPMenuUX.UX.headerLinesLimit
-        label.adjustsFontForContentSizeCategory = true
-        label.translatesAutoresizingMaskIntoConstraints = false
-    }
-
-    private let siteDomainLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.caption1.scaledFont()
-        label.numberOfLines = 0
-        label.adjustsFontForContentSizeCategory = true
-        label.translatesAutoresizingMaskIntoConstraints = false
-    }
-
-    private var closeButton: CloseButton = .build { button in
-        button.layer.cornerRadius = 0.5 * TPMenuUX.UX.closeButtonSize
-    }
+    private var headerContainer: TrackingProtectionHeaderView = .build()
 
     // MARK: Connection Details View
-    private let connectionDetailsHeaderView: UIView = .build { view in
-        view.layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
-        view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-        view.layer.masksToBounds = true
-    }
-    private let connectionDetailsContentView: UIView = .build { view in
-        view.layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
-        view.layer.masksToBounds = true
-    }
-
-    private let foxStatusImage: UIImageView = .build { image in
-        image.contentMode = .scaleAspectFit
-        image.clipsToBounds = true
-    }
-
-    private var connectionDetailsLabelsContainer: UIStackView = .build { stack in
-        stack.backgroundColor = .clear
-        stack.distribution = .fillProportionally
-        stack.alignment = .leading
-        stack.axis = .vertical
-        stack.spacing = TPMenuUX.UX.connectionDetailsStackSpacing
-    }
-
-    private var connectionDetailsTitleLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Bold.subheadline.scaledFont()
-        label.numberOfLines = 0
-        label.adjustsFontForContentSizeCategory = true
-    }
-
-    private let connectionDetailsStatusLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.subheadline.scaledFont()
-        label.numberOfLines = 0
-        label.adjustsFontForContentSizeCategory = true
-    }
+    private var connectionDetailsHeaderView: TrackingProtectionConnectionDetailsView = .build()
 
     // MARK: Blocked Trackers View
+    private var trackersView: TrackingProtectionBlockedTrackersView = .build()
     private var trackersConnectionContainer: UIStackView = .build { stack in
         stack.backgroundColor = .clear
         stack.distribution = .fillProportionally
@@ -173,91 +64,12 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
         stack.axis = .vertical
     }
 
-    private let trackersView: UIView = .build { view in
-        view.backgroundColor = .clear
-    }
-
-    private let shieldImage: UIImageView = .build { image in
-        image.contentMode = .scaleAspectFit
-        image.clipsToBounds = true
-        image.layer.masksToBounds = true
-        image.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.shield)
-            .withRenderingMode(.alwaysTemplate)
-    }
-
-    private let trackersLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.body.scaledFont()
-        label.numberOfLines = 0
-        label.adjustsFontForContentSizeCategory = true
-    }
-
-    private let trackersDetailArrow: UIImageView = .build { image in
-        image.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.chevronLeft)
-            .withRenderingMode(.alwaysTemplate)
-            .imageFlippedForRightToLeftLayoutDirection()
-        image.transform = CGAffineTransform(rotationAngle: .pi)
-    }
-
-    private let trackersHorizontalLine: UIView = .build { _ in }
-    private let trackersButton: UIButton = .build { button in }
-
     // MARK: Connection Status View
-    private let connectionView: UIView = .build { view in
-        view.backgroundColor = .clear
-    }
-
-    private let connectionStatusImage: UIImageView = .build { image in
-        image.contentMode = .scaleAspectFit
-        image.clipsToBounds = true
-        image.layer.masksToBounds = true
-    }
-
-    private let connectionStatusLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.body.scaledFont()
-        label.numberOfLines = 0
-        label.adjustsFontForContentSizeCategory = true
-    }
-
-    private let connectionDetailArrow: UIImageView = .build { image in
-        image.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.chevronLeft)
-            .withRenderingMode(.alwaysTemplate)
-            .imageFlippedForRightToLeftLayoutDirection()
-        image.transform = CGAffineTransform(rotationAngle: .pi)
-    }
-
-    private let connectionButton: UIButton = .build { button in }
-    private let connectionHorizontalLine: UIView = .build { _ in }
+    private let connectionStatusView: TrackingProtectionConnectionStatusView = .build()
+    private let connectionHorizontalLine: UIView = .build()
 
     // MARK: Toggle View
-    private let toggleView: UIView = .build { view in
-        view.layer.cornerRadius = TPMenuUX.UX.viewCornerRadius
-        view.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-        view.backgroundColor = .clear
-        view.translatesAutoresizingMaskIntoConstraints = false
-    }
-    private let toggleLabelsContainer: UIStackView = .build { stack in
-        stack.backgroundColor = .clear
-        stack.distribution = .fill
-        stack.alignment = .leading
-        stack.axis = .vertical
-        stack.spacing = TPMenuUX.UX.headerLabelDistance
-    }
-
-    private let toggleLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.body.scaledFont()
-        label.numberOfLines = 0
-        label.adjustsFontForContentSizeCategory = true
-    }
-
-    private let toggleSwitch: UISwitch = .build { toggleSwitch in
-        toggleSwitch.isEnabled = true
-    }
-
-    private let toggleStatusLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.caption1.scaledFont()
-        label.numberOfLines = 0
-        label.adjustsFontForContentSizeCategory = true
-    }
+    private let toggleView: TrackingProtectionToggleView = .build()
 
     // MARK: Clear Cookies View
     private lazy var clearCookiesButton: TrackingProtectionButton = .build { button in
@@ -385,74 +197,25 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
 
     // MARK: Header Setup
     private func setupHeaderView() {
-        headerLabelsContainer.addArrangedSubview(siteDisplayTitleLabel)
-        headerLabelsContainer.addArrangedSubview(siteDomainLabel)
-
-        headerContainer.addSubviews(favicon, headerLabelsContainer, closeButton)
         view.addSubview(headerContainer)
-
-        faviconHeightConstraint = favicon.heightAnchor.constraint(equalToConstant: TPMenuUX.UX.faviconImageSize)
-        faviconWidthConstraint = favicon.widthAnchor.constraint(equalToConstant: TPMenuUX.UX.faviconImageSize)
-        let topDistance = asPopover ? TPMenuUX.UX.popoverTopDistance : 0
-
         let headerConstraints = [
             headerContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             headerContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             headerContainer.topAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.topAnchor,
-                constant: topDistance
-            ),
-
-            favicon.leadingAnchor.constraint(
-                equalTo: headerContainer.leadingAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-            favicon.centerYAnchor.constraint(equalTo: headerContainer.centerYAnchor),
-            faviconHeightConstraint!,
-            faviconWidthConstraint!,
-
-            headerLabelsContainer.topAnchor.constraint(
-                equalTo: headerContainer.topAnchor,
-                constant: TPMenuUX.UX.siteDomainLabelsVerticalSpacing
-            ),
-            headerLabelsContainer.bottomAnchor.constraint(
-                equalTo: headerContainer.bottomAnchor,
-                constant: -TPMenuUX.UX.siteDomainLabelsVerticalSpacing
-            ),
-            headerLabelsContainer.leadingAnchor.constraint(
-                equalTo: favicon.trailingAnchor,
-                constant: TPMenuUX.UX.siteDomainLabelsVerticalSpacing
-            ),
-            headerLabelsContainer.trailingAnchor.constraint(
-                equalTo: closeButton.leadingAnchor,
-                constant: -TPMenuUX.UX.horizontalMargin
-            ),
-
-            closeButton.trailingAnchor.constraint(
-                equalTo: headerContainer.trailingAnchor,
-                constant: -TPMenuUX.UX.horizontalMargin
-            ),
-            closeButton.topAnchor.constraint(
-                equalTo: headerContainer.topAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-            closeButton.heightAnchor.constraint(greaterThanOrEqualToConstant: TPMenuUX.UX.closeButtonSize),
-            closeButton.widthAnchor.constraint(greaterThanOrEqualToConstant: TPMenuUX.UX.closeButtonSize),
+                constant: asPopover ? TPMenuUX.UX.popoverTopDistance : 0
+            )
         ]
-
         constraints.append(contentsOf: headerConstraints)
+        headerContainer.closeButtonCallback = { [weak self] in
+            self?.enhancedTrackingProtectionMenuDelegate?.didFinish()
+        }
     }
 
     // MARK: Connection Status Header Setup
     private func setupConnectionHeaderView() {
-        connectionDetailsLabelsContainer.addArrangedSubview(connectionDetailsTitleLabel)
-        connectionDetailsLabelsContainer.addArrangedSubview(connectionDetailsStatusLabel)
-        connectionDetailsContentView.addSubviews(foxStatusImage, connectionDetailsLabelsContainer)
-        connectionDetailsHeaderView.addSubview(connectionDetailsContentView)
-
         baseView.addSubviews(connectionDetailsHeaderView)
         let connectionHeaderConstraints = [
-            // Section
             connectionDetailsHeaderView.leadingAnchor.constraint(
                 equalTo: view.leadingAnchor,
                 constant: TPMenuUX.UX.horizontalMargin
@@ -461,71 +224,17 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
                 equalTo: view.trailingAnchor,
                 constant: -TPMenuUX.UX.horizontalMargin
             ),
-            connectionDetailsHeaderView.topAnchor.constraint(equalTo: baseView.topAnchor,
-                                                             constant: TPMenuUX.UX.connectionDetailsHeaderMargins),
-            // Content
-            connectionDetailsContentView.leadingAnchor.constraint(
-                equalTo: connectionDetailsHeaderView.leadingAnchor,
-                constant: TPMenuUX.UX.connectionDetailsHeaderMargins
-            ),
-            connectionDetailsContentView.trailingAnchor.constraint(
-                equalTo: connectionDetailsHeaderView.trailingAnchor,
-                constant: -TPMenuUX.UX.connectionDetailsHeaderMargins
-            ),
-            connectionDetailsContentView.topAnchor.constraint(equalTo: connectionDetailsHeaderView.topAnchor,
-                                                              constant: TPMenuUX.UX.connectionDetailsHeaderMargins),
-            connectionDetailsContentView.bottomAnchor.constraint(equalTo: connectionDetailsHeaderView.bottomAnchor,
-                                                                 constant: -TPMenuUX.UX.connectionDetailsHeaderMargins / 2),
-            // Image
-            foxStatusImage.leadingAnchor.constraint(
-                equalTo: connectionDetailsContentView.leadingAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-            foxStatusImage.topAnchor.constraint(
-                equalTo: connectionDetailsContentView.topAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-            foxStatusImage.heightAnchor.constraint(equalToConstant: TPMenuUX.UX.foxImageSize),
-            foxStatusImage.widthAnchor.constraint(equalToConstant: TPMenuUX.UX.foxImageSize),
-
-            // Labels
-            connectionDetailsLabelsContainer.topAnchor.constraint(
-                equalTo: connectionDetailsContentView.topAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-            connectionDetailsLabelsContainer.bottomAnchor.constraint(
-                equalTo: connectionDetailsContentView.bottomAnchor,
-                constant: -TPMenuUX.UX.connectionDetailsLabelBottomSpacing / 2
-            ),
-            connectionDetailsLabelsContainer.leadingAnchor.constraint(equalTo: foxStatusImage.trailingAnchor,
-                                                                      constant: TPMenuUX.UX.siteDomainLabelsVerticalSpacing),
-            connectionDetailsLabelsContainer.trailingAnchor.constraint(equalTo:
-                                                                        connectionDetailsContentView.trailingAnchor,
-                                                                       constant: -TPMenuUX.UX.horizontalMargin),
-            connectionDetailsLabelsContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: TPMenuUX.UX.foxImageSize),
+            connectionDetailsHeaderView.topAnchor.constraint(
+                equalTo: baseView.topAnchor,
+                constant: TPMenuUX.UX.connectionDetailsHeaderMargins),
         ]
-
         constraints.append(contentsOf: connectionHeaderConstraints)
     }
 
     // MARK: Blocked Trackers Setup
     private func setupBlockedTrackersView() {
-        trackersView.addSubviews(shieldImage, trackersLabel, trackersDetailArrow, trackersButton, trackersHorizontalLine)
         baseView.addSubview(trackersConnectionContainer)
         trackersConnectionContainer.addArrangedSubview(trackersView)
-
-        shieldImageHeightConstraint = shieldImage.heightAnchor.constraint(equalToConstant: TPMenuUX.UX.iconSize)
-        trackersArrowHeightConstraint = trackersDetailArrow.heightAnchor.constraint(
-            equalToConstant: TPMenuUX.UX.iconSize
-        )
-
-        trackersLabelTopConstraint = trackersLabel.topAnchor.constraint(
-            equalTo: trackersView.topAnchor,
-            constant: TPMenuUX.UX.trackersLabelConstraintConstant)
-        trackersLabelBottomConstraint = trackersLabel.bottomAnchor.constraint(
-            equalTo: trackersView.bottomAnchor,
-            constant: -TPMenuUX.UX.trackersLabelConstraintConstant)
-
         let blockedTrackersConstraints = [
             trackersView.leadingAnchor.constraint(
                 equalTo: view.leadingAnchor,
@@ -535,162 +244,60 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
                 equalTo: view.trailingAnchor,
                 constant: -TPMenuUX.UX.horizontalMargin
             ),
-            trackersView.topAnchor.constraint(equalTo: connectionDetailsHeaderView.bottomAnchor, constant: 0),
-
-            shieldImage.leadingAnchor.constraint(
-                equalTo: trackersView.leadingAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-            shieldImage.centerYAnchor.constraint(equalTo: trackersView.centerYAnchor),
-            shieldImage.heightAnchor.constraint(equalTo: shieldImage.widthAnchor),
-            shieldImageHeightConstraint!,
-            trackersLabel.leadingAnchor.constraint(
-                equalTo: shieldImage.trailingAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-            trackersLabel.trailingAnchor.constraint(
-                equalTo: trackersDetailArrow.leadingAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-
-            trackersDetailArrow.trailingAnchor.constraint(
-                equalTo: connectionView.trailingAnchor,
-                constant: -TPMenuUX.UX.horizontalMargin
-            ),
-            trackersDetailArrow.centerYAnchor.constraint(equalTo: trackersView.centerYAnchor),
-            trackersArrowHeightConstraint!,
-            trackersDetailArrow.widthAnchor.constraint(equalTo: trackersDetailArrow.heightAnchor),
-
-            trackersButton.leadingAnchor.constraint(equalTo: trackersView.leadingAnchor),
-            trackersButton.topAnchor.constraint(equalTo: trackersView.topAnchor),
-            trackersButton.trailingAnchor.constraint(equalTo: trackersView.trailingAnchor),
-            trackersButton.bottomAnchor.constraint(equalTo: trackersView.bottomAnchor),
-
-            trackersHorizontalLine.leadingAnchor.constraint(equalTo: trackersLabel.leadingAnchor),
-            trackersHorizontalLine.trailingAnchor.constraint(equalTo: trackersView.trailingAnchor,
-                                                             constant: -TPMenuUX.UX.connectionDetailsHeaderMargins),
-            trackersHorizontalLine.heightAnchor.constraint(equalToConstant: TPMenuUX.UX.Line.height),
-            trackersView.bottomAnchor.constraint(equalTo: trackersHorizontalLine.bottomAnchor),
+            trackersView.topAnchor.constraint(equalTo: connectionDetailsHeaderView.bottomAnchor),
         ]
-
-        if let trackersLabelTopConstraint, let trackersLabelBottomConstraint {
-            constraints.append(trackersLabelTopConstraint)
-            constraints.append(trackersLabelBottomConstraint)
-        }
-
         constraints.append(contentsOf: blockedTrackersConstraints)
+        trackersView.trackersButtonCallback = {}
     }
 
     // MARK: Connection Status Setup
     private func setupConnectionStatusView() {
-        connectionView.addSubviews(connectionStatusImage, connectionStatusLabel, connectionDetailArrow)
-        connectionView.addSubviews(connectionButton, connectionHorizontalLine)
-        trackersConnectionContainer.addArrangedSubview(connectionView)
-
-        lockImageHeightConstraint = connectionStatusImage.widthAnchor.constraint(
-            equalToConstant: TPMenuUX.UX.iconSize
-        )
-        connectionArrowHeightConstraint = connectionDetailArrow.heightAnchor.constraint(
-            equalToConstant: TPMenuUX.UX.iconSize
-        )
+        trackersConnectionContainer.addArrangedSubview(connectionStatusView)
+        connectionStatusView.addSubviews(connectionHorizontalLine)
         let connectionConstraints = [
-            connectionView.leadingAnchor.constraint(
+            connectionStatusView.leadingAnchor.constraint(
                 equalTo: view.leadingAnchor,
                 constant: TPMenuUX.UX.horizontalMargin
             ),
-            connectionView.trailingAnchor.constraint(
+            connectionStatusView.trailingAnchor.constraint(
                 equalTo: view.trailingAnchor,
                 constant: -TPMenuUX.UX.horizontalMargin
             ),
-            connectionView.topAnchor.constraint(equalTo: trackersView.bottomAnchor, constant: 0),
-
-            connectionStatusImage.leadingAnchor.constraint(
-                equalTo: connectionView.leadingAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-            connectionStatusImage.centerYAnchor.constraint(equalTo: connectionView.centerYAnchor),
-            lockImageHeightConstraint!,
-            connectionStatusImage.heightAnchor.constraint(equalTo: connectionView.widthAnchor),
-
-            connectionStatusLabel.leadingAnchor.constraint(
-                equalTo: connectionStatusImage.trailingAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-            connectionStatusLabel.topAnchor.constraint(equalTo: connectionView.topAnchor,
-                                                       constant: TPMenuUX.UX.connectionStatusLabelConstraintConstant),
-            connectionStatusLabel.bottomAnchor.constraint(equalTo: connectionView.bottomAnchor,
-                                                          constant: -TPMenuUX.UX.connectionStatusLabelConstraintConstant),
-            connectionStatusLabel.trailingAnchor.constraint(
-                equalTo: connectionDetailArrow.leadingAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-
-            connectionDetailArrow.trailingAnchor.constraint(
-                equalTo: connectionView.trailingAnchor,
-                constant: -TPMenuUX.UX.horizontalMargin
-            ),
-            connectionDetailArrow.centerYAnchor.constraint(equalTo: connectionView.centerYAnchor),
-            connectionArrowHeightConstraint!,
-            connectionDetailArrow.widthAnchor.constraint(equalTo: connectionDetailArrow.heightAnchor),
-
-            connectionButton.leadingAnchor.constraint(equalTo: connectionView.leadingAnchor),
-            connectionButton.topAnchor.constraint(equalTo: connectionView.topAnchor),
-            connectionButton.trailingAnchor.constraint(equalTo: connectionView.trailingAnchor),
-            connectionButton.bottomAnchor.constraint(equalTo: connectionView.bottomAnchor),
-
-            connectionHorizontalLine.leadingAnchor.constraint(equalTo: connectionView.leadingAnchor),
-            connectionHorizontalLine.trailingAnchor.constraint(equalTo: connectionView.trailingAnchor),
+            connectionStatusView.topAnchor.constraint(equalTo: trackersView.bottomAnchor),
+            connectionHorizontalLine.leadingAnchor.constraint(equalTo: connectionStatusView.leadingAnchor),
+            connectionHorizontalLine.trailingAnchor.constraint(equalTo: connectionStatusView.trailingAnchor),
             connectionHorizontalLine.heightAnchor.constraint(equalToConstant: TPMenuUX.UX.Line.height),
-            connectionView.bottomAnchor.constraint(equalTo: connectionHorizontalLine.bottomAnchor),
+            connectionStatusView.bottomAnchor.constraint(equalTo: connectionHorizontalLine.bottomAnchor)
         ]
-
         constraints.append(contentsOf: connectionConstraints)
+        connectionStatusView.connectionStatusButtonCallback = {
+            // TODO: FXIOS-9198 #20366 Enhanced Tracking Protection Connection details screen
+            //        let detailsVC = TrackingProtectionDetailsViewController(with: viewModel.getDetailsModel(),
+            //                                                                windowUUID: windowUUID)
+            //        detailsVC.modalPresentationStyle = .pageSheet
+            //        self.present(detailsVC, animated: true)
+        }
     }
 
     // MARK: Toggle View Setup
     private func setupToggleView() {
-        toggleLabelsContainer.addArrangedSubview(toggleLabel)
-        toggleLabelsContainer.addArrangedSubview(toggleStatusLabel)
-        toggleView.addSubviews(toggleLabelsContainer, toggleSwitch)
         baseView.addSubview(toggleView)
-
         let toggleConstraints = [
             toggleView.leadingAnchor.constraint(equalTo: baseView.leadingAnchor,
                                                 constant: TPMenuUX.UX.horizontalMargin),
             toggleView.trailingAnchor.constraint(equalTo: baseView.trailingAnchor,
                                                  constant: -TPMenuUX.UX.horizontalMargin),
             toggleView.topAnchor.constraint(
-                equalTo: connectionView.bottomAnchor,
+                equalTo: connectionStatusView.bottomAnchor,
                 constant: 0
-            ),
-
-            toggleLabelsContainer.leadingAnchor.constraint(
-                equalTo: toggleView.leadingAnchor,
-                constant: TPMenuUX.UX.horizontalMargin
-            ),
-            toggleLabelsContainer.trailingAnchor.constraint(
-                equalTo: toggleSwitch.leadingAnchor,
-                constant: -TPMenuUX.UX.horizontalMargin
-            ),
-            toggleLabelsContainer.topAnchor.constraint(
-                equalTo: toggleView.topAnchor,
-                constant: TPMenuUX.UX.toggleLabelsContainerConstraintConstant
-            ),
-            toggleLabelsContainer.bottomAnchor.constraint(
-                equalTo: toggleView.bottomAnchor,
-                constant: -TPMenuUX.UX.toggleLabelsContainerConstraintConstant
-            ),
-
-            toggleSwitch.centerYAnchor.constraint(equalTo: toggleView.centerYAnchor),
-            toggleSwitch.trailingAnchor.constraint(
-                equalTo: toggleView.trailingAnchor,
-                constant: -TPMenuUX.UX.horizontalMargin
             )
         ]
-
         constraints.append(contentsOf: toggleConstraints)
-        toggleSwitch.actions(forTarget: self, forControlEvent: .valueChanged)
-        view.bringSubviewToFront(toggleSwitch)
+        toggleView.toggleSwitchedCallback = { [weak self] in
+            // site is safelisted if site ETP is disabled
+            self?.viewModel.toggleSiteSafelistStatus()
+            self?.updateProtectionViewStatus()
+        }
     }
 
     // MARK: Clear Cookies Button Setup
@@ -741,40 +348,29 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
     }
 
     private func updateViewDetails() {
-        favicon.setFavicon(FaviconImageViewModel(siteURLString: viewModel.url.absoluteString,
-                                                 faviconCornerRadius: TPMenuUX.UX.faviconCornerRadius))
+        let headerIcon = FaviconImageViewModel(siteURLString: viewModel.url.absoluteString,
+                                               faviconCornerRadius: TPMenuUX.UX.faviconCornerRadius)
+        headerContainer.setupDetails(website: viewModel.websiteTitle,
+                                     display: viewModel.displayTitle,
+                                     icon: headerIcon)
 
-        siteDomainLabel.text = viewModel.websiteTitle
-        siteDisplayTitleLabel.text = viewModel.displayTitle
-        trackersLabel.text = getTrackerString()
-        shieldImage.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.shield)
-            .withRenderingMode(.alwaysTemplate)
-        connectionStatusImage.image = viewModel.getConnectionStatusImage(themeType: currentTheme().type)
-        connectionStatusLabel.text = viewModel.connectionStatusString
-        toggleSwitch.isOn = viewModel.isSiteETPEnabled
-        viewModel.isProtectionEnabled = toggleSwitch.isOn
-        toggleLabel.text = .Menu.EnhancedTrackingProtection.switchTitle
-        toggleStatusLabel.text = toggleSwitch.isOn ?
-            .Menu.EnhancedTrackingProtection.switchOnText : .Menu.EnhancedTrackingProtection.switchOffText
-        connectionDetailsTitleLabel.text = viewModel.connectionDetailsTitle
-        connectionDetailsStatusLabel.text = viewModel.connectionDetailsHeader
-        foxStatusImage.image = viewModel.connectionDetailsImage
-    }
+        connectionDetailsHeaderView.setupDetails(title: viewModel.connectionDetailsTitle,
+                                                 status: viewModel.connectionDetailsHeader,
+                                                 image: viewModel.connectionDetailsImage)
 
-    private func getTrackerString() -> String {
-        if let trackersNumber = viewModel.contentBlockerStats?.total, trackersNumber > 0 {
-            return String(format: .Menu.EnhancedTrackingProtection.trackersBlockedLabel,
-                          String(trackersNumber))
-        } else {
-            return .Menu.EnhancedTrackingProtection.noTrackersLabel
-        }
+        trackersView.setupDetails(for: viewModel.contentBlockerStats?.total)
+        connectionStatusView.setupDetails(image: viewModel.getConnectionStatusImage(themeType: currentTheme().type),
+                                          text: viewModel.connectionStatusString)
+
+        toggleView.setupDetails(isOn: viewModel.isSiteETPEnabled)
+        viewModel.isProtectionEnabled = toggleView.toggleIsOn
     }
 
     private func setupViewActions() {
-        closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
-        connectionButton.addTarget(self, action: #selector(connectionDetailsTapped), for: .touchUpInside)
-        trackersButton.addTarget(self, action: #selector(blockedTrackersTapped), for: .touchUpInside)
-        toggleSwitch.addTarget(self, action: #selector(trackingProtectionToggleTapped), for: .valueChanged)
+        headerContainer.setupActions()
+        trackersView.setupActions()
+        connectionStatusView.setupActions()
+        toggleView.setupActions()
     }
 
     // MARK: Notifications
@@ -801,29 +397,25 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
 
     // MARK: Accessibility
     private func setupAccessibilityIdentifiers() {
-        foxStatusImage.accessibilityIdentifier = viewModel.foxImageA11yId
-        trackersDetailArrow.accessibilityIdentifier = viewModel.arrowImageA11yId
-        trackersLabel.accessibilityIdentifier = viewModel.trackersBlockedLabelA11yId
-        connectionDetailArrow.accessibilityIdentifier = viewModel.arrowImageA11yId
-        shieldImage.accessibilityIdentifier = viewModel.shieldImageA11yId
-        connectionStatusLabel.accessibilityIdentifier = viewModel.securityStatusLabelA11yId
-        toggleLabel.accessibilityIdentifier = viewModel.toggleViewTitleLabelA11yId
-        toggleStatusLabel.accessibilityIdentifier = viewModel.toggleViewBodyLabelA11yId
+        connectionDetailsHeaderView.setupAccessibilityIdentifiers(foxImageA11yId: viewModel.foxImageA11yId)
+        trackersView.setupAccessibilityIdentifiers(
+            arrowImageA11yId: viewModel.arrowImageA11yId,
+            trackersBlockedLabelA11yId: viewModel.trackersBlockedLabelA11yId,
+            shieldImageA11yId: viewModel.settingsA11yId)
+        connectionStatusView.setupAccessibilityIdentifiers(
+            arrowImageA11yId: viewModel.arrowImageA11yId,
+            securityStatusLabelA11yId: viewModel.securityStatusLabelA11yId)
+        toggleView.setupAccessibilityIdentifiers(
+            toggleViewTitleLabelA11yId: viewModel.toggleViewTitleLabelA11yId,
+            toggleViewBodyLabelA11yId: viewModel.toggleViewBodyLabelA11yId)
         clearCookiesButton.accessibilityIdentifier = viewModel.clearCookiesButtonA11yId
         settingsLinkButton.accessibilityIdentifier = viewModel.settingsA11yId
     }
 
     private func adjustLayout() {
-        let faviconSize = TPMenuUX.UX.faviconImageSize // to avoid line length warnings
-        let iconSize = TPMenuUX.UX.iconSize
-        faviconHeightConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: faviconSize), 2 * faviconSize)
-        faviconWidthConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: faviconSize), 2 * faviconSize)
-
-        shieldImageHeightConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: iconSize), 2 * iconSize)
-        trackersArrowHeightConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: iconSize), 2 * iconSize)
-
-        lockImageHeightConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: iconSize), 2 * iconSize)
-        connectionArrowHeightConstraint?.constant = min(UIFontMetrics.default.scaledValue(for: iconSize), 2 * iconSize)
+        headerContainer.adjustLayout()
+        trackersView.adjustLayout()
+        connectionStatusView.adjustLayout()
 
         if #available(iOS 16.0, *), UIDevice.current.userInterfaceIdiom == .phone {
             headerContainer.layoutIfNeeded()
@@ -840,30 +432,6 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
     }
 
     // MARK: - Button actions
-    @objc
-    func closeButtonTapped() {
-        enhancedTrackingProtectionMenuDelegate?.didFinish()
-    }
-
-    @objc
-    func connectionDetailsTapped() {
-        // TODO: FXIOS-9198 #20366 Enhanced Tracking Protection Connection details screen
-        //        let detailsVC = TrackingProtectionDetailsViewController(with: viewModel.getDetailsModel(),
-        //                                                                windowUUID: windowUUID)
-        //        detailsVC.modalPresentationStyle = .pageSheet
-        //        self.present(detailsVC, animated: true)
-    }
-
-    @objc
-    func blockedTrackersTapped() {}
-
-    @objc
-    func trackingProtectionToggleTapped() {
-        // site is safelisted if site ETP is disabled
-        viewModel.toggleSiteSafelistStatus()
-        updateProtectionViewStatus()
-    }
-
     @objc
     private func didTapClearCookiesAndSiteData() {
         viewModel.onTapClearCookiesAndSiteData(controller: self)
@@ -911,29 +479,21 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
         return themeManager.getCurrentTheme(for: windowUUID)
     }
 
-    func willDismiss() {
-    }
-
     // MARK: - Update Views
     private func updateProtectionViewStatus() {
-        if toggleSwitch.isOn {
-            toggleStatusLabel.text = .Menu.EnhancedTrackingProtection.switchOnText
-            trackersView.isHidden = false
-            trackersLabelTopConstraint?.constant = TPMenuUX.UX.trackersLabelConstraintConstant
-            trackersLabelBottomConstraint?.constant = -TPMenuUX.UX.trackersLabelConstraintConstant
+        if toggleView.toggleIsOn {
+            toggleView.setStatusLabelText(with: .Menu.EnhancedTrackingProtection.switchOnText)
+            trackersView.setVisibility(isHidden: false)
             viewModel.isProtectionEnabled = true
         } else {
-            toggleStatusLabel.text = .Menu.EnhancedTrackingProtection.switchOffText
-            trackersView.isHidden = true
-            trackersLabelTopConstraint?.constant = 0
-            trackersLabelBottomConstraint?.constant = 0
+            toggleView.setStatusLabelText(with: .Menu.EnhancedTrackingProtection.switchOffText)
+            trackersView.setVisibility(isHidden: true)
             viewModel.isProtectionEnabled = false
         }
-
-        connectionDetailsContentView.backgroundColor = viewModel.getConnectionDetailsBackgroundColor(theme: currentTheme())
-        foxStatusImage.image = viewModel.connectionDetailsImage
-        connectionDetailsTitleLabel.text = viewModel.connectionDetailsTitle
-        connectionDetailsStatusLabel.text = viewModel.connectionDetailsHeader
+        connectionDetailsHeaderView.setupDetails(color: viewModel.getConnectionDetailsBackgroundColor(theme: currentTheme()),
+                                                 title: viewModel.connectionDetailsTitle,
+                                                 status: viewModel.connectionDetailsHeader,
+                                                 image: viewModel.connectionDetailsImage)
     }
 }
 
@@ -943,33 +503,15 @@ extension TrackingProtectionViewController {
         let theme = currentTheme()
         overrideUserInterfaceStyle = theme.type.getInterfaceStyle()
         view.backgroundColor = theme.colors.layer1
-        closeButton.backgroundColor = theme.colors.layer2
-        let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
-            .tinted(withColor: theme.colors.iconSecondary)
-        closeButton.setImage(buttonImage, for: .normal)
+        headerContainer.applyTheme(theme: theme)
         connectionDetailsHeaderView.backgroundColor = theme.colors.layer2
-        trackersView.backgroundColor = theme.colors.layer2
-        trackersDetailArrow.tintColor = theme.colors.iconSecondary
-        shieldImage.tintColor = theme.colors.iconPrimary
-        connectionView.backgroundColor = theme.colors.layer2
-        connectionDetailArrow.tintColor = theme.colors.iconSecondary
-        connectionStatusImage.image = viewModel.getConnectionStatusImage(themeType: theme.type)
-        connectionDetailsContentView.backgroundColor = toggleSwitch.isOn ?
-        currentTheme().colors.layerAccentPrivateNonOpaque : theme.colors.layer3
-        headerContainer.tintColor = theme.colors.layer2
-        siteDomainLabel.textColor = theme.colors.textSecondary
-        siteDisplayTitleLabel.textColor = theme.colors.textPrimary
-        if viewModel.connectionSecure {
-            connectionStatusImage.tintColor = theme.colors.iconPrimary
-        }
-        toggleView.backgroundColor = theme.colors.layer2
-        toggleSwitch.tintColor = theme.colors.actionPrimary
-        toggleSwitch.onTintColor = theme.colors.actionPrimary
-        toggleStatusLabel.textColor = theme.colors.textSecondary
-
-        trackersHorizontalLine.backgroundColor = theme.colors.borderPrimary
+        trackersView.applyTheme(theme: theme)
+        connectionStatusView.applyTheme(theme: theme)
+        connectionStatusView.setConnectionStatusImage(image: viewModel.getConnectionStatusImage(themeType: theme.type),
+                                                      isConnectionSecure: viewModel.connectionSecure,
+                                                      theme: theme)
         connectionHorizontalLine.backgroundColor = theme.colors.borderPrimary
-
+        toggleView.applyTheme(theme: theme)
         clearCookiesButton.applyTheme(theme: theme)
         clearCookiesButton.layer.borderColor = theme.colors.borderPrimary.cgColor
         settingsLinkButton.applyTheme(theme: theme)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9726)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21369)

## :bulb: Description
Refactored TrackingProtectionViewController by splitting it into more custom views.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

