### PR TITLE
Add MTE-3430 - Add Tracking protection test id 2307063

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
@@ -130,6 +130,7 @@
         "TrackingProtectionTests\/testLockIconMenu()",
         "TrackingProtectionTests\/testLockIconSecureConnection()",
         "TrackingProtectionTests\/testProtectionLevelMoreInfoMenu()",
+        "TrackingProtectionTests\/testStrictTrackingProtection()",
         "URLValidationTests",
         "UrlBarTests",
         "WhatsNewTest",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -50,11 +50,25 @@ class TrackingProtectionTests: BaseTestCase {
             )
         }
         app.otherElements.element(matching: .any, identifier: reloadWithWithoutProtectionButton).tap()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
     }
+
     private func enableStrictMode() {
         navigator.performAction(Action.EnableStrictMode)
         app.buttons[buttonSettings].tap()
         app.buttons[buttonDone].tap()
+    }
+
+    func checkTrackingProtectionOn() -> Bool {
+        var trackingProtection = true
+        if iPad() {
+            sleep(1)
+        }
+        if app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label
+            == secureTrackingProtectionOffLabel {
+            trackingProtection = false
+        }
+        return trackingProtection
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307059
@@ -227,24 +241,38 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         navigator.openURL(trackingProtectionTestUrl)
 
-        // Check Tracking Protection On
-        XCTAssertEqual(
-            app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-            secureTrackingProtectionOnLabel
-        )
-
-        reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
-
-        XCTAssertEqual(
-            app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-            secureTrackingProtectionOffLabel
-        )
-
-        reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
-
-        XCTAssertEqual(
-            app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-            secureTrackingProtectionOnLabel
-        )
+        if checkTrackingProtectionOn() {
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOnLabel
+            )
+            navigator.nowAt(BrowserTab)
+            reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOffLabel
+            )
+            reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOnLabel
+            )
+        } else {
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOffLabel
+            )
+            navigator.nowAt(BrowserTab)
+            reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOnLabel
+            )
+            reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOffLabel
+            )
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -5,15 +5,51 @@
 import XCTest
 import Common
 
-// swiftlint:disable line_length
-let standardBlockedElementsString = "Firefox blocks cross-site trackers, social trackers, cryptominers, and fingerprinters."
-let strictBlockedElementsString = "Firefox blocks cross-site trackers, social trackers, cryptominers, fingerprinters, and tracking content."
-// swiftlint:enable line_length
-
+// Urls
 let websiteWithBlockedElements = "twitter.com"
 let differentWebsite = path(forTestPage: "test-example.html")
+let trackingProtectionTestUrl = "https://senglehardt.com/test/trackingprotection/test_pages/"
+
+// Selectors
+let buttonSettings = "Settings"
+let buttonDone = "Done"
+let reloadButton = "TabLocationView.reloadButton"
+let reloadWithWithoutProtectionButton = "shieldSlashLarge"
+let secureTrackingProtectionOnLabel = "Secure connection"
+let secureTrackingProtectionOffLabel = "Secure connection. Enhanced Tracking Protection is off."
 
 class TrackingProtectionTests: BaseTestCase {
+    
+    private func disableEnableTrackingProtectionForSite() {
+        navigator.performAction(Action.TrackingProtectionperSiteToggle)
+    }
+
+    private func checkTrackingProtectionDisabledForSite() {
+        mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
+    }
+
+    private func checkTrackingProtectionEnabledForSite() {
+        navigator.goto(TrackingProtectionContextMenuDetails)
+        mozWaitForElementToExist(app.cells.staticTexts["Enhanced Tracking Protection is ON for this site."])
+    }
+
+    private func reloadWithWithoutTrackingProtection(label: String) {
+        mozWaitForElementToExist(app.buttons.element(matching: .button, identifier: reloadButton), timeout: 10)
+        app.buttons.element(matching: .button, identifier: reloadButton).press(forDuration: 3)
+        if (label == "Without Tracking Protection"){
+            XCTAssertEqual("Reload Without Tracking Protection", app.otherElements.element(matching: .any, identifier: reloadWithWithoutProtectionButton).label)
+        } else {
+            XCTAssertEqual("Reload With Tracking Protection", app.otherElements.element(matching: .any, identifier: reloadWithWithoutProtectionButton).label)
+        }
+        app.otherElements.element(matching: .any, identifier: reloadWithWithoutProtectionButton).tap()
+    }
+    
+    private func enableStrictMode() {
+        navigator.performAction(Action.EnableStrictMode)
+        app.buttons[buttonSettings].tap()
+        app.buttons[buttonDone].tap()
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2307059
     // Smoketest
     func testStandardProtectionLevel() {
@@ -58,27 +94,6 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.goto(TrackingProtectionSettings)
         // Turn on ETP
         navigator.performAction(Action.SwitchETP)
-    }
-
-    private func disableEnableTrackingProtectionForSite() {
-        navigator.performAction(Action.TrackingProtectionperSiteToggle)
-    }
-
-    private func checkTrackingProtectionDisabledForSite() {
-        mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
-    }
-
-    private func checkTrackingProtectionEnabledForSite() {
-        navigator.goto(TrackingProtectionContextMenuDetails)
-        mozWaitForElementToExist(app.cells.staticTexts["Enhanced Tracking Protection is ON for this site."])
-    }
-
-    private func enableStrictMode() {
-        navigator.performAction(Action.EnableStrictMode)
-
-        // Dismiss the alert and go back to the site
-        app.alerts.buttons.firstMatch.tap()
-        app.buttons["Done"].tap()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2319381
@@ -192,5 +207,25 @@ class TrackingProtectionTests: BaseTestCase {
         mozWaitForElementToExist(app.staticTexts["Secure connection"])
         navigator.performAction(Action.CloseTPContextMenu)
         mozWaitForElementToNotExist(app.staticTexts["Secure connection"])
+    }
+    
+    // https://mozilla.testrail.io/index.php?/cases/view/2307063
+    func testStrictTrackingProtection() {
+        navigator.goto(TrackingProtectionSettings)
+        // Enable Strict Protection Level
+        enableStrictMode()
+        navigator.nowAt(BrowserTab)
+        navigator.openURL(trackingProtectionTestUrl)
+        
+        // Check TRacking Protection On
+        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, secureTrackingProtectionOnLabel)
+        
+        reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
+        
+        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, secureTrackingProtectionOffLabel)
+
+        reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
+        
+        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, secureTrackingProtectionOnLabel)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -19,7 +19,6 @@ let secureTrackingProtectionOnLabel = "Secure connection"
 let secureTrackingProtectionOffLabel = "Secure connection. Enhanced Tracking Protection is off."
 
 class TrackingProtectionTests: BaseTestCase {
-    
     private func disableEnableTrackingProtectionForSite() {
         navigator.performAction(Action.TrackingProtectionperSiteToggle)
     }
@@ -36,14 +35,22 @@ class TrackingProtectionTests: BaseTestCase {
     private func reloadWithWithoutTrackingProtection(label: String) {
         mozWaitForElementToExist(app.buttons.element(matching: .button, identifier: reloadButton), timeout: 10)
         app.buttons.element(matching: .button, identifier: reloadButton).press(forDuration: 3)
-        if (label == "Without Tracking Protection"){
-            XCTAssertEqual("Reload Without Tracking Protection", app.otherElements.element(matching: .any, identifier: reloadWithWithoutProtectionButton).label)
+        if label == "Without Tracking Protection" {
+            XCTAssertEqual(
+                "Reload Without Tracking Protection",
+                app.otherElements.element(matching: .any, identifier: reloadWithWithoutProtectionButton).label
+            )
         } else {
-            XCTAssertEqual("Reload With Tracking Protection", app.otherElements.element(matching: .any, identifier: reloadWithWithoutProtectionButton).label)
+            XCTAssertEqual(
+                "Reload With Tracking Protection",
+                app.otherElements.element(
+                    matching: .any,
+                    identifier: reloadWithWithoutProtectionButton
+                ).label
+            )
         }
         app.otherElements.element(matching: .any, identifier: reloadWithWithoutProtectionButton).tap()
     }
-    
     private func enableStrictMode() {
         navigator.performAction(Action.EnableStrictMode)
         app.buttons[buttonSettings].tap()
@@ -187,7 +194,10 @@ class TrackingProtectionTests: BaseTestCase {
         app.links.staticTexts["expired"].tap()
         waitUntilPageLoad()
         // The page is correctly displayed with the lock icon disabled
-        mozWaitForElementToExist(app.staticTexts["This Connection is Untrusted"], timeout: TIMEOUT_LONG)
+        mozWaitForElementToExist(
+            app.staticTexts["This Connection is Untrusted"],
+            timeout: TIMEOUT_LONG
+        )
         mozWaitForElementToExist(app.staticTexts.elementContainingText("Firefox has not connected to this website."))
         XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, "Connection not secure")
     }
@@ -208,7 +218,7 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.performAction(Action.CloseTPContextMenu)
         mozWaitForElementToNotExist(app.staticTexts["Secure connection"])
     }
-    
+
     // https://mozilla.testrail.io/index.php?/cases/view/2307063
     func testStrictTrackingProtection() {
         navigator.goto(TrackingProtectionSettings)
@@ -216,16 +226,25 @@ class TrackingProtectionTests: BaseTestCase {
         enableStrictMode()
         navigator.nowAt(BrowserTab)
         navigator.openURL(trackingProtectionTestUrl)
-        
-        // Check TRacking Protection On
-        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, secureTrackingProtectionOnLabel)
-        
+
+        // Check Tracking Protection On
+        XCTAssertEqual(
+            app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+            secureTrackingProtectionOnLabel
+        )
+
         reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
-        
-        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, secureTrackingProtectionOffLabel)
+
+        XCTAssertEqual(
+            app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+            secureTrackingProtectionOffLabel
+        )
 
         reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
-        
-        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, secureTrackingProtectionOnLabel)
+
+        XCTAssertEqual(
+            app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+            secureTrackingProtectionOnLabel
+        )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3430)

## :bulb: Description
Add test case https://mozilla.testrail.io/index.php?/cases/view/2307063 to the tracking protection test suite. Removed unused variables, cleaned the code and removed code that was waiting for an alert because now we shows a text instead of the alert.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

