### PR TITLE
Bugfix MTE-3529 DownloadsTests and iOS 16

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
@@ -121,10 +121,12 @@ class DownloadsTests: BaseTestCase {
         shareButton.tap(force: true)
         mozWaitForElementToExist(app.tables["DownloadsTable"])
         mozWaitForElementToExist(app.tables["DownloadsTable"].staticTexts[testFileNameDownloadPanel])
-        if #available(iOS 16, *) {
+        if #available(iOS 17, *) {
             mozWaitForElementToExist(app.collectionViews.cells["Copy"])
             mozWaitForElementToExist(app.collectionViews.cells["Add Tags"])
             mozWaitForElementToExist(app.collectionViews.cells["Save to Files"])
+        } else if #available(iOS 16, *) {
+            mozWaitForElementToExist(app.collectionViews.cells["Copy"])
         } else {
             mozWaitForElementToExist(app.collectionViews.buttons["Copy"])
         }
@@ -148,10 +150,12 @@ class DownloadsTests: BaseTestCase {
         app.tables.cells.staticTexts[testFileNameDownloadPanel].press(forDuration: 2)
         mozWaitForElementToExist(app.otherElements["ActivityListView"])
         mozWaitForElementToExist(app.tables["DownloadsTable"].staticTexts[testFileNameDownloadPanel])
-        if #available(iOS 16, *) {
+        if #available(iOS 17, *) {
             mozWaitForElementToExist(app.collectionViews.cells["Copy"])
             mozWaitForElementToExist(app.collectionViews.cells["Add Tags"])
             mozWaitForElementToExist(app.collectionViews.cells["Save to Files"])
+        } else if #available(iOS 16, *) {
+            mozWaitForElementToExist(app.collectionViews.cells["Copy"])
         } else {
             mozWaitForElementToExist(app.collectionViews.buttons["Copy"])
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3529)

## :bulb: Description
Some DownloadsTests fails on iOS 16 only because "Add Tags" and "Save to Files" don't have a label like iOS 17+ do.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

