### PR TITLE
Add MTE-3483 - open external link test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
@@ -104,6 +104,7 @@
         "NavigationTest\/testLongPressLinkOptionsPrivateMode()",
         "NavigationTest\/testLongPressOnAddressBar()",
         "NavigationTest\/testNavigation()",
+        "NavigationTest\/testOpenExternalLink()",
         "NavigationTest\/testOpenInNewPrivateTab()",
         "NavigationTest\/testOpenInNewTab()",
         "NavigationTest\/testPopUpBlocker()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
@@ -107,6 +107,7 @@
         "NavigationTest\/testLongPressLinkOptionsPrivateMode()",
         "NavigationTest\/testLongPressOnAddressBar()",
         "NavigationTest\/testNavigation()",
+        "NavigationTest\/testOpenExternalLink()",
         "NavigationTest\/testOpenInNewPrivateTab()",
         "NavigationTest\/testOpenInNewTab()",
         "NavigationTest\/testScrollsToTopWithMultipleTabs()",


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3483

## :bulb: Description
Added automation test for open external link scenario
