### PR TITLE
Add FXIOS-9967 Github action for syncing acorn icons

### DIFF
--- a/.github/workflows/firefox-ios-sync-acorn-icons.yml
+++ b/.github/workflows/firefox-ios-sync-acorn-icons.yml
@@ -38,7 +38,7 @@ jobs:
               run: |
                 git config --global user.name "github-actions[bot]"
                 git config --global user.email "github-actions[bot]@users.noreply.github.com"
-                git add .
+                git add latest_acorn_release.json firefox-ios/Client/Assets/Images.xcassets/ BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift
                 git commit -m "Updated Icons from Acorn repo"
 
             - name: Create Pull Request

--- a/.github/workflows/firefox-ios-sync-acorn-icons.yml
+++ b/.github/workflows/firefox-ios-sync-acorn-icons.yml
@@ -1,0 +1,53 @@
+name: Sync Icons from Acorn repo
+
+on: 
+    workflow_dispatch:
+    schedule:
+      - cron: '0 12 * * SUN'
+
+jobs:
+    download_icons_if_needed:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+    
+            - name: Set up Python
+              uses: actions/setup-python@v4
+              with:
+               python-version: '3.x'
+    
+            - name: Install dependencies
+              run: |
+               python -m pip install --upgrade pip
+               pip install requests
+    
+            - name: Run script to monitor releases
+              run: |
+               python sync_acorn_icons.py
+            
+            - name: Check changes
+              id: check_changes
+              run: |
+                if [[ $(git status --porcelain) ]]; then
+                    echo "changes_detected=true" >> $GITHUB_ENV 
+                fi
+
+            - name: Commit if needed 
+              if: ${{ env.changes_detected }}
+              run: |
+                git config --global user.name "github-actions[bot]"
+                git config --global user.email "github-actions[bot]@users.noreply.github.com"
+                git add .
+                git commit -m "Updated Icons from Acorn repo"
+
+            - name: Create Pull Request
+              if: ${{ env.changes_detected }}
+              uses: peter-evans/create-pull-request@v6
+              with:
+                  author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+                  committer: GitHub <noreply@github.com>
+                  title: Update Firefox icons from Acorn repo
+                  branch: update-firefox-project-with-acorn-icons
+                  token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firefox-ios-sync-acorn-icons.yml
+++ b/.github/workflows/firefox-ios-sync-acorn-icons.yml
@@ -23,7 +23,7 @@ jobs:
                python -m pip install --upgrade pip
                pip install requests
     
-            - name: Run script download icons if needed
+            - name: Download Acorn icons
               run: |
                python sync_acorn_icons.py
             

--- a/.github/workflows/firefox-ios-sync-acorn-icons.yml
+++ b/.github/workflows/firefox-ios-sync-acorn-icons.yml
@@ -23,12 +23,11 @@ jobs:
                python -m pip install --upgrade pip
                pip install requests
     
-            - name: Run script to monitor releases
+            - name: Run script download icons if needed
               run: |
                python sync_acorn_icons.py
             
             - name: Check changes
-              id: check_changes
               run: |
                 if [[ $(git status --porcelain) ]]; then
                     echo "changes_detected=true" >> $GITHUB_ENV 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9967)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21887)

## :bulb: Description
Add Github action to call `sync_acorn_icons.py` in order to check for icons update on Acorn repository. The action create a PR with the changes if present

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

