### PR TITLE
Add FXIOS-9703 [Microsurvey] New trigger for search

### DIFF
--- a/firefox-ios/Client/Experiments/BehavioralTargetingEvent.swift
+++ b/firefox-ios/Client/Experiments/BehavioralTargetingEvent.swift
@@ -4,8 +4,11 @@
 
 import Foundation
 
+// This events are used for behavioral targeting for our experiments
+// https://experimenter.info/mobile-behavioral-targeting
 struct BehavioralTargetingEvent {
-    static let syncLoginCompletion = "sync.login_completed_view"
-    static let homepageViewed = "homepage_viewed"
     static let appForeground = "app_cycle.foreground"
+    static let homepageViewed = "homepage_viewed"
+    static let performedSearch = "performed_search"
+    static let syncLoginCompletion = "sync.login_completed_view"
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -264,6 +264,9 @@ extension BrowserViewController: URLBarDelegate {
 
         let conversionMetrics = UserConversionMetrics()
         conversionMetrics.didPerformSearch()
+
+        Experiments.events.recordEvent(BehavioralTargetingEvent.performedSearch)
+
         GleanMetrics.Search
             .counts["\(engine.engineID ?? "custom").\(SearchLocation.actionBar.rawValue)"]
             .add()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9703)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21324)

## :bulb: Description
Add new behavioral targeting event for search. This will be used in the nimbus experiment recipe similar to the homepage one. The goal is to use glean events in the future, but in the interim we will use the separate Nimbus API.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

