### PR TITLE
Add FXIOS-9610 [Unit Tests] Updated tests for WindowManager

### DIFF
--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -56,7 +56,7 @@ protocol WindowManager {
     /// windows are being restored concurrently, we never supply the same UUID
     /// to more than one window.
     /// - Returns: a UUID for the next window to be opened.
-    func reserveNextAvailableWindowUUID() -> ReservedWindowUUID
+    func reserveNextAvailableWindowUUID(isIpad: Bool) -> ReservedWindowUUID
 
     /// Signals the WindowManager that a window event has occurred. Window events
     /// are communicated to any interested Coordinators for _all_ windows, but
@@ -165,7 +165,7 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
         windowOrderingPriority = prefs
     }
 
-    func reserveNextAvailableWindowUUID() -> ReservedWindowUUID {
+    func reserveNextAvailableWindowUUID(isIpad: Bool) -> ReservedWindowUUID {
         // Continue to provide the expected hardcoded UUID for UI tests.
         guard !AppConstants.isRunningUITests else {
             return ReservedWindowUUID(uuid: WindowUUID.DefaultUITestingUUID, isNew: false)
@@ -195,11 +195,8 @@ final class WindowManagerImplementation: WindowManager, WindowTabsSyncCoordinato
 
         // On iPhone devices, we expect there only to ever be a single window. If there
         // are >1 windows we've encountered some type of unexpected state.
-        let isIpad = (UIDevice.current.userInterfaceIdiom == .pad)
-
         let result: ReservedWindowUUID
-        // TODO: [9610] Unit tests should eventually be updated for these changes. Forthcoming.
-        if !isIpad && !AppConstants.isRunningUnitTest {
+        if !isIpad {
             // We should always have either a single UUID on disk or no UUIDs because this is a brand new app install
             if onDiskUUIDs.isEmpty {
                 result = ReservedWindowUUID(uuid: WindowUUID(), isNew: true)

--- a/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -25,7 +25,8 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
         // The logic is handled by `reserveNextAvailableWindowUUID`, but this is the point at which a window's UUID
         // is set; this same UUID will be injected throughout several of the window's related components
         // such as its TabManager instance, which also has the window UUID property as a convenience.
-        let reserved = windowManager.reserveNextAvailableWindowUUID()
+        let isIpad = (UIDevice.current.userInterfaceIdiom == .pad)
+        let reserved = windowManager.reserveNextAvailableWindowUUID(isIpad: isIpad)
         self.reservedWindowUUID = reserved
         self.window = sceneSetupHelper.configureWindowFor(scene,
                                                           windowUUID: reserved.uuid,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
@@ -42,8 +42,8 @@ final class MockWindowManager: WindowManager {
         wrappedManager.windowWillClose(uuid: uuid)
     }
 
-    func reserveNextAvailableWindowUUID() -> ReservedWindowUUID {
-        wrappedManager.reserveNextAvailableWindowUUID()
+    func reserveNextAvailableWindowUUID(isIpad: Bool) -> ReservedWindowUUID {
+        wrappedManager.reserveNextAvailableWindowUUID(isIpad: isIpad)
     }
 
     func postWindowEvent(event: WindowEvent, windowUUID: WindowUUID) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -107,15 +107,8 @@ class WindowManagerTests: XCTestCase {
         let subject = createSubject()
         mockTabDataStore.resetMockTabWindowUUIDs()
 
-        // Check that asking for two UUIDs results in two unique/random UUIDs
-        // Note: there is a possibility of collision between any two randomly-
-        // generated UUIDs but it is astronomically small (1 out of 2^122).
-        // Although iPhone should only ideally have one UUID, there is not
-        // existing id saved in onDiskUUIDs, so we are okay with generating
-        // a new one here.
         let uuid1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad)
-        let uuid2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad)
-        XCTAssertNotEqual(uuid1.uuid, uuid2.uuid)
+        XCTAssertTrue(uuid1.isNew)
     }
 
     func testNextAvailableUUIDWhenOnlyOneWindowSaved_forIpad() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -21,8 +21,8 @@ class WindowManagerTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
         DependencyHelperMock().reset()
+        super.tearDown()
     }
 
     func testConfiguringAndConnectingSingleAppWindow() {
@@ -89,19 +89,37 @@ class WindowManagerTests: XCTestCase {
         // XCTAssertEqual(secondWindowUUID, subject.activeWindow)
     }
 
-    func testNextAvailableUUIDWhenNoTabDataIsSaved() {
+    func testNextAvailableUUIDWhenNoTabDataIsSaved_forIpad() {
+        let isIpad = true
         let subject = createSubject()
         mockTabDataStore.resetMockTabWindowUUIDs()
 
         // Check that asking for two UUIDs results in two unique/random UUIDs
         // Note: there is a possibility of collision between any two randomly-
         // generated UUIDs but it is astronomically small (1 out of 2^122).
-        let uuid1 = subject.reserveNextAvailableWindowUUID()
-        let uuid2 = subject.reserveNextAvailableWindowUUID()
+        let uuid1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad)
+        let uuid2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad)
         XCTAssertNotEqual(uuid1.uuid, uuid2.uuid)
     }
 
-    func testNextAvailableUUIDWhenOnlyOneWindowSaved() {
+    func testNextAvailableUUIDWhenNoTabDataIsSaved_forIphone() {
+        let isIpad = false
+        let subject = createSubject()
+        mockTabDataStore.resetMockTabWindowUUIDs()
+
+        // Check that asking for two UUIDs results in two unique/random UUIDs
+        // Note: there is a possibility of collision between any two randomly-
+        // generated UUIDs but it is astronomically small (1 out of 2^122).
+        // Although iPhone should only ideally have one UUID, there is not
+        // existing id saved in onDiskUUIDs, so we are okay with generating
+        // a new one here.
+        let uuid1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad)
+        let uuid2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad)
+        XCTAssertNotEqual(uuid1.uuid, uuid2.uuid)
+    }
+
+    func testNextAvailableUUIDWhenOnlyOneWindowSaved_forIpad() {
+        let isIpad = true
         let subject = createSubject()
         mockTabDataStore.resetMockTabWindowUUIDs()
 
@@ -109,14 +127,32 @@ class WindowManagerTests: XCTestCase {
         mockTabDataStore.injectMockTabWindowUUID(savedUUID)
 
         // Check that asking for first UUID returns the expected UUID
-        XCTAssertEqual(savedUUID, subject.reserveNextAvailableWindowUUID().uuid)
+        XCTAssertEqual(savedUUID, subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid)
         // Open a window using this UUID
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: savedUUID)
         // Check that asking for another UUID returns a new, random UUID
-        XCTAssertNotEqual(savedUUID, subject.reserveNextAvailableWindowUUID().uuid)
+        XCTAssertNotEqual(savedUUID, subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid)
     }
 
-    func testNextAvailableUUIDWhenMultipleWindowsSaved() {
+    func testNextAvailableUUIDWhenOnlyOneWindowSaved_forIphone_onlyHasOneUUID() {
+        let isIpad = false
+        let subject = createSubject()
+        mockTabDataStore.resetMockTabWindowUUIDs()
+
+        let savedUUID = UUID()
+        mockTabDataStore.injectMockTabWindowUUID(savedUUID)
+
+        // Check that asking for first UUID returns the expected UUID
+        XCTAssertEqual(savedUUID, subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid)
+        // Open a window using this UUID
+        subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: savedUUID)
+        // Check that asking for another UUID returns the same UUID, becase there is only ever
+        // one window on the iPhone devices
+        XCTAssertEqual(savedUUID, subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid)
+    }
+
+    func testNextAvailableUUIDWhenMultipleWindowsSaved_forIpad() {
+        let isIpad = true
         let subject = createSubject()
         mockTabDataStore.resetMockTabWindowUUIDs()
 
@@ -127,9 +163,9 @@ class WindowManagerTests: XCTestCase {
         mockTabDataStore.injectMockTabWindowUUID(uuid2)
 
         // Ask for UUIDs for two windows, which we open and configure
-        let result1 = subject.reserveNextAvailableWindowUUID().uuid
+        let result1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: result1)
-        let result2 = subject.reserveNextAvailableWindowUUID().uuid
+        let result2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
         subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: result2)
 
         // Check that our UUIDs are the ones we expected
@@ -139,22 +175,53 @@ class WindowManagerTests: XCTestCase {
         XCTAssertEqual(expectedUUIDs.count, 2)
 
         // Check that asking for a 3rd UUID returns a new, random UUID
-        let result3 = subject.reserveNextAvailableWindowUUID().uuid
+        let result3 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
         XCTAssertFalse(expectedUUIDs.contains(result3))
         XCTAssertNotEqual(result1, result3)
         XCTAssertNotEqual(result2, result3)
     }
 
-    func testAllWindowTabManagers() {
+    func testNextAvailableUUIDWhenMultipleWindowsSaved_forIphone_onlyHasOneUUID() {
+        let isIpad = false
+        let subject = createSubject()
+        mockTabDataStore.resetMockTabWindowUUIDs()
+
+        let uuid1 = UUID()
+        let uuid2 = UUID()
+        let expectedUUIDs = Set<UUID>([uuid1, uuid2])
+        mockTabDataStore.injectMockTabWindowUUID(uuid1)
+        mockTabDataStore.injectMockTabWindowUUID(uuid2)
+
+        // Ask for UUIDs for two windows, which we open and configure
+        let result1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: result1)
+        let result2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: result2)
+
+        // Check that our UUIDs are the ones we expected
+        // (Note: currently the order is undefined, this may be changing soon)
+        XCTAssert(expectedUUIDs.contains(result1))
+        XCTAssert(expectedUUIDs.contains(result2))
+        XCTAssertEqual(result1, result2)
+
+        // Check that asking for a 3rd UUID returns the same UUID
+        let result3 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        XCTAssertTrue(expectedUUIDs.contains(result3))
+        XCTAssertEqual(result1, result3)
+        XCTAssertEqual(result2, result3)
+    }
+
+    func testAllWindowTabManagers_forIpad() {
+        let isIpad = true
         let subject = createSubject()
 
         let tabManager1 = MockTabManager()
         let tabManager2 = MockTabManager()
 
         // Create two separate windows with associated Tab Managers
-        let uuid1 = subject.reserveNextAvailableWindowUUID().uuid
+        let uuid1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
         subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager1), uuid: uuid1)
-        let uuid2 = subject.reserveNextAvailableWindowUUID().uuid
+        let uuid2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
         subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager2), uuid: uuid2)
 
         // Check that allWindowTabManagers returns both expected instances
@@ -170,7 +237,34 @@ class WindowManagerTests: XCTestCase {
         XCTAssert(tabManager2 === allTabManagers.first!)
     }
 
-    func testReservedUUIDsAreUnavailableInSuccessiveCalls() {
+    func testAllWindowTabManagers__forIphone_onlyHasOneUUID() {
+        let isIpad = false
+        let subject = createSubject()
+
+        let tabManager1 = MockTabManager()
+        let tabManager2 = MockTabManager()
+
+        // Create two separate windows with associated Tab Managers
+        let uuid1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager1), uuid: uuid1)
+        let uuid2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager2), uuid: uuid2)
+
+        // Check that allWindowTabManagers returns both expected instances
+        var allTabManagers = subject.allWindowTabManagers()
+        XCTAssertEqual(allTabManagers.count, 2)
+        XCTAssert(allTabManagers.contains(where: { $0 === tabManager1 }))
+        XCTAssert(allTabManagers.contains(where: { $0 === tabManager2 }))
+
+        // Close first window and check that only the 2nd tab manager instance is returned
+        subject.windowWillClose(uuid: uuid1)
+        allTabManagers = subject.allWindowTabManagers()
+        XCTAssertEqual(allTabManagers.count, 1)
+        XCTAssert(tabManager2 === allTabManagers.first!)
+    }
+
+    func testReservedUUIDsAreUnavailableInSuccessiveCalls_forIpad() {
+        let isIpad = true
         let subject = createSubject()
         mockTabDataStore.resetMockTabWindowUUIDs()
 
@@ -179,15 +273,34 @@ class WindowManagerTests: XCTestCase {
 
         // Request a UUID. We expect it to be the first persisted WindowData
         // UUID, which will also be reserved for use.
-        let requestedUUID1 = subject.reserveNextAvailableWindowUUID().uuid
+        let requestedUUID1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
         XCTAssertEqual(requestedUUID1, savedUUID)
 
         // Request a 2nd UUID. We expect it to be a different UUID.
-        let requestedUUID2 = subject.reserveNextAvailableWindowUUID().uuid
+        let requestedUUID2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
         XCTAssertNotEqual(requestedUUID2, savedUUID)
     }
 
-    func testClosingTwoWindowsInDifferentOrdersResultsInSensibleExpectedOrderWhenOpening() {
+    func testReservedUUIDsAreUnavailableInSuccessiveCalls__forIphone_onlyHasOneUUID() {
+        let isIpad = false
+        let subject = createSubject()
+        mockTabDataStore.resetMockTabWindowUUIDs()
+
+        let savedUUID = UUID()
+        mockTabDataStore.injectMockTabWindowUUID(savedUUID)
+
+        // Request a UUID. We expect it to be the first persisted WindowData
+        // UUID, which will also be reserved for use.
+        let requestedUUID1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        XCTAssertEqual(requestedUUID1, savedUUID)
+
+        // Request a 2nd UUID. We expect it to be the same UUID for iPhone devices.
+        let requestedUUID2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        XCTAssertEqual(requestedUUID2, savedUUID)
+    }
+
+    func testClosingTwoWindowsInDifferentOrdersResultsInSensibleExpectedOrderWhenOpening_forIpad() {
+        let isIpad = true
         let subject = createSubject()
         mockTabDataStore.resetMockTabWindowUUIDs()
 
@@ -207,8 +320,8 @@ class WindowManagerTests: XCTestCase {
 
         // Now attempt to re-open two windows in order. We expect window
         // 1 to open, then window 2
-        let result1 = subject.reserveNextAvailableWindowUUID().uuid
-        let result2 = subject.reserveNextAvailableWindowUUID().uuid
+        let result1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        let result2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
         XCTAssertEqual(result1, uuid1)
         XCTAssertEqual(result2, uuid2)
 
@@ -220,10 +333,54 @@ class WindowManagerTests: XCTestCase {
         subject.windowWillClose(uuid: uuid2)
 
         // Check that the next time we open the windows the order is now reversed
-        let result2_1 = subject.reserveNextAvailableWindowUUID().uuid
-        let result2_2 = subject.reserveNextAvailableWindowUUID().uuid
+        let result2_1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        let result2_2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
         XCTAssertEqual(result2_1, uuid2)
         XCTAssertEqual(result2_2, uuid1)
+    }
+
+    func testClosingTwoWindowsInDifferentOrdersResultsInSensibleExpectedOrderWhenOpening_forIphone_onlyHasOneUUID() {
+        let isIpad = false
+        let subject = createSubject()
+        mockTabDataStore.resetMockTabWindowUUIDs()
+
+        let uuid1 = UUID()
+        mockTabDataStore.injectMockTabWindowUUID(uuid1)
+        let uuid2 = UUID()
+        mockTabDataStore.injectMockTabWindowUUID(uuid2)
+
+        // Attempt to open a window using UUID 1
+        subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: uuid1)
+        // Attempt to open a window using UUID 2
+        subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: uuid2)
+
+        // Close window 2, then window 1 even though should only
+        // ever be one window on iPhone
+        subject.windowWillClose(uuid: uuid2)
+        subject.windowWillClose(uuid: uuid1)
+
+        // Now attempt to re-open two windows in order. We expect window
+        // both windows to reference the same uuid
+        let result1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        let result2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        XCTAssertEqual(result1, uuid1)
+        XCTAssertEqual(result2, uuid1)
+        XCTAssertEqual(result1, result2)
+
+        // Now re-open both windows in order...
+        subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: uuid1)
+        subject.newBrowserWindowConfigured(AppWindowInfo(), uuid: uuid2)
+        // ...but close them in the opposite order as before (close window 1, then 2)
+        subject.windowWillClose(uuid: uuid1)
+        subject.windowWillClose(uuid: uuid2)
+
+        // Check that the next time we open the windows, there still exists
+        // only one uuid
+        let result2_1 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        let result2_2 = subject.reserveNextAvailableWindowUUID(isIpad: isIpad).uuid
+        XCTAssertEqual(result2_1, uuid1)
+        XCTAssertEqual(result2_2, uuid1)
+        XCTAssertEqual(result2_1, result2_2)
     }
 
     // MARK: - Test Subject


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9610)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21205)

## :bulb: Description
Add unit tests for `reserveNextAvailableWindowUUID` which confirms that for iPhone devices, there is only one WindowUUID that exists.
- Move device check outside of the method. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

