### PR TITLE
Bugfix FXIOS-9953, FXIOS-9952, FXIOS-9951, FXIOS-9970 [Inactive Tabs] Fixes bugs with closing and restoring inactive tabs

### DIFF
--- a/BrowserKit/Tests/SiteImageViewTests/SiteImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SiteImageHandlerTests.swift
@@ -53,7 +53,6 @@ final class SiteImageHandlerTests: XCTestCase {
     }
 
     func testGetImage_favicon_noURL_stillCallsImageHandler_fetchFavicon() async {
-        let faviconURLString = "https://www.mozilla.org/media/img/favicons/mozilla/apple-touch-icon.8cbe9c835c00.png"
         let siteURL = URL(string: "https://www.mozilla.com")!
         let subject = DefaultSiteImageHandler(urlHandler: urlHandler,
                                               imageHandler: imageHandler)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/InactiveTabsManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/InactiveTabsManager.swift
@@ -6,33 +6,14 @@ import Foundation
 import Shared
 
 protocol InactiveTabsManagerProtocol {
+    /// Returns inactive normal (non-private) tabs filtered from the given tabs array.
+    /// - Parameter tabs: The array of tabs to filter.
+    /// - Returns: The non-private, inactive tabs inside the `tabs` array.
     func getInactiveTabs(tabs: [Tab]) -> [Tab]
 }
 
 class InactiveTabsManager: InactiveTabsManagerProtocol {
     func getInactiveTabs(tabs: [Tab]) -> [Tab] {
-        var inactiveTabs = [Tab]()
-        let currentDate = Date()
-        let defaultOldDay: Date
-
-        // Debug for inactive tabs to easily test in code
-        if UserDefaults.standard.bool(forKey: PrefsKeys.FasterInactiveTabsOverride) {
-            defaultOldDay = Calendar.current.date(byAdding: .second, value: -10, to: currentDate) ?? Date()
-        } else {
-            let noon = Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: currentDate) ?? Date()
-            let day14Old = Calendar.current.date(byAdding: .day, value: -14, to: noon) ?? Date()
-            defaultOldDay = day14Old
-        }
-
-        let regularTabs = tabs.filter({ $0.isPrivate == false })
-        for tab in regularTabs {
-            let tabTimeStamp = tab.lastExecutedTime ?? tab.firstCreatedTime ?? 0
-            let tabDate = Date.fromTimestamp(tabTimeStamp)
-
-            if tabDate <= defaultOldDay {
-                inactiveTabs.append(tab)
-            }
-        }
-        return inactiveTabs
+        return tabs.filter({ !$0.isPrivate && $0.isInactive })
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabViewModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabViewModel.swift
@@ -48,6 +48,9 @@ class LegacyInactiveTabViewModel {
         updateFilteredTabs()
     }
 
+    // FIXME What is this comment saying? I don't have context... the dates described are wrong, and it didn't use the
+    // debug test wrapper like the 2 other places this logic was used.
+    //
     /// This function returns any tabs that are less than four days old.
     ///
     /// Because the "Jump Back In" and "Inactive Tabs" features are separate features,
@@ -55,39 +58,11 @@ class LegacyInactiveTabViewModel {
     /// assume that if we want to use active/inactive state, we can do so without
     /// that particular feature being active but still respecting that logic.
     static func getActiveEligibleTabsFrom(_ tabs: [Tab]) -> [Tab] {
-        var activeTabs = [Tab]()
-
-        let currentDate = Date()
-        let noon = Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: currentDate) ?? Date()
-        let day14Old = Calendar.current.date(byAdding: .day, value: -14, to: noon) ?? Date()
-        let defaultOldDay = day14Old
-
-        for tab in tabs {
-            let tabTimeStamp = tab.lastExecutedTime ?? tab.firstCreatedTime ?? 0
-            let tabDate = Date.fromTimestamp(tabTimeStamp)
-
-            if tabDate > defaultOldDay || tabTimeStamp == 0 {
-                activeTabs.append(tab)
-            }
-        }
-
-        return activeTabs
+        return tabs.filter({ $0.isActive })
     }
 
     // MARK: - Private functions
     private func updateModelState(state: TabUpdateState) {
-        let currentDate = Date()
-        let defaultOldDay: Date
-
-        // Debug for inactive tabs to easily test in code
-        if UserDefaults.standard.bool(forKey: PrefsKeys.FasterInactiveTabsOverride) {
-            defaultOldDay = Calendar.current.date(byAdding: .second, value: -10, to: currentDate) ?? Date()
-        } else {
-            let noon = Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: currentDate) ?? Date()
-            let day14Old = Calendar.current.date(byAdding: .day, value: -14, to: noon) ?? Date()
-            defaultOldDay = day14Old
-        }
-
         let hasRunInactiveTabFeatureBefore = LegacyInactiveTabModel.hasRunInactiveTabFeatureBefore
         if hasRunInactiveTabFeatureBefore == false { LegacyInactiveTabModel.hasRunInactiveTabFeatureBefore = true }
 
@@ -115,9 +90,9 @@ class LegacyInactiveTabViewModel {
                 inactiveTabModel.tabWithStatus[tab.tabUUID]?.currentState = .normal
             } else if tabType?.nextState == .shouldBecomeInactive && state == .sameSession {
                 continue
-            } else if tab == selectedTab || tabDate > defaultOldDay || tabTimeStamp == 0 {
+            } else if tab == selectedTab || tab.isActive || tabTimeStamp == 0 {
                 inactiveTabModel.tabWithStatus[tab.tabUUID]?.currentState = .normal
-            } else if tabDate <= defaultOldDay {
+            } else if tab.isInactive {
                 if hasRunInactiveTabFeatureBefore == false {
                     inactiveTabModel.tabWithStatus[tab.tabUUID]?.nextState = .shouldBecomeInactive
                 } else if state == .coldStart {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabViewModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabViewModel.swift
@@ -54,7 +54,7 @@ class LegacyInactiveTabViewModel {
     /// it is not a given that a tab has an active/inactive state. Thus, we must
     /// assume that if we want to use active/inactive state, we can do so without
     /// that particular feature being active but still respecting that logic.
-    static func getActiveEligibleTabsFrom(_ tabs: [Tab], profile: Profile) -> [Tab] {
+    static func getActiveEligibleTabsFrom(_ tabs: [Tab]) -> [Tab] {
         var activeTabs = [Tab]()
 
         let currentDate = Date()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -206,6 +206,7 @@ class TabManagerMiddleware {
         var tabs = [TabModel]()
         let tabManager = tabManager(for: uuid)
         let selectedTab = tabManager.selectedTab
+        // Be careful to use active tabs and not inactive tabs
         let tabManagerTabs = isPrivateMode ? tabManager.privateTabs : tabManager.normalActiveTabs
         tabManagerTabs.forEach { tab in
             let tabModel = TabModel(tabUUID: tab.tabUUID,
@@ -304,10 +305,12 @@ class TabManagerMiddleware {
     /// - Returns: If is the last tab to be closed used to trigger dismissTabTray action
     private func closeTab(with tabUUID: TabUUID, uuid: WindowUUID, isPrivate: Bool) async -> Bool {
         let tabManager = tabManager(for: uuid)
-        let isLastTab = isPrivate ? tabManager.privateTabs.count == 1 : tabManager.normalTabs.count == 1
+        let isLastActiveTab = isPrivate
+                            ? tabManager.privateTabs.count == 1
+                            : tabManager.normalActiveTabs.count == 1
 
         await tabManager.removeTab(tabUUID)
-        return isLastTab
+        return isLastActiveTab
     }
 
     /// Close tab and trigger refresh

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -91,11 +91,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     var inactiveTabs: [Tab] {
-        let normalTabs = Set(normalTabs)
-        let normalActiveTabs = Set(normalActiveTabs)
-
-        let inactiveTabs = normalTabs.subtracting(normalActiveTabs)
-        return Array(inactiveTabs)
+        return normalTabs.filter({ $0.isInactive })
     }
 
     var privateTabs: [Tab] {

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -87,8 +87,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     var normalActiveTabs: [Tab] {
-        return LegacyInactiveTabViewModel.getActiveEligibleTabsFrom(normalTabs,
-                                                                    profile: profile)
+        return LegacyInactiveTabViewModel.getActiveEligibleTabsFrom(normalTabs)
     }
 
     var inactiveTabs: [Tab] {
@@ -833,7 +832,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         if !isPrivate, featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildAndUser) {
             // only use active tabs as viable tabs
             // we cannot use recentlyAccessedNormalTabs as this is filtering for sponsored and sorting tabs
-            return LegacyInactiveTabViewModel.getActiveEligibleTabsFrom(normalTabs, profile: profile)
+            return LegacyInactiveTabViewModel.getActiveEligibleTabsFrom(normalTabs)
         } else {
             return isPrivate ? privateTabs : normalTabs
         }
@@ -846,24 +845,33 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     private func updateIndexAfterRemovalOf(_ tab: Tab, deletedIndex: Int, viableTabsIndex: Int) {
-        let closedLastNormalTab = !tab.isPrivate && normalTabs.isEmpty
+        let closedLastNormalActiveTab = !tab.isPrivate && normalActiveTabs.isEmpty
         let closedLastPrivateTab = tab.isPrivate && privateTabs.isEmpty
 
-        if closedLastNormalTab {
+        if closedLastNormalActiveTab {
+            // When we close the last normal tab (or last active normal tab), we should show the Home screen.
             selectTab(addTab(), previous: tab)
         } else if closedLastPrivateTab {
             selectTab(mostRecentTab(inTabs: tabs) ?? tabs.last, previous: tab)
         } else if deletedIndex == _selectedIndex {
             if !selectParentTab(afterRemoving: tab) {
+                // We only consider active tabs viable (we don't want to surface a 2 week old inactive tab)
                 let viableTabs = viableTabs(isPrivate: tab.isPrivate)
+                let activeViableTabs = LegacyInactiveTabViewModel.getActiveEligibleTabsFrom(viableTabs)
 
-                if let rightOrLeftTab = viableTabs[safe: viableTabsIndex] ?? viableTabs[safe: viableTabsIndex - 1] {
+                // Try to select the active tab to the left or right of the removed tab. If that fails, fallback to
+                // selecting the most recent tab
+                if let rightOrLeftTab =
+                    activeViableTabs[safe: viableTabsIndex] ?? activeViableTabs[safe: viableTabsIndex - 1] {
                     selectTab(rightOrLeftTab, previous: tab)
                 } else {
-                    selectTab(mostRecentTab(inTabs: viableTabs) ?? viableTabs.last, previous: tab)
+                    let mostRecentTab = mostRecentTab(inTabs: activeViableTabs) ?? activeViableTabs.last
+                    selectTab(mostRecentTab, previous: tab)
                 }
             }
         } else if deletedIndex < _selectedIndex {
+            // If we delete an active tab that's before the selected active tab, we need to shift our selection index
+            // since the array size has changed.
             let selected = tabs[safe: _selectedIndex - 1]
             selectTab(selected, previous: selected)
         }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -413,7 +413,7 @@ class Tab: NSObject, ThemeApplicable {
 
         // Debug for inactive tabs to easily test in code
         if UserDefaults.standard.bool(forKey: PrefsKeys.FasterInactiveTabsOverride) {
-            inactiveDate = Calendar.current.date(byAdding: .minute, value: -2, to: currentDate) ?? Date()
+            inactiveDate = Calendar.current.date(byAdding: .second, value: -10, to: currentDate) ?? Date()
         } else {
             inactiveDate = Calendar.current.date(byAdding: .day, value: -14, to: currentDate.noon) ?? Date()
         }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -404,7 +404,7 @@ class Tab: NSObject, ThemeApplicable {
     private var alertQueue = [JSAlertInfo]()
 
     var profile: Profile
-    
+
     /// Returns true if this tab is considered inactive (has not been executed for more than a specific number of days).
     /// Note: When `FasterInactiveTabsOverride` is enabled, tabs become inactive very quickly for testing purposes.
     var isInactive: Bool {
@@ -422,12 +422,12 @@ class Tab: NSObject, ThemeApplicable {
         guard let tabTimeStamp = lastExecutedTime ?? firstCreatedTime else {
             return false
         }
-        
+
         // If the tabDate is older than our inactive date cutoff, return true
         let tabDate = Date.fromTimestamp(tabTimeStamp)
         return tabDate <= inactiveDate
     }
-    
+
     /// Returns true if this tab is considered active (has been executed within a specific numbers of days).
     /// Note: When `FasterInactiveTabsOverride` is enabled, tabs become inactive very quickly for testing purposes.
     var isActive: Bool {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -23,9 +23,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
     var inactiveTabsManager: InactiveTabsManagerProtocol
 
     override var normalActiveTabs: [Tab] {
-        let inactiveTabs = getInactiveTabs()
-        let activeTabs = tabs.filter { $0.isPrivate == false && !inactiveTabs.contains($0) }
-        return activeTabs
+        return tabs.filter { !$0.isPrivate && $0.isActive }
     }
 
     init(profile: Profile,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuStateTests.swift
@@ -20,7 +20,6 @@ final class MainMenuStateTests: XCTestCase {
 
     func testInitialization() {
         let initialState = createSubject()
-        let reducer = mainMenuReducer()
 
         XCTAssertFalse(initialState.shouldDismiss)
         XCTAssertEqual(initialState.menuElements, [])

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/SupportUtilsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/SupportUtilsTests.swift
@@ -21,7 +21,6 @@ class SupportUtilsTests: XCTestCase {
     }
 
     func testURLForPrivacyNotice_withoutContentParam() {
-        let appVersion = AppInfo.appVersion
         let languageIdentifier = Locale.preferredLanguages.first!
 
         let urlString = SupportUtils.URLForPrivacyNotice(
@@ -37,7 +36,6 @@ class SupportUtilsTests: XCTestCase {
     }
 
     func testURLForPrivacyNotice_withContentParam() {
-        let appVersion = AppInfo.appVersion
         let languageIdentifier = Locale.preferredLanguages.first!
 
         let urlString = SupportUtils.URLForPrivacyNotice(


### PR DESCRIPTION
## :scroll: Tickets

Fixes several issues:

[Jira ticket 9953](https://mozilla-hub.atlassian.net/browse/FXIOS-9953)
[Github issue 21862](https://github.com/mozilla-mobile/firefox-ios/issues/21862)

[Jira ticket 9952](https://mozilla-hub.atlassian.net/browse/FXIOS-9952)
[Github issue 21860](https://github.com/mozilla-mobile/firefox-ios/issues/21860)

[Jira ticket 9951](https://mozilla-hub.atlassian.net/browse/FXIOS-9951)
[Github issue 21859](https://github.com/mozilla-mobile/firefox-ios/issues/21859)

[Jira ticket 9970](https://mozilla-hub.atlassian.net/browse/FXIOS-9970)
[Github issue 21891](https://github.com/mozilla-mobile/firefox-ios/issues/21891)

## :bulb: Description
A bunch of the inactive tab bugs appear to be a result of 1) inactive tabs aren't accounted for in certain areas of the code, and 2) some of the testing debug logic wasn't being used properly by the LegacyInactiveTabViewModel.

### Main fixes:
- Update the LegacyTabManager to properly account for inactive tabs in removal logic for choosing the next "selected" tab
- Update TabManagerMiddleware `closeTab` function to take into account closing the last ACTIVE tab (did not filter out inactive normal tabs)
- Found 3 places where the exact same date logic to calculate active vs. inactive tabs was repeated. Moved this logic into getters inside Tab.swift. Refactored everywhere to use this common logic and simplify things.
- The previous point also fixed once instance where the debug flag for quick inactive tabs was not being used, which meant some areas of the app probably were disagreeing with other areas of the app when the debug flag was enabled.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

