### PR TITLE
Add FXIOS-9955 [Microsurvey] Border requirement with new toolbar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/ToolbarManager.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarManager.swift
@@ -7,13 +7,14 @@ import Foundation
 public enum AddressToolbarBorderPosition {
     case bottom
     case top
+    case none
 }
 
 public protocol ToolbarManager {
     /// Determines which border should be displayed for the address toolbar
     func getAddressBorderPosition(for toolbarPosition: AddressToolbarPosition,
                                   isPrivate: Bool,
-                                  scrollY: CGFloat) -> AddressToolbarBorderPosition?
+                                  scrollY: CGFloat) -> AddressToolbarBorderPosition
 
     /// Determines whether a border on top of the navigation toolbar should be displayed
     func shouldDisplayNavigationBorder(toolbarPosition: AddressToolbarPosition) -> Bool
@@ -24,7 +25,7 @@ public class DefaultToolbarManager: ToolbarManager {
 
     public func getAddressBorderPosition(for toolbarPosition: AddressToolbarPosition,
                                          isPrivate: Bool,
-                                         scrollY: CGFloat) -> AddressToolbarBorderPosition? {
+                                         scrollY: CGFloat) -> AddressToolbarBorderPosition {
         // display the top border if
         // - the toolbar is displayed at the bottom
         // display the bottom border if
@@ -35,7 +36,7 @@ public class DefaultToolbarManager: ToolbarManager {
         } else if toolbarPosition == .top && (scrollY > 0 || isPrivate) {
             return .bottom
         } else {
-            return nil
+            return .none
         }
     }
 

--- a/BrowserKit/Tests/ToolbarKitTests/ToolbarManagerTests.swift
+++ b/BrowserKit/Tests/ToolbarKitTests/ToolbarManagerTests.swift
@@ -18,7 +18,7 @@ final class ToolbarManagerTests: XCTestCase {
 
     func testAddressToolbarBorderPositionWhenTopPlacementAndNotScrolledThenShouldDisplayNoBorder() {
         let subject = createSubject()
-        XCTAssertNil(subject.getAddressBorderPosition(
+        XCTAssertEqual(AddressToolbarBorderPosition.none, subject.getAddressBorderPosition(
             for: .top,
             isPrivate: false,
             scrollY: 0))

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1312,14 +1312,6 @@ class BrowserViewController: UIViewController,
     }
 
     // MARK: - Microsurvey
-    private var isToolbarPositionBottom: Bool {
-        let toolbarState = store.state.screenState(ToolbarState.self,
-                                                   for: .toolbar,
-                                                   window: windowUUID)
-        let isBottomToolbar = toolbarState?.toolbarPosition == .bottom
-        return isToolbarRefactorEnabled ? isBottomToolbar : urlBar.isBottomSearchBar
-    }
-
     private func setupMicrosurvey() {
         guard featureFlags.isFeatureEnabled(.microsurvey, checking: .buildOnly), microsurvey == nil else { return }
 
@@ -1334,7 +1326,7 @@ class BrowserViewController: UIViewController,
         microsurvey.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(microsurvey)
 
-        if isToolbarPositionBottom {
+        if isBottomSearchBar {
             overKeyboardContainer.addArrangedViewToTop(microsurvey, animated: false, completion: {
                 self.view.layoutIfNeeded()
             })
@@ -1357,7 +1349,7 @@ class BrowserViewController: UIViewController,
         guard !shouldUseiPadSetup(), !isToolbarRefactorEnabled else { return }
         let hasMicrosurvery = microsurvey != nil
 
-        if let urlBar, isToolbarPositionBottom {
+        if let urlBar, isBottomSearchBar {
             urlBar.isMicrosurveyShown = hasMicrosurvery
             urlBar.updateTopBorderDisplay()
         }
@@ -1377,7 +1369,7 @@ class BrowserViewController: UIViewController,
     private func removeMicrosurveyPrompt() {
         guard let microsurvey else { return }
 
-        if isToolbarPositionBottom {
+        if isBottomSearchBar {
             overKeyboardContainer.removeArrangedView(microsurvey)
         } else {
             bottomContainer.removeArrangedView(microsurvey)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -37,7 +37,7 @@ final class ToolbarAction: Action {
          canGoBack: Bool? = nil,
          canGoForward: Bool? = nil,
          readerModeState: ReaderModeState? = nil,
-         addressBorderPosition: AddressToolbarBorderPosition? = nil,
+         addressBorderPosition: AddressToolbarBorderPosition = .none,
          displayNavBorder: Bool? = nil,
          lockIconImageName: String? = nil,
          isEditing: Bool? = nil,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -222,7 +222,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
     }
 
     // MARK: - Border
-    // For the top placement of the address bar, the border is only visible on scroll
+    // For the top placement of the address bar, the border is only visible on scroll. This is due to a design choice.
     private func updateTopAddressBorderPosition(action: GeneralBrowserMiddlewareAction, state: AppState) {
         guard let scrollOffset = action.scrollOffset,
               let toolbarState = state.screenState(ToolbarState.self,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -222,6 +222,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
     }
 
     // MARK: - Border
+    // For the top placement of the address bar, the border is only visible on scroll
     private func updateTopAddressBorderPosition(action: GeneralBrowserMiddlewareAction, state: AppState) {
         guard let scrollOffset = action.scrollOffset,
               let toolbarState = state.screenState(ToolbarState.self,
@@ -259,6 +260,11 @@ final class ToolbarMiddleware: FeatureFlaggable {
 
     // Update border to hide for bottom toolbars when microsurvey is shown,
     // so that it appears to belong to the app and harder to spoof
+    // 
+    // Border Requirement:
+    //  - When survey is shown and address bar is at top, hide border in between survey and nav toolbar
+    //  - When survey is shown and address bar is at bottom, hide borders for address and nav toolbar
+    //  - When survey is dismissed, show border as expected based on the toolbar requirements
     private func updateToolbarBorders(windowUUID: WindowUUID, state: AppState, isMicrosurveyShown: Bool) {
         guard let toolbarState = state.screenState(ToolbarState.self,
                                                    for: .toolbar,
@@ -292,6 +298,10 @@ final class ToolbarMiddleware: FeatureFlaggable {
                                                              scrollY: scrollOffset.y)
         var displayNavToolbarBorder = shouldDisplayNavigationToolbarBorder(toolbarPosition: addressToolbarPosition)
 
+        // If a microsurvey is shown, then we only want to show the top border for the microsurvey
+        // and the toolbars should have no borders if they are stacked underneath the microsurvey.
+        // This is to avoid spoofing. In the case where the address bar is on top, then the microsurvey
+        // should not affect its address border position.
         if isMicrosurveyShown(action: action, state: state) {
             displayNavToolbarBorder = false
             let isAddressToolbarOnBottom = addressToolbarPosition == .bottom

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -249,7 +249,11 @@ final class ToolbarMiddleware: FeatureFlaggable {
     }
 
     private func isMicrosurveyShown(action: GeneralBrowserMiddlewareAction, state: AppState) -> Bool {
-        let bvcState = state.screenState(BrowserViewControllerState.self, for: .browserViewController, window: action.windowUUID)
+        let bvcState = state.screenState(
+            BrowserViewControllerState.self,
+            for: .browserViewController,
+            window: action.windowUUID
+        )
         return bvcState?.microsurveyState.showPrompt ?? false
     }
 

--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -22,6 +22,6 @@ features:
           one_tap_new_tab: false
       - channel: developer
         value:
-          enabled: false
+          enabled: true
           one_tap_new_tab: false
 

--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -22,6 +22,6 @@ features:
           one_tap_new_tab: false
       - channel: developer
         value:
-          enabled: true
+          enabled: false
           one_tap_new_tab: false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9955)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21865)

## :bulb: Description

**Requirements**
Add border requirement for microsurvey with the new toolbar
- When survey is shown, hide border in between survey and toolbar
- When survey is shown and search bar is at bottom, hide border between search and survey
- When survey is dismissed, show border as normal

**Summary**
* Added a new `.none` case for `AddressToolbarBorderPosition` to be explicit that there is no border instead of using `nil`
* Utilized existing `isBottomSearchBar` instead of `isToolbarPositionBottom` because it seems that the state was not updated in time and the existing field provided a more reliable check after changing the address bar position

There are now three cases where we want to update the border:
1. **Microsurvey is shown** - update borders depending if toolbar position is top or bottom
2. **Scrolling** - updated to only change the address toolbar when on top since that seems to only be the concerned when scrolling
3. **Toolbar position has changed** - updated to check if microsurvey is shown, if so then we update the border for both nav and address bar

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
See iPhone, iPad should not be impacted since the main issue is the bottom toolbars

https://github.com/user-attachments/assets/c832163c-fd95-47ff-b85e-1e9d04ffd683

