### PR TITLE
Fix FXIOS-10118 - CSS nesting breaks layout in iOS versions less than 17.2

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.css
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.css
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/* TODO(issam, FXIOS-10123): switch to nest rules once the min supported version is >= 17.2 */
 :root {
   --background-surface: #f9f9fb;
   --background-primary: #ffffff;
@@ -28,42 +29,42 @@ body {
 
 form {
   display: grid;
+}
 
-  input,
-  textarea,
-  select {
-    order: 2;
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-    appearance: none;
-    -webkit-appearance: none;
-    outline: none;
-    background-color: transparent;
-    color: var(--text-primary);
-    font: -apple-system-body;
-  }
+label {
+  background-color: var(--background-primary);
+  border-bottom: 0.5px solid var(--border-primary);
+  display: flex;
+  flex-direction: column;
+  min-height: 68px;
+  padding: 11px 16px;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent; /* Remove tap highlight interaction */
+}
 
-  textarea {
-    overflow: hidden;
-    resize: none;
-  }
+label input,
+label textarea,
+label select {
+  order: 2;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  outline: none;
+  background-color: transparent;
+  color: var(--text-primary);
+  font: -apple-system-body;
+}
 
-  label {
-    background-color: var(--background-primary);
-    border-bottom: 0.5px solid var(--border-primary);
-    display: flex;
-    flex-direction: column;
-    min-height: 68px;
-    padding: 11px 16px;
-    box-sizing: border-box;
-    -webkit-tap-highlight-color: transparent; /* Remove tap highlight interaction */
+label textarea {
+  overflow: hidden;
+  resize: none;
+}
 
-    span {
-      font: -apple-system-subheadline;
-      color: var(--text-secondary);
-    }
-  }
+label span {
+  font: -apple-system-subheadline;
+  color: var(--text-secondary);
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10118)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22162)

## :bulb: Description
This PR:
- Un-nests CSS rules in `AddressFormManager.css`

⚠️ **NOTE:** We can only nest css rules once the min supported version is 17.2. [Prior versions](https://caniuse.com/css-nesting) had minimal support or none whatsoever.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~Wrote unit tests and/or ensured the tests suite is passing~
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed, I updated documentation / comments for complex code and public methods~
- [ ] ~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~

