### PR TITLE
Refactor FXIOS-9936 [Microsurvey] Middleware to avoid sending unnecessary actions

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptAction.swift
@@ -24,6 +24,4 @@ enum MicrosurveyPromptActionType: ActionType {
 
 enum MicrosurveyPromptMiddlewareActionType: ActionType {
     case initialize
-    case dismissPrompt
-    case openSurvey
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
@@ -21,9 +21,9 @@ final class MicrosurveyPromptMiddleware {
         case MicrosurveyPromptActionType.showPrompt:
             self.checkIfMicrosurveyShouldShow(windowUUID: windowUUID)
         case MicrosurveyPromptActionType.closePrompt:
-            self.dismissPrompt(windowUUID: windowUUID)
+            self.dismissPrompt()
         case MicrosurveyPromptActionType.continueToSurvey:
-            self.openSurvey(windowUUID: windowUUID)
+            self.openSurvey()
         default:
            break
         }
@@ -47,21 +47,11 @@ final class MicrosurveyPromptMiddleware {
         microsurveyManager.handleMessageDisplayed()
     }
 
-    private func dismissPrompt(windowUUID: WindowUUID) {
-        let newAction = MicrosurveyPromptMiddlewareAction(
-            windowUUID: windowUUID,
-            actionType: MicrosurveyPromptMiddlewareActionType.dismissPrompt
-        )
-        store.dispatch(newAction)
+    private func dismissPrompt() {
         microsurveyManager.handleMessageDismiss()
     }
 
-    private func openSurvey(windowUUID: WindowUUID) {
-        let newAction = MicrosurveyPromptMiddlewareAction(
-            windowUUID: windowUUID,
-            actionType: MicrosurveyPromptMiddlewareActionType.openSurvey
-        )
-        store.dispatch(newAction)
+    private func openSurvey() {
         microsurveyManager.handleMessagePressed()
     }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -42,14 +42,14 @@ struct MicrosurveyPromptState: StateType, Equatable {
                 showSurvey: false,
                 model: model
             )
-        case MicrosurveyPromptMiddlewareActionType.dismissPrompt:
+        case MicrosurveyPromptActionType.closePrompt:
             return MicrosurveyPromptState(
                 windowUUID: state.windowUUID,
                 showPrompt: false,
                 showSurvey: false,
                 model: state.model
             )
-        case MicrosurveyPromptMiddlewareActionType.openSurvey:
+        case MicrosurveyPromptActionType.continueToSurvey:
             return MicrosurveyPromptState(
                 windowUUID: state.windowUUID,
                 showPrompt: true,

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyAction.swift
@@ -16,7 +16,6 @@ final class MicrosurveyAction: Action {
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
-final class MicrosurveyMiddlewareAction: Action { }
 
 enum MicrosurveyActionType: ActionType {
     case closeSurvey
@@ -24,9 +23,4 @@ enum MicrosurveyActionType: ActionType {
     case tapPrivacyNotice
     case surveyDidAppear
     case confirmationViewed
-}
-
-enum MicrosurveyMiddlewareActionType: ActionType {
-    case dismissSurvey
-    case navigateToPrivacyNotice
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
@@ -17,7 +17,7 @@ final class MicrosurveyMiddleware {
         case MicrosurveyActionType.closeSurvey:
             self.dismissSurvey(windowUUID: windowUUID, surveyId: surveyId)
         case MicrosurveyActionType.tapPrivacyNotice:
-            self.navigateToPrivacyNotice(windowUUID: windowUUID, surveyId: surveyId)
+            self.sendTelemtryForNavigatingToPrivacyNotice(surveyId: surveyId)
         case MicrosurveyActionType.submitSurvey:
             self.sendTelemetryAndClosePrompt(windowUUID: windowUUID, action: action, surveyId: surveyId)
         case MicrosurveyActionType.surveyDidAppear:
@@ -30,21 +30,11 @@ final class MicrosurveyMiddleware {
     }
 
     private func dismissSurvey(windowUUID: WindowUUID, surveyId: String) {
-        let newAction = MicrosurveyMiddlewareAction(
-            windowUUID: windowUUID,
-            actionType: MicrosurveyMiddlewareActionType.dismissSurvey
-        )
-        store.dispatch(newAction)
         microsurveyTelemetry.dismissButtonTapped(surveyId: surveyId)
         closeMicrosurveyPrompt(windowUUID: windowUUID)
     }
 
-    private func navigateToPrivacyNotice(windowUUID: WindowUUID, surveyId: String) {
-        let newAction = MicrosurveyMiddlewareAction(
-            windowUUID: windowUUID,
-            actionType: MicrosurveyMiddlewareActionType.navigateToPrivacyNotice
-        )
-        store.dispatch(newAction)
+    private func sendTelemtryForNavigatingToPrivacyNotice(surveyId: String) {
         microsurveyTelemetry.privacyNoticeTapped(surveyId: surveyId)
     }
 

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
@@ -48,13 +48,13 @@ struct MicrosurveyState: ScreenState, Equatable {
         guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return state }
 
         switch action.actionType {
-        case MicrosurveyMiddlewareActionType.dismissSurvey:
+        case MicrosurveyActionType.closeSurvey:
             return MicrosurveyState(
                 windowUUID: state.windowUUID,
                 shouldDismiss: true,
                 showPrivacy: false
             )
-        case MicrosurveyMiddlewareActionType.navigateToPrivacyNotice:
+        case MicrosurveyActionType.tapPrivacyNotice:
             return MicrosurveyState(
                 windowUUID: state.windowUUID,
                 shouldDismiss: false,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
@@ -14,8 +14,8 @@ final class MicrosurveyPromptStateTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
         DependencyHelperMock().reset()
+        super.tearDown()
     }
 
     func testShowPromptAction() {
@@ -24,7 +24,10 @@ final class MicrosurveyPromptStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.showPrompt, false)
 
-        let action = getAction(for: .initialize)
+        let action = MicrosurveyPromptMiddlewareAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: MicrosurveyPromptMiddlewareActionType.initialize
+        )
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.showPrompt, true)
@@ -42,7 +45,7 @@ final class MicrosurveyPromptStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.showPrompt, true)
 
-        let action = getAction(for: .dismissPrompt)
+        let action = getAction(for: .closePrompt)
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.showPrompt, false)
@@ -55,7 +58,7 @@ final class MicrosurveyPromptStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.showSurvey, false)
 
-        let action = getAction(for: .openSurvey)
+        let action = getAction(for: .continueToSurvey)
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.showSurvey, true)
@@ -71,7 +74,7 @@ final class MicrosurveyPromptStateTests: XCTestCase {
         return MicrosurveyPromptState.reducer
     }
 
-    private func getAction(for actionType: MicrosurveyPromptMiddlewareActionType) -> MicrosurveyPromptMiddlewareAction {
-        return  MicrosurveyPromptMiddlewareAction(windowUUID: .XCTestDefaultUUID, actionType: actionType)
+    private func getAction(for actionType: MicrosurveyPromptActionType) -> MicrosurveyPromptAction {
+        return  MicrosurveyPromptAction(windowUUID: .XCTestDefaultUUID, actionType: actionType)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyStateTests.swift
@@ -14,8 +14,8 @@ final class MicrosurveyStateTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
         DependencyHelperMock().reset()
+        super.tearDown()
     }
 
     func testDismissSurveyAction() {
@@ -24,7 +24,7 @@ final class MicrosurveyStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.shouldDismiss, false)
 
-        let action = getAction(for: .dismissSurvey)
+        let action = getAction(for: .closeSurvey)
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.shouldDismiss, true)
@@ -37,7 +37,7 @@ final class MicrosurveyStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.showPrivacy, false)
 
-        let action = getAction(for: .navigateToPrivacyNotice)
+        let action = getAction(for: .tapPrivacyNotice)
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.showPrivacy, true)
@@ -53,7 +53,7 @@ final class MicrosurveyStateTests: XCTestCase {
         return MicrosurveyState.reducer
     }
 
-    private func getAction(for actionType: MicrosurveyMiddlewareActionType) -> MicrosurveyMiddlewareAction {
-        return  MicrosurveyMiddlewareAction(windowUUID: .XCTestDefaultUUID, actionType: actionType)
+    private func getAction(for actionType: MicrosurveyActionType) -> MicrosurveyAction {
+        return  MicrosurveyAction(surveyId: "", windowUUID: .XCTestDefaultUUID, actionType: actionType)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9936)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21788)

## :bulb: Description
Based on a recent discussion during thursday meeting, removing dispatched actions from microsurvey middleware since they are unnecessary as the state can be updated from the same action that was dispatched. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

