### PR TITLE
Add FXIOS-10274 Remote Tab Management: Send close tab command

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
@@ -6,20 +6,28 @@ import Common
 import Redux
 import Storage
 
+import struct MozillaAppServices.Device
+
 /// Defines actions sent to Redux for Sync tab in tab tray
 class RemoteTabsPanelAction: Action {
     let clientAndTabs: [ClientAndTabs]?
     let reason: RemoteTabsPanelEmptyStateReason?
     let url: URL?
+    let targetDeviceId: String?
+    let devices: [Device]?
 
     init(clientAndTabs: [ClientAndTabs]? = nil,
          reason: RemoteTabsPanelEmptyStateReason? = nil,
          url: URL? = nil,
+         targetDeviceId: String? = nil,
+         devices: [Device]? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
         self.clientAndTabs = clientAndTabs
         self.reason = reason
         self.url = url
+        self.targetDeviceId = targetDeviceId
+        self.devices = devices
         super.init(windowUUID: windowUUID,
                    actionType: actionType)
     }
@@ -28,8 +36,14 @@ class RemoteTabsPanelAction: Action {
 enum RemoteTabsPanelActionType: ActionType {
     case panelDidAppear
     case refreshTabs
+    case refreshTabsWithCache
     case refreshDidBegin
     case refreshDidFail
     case refreshDidSucceed
+    case closeTabCompatible
     case openSelectedURL
+    case closeSelectedRemoteURL
+    case undoCloseSelectedRemoteURL
+    case flushTabCommands
+    case remoteDevicesChanged
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -67,7 +67,15 @@ class TabManagerMiddleware {
         case RemoteTabsPanelActionType.openSelectedURL:
             guard let url = action.url else { return }
             openSelectedURL(url: url, showOverlay: false, windowUUID: action.windowUUID)
-
+        case RemoteTabsPanelActionType.closeSelectedRemoteURL:
+            guard let url = action.url, let deviceId = action.targetDeviceId else { return }
+            closeSelectedRemoteTab(deviceId: deviceId, url: url, windowUUID: action.windowUUID)
+        case RemoteTabsPanelActionType.undoCloseSelectedRemoteURL:
+            guard let url = action.url, let deviceId = action.targetDeviceId else { return }
+            undoCloseSelectedRemoteTab(deviceId: deviceId, url: url, windowUUID: action.windowUUID)
+        case RemoteTabsPanelActionType.flushTabCommands:
+            guard let deviceId = action.targetDeviceId else { return }
+            flushTabCommands(deviceId: deviceId, windowUUID: action.windowUUID)
         default:
             break
         }
@@ -185,6 +193,18 @@ class TabManagerMiddleware {
                                      object: .syncTab)
         let urlRequest = URLRequest(url: url)
         self.addNewTab(with: urlRequest, isPrivate: false, showOverlay: showOverlay, for: windowUUID)
+    }
+
+    private func closeSelectedRemoteTab(deviceId: String, url: URL, windowUUID: WindowUUID) {
+        self.profile.addTabToCommandQueue(deviceId, url: url)
+    }
+
+    private func undoCloseSelectedRemoteTab(deviceId: String, url: URL, windowUUID: WindowUUID) {
+        self.profile.removeTabFromCommandQueue(deviceId, url: url)
+    }
+
+    private func flushTabCommands(deviceId: String, windowUUID: WindowUUID) {
+        self.profile.flushTabCommands(toDeviceId: deviceId)
     }
 
     /// Gets initial state for TabTrayModel includes panelType, if is on Private mode,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -13,7 +13,8 @@ import enum MozillaAppServices.VisitType
 class RemoteTabsTableViewController: UITableViewController,
                                      Themeable,
                                      CollapsibleTableViewSection,
-                                     LibraryPanelContextMenu {
+                                     LibraryPanelContextMenu,
+                                     FeatureFlaggable {
     struct UX {
         static let rowHeight = SiteTableViewControllerUX.RowHeight
     }
@@ -22,6 +23,7 @@ class RemoteTabsTableViewController: UITableViewController,
 
     private(set) var state: RemoteTabsPanelState
     private var hiddenSections = Set<Int>()
+    private let logger: Logger
 
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
@@ -33,20 +35,34 @@ class RemoteTabsTableViewController: UITableViewController,
     private var isShowingEmptyView: Bool { state.showingEmptyState != nil }
     private let emptyView: RemoteTabsEmptyView = .build()
 
+    private var closeTabRemoteDeviceId: String?
+    private var closeTab: RemoteTab?
+    private var tabCommandsFlushTimer: Timer?
+    private let tabCommandsFlushDelay = 6.0
+
     private lazy var longPressRecognizer: UILongPressGestureRecognizer = {
         return UILongPressGestureRecognizer(target: self, action: #selector(longPress))
     }()
+
+    // Checks whether we have allowed the user to close tabs on other
+    // devices
+    private var closeRemoteTabsEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.closeRemoteTabs, checking: .buildOnly)
+    }
 
     // MARK: - Initializer
 
     init(state: RemoteTabsPanelState,
          windowUUID: WindowUUID,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
-         notificationCenter: NotificationProtocol = NotificationCenter.default) {
+         notificationCenter: NotificationProtocol = NotificationCenter.default,
+         logger: Logger = DefaultLogger.shared
+    ) {
         self.state = state
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
+        self.logger = logger
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -275,8 +291,70 @@ class RemoteTabsTableViewController: UITableViewController,
                             didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
         let tab = state.clientAndTabs[indexPath.section].tabs[indexPath.item]
+
         // Remote panel delegate for cell selection
         remoteTabsPanel?.remoteTabsClientAndTabsDataSourceDidSelectURL(tab.URL, visitType: VisitType.typed)
+    }
+
+    override func tableView(_ tableView: UITableView,
+                            commit editingStyle: UITableViewCell.EditingStyle,
+                            forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            let clientAndTabs = state.clientAndTabs[indexPath.section]
+            guard let fxaDeviceId = clientAndTabs.client.fxaDeviceId else {
+                // This is a state we probably shouldn't be able to get into
+                // so logging the error
+                logger.log("Error retrieving remote device ID to close tab",
+                           level: .fatal,
+                           category: .tabs)
+                return
+            }
+            let tab = clientAndTabs.tabs[indexPath.item]
+
+            // Setting the two private variables below so that the toast button action function has access to them
+            // since that function cannot have any parameters.
+            self.closeTabRemoteDeviceId = fxaDeviceId
+            self.closeTab = tab
+
+            // Creating a modal with an undo button that will allow the user to undo closing the last remote tab
+            // they attempted to close
+            ActionToast(
+                text: .TabsTray.CloseTabsToast.SingleTabTitle,
+                bottomContainer: view,
+                theme: themeManager.getCurrentTheme(for: windowUUID),
+                buttonTitle: .UndoString,
+                buttonAction: self.undo
+            ).show()
+
+            self.remoteTabsPanel?.remoteTabsClientAndTabsDataSourceDidCloseURL(deviceId: fxaDeviceId, url: tab.URL)
+
+            // Initiating the process of sending (i.e. executing) any unsent commands
+            self.flushTabCommands(deviceId: fxaDeviceId)
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        let clientAndTabs = state.clientAndTabs[indexPath.section]
+        guard let deviceId = clientAndTabs.client.fxaDeviceId else {
+            // should not get into this situation, we should probs throw an error
+            // re above, can't throw from here so logging
+            logger.log("Error retrieving remote device ID to close tab",
+                       level: .fatal,
+                       category: .tabs)
+            return false
+        }
+
+        // Checking whether the device has the capability to send a close remote tab command
+        let isCloseRemoteTabCompatible = self.state.devices.first(where: { $0.id == deviceId })?
+                                                            .capabilities.contains(.closeTabs) ?? false
+
+        // Enabling close tab UI if the capability on this device exists and the feature is enabled
+        return isCloseRemoteTabCompatible && closeRemoteTabsEnabled
+    }
+
+    override func tableView(_ tableView: UITableView,
+                            titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {
+         return .ContextualHints.ContextualHintsCloseAccessibility
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -315,5 +393,32 @@ class RemoteTabsTableViewController: UITableViewController,
         * This will be the real time that the other client uploaded tabs.
         */
         return headerView
+    }
+
+    private func undo() {
+        guard let tabUrl = self.closeTab?.URL, let deviceId = self.closeTabRemoteDeviceId else {
+            return
+        }
+
+        // Removing the close tab command from the command queue
+        remoteTabsPanel?.remoteTabsClientAndTabsDataSourceDidUndo(deviceId: deviceId, url: tabUrl)
+
+        // Initiating the process of sending any unsent commands
+        self.flushTabCommands(deviceId: deviceId)
+    }
+
+    private func flushTabCommands(deviceId: String) {
+        // If the timer property is set and is valid, we reset it. This will prevent flush
+        // from being executed too often. It will run `self.tabCommandsFlushDelay` seconds
+        // after the last interaction with the close tab UI.
+        if self.tabCommandsFlushTimer != nil && self.tabCommandsFlushTimer?.isValid ?? false {
+            self.tabCommandsFlushTimer?.invalidate()
+            self.tabCommandsFlushTimer = nil
+        }
+
+        self.tabCommandsFlushTimer = Timer.scheduledTimer(withTimeInterval: self.tabCommandsFlushDelay,
+                                                          repeats: false) { _ in
+            self.remoteTabsPanel?.remoteTabsClientAndTabsDataSourceDidTabCommandsFlush(deviceId: deviceId)
+        }
     }
 }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -517,6 +517,14 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
         }
     }
 
+    @MainActor
+    func closeTab(by url: URL) async {
+        // Find the tab with the specified URL
+        if let tabToClose = tabs.first(where: { $0.url == url }) {
+            await self.removeTab(tabToClose.tabUUID)
+        }
+    }
+
     // MARK: - Update Menu Items
     private func updateMenuItemsForSelectedTab() {
         guard let selectedTab,

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -25,6 +25,7 @@ import struct MozillaAppServices.HistoryMigrationResult
 import struct MozillaAppServices.SyncParams
 import struct MozillaAppServices.SyncResult
 import struct MozillaAppServices.VisitObservation
+import struct MozillaAppServices.PendingCommand
 
 public protocol SyncManager {
     var isSyncing: Bool { get }
@@ -138,6 +139,10 @@ protocol Profile: AnyObject {
 
     @discardableResult
     func storeTabs(_ tabs: [RemoteTab]) -> Deferred<Maybe<Int>>
+
+    func addTabToCommandQueue(_ deviceId: String, url: URL)
+    func removeTabFromCommandQueue(_ deviceId: String, url: URL)
+    func flushTabCommands(toDeviceId: String?)
 
     func sendItem(_ item: ShareItem, toDevices devices: [RemoteDevice]) -> Success
     func pollCommands(forcePoll: Bool)
@@ -560,6 +565,14 @@ open class BrowserProfile: Profile {
         return self.tabs.setLocalTabs(localTabs: tabs)
     }
 
+    func addTabToCommandQueue(_ deviceId: String, url: URL) {
+        tabs.addRemoteCommand(deviceId: deviceId, url: url)
+    }
+
+    func removeTabFromCommandQueue(_ deviceId: String, url: URL) {
+        tabs.removeRemoteCommand(deviceId: deviceId, url: url)
+    }
+
     public func sendItem(_ item: ShareItem, toDevices devices: [RemoteDevice]) -> Success {
         let deferred = Success()
         if let accountManager = RustFirefoxAccounts.shared.accountManager {
@@ -579,6 +592,21 @@ open class BrowserProfile: Profile {
             deferred.fill(Maybe(success: ()))
         }
         return deferred
+    }
+
+    public func flushTabCommands(toDeviceId: String?) {
+        guard let deviceId = toDeviceId,
+            let constellation = RustFirefoxAccounts.shared.accountManager?.deviceConstellation() else {
+            return
+        }
+
+        // send all unsent close tab commands
+        self.tabs.getUnsentCommandUrlsByDeviceId(deviceId: deviceId) { urls in
+            constellation.sendEventToDevice(targetDeviceId: deviceId, e: .closeTabs(urls: urls))
+        }
+
+        // mark tab commands as sent
+        self.tabs.setPendingCommandsSent(deviceId: deviceId)
     }
 
     public func setCommandArrived() {

--- a/firefox-ios/Storage/Rust/RustRemoteTabs.swift
+++ b/firefox-ios/Storage/Rust/RustRemoteTabs.swift
@@ -7,14 +7,19 @@ import Shared
 import Common
 
 import class MozillaAppServices.TabsStore
+import class MozillaAppServices.RemoteCommandStore
 import enum MozillaAppServices.TabsApiError
+import enum MozillaAppServices.RemoteCommand
 import struct MozillaAppServices.ClientRemoteTabs
 import struct MozillaAppServices.RemoteTabRecord
+import struct MozillaAppServices.PendingCommand
 
 public class RustRemoteTabs {
     let databasePath: String
     let queue: DispatchQueue
     var store: TabsStore?
+    internal var commandQueue: RemoteTabsCommandQueue?
+
     private(set) var isOpen = false
     private var didAttemptToMoveToBackup = false
     private let logger: Logger
@@ -30,6 +35,8 @@ public class RustRemoteTabs {
     private func open() -> NSError? {
         store = TabsStore(path: databasePath)
         isOpen = true
+        commandQueue = RemoteTabsCommandQueue()
+        commandQueue?.openCommandStore(tabsStore: store!)
         return nil
     }
 
@@ -164,6 +171,207 @@ public class RustRemoteTabs {
         queue.async { [unowned self] in
            self.store?.registerWithSyncManager()
         }
+    }
+
+    // MARK: Remote Command APIs
+    public func addRemoteCommand(deviceId: String, url: URL) {
+        DispatchQueue.global().async { [unowned self] in
+            guard let commandQueue = self.commandQueue else {
+                let err = TabsApiError.UnexpectedTabsError(reason: "Command queue is not initialized") as MaybeErrorType
+                self.logger.log(err.description,
+                                level: .warning,
+                                category: .tabs)
+                return
+            }
+            commandQueue
+                .addRemoteCommand(deviceId: deviceId, command: RemoteCommand.closeTab(url: url.absoluteString)) { result in
+                    self.handleCommandQueueErrors(result: result)
+                }
+        }
+    }
+
+    public func removeRemoteCommand(deviceId: String, url: URL) {
+        DispatchQueue.global().async { [unowned self] in
+            guard let commandQueue = self.commandQueue else {
+                let err = TabsApiError.UnexpectedTabsError(reason: "Command queue is not initialized") as MaybeErrorType
+                self.logger.log(err.description,
+                                level: .warning,
+                                category: .tabs)
+                return
+            }
+            commandQueue
+                .removeRemoteCommand(deviceId: deviceId,
+                                     command: RemoteCommand.closeTab(url: url.absoluteString)) { result in
+                    self.handleCommandQueueErrors(result: result)
+                }
+        }
+    }
+
+    public func getUnsentCommandUrlsByDeviceId(deviceId: String, completion: @escaping ([String]) -> Void) {
+        DispatchQueue.global().async { [unowned self] in
+            self.getUnsentCommandsByDeviceId(deviceId: deviceId) { commands in
+                let urls = commands.map { item in
+                    switch item.command {
+                    case .closeTab(let url):
+                        return url
+                    }
+                }
+                completion(urls)
+            }
+        }
+    }
+
+    public func setPendingCommandsSent(deviceId: String) {
+        DispatchQueue.global().async { [unowned self] in
+            guard let commandQueue = self.commandQueue else {
+                let err = TabsApiError.UnexpectedTabsError(reason: "Command queue is not initialized") as MaybeErrorType
+                self.logger.log(err.description,
+                                level: .warning,
+                                category: .tabs)
+                return
+            }
+
+            self.getUnsentCommandsByDeviceId(deviceId: deviceId) { commands in
+                commandQueue.setPendingCommandsSent(deviceId: deviceId, commands: commands) { errors in
+                    if errors.isEmpty {
+                        return
+                    } else {
+                        let errHeader = "Failed to set some pending commands as sent:\n"
+                        let errMessages: String = errors.reduce(errHeader, { result, err in
+                            result.appending("  - \(err.localizedDescription)\n")
+                        })
+                        self.logger.log(errMessages,
+                                        level: .warning,
+                                        category: .tabs)
+                    }
+                }
+            }
+        }
+    }
+
+    private func getUnsentCommandsByDeviceId(deviceId: String, completion: @escaping ([PendingCommand]) -> Void) {
+        guard let commandQueue = self.commandQueue else {
+            let err = TabsApiError.UnexpectedTabsError(reason: "Command queue is not initialized") as MaybeErrorType
+            self.logger.log(err.description,
+                            level: .warning,
+                            category: .tabs)
+            completion([PendingCommand]())
+            return
+        }
+
+        commandQueue.getUnsentCommands { result in
+            switch result {
+            case .success(let commands):
+                let filteredCommands = commands.filter { $0.deviceId == deviceId }
+                completion(filteredCommands)
+            case .failure(let error):
+                self.logger.log("Failed to get unsent commands: \(String(describing: error))",
+                                level: .warning,
+                                category: .tabs)
+                completion([PendingCommand]())
+            }
+        }
+    }
+
+    private func handleCommandQueueErrors(result: Result<Bool, any Error>) {
+        switch result {
+        case .success(let didSucceed):
+            if !didSucceed {
+                self.logger.log("Unexpected error while attempting to update command queue",
+                                level: .warning,
+                                category: .tabs)
+            }
+        case .failure(let error):
+            self.logger.log("Failed to update command queue: \(String(describing: error))",
+                            level: .warning,
+                            category: .tabs)
+        }
+    }
+}
+
+internal class RemoteTabsCommandQueue {
+    var commandStore: RemoteCommandStore?
+
+    init() {}
+
+    func openCommandStore(tabsStore: TabsStore) {
+        self.commandStore = tabsStore.newRemoteCommandStore()
+    }
+
+    func addRemoteCommand(deviceId: String,
+                          command: RemoteCommand,
+                          completion: @escaping (Result<Bool, Error>) -> Void) {
+        guard let commandStore = self.commandStore else {
+            completion(.failure(TabsApiError.UnexpectedTabsError(reason: "Command store is not initialized")))
+            return
+        }
+
+        do {
+            let didSucceed = try commandStore.addRemoteCommand(deviceId: deviceId, command: command)
+            completion(.success(didSucceed))
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    func removeRemoteCommand(deviceId: String,
+                             command: RemoteCommand,
+                             completion: @escaping (Result<Bool, Error>) -> Void) {
+        guard let commandStore = self.commandStore else {
+            completion(.failure(TabsApiError.UnexpectedTabsError(reason: "Command store is not initialized")))
+            return
+        }
+
+        do {
+            let didSucceed = try commandStore.removeRemoteCommand(deviceId: deviceId, command: command)
+            completion(.success(didSucceed))
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    func getUnsentCommands(completion: @escaping (Result<[PendingCommand], Error>) -> Void) {
+        guard let commandStore = self.commandStore else {
+            completion(.failure(TabsApiError.UnexpectedTabsError(reason: "Command store is not initialized")))
+            return
+        }
+
+        do {
+            let commands = try commandStore.getUnsentCommands()
+            completion(.success(commands))
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    func setPendingCommandsSent(deviceId: String,
+                                commands: [PendingCommand],
+                                completion: @escaping ([Error]) -> Void) {
+        guard let commandStore = self.commandStore else {
+            completion([TabsApiError.UnexpectedTabsError(reason: "Command store is not initialized")])
+            return
+        }
+
+        var errors = [Error]()
+        commands.forEach {
+            do {
+                let pendingCommand = PendingCommand(deviceId: deviceId,
+                                                    command: $0.command,
+                                                    timeRequested: Date().toMillisecondsSince1970(),
+                                                    timeSent: nil)
+                let didSetSent = try commandStore.setPendingCommandSent(command: pendingCommand)
+                if !didSetSent {
+                    switch $0.command {
+                    case .closeTab(let url):
+                        let errMsg = "Unknown error setting close tab command for URL \(url) on device \(deviceId) to sent"
+                        errors.append(TabsApiError.UnexpectedTabsError(reason: errMsg))
+                    }
+                }
+            } catch {
+                errors.append(error)
+            }
+        }
+        completion(errors)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
@@ -288,6 +288,18 @@ open class MockProfile: Client.Profile {
         return deferMaybe(0)
     }
 
+    public func addTabToCommandQueue(_ deviceId: String, url: URL) {
+        return
+    }
+
+    public func removeTabFromCommandQueue(_ deviceId: String, url: URL) {
+        return
+    }
+
+    public func flushTabCommands(toDeviceId: String?) {
+        return
+    }
+
     public func sendItem(_ item: ShareItem, toDevices devices: [RemoteDevice]) -> Success {
         return succeed()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelStateTests.swift
@@ -8,6 +8,8 @@ import Storage
 import Shared
 import XCTest
 
+import struct MozillaAppServices.Device
+
 @testable import Client
 
 final class RemoteTabPanelStateTests: XCTestCase {
@@ -42,16 +44,28 @@ final class RemoteTabPanelStateTests: XCTestCase {
         let initialState = createSubject()
         let reducer = remoteTabsPanelReducer()
         let testTabs = generateOneClientTwoTabs()
+        let deviceId = "AAAAAA"
+        let device = Device(id: deviceId,
+                            displayName: "test device",
+                            deviceType: .mobile,
+                            capabilities: [.closeTabs, .sendTab],
+                            pushSubscription: nil,
+                            pushEndpointExpired: false,
+                            isCurrentDevice: true,
+                            lastAccessTime: nil)
 
         XCTAssertEqual(initialState.clientAndTabs.count, 0)
 
         let action = RemoteTabsPanelAction(clientAndTabs: testTabs,
+                                           devices: [device],
                                            windowUUID: WindowUUID.XCTestDefaultUUID,
                                            actionType: RemoteTabsPanelActionType.refreshDidSucceed)
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.clientAndTabs.count, 1)
         XCTAssertEqual(newState.clientAndTabs.first!.tabs.count, 2)
+        XCTAssertEqual(newState.devices.count, 1)
+        XCTAssertEqual(newState.devices[0].id, deviceId)
     }
 
     func testTabsRefreshFailedStateChange() {
@@ -65,6 +79,29 @@ final class RemoteTabPanelStateTests: XCTestCase {
 
         XCTAssertEqual(newState.refreshState, RemoteTabsPanelRefreshState.idle)
         XCTAssertNotNil(newState.showingEmptyState)
+    }
+
+    func testRemoteDevicesChanged() {
+        let initialState = createSubject()
+        let reducer = remoteTabsPanelReducer()
+        let deviceId = "AAAAAA"
+        let device = Device(id: deviceId,
+                            displayName: "test device",
+                            deviceType: .mobile,
+                            capabilities: [.closeTabs, .sendTab],
+                            pushSubscription: nil,
+                            pushEndpointExpired: false,
+                            isCurrentDevice: true,
+                            lastAccessTime: nil)
+
+        let action = RemoteTabsPanelAction(clientAndTabs: nil,
+                                           devices: [device],
+                                           windowUUID: WindowUUID.XCTestDefaultUUID,
+                                           actionType: RemoteTabsPanelActionType.remoteDevicesChanged)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.devices.count, 1)
+        XCTAssertEqual(newState.devices[0].id, deviceId)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelTests.swift
@@ -72,7 +72,8 @@ final class RemoteTabPanelTests: XCTestCase {
                                     refreshState: .idle,
                                     allowsRefresh: true,
                                     clientAndTabs: fakeData,
-                                    showingEmptyState: nil)
+                                    showingEmptyState: nil,
+                                    devices: [])
     }
 
     private func createSubject(state: RemoteTabsPanelState,

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustRemoteTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustRemoteTabsTests.swift
@@ -137,4 +137,166 @@ class RustRemoteTabsTests: XCTestCase {
         }
         XCTAssertTrue(filteredResult.isEmpty)
     }
+
+    func testAddRemoteCommand() {
+        mockTabs.commandQueue?.getUnsentCommands { getResult in
+            switch getResult {
+            case .success(let commands):
+                // checking that the command queue is empty
+                XCTAssert(commands.isEmpty)
+
+                // adding the record to the command queue
+                let deviceId = "AAAAAA"
+                let url = "https://test.com"
+                self.mockTabs.commandQueue?.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url)) { addResult in
+                    switch addResult {
+                    case .success(let didAddCommand):
+                        XCTAssert(didAddCommand)
+
+                        // checking that the command queue has the added record
+                        self.mockTabs.commandQueue?.getUnsentCommands { getResult2 in
+                            switch getResult2 {
+                            case .success(let commands2):
+                                XCTAssertEqual(commands2.count, 1)
+                                XCTAssertEqual(commands2[0].deviceId, deviceId)
+                            case .failure(let error):
+                                XCTFail("Expected to get unsent commands successfully after add \(error)")
+                            }
+                        }
+                    case .failure(let error):
+                        XCTFail("Expected to add a command successfully \(error)")
+                    }
+                }
+            case .failure(let error):
+                XCTFail("Expected to get unsent commands successfully \(error)")
+            }
+        }
+    }
+
+    func testRemoveRemoteCommand() {
+        // adding the record to the command queue
+        let deviceId = "BBBBBB"
+        let url = "https://test.com"
+
+        self.mockTabs.commandQueue?.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url)) { addResult in
+            switch addResult {
+            case .success(let didAddCommand):
+                XCTAssertTrue(didAddCommand)
+
+                // checking that the command queue has the added record
+                self.mockTabs.commandQueue?.getUnsentCommands { getResult in
+                    switch getResult {
+                    case .success(let commands):
+                        XCTAssertEqual(commands.count, 1)
+                        XCTAssertEqual(commands[0].deviceId, deviceId)
+
+                        // removing the record from the command queue
+                        self.mockTabs.commandQueue?.removeRemoteCommand(deviceId: deviceId,
+                                                                        command: .closeTab(url: url)) { removeResult in
+                            switch removeResult {
+                            case .success(let didRemove):
+                                XCTAssert(didRemove)
+
+                                // checking that record is removed from command queue
+                                self.mockTabs.commandQueue?.getUnsentCommands { getResult2 in
+                                    switch getResult2 {
+                                    case .success(let commands2):
+                                        XCTAssert(commands2.isEmpty)
+                                    case .failure(let error):
+                                        XCTFail("Expected to get unsent commands after remove successfully \(error)")
+                                    }
+                                }
+                            case .failure(let error):
+                                XCTFail("Expected to remove command successfully \(error)")
+                            }
+                        }
+                    case .failure(let error):
+                        XCTFail("Expected to get unsent commands successfully \(error)")
+                    }
+                }
+            case .failure(let error):
+                XCTFail("Expected to add a command successfully \(error)")
+            }
+        }
+    }
+
+    func testSetPendingCommandsSent() {
+        // adding the record to the command queue
+        let deviceId = "CCCCC"
+        let url = "https://test.com"
+
+        mockTabs.commandQueue?.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url)) { addResult in
+            switch addResult {
+            case .success(let didAddCommand):
+                XCTAssertTrue(didAddCommand)
+
+                // retrieving unsent commands
+                self.mockTabs.commandQueue?.getUnsentCommands { getResult in
+                    switch getResult {
+                    case .success(let commands):
+                        XCTAssertEqual(commands.count, 1)
+                        XCTAssertEqual(commands[0].deviceId, deviceId)
+
+                        // setting command as sent
+                        let command = PendingCommand(deviceId: deviceId,
+                                                     command: .closeTab(url: url),
+                                                     timeRequested: Date().toMillisecondsSince1970(),
+                                                     timeSent: nil)
+                        self.mockTabs.commandQueue?.setPendingCommandsSent(deviceId: deviceId,
+                                                                           commands: [command]) { errors in
+                            XCTAssert(errors.isEmpty)
+
+                            // retrieving unsent commands
+                            self.mockTabs.commandQueue?.getUnsentCommands { getResult2 in
+                                switch getResult2 {
+                                case .success(let commands):
+                                    XCTAssert(commands.isEmpty)
+                                case .failure(let error):
+                                    XCTFail("Expected to retrieve unsent commands successfully \(error)")
+                                }
+                            }
+                        }
+                    case .failure(let error):
+                        XCTFail("Expected to retrieve added unsent command successfully \(error)")
+                    }
+                }
+            case .failure(let error):
+                XCTFail("Expected to add a command successfully \(error)")
+            }
+        }
+    }
+
+    func testGetUnsentCommandUrlsByDeviceId() {
+        // adding the record to the command queue
+        let deviceId = "DDDD"
+        let url = "https://test.com"
+        let url2 = "https://test2.com"
+
+        mockTabs.commandQueue?.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url)) { addResult in
+            switch addResult {
+            case .success(let didAddCommand):
+                XCTAssert(didAddCommand)
+
+                // adding another record to the command queue
+                self.mockTabs.commandQueue?.addRemoteCommand(deviceId: deviceId,
+                                                             command: .closeTab(url: url2)) { addResult2 in
+                    switch addResult2 {
+                    case .success(let didAddCommit2):
+                        XCTAssert(didAddCommit2)
+
+                        // getting unsent command urls
+                        self.mockTabs.getUnsentCommandUrlsByDeviceId(deviceId: deviceId) { urls in
+                            XCTAssertEqual(urls.count, 2)
+                            XCTAssert(urls.contains(url))
+                            XCTAssert(urls.contains(url2))
+                        }
+                    case .failure(let error):
+                        XCTFail("Expected to add second command successfully \(error)")
+                    }
+                }
+            case .failure(let error):
+                XCTFail("Expected to add a command succesfully \(error)")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 📝 Re: the size of this pull request . . .
To mitigate reviewing a PR this large, I have organized my changes in multiple commits which I have summarized in the Description section below. While converting these commits into separate PRs may make reviewing even easier (although I'm not fully convinced of that but . . .), it will make managing requested changes amongst these hierarchically dependent PRs a nightmare. But if that is the strong preference I will of course comply. I'm also open to meeting for a live code review, whatever works. 😊 

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10274)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22500)

## :bulb: Description

### Feature Summary
This PR, which is targeting v132, is for implementing the remote tab management send capability which will allow users to close tabs on remote devices from the Remote Tabs Panel on their iOS device. Once these changes are released, a user will be able to swipe a remote tab to click the close button. Thereafter an undo modal will appear which, when clicked, will undo the close action leaving the remote tab unaffected. Seconds after the user's last interaction with either a close or undo button, the close tab commands will be sent to the respective remote device closing the selected tabs.

### Commit Summary
- [Storage Changes](https://github.com/mozilla-mobile/firefox-ios/pull/22156/commits/0a625d068c6cd743640d7a94cbb369ca06192a21)
  Includes the addition of an internal `RemoteTabsCommandQueue` class which manages any close tab commands a user's actions generate and is exposed for use via the `commandQueue` property of the `RustRemoteTabs` class. When a user closes a remote tab, a command is added to the queue. When they undo the close action the command is removed from the queue. Seconds after the user stops interacting with the close tab UI all of the unsent commands are retrieved, executed (or sent), and marked as sent. This commit also includes most of the unit tests (which is why it's so much larger than the others). 😅 

- [Profile Changes](https://github.com/mozilla-mobile/firefox-ios/pull/22156/commits/eb9bdfd65d1d41ea3fd5ebeb78ecef829c08d71f)
  This is a pretty small commit that exposes the storage changes via the user's profile. The only noteworthy change is the `flushTabCommands` function which is what is called seconds after a user stops interacting with the close tab UI. It's responsible for sending any unsent commands and marking those commands as sent.

- [Remote Tab Panel Action and State Changes](https://github.com/mozilla-mobile/firefox-ios/pull/22156/commits/f03a58b71008c96d68015cbc809ee45ef82b92b7)
  This commit is adding the `targetDeviceId` and `devices` properties to the `RemoteTabsPanelAction` class, both of which are necessary for managing close tab functionality. It also adds the following action types:
  - `refreshTabsWithCache`: pulling cached tabs data for the close remote tab feature as pulling fresh tabs data isn't necessary
  - `closeTabCompatible`: checking that the iOS device sending the close remote tab has that capability. If the device doesn't have the capability the close tab UI isn't displayed.
  - `closeSelectedRemoteURL`: closing the remote tab (this is the action type for when the user swipes to close)
  - `undoCloseSelectedRemoteURL`: undoing the close action (e.g. clicking the undo button in the modal after swiping to close)
  - `flushTabCommands`: flushing the tab commands, which executes the profiles `flushTabCommands` function and is triggered seconds after a user stops interacting with the close tab UI
  - `remoteDevicesChanged`: responding to the `constellationStateUpdate` FxA notification which will eventually update the `devices` property in the remote tab panel state.
 
  These changes also include adding a `devices` property to `RemoteTabsPanelState` class and a reducer case for the `remoteDevicesChanged` action type and updating the `refreshDidSucceed` case to set the `devices` property as needed.

- [Middleware](https://github.com/mozilla-mobile/firefox-ios/pull/22156/commits/a54d5e868896784d5e7be6ef12bde8b831225bfa)
 This is mostly scaffolding code. The only noteworthy changes are in `RemoteTabsPanelMiddleware` for retrieving devices as well as client and tabs data in the `getSyncState` function and adding the observer logic for the `constellationStateUpdate` action type.
 
 - [UI Changes](https://github.com/mozilla-mobile/firefox-ios/pull/22156/commits/0d09111e2b761b8de2ab7e40253c3e9d9953051e)
  This should be the easiest to grok of all the commits as this commit comprises the UI changes for the close remote tab feature. There are also inline comments where context may be important.

Please feel free to reach out with any questions or to request a live code review.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

