### PR TITLE
Refactor MTE-3514 Use save-cache and restore-cache steps

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -836,7 +836,7 @@ workflows:
 
             ./firefox-ios/l10n-screenshots.sh en-US
         title: Generate screenshots
-    - save-cache@1
+    - save-cache@1:
         inputs:
         - key: l10n-screenshots-dd-{{ git rev-parse HEAD }}
           paths: l10n-screenshots-dd

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -838,7 +838,7 @@ workflows:
         title: Generate screenshots
     - save-cache@1:
         inputs:
-        - key: l10n-screenshots-dd-{{ git rev-parse HEAD }}
+        - key: l10n-screenshots-dd-{{ checksum "package-lock.json" }}
           paths: l10n-screenshots-dd
     - deploy-to-bitrise-io@2:
         inputs:
@@ -860,7 +860,7 @@ workflows:
     - certificate-and-profile-installer@1: {}
     - restore-cache@2:
         inputs:
-        - key: l10n-screenshots-dd-{{ git rev-parse HEAD }}
+        - key: l10n-screenshots-dd-{{ checksum "package-lock.json" }}
           paths: l10n-screenshots-dd
         title: Download derived data path
     - script@1.1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -839,7 +839,7 @@ workflows:
         title: Generate screenshots
     - save-cache@1:
         inputs:
-        - key: l10n-screenshots-dd-{{ checksum "package-lock.json" }}
+        - key: l10n-screenshots-dd-`git rev-parse HEAD`
         - paths: l10n-screenshots-dd
     - deploy-to-bitrise-io@2:
         inputs:
@@ -862,7 +862,7 @@ workflows:
     - restore-cache@2:
         inputs:
         - key: |-
-            l10n-screenshots-dd-{{ git rev-parse HEAD }}
+            l10n-screenshots-dd-`git rev-parse HEAD`
             l10n-screenshots-dd-
         - paths: l10n-screenshots-dd
         title: Download derived data path

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -835,11 +835,10 @@ workflows:
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
-            echo $GIT_CLONE_COMMIT_HASH
         title: Generate screenshots
     - save-cache@1:
         inputs:
-        - key: l10n-screenshots-dd-{{ echo $GIT_CLONE_COMMIT_HASH }}
+        - key: l10n-screenshots-dd-$GIT_CLONE_COMMIT_HASH
         - paths: l10n-screenshots-dd
     - deploy-to-bitrise-io@2:
         inputs:
@@ -862,7 +861,7 @@ workflows:
     - restore-cache@2:
         inputs:
         - key: |-
-            l10n-screenshots-dd-`git log --pretty=format:'%h' -n 1`
+            l10n-screenshots-dd-$GIT_CLONE_COMMIT_HASH
             l10n-screenshots-dd-
         - paths: l10n-screenshots-dd
         title: Download derived data path

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -838,8 +838,8 @@ workflows:
         title: Generate screenshots
     - save-cache@1:
         inputs:
-        - key: l10n-screenshots-dd-{{ checksum "package-lock.json" }}
-          paths: l10n-screenshots-dd
+        - key: l10n-screenshots-dd-{{ git rev-parse HEAD }}
+        - paths: l10n-screenshots-dd
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: l10n-screenshots/en-US/en-US
@@ -860,8 +860,10 @@ workflows:
     - certificate-and-profile-installer@1: {}
     - restore-cache@2:
         inputs:
-        - key: l10n-screenshots-dd-{{ checksum "package-lock.json" }}
-          paths: l10n-screenshots-dd
+        - key: |-
+            l10n-screenshots-dd-{{ git rev-parse HEAD }}
+            l10n-screenshots-dd-
+        - paths: l10n-screenshots-dd
         title: Download derived data path
     - script@1.1:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -860,9 +860,7 @@ workflows:
     - certificate-and-profile-installer@1: {}
     - restore-cache@2:
         inputs:
-        - key: |-
-            l10n-screenshots-dd-{{ git rev-parse HEAD }}
-            l10n-screenshots-dd-
+        - key: l10n-screenshots-dd-{{ git rev-parse HEAD }}
           paths: l10n-screenshots-dd
         title: Download derived data path
     - script@1.1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -836,10 +836,10 @@ workflows:
 
             ./firefox-ios/l10n-screenshots.sh en-US
         title: Generate screenshots
-    - deploy-to-bitrise-io@2:
+    - save-cache@1
         inputs:
-        - deploy_path: l10n-screenshots-dd/
-        - is_compress: 'true'
+        - key: l10n-screenshots-dd
+          paths: l10n-screenshots-dd
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: l10n-screenshots/en-US/en-US
@@ -858,27 +858,10 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@6.2: {}
     - certificate-and-profile-installer@1: {}
-    - script@1:
+    - restore-cache@2:
         inputs:
-        - content: >-
-            #!/usr/bin/env bash
-
-            # fail if any commands fails
-
-            set -e
-
-            # debug log
-
-            set -x
-
-            curl --location --retry 5 --output l10n-screenshots-dd.zip
-            "$MOZ_DERIVED_DATA_PATH"
-
-            mkdir l10n-screenshots-dd
-
-            unzip l10n-screenshots-dd.zip -d l10n-screenshots-dd
-
-            rm l10n-screenshots-dd.zip
+        - key: l10n-screenshots-dd
+          paths: l10n-screenshots-dd
         title: Download derived data path
     - script@1.1:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -835,11 +835,11 @@ workflows:
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
-            git rev-parse HEAD
+            git log --pretty=format:'%h' -n 1
         title: Generate screenshots
     - save-cache@1:
         inputs:
-        - key: l10n-screenshots-dd-`git rev-parse HEAD`
+        - key: l10n-screenshots-dd-`git log --pretty=format:'%h' -n 1`
         - paths: l10n-screenshots-dd
     - deploy-to-bitrise-io@2:
         inputs:
@@ -862,7 +862,7 @@ workflows:
     - restore-cache@2:
         inputs:
         - key: |-
-            l10n-screenshots-dd-`git rev-parse HEAD`
+            l10n-screenshots-dd-`git log --pretty=format:'%h' -n 1`
             l10n-screenshots-dd-
         - paths: l10n-screenshots-dd
         title: Download derived data path

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -838,7 +838,7 @@ workflows:
         title: Generate screenshots
     - save-cache@1:
         inputs:
-        - key: l10n-screenshots-dd-{{ git rev-parse HEAD }}
+        - key: l10n-screenshots-dd-{{ `git rev-parse HEAD` }}
         - paths: l10n-screenshots-dd
     - deploy-to-bitrise-io@2:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -838,7 +838,7 @@ workflows:
         title: Generate screenshots
     - save-cache@1
         inputs:
-        - key: l10n-screenshots-dd
+        - key: l10n-screenshots-dd-{{ git rev-parse HEAD }}
           paths: l10n-screenshots-dd
     - deploy-to-bitrise-io@2:
         inputs:
@@ -860,7 +860,9 @@ workflows:
     - certificate-and-profile-installer@1: {}
     - restore-cache@2:
         inputs:
-        - key: l10n-screenshots-dd
+        - key: |-
+            l10n-screenshots-dd-{{ git rev-parse HEAD }}
+            l10n-screenshots-dd-
           paths: l10n-screenshots-dd
         title: Download derived data path
     - script@1.1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -835,11 +835,11 @@ workflows:
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
-            git log --pretty=format:'%h' -n 1
+            echo $GIT_CLONE_COMMIT_HASH
         title: Generate screenshots
     - save-cache@1:
         inputs:
-        - key: l10n-screenshots-dd-`git log --pretty=format:'%h' -n 1`
+        - key: l10n-screenshots-dd-{{ echo $GIT_CLONE_COMMIT_HASH }}
         - paths: l10n-screenshots-dd
     - deploy-to-bitrise-io@2:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -835,10 +835,11 @@ workflows:
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
+            git rev-parse HEAD
         title: Generate screenshots
     - save-cache@1:
         inputs:
-        - key: l10n-screenshots-dd-{{ `git rev-parse HEAD` }}
+        - key: l10n-screenshots-dd-{{ checksum "package-lock.json" }}
         - paths: l10n-screenshots-dd
     - deploy-to-bitrise-io@2:
         inputs:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3514)

## :bulb: Description
Bitrise team has advised us to use the steps `save-cache` and `restore-cache` for passing derived data between the jobs because they have a larger capacity than `deploy-to-bitrise`.

Here I use the steps to demonstrate how they can be used in L10n related workflows.

L10nBuild: https://app.bitrise.io/build/04dc31be-bff4-4e64-9778-6fc868f9bcae
L10nScreenshot: https://app.bitrise.io/build/9af02c87-93ae-4f9e-bcec-42703668d6ea

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

