### PR TITLE
Add FXIOS-10071 [Native Error Page] Feature flag switch in settings debug menu

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -47,7 +47,8 @@ enum NimbusFeatureFlagID: String, CaseIterable {
         switch self {
         case .closeRemoteTabs,
                 .microsurvey,
-                .menuRefactor:
+                .menuRefactor,
+                .nativeErrorPage:
             return rawValue + PrefsKeys.FeatureFlags.DebugSuffixKey
         default:
             return nil

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -45,6 +45,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     statusText: format(string: "Toggle to use the new menu")
                 ) { [weak self] _ in
                     self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .nativeErrorPage,
+                    titleText: format(string: "Enable Native Error Page"),
+                    statusText: format(string: "Toggle to display natively created error pages")
+                ) { [weak self] _ in
+                    self?.reloadView()
                 }
             ]
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10071)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22069)

## :bulb: Description
Added switch in settings debug menu to on/off new error pages feature. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

