### PR TITLE
Add MTE-3388 Use Github Actions for smoke test and selected full functional tests

### DIFF
--- a/.github/workflows/firefox-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/firefox-ios-ui-tests-previous-os.yml
@@ -198,7 +198,7 @@ jobs:
     run-fullfunctionaltests:
       name: Run full functional tests
       runs-on: macos-14
-      if: ${{ always() }}
+      if: false
       needs: run-smoketests
       strategy:
         fail-fast: false

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -207,11 +207,12 @@ jobs:
     run-fullfunctionaltests:
       name: Run full functional tests
       runs-on: macos-14
-      needs: compile
+      needs: run-smoketests
+      if: false
       strategy:
         fail-fast: false
         matrix:
-          ios_simulator: ['iPhone 15 Pro Max']
+          ios_simulator: ['iPhone 15 Pro Max', 'iPad Pro (12.9 inch) (6th generation)']
       steps:
         - name: Check out source code
           uses: actions/checkout@v4.1.7

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -117,10 +117,10 @@ jobs:
               id: slack
               uses: slackapi/slack-github-action@v1.26.0
               with:
-                channel-id: ${{ secrets.CHANNEL_ID }}
                 payload-file-path: ${{ env.browser }}/slack.json
               env:
-                SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+                SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
                 ios_simulator: ${{ matrix.ios_simulator }}
                 pass_fail:  ${{ steps.run-tests.outcome == 'success' && ':white_check_mark:' || ':x:' }}
                 xcodebuild_test_plan: ${{ matrix.xcodebuild_test_plan }}

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -54,7 +54,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                xcodebuild_test_plan: ['SmokeTest', 'FullFunctionalTests']
+                xcodebuild_test_plan: ['SmokeTest'] # , 'FullFunctionalTests']
                 ios_simulator: [ 'iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
         steps:
             - name: Check out source code

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -117,10 +117,10 @@ jobs:
               id: slack
               uses: slackapi/slack-github-action@v1.26.0
               with:
+                channel-id: ${{ secrets.CHANNEL_ID }}
                 payload-file-path: ${{ env.browser }}/slack.json
               env:
-                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-                SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+                SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
                 ios_simulator: ${{ matrix.ios_simulator }}
                 pass_fail:  ${{ steps.run-tests.outcome == 'success' && ':white_check_mark:' || ':x:' }}
                 xcodebuild_test_plan: ${{ matrix.xcodebuild_test_plan }}

--- a/test-fixtures/generate-metrics.sh
+++ b/test-fixtures/generate-metrics.sh
@@ -5,7 +5,7 @@ set -e
 BUILD_LOG_FILE="$1"
 TYPE_LOG_FILE="$2"
 THRESHOLD_UNIT_TEST=9
-THRESHOLD_XCUITEST=21
+THRESHOLD_XCUITEST=22
 
 WARNING_COUNT=$(grep -E -v "SourcePackages/checkouts" "$BUILD_LOG_FILE" | grep -E "(^|:)[0-9]+:[0-9]+:|warning:|ld: warning:|<unknown>:0: warning:|fatal|===" | uniq | wc -l)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3388)

## :bulb: Description
After examining the Github Actions workflow runs, I have decided to *keep* the following existing Jenkins job and disable the corresponding Github Actions workflow for now:
* firefox-ios-full-functional-ipad
* firefox-ios-full-functional-iphone
* firefox-ios-iphone-iOS-15
* firefox-ios-iphone-iOS-16
* focus-ios-full-functional-ipad-M1
* focus-ios-full-functional-iphone-M1

Some full functional tests on iOS 17.5 times out on Github Actions but not on elsewhere.

The following Jenkins jobs can be disabled:
* firefox-ios-smoketest-ipad
* firefox-ios-smoketest-iphone
* focus-ios-iphone-iOS-15
* focus-ios-iphone-iOS-16
* focus-ios-smoke-test-ipad-M1
* focus-ios-smoke-test-iphone-M1

Focus smoke tests: https://github.com/mozilla-mobile/firefox-ios/actions/runs/10817892082
Focus smoke tests and full functional tests for iOS 15 and 16: https://github.com/mozilla-mobile/firefox-ios/actions/runs/10817623855
Firefox smoke tests: https://github.com/mozilla-mobile/firefox-ios/actions/runs/10817618757
Firefox smoke tests for iOS 15 and 16: https://github.com/mozilla-mobile/firefox-ios/actions/runs/10817621420


Notes: https://docs.google.com/spreadsheets/d/1GSmDIS5kw3GuUqolbyTjR8IqBki-Sayjp1RTOiGcA1c/edit?gid=0#gid=0


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

