### PR TITLE
Fix MTE-3406 - testAutofillCreditCardsToggleOnOff smoke test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -154,6 +154,7 @@ class CreditCardsTests: BaseTestCase {
             }
             mozWaitForElementToNotExist(app.buttons[useSavedCard])
             dismissSavedCardsPrompt()
+            swipeDown(nrOfSwipes: 3)
             navigator.goto(CreditCardsSettings)
             unlockLoginsView()
             mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3406

## :bulb: Description
Some changes were made to the credit card screen, we need to scroll up to make the menu button visible.
