### PR TITLE
Add FXIOS-10094 [Unit Tests] Add store utility for tests

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -850,6 +850,7 @@
 		8AA020EF2B9A37E500771DE0 /* NimbusSplashScreenFeatureLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA020EE2B9A37E500771DE0 /* NimbusSplashScreenFeatureLayer.swift */; };
 		8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */; };
 		8AA7347B28AEDB3100443D24 /* PocketViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */; };
+		8AA8389D2CA2FEFC003FA256 /* StoreTestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA8389C2CA2FEFC003FA256 /* StoreTestUtility.swift */; };
 		8AAAB0592C1B7240008830B3 /* MockRustFirefoxSuggest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAAB0582C1B723F008830B3 /* MockRustFirefoxSuggest.swift */; };
 		8AAAB05B2C1B7268008830B3 /* ClientTabsSearchWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAAB05A2C1B7268008830B3 /* ClientTabsSearchWrapper.swift */; };
 		8AAAB05F2C1B72C9008830B3 /* SearchHighlightItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAAB05E2C1B72C9008830B3 /* SearchHighlightItem.swift */; };
@@ -6949,6 +6950,7 @@
 		8AA020EE2B9A37E500771DE0 /* NimbusSplashScreenFeatureLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusSplashScreenFeatureLayer.swift; sourceTree = "<group>"; };
 		8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryWrapperTests.swift; sourceTree = "<group>"; };
 		8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketViewModelTests.swift; sourceTree = "<group>"; };
+		8AA8389C2CA2FEFC003FA256 /* StoreTestUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTestUtility.swift; sourceTree = "<group>"; };
 		8AAAB0582C1B723F008830B3 /* MockRustFirefoxSuggest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockRustFirefoxSuggest.swift; sourceTree = "<group>"; };
 		8AAAB05A2C1B7268008830B3 /* ClientTabsSearchWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientTabsSearchWrapper.swift; sourceTree = "<group>"; };
 		8AAAB05E2C1B72C9008830B3 /* SearchHighlightItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHighlightItem.swift; sourceTree = "<group>"; };
@@ -10536,6 +10538,7 @@
 				C8E78BDC27F4A1E700C48BAA /* HistoryDeletionUtilityTests.swift */,
 				8A1E3BE128CBACD7003388C4 /* SponsoredContentFilterUtilityTests.swift */,
 				8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */,
+				8AA8389C2CA2FEFC003FA256 /* StoreTestUtility.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -16082,6 +16085,7 @@
 				21534904288201E300FADB4D /* GleanPlumbMessageManagerTests.swift in Sources */,
 				AB03032F2AB8561700DCD8EF /* FakespotOptInViewModelTests.swift in Sources */,
 				21BFEEF82A05A0370033048D /* TabMigrationUtilityTests.swift in Sources */,
+				8AA8389D2CA2FEFC003FA256 /* StoreTestUtility.swift in Sources */,
 				DFD1046D2B23539600938418 /* ProductAdsCacheTests.swift in Sources */,
 				E1390FB628B040E900C9EF3E /* WallpaperSelectorViewModelTests.swift in Sources */,
 				39AF317429DAE37E00F8E6F7 /* NimbusMessagingMessageTests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
@@ -8,11 +8,13 @@ import XCTest
 
 @testable import Client
 
-final class MicrosurveyMiddlewareTests: XCTestCase {
+final class MicrosurveyMiddlewareIntegrationTests: XCTestCase, StoreTestUtility {
+    let storeUtilityHelper = StoreTestUtilityHelper()
     override func setUp() {
         super.setUp()
         Glean.shared.resetGlean(clearStores: true)
         DependencyHelperMock().bootstrapDependencies()
+        setupTestingStore()
     }
 
     override func tearDown() {
@@ -22,8 +24,6 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
     }
 
     func testDismissSurveyAction() throws {
-        setupTestingStore()
-
         let action = getAction(for: .closeSurvey)
         store.dispatch(action)
 
@@ -41,8 +41,6 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
     }
 
     func testPrivacyNoticeTappedAction() throws {
-        setupTestingStore()
-
         let action = getAction(for: .tapPrivacyNotice)
         store.dispatch(action)
 
@@ -60,8 +58,6 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
     }
 
     func testSubmitSurveyAction() throws {
-        setupTestingStore()
-
         let action = MicrosurveyAction(
             surveyId: "microsurvey-id",
             userSelection: "Neutral",
@@ -85,8 +81,6 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
     }
 
     func testConfirmationViewedAction() throws {
-        setupTestingStore()
-
         let action = getAction(for: .confirmationViewed)
         store.dispatch(action)
 
@@ -103,7 +97,8 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
         )
     }
 
-    private func setupAppState() -> AppState {
+    // MARK: StoreTestUtility
+    func setupAppState() -> AppState {
         return AppState(
             activeScreens: ActiveScreensState(
                 screens: [
@@ -122,21 +117,16 @@ final class MicrosurveyMiddlewareTests: XCTestCase {
         )
     }
 
-    private func setupTestingStore() {
-        store = Store(
-            state: setupAppState(),
-            reducer: AppState.reducer,
+    func setupTestingStore() {
+        storeUtilityHelper.setupTestingStore(
+            with: setupAppState(),
             middlewares: [MicrosurveyMiddleware().microsurveyProvider]
         )
     }
 
     // In order to avoid flaky tests, we should reset the store
     // similar to production
-    private func resetTestingStore() {
-        store = Store(
-            state: AppState(),
-            reducer: AppState.reducer,
-            middlewares: middlewares
-        )
+    func resetTestingStore() {
+        storeUtilityHelper.resetTestingStore()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
@@ -12,7 +12,7 @@ protocol StoreTestUtility {
     func resetTestingStore()
 }
 
-// Utility class used when replacing the global store for testing purposes
+/// Utility class used when replacing the global store for testing purposes
 class StoreTestUtilityHelper {
     func setupTestingStore(with appState: AppState, middlewares: [Middleware<AppState>]) {
         store = Store(
@@ -22,8 +22,8 @@ class StoreTestUtilityHelper {
         )
     }
 
-    // In order to avoid flaky tests, we should reset the store
-    // similar to production
+    /// In order to avoid flaky tests, we should reset the store
+    /// similar to production
     func resetTestingStore() {
         store = Store(
             state: AppState(),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Redux
+@testable import Client
+
+protocol StoreTestUtility {
+    func setupAppState() -> AppState
+    func setupTestingStore()
+    func resetTestingStore()
+}
+
+// Utility class used when replacing the global store for testing purposes
+class StoreTestUtilityHelper {
+    func setupTestingStore(with appState: AppState, middlewares: [Middleware<AppState>]) {
+        store = Store(
+            state: appState,
+            reducer: AppState.reducer,
+            middlewares: middlewares
+        )
+    }
+
+    // In order to avoid flaky tests, we should reset the store
+    // similar to production
+    func resetTestingStore() {
+        store = Store(
+            state: AppState(),
+            reducer: AppState.reducer,
+            middlewares: middlewares
+        )
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10094)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22124)

## :bulb: Description
Create `StoreTestUtility` that can be conformed by test classes that want to override the global store with a testable store.
Add `StoreTestUtilityHelper` which is a concrete class that can be used by the test class. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

