### PR TITLE
Bugfix MTE-2911 Fix slack notification

### DIFF
--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -137,6 +137,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
           ios_simulator: ${{ matrix.ios_simulator }}
+          ios_version: ${{ matrix.ios_version }}
           pass_fail:  ${{ steps.run-smoketests.outcome == 'success' && ':white_check_mark:' || ':x:' }}
           xcodebuild_test_plan: SmokeTests
           ref_name: ${{ github.ref_name }}
@@ -152,7 +153,8 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          os_simulator: ${{ matrix.ios_simulator }}
+          ios_simulator: ${{ matrix.ios_simulator }}
+          ios_version: ${{ matrix.ios_version }}
           pass_fail:  ${{ steps.run-fullfunctionaltests.outcome == 'success' && ':white_check_mark:' || ':x:' }}
           xcodebuild_test_plan: FullFunctionalTests
           ref_name: ${{ github.ref_name }}

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -1,6 +1,8 @@
 name: Focus iOS 15 & 16 tests
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * 1,3,5"
 
 env:
     browser: focus-ios


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2911)

## :bulb: Description
* Slack notification steps miss `ios_version` and `ios_simulator` arguments. I've added those argument to the slack notification step.
* The job is scheduled to run every other day.

Previously:
![Screenshot 2024-09-06 at 1 03 02 AM](https://github.com/user-attachments/assets/c3e07f2b-af8b-451d-a14d-7bb83aef1cb0)

Successful workflow: https://github.com/mozilla-mobile/firefox-ios/actions/runs/10732385214/job/29764013442

The Slack notifications now consist of the iOS version and the device.
![Screenshot 2024-09-06 at 1 01 29 AM](https://github.com/user-attachments/assets/518559c5-57a0-42e6-9668-b28e60cea0fd)

## :pencil: Checklist

You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

