### PR TITLE
Bugfix FXIOS-9813 VoiceOver not going to grabber element after submit button pressed in Microsurvey

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -342,6 +342,7 @@ final class MicrosurveyViewController: UIViewController,
             ]
         )
         confirmationView.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+        UIAccessibility.post(notification: .screenChanged, argument: nil)
         store.dispatch(
             MicrosurveyAction(
                 surveyId: model.id,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9813)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21556)

## :bulb: Description
Bugfix VoiceOver not going to grabber element after submit button pressed in Microsurvey.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

