### PR TITLE
Add FXIOS-9683 [Unit Tests] Tab Peek State tests

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -795,6 +795,7 @@
 		8A7A93EE2810ADF2005E7E1B /* ContileProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A93ED2810ADF2005E7E1B /* ContileProviderTests.swift */; };
 		8A7AE4442BAB510B0072DAEC /* LibraryPanelCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7AE4432BAB510B0072DAEC /* LibraryPanelCoordinatorDelegate.swift */; };
 		8A7AE4472BAC78230072DAEC /* MockLibraryNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7AE4452BAC76B00072DAEC /* MockLibraryNavigationHandler.swift */; };
+		8A7AF0C72C9A119A009691B5 /* TabPeekStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7AF0C52C9A1167009691B5 /* TabPeekStateTests.swift */; };
 		8A7D1AC52BA3542600162F4B /* splashScreen.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A7D1AC42BA3542600162F4B /* splashScreen.json */; };
 		8A8158CB2C2C77B000281F72 /* MicrosurveyTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8158CA2C2C77B000281F72 /* MicrosurveyTelemetry.swift */; };
 		8A827E302C20C7F5008D5E3C /* MicrosurveyMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A827E2E2C20C55E008D5E3C /* MicrosurveyMiddlewareTests.swift */; };
@@ -6807,6 +6808,7 @@
 		8A7A93ED2810ADF2005E7E1B /* ContileProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContileProviderTests.swift; sourceTree = "<group>"; };
 		8A7AE4432BAB510B0072DAEC /* LibraryPanelCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPanelCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		8A7AE4452BAC76B00072DAEC /* MockLibraryNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLibraryNavigationHandler.swift; sourceTree = "<group>"; };
+		8A7AF0C52C9A1167009691B5 /* TabPeekStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabPeekStateTests.swift; sourceTree = "<group>"; };
 		8A7D1AC42BA3542600162F4B /* splashScreen.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = splashScreen.json; sourceTree = "<group>"; };
 		8A8158CA2C2C77B000281F72 /* MicrosurveyTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyTelemetry.swift; sourceTree = "<group>"; };
 		8A827E2E2C20C55E008D5E3C /* MicrosurveyMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyMiddlewareTests.swift; sourceTree = "<group>"; };
@@ -9377,6 +9379,7 @@
 		21D8EA942ABE0511003FF16E /* TabTray */ = {
 			isa = PBXGroup;
 			children = (
+				8A7AF0C42C9A1135009691B5 /* Redux */,
 				21B548982B1E7FDF00DC1DF8 /* InactiveTabsManagerTests.swift */,
 				219935ED2B07B9B300E5966F /* Legacy */,
 				1D8487B52AD6038100F7527C /* RemoteTabPanelStateTests.swift */,
@@ -10668,6 +10671,14 @@
 				8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */,
 			);
 			path = Pocket;
+			sourceTree = "<group>";
+		};
+		8A7AF0C42C9A1135009691B5 /* Redux */ = {
+			isa = PBXGroup;
+			children = (
+				8A7AF0C52C9A1167009691B5 /* TabPeekStateTests.swift */,
+			);
+			path = Redux;
 			sourceTree = "<group>";
 		};
 		8A827E332C20C8C0008D5E3C /* Mock */ = {
@@ -16168,6 +16179,7 @@
 				21FA8FAE2AE856460013B815 /* TabsCoordinatorTests.swift in Sources */,
 				E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */,
 				5AF6254328A57A4600A90253 /* HistoryHighlightsDataAdaptorTests.swift in Sources */,
+				8A7AF0C72C9A119A009691B5 /* TabPeekStateTests.swift in Sources */,
 				0AFF7F642C7784D600265214 /* MockDataCleaner.swift in Sources */,
 				8AE80BAD2891957C00BC12EA /* TopSitesDimensionTests.swift in Sources */,
 				D82ED2641FEB3C420059570B /* DefaultSearchPrefsTests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Redux/TabPeekStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Redux/TabPeekStateTests.swift
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+final class TabPeekStateTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        DependencyHelperMock().reset()
+        super.tearDown()
+    }
+
+    func testLoadTabPeekAction_showAddBookmarks_andSendToDevice() {
+        let initialState = createSubject()
+        let reducer = tabPeekReducer()
+
+        XCTAssertEqual(initialState.showAddToBookmarks, false)
+        XCTAssertEqual(initialState.showSendToDevice, false)
+
+        let action = getAction(for: .loadTabPeek)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.showAddToBookmarks, true)
+        XCTAssertEqual(newState.showSendToDevice, true)
+    }
+
+    func testLoadTabPeekAction_doesNotShowAddBookmarks_orSendToDevice() {
+        let initialState = createSubject()
+        let reducer = tabPeekReducer()
+
+        XCTAssertEqual(initialState.showAddToBookmarks, false)
+        XCTAssertEqual(initialState.showSendToDevice, false)
+
+        let model = TabPeekModel(
+            canTabBeSaved: false,
+            isSyncEnabled: true,
+            screenshot: UIImage(),
+            accessiblityLabel: ""
+        )
+        let action = getAction(for: .loadTabPeek, with: model)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.showAddToBookmarks, false)
+        XCTAssertEqual(newState.showSendToDevice, false)
+    }
+
+    func testLoadTabPeekAction_showBookmarks_andDoesNotShowDevice() {
+        let initialState = createSubject()
+        let reducer = tabPeekReducer()
+
+        XCTAssertEqual(initialState.showAddToBookmarks, false)
+        XCTAssertEqual(initialState.showSendToDevice, false)
+
+        let model = TabPeekModel(
+            canTabBeSaved: true,
+            isSyncEnabled: false,
+            screenshot: UIImage(),
+            accessiblityLabel: ""
+        )
+        let action = getAction(for: .loadTabPeek, with: model)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.showAddToBookmarks, true)
+        XCTAssertEqual(newState.showSendToDevice, false)
+    }
+
+    // MARK: - Private
+    private func createSubject() -> TabPeekState {
+        return TabPeekState(windowUUID: .XCTestDefaultUUID)
+    }
+
+    private func tabPeekReducer() -> Reducer<TabPeekState> {
+        return TabPeekState.reducer
+    }
+
+    private func getAction(
+        for actionType: TabPeekActionType,
+        with model: TabPeekModel = TabPeekModel(
+            canTabBeSaved: true,
+            isSyncEnabled: true,
+            screenshot: UIImage(),
+            accessiblityLabel: "tabpeek-a11y-label"
+        )
+    ) -> TabPeekAction {
+        return TabPeekAction(
+            tabPeekModel: model,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: actionType
+        )
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9683)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21300)

## :bulb: Description
Add unit tests to check state for different cases for actions reduced in `TabPeekState`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)