### PR TITLE
Refactor FXIOS-7301 - Remove 3 closure_body_length violations from CreditCardItemRow.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -87,7 +87,7 @@ struct CreditCardItemRow: View {
 
     private var creditCardContent: some View {
         return VStack(spacing: 0) {
-            getCreditCardName()
+            creditCardName
 
             getCreditCardNumber()
 
@@ -95,7 +95,7 @@ struct CreditCardItemRow: View {
         }
     }
 
-    private func getCreditCardName() -> some View {
+    private var creditCardName: some View {
         return Text(item.ccName)
             .font(.body)
             .foregroundColor(titleTextColor)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -87,11 +87,7 @@ struct CreditCardItemRow: View {
 
     private func getCreditCardContent() -> some View {
         return VStack(spacing: 0) {
-            Text(item.ccName)
-                .font(.body)
-                .foregroundColor(titleTextColor)
-                .frame(maxWidth: .infinity,
-                       alignment: .leading)
+            getCreditCardName()
 
             AdaptiveStack(horizontalAlignment: .leading,
                           spacing: isAccessibilityCategory ? 0 : 5,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -30,31 +30,20 @@ struct CreditCardItemRow: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
-            AdaptiveStack(horizontalAlignment: .leading,
-                          verticalAlignment: .center,
-                          spacing: isAccessibilityCategory ? 5 : 24,
-                          isAccessibilityCategory: isAccessibilityCategory) {
-                getImage(creditCard: item)
-                    .renderingMode(.original)
-                    .resizable()
-                    .frame(width: 48, height: 48)
-                    .aspectRatio(contentMode: .fit)
-
-                creditCardData
-            }
-            .padding(.leading, 16)
-            .padding(.trailing, 16)
-            .padding(.top, 11)
-            .padding(.bottom, 11)
-            .background(isTapping ? backgroundHoverColor : backgroundColor)
-            .onTapGesture {
-                isTapping = true
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    isTapping = false
-                    didSelectAction?()
+            creditCardContent
+                .padding(.leading, 16)
+                .padding(.trailing, 16)
+                .padding(.top, 11)
+                .padding(.bottom, 11)
+                .background(isTapping ? backgroundHoverColor : backgroundColor)
+                .onTapGesture {
+                    isTapping = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        isTapping = false
+                        didSelectAction?()
+                    }
                 }
-            }
-            .accessibility(addTraits: .isButton)
+                .accessibility(addTraits: .isButton)
             Rectangle()
                 .fill(separatorColor)
                 .frame(maxWidth: .infinity)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -85,7 +85,7 @@ struct CreditCardItemRow: View {
         return Image(decorative: image)
     }
 
-    func getCreditCardContent() -> some View {
+    private func getCreditCardContent() -> some View {
         return VStack(spacing: 0) {
             Text(item.ccName)
                 .font(.body)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -40,41 +40,7 @@ struct CreditCardItemRow: View {
                     .frame(width: 48, height: 48)
                     .aspectRatio(contentMode: .fit)
 
-                VStack(spacing: 0) {
-                    Text(item.ccName)
-                        .font(.body)
-                        .foregroundColor(titleTextColor)
-                        .frame(maxWidth: .infinity,
-                               alignment: .leading)
-
-                    AdaptiveStack(horizontalAlignment: .leading,
-                                  spacing: isAccessibilityCategory ? 0 : 5,
-                                  isAccessibilityCategory: isAccessibilityCategory) {
-                        Text(item.ccType)
-                            .font(.body)
-                            .foregroundColor(titleTextColor)
-                        Text(verbatim: "••••\(item.ccNumberLast4)")
-                            .font(.subheadline)
-                            .foregroundColor(subTextColor)
-                    }
-                    .frame(maxWidth: .infinity,
-                           alignment: .leading)
-                    .padding(.top, 3)
-                    .padding(.bottom, 3)
-
-                    AdaptiveStack(horizontalAlignment: .leading,
-                                  spacing: isAccessibilityCategory ? 0 : 5,
-                                  isAccessibilityCategory: isAccessibilityCategory) {
-                        Text(String.CreditCard.DisplayCard.ExpiresLabel)
-                            .font(.body)
-                            .foregroundColor(subTextColor)
-                        Text(verbatim: "\(item.ccExpMonth)/\(item.ccExpYear % 100)")
-                            .font(.subheadline)
-                            .foregroundColor(subTextColor)
-                    }
-                    .frame(maxWidth: .infinity,
-                           alignment: .leading)
-                }
+                getCreditCardContent()
             }
             .padding(.leading, 16)
             .padding(.trailing, 16)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -40,7 +40,7 @@ struct CreditCardItemRow: View {
                     .frame(width: 48, height: 48)
                     .aspectRatio(contentMode: .fit)
 
-                creditCardContent
+                creditCardData
             }
             .padding(.leading, 16)
             .padding(.trailing, 16)
@@ -85,7 +85,7 @@ struct CreditCardItemRow: View {
         return Image(decorative: image)
     }
 
-    private var creditCardContent: some View {
+    private var creditCardData: some View {
         return VStack(spacing: 0) {
             creditCardName
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -91,18 +91,7 @@ struct CreditCardItemRow: View {
 
             getCreditCardNumber()
 
-            AdaptiveStack(horizontalAlignment: .leading,
-                          spacing: isAccessibilityCategory ? 0 : 5,
-                          isAccessibilityCategory: isAccessibilityCategory) {
-                Text(String.CreditCard.DisplayCard.ExpiresLabel)
-                    .font(.body)
-                    .foregroundColor(subTextColor)
-                Text(verbatim: "\(item.ccExpMonth)/\(item.ccExpYear % 100)")
-                    .font(.subheadline)
-                    .foregroundColor(subTextColor)
-            }
-            .frame(maxWidth: .infinity,
-                   alignment: .leading)
+            getCreditCardExpiration()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -85,6 +85,21 @@ struct CreditCardItemRow: View {
         return Image(decorative: image)
     }
 
+    private var creditCardContent: some View {
+        return AdaptiveStack(horizontalAlignment: .leading,
+                             verticalAlignment: .center,
+                             spacing: isAccessibilityCategory ? 5 : 24,
+                             isAccessibilityCategory: isAccessibilityCategory) {
+            getImage(creditCard: item)
+                .renderingMode(.original)
+                .resizable()
+                .frame(width: 48, height: 48)
+                .aspectRatio(contentMode: .fit)
+
+            creditCardData
+        }
+    }
+
     private var creditCardData: some View {
         return VStack(spacing: 0) {
             creditCardName

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -119,6 +119,44 @@ struct CreditCardItemRow: View {
         return Image(decorative: image)
     }
 
+    func getCreditCardContent() -> some View {
+        return VStack(spacing: 0) {
+            Text(item.ccName)
+                .font(.body)
+                .foregroundColor(titleTextColor)
+                .frame(maxWidth: .infinity,
+                       alignment: .leading)
+
+            AdaptiveStack(horizontalAlignment: .leading,
+                          spacing: isAccessibilityCategory ? 0 : 5,
+                          isAccessibilityCategory: isAccessibilityCategory) {
+                Text(item.ccType)
+                    .font(.body)
+                    .foregroundColor(titleTextColor)
+                Text(verbatim: "••••\(item.ccNumberLast4)")
+                    .font(.subheadline)
+                    .foregroundColor(subTextColor)
+            }
+            .frame(maxWidth: .infinity,
+                   alignment: .leading)
+            .padding(.top, 3)
+            .padding(.bottom, 3)
+
+            AdaptiveStack(horizontalAlignment: .leading,
+                          spacing: isAccessibilityCategory ? 0 : 5,
+                          isAccessibilityCategory: isAccessibilityCategory) {
+                Text(String.CreditCard.DisplayCard.ExpiresLabel)
+                    .font(.body)
+                    .foregroundColor(subTextColor)
+                Text(verbatim: "\(item.ccExpMonth)/\(item.ccExpYear % 100)")
+                    .font(.subheadline)
+                    .foregroundColor(subTextColor)
+            }
+            .frame(maxWidth: .infinity,
+                   alignment: .leading)
+        }
+    }
+
     func applyTheme(theme: Theme) {
         let color = theme.colors
         titleTextColor = Color(color.textPrimary)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -131,6 +131,21 @@ struct CreditCardItemRow: View {
         .padding(.bottom, 3)
     }
 
+    private func getCreditCardExpiration() -> some View {
+        return AdaptiveStack(horizontalAlignment: .leading,
+                             spacing: isAccessibilityCategory ? 0 : 5,
+                             isAccessibilityCategory: isAccessibilityCategory) {
+            Text(String.CreditCard.DisplayCard.ExpiresLabel)
+                .font(.body)
+                .foregroundColor(subTextColor)
+            Text(verbatim: "\(item.ccExpMonth)/\(item.ccExpYear % 100)")
+                .font(.subheadline)
+                .foregroundColor(subTextColor)
+        }
+        .frame(maxWidth: .infinity,
+               alignment: .leading)
+    }
+
     func applyTheme(theme: Theme) {
         let color = theme.colors
         titleTextColor = Color(color.textPrimary)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -89,20 +89,7 @@ struct CreditCardItemRow: View {
         return VStack(spacing: 0) {
             getCreditCardName()
 
-            AdaptiveStack(horizontalAlignment: .leading,
-                          spacing: isAccessibilityCategory ? 0 : 5,
-                          isAccessibilityCategory: isAccessibilityCategory) {
-                Text(item.ccType)
-                    .font(.body)
-                    .foregroundColor(titleTextColor)
-                Text(verbatim: "••••\(item.ccNumberLast4)")
-                    .font(.subheadline)
-                    .foregroundColor(subTextColor)
-            }
-            .frame(maxWidth: .infinity,
-                   alignment: .leading)
-            .padding(.top, 3)
-            .padding(.bottom, 3)
+            getCreditCardNumber()
 
             AdaptiveStack(horizontalAlignment: .leading,
                           spacing: isAccessibilityCategory ? 0 : 5,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -91,7 +91,7 @@ struct CreditCardItemRow: View {
 
             creditCardNumber
 
-            getCreditCardExpiration()
+            creditCardExpiration
         }
     }
 
@@ -120,7 +120,7 @@ struct CreditCardItemRow: View {
         .padding(.bottom, 3)
     }
 
-    private func getCreditCardExpiration() -> some View {
+    private var creditCardExpiration: some View {
         return AdaptiveStack(horizontalAlignment: .leading,
                              spacing: isAccessibilityCategory ? 0 : 5,
                              isAccessibilityCategory: isAccessibilityCategory) {

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -127,6 +127,23 @@ struct CreditCardItemRow: View {
                    alignment: .leading)
     }
 
+    private func getCreditCardNumber() -> some View {
+        return AdaptiveStack(horizontalAlignment: .leading,
+                             spacing: isAccessibilityCategory ? 0 : 5,
+                             isAccessibilityCategory: isAccessibilityCategory) {
+            Text(item.ccType)
+                .font(.body)
+                .foregroundColor(titleTextColor)
+            Text(verbatim: "••••\(item.ccNumberLast4)")
+                .font(.subheadline)
+                .foregroundColor(subTextColor)
+        }
+        .frame(maxWidth: .infinity,
+               alignment: .leading)
+        .padding(.top, 3)
+        .padding(.bottom, 3)
+    }
+
     func applyTheme(theme: Theme) {
         let color = theme.colors
         titleTextColor = Color(color.textPrimary)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -40,7 +40,7 @@ struct CreditCardItemRow: View {
                     .frame(width: 48, height: 48)
                     .aspectRatio(contentMode: .fit)
 
-                getCreditCardContent()
+                creditCardContent
             }
             .padding(.leading, 16)
             .padding(.trailing, 16)
@@ -85,7 +85,7 @@ struct CreditCardItemRow: View {
         return Image(decorative: image)
     }
 
-    private func getCreditCardContent() -> some View {
+    private var creditCardContent: some View {
         return VStack(spacing: 0) {
             getCreditCardName()
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -89,7 +89,7 @@ struct CreditCardItemRow: View {
         return VStack(spacing: 0) {
             creditCardName
 
-            getCreditCardNumber()
+            creditCardNumber
 
             getCreditCardExpiration()
         }
@@ -103,7 +103,7 @@ struct CreditCardItemRow: View {
                    alignment: .leading)
     }
 
-    private func getCreditCardNumber() -> some View {
+    private var creditCardNumber: some View {
         return AdaptiveStack(horizontalAlignment: .leading,
                              spacing: isAccessibilityCategory ? 0 : 5,
                              isAccessibilityCategory: isAccessibilityCategory) {

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -123,6 +123,14 @@ struct CreditCardItemRow: View {
         }
     }
 
+    private func getCreditCardName() -> some View {
+        return Text(item.ccName)
+            .font(.body)
+            .foregroundColor(titleTextColor)
+            .frame(maxWidth: .infinity,
+                   alignment: .leading)
+    }
+
     func applyTheme(theme: Theme) {
         let color = theme.colors
         titleTextColor = Color(color.textPrimary)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 3 `closure_body_length` violations from the `CreditCardItemRow.swift` file. To do this, I've extracted some view creations to new computed properties.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

