### PR TITLE
Fix FXIOS-9950 - Change string for address update toast

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
@@ -37,7 +37,7 @@ enum AddressModifiedStatus {
     var message: String {
         switch self {
         case .saved: return .Addresses.Settings.Edit.AddressSavedConfirmation
-        case .updated: return .Addresses.Settings.Edit.AddressUpdatedConfirmation
+        case .updated: return .Addresses.Settings.Edit.AddressUpdatedConfirmationV2
         case .removed: return .Addresses.Settings.Edit.AddressRemovedConfirmation
         case .error(let type): return type.message
         }

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
@@ -36,7 +36,8 @@ enum AddressModifiedStatus {
 
     var message: String {
         switch self {
-        case .saved, .updated: return .Addresses.Settings.Edit.AddressSavedConfirmation
+        case .saved: return .Addresses.Settings.Edit.AddressSavedConfirmation
+        case .updated: return .Addresses.Settings.Edit.AddressUpdatedConfirmation
         case .removed: return .Addresses.Settings.Edit.AddressRemovedConfirmation
         case .error(let type): return type.message
         }

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/AddressModifiedStatus.swift
@@ -36,8 +36,7 @@ enum AddressModifiedStatus {
 
     var message: String {
         switch self {
-        case .saved: return .Addresses.Settings.Edit.AddressSavedConfirmation
-        case .updated: return .Addresses.Settings.Edit.AddressUpdatedConfirmation
+        case .saved, .updated: return .Addresses.Settings.Edit.AddressSavedConfirmation
         case .removed: return .Addresses.Settings.Edit.AddressRemovedConfirmation
         case .error(let type): return type.message
         }

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -353,7 +353,13 @@ extension String {
                     comment: "Suggestion to try again after an error occurred while trying to save an address."
                 )
                 public static let AddressUpdatedConfirmation = MZLocalizedString(
-                    key: "Addresses.Toast.AddressUpdatedConfirmation.v130",
+                    key: "Addresses.Toast.AddressUpdatedConfirmation.v129",
+                    tableName: "EditAddress",
+                    value: "Address Information Updated",
+                    comment: "Toast message confirming that an address has been successfully updated."
+                )
+                 public static let AddressUpdatedConfirmationV2 = MZLocalizedString(
+                    key: "Addresses.Toast.AddressUpdatedConfirmation.v132.v2",
                     tableName: "EditAddress",
                     value: "Address Saved",
                     comment: "Toast message confirming that an address has been successfully updated."
@@ -7046,11 +7052,6 @@ extension String {
                 tableName: "Microsurvey",
                 value: "Selected",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states whether the survey option was selected.")
-            public static let AddressUpdatedConfirmation = MZLocalizedString(
-                key: "Addresses.Toast.AddressUpdatedConfirmation.v129",
-                tableName: "EditAddress",
-                value: "Address Information Updated",
-                comment: "Toast message confirming that an address has been successfully updated.")
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -352,6 +352,12 @@ extension String {
                     value: "Try again",
                     comment: "Suggestion to try again after an error occurred while trying to save an address."
                 )
+                public static let AddressUpdatedConfirmation = MZLocalizedString(
+                    key: "Addresses.Toast.AddressUpdatedConfirmation.v130",
+                    tableName: "EditAddress",
+                    value: "Address Saved",
+                    comment: "Toast message confirming that an address has been successfully updated."
+                )
                 public static let RemoveAddressTitle = MZLocalizedString(
                     key: "Addresses.EditAddress.Alert.Title.v129",
                     tableName: "EditAddress",

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -352,12 +352,6 @@ extension String {
                     value: "Try again",
                     comment: "Suggestion to try again after an error occurred while trying to save an address."
                 )
-                public static let AddressUpdatedConfirmation = MZLocalizedString(
-                    key: "Addresses.Toast.AddressUpdatedConfirmation.v129",
-                    tableName: "EditAddress",
-                    value: "Address Information Updated",
-                    comment: "Toast message confirming that an address has been successfully updated."
-                )
                 public static let RemoveAddressTitle = MZLocalizedString(
                     key: "Addresses.EditAddress.Alert.Title.v129",
                     tableName: "EditAddress",
@@ -7046,6 +7040,11 @@ extension String {
                 tableName: "Microsurvey",
                 value: "Selected",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states whether the survey option was selected.")
+            public static let AddressUpdatedConfirmation = MZLocalizedString(
+                key: "Addresses.Toast.AddressUpdatedConfirmation.v129",
+                tableName: "EditAddress",
+                value: "Address Information Updated",
+                comment: "Toast message confirming that an address has been successfully updated.")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9950)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21852)

## :bulb: Description
⚠️ **NOTE:** This came up as part of the UAT done by laura and jeff. For more context [see this figma board](https://www.figma.com/design/ha5Ou9kMkwLqI9CQ4QY1vI/Address-Autofill?node-id=2088-30507&node-type=SECTION&m=dev).

This PR:

- Removes `Addresses.Toast.AddressUpdatedConfirmation` and uses `Addresses.Toast.AddressSavedConfirmation` for update as well.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~Wrote unit tests and/or ensured the tests suite is passing~
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed, I updated documentation / comments for complex code and public methods~
- [ ] ~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~

