### PR TITLE
Fix FXIOS-9949 - `Address edit` title should only be shown after edit button tap

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -83,28 +83,36 @@ struct AddressListView: View {
                         )
 
                 case .edit:
+                    let title = viewModel.isEditMode ?
+                        String.Addresses.Settings.Edit.AutofillEditAddressTitle :
+                        String.Addresses.Settings.Edit.AutofillViewAddressTitle
+
+                    let primaryButtonLabel = viewModel.isEditMode ?
+                        String.Addresses.Settings.Edit.AutofillSaveButton :
+                        String.Addresses.Settings.Edit.EditNavBarButtonLabel
+
+                    let cancelButtonLabel = viewModel.isEditMode ?
+                        String.Addresses.Settings.Edit.AutofillCancelButton :
+                        String.Addresses.Settings.Edit.CloseNavBarButtonLabel
+
                     EditAddressViewControllerRepresentable(model: viewModel)
-                        .navigationBarTitle(String.Addresses.Settings.Edit.AutofillEditAddressTitle, displayMode: .inline)
+                        .navigationBarTitle(title, displayMode: .inline)
                         .toolbar {
                             ToolbarItemGroup(placement: .cancellationAction) {
-                                if viewModel.isEditMode {
-                                    Button(String.Addresses.Settings.Edit.AutofillCancelButton) {
+                                Button(cancelButtonLabel) {
+                                    if viewModel.isEditMode {
                                         viewModel.cancelEditButtonTap()
-                                    }
-                                } else {
-                                    Button(String.Addresses.Settings.Edit.CloseNavBarButtonLabel) {
+                                    } else {
                                         viewModel.closeEditButtonTap()
                                     }
                                 }
                             }
 
                             ToolbarItemGroup(placement: .primaryAction) {
-                                if viewModel.isEditMode {
-                                    Button(String.Addresses.Settings.Edit.AutofillSaveButton) {
+                                Button(primaryButtonLabel) {
+                                    if viewModel.isEditMode {
                                         viewModel.saveEditButtonTap()
-                                    }
-                                } else {
-                                    Button(String.Addresses.Settings.Edit.EditNavBarButtonLabel) {
+                                    } else {
                                         viewModel.editButtonTap()
                                     }
                                 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -83,23 +83,11 @@ struct AddressListView: View {
                         )
 
                 case .edit:
-                    let title = viewModel.isEditMode ?
-                        String.Addresses.Settings.Edit.AutofillEditAddressTitle :
-                        String.Addresses.Settings.Edit.AutofillViewAddressTitle
-
-                    let primaryButtonLabel = viewModel.isEditMode ?
-                        String.Addresses.Settings.Edit.AutofillSaveButton :
-                        String.Addresses.Settings.Edit.EditNavBarButtonLabel
-
-                    let cancelButtonLabel = viewModel.isEditMode ?
-                        String.Addresses.Settings.Edit.AutofillCancelButton :
-                        String.Addresses.Settings.Edit.CloseNavBarButtonLabel
-
                     EditAddressViewControllerRepresentable(model: viewModel)
-                        .navigationBarTitle(title, displayMode: .inline)
+                        .navigationBarTitle(viewModel.editNavigationbarTitle, displayMode: .inline)
                         .toolbar {
                             ToolbarItemGroup(placement: .cancellationAction) {
-                                Button(cancelButtonLabel) {
+                                Button(viewModel.cancelButtonLabel) {
                                     if viewModel.isEditMode {
                                         viewModel.cancelEditButtonTap()
                                     } else {
@@ -109,7 +97,7 @@ struct AddressListView: View {
                             }
 
                             ToolbarItemGroup(placement: .primaryAction) {
-                                Button(primaryButtonLabel) {
+                                Button(viewModel.primaryButtonLabel) {
                                     if viewModel.isEditMode {
                                         viewModel.saveEditButtonTap()
                                     } else {

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -57,6 +57,24 @@ final class AddressListViewModel: ObservableObject, FeatureFlaggable {
 
     let editAddressWebViewManager: WebViewPreloadManaging
 
+    var cancelButtonLabel: String {
+        isEditMode ?
+            .Addresses.Settings.Edit.AutofillCancelButton :
+            .Addresses.Settings.Edit.CloseNavBarButtonLabel
+    }
+
+    var primaryButtonLabel: String {
+        isEditMode ?
+            .Addresses.Settings.Edit.AutofillSaveButton :
+            .Addresses.Settings.Edit.EditNavBarButtonLabel
+    }
+
+    var editNavigationbarTitle: String {
+        isEditMode ?
+            .Addresses.Settings.Edit.AutofillEditAddressTitle :
+            .Addresses.Settings.Edit.AutofillViewAddressTitle
+    }
+
     // MARK: - Initializer
 
     /// Initializes the AddressListViewModel.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9949)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21853)


## :bulb: Description

⚠️ **NOTE:** This came up as part of the UAT done by laura and jeff. For more context [see this figma board](https://www.figma.com/design/ha5Ou9kMkwLqI9CQ4QY1vI/Address-Autofill?node-id=2088-30507&node-type=SECTION&m=dev).

This PR:
- Shows `Edit address` title only after edit button tap otherwise the title should be `View address`.

Before: In edit mode `Edit address` is always the title of the view.


https://github.com/user-attachments/assets/4beb6cd7-2254-4772-970e-0af09b9bb830


After: In edit mode `Edit address` is only shown after edit button is tapped.

https://github.com/user-attachments/assets/4b5e954a-ebf3-4c96-ae07-0fa2d763272f




## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~Wrote unit tests and/or ensured the tests suite is passing~
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed, I updated documentation / comments for complex code and public methods~
- [ ] ~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~

