### PR TITLE
Bugfix FXIOS-10113 #22141 Fix memory leak from AddressListViewModel

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
@@ -142,4 +142,9 @@ class AddressAutofillSettingsViewController: SensitiveViewController, Themeable 
     func addAddress() {
         self.viewModel.addressListViewModel.addAddressButtonTap()
     }
+
+    deinit {
+        addressAutofillSettingsPageView.removeFromParent()
+        addressAutofillSettingsPageView.view.removeFromSuperview()
+    }
 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -163,13 +163,13 @@ final class AddressListViewModel: ObservableObject, FeatureFlaggable {
     }
 
     private func updateLocal(id: String, updatedAddress: UpdatableAddressFields) {
-        self.addressProvider.updateAddress(id: id, address: updatedAddress) { result in
+        self.addressProvider.updateAddress(id: id, address: updatedAddress) { [weak self] result in
             DispatchQueue.main.async {
                 switch result {
                 case .success:
-                    self.presentToast?(.updated)
+                    self?.presentToast?(.updated)
                 case .failure:
-                    self.presentToast?(
+                    self?.presentToast?(
                         .error(
                             .update(action: { [weak self] in
                                 self?.destination = .edit(
@@ -195,8 +195,8 @@ final class AddressListViewModel: ObservableObject, FeatureFlaggable {
                         )
                     )
                 }
-                self.destination = nil
-                self.fetchAddresses()
+                self?.destination = nil
+                self?.fetchAddresses()
             }
         }
     }
@@ -217,13 +217,13 @@ final class AddressListViewModel: ObservableObject, FeatureFlaggable {
     }
 
     private func saveLocal(address: UpdatableAddressFields) {
-        self.addressProvider.addAddress(address: address) { result in
+        self.addressProvider.addAddress(address: address) { [weak self] result in
             DispatchQueue.main.async {
                 switch result {
                 case .success:
-                    self.presentToast?(.saved)
+                    self?.presentToast?(.saved)
                 case .failure:
-                    self.presentToast?(
+                    self?.presentToast?(
                         .error(
                             .save(action: { [weak self] in
                                 self?.destination = .add(
@@ -249,8 +249,8 @@ final class AddressListViewModel: ObservableObject, FeatureFlaggable {
                         )
                     )
                 }
-                self.destination = nil
-                self.fetchAddresses()
+                self?.destination = nil
+                self?.fetchAddresses()
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -158,9 +158,9 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
 
     private func evaluateJavaScript(_ jsCode: String) {
         guard let webView else { return }
-        webView.evaluateJavaScript(jsCode) { result, error in
+        webView.evaluateJavaScript(jsCode) { [weak self] result, error in
             if let error = error {
-                self.logger.log(
+                self?.logger.log(
                     "JavaScript execution error",
                     level: .warning,
                     category: .autofill,
@@ -194,8 +194,8 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
         alertController.addAction(UIAlertAction(
             title: String.Addresses.Settings.Edit.RemoveButtonTitle,
             style: .destructive,
-            handler: { _ in
-                self.model.removeConfimationButtonTap()
+            handler: { [weak self] _ in
+                self?.model.removeConfimationButtonTap()
             }
         ))
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10113)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22141)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
AddressListViewModel is retained in the memory when going between Address Settings Screen and back

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

