### PR TITLE
Bugfix FXIOS-9735 ⁃ [Landscape] The private tab tray icon mask is missing when rotating the device in landscape

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2915,7 +2915,7 @@ class BrowserViewController: UIViewController,
         }
 
         if !isToolbarRefactorEnabled {
-            let isPrivate = (currentTheme.type == .privateMode)
+            let isPrivate = tabManager.selectedTab?.isPrivate ?? false
             urlBar.applyUIMode(isPrivate: isPrivate, theme: currentTheme)
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9735)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21394)

## :bulb: Description
Changed the logic to verify if we are in private mode or not

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

