### PR TITLE
Bugfix FXIOS-9925 ⁃ Unhide/Hide arrow icon for Trackers blocked view when (No) trackers are found

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionBlockedTrackersView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionBlockedTrackersView.swift
@@ -109,7 +109,7 @@ final class TrackingProtectionBlockedTrackersView: UIView, ThemeApplicable {
         shieldImage.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.shield)
             .withRenderingMode(.alwaysTemplate)
         if let trackersBlocked {
-            trackersDetailArrow.isHidden = trackersBlocked > 0 ? false : true
+            trackersDetailArrow.isHidden = trackersBlocked == 0
         }
     }
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionBlockedTrackersView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionBlockedTrackersView.swift
@@ -108,6 +108,9 @@ final class TrackingProtectionBlockedTrackersView: UIView, ThemeApplicable {
         trackersLabel.text = getTrackerString(for: trackersBlocked)
         shieldImage.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.shield)
             .withRenderingMode(.alwaysTemplate)
+        if let trackersBlocked {
+            trackersDetailArrow.isHidden = trackersBlocked > 0 ? false : true
+        }
     }
 
     func setupAccessibilityIdentifiers(arrowImageA11yId: String,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9925)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21775)

## :bulb: Description
Hide/Unhide Trackers Blocked arrow based on the trackers blocked number.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

