### PR TITLE
Bugfix FXIOS-10004 [Toolbar redesign] Fix address toolbar bottom borders on scroll

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -455,9 +455,6 @@ extension TabScrollingController: UIGestureRecognizerDelegate {
 }
 
 extension TabScrollingController: UIScrollViewDelegate {
-    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-    }
-
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         guard !tabIsLoading(), !isBouncingAtBottom(), isAbleToScroll, let tab else { return }
 

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -52,7 +52,6 @@ class TabScrollingController: NSObject, FeatureFlaggable, SearchBarLocationProvi
     var headerTopConstraint: Constraint?
 
     private var lastPanTranslation: CGFloat = 0
-    private var lastContentOffsetY: CGFloat = 0
     private var scrollDirection: ScrollDirection = .down
     var toolbarState: ToolbarState = .visible
 
@@ -457,7 +456,6 @@ extension TabScrollingController: UIGestureRecognizerDelegate {
 
 extension TabScrollingController: UIScrollViewDelegate {
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        lastContentOffsetY = scrollView.contentOffset.y
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
@@ -482,15 +480,22 @@ extension TabScrollingController: UIScrollViewDelegate {
             setOffset(y: 0, for: scrollView)
         }
 
-        let scrolledToTop = lastContentOffsetY > 0 && scrollView.contentOffset.y <= 0
-        let scrolledDown = lastContentOffsetY == 0 && scrollView.contentOffset.y > 0
+        let toolbarState = store.state.screenState(Client.ToolbarState.self, for: .toolbar, window: windowUUID)
 
-        if scrolledDown || scrolledToTop {
-            lastContentOffsetY = scrollView.contentOffset.y
-            let action = GeneralBrowserMiddlewareAction(scrollOffset: scrollView.contentOffset,
-                                                        windowUUID: windowUUID,
-                                                        actionType: GeneralBrowserMiddlewareActionType.websiteDidScroll)
-            store.dispatch(action)
+        guard let toolbarState,
+              let borderPosition = toolbarState.addressToolbar.borderPosition
+        else { return }
+
+        // Only dispatch the action to update the toolbar border if needed, which is only if either
+        // a) we scroll down, and the toolbar border is not already at the bottom (so we show it), or
+        // b) we scroll up past the top of the scroll view, and the border is currently at the bottom (so we hide it)
+        if (scrollView.contentOffset.y > 0 && borderPosition != .bottom)
+           || (scrollView.contentOffset.y < 0 && borderPosition != .none) {
+            store.dispatch(
+                GeneralBrowserMiddlewareAction(
+                    scrollOffset: scrollView.contentOffset,
+                    windowUUID: windowUUID,
+                    actionType: GeneralBrowserMiddlewareActionType.websiteDidScroll))
         }
 
         guard isAnimatingToolbar else { return }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -237,10 +237,6 @@ final class ToolbarMiddleware: FeatureFlaggable {
             scrollY: scrollOffset.y
         )
 
-        let needsAddressToolbarUpdate = toolbarState.addressToolbar.borderPosition != addressBorderPosition
-
-        guard needsAddressToolbarUpdate else { return }
-
         let toolbarAction = ToolbarAction(
             addressBorderPosition: addressBorderPosition,
             windowUUID: action.windowUUID,

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -394,7 +394,7 @@ class HomepageViewController:
             store.dispatch(action)
         }
     }
-    
+
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         // We only handle status bar overlay alpha if there's a wallpaper applied on the homepage
         if WallpaperManager().currentWallpaper.type != .defaultWallpaper {

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -43,7 +43,6 @@ class HomepageViewController:
     private var jumpBackInContextualHintViewController: ContextualHintViewController
     private var syncTabContextualHintViewController: ContextualHintViewController
     private var collectionView: UICollectionView! = nil
-    private var lastContentOffsetY: CGFloat = 0
     private var logger: Logger
     var windowUUID: WindowUUID { return tabManager.windowUUID }
     var currentWindowUUID: UUID? { return windowUUID }
@@ -397,7 +396,6 @@ class HomepageViewController:
     }
 
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        lastContentOffsetY = scrollView.contentOffset.y
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -409,9 +407,11 @@ class HomepageViewController:
                                                          theme: theme)
         }
 
+        let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID)
+
         // Only dispatch action when user is in edit mode to avoid having the toolbar re-displayed
         if featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly),
-           let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID),
+           let toolbarState,
            toolbarState.addressToolbar.isEditing {
             // When the user scrolls the homepage we cancel edit mode
             // On a website we just dismiss the keyboard
@@ -424,15 +424,20 @@ class HomepageViewController:
             }
         }
 
-        let scrolledToTop = lastContentOffsetY > 0 && scrollView.contentOffset.y <= 0
-        let scrolledDown = lastContentOffsetY == 0 && scrollView.contentOffset.y > 0
+        guard let toolbarState,
+              let borderPosition = toolbarState.addressToolbar.borderPosition
+        else { return }
 
-        if scrolledDown || scrolledToTop {
-            lastContentOffsetY = scrollView.contentOffset.y
-            let action = GeneralBrowserMiddlewareAction(scrollOffset: scrollView.contentOffset,
-                                                        windowUUID: windowUUID,
-                                                        actionType: GeneralBrowserMiddlewareActionType.websiteDidScroll)
-            store.dispatch(action)
+        // Only dispatch the action to update the toolbar border if needed, which is only if either
+        // a) we scroll down, and the toolbar border is not already at the bottom (so we show it), or
+        // b) we scroll up past the top of the scroll view, and the border is currently at the bottom (so we hide it)
+        if (scrollView.contentOffset.y > 0 && borderPosition != .bottom)
+           || (scrollView.contentOffset.y < 0 && borderPosition != .none) {
+            store.dispatch(
+                GeneralBrowserMiddlewareAction(
+                    scrollOffset: scrollView.contentOffset,
+                    windowUUID: windowUUID,
+                    actionType: GeneralBrowserMiddlewareActionType.websiteDidScroll))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewController.swift
@@ -394,10 +394,7 @@ class HomepageViewController:
             store.dispatch(action)
         }
     }
-
-    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-    }
-
+    
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         // We only handle status bar overlay alpha if there's a wallpaper applied on the homepage
         if WallpaperManager().currentWallpaper.type != .defaultWallpaper {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10004)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21964)

## :bulb: Description
- Always show address toolbar bottom border when scrolling down (even from a negative scroll offset)

### 📹 Video
https://github.com/user-attachments/assets/0affed69-be59-48e4-9e04-b5e999d32077


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

