### PR TITLE
Localize FXIOS-8948 Private browsing a11y string

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -6116,9 +6116,9 @@ extension String {
 // MARK: - Tab Tray v1
 extension String {
     public static let TabTrayToggleAccessibilityLabel = MZLocalizedString(
-        key: "Private Mode",
+        key: "PrivateBrowsing.Toggle.A11y.Label.v132",
         tableName: "PrivateBrowsing",
-        value: nil,
+        value: "Private browsing",
         comment: "Accessibility label for toggling on/off private mode")
     public static let TabTrayToggleAccessibilityHint = MZLocalizedString(
         key: "Turns private mode on or off",
@@ -7135,6 +7135,13 @@ extension String {
                 tableName: "Microsurvey",
                 value: "Selected",
                 comment: "After engaging with the microsurvey prompt, the microsurvey pops up as a bottom sheet for the user to answer, this is the accessibility label that states whether the survey option was selected.")
+        }
+        struct v132 {
+            public static let TabTrayToggleAccessibilityLabel = MZLocalizedString(
+                key: "Private Mode",
+                tableName: "PrivateBrowsing",
+                value: nil,
+                comment: "Accessibility label for toggling on/off private mode")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8948)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19759)

## :bulb: Description
- Change "Private mode" to "Private browsing"

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

