### PR TITLE
Add FXIOS-9978-[Native Error Page] Screenshot feature for tab tray

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -20,20 +20,26 @@ class ScreenshotHelper {
         self.logger = logger
     }
 
-    // TODO: FXIOS-9978 - Screenshot of native error page for tab manager
     /// Takes a screenshot of the WebView to be displayed on the tab view page
     /// If taking a screenshot of the home page, uses our custom screenshot `UIView` extension function
     /// If taking a screenshot of a website, uses apple's `takeSnapshot` function
     func takeScreenshot(_ tab: Tab) {
-        guard let webView = tab.webView, let url = tab.url else {
+        guard let webView = tab.webView else {
             logger.log("Tab Snapshot Error",
                        level: .debug,
                        category: .tabs,
                        description: "Tab webView or url is nil")
             return
         }
-        // Handle home page snapshots, can not use Apple API snapshot function for this
-        if InternalURL(url)?.isAboutHomeURL ?? false {
+        /// Handle home page snapshots, can not use Apple API snapshot function for this
+        guard let browserVC = controller else {
+            return
+        }
+
+        /// Added condition for native error page. Instead of checking url,
+        /// we check the ContentContainer.
+        if browserVC.contentContainer.hasHomepage || browserVC.contentContainer.hasPrivateHomepage
+            || browserVC.contentContainer.hasNativeErrorPage {
             if let homeview = controller?.contentContainer.contentView {
                 let screenshot = homeview.screenshot(quality: UIConstants.ActiveScreenshotQuality)
                 tab.hasHomeScreenshot = true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9978)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21912)

## :bulb: Description
Screenshot of new error page should be visible in tab tray. 
Previously we were saving the screenshot of webview in case of error page. 
Now it will save screenshot of native error page.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

