### PR TITLE
Refactor FXIOS-10096 [WIP] Content blocking: cleanup, refactors + support for custom JSON lists

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -8,6 +8,9 @@ import Foundation
 /// Categories are sorted in alphabetical order.
 /// Do not add new categories unless discussing with the team beforehand.
 public enum LoggerCategory: String {
+    /// Related to content (trackers, advertisements) blocking
+    case adblock
+
     /// Related to address and credit card autofill
     case autofill
 

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker+Safelist.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker+Safelist.swift
@@ -33,7 +33,10 @@ extension ContentBlocker {
         // Note that * is added to the front of domains, so foo.com becomes *foo.com
         let list = "'*" + safelistedDomains.domainSet.joined(separator: "','*") + "'"
 
-        return ", {'action': { 'type': 'ignore-previous-rules' }, 'trigger': { 'url-filter': '.*', 'if-domain': [\(list)] }}".replacingOccurrences(of: "'", with: "\"")
+        return
+        """
+        , {"action": { "type": "ignore-previous-rules" }, "trigger": { "url-filter": ".*", "if-domain": [\(list)] }}
+        """
     }
 
     func safelist(enable: Bool, url: URL, completion: (() -> Void)?) {

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker+Safelist.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker+Safelist.swift
@@ -33,10 +33,11 @@ extension ContentBlocker {
         // Note that * is added to the front of domains, so foo.com becomes *foo.com
         let list = "'*" + safelistedDomains.domainSet.joined(separator: "','*") + "'"
 
-        return
+        let script =
         """
         , {"action": { "type": "ignore-previous-rules" }, "trigger": { "url-filter": ".*", "if-domain": [\(list)] }}
         """
+        return script
     }
 
     func safelist(enable: Bool, url: URL, completion: (() -> Void)?) {

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -48,7 +48,7 @@ enum BlocklistFileName: String, CaseIterable {
     }()
 
     var filename: String { return self.rawValue }
-    
+
     /// Blocklist files compiled for Basic tracking protection mode
     static var basic: [BlocklistFileName] {
         return [

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -249,7 +249,10 @@ extension ContentBlocker {
         DispatchQueue.global().async {
             var source = ""
             do {
-                let fileTrimmed = file.hasSuffix(".json") ? String(file.dropLast(5)) : file
+                let jsonSuffix = ".json"
+                let suffixLength = jsonSuffix.count
+                // Trim off .json suffix if needed, we only want the raw file name
+                let fileTrimmed = file.hasSuffix(jsonSuffix) ? String(file.dropLast(suffixLength)) : file
                 if let path = Bundle.main.path(forResource: fileTrimmed, ofType: "json") {
                     source = try String(contentsOfFile: path, encoding: .utf8)
                 }

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -196,7 +196,6 @@ class ContentBlocker {
     }
 
     private func add(contentRuleList: WKContentRuleList, toTab tab: ContentBlockerTab) {
-        print("DBG: adding content rule: \(contentRuleList.identifier ?? "<nil>")")
         tab.currentWebView()?.configuration.userContentController.add(contentRuleList)
     }
 

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -40,11 +40,16 @@ enum BlocklistFileName: String, CaseIterable {
 
     case advertisingCookies = "disconnect-block-cookies-advertising"
     case analyticsCookies = "disconnect-block-cookies-analytics"
-    // case contentCookies = "disconnect-block-cookies-content"
     case socialCookies = "disconnect-block-cookies-social"
 
-    var filename: String { return self.rawValue }
+    /// All blocklist files supported at runtime (both for Basic and Strict modes)
+    static let allBlocklistFileNames: [String] = {
+        return BlocklistFileName.allCases.map { $0.filename } + customBlocklistFileNames
+    }()
 
+    var filename: String { return self.rawValue }
+    
+    /// Blocklist files compiled for Basic tracking protection mode
     static var basic: [BlocklistFileName] {
         return [
             .advertisingCookies,
@@ -54,19 +59,41 @@ enum BlocklistFileName: String, CaseIterable {
             .fingerprinting
         ]
     }
+
+    /// Blocklist files compiled for Strict tracking protection mode
+    /// If any custom JSON files are included in the bundle with the
+    /// required prefix they will also be compiled and applied for Strict.
     static var strict: [BlocklistFileName] {
         return [
             .advertisingURLs,
             .analyticsURLs,
             .socialURLs,
-            cryptomining,
-            fingerprinting
+            .cryptomining,
+            .fingerprinting
         ]
     }
 
-    static func listsForMode(strict: Bool) -> [BlocklistFileName] {
-        return strict ? BlocklistFileName.strict : BlocklistFileName.basic
+    static func listsForMode(strict: Bool) -> [String] {
+        return strict ? (Self.strict.map { $0.filename } + customBlocklistFileNames) : Self.basic.map { $0.filename }
     }
+
+    static let customBlocklistJSONFilePrefix = "fxcb-"
+    static let customBlocklistFileNames: [String] = {
+        var filenames: [String] = []
+        // Search the bundle for resources that match content blocking prefix + JSON type.
+        // This allows custom block lists to be more easily tested and loaded within the
+        // iOS client. Any custom lists can be bundled as json with the `fxcb-` prefix
+        // and they will be loaded alongside our standard Disconnect files.
+        if let resourceDir = Bundle.main.resourcePath,
+           let contents = try? FileManager.default.contentsOfDirectory(atPath: resourceDir) {
+            let filePrefix = customBlocklistJSONFilePrefix
+            contents.forEach {
+                guard $0.hasPrefix(filePrefix) && $0.hasSuffix("json") else { return }
+                filenames.append($0)
+            }
+        }
+        return filenames
+    }()
 }
 
 enum BlockerStatus: String {
@@ -77,8 +104,10 @@ enum BlockerStatus: String {
 }
 
 struct NoImageModeDefaults {
-    static let Script = "[{'trigger':{'url-filter':'.*','resource-type':['image']},'action':{'type':'block'}}]"
-        .replacingOccurrences(of: "'", with: "\"")
+    static let Script =
+    """
+    [{"trigger":{"url-filter":".*","resource-type":["image"]},"action":{"type":"block"}}]
+    """
     static let ScriptName = "images"
 }
 
@@ -92,41 +121,21 @@ class ContentBlocker {
     static let shared = ContentBlocker()
 
     private init(logger: Logger = DefaultLogger.shared) {
-        let blockImages = NoImageModeDefaults.Script
         self.logger = logger
-        ruleStore?.compileContentRuleList(
-            forIdentifier: NoImageModeDefaults.ScriptName,
-            encodedContentRuleList: blockImages) { rule, error in
-                guard error == nil else {
-                    logger.log(
-                        "We errored with error: \(String(describing: error))",
-                        level: .warning,
-                        category: .webview
-                    )
-                    assert(error == nil)
-                    return
-                }
 
-                guard rule != nil else {
-                    logger.log(
-                        "We came across a nil rule set for NoImageMode at this point.",
-                        level: .warning,
-                        category: .webview
-                    )
-                    assert(rule != nil)
-                    return
-                }
-
-                self.blockImagesRule = rule
-        }
+        // Compile No Image Mode script
+        compileNoImageModeScript()
 
         // Read the safelist at startup
         if let list = readSafelistFile() {
             safelistedDomains.domainSet = Set(list)
         }
 
+        // Startup tracking stats checker
         TPStatsBlocklistChecker.shared.startup()
 
+        // General list startup: remove old content-block lists (if needed) and compile latest lists
+        logger.log("ContentBlocker startup...", level: .info, category: .adblock)
         removeOldListsByHashFromStore { [weak self] in
             self?.removeOldListsByNameFromStore {
                 self?.compileListsNotInStore {
@@ -150,7 +159,7 @@ class ContentBlocker {
     func setupTrackingProtection(
         forTab tab: ContentBlockerTab,
         isEnabled: Bool,
-        rules: [BlocklistFileName],
+        rules: [String],
         completion: (() -> Void)?
     ) {
         removeTrackingProtection(forTab: tab)
@@ -163,9 +172,8 @@ class ContentBlocker {
         let group = DispatchGroup()
 
         for list in rules {
-            let name = list.filename
             group.enter()
-            ruleStore?.lookUpContentRuleList(forIdentifier: name) { rule, error in
+            ruleStore?.lookUpContentRuleList(forIdentifier: list) { rule, error in
                 if let rule = rule {
                     self.add(contentRuleList: rule, toTab: tab)
                 }
@@ -188,7 +196,30 @@ class ContentBlocker {
     }
 
     private func add(contentRuleList: WKContentRuleList, toTab tab: ContentBlockerTab) {
+        print("DBG: adding content rule: \(contentRuleList.identifier ?? "<nil>")")
         tab.currentWebView()?.configuration.userContentController.add(contentRuleList)
+    }
+
+    private func compileNoImageModeScript() {
+        let logger = self.logger
+        let blockImages = NoImageModeDefaults.Script
+        ruleStore?.compileContentRuleList(
+            forIdentifier: NoImageModeDefaults.ScriptName,
+            encodedContentRuleList: blockImages) { rule, error in
+                if let error {
+                    logger.log("No Image script failed compilation: \(error))", level: .warning, category: .adblock)
+                    assertionFailure()
+                    return
+                }
+
+                guard rule != nil else {
+                    logger.log("Nil rule set for NoImageMode.", level: .warning, category: .adblock)
+                    assertionFailure()
+                    return
+                }
+
+                self.blockImagesRule = rule
+        }
     }
 
     func noImageMode(enabled: Bool, forTab tab: ContentBlockerTab) {
@@ -215,13 +246,17 @@ class ContentBlocker {
 // ruleStore.
 extension ContentBlocker {
     private func loadJsonFromBundle(forResource file: String, completion: @escaping (_ jsonString: String) -> Void) {
-        DispatchQueue.global().async { [weak self] in
-            guard let path = Bundle.main.path(forResource: file, ofType: "json"),
-                  let source = try? String(contentsOfFile: path, encoding: .utf8)
-            else {
-                self?.logger.log("Error unwrapping the resource contents", level: .warning, category: .webview)
-                assertionFailure("Error unwrapping the resource contents")
-                return
+        let logger = self.logger
+        DispatchQueue.global().async {
+            var source = ""
+            do {
+                let fileTrimmed = file.hasSuffix(".json") ? String(file.dropLast(5)) : file
+                if let path = Bundle.main.path(forResource: fileTrimmed, ofType: "json") {
+                    source = try String(contentsOfFile: path, encoding: .utf8)
+                }
+            } catch let error {
+                logger.log("Error loading content-blocking JSON: \(error)", level: .warning, category: .adblock)
+                assertionFailure("Error loading JSON from bundle.")
             }
 
             DispatchQueue.main.async {
@@ -232,6 +267,7 @@ extension ContentBlocker {
 
     func removeAllRulesInStore(completion: @escaping () -> Void) {
         let dispatchGroup = DispatchGroup()
+        let logger = self.logger
         ruleStore?.getAvailableContentRuleListIdentifiers { [weak self] available in
             guard let available = available else {
                 completion()
@@ -243,6 +279,7 @@ extension ContentBlocker {
                     dispatchGroup.leave()
                 }
             }
+            logger.log("Removed \(available.count) lists from rule store.", level: .info, category: .adblock)
             dispatchGroup.notify(queue: DispatchQueue.main) {
                 completion()
             }
@@ -259,17 +296,17 @@ extension ContentBlocker {
     }
 
     private func hasBlockerFileChanged() -> Bool {
-        let blocklists = BlocklistFileName.allCases
+        let blocklists = BlocklistFileName.allBlocklistFileNames
         let defaults = UserDefaults.standard
         var hasChanged = false
 
         for list in blocklists {
-            guard let path = Bundle.main.path(forResource: list.filename, ofType: "json"),
+            guard let path = Bundle.main.path(forResource: list, ofType: "json"),
                   let newHash = calculateHash(forFileAtPath: path) else { continue }
 
-            let oldHash = defaults.string(forKey: list.filename)
+            let oldHash = defaults.string(forKey: list)
             if oldHash != newHash {
-                defaults.set(newHash, forKey: list.filename)
+                defaults.set(newHash, forKey: list)
                 hasChanged = true
             }
         }
@@ -281,10 +318,12 @@ extension ContentBlocker {
     // remove all the content blockers and reload them.
     func removeOldListsByHashFromStore(completion: @escaping () -> Void) {
         if hasBlockerFileChanged() {
+            logger.log("Did remove stale content blocking cache (update required)", level: .info, category: .adblock)
             removeAllRulesInStore {
                 completion()
             }
         } else {
+            logger.log("Cached content blocking lists Ok.", level: .info, category: .adblock)
             completion()
         }
     }
@@ -292,13 +331,14 @@ extension ContentBlocker {
     func removeOldListsByNameFromStore(completion: @escaping () -> Void) {
         var noMatchingIdentifierFoundForRule = false
 
+        let logger = self.logger
         ruleStore?.getAvailableContentRuleListIdentifiers { available in
-            guard let available = available else {
+            guard let available else {
                 completion()
                 return
             }
 
-            let blocklists = BlocklistFileName.allCases.map { $0.filename }
+            let blocklists = BlocklistFileName.allBlocklistFileNames
             // If any file from the list on disk is not installed, remove all the rules and re-install them
             for listOnDisk in blocklists where !available.contains(where: { $0 == listOnDisk }) {
                 noMatchingIdentifierFoundForRule = true
@@ -306,31 +346,41 @@ extension ContentBlocker {
             }
 
             if !noMatchingIdentifierFoundForRule {
+                logger.log("All lists are installed.", level: .info, category: .adblock)
                 completion()
-                return
-            }
-
-            self.removeAllRulesInStore {
-                completion()
+            } else {
+                logger.log("Some lists not installed, will re-install all.", level: .info, category: .adblock)
+                self.removeAllRulesInStore {
+                    completion()
+                }
             }
         }
     }
 
     func compileListsNotInStore(completion: @escaping () -> Void) {
-        let blocklists = BlocklistFileName.allCases.map { $0.filename }
+        // Compile the content blocking (in WebKit's required JSON format) for use with WKWebView
+        logger.log("Compiling any lists not already in rule store...", level: .info, category: .adblock)
+        let blocklists = BlocklistFileName.allBlocklistFileNames
         let dispatchGroup = DispatchGroup()
+        let totalListCount = blocklists.count
+        var listsCompiledCount = 0
+        var errorCount = 0
         blocklists.forEach { filename in
             dispatchGroup.enter()
             ruleStore?.lookUpContentRuleList(forIdentifier: filename) { [weak self] contentRuleList, error in
+                // If the rule was found, we can exit immediately
                 if contentRuleList != nil {
                     dispatchGroup.leave()
                     return
                 }
+
+                self?.logger.log("Will compile list: \(filename)", level: .info, category: .adblock)
                 self?.loadJsonFromBundle(forResource: filename) { jsonString in
                     var str = jsonString
-                    guard let self,
-                          let range = str.range(of: "]", options: String.CompareOptions.backwards)
-                    else {
+
+                    // Here we find the closing array bracket in the JSON string
+                    // and append our safelist as a rule to the end of the JSON.
+                    guard let self, let range = str.range(of: "]", options: String.CompareOptions.backwards) else {
                         dispatchGroup.leave()
                         return
                     }
@@ -339,13 +389,18 @@ extension ContentBlocker {
                         forIdentifier: filename,
                         encodedContentRuleList: str
                     ) { rule, error in
+                        listsCompiledCount += 1
+                        errorCount += (error == nil ? 0 : 1)
                         self.compileContentRuleListCompletion(dispatchGroup: dispatchGroup, rule: rule, error: error)
                     }
                 }
             }
         }
 
-        dispatchGroup.notify(queue: .main) {
+        dispatchGroup.notify(queue: .main) { [weak self] in
+            self?.logger.log("Compiled \(listsCompiledCount) of \(totalListCount) lists checked. \(errorCount) errors.",
+                             level: .info,
+                             category: .adblock)
             completion()
         }
     }
@@ -356,22 +411,14 @@ extension ContentBlocker {
         defer {
             dispatchGroup.leave()
         }
-        guard error == nil else {
-            self.logger.log(
-                "Content blocker errored with: \(String(describing: error))",
-                level: .warning,
-                category: .webview
-            )
-            assert(error == nil)
+        if let error {
+            logger.log("Content blocker compilation failed: \(error)", level: .warning, category: .adblock)
+            assertionFailure()
             return
         }
         guard rule != nil else {
-            self.logger.log(
-                "We came across a nil rule set for BlockList.",
-                level: .warning,
-                category: .webview
-            )
-            assert(rule != nil)
+            logger.log("Nil rule set for BlockList.", level: .warning, category: .adblock)
+            assertionFailure()
             return
         }
     }

--- a/firefox-ios/Client/ContentBlocker/TabContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/TabContentBlocker.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import WebKit
+import Common
 
 extension Notification.Name {
    public static let didChangeContentBlocking = Notification.Name("didChangeContentBlocking")
@@ -17,7 +18,7 @@ protocol ContentBlockerTab: AnyObject {
 
 class TabContentBlocker {
     weak var tab: ContentBlockerTab?
-
+    let logger: Logger
     var isEnabled: Bool {
         return false
     }
@@ -25,7 +26,7 @@ class TabContentBlocker {
     @objc
     func notifiedTabSetupRequired() {}
 
-    func currentlyEnabledLists() -> [BlocklistFileName] {
+    func currentlyEnabledLists() -> [String] {
         return []
     }
 
@@ -51,8 +52,9 @@ class TabContentBlocker {
 
     var stats = TPPageStats()
 
-    init(tab: ContentBlockerTab) {
+    init(tab: ContentBlockerTab, logger: Logger = DefaultLogger.shared) {
         self.tab = tab
+        self.logger = logger
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(notifiedTabSetupRequired),

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -832,7 +832,10 @@ extension BrowserViewController: WKNavigationDelegate {
         // When tab url changes after web content starts loading on the page
         // We notify the content blocker change so that content blocker status
         // can be correctly shown on beside the URL bar
+
+        // TODO: content blocking hasn't really changed, can we improve code clarity here? [FXIOS-10091]
         tab.contentBlocker?.notifyContentBlockingChanged()
+
         self.scrollController.resetZoomState()
 
         if tabManager.selectedTab === tab {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -554,6 +554,10 @@ class BrowserViewController: UIViewController,
 
         // Update lock icon without redrawing the whole locationView
         if let tab = tabManager.selectedTab, !isToolbarRefactorEnabled {
+            // It appears this was added to fix an issue with the lock icon, so we're
+            // calling into this for some kind of beneficial side effect. We should
+            // probably explore a different solution; tab content blocking does not
+            // change every time the app is brought forward. [FXIOS-10091]
             urlBar.locationView.tabDidChangeContentBlocking(tab)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
+++ b/firefox-ios/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
@@ -104,6 +104,7 @@ class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
     func setupForTab(completion: (() -> Void)? = nil) {
         guard let tab = tab else { return }
         let rules = BlocklistFileName.listsForMode(strict: blockingStrengthPref == .strict)
+        logger.log("Setup tracking protection for tab: \(tab)", level: .info, category: .adblock)
         ContentBlocker.shared.setupTrackingProtection(
             forTab: tab,
             isEnabled: isEnabled,
@@ -113,16 +114,13 @@ class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
     }
 
     override func notifiedTabSetupRequired() {
-        setupForTab(completion: { [weak self] in
-            guard let tab = self?.tab as? Tab else { return }
-            tab.reloadPage()
-        })
-        if let tab = tab as? Tab {
-            TabEvent.post(.didChangeContentBlocking, for: tab)
-        }
+        guard let tab = self.tab as? Tab else { return }
+        logger.log("Notified tab setup required", level: .info, category: .adblock)
+        setupForTab(completion: { tab.reloadPage() })
+        TabEvent.post(.didChangeContentBlocking, for: tab)
     }
 
-    override func currentlyEnabledLists() -> [BlocklistFileName] {
+    override func currentlyEnabledLists() -> [String] {
         return BlocklistFileName.listsForMode(strict: blockingStrengthPref == .strict)
     }
 

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -46,6 +46,7 @@ class TabLocationView: UIView, FeatureFlaggable {
     var notificationCenter: NotificationProtocol = NotificationCenter.default
     private var themeManager: ThemeManager = AppContainer.shared.resolve()
     let windowUUID: WindowUUID
+    let logger: Logger
 
     /// Tracking protection button, gets updated from tabDidChangeContentBlocking
     var blockerStatus: BlockerStatus = .noBlockedURLs {
@@ -169,8 +170,9 @@ class TabLocationView: UIView, FeatureFlaggable {
         return reloadButton
     }()
 
-    init(windowUUID: WindowUUID) {
+    init(windowUUID: WindowUUID, logger: Logger = DefaultLogger.shared) {
         self.windowUUID = windowUUID
+        self.logger = logger
         super.init(frame: .zero)
         setupNotifications(
             forObserver: self,
@@ -538,6 +540,7 @@ extension TabLocationView: TabEventHandler {
     var tabEventWindowResponseType: TabEventHandlerWindowResponseType { return .singleWindow(windowUUID) }
 
     func tabDidChangeContentBlocking(_ tab: Tab) {
+        logger.log("Tab did change content blocking", level: .info, category: .adblock)
         guard let blocker = tab.contentBlocker else { return }
 
         ensureMainThread { [self] in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10096)

## :bulb: Description

Clean-up and refactors to our content blocking code. Primarily this is for improvements to readability and performance but it also adds support for custom-loading content lists; right now this feature is entirely for developer convenience and has no effect for end users, but it will allow us to test custom content blocker lists more easily in the app moving forward.

Please note: all of this code is (to some extent) an ongoing WIP as we are currently exploring improvements to our ad-blocking. Additional changes will likely be forthcoming.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

