### PR TITLE
Refactor FXIOS-21112 Update Fonts related to LegacyTabCell

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyTabCell.swift
@@ -56,7 +56,7 @@ class LegacyTabCell: UICollectionViewCell,
     private lazy var titleText: UILabel = .build { label in
         label.isUserInteractionEnabled = false
         label.numberOfLines = 1
-        label.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12, weight: .semibold)
+        label.font = FXFontStyles.Bold.caption1.scaledFont()
     }
 
     private lazy var smallFaviconView: FaviconImageView = .build { _ in }
@@ -242,7 +242,7 @@ class LegacyTabCell: UICollectionViewCell,
         screenshotView.image = nil
         backgroundHolder.transform = .identity
         backgroundHolder.alpha = 1
-        self.titleText.font = DefaultDynamicFontHelper.preferredFont(withTextStyle: .body, size: 12, weight: .semibold)
+        self.titleText.font = FXFontStyles.Bold.caption1.scaledFont()
         layer.shadowOffset = .zero
         layer.shadowPath = nil
         layer.shadowOpacity = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9541)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21112)

## :bulb: Description
This PR replaces the usage of DefaultDynamicFontHelper with FXFontStyles for LegacyTabCell.

Before:
<img width="300" alt="Simulator Screenshot - iPhone 8 - 2024-09-03 at 15 23 07" src="https://github.com/user-attachments/assets/9097fe3a-9bb1-444e-8f71-aa748809a7f6">

After: 
<img width="300" alt="Simulator Screenshot - iPhone 8 - 2024-09-03 at 15 23 15" src="https://github.com/user-attachments/assets/5c469580-1514-4d2e-aa68-b124a674239c">

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

