### PR TITLE
Bugfix FXIOS-9988: [Toolbar redesign] Correctly apply address toolbar border

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -231,20 +231,21 @@ final class ToolbarMiddleware: FeatureFlaggable {
     }
 
     private func updateToolbarPosition(action: GeneralBrowserMiddlewareAction, state: AppState) {
-        guard let toolbarPosition = action.toolbarPosition,
+        guard let searchBarPosition = action.toolbarPosition,
               let scrollOffset = action.scrollOffset,
               let toolbarState = state.screenState(ToolbarState.self,
                                                    for: .toolbar,
                                                    window: action.windowUUID)
         else { return }
 
-        let position = addressToolbarPositionFromSearchBarPosition(toolbarPosition)
-        let addressBorderPosition = getAddressBorderPosition(toolbarPosition: position,
+        let addressToolbarPosition = addressToolbarPositionFromSearchBarPosition(searchBarPosition)
+        let addressBorderPosition = getAddressBorderPosition(toolbarPosition: addressToolbarPosition,
                                                              isPrivate: toolbarState.isPrivateMode,
                                                              scrollY: scrollOffset.y)
-        let displayNavToolbarBorder = shouldDisplayNavigationToolbarBorder(toolbarPosition: position)
+        let displayNavToolbarBorder = shouldDisplayNavigationToolbarBorder(toolbarPosition: addressToolbarPosition)
 
-        let toolbarAction = ToolbarAction(addressBorderPosition: addressBorderPosition,
+        let toolbarAction = ToolbarAction(toolbarPosition: searchBarPosition,
+                                          addressBorderPosition: addressBorderPosition,
                                           displayNavBorder: displayNavToolbarBorder,
                                           windowUUID: action.windowUUID,
                                           actionType: ToolbarActionType.toolbarPositionChanged)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9988)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21933)

## :bulb: Description
- When switching the address toolbar position, the correct border will now be applied

### :memo: Notes
- The problem was that we were not passing the `toolbarPosition` state when dispatching `ToolbarActionType.toolbarPositionChanged` from the toolbar middleware, even though the reducer requires this property to return the correct state

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

