### PR TITLE
Bugfix MTE-3381 Unable to upload derived data to Bitrise

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -838,10 +838,6 @@ workflows:
         title: Generate screenshots
     - deploy-to-bitrise-io@2.9.2:
         inputs:
-        - deploy_path: l10n-screenshots-dd/
-        - is_compress: 'true'
-    - deploy-to-bitrise-io@2.9.2:
-        inputs:
         - deploy_path: l10n-screenshots/en-US/en-US
         - is_compress: 'true'
     - cache-push@2.3: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -836,11 +836,11 @@ workflows:
 
             ./firefox-ios/l10n-screenshots.sh en-US
         title: Generate screenshots
-    - deploy-to-bitrise-io@1.10:
+    - deploy-to-bitrise-io@2.9.2:
         inputs:
         - deploy_path: l10n-screenshots-dd/
         - is_compress: 'true'
-    - deploy-to-bitrise-io@1.10:
+    - deploy-to-bitrise-io@2.9.2:
         inputs:
         - deploy_path: l10n-screenshots/en-US/en-US
         - is_compress: 'true'


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3381)

## :bulb: Description
Bitrise can only upload artifact less than 2GB in size. The derived data folder exceeds the 2GB limit even after it is compressed.

We may not need to upload derived data to Bitrise after Firefox iOS has been compiled. (Thoughts?)

Bitrise L10nBuild: https://app.bitrise.io/build/13c69956-4d6d-4e9b-8a23-892871f89d90
See: https://devcenter.bitrise.io/en/builds/managing-build-files/build-artifacts-online.html

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

