### PR TITLE
Bugfix FXIOS-9969 [Error Page] homepage top sites access from error page

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -384,7 +384,11 @@ class HomepageViewController:
 
     @objc
     private func dismissKeyboard() {
-        if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("internal://") ?? false {
+        /* homepage and error page, both are "internal" url, making
+           topsites on homepage inaccessible from error page 
+           when address bar is selected hence using "about/home".
+        */
+        if currentTab?.lastKnownUrl?.absoluteString.hasPrefix("\(InternalURL.baseUrl)/\(AboutHomeHandler.path)") ?? false {
             overlayManager.cancelEditing(shouldCancelLoading: false)
 
             let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.cancelEdit)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9969)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21889)

## :bulb: Description
Checking `about/home` instead of `internal` for home page url.
This is to distinguish between home page and error page (both are internal urls) when user clicks on address bar on certificate error page and try to access top sites from home page that is in background. 
Refer Github issue for bug screen-capture.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

