### PR TITLE
Bugfix MTE-3417 EngagementNotificationTests fails at setUp() intermittently

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/EngagementNotificationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/EngagementNotificationTests.swift
@@ -7,13 +7,19 @@ import XCTest
 class EngagementNotificationTests: BaseTestCase {
     override func setUp() {
         // Fresh install the app
-        removeApp()
+        // removeApp() does not work on iOS 15 and 16 intermittently
+        if #available(iOS 17, *) {
+            removeApp()
+        }
         // The app is correctly installed
         super.setUp()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307101
-    func testDontAllowNotifications() {
+    func testDontAllowNotifications() throws {
+        if #unavailable(iOS 17) {
+            throw XCTSkip("setUp() fails to remove app intermittently")
+        }
         // Skip login
         navigator.nowAt(BrowserTab)
         waitForTabsButton()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3417)

## :bulb: Description
`remoteApp()` from `setUp()` fails intermittently because the buttons on the `springboard` may not be visible or hittable on iOS 15 and 16. The rest of full functional tests could not proceed due to the `springboard` fails to close.

I have run the test repeatedly (100 times) on iOS 17 simulator.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

