### PR TITLE
Add FXIOS-9907 Add SVG Support for favicons [Favicon Refactor]

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -77,9 +77,7 @@ let package = Package(
             swiftSettings: [.unsafeFlags(["-enable-testing"])]),
         .testTarget(
             name: "SiteImageViewTests",
-            dependencies: ["SiteImageView"],
-            resources: [.copy("testSVG")]
-        ),
+            dependencies: ["SiteImageView"]),
         .target(
             name: "Common",
             dependencies: ["Dip",

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -57,7 +57,10 @@ let package = Package(
             url: "https://github.com/getsentry/sentry-cocoa.git",
             exact: "8.35.0"),
         .package(url: "https://github.com/nbhasin2/GCDWebServer.git",
-                 branch: "master")
+                branch: "master"),
+        .package(
+            url: "https://github.com/SVGKit/SVGKit.git",
+            exact: "3.0.0"),
     ],
     targets: [
         .target(
@@ -69,7 +72,7 @@ let package = Package(
             dependencies: ["ComponentLibrary"]),
         .target(
             name: "SiteImageView",
-            dependencies: ["Fuzi", "Kingfisher", "Common"],
+            dependencies: ["Fuzi", "Kingfisher", "Common", "SVGKit"],
             swiftSettings: [.unsafeFlags(["-enable-testing"])]),
         .testTarget(
             name: "SiteImageViewTests",

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -56,11 +56,12 @@ let package = Package(
         .package(
             url: "https://github.com/getsentry/sentry-cocoa.git",
             exact: "8.35.0"),
-        .package(url: "https://github.com/nbhasin2/GCDWebServer.git",
-                branch: "master"),
         .package(
-            url: "https://github.com/SVGKit/SVGKit.git",
-            exact: "3.0.0"),
+            url: "https://github.com/nbhasin2/GCDWebServer.git",
+            branch: "master"),
+        .package(
+            url: "https://github.com/swhitty/SwiftDraw",
+            exact: "0.17.0"),
     ],
     targets: [
         .target(
@@ -72,11 +73,13 @@ let package = Package(
             dependencies: ["ComponentLibrary"]),
         .target(
             name: "SiteImageView",
-            dependencies: ["Fuzi", "Kingfisher", "Common", "SVGKit"],
+            dependencies: ["Fuzi", "Kingfisher", "Common", "SwiftDraw"],
             swiftSettings: [.unsafeFlags(["-enable-testing"])]),
         .testTarget(
             name: "SiteImageViewTests",
-            dependencies: ["SiteImageView"]),
+            dependencies: ["SiteImageView"],
+            resources: [.copy("testSVG")]
+        ),
         .target(
             name: "Common",
             dependencies: ["Dip",

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "BrowserKit",
     platforms: [
         .iOS(.v15),
-        .macOS(.v10_14)
+        .macOS(.v10_15)
     ],
     products: [
         .library(

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/DefaultSiteImageDownloader.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/DefaultSiteImageDownloader.swift
@@ -20,7 +20,7 @@ class DefaultSiteImageDownloader: ImageDownloader, SiteImageDownloader {
                        completionHandler: ((Result<SiteImageLoadingResult, Error>) -> Void)?
     ) -> DownloadTask? {
         return downloadImage(with: url,
-                             options: nil,
+                             options: [.processor(SVGImageProcessor())],
                              completionHandler: { result in
             switch result {
             case .success(let value):

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SVGImageProcessor.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SVGImageProcessor.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Kingfisher
+import SVGKit
+
+/// A Kingfisher image processor to parse SVG image data.
+/// - Documentation: https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#creating-your-own-processor
+public struct SVGImageProcessor: ImageProcessor {
+    // `identifier` should be the same for processors with the same properties/functionality
+    // It will be used when storing and retrieving the image to/from cache.
+    public var identifier: String = "com.mozilla.SVGImageProcessor"
+
+    // Convert input data/image to target image and return it.
+    public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
+        switch item {
+        case .image(let image):
+            // A previous processor already converted the image to an image object.
+            // You can do whatever you want to apply to the image and return the result.
+            return image
+        case .data(let data):
+            // Your own way to convert some data to an image.
+            return SVGKImage(data: data)?.uiImage
+        }
+    }
+}

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SVGImageProcessor.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SVGImageProcessor.swift
@@ -23,8 +23,13 @@ public struct SVGImageProcessor: ImageProcessor {
             // You can do whatever you want to apply to the image and return the result.
             return image
         case .data(let data):
-            // Your own way to convert some data to an image.
-            return SVG(data: data)?.rasterize(with: defaultFaviconSize)
+            if let image = UIImage(data: data) {
+                return image
+            } else if let svgImage = SVG(data: data)?.rasterize(with: defaultFaviconSize) {
+                return svgImage
+            } else {
+                return nil
+            }
         }
     }
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SVGImageProcessor.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SVGImageProcessor.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 import Kingfisher
-import SVGKit
+import SwiftDraw
 
 /// A Kingfisher image processor to parse SVG image data.
 /// - Documentation: https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#creating-your-own-processor
@@ -12,6 +12,8 @@ public struct SVGImageProcessor: ImageProcessor {
     // `identifier` should be the same for processors with the same properties/functionality
     // It will be used when storing and retrieving the image to/from cache.
     public var identifier: String = "com.mozilla.SVGImageProcessor"
+
+    private let defaultFaviconSize = CGSize(width: 360, height: 360) // FIXME Hero size?
 
     // Convert input data/image to target image and return it.
     public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
@@ -22,7 +24,7 @@ public struct SVGImageProcessor: ImageProcessor {
             return image
         case .data(let data):
             // Your own way to convert some data to an image.
-            return SVGKImage(data: data)?.uiImage
+            return SVG(data: data)?.rasterize(with: defaultFaviconSize)
         }
     }
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SVGImageProcessor.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SVGImageProcessor.swift
@@ -27,9 +27,8 @@ public struct SVGImageProcessor: ImageProcessor {
                 return image
             } else if let svgImage = SVG(data: data)?.rasterize(with: defaultFaviconSize) {
                 return svgImage
-            } else {
-                return nil
             }
+            return nil
         }
     }
 }

--- a/BrowserKit/Tests/SiteImageViewTests/SVGImageProcessorTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SVGImageProcessorTests.swift
@@ -25,7 +25,7 @@ class SVGImageProcessorTests: XCTestCase {
             }
         }
 
-        await fulfillment(of: [exp], timeout: 200.0)
+        await fulfillment(of: [exp], timeout: 2.0)
     }
 
     func testDownloadingICOImage_withKingfisherProcessor() async {

--- a/BrowserKit/Tests/SiteImageViewTests/SVGImageProcessorTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SVGImageProcessorTests.swift
@@ -45,7 +45,7 @@ class SVGImageProcessorTests: XCTestCase {
         await fulfillment(of: [exp], timeout: 2.0)
     }
 
-    func testSVGKit_processesSVG() async {
+    func testParsingAndRasterizingSVG_fromWebData() async {
         let rasterSize = CGSize(width: 240, height: 240)
 
         guard let svgData = try? Data(contentsOf: svgFaviconURL) else {

--- a/BrowserKit/Tests/SiteImageViewTests/SVGImageProcessorTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SVGImageProcessorTests.swift
@@ -8,15 +8,33 @@ import SwiftDraw
 import Kingfisher
 
 class SVGImageProcessorTests: XCTestCase {
-    let faviconURL = URL(string: "https://news.ycombinator.com/y18.svg")!
+    let svgFaviconURL = URL(string: "https://news.ycombinator.com/y18.svg")!
+    let icoFaviconURL = URL(string: "https://www.mozilla.org/favicon.ico")!
 
     func testDownloadingSVGImage_withKingfisherProcessor() async {
         let exp = expectation(description: "Image download and parse")
 
         let siteDownloader = DefaultSiteImageDownloader()
-        siteDownloader.downloadImage(with: faviconURL, options: [.processor(SVGImageProcessor())]) { result in
+        siteDownloader.downloadImage(with: svgFaviconURL, options: [.processor(SVGImageProcessor())]) { result in
             switch result {
-            case .success(let value):
+            case .success:
+                exp.fulfill()
+            case .failure(let error):
+                XCTFail("Should not have an error: \(error) \(error.errorDescription ?? "")")
+                exp.fulfill()
+            }
+        }
+
+        await fulfillment(of: [exp], timeout: 200.0)
+    }
+
+    func testDownloadingICOImage_withKingfisherProcessor() async {
+        let exp = expectation(description: "Image download and parse")
+
+        let siteDownloader = DefaultSiteImageDownloader()
+        siteDownloader.downloadImage(with: icoFaviconURL, options: [.processor(SVGImageProcessor())]) { result in
+            switch result {
+            case .success:
                 exp.fulfill()
             case .failure(let error):
                 XCTFail("Should not have an error: \(error) \(error.errorDescription ?? "")")
@@ -30,7 +48,7 @@ class SVGImageProcessorTests: XCTestCase {
     func testSVGKit_processesSVG() async {
         let rasterSize = CGSize(width: 240, height: 240)
 
-        guard let svgData = try? Data(contentsOf: faviconURL) else {
+        guard let svgData = try? Data(contentsOf: svgFaviconURL) else {
             XCTFail("Failed to download SVG image")
             return
         }

--- a/BrowserKit/Tests/SiteImageViewTests/SVGImageProcessorTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SVGImageProcessorTests.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import SiteImageView
+import SwiftDraw
+import Kingfisher
+
+class SVGImageProcessorTests: XCTestCase {
+    let faviconURL = URL(string: "https://news.ycombinator.com/y18.svg")!
+
+    func testDownloadingSVGImage_withKingfisherProcessor() async {
+        let exp = expectation(description: "Image download and parse")
+
+        let siteDownloader = DefaultSiteImageDownloader()
+        siteDownloader.downloadImage(with: faviconURL, options: [.processor(SVGImageProcessor())]) { result in
+            switch result {
+            case .success(let value):
+                exp.fulfill()
+            case .failure(let error):
+                XCTFail("Should not have an error: \(error) \(error.errorDescription ?? "")")
+                exp.fulfill()
+            }
+        }
+
+        await fulfillment(of: [exp], timeout: 2.0)
+    }
+
+    func testSVGKit_processesSVG() async {
+        let rasterSize = CGSize(width: 240, height: 240)
+
+        guard let svgData = try? Data(contentsOf: faviconURL) else {
+            XCTFail("Failed to download SVG image")
+            return
+        }
+
+        guard let svgParsed = SVG(data: svgData) else {
+            XCTFail("Failed to parse SVG data")
+            return
+        }
+
+        // Test
+        let imageFromData = svgParsed.rasterize(with: rasterSize)
+        XCTAssertEqual(imageFromData.size, rasterSize)
+    }
+}

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "cocoalumberjack",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
-      "state" : {
-        "revision" : "4b8714a7fb84d42393314ce897127b3939885ec3",
-        "version" : "3.8.5"
-      }
-    },
-    {
       "identity" : "dip",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AliSoftware/Dip.git",
@@ -127,15 +118,6 @@
       }
     },
     {
-      "identity" : "svgkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SVGKit/SVGKit",
-      "state" : {
-        "revision" : "58152b9f7c85eab239160b36ffdfd364aa43d666",
-        "version" : "3.0.0"
-      }
-    },
-    {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
@@ -163,12 +145,12 @@
       }
     },
     {
-      "identity" : "swift-log",
+      "identity" : "swiftdraw",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log",
+      "location" : "https://github.com/swhitty/SwiftDraw",
       "state" : {
-        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
-        "version" : "1.6.1"
+        "revision" : "a5c680f07b33f4cc9a451491b417b8119de23c6e",
+        "version" : "0.17.0"
       }
     },
     {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "cocoalumberjack",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
+      "state" : {
+        "revision" : "4b8714a7fb84d42393314ce897127b3939885ec3",
+        "version" : "3.8.5"
+      }
+    },
+    {
       "identity" : "dip",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AliSoftware/Dip.git",
@@ -118,6 +127,15 @@
       }
     },
     {
+      "identity" : "svgkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SVGKit/SVGKit",
+      "state" : {
+        "revision" : "58152b9f7c85eab239160b36ffdfd364aa43d666",
+        "version" : "3.0.0"
+      }
+    },
+    {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
@@ -142,6 +160,15 @@
       "state" : {
         "revision" : "f0525da24dc3c6cbb2b6b338b65042bc91cbc4bb",
         "version" : "3.3.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9907)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21725)

Also a related feature request:
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9807)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21536)


## :bulb: Description
This PR solves a feature request and what appeared to be a regression after the v131 favicon refactor.

SVG images have never been handled by our app. So now that we are no longer bundling favicon images, it became apparent with sites like [Hacker News](https://news.ycombinator.com/) (which use [favicon.svg](https://news.ycombinator.com/y18.svg)) did not download the correct favicon.

We are using the lightweight [SwiftDraw](https://github.com/swhitty/SwiftDraw) package and a new [Kingfisher Image Processor](https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#creating-your-own-processor) to handle SVG images.

@issammani also mentioned a possible JavaScript solution:
> The only native way I know of is using the browser's svg rendering engine. In theory, we could send the url response contents to JS and use  [canvas.toBlob()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob) to convert the "svg text"  to png or jpeg data and send that back. It should work but I haven't tried it yet.

For now this Swift Package works well and is lightweight. It also enables us to continue using our existing code paths by simply adding SVG support to Kingfisher, so we don't have to do any re-architecting of the current favicon solution.

### Testing Details

1. Visit https://news.ycombinator.com/
2. Ensure you see a "Y" icon and not a fallback "N" letter icon
3. Test other sites continue to render favicons like usual

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

