### PR TITLE
Refactor FXIOS-9968 Studies opt out on Firefox iOS when telemetry usage is unchecked

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -51,6 +51,10 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
     weak var parentCoordinator: SettingsFlowDelegate?
 
+    // MARK: - Data Settings
+    private var sendAnonymousUsageDataSetting: BoolSetting?
+    private var studiesToggleSetting: BoolSetting?
+
     // MARK: - Initializers
     init(with profile: Profile,
          and tabManager: TabManager,
@@ -65,6 +69,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         self.tabManager = tabManager
         self.settingsDelegate = delegate
         setupNavigationBar()
+        setupDataSettings()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -158,6 +163,31 @@ class AppSettingsTableViewController: SettingsTableViewController,
         default:
             break
         }
+    }
+
+    // MARK: Data settings setup
+
+    private func setupDataSettings() {
+        let anonymousUsageDataSetting = SendAnonymousUsageDataSetting(
+            prefs: profile.prefs,
+            delegate: settingsDelegate,
+            theme: themeManager.getCurrentTheme(for: windowUUID),
+            settingsDelegate: parentCoordinator
+        )
+
+        let studiesSetting = StudiesToggleSetting(
+            prefs: profile.prefs,
+            delegate: settingsDelegate,
+            theme: themeManager.getCurrentTheme(for: windowUUID),
+            settingsDelegate: parentCoordinator
+        )
+
+        anonymousUsageDataSetting.shouldSendUsageData = { value in
+            studiesSetting.updateSetting(for: value)
+        }
+
+        sendAnonymousUsageDataSetting = anonymousUsageDataSetting
+        studiesToggleSetting = studiesSetting
     }
 
     // MARK: - Generate Settings
@@ -318,17 +348,12 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getSupportSettings() -> [SettingSection] {
+        guard let sendAnonymousUsageDataSetting, let studiesToggleSetting else { return [] }
         let supportSettings = [
             ShowIntroductionSetting(settings: self, settingsDelegate: self),
             SendFeedbackSetting(settingsDelegate: parentCoordinator),
-            SendAnonymousUsageDataSetting(prefs: profile.prefs,
-                                          delegate: settingsDelegate,
-                                          theme: themeManager.getCurrentTheme(for: windowUUID),
-                                          settingsDelegate: parentCoordinator),
-            StudiesToggleSetting(prefs: profile.prefs,
-                                 delegate: settingsDelegate,
-                                 theme: themeManager.getCurrentTheme(for: windowUUID),
-                                 settingsDelegate: parentCoordinator),
+            sendAnonymousUsageDataSetting,
+            studiesToggleSetting,
             OpenSupportPageSetting(delegate: settingsDelegate,
                                    theme: themeManager.getCurrentTheme(for: windowUUID),
                                    settingsDelegate: parentCoordinator),

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SendAnonymousUsageDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SendAnonymousUsageDataSetting.swift
@@ -9,6 +9,8 @@ import Shared
 class SendAnonymousUsageDataSetting: BoolSetting {
     private weak var settingsDelegate: SupportSettingsDelegate?
 
+    var shouldSendUsageData: ((Bool) -> Void)?
+
     init(prefs: Prefs,
          delegate: SettingsDelegate?,
          theme: Theme,
@@ -38,16 +40,23 @@ class SendAnonymousUsageDataSetting: BoolSetting {
             prefKey: AppConstants.prefSendUsageData,
             defaultValue: true,
             attributedTitleText: NSAttributedString(string: .SendUsageSettingTitle),
-            attributedStatusText: statusText,
-            settingDidChange: {
-//                AdjustHelper.setEnabled($0)
-                DefaultGleanWrapper.shared.setUpload(isEnabled: $0)
-                Experiments.setTelemetrySetting($0)
-            }
+            attributedStatusText: statusText
         )
+
+        setupSettingDidChange()
+
         // We make sure to set this on initialization, in case the setting is turned off
         // in which case, we would to make sure that users are opted out of experiments
         Experiments.setTelemetrySetting(prefs.boolForKey(AppConstants.prefSendUsageData) ?? true)
+    }
+
+    private func setupSettingDidChange() {
+        self.settingDidChange = { [weak self] value in
+            // AdjustHelper.setEnabled($0)
+            DefaultGleanWrapper.shared.setUpload(isEnabled: value)
+            Experiments.setTelemetrySetting(value)
+            self?.shouldSendUsageData?(value)
+        }
     }
 
     override var accessibilityIdentifier: String? {

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/StudiesToggleSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/StudiesToggleSetting.swift
@@ -45,7 +45,7 @@ class StudiesToggleSetting: BoolSetting {
 
         let sendUsageDataPref = prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
 
-        // Special Case (EXP-4780) disable the studies if usage data is disabled
+        // Special Case (EXP-4780) disable studies if usage data is disabled
         updateSetting(for: sendUsageDataPref)
     }
 
@@ -57,7 +57,7 @@ class StudiesToggleSetting: BoolSetting {
 
     func updateSetting(for isUsageEnabled: Bool) {
         guard !isUsageEnabled else {
-            // Note: switch should be enabled only when studies are enabled
+            // Note: switch should be enabled only when telemetry usage is enabled
             control.setSwitchTappable(to: true)
             // We make sure to set this on initialization, in case the setting is turned off
             // in which case, we would to make sure that users are opted out of experiments
@@ -65,7 +65,7 @@ class StudiesToggleSetting: BoolSetting {
             return
         }
 
-        // Special Case (EXP-4780) Disable the Studies setting if usage data is disabled
+        // Special Case (EXP-4780) disable Studies if usage data is disabled
         control.setSwitchTappable(to: false)
         control.toggleSwitch(to: false)
         writeBool(control.switchView)

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -196,6 +196,14 @@ class PaddedSwitch: UIView {
         switchView.isEnabled = isEnabled
     }
 
+    func setSwitchTappable(to value: Bool) {
+        switchView.isEnabled = value
+    }
+
+    func toggleSwitch(to value: Bool, animated: Bool = true) {
+        switchView.setOn(value, animated: animated)
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -206,10 +214,10 @@ class PaddedSwitch: UIView {
 class BoolSetting: Setting, FeatureFlaggable {
     // Sometimes a subclass will manage its own pref setting. In that case the prefkey will be nil
     let prefKey: String?
-
     let prefs: Prefs?
+
+    var settingDidChange: ((Bool) -> Void)?
     private let defaultValue: Bool?
-    private let settingDidChange: ((Bool) -> Void)?
     private let statusText: NSAttributedString?
     private let featureFlagName: NimbusFeatureFlagID?
 
@@ -332,7 +340,6 @@ class BoolSetting: Setting, FeatureFlaggable {
     func switchValueChanged(_ control: UISwitch) {
         writeBool(control)
         settingDidChange?(control.isOn)
-
         if let featureFlagName = featureFlagName {
             TelemetryWrapper.recordEvent(category: .action,
                                          method: .change,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket - FXIOS-9968](https://mozilla-hub.atlassian.net/browse/FXIOS-9968)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21888)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
These should mostly be visual changes but I did add additional check to ensure we also disable the toggle and save it in prefs. 

Although experiments are by default disabled if you are not reporting telemetry > [LINK](https://github.com/mozilla-mobile/firefox-ios/blob/92534b00acfed433a27a78d800281c6864dc5cb9/firefox-ios/Client/Experiments/Experiments.swift#L74)

Below are some cases I added in the video. 

A) Initially both are enabled
B) Turning telemetry Off should also turn Off studies
C) Turning telemetry On doesn't automatically turn on studies

FYI Studies are another name for experiments.

https://github.com/user-attachments/assets/f611aa06-0eff-4f6e-9df8-a11932273400


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

