### PR TITLE
Bugfix MTE-3458 testSaveLogin for Github Actions only

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -114,7 +114,7 @@ class LoginTest: BaseTestCase {
             mozWaitForElementToExist(app.staticTexts[domain])
             // XCTAssertTrue(app.staticTexts[domainSecondLogin].exists)
             // Workaround for Bitrise specific issue. "vagrant" user is used in Bitrise.
-            if (ProcessInfo.processInfo.environment["HOME"]!).contains(String("vagrant")) {
+            if (ProcessInfo.processInfo.environment["HOME"]!).contains(String("vagrant") || ProcessInfo.processInfo.environment["HOME"]!).contains(String("runner")) {
                 XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
             } else {
                 XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -114,7 +114,10 @@ class LoginTest: BaseTestCase {
             mozWaitForElementToExist(app.staticTexts[domain])
             // XCTAssertTrue(app.staticTexts[domainSecondLogin].exists)
             // Workaround for Bitrise specific issue. "vagrant" user is used in Bitrise.
-            if (ProcessInfo.processInfo.environment["HOME"]!).contains(String("vagrant") || ProcessInfo.processInfo.environment["HOME"]!).contains(String("runner")) {
+            if (ProcessInfo.processInfo.environment["HOME"]!).contains(String("vagrant")) {
+                XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
+            // Workaround for Github Actions specific issue. "runner" user is used in Github Actions.
+            } else if (ProcessInfo.processInfo.environment["HOME"]!).contains(String("runner")) {
                 XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
             } else {
                 XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 2)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3458)

## :bulb: Description
`testSaveLogin()` fails consistently on Github Actions only. It requires accommodation because the simulator from the runner could contain a login already.

Github Actions workflow run: https://github.com/mozilla-mobile/firefox-ios/actions/runs/10813782856

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

