### PR TITLE
Refactor MTE-3342 CreditCardsTests for iOS 18

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -274,7 +274,7 @@ class CreditCardsTests: BaseTestCase {
             app.buttons[useSavedCard].tap()
             unlockLoginsView()
             mozWaitForElementToExist(app.staticTexts["Use saved card"])
-            app.scrollViews.otherElements.tables.cells.element(boundBy: 1).tap()
+            app.scrollViews.otherElements.tables.cells["creditCardCell_1"].tap()
             validateAutofillCardInfo(cardNr: "4111 1111 1111 1111", expirationNr: "06 / 40", name: "Test2")
             dismissSavedCardsPrompt()
             app.swipeUp()
@@ -285,7 +285,9 @@ class CreditCardsTests: BaseTestCase {
             app.buttons[useSavedCard].tap()
             unlockLoginsView()
             mozWaitForElementToExist(app.staticTexts["Use saved card"])
-            app.scrollViews.otherElements.tables.cells.element(boundBy: 2).tap()
+            app.scrollViews.element.swipeUp()
+            mozWaitForElementToExist(app.scrollViews.otherElements.tables.cells["creditCardCell_2"])
+            app.scrollViews.otherElements.tables.cells["creditCardCell_2"].tap()
             validateAutofillCardInfo(cardNr: "5346 7556 0029 9631", expirationNr: "07 / 40", name: "Test3")
         }
     }
@@ -665,6 +667,9 @@ class CreditCardsTests: BaseTestCase {
         let cardNumber = app.webViews["contentView"].webViews.textFields["Card number"]
         mozWaitForElementToExist(cardNumber)
         cardNumber.tapOnApp()
+        if !app.buttons[useSavedCard].isHittable {
+            cardNumber.tapOnApp()
+        }
         // Use saved card prompt is displayed
         mozWaitForElementToExist(app.buttons[useSavedCard])
         // Expand the prompt


### PR DESCRIPTION
…CanBeAdded

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3342)


## :bulb: Description
CreditCardsTests fails intermittently on iOS 18 due to the following:
* `testVerifyThatMultipleCardsCanBeAdded`: The 3rd credit card in the list may not be visible/hittable.
* Other tests: Save credit card prompt may not be displayed.

I'd like to try the updates in the nightly testing.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

