### PR TITLE
Bugfix MTE-3379 Re-login steps for test_sync_disconnect_connect_fxa

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -284,12 +284,12 @@ class IntegrationTests: BaseTestCase {
         navigator.nowAt(SettingsScreen)
         app.tables.cells["SignInToSync"].tap()
         app.buttons["EmailSignIn.button"].tap()
-
-        mozWaitForElementToExist(app.secureTextFields.element(boundBy: 0))
-        app.secureTextFields.element(boundBy: 0).tap()
-        app.secureTextFields.element(boundBy: 0).typeText(userState.fxaPassword!)
-        mozWaitForElementToExist(app.webViews.buttons.element(boundBy: 0))
-        app.webViews.buttons.element(boundBy: 0).tap()
+        
+        navigator.nowAt(FxASigninScreen)
+        mozWaitForElementToExist(app.staticTexts["Enter your password"], timeout: TIMEOUT_LONG)
+        navigator.performAction(Action.FxATypePasswordExistingAccount)
+        navigator.performAction(Action.FxATapOnSignInButton)
+        mozWaitForElementToNotExist(app.staticTexts["Enter your password"], timeout: TIMEOUT_LONG)
 
         navigator.nowAt(SettingsScreen)
         mozWaitForElementToExist(app.staticTexts["GENERAL"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -284,7 +284,7 @@ class IntegrationTests: BaseTestCase {
         navigator.nowAt(SettingsScreen)
         app.tables.cells["SignInToSync"].tap()
         app.buttons["EmailSignIn.button"].tap()
-        
+
         navigator.nowAt(FxASigninScreen)
         mozWaitForElementToExist(app.staticTexts["Enter your password"], timeout: TIMEOUT_LONG)
         navigator.performAction(Action.FxATypePasswordExistingAccount)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3379)

## :bulb: Description
A change in the login page changes the indexes of buttons from the sign-in page. In particular, the test previously assumed that the "Sign in" button is the first button on the page. The button is no longer the case to be the first button, so the wrong button has been clicked ("eye" icon from password field). The test fails here:
<img width="376" alt="Screenshot 2024-09-03 at 5 10 26 PM" src="https://github.com/user-attachments/assets/e7d46ccd-79b1-490b-88ea-8640d4d08f13">

The test is updated so that `navigator.performAction` is used. The same steps are taken to enter password throughout the sync integration tests.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

