### PR TITLE
Revert "Bugfix MTE-3381 Unable to upload derived data to Bitrise"

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -836,7 +836,11 @@ workflows:
 
             ./firefox-ios/l10n-screenshots.sh en-US
         title: Generate screenshots
-    - deploy-to-bitrise-io@2.9.2:
+    - deploy-to-bitrise-io@1.10:
+        inputs:
+        - deploy_path: l10n-screenshots-dd/
+        - is_compress: 'true'
+    - deploy-to-bitrise-io@1.10:
         inputs:
         - deploy_path: l10n-screenshots/en-US/en-US
         - is_compress: 'true'


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#21876