### PR TITLE
Bugfix MTE-3381 Workaround for derived data size

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -836,11 +836,11 @@ workflows:
 
             ./firefox-ios/l10n-screenshots.sh en-US
         title: Generate screenshots
-    - deploy-to-bitrise-io@2.9.2:
+    - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: l10n-screenshots-dd/
         - is_compress: 'true'
-    - deploy-to-bitrise-io@2.9.2:
+    - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: l10n-screenshots/en-US/en-US
         - is_compress: 'true'
@@ -899,7 +899,7 @@ workflows:
               mv "$locale.zip" artifacts/
             done
         title: Generate screenshots
-    - deploy-to-bitrise-io@2.9.2:
+    - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: artifacts/
     envs:
@@ -1261,7 +1261,7 @@ workflows:
             sed 's/.*=//;s/'\''/"/g' data.txt > test.json
             cat test.json
             python3 perfTestTransform.py
-    - deploy-to-bitrise-io@2.9.2: {}
+    - deploy-to-bitrise-io@2: {}
     before_run:
     - 1_git_clone_and_post_clone
     - 2_certificate_and_profile

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -835,7 +835,12 @@ workflows:
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
-    - deploy-to-bitrise-io@2.9.2:
+        title: Generate screenshots
+    - deploy-to-bitrise-io@2.92:
+        inputs:
+        - deploy_path: l10n-screenshots-dd/
+        - is_compress: 'true'
+    - deploy-to-bitrise-io@2.92:
         inputs:
         - deploy_path: l10n-screenshots/en-US/en-US
         - is_compress: 'true'
@@ -853,6 +858,28 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@6.2: {}
     - certificate-and-profile-installer@1: {}
+    - script@1:
+        inputs:
+        - content: >-
+            #!/usr/bin/env bash
+
+            # fail if any commands fails
+
+            set -e
+
+            # debug log
+
+            set -x
+
+            curl --location --retry 5 --output l10n-screenshots-dd.zip
+            "$MOZ_DERIVED_DATA_PATH"
+
+            mkdir l10n-screenshots-dd
+
+            unzip l10n-screenshots-dd.zip -d l10n-screenshots-dd
+
+            rm l10n-screenshots-dd.zip
+        title: Download derived data path
     - script@1.1:
         inputs:
         - content: |-
@@ -863,7 +890,7 @@ workflows:
             set -x
             gem install fastlane -v 2.219.0
             fastlane -version
-            ./firefox-ios/l10n-screenshots.sh $MOZ_LOCALES
+            ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES
 
             mkdir -p artifacts
 
@@ -872,7 +899,7 @@ workflows:
               mv "$locale.zip" artifacts/
             done
         title: Generate screenshots
-    - deploy-to-bitrise-io@1.10:
+    - deploy-to-bitrise-io@2.92:
         inputs:
         - deploy_path: artifacts/
     envs:
@@ -1234,7 +1261,7 @@ workflows:
             sed 's/.*=//;s/'\''/"/g' data.txt > test.json
             cat test.json
             python3 perfTestTransform.py
-    - deploy-to-bitrise-io@1.9: {}
+    - deploy-to-bitrise-io@2.92: {}
     before_run:
     - 1_git_clone_and_post_clone
     - 2_certificate_and_profile

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -835,12 +835,7 @@ workflows:
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
-        title: Generate screenshots
-    - deploy-to-bitrise-io@1.10:
-        inputs:
-        - deploy_path: l10n-screenshots-dd/
-        - is_compress: 'true'
-    - deploy-to-bitrise-io@1.10:
+    - deploy-to-bitrise-io@2.9.2:
         inputs:
         - deploy_path: l10n-screenshots/en-US/en-US
         - is_compress: 'true'
@@ -858,28 +853,6 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@6.2: {}
     - certificate-and-profile-installer@1: {}
-    - script@1:
-        inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
-            # fail if any commands fails
-
-            set -e
-
-            # debug log
-
-            set -x
-
-            curl --location --retry 5 --output l10n-screenshots-dd.zip
-            "$MOZ_DERIVED_DATA_PATH"
-
-            mkdir l10n-screenshots-dd
-
-            unzip l10n-screenshots-dd.zip -d l10n-screenshots-dd
-
-            rm l10n-screenshots-dd.zip
-        title: Download derived data path
     - script@1.1:
         inputs:
         - content: |-
@@ -890,7 +863,7 @@ workflows:
             set -x
             gem install fastlane -v 2.219.0
             fastlane -version
-            ./firefox-ios/l10n-screenshots.sh --test-without-building $MOZ_LOCALES
+            ./firefox-ios/l10n-screenshots.sh $MOZ_LOCALES
 
             mkdir -p artifacts
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -456,7 +456,7 @@ workflows:
             echo "Adding com.apple.developer.web-browser to entitlements"
 
             /usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" firefox-ios/Client/Entitlements/FennecApplication.entitlements
-    - cache-pull@2.1: {}
+    - cache-pull@2: {}
   2_certificate_and_profile:
     steps:
     - certificate-and-profile-installer@1: {}
@@ -673,7 +673,7 @@ workflows:
     - activate-ssh-key@4.0:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@6.2: {}
-    - cache-pull@2.4: {}
+    - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
         run_if: '{{getenv "NEW_XCODE_VERSION" | eq "New_Version_Found" | or (getenv "RUN_ALL_STEPS" | eq "Run_All_Steps")}}'
@@ -767,7 +767,7 @@ workflows:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@6.2: {}
-    - cache-pull@2.1: {}
+    - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
         inputs:
@@ -1221,7 +1221,7 @@ workflows:
 
   Bitrise_Performance_Test:
     steps:
-    - cache-pull@2.1:
+    - cache-pull@2:
         is_always_run: true
     - xcode-test@4.5:
         inputs:
@@ -1285,7 +1285,7 @@ workflows:
         - scheme: Fennec_Enterprise
         - configuration: Fennec_Enterprise
     - deploy-to-bitrise-io@2: {}
-    - cache-pull@2.7.2:
+    - cache-pull@2:
         inputs:
         - cache_paths: "$HOME/sdk/google-cloud-sdk"
     - script@1:
@@ -1465,7 +1465,7 @@ workflows:
             # do not double-quote $TEST_PLAN, as it is a wildcard and we need it to expand
             ( cd "$PRODUCTS_DIR" && zip -r "${SCHEME}.zip" "${SCHEME}-${SDK}" ${TEST_PLAN}*.xctestrun )
             mv "${PRODUCTS_DIR}/${SCHEME}.zip" "$TARGET_ARCHIVE"
-    - cache-pull@2.7.2:
+    - cache-pull@2:
         inputs:
         - cache_paths: "$HOME/google-cloud-sdk"
     - script@1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -836,11 +836,11 @@ workflows:
 
             ./firefox-ios/l10n-screenshots.sh en-US
         title: Generate screenshots
-    - deploy-to-bitrise-io@2.92:
+    - deploy-to-bitrise-io@2.9.2:
         inputs:
         - deploy_path: l10n-screenshots-dd/
         - is_compress: 'true'
-    - deploy-to-bitrise-io@2.92:
+    - deploy-to-bitrise-io@2.9.2:
         inputs:
         - deploy_path: l10n-screenshots/en-US/en-US
         - is_compress: 'true'
@@ -899,7 +899,7 @@ workflows:
               mv "$locale.zip" artifacts/
             done
         title: Generate screenshots
-    - deploy-to-bitrise-io@2.92:
+    - deploy-to-bitrise-io@2.9.2:
         inputs:
         - deploy_path: artifacts/
     envs:
@@ -1261,7 +1261,7 @@ workflows:
             sed 's/.*=//;s/'\''/"/g' data.txt > test.json
             cat test.json
             python3 perfTestTransform.py
-    - deploy-to-bitrise-io@2.92: {}
+    - deploy-to-bitrise-io@2.9.2: {}
     before_run:
     - 1_git_clone_and_post_clone
     - 2_certificate_and_profile


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3381)

## :bulb: Description
Bitrise support asked us to bump the version of `deploy-to-bitrise-io` to take advantage of the increased limit of uploaded files.

L10nBuild: https://app.bitrise.io/build/fe15d19c-025b-46c3-b3ed-acf431c15065

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

