### PR TITLE
Refactor FXIOS-7301 - Help to remove 1 closure_body_length violation from FakespotState.swift (2/3)

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -82,7 +82,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleTabDidReload(action: action, state: state)
 
         case FakespotActionType.pressedShoppingButton:
-            return handlePressedShopping(action: action, state: state)
+            return handlePressedShopping(state: state)
 
         case FakespotActionType.show:
             var state = state
@@ -175,7 +175,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handlePressedShopping(action: FakespotAction, state: FakespotState) -> FakespotState {
+    fileprivate static func handlePressedShopping(state: FakespotState) -> FakespotState {
         var state = state
         state.isOpen = !state.isOpen
         state.sidebarOpenForiPadLandscape = state.isOpen

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -82,13 +82,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleTabDidReload(action: action, state: state)
 
         case FakespotActionType.pressedShoppingButton:
-            var state = state
-            state.isOpen = !state.isOpen
-            state.sidebarOpenForiPadLandscape = state.isOpen
-            if !state.isOpen {
-                state.sendSurfaceDisplayedTelemetryEvent = true
-            }
-            return state
+            return handlePressedShopping(action: action, state: state)
 
         case FakespotActionType.show:
             var state = state

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -185,7 +185,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handleDismiss(state: FakespotState) -> FakespotState {
+    private static func handleDismiss(state: FakespotState) -> FakespotState {
         var state = state
         state.isOpen = false
         state.sidebarOpenForiPadLandscape = false

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -88,11 +88,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleShow(state: state)
 
         case FakespotActionType.dismiss:
-            var state = state
-            state.isOpen = false
-            state.sidebarOpenForiPadLandscape = false
-            state.sendSurfaceDisplayedTelemetryEvent = true
-            return state
+            return handleDismiss(state: state)
 
         case FakespotActionType.setAppearanceTo:
             let isEnabled = action.isOpen ?? state.isOpen

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -82,7 +82,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleTabDidReload(action: action, state: state)
 
         case FakespotActionType.pressedShoppingButton:
-            return handlePressedShopping(state: state)
+            return handlePressedShoppingButton(state: state)
 
         case FakespotActionType.show:
             return handleShow(state: state)
@@ -168,7 +168,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    private static func handlePressedShopping(state: FakespotState) -> FakespotState {
+    private static func handlePressedShoppingButton(state: FakespotState) -> FakespotState {
         var state = state
         state.isOpen = !state.isOpen
         state.sidebarOpenForiPadLandscape = state.isOpen

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -85,10 +85,7 @@ struct FakespotState: ScreenState, Equatable {
             return handlePressedShopping(state: state)
 
         case FakespotActionType.show:
-            var state = state
-            state.isOpen = true
-            state.sidebarOpenForiPadLandscape = true
-            return state
+            return handleShow(state: state)
 
         case FakespotActionType.dismiss:
             var state = state

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -184,4 +184,11 @@ struct FakespotState: ScreenState, Equatable {
         }
         return state
     }
+
+    fileprivate static func handleShow(state: FakespotState) -> FakespotState {
+        var state = state
+        state.isOpen = true
+        state.sidebarOpenForiPadLandscape = true
+        return state
+    }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -157,7 +157,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handleTabDidReload(action: FakespotAction, state: FakespotState) -> FakespotState {
+    private static func handleTabDidReload(action: FakespotAction, state: FakespotState) -> FakespotState {
         guard let tabUUID = action.tabUUID,
                 state.currentTabUUID == tabUUID,
                 let productId = action.productId

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -79,14 +79,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleTabDidChange(action: action, state: state)
 
         case FakespotActionType.tabDidReload:
-            guard let tabUUID = action.tabUUID,
-                    state.currentTabUUID == tabUUID,
-                    let productId = action.productId
-            else { return state }
-
-            var state = state
-            state.telemetryState[tabUUID]?.adEvents[productId] = AdTelemetryState()
-            return state
+            return handleTabDidReload(action: action, state: state)
 
         case FakespotActionType.pressedShoppingButton:
             var state = state

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -178,7 +178,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handleShow(state: FakespotState) -> FakespotState {
+    private static func handleShow(state: FakespotState) -> FakespotState {
         var state = state
         state.isOpen = true
         state.sidebarOpenForiPadLandscape = true

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -188,4 +188,12 @@ struct FakespotState: ScreenState, Equatable {
         state.sidebarOpenForiPadLandscape = true
         return state
     }
+
+    fileprivate static func handleDismiss(state: FakespotState) -> FakespotState {
+        var state = state
+        state.isOpen = false
+        state.sidebarOpenForiPadLandscape = false
+        state.sendSurfaceDisplayedTelemetryEvent = true
+        return state
+    }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -168,7 +168,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handlePressedShopping(state: FakespotState) -> FakespotState {
+    private static func handlePressedShopping(state: FakespotState) -> FakespotState {
         var state = state
         state.isOpen = !state.isOpen
         state.sidebarOpenForiPadLandscape = state.isOpen

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -176,4 +176,15 @@ struct FakespotState: ScreenState, Equatable {
 
         return state
     }
+
+    fileprivate static func handleTabDidReload(action: FakespotAction, state: FakespotState) -> FakespotState {
+        guard let tabUUID = action.tabUUID,
+                state.currentTabUUID == tabUUID,
+                let productId = action.productId
+        else { return state }
+
+        var state = state
+        state.telemetryState[tabUUID]?.adEvents[productId] = AdTelemetryState()
+        return state
+    }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -180,4 +180,14 @@ struct FakespotState: ScreenState, Equatable {
         state.telemetryState[tabUUID]?.adEvents[productId] = AdTelemetryState()
         return state
     }
+
+    fileprivate static func handlePressedShopping(action: FakespotAction, state: FakespotState) -> FakespotState {
+        var state = state
+        state.isOpen = !state.isOpen
+        state.sidebarOpenForiPadLandscape = state.isOpen
+        if !state.isOpen {
+            state.sendSurfaceDisplayedTelemetryEvent = true
+        }
+        return state
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR help to remove 1 `closure_body_length` violation from the `FakespotState.swift` file. It extracts to new functions the logic to:
- handle tab did reload
- handle pressed shopping
- handle show
- handle dismiss

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

