### PR TITLE
Refactor FXIOS-9739 Update top tabs background color

### DIFF
--- a/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
@@ -72,7 +72,7 @@ private struct PrivateModeColorPalette: ThemeColourPalette {
     var actionError: UIColor = FXColors.Pink70.withAlphaComponent(0.69)
     var actionInfo: UIColor = FXColors.Blue60
     var actionTabActive: UIColor = FXColors.Purple60
-    var actionTabInactive: UIColor = FXColors.Ink50
+    var actionTabInactive: UIColor = FXColors.Ink90
 
     // MARK: - Text
     var textPrimary: UIColor = FXColors.LightGrey05


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9739)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21399)

## :bulb: Description
Updates the color for inactive private top tabs.
![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-09-06 at 17 08 51](https://github.com/user-attachments/assets/eee6e170-dee6-42cc-8159-577e3fa454f0)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

