### PR TITLE
Add FXIOS-9962 - Add shared files from mozilla central for password generator

### DIFF
--- a/firefox-ios/Client/Assets/CC_Script/CC_Python_Update.py
+++ b/firefox-ios/Client/Assets/CC_Script/CC_Python_Update.py
@@ -40,6 +40,11 @@ FILES_TO_DOWNLOAD = [
     "toolkit/components/passwordmgr/LoginManager.shared.mjs",
     "toolkit/components/formautofill/Overrides.ios.js",
     "toolkit/modules/third_party/fathom/fathom.mjs",
+    "toolkit/components/passwordmgr/shared/LoginFormFactory.sys.mjs",
+    "toolkit/components/passwordmgr/shared/NewPasswordModel.sys.mjs",
+    "toolkit/components/passwordmgr/shared/PasswordGenerator.sys.mjs ",
+    "toolkit/components/passwordmgr/shared/PasswordRulesParser.sys.mjs",
+    "toolkit/components/passwordmgr/LoginManager.shared.sys.mjs",
 ]
 
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9962)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21881)

## :bulb: Description
This PR: 
- Adds  `LoginFormFactory.sys.mjs` which is a utiliy to deal with forms and inputs on a document.
- Adds  `NewPasswordModel.sys.mjs` which a pre-trained fathom model to detect `new-password` fields.
- Adds `PasswordGenerator.sys.mjs` which is used to generate the secure passwords based on rules.
- Adds `PasswordRulesParser.sys.mjs` which will parse the rules from [RemotePasswordRules.json](https://github.com/mozilla-mobile/firefox-ios/blob/9da08755338947ba7165131894867e9ef94460f6/firefox-ios/Client/Assets/RemoteSettingsData/RemotePasswordRules.json).
- Adds `LoginManager.shared.sys.mjs` which has shared utils from the password manager.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~Wrote unit tests and/or ensured the tests suite is passing~
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed, I updated documentation / comments for complex code and public methods~
- [ ] ~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~

