### PR TITLE
Bugfix FXIOS-9933 #21791 Password screen no longer blurs (blank instead) when app is backgrounded

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -517,28 +517,27 @@ class BrowserViewController: UIViewController,
 
     @objc
     func appDidBecomeActiveNotification() {
-        guard canShowPrivacyView else { return }
-        // Re-show any components that might have been hidden because they were being displayed
-        // as part of a private mode tab
-        UIView.animate(
-            withDuration: 0.2,
-            delay: 0,
-            options: UIView.AnimationOptions(),
-            animations: {
-                self.contentStackView.alpha = 1
-
-                if self.isToolbarRefactorEnabled {
-                    self.addressToolbarContainer.alpha = 1
-                } else {
-                    self.urlBar.locationContainer.alpha = 1
-                }
-
-                self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
-                self.presentedViewController?.view.alpha = 1
-            }, completion: { _ in
-                self.webViewContainerBackdrop.alpha = 0
-                self.view.sendSubviewToBack(self.webViewContainerBackdrop)
-            })
+        if canShowPrivacyView {
+            // Re-show any components that might have been hidden because they were being displayed
+            // as part of a private mode tab
+            UIView.animate(
+                withDuration: 0.2,
+                delay: 0,
+                options: UIView.AnimationOptions(),
+                animations: {
+                    self.contentStackView.alpha = 1
+                    if self.isToolbarRefactorEnabled {
+                        self.addressToolbarContainer.alpha = 1
+                    } else {
+                        self.urlBar.locationContainer.alpha = 1
+                    }
+                    self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
+                    self.presentedViewController?.view.alpha = 1
+                }, completion: { _ in
+                    self.webViewContainerBackdrop.alpha = 0
+                    self.view.sendSubviewToBack(self.webViewContainerBackdrop)
+                })
+        }
 
         if let tab = tabManager.selectedTab, !tab.isFindInPageMode {
             // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -517,27 +517,25 @@ class BrowserViewController: UIViewController,
 
     @objc
     func appDidBecomeActiveNotification() {
-        if canShowPrivacyView {
-            // Re-show any components that might have been hidden because they were being displayed
-            // as part of a private mode tab
-            UIView.animate(
-                withDuration: 0.2,
-                delay: 0,
-                options: UIView.AnimationOptions(),
-                animations: {
-                    self.contentStackView.alpha = 1
-                    if self.isToolbarRefactorEnabled {
-                        self.addressToolbarContainer.alpha = 1
-                    } else {
-                        self.urlBar.locationContainer.alpha = 1
-                    }
-                    self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
-                    self.presentedViewController?.view.alpha = 1
-                }, completion: { _ in
-                    self.webViewContainerBackdrop.alpha = 0
-                    self.view.sendSubviewToBack(self.webViewContainerBackdrop)
-                })
-        }
+        // Re-show any components that might have been hidden because they were being displayed
+        // as part of a private mode tab
+        UIView.animate(
+            withDuration: 0.2,
+            delay: 0,
+            options: UIView.AnimationOptions(),
+            animations: {
+                self.contentStackView.alpha = 1
+                if self.isToolbarRefactorEnabled {
+                    self.addressToolbarContainer.alpha = 1
+                } else {
+                    self.urlBar.locationContainer.alpha = 1
+                }
+                self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
+                self.presentedViewController?.view.alpha = 1
+            }, completion: { _ in
+                self.webViewContainerBackdrop.alpha = 0
+                self.view.sendSubviewToBack(self.webViewContainerBackdrop)
+            })
 
         if let tab = tabManager.selectedTab, !tab.isFindInPageMode {
             // Re-show toolbar which might have been hidden during scrolling (prior to app moving into the background)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -492,7 +492,8 @@ class BrowserViewController: UIViewController,
         // If we are displaying a private tab, hide any elements in the tab that we wouldn't want shown
         // when the app is in the home switcher
         guard let privateTab = tabManager.selectedTab,
-              privateTab.isPrivate
+              privateTab.isPrivate,
+              canShowPrivacyView
         else { return }
 
         view.bringSubviewToFront(webViewContainerBackdrop)
@@ -508,8 +509,15 @@ class BrowserViewController: UIViewController,
         presentedViewController?.view.alpha = 0
     }
 
+    var canShowPrivacyView: Bool {
+        // Show privacy view if no view controller is presented
+        // or if the presented view is a PhotonActionSheet.
+        self.presentedViewController == nil || presentedViewController is PhotonActionSheet
+    }
+
     @objc
     func appDidBecomeActiveNotification() {
+        guard canShowPrivacyView else { return }
         // Re-show any components that might have been hidden because they were being displayed
         // as part of a private mode tab
         UIView.animate(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9933)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21791)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I narrowed down this bug that occurs when a private tab is open, and the user navigates to one of the privacy-sensitive screens in the Settings. If the underlying tab is a regular tab, the functionality works as expected.

The issue seems to stem from two implementations: one in SensitiveViewController and the other in BVC, which interferes with the first. I found a [related issue](https://github.com/mozilla-mobile/firefox-ios/issues/6730) from a while ago, where the sensitive screen background was a solid magenta color. This seems to have changed when new colors were introduced, and the current blurred background might have been a product decision.

For now, the issue can be resolved by displaying the sensitive view only when there is no presentation controller. However, there is still one edge case involving a popover menu.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

