### PR TITLE
Add FXIOS-10055 Support trackpad right click on homepage cells

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -258,6 +258,8 @@ class HomepageViewController:
         collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         collectionView.backgroundColor = .clear
         collectionView.accessibilityIdentifier = a11y.collectionView
+        let interaction = UIContextMenuInteraction(delegate: self)
+        collectionView.addInteraction(interaction)
         contentStackView.addArrangedSubview(collectionView)
     }
 
@@ -882,6 +884,22 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
 
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
         return true
+    }
+}
+
+// MARK: - UIContextMenuInteractionDelegate
+extension HomepageViewController: UIContextMenuInteractionDelegate {
+    //Handles iPad trackpad right clicks
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
+                                configurationForMenuAtLocation location: CGPoint)
+    -> UIContextMenuConfiguration? {
+        let locationInCollectionView = interaction.location(in: collectionView)
+        guard let indexPath = collectionView.indexPathForItem(at: locationInCollectionView),
+              let viewModel = viewModel.getSectionViewModel(shownSection: indexPath.section) as? HomepageSectionHandler
+        else { return nil }
+        
+        viewModel.handleLongPress(with: collectionView, indexPath: indexPath)
+        return nil
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -258,8 +258,7 @@ class HomepageViewController:
         collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         collectionView.backgroundColor = .clear
         collectionView.accessibilityIdentifier = a11y.collectionView
-        let interaction = UIContextMenuInteraction(delegate: self)
-        collectionView.addInteraction(interaction)
+        collectionView.addInteraction(UIContextMenuInteraction(delegate: self))
         contentStackView.addArrangedSubview(collectionView)
     }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -890,9 +890,10 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
 // MARK: - UIContextMenuInteractionDelegate
 extension HomepageViewController: UIContextMenuInteractionDelegate {
     // Handles iPad trackpad right clicks
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
-                                configurationForMenuAtLocation location: CGPoint)
-    -> UIContextMenuConfiguration? {
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        configurationForMenuAtLocation location: CGPoint
+    ) -> UIContextMenuConfiguration? {
         let locationInCollectionView = interaction.location(in: collectionView)
         guard let indexPath = collectionView.indexPathForItem(at: locationInCollectionView),
               let viewModel = viewModel.getSectionViewModel(shownSection: indexPath.section) as? HomepageSectionHandler

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -889,7 +889,7 @@ extension HomepageViewController: UIPopoverPresentationControllerDelegate {
 
 // MARK: - UIContextMenuInteractionDelegate
 extension HomepageViewController: UIContextMenuInteractionDelegate {
-    //Handles iPad trackpad right clicks
+    // Handles iPad trackpad right clicks
     func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
                                 configurationForMenuAtLocation location: CGPoint)
     -> UIContextMenuConfiguration? {
@@ -897,7 +897,7 @@ extension HomepageViewController: UIContextMenuInteractionDelegate {
         guard let indexPath = collectionView.indexPathForItem(at: locationInCollectionView),
               let viewModel = viewModel.getSectionViewModel(shownSection: indexPath.section) as? HomepageSectionHandler
         else { return nil }
-        
+
         viewModel.handleLongPress(with: collectionView, indexPath: indexPath)
         return nil
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10055)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22034)

## :bulb: Description
- Add support for right clicking homepage cells via trackpad to open their context menu (similar to long press)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

