### PR TITLE
Add FXIOS-9127 [Menu] Add homepage check

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -611,6 +611,7 @@
 		810FF3582B1784E7009F062C /* PrivateModeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810FF3572B1784E7009F062C /* PrivateModeAction.swift */; };
 		81122E212B221AC0003DD9F8 /* SearchScreenState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81122E202B221AC0003DD9F8 /* SearchScreenState.swift */; };
 		814A62462B587A3E00608195 /* DefaultThemeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814A62452B587A3E00608195 /* DefaultThemeManagerTests.swift */; };
+		814B60F52C90C0A0000997BE /* MainMenuConfigurationUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814B60F42C90C0A0000997BE /* MainMenuConfigurationUtility.swift */; };
 		8187561A2BB4618500DCD1F3 /* OnboardingViewControllerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818756192BB4618500DCD1F3 /* OnboardingViewControllerState.swift */; };
 		819656152C80C55300E62323 /* MainMenuState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819656142C80C55300E62323 /* MainMenuState.swift */; };
 		819656172C80C6F300E62323 /* MenuKit in Frameworks */ = {isa = PBXBuildFile; productRef = 819656162C80C6F300E62323 /* MenuKit */; };
@@ -6548,6 +6549,7 @@
 		810FF3572B1784E7009F062C /* PrivateModeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateModeAction.swift; sourceTree = "<group>"; };
 		81122E202B221AC0003DD9F8 /* SearchScreenState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScreenState.swift; sourceTree = "<group>"; };
 		814A62452B587A3E00608195 /* DefaultThemeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultThemeManagerTests.swift; sourceTree = "<group>"; };
+		814B60F42C90C0A0000997BE /* MainMenuConfigurationUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuConfigurationUtility.swift; sourceTree = "<group>"; };
 		81504EA4876ED3D974FDA0F6 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		81584D62B22049E40FC78F93 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		816D458CBEAE2A6721134028 /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
@@ -10330,6 +10332,7 @@
 				81F617C52C875564003799BF /* Redux */,
 				81A3F6EF2C2DAEE200BDD86B /* MainMenuCoordinator.swift */,
 				81F617CA2C877EC7003799BF /* MainMenuTelemetry.swift */,
+				814B60F42C90C0A0000997BE /* MainMenuConfigurationUtility.swift */,
 			);
 			path = MainMenu;
 			sourceTree = "<group>";
@@ -15254,6 +15257,7 @@
 				43BDBBFE2752FA8600254DE4 /* LegacyTabCell.swift in Sources */,
 				E60D03181D511398002FE3F6 /* SyncDisplayState.swift in Sources */,
 				C4E3983D1D21F1E7004E89BA /* TopTabCell.swift in Sources */,
+				814B60F52C90C0A0000997BE /* MainMenuConfigurationUtility.swift in Sources */,
 				210E0EBA298D9D6400BB4F33 /* OpenSearchEngine.swift in Sources */,
 				FA9293D41D6580E100AC8D33 /* QRCodeViewController.swift in Sources */,
 				8AAEBA082BF52708000C02B5 /* MicrosurveyCoordinator.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -447,6 +447,12 @@ class BrowserCoordinator: BaseCoordinator,
         coordinator.startModal()
     }
 
+    func openURLInNewTab(_ url: URL?) {
+        if let url = url {
+            browserViewController.openURLInNewTab(url, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false)
+        }
+    }
+
     func openNewTab(inPrivateMode isPrivate: Bool) {
         handle(homepanelSection: isPrivate ? .newPrivateTab : .newTab)
     }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -2,4 +2,296 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
+import MenuKit
+import Shared
+
+struct MainMenuConfigurationUtility: Equatable {
+    func generateMenuElements(
+        with uuid: WindowUUID,
+        tabIsHomepage isHomepage: Bool?
+    ) -> [MenuSection] {
+        // Always include these sections
+        var menuSections: [MenuSection] = [
+            getNewTabSection(with: uuid),
+            getLibrariesSection(with: uuid),
+            getOtherToolsSection(with: uuid, isHomepage: isHomepage ?? false)
+        ]
+
+        // Conditionally add tools section if this is a website
+        if let isHomepage = isHomepage, !isHomepage {
+            menuSections.insert(getToolsSection(with: uuid), at: 1)
+        }
+
+        return menuSections
+    }
+
+    private func getNewTabSection(with uuid: WindowUUID) -> MenuSection {
+        return MenuSection(options: [
+            MenuElement(
+                title: .MainMenu.TabsSection.NewTab,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.show(.newTab)
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.TabsSection.NewPrivateTab,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.show(.newPrivateTab)
+                        )
+                    )
+                }
+            )
+        ])
+    }
+
+    private func getToolsSection(with uuid: WindowUUID) -> MenuSection {
+        return MenuSection(options: [
+            MenuElement(
+                title: .MainMenu.ToolsSection.SwitchToDesktopSite,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.closeMenu
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.ToolsSection.FindInPage,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.closeMenu
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.ToolsSection.Tools,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.closeMenu
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.ToolsSection.Save,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.closeMenu
+                        )
+                    )
+                }
+            )
+        ])
+    }
+    private func getLibrariesSection(with uuid: WindowUUID) -> MenuSection {
+        return MenuSection(options: [
+            MenuElement(
+                title: .MainMenu.PanelLinkSection.Bookmarks,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.show(.bookmarks)
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.PanelLinkSection.History,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.show(.history)
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.PanelLinkSection.Downloads,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.show(.downloads)
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.PanelLinkSection.Passwords,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.show(.passwords)
+                        )
+                    )
+                }
+            )
+        ])
+    }
+
+    private func getOtherToolsSection(
+        with uuid: WindowUUID,
+        isHomepage: Bool
+    ) -> MenuSection {
+        let homepageOptions = [
+            MenuElement(
+                title: .MainMenu.OtherToolsSection.CustomizeHomepage,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.show(.customizeHomepage)
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: String(
+                    format: .MainMenu.OtherToolsSection.WhatsNew,
+                    AppName.shortName.rawValue
+                ),
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.show(.goToURL(SupportUtils.URLForWhatsNew))
+                        )
+                    )
+                }
+            )
+        ]
+
+        let standardOptions = [
+            MenuElement(
+                title: .MainMenu.OtherToolsSection.GetHelp,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.show(.goToURL(SupportUtils.URLForGetHelp))
+                        )
+                    )
+                }
+            ),
+            MenuElement(
+                title: .MainMenu.OtherToolsSection.Settings,
+                iconName: "",
+                isEnabled: true,
+                isActive: false,
+                a11yLabel: "",
+                a11yHint: "",
+                a11yId: "",
+                action: {
+                    store.dispatch(
+                        MainMenuAction(
+                            windowUUID: uuid,
+                            actionType: MainMenuActionType.show(.settings)
+                        )
+                    )
+                }
+            )
+        ]
+
+        return MenuSection(options: isHomepage ? homepageOptions + standardOptions : standardOptions)
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -7,6 +7,7 @@ import Foundation
 import Shared
 
 protocol MainMenuCoordinatorDelegate: AnyObject {
+    func openURLInNewTab(_ url: URL?)
     func openNewTab(inPrivateMode: Bool)
     func showLibraryPanel(_ panel: Route.HomepanelSection)
     func showSettings(at destination: Route.SettingsSection)
@@ -45,9 +46,8 @@ class MainMenuCoordinator: BaseCoordinator, FeatureFlaggable {
                 self.navigationHandler?.showSettings(at: .homePage)
             case .downloads:
                 self.navigationHandler?.showLibraryPanel(.downloads)
-            case .getHelp:
-                break
-//                self.navigationHandler?.openupr
+            case .goToURL(let url):
+                self.navigationHandler?.openURLInNewTab(url)
             case .history:
                 self.navigationHandler?.showLibraryPanel(.history)
             case .newTab:

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
@@ -14,6 +14,7 @@ final class MainMenuAction: Action {
 
 enum MainMenuActionType: ActionType {
     case viewDidLoad
+    case updateTabInfo(MenuTabInfo?)
     case mainMenuDidAppear
     case toggleNightMode
     case closeMenu

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuAction.swift
@@ -17,17 +17,16 @@ enum MainMenuActionType: ActionType {
     case mainMenuDidAppear
     case toggleNightMode
     case closeMenu
-    case newTab(isPrivate: Bool)
     case show(MainMenuNavigationDestination)
 }
 
-enum MainMenuNavigationDestination {
+enum MainMenuNavigationDestination: Equatable {
     case newTab
     case newPrivateTab
     case bookmarks
     case customizeHomepage
     case downloads
-    case getHelp
+    case goToURL(URL?)
     case history
     case passwords
     case settings

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -61,12 +61,6 @@ struct MainMenuState: ScreenState, Equatable {
                 windowUUID: state.windowUUID,
                 menuElements: MainMenuConfigurationUtility().populateMenuElements(with: state.windowUUID)
             )
-        case MainMenuActionType.newTab(isPrivate: let isPrivate):
-            return MainMenuState(
-                windowUUID: state.windowUUID,
-                menuElements: MainMenuConfigurationUtility().populateMenuElements(with: state.windowUUID),
-                navigationDestination: isPrivate ? .newPrivateTab : .newTab
-            )
         case MainMenuActionType.show(let destination):
             return MainMenuState(
                 windowUUID: state.windowUUID,
@@ -113,7 +107,7 @@ struct MainMenuConfigurationUtility {
                     store.dispatch(
                         MainMenuAction(
                             windowUUID: uuid,
-                            actionType: MainMenuActionType.newTab(isPrivate: false)
+                            actionType: MainMenuActionType.show(.newTab)
                         )
                     )
                 }
@@ -130,7 +124,7 @@ struct MainMenuConfigurationUtility {
                     store.dispatch(
                         MainMenuAction(
                             windowUUID: uuid,
-                            actionType: MainMenuActionType.newTab(isPrivate: true)
+                            actionType: MainMenuActionType.show(.newPrivateTab)
                         )
                     )
                 }
@@ -249,7 +243,7 @@ struct MainMenuConfigurationUtility {
                     store.dispatch(
                         MainMenuAction(
                             windowUUID: uuid,
-                            actionType: MainMenuActionType.closeMenu
+                            actionType: MainMenuActionType.show(.goToURL(SupportUtils.URLForWhatsNew))
                         )
                     )
                 }
@@ -266,7 +260,7 @@ struct MainMenuConfigurationUtility {
                     store.dispatch(
                         MainMenuAction(
                             windowUUID: uuid,
-                            actionType: MainMenuActionType.closeMenu
+                            actionType: MainMenuActionType.show(.goToURL(SupportUtils.URLForGetHelp))
                         )
                     )
                 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -7,11 +7,19 @@ import MenuKit
 import Shared
 import Redux
 
+struct MenuTabInfo: Equatable {
+    let url: URL?
+    let isHomepage: Bool
+}
+
 struct MainMenuState: ScreenState, Equatable {
     var windowUUID: WindowUUID
     var menuElements: [MenuSection]
-    var navigationDestination: MainMenuNavigationDestination?
     var shouldDismiss: Bool
+
+    var navigationDestination: MainMenuNavigationDestination?
+    var currentTabInfo: MenuTabInfo?
+    private let menuConfigurator = MainMenuConfigurationUtility()
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let mainMenuState = store.state.screenState(
@@ -26,6 +34,7 @@ struct MainMenuState: ScreenState, Equatable {
         self.init(
             windowUUID: mainMenuState.windowUUID,
             menuElements: mainMenuState.menuElements,
+            currentTabInfo: mainMenuState.currentTabInfo,
             navigationDestination: mainMenuState.navigationDestination,
             shouldDismiss: mainMenuState.shouldDismiss
         )
@@ -35,6 +44,7 @@ struct MainMenuState: ScreenState, Equatable {
         self.init(
             windowUUID: windowUUID,
             menuElements: [],
+            currentTabInfo: nil,
             navigationDestination: nil,
             shouldDismiss: false
         )
@@ -43,11 +53,13 @@ struct MainMenuState: ScreenState, Equatable {
     private init(
         windowUUID: WindowUUID,
         menuElements: [MenuSection],
+        currentTabInfo: MenuTabInfo?,
         navigationDestination: MainMenuNavigationDestination? = nil,
         shouldDismiss: Bool = false
     ) {
         self.windowUUID = windowUUID
         self.menuElements = menuElements
+        self.currentTabInfo = currentTabInfo
         self.navigationDestination = navigationDestination
         self.shouldDismiss = shouldDismiss
     }
@@ -59,229 +71,38 @@ struct MainMenuState: ScreenState, Equatable {
         case MainMenuActionType.viewDidLoad:
             return MainMenuState(
                 windowUUID: state.windowUUID,
-                menuElements: MainMenuConfigurationUtility().populateMenuElements(with: state.windowUUID)
+                menuElements: state.menuElements,
+                currentTabInfo: state.currentTabInfo
+            )
+        case MainMenuActionType.updateTabInfo(let info):
+            return MainMenuState(
+                windowUUID: state.windowUUID,
+                menuElements: state.menuConfigurator.generateMenuElements(
+                    with: state.windowUUID,
+                    tabIsHomepage: info?.isHomepage
+                ),
+                currentTabInfo: info
             )
         case MainMenuActionType.show(let destination):
             return MainMenuState(
                 windowUUID: state.windowUUID,
-                menuElements: MainMenuConfigurationUtility().populateMenuElements(with: state.windowUUID),
+                menuElements: state.menuElements,
+                currentTabInfo: state.currentTabInfo,
                 navigationDestination: destination
             )
         case MainMenuActionType.closeMenu:
             return MainMenuState(
                 windowUUID: state.windowUUID,
                 menuElements: state.menuElements,
+                currentTabInfo: state.currentTabInfo,
                 shouldDismiss: true
             )
         default:
             return MainMenuState(
                 windowUUID: state.windowUUID,
-                menuElements: state.menuElements
+                menuElements: state.menuElements,
+                currentTabInfo: state.currentTabInfo
             )
         }
-    }
-}
-
-struct MainMenuConfigurationUtility {
-    func populateMenuElements(with uuid: WindowUUID) -> [MenuSection] {
-        return [
-            getNewTabSection(with: uuid),
-            getLibrariesSection(with: uuid),
-            getOtherToolsSection(with: uuid)
-        ]
-    }
-
-    private func getNewTabSection(
-        with uuid: WindowUUID
-    ) -> MenuSection {
-        return MenuSection(options: [
-            MenuElement(
-                title: .MainMenu.TabsSection.NewTab,
-                iconName: "",
-                isEnabled: true,
-                isActive: false,
-                a11yLabel: "",
-                a11yHint: "",
-                a11yId: "",
-                action: {
-                    store.dispatch(
-                        MainMenuAction(
-                            windowUUID: uuid,
-                            actionType: MainMenuActionType.show(.newTab)
-                        )
-                    )
-                }
-            ),
-            MenuElement(
-                title: .MainMenu.TabsSection.NewPrivateTab,
-                iconName: "",
-                isEnabled: true,
-                isActive: false,
-                a11yLabel: "",
-                a11yHint: "",
-                a11yId: "",
-                action: {
-                    store.dispatch(
-                        MainMenuAction(
-                            windowUUID: uuid,
-                            actionType: MainMenuActionType.show(.newPrivateTab)
-                        )
-                    )
-                }
-            )
-        ])
-    }
-
-    private func getLibrariesSection(
-        with uuid: WindowUUID
-    ) -> MenuSection {
-        return MenuSection(options: [
-            MenuElement(
-                title: .MainMenu.PanelLinkSection.Bookmarks,
-                iconName: "",
-                isEnabled: true,
-                isActive: false,
-                a11yLabel: "",
-                a11yHint: "",
-                a11yId: "",
-                action: {
-                    store.dispatch(
-                        MainMenuAction(
-                            windowUUID: uuid,
-                            actionType: MainMenuActionType.show(.bookmarks)
-                        )
-                    )
-                }
-            ),
-            MenuElement(
-                title: .MainMenu.PanelLinkSection.History,
-                iconName: "",
-                isEnabled: true,
-                isActive: false,
-                a11yLabel: "",
-                a11yHint: "",
-                a11yId: "",
-                action: {
-                    store.dispatch(
-                        MainMenuAction(
-                            windowUUID: uuid,
-                            actionType: MainMenuActionType.show(.history)
-                        )
-                    )
-                }
-            ),
-            MenuElement(
-                title: .MainMenu.PanelLinkSection.Downloads,
-                iconName: "",
-                isEnabled: true,
-                isActive: false,
-                a11yLabel: "",
-                a11yHint: "",
-                a11yId: "",
-                action: {
-                    store.dispatch(
-                        MainMenuAction(
-                            windowUUID: uuid,
-                            actionType: MainMenuActionType.show(.downloads)
-                        )
-                    )
-                }
-            ),
-            MenuElement(
-                title: .MainMenu.PanelLinkSection.Passwords,
-                iconName: "",
-                isEnabled: true,
-                isActive: false,
-                a11yLabel: "",
-                a11yHint: "",
-                a11yId: "",
-                action: {
-                    store.dispatch(
-                        MainMenuAction(
-                            windowUUID: uuid,
-                            actionType: MainMenuActionType.show(.passwords)
-                        )
-                    )
-                }
-            )
-        ])
-    }
-
-    private func getOtherToolsSection(
-        with uuid: WindowUUID
-    ) -> MenuSection {
-        return MenuSection(options: [
-            MenuElement(
-                title: .MainMenu.OtherToolsSection.CustomizeHomepage,
-                iconName: "",
-                isEnabled: true,
-                isActive: false,
-                a11yLabel: "",
-                a11yHint: "",
-                a11yId: "",
-                action: {
-                    store.dispatch(
-                        MainMenuAction(
-                            windowUUID: uuid,
-                            actionType: MainMenuActionType.show(.customizeHomepage)
-                        )
-                    )
-                }
-            ),
-            MenuElement(
-                title: String(
-                    format: .MainMenu.OtherToolsSection.WhatsNew,
-                    AppName.shortName.rawValue
-                ),
-                iconName: "",
-                isEnabled: true,
-                isActive: false,
-                a11yLabel: "",
-                a11yHint: "",
-                a11yId: "",
-                action: {
-                    store.dispatch(
-                        MainMenuAction(
-                            windowUUID: uuid,
-                            actionType: MainMenuActionType.show(.goToURL(SupportUtils.URLForWhatsNew))
-                        )
-                    )
-                }
-            ),
-            MenuElement(
-                title: .MainMenu.OtherToolsSection.GetHelp,
-                iconName: "",
-                isEnabled: true,
-                isActive: false,
-                a11yLabel: "",
-                a11yHint: "",
-                a11yId: "",
-                action: {
-                    store.dispatch(
-                        MainMenuAction(
-                            windowUUID: uuid,
-                            actionType: MainMenuActionType.show(.goToURL(SupportUtils.URLForGetHelp))
-                        )
-                    )
-                }
-            ),
-            MenuElement(
-                title: .MainMenu.OtherToolsSection.Settings,
-                iconName: "",
-                isEnabled: true,
-                isActive: false,
-                a11yLabel: "",
-                a11yHint: "",
-                a11yId: "",
-                action: {
-                    store.dispatch(
-                        MainMenuAction(
-                            windowUUID: uuid,
-                            actionType: MainMenuActionType.show(.settings)
-                        )
-                    )
-                }
-            )
-        ])
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -29,6 +29,8 @@ class TabManagerMiddleware {
             self.resolveTabTrayActions(action: action, state: state)
         } else if let action = action as? TabPanelViewAction {
             self.resovleTabPanelViewActions(action: action, state: state)
+        } else if let action = action as? MainMenuAction {
+            self.resolveMainMenuActions(with: action, appState: state)
         }
     }
 
@@ -622,5 +624,30 @@ class TabManagerMiddleware {
                                          value: .syncPanel,
                                          extras: nil)
         }
+    }
+
+    // MARK: - Main menu actions
+    private func resolveMainMenuActions(with action: MainMenuAction, appState: AppState) {
+        switch action.actionType {
+        case MainMenuActionType.viewDidLoad:
+            store.dispatch(
+                MainMenuAction(
+                    windowUUID: action.windowUUID,
+                    actionType: MainMenuActionType.updateTabInfo(
+                        getTabInfo(forWindow: action.windowUUID)
+                    )
+                )
+            )
+        default:
+            break
+        }
+    }
+
+    private func getTabInfo(forWindow windowUUID: WindowUUID) -> MenuTabInfo? {
+        guard let selectedTab = tabManager(for: windowUUID).selectedTab else { return nil }
+        return MenuTabInfo(
+            url: selectedTab.url,
+            isHomepage: selectedTab.isFxHomeTab
+        )
     }
 }

--- a/firefox-ios/Shared/SupportUtils.swift
+++ b/firefox-ios/Shared/SupportUtils.swift
@@ -18,6 +18,11 @@ public struct SupportUtils {
         return URL(string: "https://www.mozilla.org/en-US/firefox/ios/notes/")
     }
 
+    public static var URLForGetHelp: URL? {
+        // Returns the predefined URL associated to the menu's Get Help button action.
+        return URL(string: "https://support.mozilla.org/products/ios")
+    }
+
     public static var URLForPocketLearnMore: URL? {
         // Returns the predefined URL associated to homepage Pocket's Learn more action.
         return URL(string: "https://www.mozilla.org/firefox/pocket/?utm_source=ff_ios")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9127)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20235)

## :bulb: Description
This PR:
- Moves the configurator to its own place
- Cleans up the action enum
- Adds behaviour to show/hide menu sections based on whether the current page is a site or a homepage

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

