### PR TITLE
Bugfix MTE-3428 Focus iOS build failure

### DIFF
--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -33,9 +33,6 @@ jobs:
               id: compile
               run: |
                 xcodebuild \
-                  -resolvePackageDependencies \
-                  -onlyUsePackageVersionsFromResolvedFile
-                xcodebuild \
                   build-for-testing \
                   -scheme ${{ env.xcodebuild_scheme }} \
                   -target ${{ env.xcodebuild_target }} \


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3428)

## :bulb: Description
Focus iOS XCUITest has been failing for the last few days on Github Actions: https://github.com/mozilla-mobile/firefox-ios/actions/runs/10784126002. The build fails at the following command:
```
  xcodebuild \
    -resolvePackageDependencies \
    -onlyUsePackageVersionsFromResolvedFile
```
I can reproduce the error on `swiftdraw` locally. 

Without this step, I could still build focus successfully. Let's remove the step.

Workflow using this branch: https://github.com/mozilla-mobile/firefox-ios/actions/runs/10785481773

Question: Is there a good reason why resolve package dependencies failed? 😞 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

