### PR TITLE
 Add FXIOS-9641 [Native Error Page] Presenting error page using Redux 

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -12,12 +12,13 @@ class GeneralBrowserAction: Action {
     let toastType: ToastType?
     let showOverlay: Bool?
     let buttonTapped: UIButton?
-
+    let isNativeErrorPage: Bool?
     init(selectedTabURL: URL? = nil,
          isPrivateBrowsing: Bool? = nil,
          toastType: ToastType? = nil,
          showOverlay: Bool? = nil,
          buttonTapped: UIButton? = nil,
+         isNativeErrorPage: Bool? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
         self.selectedTabURL = selectedTabURL
@@ -25,6 +26,7 @@ class GeneralBrowserAction: Action {
         self.toastType = toastType
         self.buttonTapped = buttonTapped
         self.showOverlay = showOverlay
+        self.isNativeErrorPage = isNativeErrorPage
         super.init(windowUUID: windowUUID,
                    actionType: actionType)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -167,7 +167,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         case PrivateModeActionType.privateModeUpdated:
             let privacyState = action.isPrivate ?? false
             var browserViewType = state.browserViewType
-            if browserViewType != .webview {
+            if browserViewType != .webview && browserViewType != .nativeErrorPage {
                 browserViewType = privacyState ? .privateHomepage : .normalHomepage
             }
             return BrowserViewControllerState(
@@ -428,9 +428,13 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         let isAboutHomeURL = InternalURL(action.selectedTabURL)?.isAboutHomeURL ?? false
         var browserViewType = BrowserViewType.normalHomepage
         let isPrivateBrowsing = action.isPrivateBrowsing ?? false
+        let isNativeErrorPage = action.isNativeErrorPage ?? false
+        let isErrorURL = InternalURL(action.selectedTabURL)?.isErrorPage ?? false
 
         if isAboutHomeURL {
             browserViewType = isPrivateBrowsing ? .privateHomepage : .normalHomepage
+        } else if isNativeErrorPage && isErrorURL {
+            browserViewType = .nativeErrorPage
         } else {
             browserViewType = .webview
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewType.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 enum BrowserViewType {
+    case nativeErrorPage
     case normalHomepage
     case privateHomepage
     case webview

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1406,6 +1406,8 @@ class BrowserViewController: UIViewController,
                    category: .coordinator)
 
         switch browserViewType {
+        case .nativeErrorPage:
+            showEmbeddedNativeErrorPage()
         case .normalHomepage:
             showEmbeddedHomepage(inline: true, isPrivate: false)
         case .privateHomepage:

--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -20,11 +20,10 @@ class ScreenshotHelper {
         self.logger = logger
     }
 
+    // TODO: FXIOS-9978 - Screenshot of native error page for tab manager
     /// Takes a screenshot of the WebView to be displayed on the tab view page
-    /**
-     If taking a screenshot of the home page, uses our custom screenshot `UIView` extension function
-     If taking a screenshot of a website, uses apple's `takeSnapshot` function
-     */
+    /// If taking a screenshot of the home page, uses our custom screenshot `UIView` extension function
+    /// If taking a screenshot of a website, uses apple's `takeSnapshot` function
     func takeScreenshot(_ tab: Tab) {
         guard let webView = tab.webView, let url = tab.url else {
             logger.log("Tab Snapshot Error",

--- a/firefox-ios/Client/Frontend/Components/ContentContainer.swift
+++ b/firefox-ios/Client/Frontend/Components/ContentContainer.swift
@@ -36,6 +36,10 @@ class ContentContainer: UIView {
         return type == .webview
     }
 
+    var hasNativeErrorPage: Bool {
+        return type == .nativeErrorPage
+    }
+
     /// Determine if the content can be added, making sure we only add once
     /// - Parameters:
     ///   - viewController: The view controller to add to the container
@@ -75,9 +79,10 @@ class ContentContainer: UIView {
     // MARK: - Private
 
     private func removePreviousContent() {
-        // Only remove previous content when it's the homepage. We're not remving the webview controller for now
-        // since if it's not loaded, the webview doesn't layout it's WKCompositingView which result in black screen
-        guard hasHomepage || hasPrivateHomepage else { return }
+        // Only remove previous content when it's the homepage or native error page.
+        // We're not removing the webview controller for now since if it's not loaded, the
+        // webview doesn't layout it's WKCompositingView which result in black screen
+        guard hasHomepage || hasPrivateHomepage || hasNativeErrorPage else { return }
         contentController?.willMove(toParent: nil)
         contentController?.view.removeFromSuperview()
         contentController?.removeFromParent()

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -421,8 +421,16 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
 
     private func didSelectTab(_ url: URL?) {
         tabsTelemetry.stopTabSwitchMeasurement()
+        let isNativeErrorPage = featureFlags.isFeatureEnabled(.nativeErrorPage, checking: .buildOnly)
+
+        // If app starts with error url, first homepage appears and
+        // then error page is loaded. To directly load error page
+        // isNativeErrorPage flag is added. If native error page flag enabled
+        // then isNativeErrorPage = true.
+
         let action = GeneralBrowserAction(selectedTabURL: url,
                                           isPrivateBrowsing: selectedTab?.isPrivate ?? false,
+                                          isNativeErrorPage: isNativeErrorPage,
                                           windowUUID: windowUUID,
                                           actionType: GeneralBrowserActionType.updateSelectedTab)
         store.dispatch(action)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -54,6 +54,32 @@ final class BrowserViewControllerStateTests: XCTestCase {
         XCTAssertEqual(newState.displayView, .dataClearance)
     }
 
+    func testPrivateModeAction() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertEqual(initialState.browserViewType, .normalHomepage)
+
+        let action = getPrivateModeAction(isPrivate: true, for: .privateModeUpdated)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.browserViewType, .privateHomepage)
+    }
+
+    func testUpdateSelectedTabAction() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertEqual(initialState.browserViewType, .normalHomepage)
+
+        let action = getGeneralBrowserAction(selectedTabURL: URL(string: "internal://local/errorpage"),
+                                             isNativeErrorPage: true,
+                                             for: .updateSelectedTab)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.browserViewType, .nativeErrorPage)
+    }
+
     // MARK: - Private
     private func createSubject() -> BrowserViewControllerState {
         return BrowserViewControllerState(windowUUID: .XCTestDefaultUUID)
@@ -65,5 +91,18 @@ final class BrowserViewControllerStateTests: XCTestCase {
 
     private func getAction(for actionType: GeneralBrowserActionType) -> GeneralBrowserAction {
         return  GeneralBrowserAction(windowUUID: .XCTestDefaultUUID, actionType: actionType)
+    }
+
+    private func getPrivateModeAction(isPrivate: Bool, for actionType: PrivateModeActionType) -> PrivateModeAction {
+        return  PrivateModeAction(isPrivate: isPrivate, windowUUID: .XCTestDefaultUUID, actionType: actionType)
+    }
+
+    func getGeneralBrowserAction(selectedTabURL: URL? = nil,
+                                 isNativeErrorPage: Bool? = nil,
+                                 for actionType: GeneralBrowserActionType) -> GeneralBrowserAction {
+        return  GeneralBrowserAction(selectedTabURL: selectedTabURL,
+                                     isNativeErrorPage: isNativeErrorPage,
+                                     windowUUID: .XCTestDefaultUUID,
+                                     actionType: actionType)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9641)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21239)

## :bulb: Description
1. Added `nativeErrorPage` case in `BrowserViewType`: This will be primarily used to show new error pages.
2. For `PrivacyModeAction`, added check for  `BrowserViewType.nativeErrorPage` when action type is `privateModeUpdated`.
3. Added `hasNativeErrorPage` in `ContentContainer` : This will check if the current container has a new error page.
4. Added `isNativeErrorPage` flag in `GeneralBrowserAction`.
5. Added check for nativeErrorPage feature flag in `TabManagerImplementation`. This will update GeneralBrowserAction when action type is `updateSelectedTab`.
6. Made `ErrorPageHandler` feature flaggable to check `nativeErrorPage` feature flag.
7. Added unit test cases for `reduceStateForPrivateModeAction` and `resolveStateForUpdateSelectedTab` methods. 
8. Added TODO for future changes.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

