### PR TITLE
Bugfix FXIOS-9906 - Send ok response to can_link_account channel message

### DIFF
--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -22,7 +22,7 @@ enum FxAPageType: Equatable {
 // See https://mozilla.github.io/ecosystem-platform/docs/fxa-engineering/fxa-webchannel-protocol
 // For details on message types.
 private enum RemoteCommand: String {
-    // case canLinkAccount = "can_link_account"
+     case canLinkAccount = "fxaccounts:can_link_account"
     // case loaded = "fxaccounts:loaded"
     case status = "fxaccounts:fxa_status"
     case oauthLogin = "fxaccounts:oauth_login"
@@ -283,6 +283,10 @@ extension FxAWebViewModel {
                                         email: email,
                                         verified: verified)
                 profile.rustFxA.accountManager?.setUserData(userData: userData) { }
+            case .canLinkAccount:
+                if let id = id {
+                    onCanLinkAccount(msgId: id, webView: webView)
+                }
             }
         }
     }
@@ -391,6 +395,19 @@ extension FxAWebViewModel {
         profile.rustFxA.accountManager?.handlePasswordChanged(newSessionToken: sessionToken) {
             NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
         }
+    }
+
+    private func onCanLinkAccount(msgId: Int, webView: WKWebView) {
+        let cmd = RemoteCommand.canLinkAccount.rawValue
+        let typeId = "account_updates"
+        // Respond with an 'ok' message immediately today so FxA does not need to support conditional logic on the
+        // server-side just for iOS.
+        // For proper account merging support, see: https://github.com/mozilla-mobile/firefox-ios/issues/21873
+        let data = """
+            { "ok": true }
+        """
+
+        runJS(webView: webView, typeId: typeId, messageId: msgId, command: cmd, data: data)
     }
 
     func shouldAllowRedirectAfterLogIn(basedOn navigationURL: URL?) -> WKNavigationActionPolicy {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9906)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21723)

## :bulb: Description
Responds to FxA's `can_link_account` WebChannel message with an `{ "ok": true }` as a placeholder until https://github.com/mozilla-mobile/firefox-ios/issues/21873 is fixed.

Tested this against a local FxA server by removing [this line in the sign-in flow](https://github.com/mozilla/fxa/blob/73bd174c9d1c96006a9fdbb96642e6ed34edf174/packages/fxa-settings/src/pages/Signin/container.tsx#L238), and using this patch in iOS to make the WKWebView [inspectable](https://developer.apple.com/documentation/safari-developer-tools/inspecting-ios) from Safari Desktop:

```diff
diff --git a/firefox-ios/RustFxA/FxAWebViewController.swift b/firefox-ios/RustFxA/FxAWebViewController.swift
index 08697e292..b2513dbe0 100755
--- a/firefox-ios/RustFxA/FxAWebViewController.swift
+++ b/firefox-ios/RustFxA/FxAWebViewController.swift
@@ -59,6 +59,9 @@ class FxAWebViewController: UIViewController {
         webView.accessibilityLabel = .FxAWebContentAccessibilityLabel
         webView.scrollView.bounces = false  // Don't allow overscrolling.
         webView.customUserAgent = FxAWebViewModel.mobileUserAgent
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
 
         self.logger = logger
 
```

No unit tests added for now. Would like some examples that I could follow, thanks!

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

