### PR TITLE
Bugfix MTE-3380 Update L10n screenshot tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -126,3 +126,9 @@ class L10nBaseSnapshotTests: XCTestCase {
         mozWaitForElementToNotExist(progressIndicator, timeout: 30.0)
     }
 }
+
+extension XCUIElement {
+    func tapOnApp() {
+        coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -54,6 +54,22 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         // Swipe to the Homescreen
         app.buttons["\(rootA11yId)SecondaryButton"].tap()
         currentScreen += 1
+        mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"])
+        mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"])
+        mozWaitForElementToExist(app.buttons["\(rootA11yId)PrimaryButton"])
+        mozWaitForElementToExist(app.buttons["\(rootA11yId)SecondaryButton"])
+        snapshot("Onboarding-4")
+
+        app.buttons["\(rootA11yId)PrimaryButton"].tap()
+        currentScreen += 1
+        mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)TitleLabel"])
+        mozWaitForElementToExist(app.scrollViews.staticTexts["\(rootA11yId)DescriptionLabel"])
+        mozWaitForElementToExist(app.buttons["\(rootA11yId)PrimaryButton"])
+        mozWaitForElementToExist(app.buttons["\(rootA11yId)SecondaryButton"])
+        snapshot("Onboarding-5")
+
+        app.buttons["\(rootA11yId)PrimaryButton"].tap()
+        currentScreen += 1
         mozWaitForElementToExist(app.textFields["url"])
         mozWaitForElementToExist(app.webViews["contentView"])
         snapshot("Homescreen-first-visit")

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -164,46 +164,4 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         app.tables["Login Detail List"].cells.element(boundBy: 4).tap()
         snapshot("RemoveLoginDetailedView")
     }
-
-    @MainActor
-    func testFakespotAvailable() throws {
-        navigator.openURL("https://www.walmart.com")
-        waitUntilPageLoad()
-
-        // Search for and open a shoe listing
-        let website = app.webViews["contentView"].firstMatch
-        mozWaitForElementToExist(website.searchFields["Search"])
-        website.searchFields["Search"].tap()
-        website.searchFields["Search"].typeText("end table")
-        mozWaitForElementToExist(website.otherElements.buttons.firstMatch, timeout: 30)
-        website.otherElements.buttons.element(boundBy: 1).tap()
-        waitUntilPageLoad()
-        app.swipeUp()
-        mozWaitForElementToExist(website.staticTexts["Sponsored"].firstMatch)
-        mozWaitForElementToExist(website.staticTexts["Options"].firstMatch)
-        website.staticTexts["Options"].firstMatch.tap()
-
-        // Tap the shopping cart icon
-        waitUntilPageLoad()
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shoppingButton])
-        app.buttons[AccessibilityIdentifiers.Toolbar.shoppingButton].tap()
-        mozWaitForElementToExist(app.staticTexts[AccessibilityIdentifiers.Shopping.sheetHeaderTitle])
-        snapshot("ReviewChecker")
-
-        // Open Menu
-        app.buttons["Shopping.OptInCard.MainButton"].tap()
-        snapshot("YesTryIt")
-
-        // Tap on each option in that menu
-        mozWaitForElementToExist(app.buttons["Shopping.ReviewQualityCard.ExpandButton"])
-        app.buttons["Shopping.ReviewQualityCard.ExpandButton"].tap()
-        snapshot("ReviewQualityCard-1")
-        app.swipeUp(velocity: 15)
-        snapshot("ReviewQualityCard-2")
-        app.buttons["Shopping.ReviewQualityCard.ExpandButton"].tap()
-
-        mozWaitForElementToExist(app.buttons["Shopping.SettingsCard.ExpandButton"])
-        app.buttons["Shopping.SettingsCard.ExpandButton"].tap()
-        snapshot("SettingsCard")
-    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3380)

## :bulb: Description
`testIntro()` and `testFakespotAvailable()` have been failing. `testIntro()` may be updated for the new additional welcome screens. `testFakespotAvailable()` may be removed because Fakespot no longer applies to Firefox iOS.

See "Generate Screenshots" step from this failed Bitrise workflow: https://app.bitrise.io/build/50ee192d-421c-48df-be06-138196ac5a10 (Note: The passing green checkmark is misleading.)

L10nBuild with this branch: https://app.bitrise.io/build/aab7b0b8-1d13-4650-bb86-868e1074cda1

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

