### PR TITLE
Bugfix FXIOS-9294 during load of new url the previous one was changing intermittently

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -378,6 +378,7 @@ extension BrowserViewController: WKNavigationDelegate {
         // (orange color) as soon as the page has loaded.
         if let url = webView.url {
             guard !url.isReaderModeURL else { return }
+            tabManager.selectedTab?.url = url
             updateReaderModeState(for: tabManager.selectedTab, readerModeState: .unavailable)
             hideReaderModeBar(animated: false)
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1538,11 +1538,15 @@ class BrowserViewController: UIViewController,
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         if !isToolbarRefactorEnabled {
             urlBar.currentURL = url
+        } else {
+            store.dispatch(ToolbarMiddlewareAction(url: url,
+                                                   windowUUID: windowUUID,
+                                                   actionType: ToolbarMiddlewareActionType.urlDidChange))
         }
         overlayManager.finishEditing(shouldCancelLoading: false)
 
         if let nav = tab.loadRequest(URLRequest(url: url)) {
-            self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
+            recordNavigationInTab(tab, navigation: nav, visitType: visitType)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9800)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21519)

## :bulb: Description
Bug fix Address bar changin the url during the load of new web site to the previous one and then back to requested one.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

