### PR TITLE
Add FXIOS-9966 script to fetch acorn icons from its repo and sync them with local ones

### DIFF
--- a/sync_acorn_icons.py
+++ b/sync_acorn_icons.py
@@ -38,46 +38,24 @@ def download_icons_and_save():
     subprocess.run(["git", "clone", "https://github.com/FirefoxUX/acorn-icons"])
 
     target_dir_to_copy = [16, 20, 24, 30]
-    output_folder_path = "../output_icons"
-
+    asset_folder_path = "../firefox-ios/Client/Assets/Images.xcassets/"
+    images_list_present = os.listdir(asset_folder_path)
     for dir in target_dir_to_copy:
         dir_path = f"acorn-icons/icons/mobile/{dir}/pdf"
         directory_tree = os.walk(dir_path)
 
         for dir_object in directory_tree:
             for file in dir_object[2]:
-                if file.endswith(".pdf"):
-                    icon_path = os.path.join(dir_object[0], file)
-                    folder_name = f"{os.path.splitext(file)[0]}.imageset"
-
-                    destination_folder = os.path.join(output_folder_path, folder_name)
+                icon_path = os.path.join(dir_object[0], file)
+                folder_name = f"{os.path.splitext(file)[0]}.imageset".replace("Dark", "").replace("Light", "")
+                
+                # file has to be a pdf and we need the file already present in the images folder
+                if file.endswith(".pdf") and folder_name in images_list_present: 
+                    destination_folder = os.path.join(asset_folder_path, folder_name)
                     os.makedirs(destination_folder, exist_ok=True)
                     
                     destination_file = os.path.join(destination_folder, file)
                     shutil.copy(icon_path, destination_file)
-                    
-                    # Create the content.json file in the same folder
-                    contents_json_file = {
-                        "images": [
-                            {
-                                "filename": file,
-                                "idiom": "universal"
-                            }
-                        ],
-                        "info": {
-                            "author": "xcode",
-                            "version": 1
-                        },
-                        "properties": {
-                            "preserves-vector-representation": True
-                        }
-                    }
-                    
-                    # Write the content.json file
-                    json_filename = os.path.join(destination_folder, "Contents.json")
-                    with open(json_filename, "w") as json_file:
-                        json.dump(contents_json_file, json_file, indent=4)
-                    
                     print(f"Copied {file} to {destination_folder} and created Contents.json")
     
     os.chdir("..")
@@ -92,14 +70,14 @@ def sort_icons_by_size() -> dict:
         "Large": []
     }
 
-    output_icons_dir = "output_icons"
-    for folder in os.listdir(output_icons_dir):
+    asset_folder_path = "firefox-ios/Client/Assets/Images.xcassets/"
+    for folder in os.listdir(asset_folder_path):
         if folder.endswith(".imageset"):
             file_name = folder.split(".")[0]
             
             size_key = next((key for key in icons_by_size if key in file_name), None)
             
-            if size_key:
+            if size_key == "ExtraLarge":
                 icon_name = file_name.replace(size_key, "")
                 icons_by_size[size_key].append((icon_name, file_name))
 
@@ -153,5 +131,3 @@ def generate_standard_image_identifiers_swift(sorted_icons: dict):
 download_icons_and_save()
 sorted_icons = sort_icons_by_size()
 generate_standard_image_identifiers_swift(sorted_icons)
-
-## Update just the images that are already there, not all that

--- a/sync_acorn_icons.py
+++ b/sync_acorn_icons.py
@@ -1,8 +1,9 @@
 import requests
 import json
-import subprocess
 import os
 import shutil
+import subprocess
+import json
 
 def fetch_latest_release_from_acorn() -> dict|None:
     owner = "FirefoxUX" 
@@ -30,44 +31,28 @@ def save_latest_release_if_needed(data: dict) -> bool:
     file.close()
     return should_fetch_new_icons
 
+def download_icons_and_save():
+    temp_dir_folder_name = "temp_dir"
+    os.makedirs(temp_dir_folder_name, exist_ok=True)
+    os.chdir(temp_dir_folder_name)
+    subprocess.run(["git", "clone", "https://github.com/FirefoxUX/acorn-icons"])
 
-'''
-latest_release_obj = fetch_latest_release_from_acorn()
-if latest_release_obj:
-    should_fetch_new_release = save_latest_release_if_needed(latest_release_obj)
-'''
-import os
-import shutil
-import subprocess
-import json
+    target_dir_to_copy = [16, 20, 24, 30]
+    output_folder_path = "../output_icons"
 
-# Step 1: Set up temporary directory and output directory
-os.makedirs("temp_dir", exist_ok=True)
-os.makedirs("output_icons", exist_ok=True)
-os.chdir("temp_dir")
-subprocess.run(["git", "clone", "https://github.com/FirefoxUX/acorn-icons"])
+    for dir in target_dir_to_copy:
+        dir_path = f"acorn-icons/icons/mobile/{dir}/pdf"
+        directory_tree = os.walk(dir_path)
 
-# Step 2: Define target directories to copy PDFs from
-target_dir_to_copy = [16, 20, 24, 30]
-output_folder_path = "../output_icons"
-
-# Step 3: Walk through target directories and process PDF files
-for dir in target_dir_to_copy:
-    dir_path = f"acorn-icons/icons/mobile/{dir}/pdf"
-    
-    if os.path.exists(dir_path):
-        content = os.walk(dir_path)
-        for sub_content in content:
-            for file in sub_content[2]:
+        for dir_object in directory_tree:
+            for file in dir_object[2]:
                 if file.endswith(".pdf"):
-                    icon_path = os.path.join(sub_content[0], file)
-                    
-                    # Create folder for the file in output_icons with .imageset suffix
-                    folder_name = os.path.splitext(file)[0] + ".imageset"
+                    icon_path = os.path.join(dir_object[0], file)
+                    folder_name = f"{os.path.splitext(file)[0]}.imageset"
+
                     destination_folder = os.path.join(output_folder_path, folder_name)
                     os.makedirs(destination_folder, exist_ok=True)
                     
-                    # Copy the PDF file to the new folder
                     destination_file = os.path.join(destination_folder, file)
                     shutil.copy(icon_path, destination_file)
                     
@@ -94,79 +79,79 @@ for dir in target_dir_to_copy:
                         json.dump(contents_json_file, json_file, indent=4)
                     
                     print(f"Copied {file} to {destination_folder} and created Contents.json")
+    
+    os.chdir("..")
+    subprocess.run(["rm", "-rf", temp_dir_folder_name])
 
-# Dictionary to hold the icons by size
-icons_by_size = {
-    "Small": [],
-    "Medium": [],
-    "ExtraLarge": [],
-    "Large": []
-}
+def sort_icons_by_size() -> dict:
+    icons_by_size: dict[str, list[tuple[str]]] = {
+        "Small": [],
+        "Medium": [],
+        # Extra Large should be before Large since next() method will pick always Large either 
+        "ExtraLarge": [],
+        "Large": []
+    }
 
-# Directory containing the icons
-output_icons_dir = "../output_icons"
+    output_icons_dir = "output_icons"
+    for folder in os.listdir(output_icons_dir):
+        if folder.endswith(".imageset"):
+            file_name = folder.split(".")[0]
+            
+            size_key = next((key for key in icons_by_size if key in file_name), None)
+            
+            if size_key:
+                icon_name = file_name.replace(size_key, "")
+                icons_by_size[size_key].append((icon_name, file_name))
 
-# Step 1: Iterate through the `.imageset` folders and sort icons by size
-for folder in os.listdir(output_icons_dir):
-    if folder.endswith(".imageset"):
-        # Extract file name (without extension)
-        file_name = folder.split(".")[0]
-        
-        # Dynamically determine the size_key by searching for the key in the folder name
-        size_key = next((key for key in icons_by_size if key in file_name), None)
-        
-        if size_key:
-            # Clean up icon name by removing size designators
-            icon_name = file_name.replace(size_key, "")
-            # Add the cleaned icon name to the corresponding size category
-            icons_by_size[size_key].append(icon_name)
+    return icons_by_size
 
-# Step 2: Create the Swift file content
-swift_file_content = """
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
+def generate_standard_image_identifiers_swift(sorted_icons: dict):
+    swift_file_content = """
+    // This Source Code Form is subject to the terms of the Mozilla Public
+    // License, v. 2.0. If a copy of the MPL was not distributed with this
+    // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Foundation
+    import Foundation
 
-/// This struct defines all the standard image identifiers of icons and images used in the app.
-/// When adding new identifiers, please respect alphabetical order.
-/// Sing the song if you must.
-public struct StandardImageIdentifiers {
-"""
+    /// This struct defines all the standard image identifiers of icons and images used in the app.
+    /// When adding new identifiers, please respect alphabetical order.
+    /// Sing the song if you must.
+    public struct StandardImageIdentifiers {
+    """
 
-# Step 3: Generate Swift structs for each size category
-size_struct_map = {
-    "Small": "16x16",
-    "Medium": "20x20",
-    "Large": "24x24",
-    "ExtraLarge": "30x30"
-}
+    size_struct_map = {
+        "Small": "16x16",
+        "Medium": "20x20",
+        "Large": "24x24",
+        "ExtraLarge": "30x30"
+    }
 
-for size, struct_name in size_struct_map.items():
-    if icons_by_size[size]:
-        swift_file_content += f"    // Icon size {struct_name}\n"
-        swift_file_content += f"    public struct {size} {{\n"
-        
-        # Sort icons alphabetically and add them to the struct
-        for icon in sorted(icons_by_size[size]):
-            swift_file_content += f"        public static let {icon} = \"{icon}\"\n"
-        
-        swift_file_content += "    }\n"
+    for size, struct_name in size_struct_map.items():
+        if sorted_icons[size]:
+            swift_file_content += f"    // Icon size {struct_name}\n"
+            swift_file_content += f"    public struct {size} {{\n"
+            
+            # Sort icons alphabetically and add them to the struct
+            for icon_info in sorted(sorted_icons[size]):
+                swift_file_content += f"        public static let {icon_info[0]} = \"{icon_info[1]}\"\n"
+            
+            swift_file_content += "    }\n"
 
-# Closing the main struct
-swift_file_content += "}"
+    # Closing the main struct
+    swift_file_content += "}"
 
-# Step 4: Write the generated Swift file content to a .swift file
-with open("../StandardImageIdentifiers.swift", "w") as swift_file:
-    swift_file.write(swift_file_content)
+    # Step 4: Write the generated Swift file content to a .swift file
+    with open("StandardImageIdentifiers.swift", "w") as swift_file:
+        swift_file.write(swift_file_content)
 
-print("Swift file 'StandardImageIdentifiers.swift' generated successfully.")
 
-# Step 4: Clean up temporary directory
-os.chdir("..")
-subprocess.run(["rm", "StandardImageIdentifiers.swift"])
-subprocess.run(["rm", "-rf", "output_icons"])
-subprocess.run(["rm", "-rf", "temp_dir"])
+    print("PDF files have been processed and copied with content.json files.")
 
-print("PDF files have been processed and copied with content.json files.")
+
+
+
+download_icons_and_save()
+sorted_icons = sort_icons_by_size()
+generate_standard_image_identifiers_swift(sorted_icons)
+
+## Update just the images that are already there, not all that

--- a/sync_acorn_icons.py
+++ b/sync_acorn_icons.py
@@ -49,8 +49,10 @@ def download_icons_and_save():
                 icon_path = os.path.join(dir_object[0], file)
                 folder_name = f"{os.path.splitext(file)[0]}.imageset".replace("Dark", "").replace("Light", "")
 
+                original_file_path = f"{asset_folder_path}{folder_name}/{file}"
                 # file has to be a pdf and we need the file already present in the images folder
-                if file.endswith(".pdf") and folder_name in images_list_present: 
+                # the file need to be already in the original folder, no different file can be added
+                if file.endswith(".pdf") and folder_name in images_list_present and os.path.exists(original_file_path):
                     destination_folder = os.path.join(asset_folder_path, folder_name)
                     os.makedirs(destination_folder, exist_ok=True)
                     

--- a/sync_acorn_icons.py
+++ b/sync_acorn_icons.py
@@ -31,28 +31,28 @@ def save_latest_release_if_needed(data: dict) -> bool:
     file.close()
     return should_fetch_new_icons
 
-def download_icons_and_save():
+def download_icons_and_save_in_assets():
     temp_dir_folder_name = "temp_dir"
     os.makedirs(temp_dir_folder_name, exist_ok=True)
     os.chdir(temp_dir_folder_name)
     subprocess.run(["git", "clone", "https://github.com/FirefoxUX/acorn-icons"])
 
-    target_dir_to_copy = [16, 20, 24, 30]
+    target_size_to_copy = [16, 20, 24, 30]
     asset_folder_path = "../firefox-ios/Client/Assets/Images.xcassets/"
-    images_list_present = os.listdir(asset_folder_path)
-    for dir in target_dir_to_copy:
-        dir_path = f"acorn-icons/icons/mobile/{dir}/pdf"
-        directory_tree = os.walk(dir_path)
+    asset_folder_list = os.listdir(asset_folder_path)
+    for size in target_size_to_copy:
+        icons_dir_path = f"acorn-icons/icons/mobile/{size}/pdf"
+        directory_tree = os.walk(icons_dir_path)
 
         for dir_object in directory_tree:
             for file in dir_object[2]:
                 icon_path = os.path.join(dir_object[0], file)
                 folder_name = f"{os.path.splitext(file)[0]}.imageset".replace("Dark", "").replace("Light", "")
 
-                original_file_path = f"{asset_folder_path}{folder_name}/{file}"
+                asset_file_path = f"{asset_folder_path}{folder_name}/{file}"
                 # file has to be a pdf and we need the file already present in the images folder
-                # the file need to be already in the original folder, no different file can be added
-                if file.endswith(".pdf") and folder_name in images_list_present and os.path.exists(original_file_path):
+                # the file need to be already in the asset folder, no different file can be added
+                if file.endswith(".pdf") and folder_name in asset_folder_list and os.path.exists(asset_file_path):
                     destination_folder = os.path.join(asset_folder_path, folder_name)
                     os.makedirs(destination_folder, exist_ok=True)
                     
@@ -67,7 +67,7 @@ def sort_icons_by_size() -> dict:
     icons_by_size: dict[str, list[tuple[str]]] = {
         "Small": [],
         "Medium": [],
-        # Extra Large should be before Large since next() method will pick always Large either 
+        # Extra Large should be before Large since next() will pick Large also for ExtraLarge case
         "ExtraLarge": [],
         "Large": []
     }
@@ -117,11 +117,10 @@ public struct StandardImageIdentifiers {
             
             swift_file_content += "    }\n"
 
-    # Closing the main struct
     swift_file_content += "}"
 
-    # Step 4: Write the generated Swift file content to a .swift file
-    with open("StandardImageIdentifiers.swift", "w") as swift_file:
+    standard_image_file_path = "BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift"
+    with open(standard_image_file_path, "w") as swift_file:
         swift_file.write(swift_file_content)
 
 
@@ -130,6 +129,6 @@ public struct StandardImageIdentifiers {
 
 
 
-download_icons_and_save()
+download_icons_and_save_in_assets()
 sorted_icons = sort_icons_by_size()
 generate_standard_image_identifiers_swift(sorted_icons)

--- a/sync_acorn_icons.py
+++ b/sync_acorn_icons.py
@@ -3,7 +3,6 @@ import json
 import os
 import shutil
 import subprocess
-import json
 
 def fetch_latest_release_from_acorn() -> dict|None:
     owner = "FirefoxUX" 

--- a/sync_acorn_icons.py
+++ b/sync_acorn_icons.py
@@ -23,6 +23,10 @@ def save_latest_release_if_needed(data: dict) -> bool:
     :returns bool: True if a new release has been deteceted, otherwise False
     '''
     file_path = "latest_acorn_release.json"
+    if not os.path.exists(file_path):
+        with open(file_path, "w"):
+            pass
+        
     file = open(file_path, "r+")
     should_fetch_new_icons = False
     if not file.read():

--- a/sync_acorn_icons.py
+++ b/sync_acorn_icons.py
@@ -1,0 +1,172 @@
+import requests
+import json
+import subprocess
+import os
+import shutil
+
+def fetch_latest_release_from_acorn() -> dict|None:
+    owner = "FirefoxUX" 
+    repo = "acorn-icons"    
+    url = f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
+    response = requests.get(url=url)
+    if response.status_code == 200:
+        return response.json()
+    
+def save_latest_release_if_needed(data: dict) -> bool:
+    file = open("latest_acorn_release.json", "r+")
+    should_fetch_new_icons = False
+    if len(file.read()) == 0:
+        json.dump(data, fp=file, indent=4)
+        should_fetch_new_icons = True
+    else:
+        file.flush()
+        current_fetched_id = data["id"]
+        saved_id = json.load(file)["id"]
+        if current_fetched_id == saved_id:
+            # new release has to be fetched
+            file.truncate(0)
+            json.dump(data, fp=file, indent=4)
+            should_fetch_new_icons = True
+    file.close()
+    return should_fetch_new_icons
+
+
+'''
+latest_release_obj = fetch_latest_release_from_acorn()
+if latest_release_obj:
+    should_fetch_new_release = save_latest_release_if_needed(latest_release_obj)
+'''
+import os
+import shutil
+import subprocess
+import json
+
+# Step 1: Set up temporary directory and output directory
+os.makedirs("temp_dir", exist_ok=True)
+os.makedirs("output_icons", exist_ok=True)
+os.chdir("temp_dir")
+subprocess.run(["git", "clone", "https://github.com/FirefoxUX/acorn-icons"])
+
+# Step 2: Define target directories to copy PDFs from
+target_dir_to_copy = [16, 20, 24, 30]
+output_folder_path = "../output_icons"
+
+# Step 3: Walk through target directories and process PDF files
+for dir in target_dir_to_copy:
+    dir_path = f"acorn-icons/icons/mobile/{dir}/pdf"
+    
+    if os.path.exists(dir_path):
+        content = os.walk(dir_path)
+        for sub_content in content:
+            for file in sub_content[2]:
+                if file.endswith(".pdf"):
+                    icon_path = os.path.join(sub_content[0], file)
+                    
+                    # Create folder for the file in output_icons with .imageset suffix
+                    folder_name = os.path.splitext(file)[0] + ".imageset"
+                    destination_folder = os.path.join(output_folder_path, folder_name)
+                    os.makedirs(destination_folder, exist_ok=True)
+                    
+                    # Copy the PDF file to the new folder
+                    destination_file = os.path.join(destination_folder, file)
+                    shutil.copy(icon_path, destination_file)
+                    
+                    # Create the content.json file in the same folder
+                    contents_json_file = {
+                        "images": [
+                            {
+                                "filename": file,
+                                "idiom": "universal"
+                            }
+                        ],
+                        "info": {
+                            "author": "xcode",
+                            "version": 1
+                        },
+                        "properties": {
+                            "preserves-vector-representation": True
+                        }
+                    }
+                    
+                    # Write the content.json file
+                    json_filename = os.path.join(destination_folder, "Contents.json")
+                    with open(json_filename, "w") as json_file:
+                        json.dump(contents_json_file, json_file, indent=4)
+                    
+                    print(f"Copied {file} to {destination_folder} and created Contents.json")
+
+# Dictionary to hold the icons by size
+icons_by_size = {
+    "Small": [],
+    "Medium": [],
+    "ExtraLarge": [],
+    "Large": []
+}
+
+# Directory containing the icons
+output_icons_dir = "../output_icons"
+
+# Step 1: Iterate through the `.imageset` folders and sort icons by size
+for folder in os.listdir(output_icons_dir):
+    if folder.endswith(".imageset"):
+        # Extract file name (without extension)
+        file_name = folder.split(".")[0]
+        
+        # Dynamically determine the size_key by searching for the key in the folder name
+        size_key = next((key for key in icons_by_size if key in file_name), None)
+        
+        if size_key:
+            # Clean up icon name by removing size designators
+            icon_name = file_name.replace(size_key, "")
+            # Add the cleaned icon name to the corresponding size category
+            icons_by_size[size_key].append(icon_name)
+
+# Step 2: Create the Swift file content
+swift_file_content = """
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// This struct defines all the standard image identifiers of icons and images used in the app.
+/// When adding new identifiers, please respect alphabetical order.
+/// Sing the song if you must.
+public struct StandardImageIdentifiers {
+"""
+
+# Step 3: Generate Swift structs for each size category
+size_struct_map = {
+    "Small": "16x16",
+    "Medium": "20x20",
+    "Large": "24x24",
+    "ExtraLarge": "30x30"
+}
+
+for size, struct_name in size_struct_map.items():
+    if icons_by_size[size]:
+        swift_file_content += f"    // Icon size {struct_name}\n"
+        swift_file_content += f"    public struct {size} {{\n"
+        
+        # Sort icons alphabetically and add them to the struct
+        for icon in sorted(icons_by_size[size]):
+            swift_file_content += f"        public static let {icon} = \"{icon}\"\n"
+        
+        swift_file_content += "    }\n"
+
+# Closing the main struct
+swift_file_content += "}"
+
+# Step 4: Write the generated Swift file content to a .swift file
+with open("../StandardImageIdentifiers.swift", "w") as swift_file:
+    swift_file.write(swift_file_content)
+
+print("Swift file 'StandardImageIdentifiers.swift' generated successfully.")
+
+# Step 4: Clean up temporary directory
+os.chdir("..")
+subprocess.run(["rm", "StandardImageIdentifiers.swift"])
+subprocess.run(["rm", "-rf", "output_icons"])
+subprocess.run(["rm", "-rf", "temp_dir"])
+
+print("PDF files have been processed and copied with content.json files.")

--- a/sync_acorn_icons.py
+++ b/sync_acorn_icons.py
@@ -48,7 +48,7 @@ def download_icons_and_save():
             for file in dir_object[2]:
                 icon_path = os.path.join(dir_object[0], file)
                 folder_name = f"{os.path.splitext(file)[0]}.imageset".replace("Dark", "").replace("Light", "")
-                
+
                 # file has to be a pdf and we need the file already present in the images folder
                 if file.endswith(".pdf") and folder_name in images_list_present: 
                     destination_folder = os.path.join(asset_folder_path, folder_name)
@@ -77,7 +77,7 @@ def sort_icons_by_size() -> dict:
             
             size_key = next((key for key in icons_by_size if key in file_name), None)
             
-            if size_key == "ExtraLarge":
+            if size_key:
                 icon_name = file_name.replace(size_key, "")
                 icons_by_size[size_key].append((icon_name, file_name))
 
@@ -85,17 +85,17 @@ def sort_icons_by_size() -> dict:
 
 def generate_standard_image_identifiers_swift(sorted_icons: dict):
     swift_file_content = """
-    // This Source Code Form is subject to the terms of the Mozilla Public
-    // License, v. 2.0. If a copy of the MPL was not distributed with this
-    // file, You can obtain one at http://mozilla.org/MPL/2.0/
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-    import Foundation
+import Foundation
 
-    /// This struct defines all the standard image identifiers of icons and images used in the app.
-    /// When adding new identifiers, please respect alphabetical order.
-    /// Sing the song if you must.
-    public struct StandardImageIdentifiers {
-    """
+/// This struct defines all the standard image identifiers of icons and images used in the app.
+/// When adding new identifiers, please respect alphabetical order.
+/// Sing the song if you must.
+public struct StandardImageIdentifiers {
+"""
 
     size_struct_map = {
         "Small": "16x16",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9966)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21886)

## :bulb: Description
Add a python script that keep tracks of the latest acorn icons release and if there is a new version it clones the repo and syncs the icon with the firefox-ios asset folder.
The code generates also the `StandardImageIdentifier.swift`.

At the moment since the script won't add any new images different that the one already locally stored, the `StandardImageIdentifier.swift` generation can be avoided, but it is nice to have it for later and also beacuse it keeps the properties of the struct sorted.

In order to test it make sure to have the package `requests` installed.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

