### PR TITLE
Bugfix FXIOS-9855 [Unit Tests] add more info for credit card tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
@@ -286,11 +286,13 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         let expectation = expectation(description: "wait for credit card fields to be saved")
 
         viewModel.didTapMainButton { _ in
+            XCTAssertNotNil(self.viewModel)
+            XCTAssertNotNil(self.mockAutofill)
             XCTAssertEqual(self.mockAutofill.addCreditCardCalledCount, 1)
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 1.0)
+        waitForExpectations(timeout: 5.0)
     }
 
     func test_didTapMainButton_withUpdateState_callsAddCreditCard() {
@@ -299,11 +301,13 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         let expectation = expectation(description: "wait for credit card fields to be updated")
 
         viewModel.didTapMainButton { _ in
+            XCTAssertNotNil(self.viewModel)
+            XCTAssertNotNil(self.mockAutofill)
             XCTAssertEqual(self.mockAutofill.updateCreditCardCalledCount, 1)
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 1.0)
+        waitForExpectations(timeout: 5.0)
     }
 
     func test_updateCreditCardList_callsListCreditCards() {
@@ -313,6 +317,8 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         viewModel.state = .selectSavedCard
 
         viewModel.updateCreditCardList({ cards in
+            XCTAssertNotNil(self.viewModel)
+            XCTAssertNotNil(self.mockAutofill)
             XCTAssertEqual(self.viewModel.creditCards, cards)
             XCTAssertEqual(cards?.count, 1)
             XCTAssertEqual(cards?.first?.guid, "1")
@@ -320,7 +326,7 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
             XCTAssertEqual(self.mockAutofill.listCreditCardsCalledCount, 1)
             expectation.fulfill()
         })
-        waitForExpectations(timeout: 1.0)
+        waitForExpectations(timeout: 5.0)
     }
 
     func test_updateCreditCardList_withoutSelectedSavedCardState_doesNotCallListCreditCards() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9855)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21636)

## :bulb: Description
Add more assertions to double check whether this is failing on the nil value. Also added extra timing just in case.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshot

![Screenshot 2024-09-05 at 12 44 52 PM](https://github.com/user-attachments/assets/f971b0f4-255f-4e4f-8707-e243f19600ce)
