### PR TITLE
Bugfix FXIOS-9858 ⁃ Option to Copy link should not be available when long tapping the address bar on homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2032,6 +2032,7 @@ class BrowserViewController: UIViewController,
 
     func presentLocationViewActionSheet(from view: UIView) {
         let actions = getLongPressLocationBarActions(with: view, alertContainer: contentContainer)
+        guard !actions.isEmpty else { return }
         let generator = UIImpactFeedbackGenerator(style: .heavy)
         generator.impactOccurred()
 

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -82,11 +82,16 @@ extension PhotonActionSheetProtocol {
             }
         }
 
+        var actionItems: [PhotonRowActions] = []
         if UIPasteboard.general.hasStrings {
-            return [pasteGoAction.items, pasteAction.items, copyAddressAction.items]
-        } else {
-            return [copyAddressAction.items]
+            actionItems.append(contentsOf: [pasteGoAction.items, pasteAction.items])
         }
+
+        if tabManager.selectedTab?.canonicalURL?.displayURL != nil {
+            actionItems.append(copyAddressAction.items)
+        }
+
+        return actionItems
     }
 
     func getRefreshLongPressMenu(for tab: Tab) -> [PhotonRowActions] {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9858)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21642)

## :bulb: Description
Hide Copy Address option from the logn tap menu when toolbar address is empty

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

