### PR TITLE
Add FXIOS-9932 [Microsurvey] New trigger for sync survey

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
+++ b/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
@@ -71,6 +71,7 @@ extension AppDelegate {
         guard self.profile.hasSyncableAccount() else { return }
         profile.prefs.setBool(true, forKey: PrefsKeys.Sync.signedInFxaAccount)
         let remoteCount = newState.remoteDevices.count
+        // The additional +1 is to also add a count for the local device being used
         let devicesCount = Int32(remoteCount + 1)
         self.profile.prefs.setInt(devicesCount, forKey: PrefsKeys.Sync.numberOfSyncedDevices)
     }

--- a/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
+++ b/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
@@ -57,6 +57,7 @@ extension AppDelegate {
             queue: nil
         ) { notification in
             if let newState = notification.userInfo?["newState"] as? ConstellationState {
+                self.setPreferencesForSyncedAccount(for: newState)
                 if newState.localDevice?.pushEndpointExpired ?? false {
                     NotificationCenter.default.post(name: .RegisterForPushNotifications, object: nil)
                     // Our endpoint expired, we should check for missed messages
@@ -64,6 +65,14 @@ extension AppDelegate {
                 }
             }
         }
+    }
+
+    private func setPreferencesForSyncedAccount(for newState: ConstellationState) {
+        guard self.profile.hasSyncableAccount() else { return }
+        profile.prefs.setBool(true, forKey: PrefsKeys.Sync.signedInFxaAccount)
+        let remoteCount = newState.remoteDevices.count
+        let devicesCount = Int32(remoteCount + 1)
+        self.profile.prefs.setInt(devicesCount, forKey: PrefsKeys.Sync.numberOfSyncedDevices)
     }
 }
 

--- a/firefox-ios/Client/Experiments/Messaging/GleanPlumbContextProvider.swift
+++ b/firefox-ios/Client/Experiments/Messaging/GleanPlumbContextProvider.swift
@@ -14,6 +14,8 @@ class GleanPlumbContextProvider {
         case isInactiveNewUser = "is_inactive_new_user"
         case allowedTipsNotifications = "allowed_tips_notifications"
         case numberOfAppLaunches = "number_of_app_launches"
+        case numberOfSyncedDevices = "number_of_sync_devices"
+        case signedInFxaAccount = "is_fxa_signed_in"
     }
 
     struct Constant {
@@ -40,6 +42,14 @@ class GleanPlumbContextProvider {
 
     private var numberOfAppLaunches: Int32 {
         return profile.prefs.intForKey(PrefsKeys.Session.Count) ?? 0
+    }
+
+    private var numberOfSyncedDevices: Int32 {
+        return profile.prefs.intForKey(PrefsKeys.Sync.numberOfSyncedDevices) ?? 0
+    }
+
+    private var signedInFxaAccount: Bool {
+        return profile.prefs.boolForKey(PrefsKeys.Sync.signedInFxaAccount) ?? false
     }
 
     var isInactiveNewUser: Bool {
@@ -73,6 +83,9 @@ class GleanPlumbContextProvider {
                 ContextKey.isDefaultBrowser.rawValue: isDefaultBrowser,
                 ContextKey.isInactiveNewUser.rawValue: isInactiveNewUser,
                 ContextKey.numberOfAppLaunches.rawValue: numberOfAppLaunches,
-                ContextKey.allowedTipsNotifications.rawValue: allowedTipsNotifications]
+                ContextKey.numberOfSyncedDevices.rawValue: numberOfSyncedDevices,
+                ContextKey.allowedTipsNotifications.rawValue: allowedTipsNotifications,
+                ContextKey.signedInFxaAccount.rawValue: signedInFxaAccount
+        ]
     }
 }

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -167,7 +167,6 @@ public class RustSyncManager: NSObject, SyncManager {
 
     private func setPreferenceForSignIn() {
         let signedInFxaAccountValue = profile?.prefs.boolForKey(PrefsKeys.Sync.signedInFxaAccount)
-        
         // We only want to set the prefs if it has not been set (nil)
         // There is a case where a user has a syncable account, but returns
         // false so we check if nil here.

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -138,9 +138,8 @@ public class RustSyncManager: NSObject, SyncManager {
 
     public func applicationDidBecomeActive() {
         backgrounded = false
-
+        setPreferenceForSignIn()
         guard let profile = profile, profile.hasSyncableAccount() else { return }
-
         beginTimedSyncs()
 
         // Sync now if it's been more than our threshold.
@@ -164,6 +163,19 @@ public class RustSyncManager: NSObject, SyncManager {
 
     public func applicationDidEnterBackground() {
         backgrounded = true
+    }
+
+    private func setPreferenceForSignIn() {
+        let signedInFxaAccountValue = profile?.prefs.boolForKey(PrefsKeys.Sync.signedInFxaAccount)
+
+        guard signedInFxaAccountValue == nil else { return }
+        let userHasSyncableAccount = profile?.hasSyncableAccount() ?? false
+        profile?.prefs.setBool(userHasSyncableAccount, forKey: PrefsKeys.Sync.signedInFxaAccount)
+    }
+
+    private func resetUserSyncPreferences() {
+        profile?.prefs.setBool(false, forKey: PrefsKeys.Sync.signedInFxaAccount)
+        profile?.prefs.setInt(0, forKey: PrefsKeys.Sync.numberOfSyncedDevices)
     }
 
     private func beginSyncing() {
@@ -236,12 +248,13 @@ public class RustSyncManager: NSObject, SyncManager {
         // Only sync if we're green lit. This makes sure that we don't sync unverified
         // accounts.
         guard let profile = profile, profile.hasSyncableAccount() else { return succeed() }
-
+        setPreferenceForSignIn()
         beginTimedSyncs()
         return syncEverything(why: .enabledChange)
     }
 
     public func onRemovedAccount() -> Success {
+        resetUserSyncPreferences()
         let clearPrefs: () -> Success = {
             withExtendedLifetime(self) {
                 // Clear prefs after we're done clearing everything else -- just in case

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -167,7 +167,10 @@ public class RustSyncManager: NSObject, SyncManager {
 
     private func setPreferenceForSignIn() {
         let signedInFxaAccountValue = profile?.prefs.boolForKey(PrefsKeys.Sync.signedInFxaAccount)
-
+        
+        // We only want to set the prefs if it has not been set (nil)
+        // There is a case where a user has a syncable account, but returns
+        // false so we check if nil here.
         guard signedInFxaAccountValue == nil else { return }
         let userHasSyncableAccount = profile?.hasSyncableAccount() ?? false
         profile?.prefs.setBool(userHasSyncableAccount, forKey: PrefsKeys.Sync.signedInFxaAccount)

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -90,6 +90,11 @@ public struct PrefsKeys {
         public static let showSearchSuggestions = "FirefoxSuggestShowSearchSuggestions"
     }
 
+    public struct Sync {
+        public static let numberOfSyncedDevices = "numberOfSyncedDevicesKey"
+        public static let signedInFxaAccount = "signedInFxaAccountKey"
+    }
+
     public struct UserFeatureFlagPrefs {
         public static let ASPocketStories = "ASPocketStoriesUserPrefsKey"
         public static let BookmarksSection = "BookmarksSectionUserPrefsKey"

--- a/firefox-ios/Sync/SyncConstants.swift
+++ b/firefox-ios/Sync/SyncConstants.swift
@@ -6,7 +6,6 @@ import Foundation
 
 public struct SyncConstants {
     // Suitable for use in dispatch_time().
-    public static let SyncDelayTriggered: Int = 3000
     public static let SyncOnForegroundMinimumDelayMillis: UInt64 = 5 * 60 * 1000
     public static let SyncOnForegroundAfterMillis: Int64 = 10000
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/GleanPlumbContextProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/GleanPlumbContextProviderTests.swift
@@ -22,9 +22,10 @@ class GleanPlumbContextProviderTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
+        profile = nil
         userDefaults = nil
         contextProvider = nil
+        super.tearDown()
     }
 
     func testNumberOfLaunches_withFirstLaunch() {
@@ -39,6 +40,27 @@ class GleanPlumbContextProviderTests: XCTestCase {
         let context = contextProvider.createAdditionalDeviceContext()
         let numberOfAppLaunches = context["number_of_app_launches"] as? Int32
         XCTAssertEqual(numberOfAppLaunches, 2)
+    }
+
+    func testCreateAdditionalDeviceContext_withNumberOfSyncedDevices() {
+        profile.prefs.setInt(2, forKey: PrefsKeys.Sync.numberOfSyncedDevices)
+        let context = contextProvider.createAdditionalDeviceContext()
+        let numberOfSyncedDevices = context["number_of_sync_devices"] as? Int32
+        XCTAssertEqual(numberOfSyncedDevices, 2)
+    }
+
+    func testCreateAdditionalDeviceContext_withSignedInCheck_returnTrue() {
+        profile.prefs.setBool(true, forKey: PrefsKeys.Sync.signedInFxaAccount)
+        let context = contextProvider.createAdditionalDeviceContext()
+        let signedInFxaAccountStatus = context["is_fxa_signed_in"] as? Bool
+        XCTAssertEqual(signedInFxaAccountStatus, true)
+    }
+
+    func testCreateAdditionalDeviceContext_withSignedInCheck_returnFalse() {
+        profile.prefs.setBool(false, forKey: PrefsKeys.Sync.signedInFxaAccount)
+        let context = contextProvider.createAdditionalDeviceContext()
+        let signedInFxaAccountStatus = context["is_fxa_signed_in"] as? Bool
+        XCTAssertEqual(signedInFxaAccountStatus, false)
     }
 
     func testIsInactiveNewUser_noFirstAppUse() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RustSyncManagerTests.swift
@@ -5,6 +5,7 @@
 @testable import Client
 import Sync
 import Storage
+import Shared
 import XCTest
 
 class RustSyncManagerTests: XCTestCase {
@@ -210,5 +211,19 @@ class RustSyncManagerTests: XCTestCase {
         let key = try XCTUnwrap(profile.prefs.boolForKey(Keys.addressesEnabledPrefKey))
         XCTAssertFalse(key)
         XCTAssertNil(profile.prefs.boolForKey(Keys.addressesStateChangedPrefKey))
+    }
+
+    func test_applicationDidBecomeActive_updateSignInPrefs() throws {
+        rustSyncManager.applicationDidBecomeActive()
+        let value = try XCTUnwrap(profile.prefs.boolForKey(PrefsKeys.Sync.signedInFxaAccount))
+        XCTAssertFalse(value)
+    }
+
+    func test_onRemovedAccount_updatePrefs() throws {
+        _ = rustSyncManager.onRemovedAccount()
+        let signedInStatus = try XCTUnwrap(profile.prefs.boolForKey(PrefsKeys.Sync.signedInFxaAccount))
+        let syncedDevicesCount = try XCTUnwrap(profile.prefs.intForKey(PrefsKeys.Sync.numberOfSyncedDevices))
+        XCTAssertFalse(signedInStatus)
+        XCTAssertEqual(syncedDevicesCount, 0)
     }
 }

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -47,7 +47,7 @@ import:
                 surface: microsurvey
                 style: MICROSURVEY
                 trigger-if-all:
-                    - SECOND_HOMEPAGE_VIEW
+                  - SECOND_HOMEPAGE_VIEW
                 title: Microsurvey/Microsurvey.Prompt.TitleLabel.v127
                 text: "How satisfied are you with your Firefox homepage?" # Should not show this message if this is nil
                 button-label: Microsurvey/Microsurvey.Prompt.Button.v127

--- a/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-evergreen-messages.fml.yaml
@@ -47,7 +47,7 @@ import:
                 surface: microsurvey
                 style: MICROSURVEY
                 trigger-if-all:
-                  - SECOND_HOMEPAGE_VIEW
+                    - SECOND_HOMEPAGE_VIEW
                 title: Microsurvey/Microsurvey.Prompt.TitleLabel.v127
                 text: "How satisfied are you with your Firefox homepage?" # Should not show this message if this is nil
                 button-label: Microsurvey/Microsurvey.Prompt.Button.v127

--- a/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
+++ b/firefox-ios/nimbus-features/messaging/messaging-firefox-ios.fml.yaml
@@ -36,6 +36,8 @@ import:
               INACTIVE_NEW_USER:        "is_inactive_new_user"
               ALLOWED_TIPS_NOTIFICATIONS: "allowed_tips_notifications"
 
+              FXA_CURRENTLY_SIGNED_IN: "is_fxa_signed_in == true"
+
               # Behavioral Targeting Events
               SECOND_HOMEPAGE_VIEW:  "'homepage_viewed'|eventSum('Years', 4, 0) >= 2"
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9932)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21788)

## :bulb: Description
**Context**
We want to be able to show a microsurvey depending on whether a user is signed in and how many devices are synced.

**Summary**
Added new user prefs to capture if user is signed in and how many devices are connected to sync. This will be used in nimbus as a trigger for the sync microsurvey. 

We check if the user is signed in or not, when the `appDidBecomeActive` is called in the sync manager as well as when an account is added or removed. We only check how many devices there are when it is connected to sync and we do this when the device constellation state is updated. If the user is not signed in to sync, then we return 0 devices.

**User Cases**
- New user, goes through onboarding flow (not signed in; 0 devices)
- New user, goes through onboarding flow, signs in (signed in; 1 device)
- New user, goes through onboarding flow, signs in + signs into desktop as well (signed in; 2 devices)
- Existing user, not synced (not signed in; 0 devices)
- Existing user, synced (signed in, # of devices in the list)

Open to suggestions for improvement in where / when we are setting this defaults as well.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

