### PR TITLE
Bugfix FXIOS-9754 ⁃ Enhanced tracking protection is still visible when turned off from settings

### DIFF
--- a/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
@@ -50,6 +50,7 @@ class EnhancedTrackingProtectionCoordinator: BaseCoordinator,
             )
 
             enhancedTrackingProtectionMenuVC = TrackingProtectionViewController(viewModel: etpViewModel,
+                                                                                profile: profile,
                                                                                 windowUUID: tabManager.windowUUID)
             enhancedTrackingProtectionMenuVC?.enhancedTrackingProtectionMenuDelegate = self
         } else {

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionToggleView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionToggleView.swift
@@ -84,6 +84,10 @@ final class TrackingProtectionToggleView: UIView, ThemeApplicable {
         ])
     }
 
+    func setToggleSwitchVisibility(with isHidden: Bool) {
+        toggleSwitch.isHidden = isHidden
+    }
+
     func setStatusLabelText(with text: String) {
         toggleStatusLabel.text = text
     }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -34,6 +34,7 @@ protocol TrackingProtectionMenuDelegate: AnyObject {
 
 class TrackingProtectionViewController: UIViewController, Themeable, Notifiable, UIScrollViewDelegate {
     var themeManager: ThemeManager
+    var profile: Profile?
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
     let windowUUID: WindowUUID
@@ -105,10 +106,12 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
     // MARK: - View lifecycle
 
     init(viewModel: TrackingProtectionModel,
+         profile: Profile,
          windowUUID: WindowUUID,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.viewModel = viewModel
+        self.profile = profile
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
@@ -483,7 +486,8 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
 
     // MARK: - Update Views
     private func updateProtectionViewStatus() {
-        if toggleView.toggleIsOn {
+        let isContentBlockingConfigEnabled = profile?.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? false
+        if toggleView.toggleIsOn, isContentBlockingConfigEnabled {
             toggleView.setStatusLabelText(with: .Menu.EnhancedTrackingProtection.switchOnText)
             trackersView.setVisibility(isHidden: false)
             viewModel.isProtectionEnabled = true
@@ -492,6 +496,7 @@ class TrackingProtectionViewController: UIViewController, Themeable, Notifiable,
             trackersView.setVisibility(isHidden: true)
             viewModel.isProtectionEnabled = false
         }
+        toggleView.setToggleSwitchVisibility(with: !isContentBlockingConfigEnabled)
         connectionDetailsHeaderView.setupDetails(color: viewModel.getConnectionDetailsBackgroundColor(theme: currentTheme()),
                                                  title: viewModel.connectionDetailsTitle,
                                                  status: viewModel.connectionDetailsHeader,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9754)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21423)

## :bulb: Description
Hide/Unhide Tracking Protection Toggle Switch if Enhanced Tracking Protection is disabled/enabled from Privacy Settings

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

