### PR TITLE
Add FXIOS-21837 [Onboarding] Add opening iOS FX settings option in main onboarding flow

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
@@ -336,6 +336,8 @@ extension IntroViewController: OnboardingCardDelegate {
                 windowUUID: windowUUID,
                 from: cardName,
                 selector: #selector(dismissPrivacyPolicyViewController))
+        case .openIosFxSettings:
+            DefaultApplicationHelper().openSettings()
         case .endOnboarding:
             closeOnboarding()
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Mocks/MockOnboardingCardDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Mocks/MockOnboardingCardDelegate.swift
@@ -57,6 +57,8 @@ class MockOnboardinCardDelegateController: UIViewController,
             presentPrivacyPolicy(from: cardName,
                                  selector: nil,
                                  completion: {})
+        case .openIosFxSettings:
+            DefaultApplicationHelper().openSettings()
         case .endOnboarding:
             self.action = .endOnboarding
         }

--- a/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
@@ -432,6 +432,10 @@ enums:
       read-privacy-policy:
         description: >
           Will open a webview where the user can read the privacy policy
+      open-ios-fx-settings:
+        description: >
+          Will take the user to the default browser settings
+          in the iOS system settings
       end-onboarding:
         description: >
           Will end the onboarding on a set card


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/OMC-965)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21837)

## :bulb: Description
- Add open-ios-fx-settings to the list of variants for the onboarding welcome card's primary button.
- Update the switch case in IntroViewController to handle the open-ios-fx-settings action.


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
  _- No UI changes_
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

