### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from HistoryPanel.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -455,7 +455,7 @@ class HistoryPanel: UIViewController,
             withIdentifier: TwoLineImageOverlayCell.cellIdentifier,
             for: indexPath
         ) as? TwoLineImageOverlayCell else {
-            logger.log("History Panel - cannot create TwoLineImageOverlayCell for STG",
+            logger.log("History Panel - cannot create TwoLineImageOverlayCell for Search Term Group",
                        level: .debug,
                        category: .library)
             return nil

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -418,6 +418,23 @@ class HistoryPanel: UIViewController,
         }
     }
 
+    private func getHistoryActionableCell(historyActionable: HistoryActionablesModel,
+                                          indexPath: IndexPath) -> UITableViewCell? {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: OneLineTableViewCell.cellIdentifier,
+            for: indexPath
+        ) as? OneLineTableViewCell
+        else {
+            logger.log("History Panel - cannot create OneLineTableViewCell for historyActionable",
+                       level: .debug,
+                       category: .library)
+            return nil
+        }
+
+        let actionableCell = configureHistoryActionableCell(historyActionable, cell)
+        return actionableCell
+    }
+
     private func configureHistoryActionableCell(
         _ historyActionable: HistoryActionablesModel,
         _ cell: OneLineTableViewCell

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -461,6 +461,21 @@ class HistoryPanel: UIViewController,
         return cell
     }
 
+    private func getGroupCell(searchTermGroup: ASGroup<Site>, indexPath: IndexPath) -> UITableViewCell? {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: TwoLineImageOverlayCell.cellIdentifier,
+            for: indexPath
+        ) as? TwoLineImageOverlayCell else {
+            logger.log("History Panel - cannot create TwoLineImageOverlayCell for STG",
+                       level: .debug,
+                       category: .library)
+            return nil
+        }
+
+        let asGroupCell = configureASGroupCell(searchTermGroup, cell)
+        return asGroupCell
+    }
+
     private func configureASGroupCell(
         _ asGroup: ASGroup<Site>,
         _ cell: TwoLineImageOverlayCell

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -372,18 +372,7 @@ class HistoryPanel: UIViewController,
             }
 
             if let site = item as? Site {
-                guard let cell = tableView.dequeueReusableCell(
-                    withIdentifier: TwoLineImageOverlayCell.accessoryUsageReuseIdentifier,
-                    for: indexPath
-                ) as? TwoLineImageOverlayCell else {
-                    self.logger.log("History Panel - cannot create TwoLineImageOverlayCell for site",
-                                    level: .debug,
-                                    category: .library)
-                    return nil
-                }
-
-                let siteCell = self.configureSiteCell(site, cell)
-                return siteCell
+                return self.getSiteCell(site: site, indexPath: indexPath)
             }
 
             if let searchTermGroup = item as? ASGroup<Site> {

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -376,18 +376,7 @@ class HistoryPanel: UIViewController,
             }
 
             if let searchTermGroup = item as? ASGroup<Site> {
-                guard let cell = tableView.dequeueReusableCell(
-                    withIdentifier: TwoLineImageOverlayCell.cellIdentifier,
-                    for: indexPath
-                ) as? TwoLineImageOverlayCell else {
-                    self.logger.log("History Panel - cannot create TwoLineImageOverlayCell for STG",
-                                    level: .debug,
-                                    category: .library)
-                    return nil
-                }
-
-                let asGroupCell = self.configureASGroupCell(searchTermGroup, cell)
-                return asGroupCell
+                return self.getGroupCell(searchTermGroup: searchTermGroup, indexPath: indexPath)
             }
 
             // This should never happen! You will have an empty row!

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -368,19 +368,7 @@ class HistoryPanel: UIViewController,
 
             if var historyActionable = item as? HistoryActionablesModel {
                 historyActionable.configureImage(for: windowUUID)
-                guard let cell = tableView.dequeueReusableCell(
-                    withIdentifier: OneLineTableViewCell.cellIdentifier,
-                    for: indexPath
-                ) as? OneLineTableViewCell
-                else {
-                    self.logger.log("History Panel - cannot create OneLineTableViewCell for historyActionable",
-                                    level: .debug,
-                                    category: .library)
-                    return nil
-                }
-
-                let actionableCell = self.configureHistoryActionableCell(historyActionable, cell)
-                return actionableCell
+                return self.getHistoryActionableCell(historyActionable: historyActionable, indexPath: indexPath)
             }
 
             if let site = item as? Site {

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -372,7 +372,7 @@ class HistoryPanel: UIViewController,
             }
 
             if let site = item as? Site {
-                return self.getSiteCell(site: site, indexPath: indexPath)
+                return getSiteCell(site: site, indexPath: indexPath)
             }
 
             if let searchTermGroup = item as? ASGroup<Site> {

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -364,7 +364,7 @@ class HistoryPanel: UIViewController,
             HistoryPanelSections,
             AnyHashable
         >(tableView: tableView) { [weak self] (tableView, indexPath, item) -> UITableViewCell? in
-            guard let self = self else { return nil }
+            guard let self else { return nil }
 
             if var historyActionable = item as? HistoryActionablesModel {
                 historyActionable.configureImage(for: windowUUID)

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -368,7 +368,7 @@ class HistoryPanel: UIViewController,
 
             if var historyActionable = item as? HistoryActionablesModel {
                 historyActionable.configureImage(for: windowUUID)
-                return self.getHistoryActionableCell(historyActionable: historyActionable, indexPath: indexPath)
+                return getHistoryActionableCell(historyActionable: historyActionable, indexPath: indexPath)
             }
 
             if let site = item as? Site {

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -376,7 +376,7 @@ class HistoryPanel: UIViewController,
             }
 
             if let searchTermGroup = item as? ASGroup<Site> {
-                return self.getGroupCell(searchTermGroup: searchTermGroup, indexPath: indexPath)
+                return getGroupCell(searchTermGroup: searchTermGroup, indexPath: indexPath)
             }
 
             // This should never happen! You will have an empty row!

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -441,6 +441,21 @@ class HistoryPanel: UIViewController,
         return cell
     }
 
+    private func getSiteCell(site: Site, indexPath: IndexPath) -> UITableViewCell? {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: TwoLineImageOverlayCell.accessoryUsageReuseIdentifier,
+            for: indexPath
+        ) as? TwoLineImageOverlayCell else {
+            logger.log("History Panel - cannot create TwoLineImageOverlayCell for site",
+                       level: .debug,
+                       category: .library)
+            return nil
+        }
+
+        let siteCell = configureSiteCell(site, cell)
+        return siteCell
+    }
+
     private func configureSiteCell(
         _ site: Site,
         _ cell: TwoLineImageOverlayCell


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `HistoryPanel.swift` file. It extracts the following logics to new functions:
- create history actionable cell
- create site cell
- create group cell

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

