### PR TITLE
Bugfix FXIOS-9937 - Fix incorrect delete webchannel message

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -9,6 +9,8 @@ import Sync
 import Account
 
 class ManageFxAccountSetting: Setting {
+    private var notification: NSObjectProtocol?
+
     let profile: Profile
 
     override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
@@ -27,6 +29,14 @@ class ManageFxAccountSetting: Setting {
                 ]
             )
         )
+
+        notification = NotificationCenter.default.addObserver(
+            forName: .accountLoggedOut,
+            object: nil,
+            queue: .main
+        ) { [weak settings] _ in
+            settings?.dismiss(animated: true, completion: nil)
+        }
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
@@ -36,6 +46,12 @@ class ManageFxAccountSetting: Setting {
                                                   dismissalStyle: .popToRootVC,
                                                   deepLinkParams: fxaParams)
         navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    deinit {
+        if let notification = notification {
+            NotificationCenter.default.removeObserver(notification)
+        }
     }
 }
 

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -29,7 +29,7 @@ private enum RemoteCommand: String {
     case login = "fxaccounts:login"
     case changePassword = "fxaccounts:change_password"
     case signOut = "fxaccounts:logout"
-    case deleteAccount = "fxaccounts:delete_account"
+    case deleteAccount = "fxaccounts:delete"
     case profileChanged = "profile:change"
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9937)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21814)

## :bulb: Description
The patch matches what we have in desktop and Android (see bug links), and in addition also observes the `accountLoggedOut` message to dismiss the `ManageFxAccountSetting` screen which would otherwise incorrectly show the user as still signed in.

I have no written a unit test yet, but will do that if CI can give me some hints.

https://github.com/user-attachments/assets/9711293c-4163-4477-b97a-89b4f57bfa31

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

