### PR TITLE
Add FXIOS-10121 Pre-push check for swiftlint violations

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+echo "Starting Swiftlint Check..."
+swiftlint --strict
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
+    echo "Violations found. Please fix the issues before pushing."
+    exit 1
+else 
+    echo "🎉  Hooray. No violation. You may proceed."
+fi
+
 # get the URL of a remote
 get_remote_url() {
   remote_name=$1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10121)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22168)

## :bulb: Description
Currently, swiftlint violations are warnings locally, but fails in our CI / CD pipeline. Sometimes we can miss them before we push so we would like to capture these before we hit CI / CD. Added a quick addition to our existing pre-push hook to check for violations.

It runs through all the files in this PR, let me know if effort is worth trying to only check files related to the PR. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

# Screenshots
## Screenshots 
| Success | Fail |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/0446504f-f81b-4937-905c-4e43bce408cf) |![image](https://github.com/user-attachments/assets/22de4b67-22dc-4309-9de5-5bd2824dbcbb)|

