### PR TITLE
Bugfix - Fix race condition in the redux library

### DIFF
--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -85,8 +85,7 @@ public class Store<State: StateType>: DefaultDispatchStore {
         guard !isProcessingActions else { return }
         isProcessingActions = true
         while !actionQueue.isEmpty {
-            let action = actionQueue.first!
-            actionQueue.remove(at: 0)
+            let action = actionQueue.removeFirst()
             executeAction(action)
         }
         isProcessingActions = false

--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -68,15 +68,14 @@ public class Store<State: StateType>: DefaultDispatchStore {
     }
 
     public func dispatch(_ action: Action) {
-        guard Thread.isMainThread && !actionRunning else {
-            DispatchQueue.main.async { [weak self] in self?.dispatch(action) }
-            return
-        }
-
         logger.log("Dispatched action: \(action.displayString())", level: .info, category: .redux)
 
-        actionRunning = true; defer { actionRunning = false }
+        DispatchQueue.main.async { [weak self] in
+            self?.executeAction(action)
+        }
+    }
 
+    private func executeAction(_ action: Action) {
         // Each active screen state is given an opportunity to be reduced using the dispatched action
         // (Note: this is true even if the action's UUID differs from the screen's window's UUID).
         // Typically, reducers should compare the action's UUID to the incoming state UUID and skip

--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -72,15 +72,13 @@ public class Store<State: StateType>: DefaultDispatchStore {
     public func dispatch(_ action: Action) {
         logger.log("Dispatched action: \(action.displayString())", level: .info, category: .redux)
 
-        if Thread.isMainThread {
-            actionQueue.append(action)
-            processQueuedActions()
-        } else {
-            DispatchQueue.main.async { [weak self] in
-                self?.actionQueue.append(action)
-                self?.processQueuedActions()
-            }
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in self?.dispatch(action) }
+            return
         }
+
+        actionQueue.append(action)
+        processQueuedActions()
     }
 
     private func processQueuedActions() {

--- a/BrowserKit/Tests/ReduxTests/Mocks/MockState.swift
+++ b/BrowserKit/Tests/ReduxTests/Mocks/MockState.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import Redux
+
+struct MockState: StateType, Equatable {
+    let counter: Int
+
+    static var actionsReduced = [ActionType]()
+    static var runMidReducerActions = false
+    static var midReducerActions: (() -> Void)?
+
+    init(midReducerActions: (() -> Void)? = nil) {
+        counter = 0
+        MockState.actionsReduced = [ActionType]()
+        MockState.runMidReducerActions = false
+    }
+
+    static let reducer: Reducer<Self> = { state, action in
+        MockState.actionsReduced.append(action.actionType)
+
+        if MockState.runMidReducerActions {
+            MockState.midReducerActions?()
+        }
+
+        return state
+    }
+}

--- a/BrowserKit/Tests/ReduxTests/StoreTests.swift
+++ b/BrowserKit/Tests/ReduxTests/StoreTests.swift
@@ -1,0 +1,141 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Redux
+
+final class StoreTests: XCTestCase {
+    var mockState = MockState()
+
+    override func setUp() {
+        super.setUp()
+        mockState = MockState()
+    }
+
+    func testDispatchBasicAction_mainThread() {
+        let store = Store(state: mockState,
+                          reducer: MockState.reducer,
+                          middlewares: [])
+
+        let action = FakeReduxAction(
+            windowUUID: UUID(),
+            actionType: FakeReduxActionType.counterIncreased)
+
+        store.dispatch(action)
+
+        XCTAssertEqual(MockState.actionsReduced[0] as? FakeReduxActionType, FakeReduxActionType.counterIncreased)
+    }
+
+    func testDispatchMultipleActions_mainThread() {
+        let store = Store(state: mockState,
+                          reducer: MockState.reducer,
+                          middlewares: [])
+
+        let action1 = FakeReduxAction(
+            windowUUID: UUID(),
+            actionType: FakeReduxActionType.counterIncreased)
+        store.dispatch(action1)
+
+        let action2 = FakeReduxAction(
+            windowUUID: UUID(),
+            actionType: FakeReduxActionType.counterDecreased)
+        store.dispatch(action2)
+
+        let action3 = FakeReduxAction(
+            windowUUID: UUID(),
+            actionType: FakeReduxActionType.increaseCounter)
+        store.dispatch(action3)
+
+        XCTAssertEqual(MockState.actionsReduced[0] as? FakeReduxActionType, FakeReduxActionType.counterIncreased)
+        XCTAssertEqual(MockState.actionsReduced[1] as? FakeReduxActionType, FakeReduxActionType.counterDecreased)
+        XCTAssertEqual(MockState.actionsReduced[2] as? FakeReduxActionType, FakeReduxActionType.increaseCounter)
+    }
+
+    func testDispatchBasicAction_backgroundThread() async {
+        let expectation = expectation(description: "Wait for actions to run")
+
+        let store = Store(state: mockState,
+                          reducer: MockState.reducer,
+                          middlewares: [])
+
+        let action = FakeReduxAction(
+            windowUUID: UUID(),
+            actionType: FakeReduxActionType.counterIncreased)
+
+        Task.detached(priority: .background) {
+            store.dispatch(action)
+            await MainActor.run {
+                expectation.fulfill()
+            }
+        }
+
+        await fulfillment(of: [expectation])
+
+        XCTAssertEqual(MockState.actionsReduced[0] as? FakeReduxActionType, FakeReduxActionType.counterIncreased)
+    }
+
+    func testDispatchMultipleActions_mixThread() async {
+        let expectation = expectation(description: "Wait for actions to run")
+
+        let store = Store(state: mockState,
+                          reducer: MockState.reducer,
+                          middlewares: [])
+
+        Task.detached(priority: .background) {
+            let action1 = FakeReduxAction(
+                windowUUID: UUID(),
+                actionType: FakeReduxActionType.counterIncreased)
+            store.dispatch(action1)
+            await MainActor.run {
+                expectation.fulfill()
+            }
+        }
+
+        let action2 = FakeReduxAction(
+            windowUUID: UUID(),
+            actionType: FakeReduxActionType.counterDecreased)
+        store.dispatch(action2)
+
+        let action3 = FakeReduxAction(
+            windowUUID: UUID(),
+            actionType: FakeReduxActionType.increaseCounter)
+        store.dispatch(action3)
+
+        await fulfillment(of: [expectation])
+
+        XCTAssertEqual(MockState.actionsReduced[0] as? FakeReduxActionType, FakeReduxActionType.counterDecreased)
+        XCTAssertEqual(MockState.actionsReduced[1] as? FakeReduxActionType, FakeReduxActionType.increaseCounter)
+        XCTAssertEqual(MockState.actionsReduced[2] as? FakeReduxActionType, FakeReduxActionType.counterIncreased)
+    }
+
+    func testDispatchAction_withMidReduceActions() {
+        let store = Store(state: mockState,
+                          reducer: MockState.reducer,
+                          middlewares: [])
+
+        MockState.runMidReducerActions = true
+        MockState.midReducerActions = {
+            MockState.runMidReducerActions = false
+
+            let action2 = FakeReduxAction(
+                windowUUID: UUID(),
+                actionType: FakeReduxActionType.increaseCounter)
+            store.dispatch(action2)
+
+            let action3 = FakeReduxAction(
+                windowUUID: UUID(),
+                actionType: FakeReduxActionType.decreaseCounter)
+            store.dispatch(action3)
+        }
+        let action = FakeReduxAction(
+            windowUUID: UUID(),
+            actionType: FakeReduxActionType.counterIncreased)
+
+        store.dispatch(action)
+
+        XCTAssertEqual(MockState.actionsReduced[0] as? FakeReduxActionType, FakeReduxActionType.counterIncreased)
+        XCTAssertEqual(MockState.actionsReduced[1] as? FakeReduxActionType, FakeReduxActionType.increaseCounter)
+        XCTAssertEqual(MockState.actionsReduced[2] as? FakeReduxActionType, FakeReduxActionType.decreaseCounter)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -12,24 +12,54 @@
     "codeCoverage" : {
       "targets" : [
         {
+          "containerPath" : "container:..\/BrowserKit",
+          "identifier" : "Common",
+          "name" : "Common"
+        },
+        {
+          "containerPath" : "container:..\/BrowserKit",
+          "identifier" : "ComponentLibrary",
+          "name" : "ComponentLibrary"
+        },
+        {
+          "containerPath" : "container:..\/BrowserKit",
+          "identifier" : "ContentBlockingGenerator",
+          "name" : "ContentBlockingGenerator"
+        },
+        {
+          "containerPath" : "container:..\/BrowserKit",
+          "identifier" : "MenuKit",
+          "name" : "MenuKit"
+        },
+        {
+          "containerPath" : "container:..\/BrowserKit",
+          "identifier" : "Redux",
+          "name" : "Redux"
+        },
+        {
+          "containerPath" : "container:..\/BrowserKit",
+          "identifier" : "SiteImageView",
+          "name" : "SiteImageView"
+        },
+        {
+          "containerPath" : "container:..\/BrowserKit",
+          "identifier" : "TabDataStore",
+          "name" : "TabDataStore"
+        },
+        {
+          "containerPath" : "container:..\/BrowserKit",
+          "identifier" : "ToolbarKit",
+          "name" : "ToolbarKit"
+        },
+        {
+          "containerPath" : "container:..\/BrowserKit",
+          "identifier" : "WebEngine",
+          "name" : "WebEngine"
+        },
+        {
           "containerPath" : "container:Client.xcodeproj",
           "identifier" : "F84B21BD1A090F8100AAB793",
           "name" : "Client"
-        },
-        {
-          "containerPath" : "container:Client.xcodeproj",
-          "identifier" : "2FA435FA1ABB83B4008031D1",
-          "name" : "Account"
-        },
-        {
-          "containerPath" : "container:Client.xcodeproj",
-          "identifier" : "2FCAE2191ABB51F800877008",
-          "name" : "Storage"
-        },
-        {
-          "containerPath" : "container:Client.xcodeproj",
-          "identifier" : "E69DB0741E97DEA9008A67E6",
-          "name" : "SyncTelemetry"
         },
         {
           "containerPath" : "container:Client.xcodeproj",
@@ -43,11 +73,6 @@
         },
         {
           "containerPath" : "container:Client.xcodeproj",
-          "identifier" : "390527491C874D35007E0BB7",
-          "name" : "Today"
-        },
-        {
-          "containerPath" : "container:Client.xcodeproj",
           "identifier" : "047F9B2624E1FE1C00CD7DF7",
           "name" : "WidgetKitExtension"
         },
@@ -57,29 +82,14 @@
           "name" : "CredentialProvider"
         },
         {
-          "containerPath" : "container:BrowserKit",
-          "identifier" : "Common",
-          "name" : "Common"
+          "containerPath" : "container:Client.xcodeproj",
+          "identifier" : "2FA435FA1ABB83B4008031D1",
+          "name" : "Account"
         },
         {
-          "containerPath" : "container:BrowserKit",
-          "identifier" : "ComponentLibrary",
-          "name" : "ComponentLibrary"
-        },
-        {
-          "containerPath" : "container:BrowserKit",
-          "identifier" : "Redux",
-          "name" : "Redux"
-        },
-        {
-          "containerPath" : "container:BrowserKit",
-          "identifier" : "SiteImageView",
-          "name" : "SiteImageView"
-        },
-        {
-          "containerPath" : "container:BrowserKit",
-          "identifier" : "TabDataStore",
-          "name" : "TabDataStore"
+          "containerPath" : "container:Client.xcodeproj",
+          "identifier" : "2FCAE2191ABB51F800877008",
+          "name" : "Storage"
         }
       ]
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
While helping Roux debug an issue with his redux code he uncovered a race condition in redux itself. This PR should address that race condition.

The issue was that if multiple actions are dispatched during the process of reducing for an ongoing action then those actions can be dispatched out of order.

This fix removes the actionRunning check because it's not working as expected and instead dispatches each action async on the main thread. Since all actions are executed on the main thread this means that actions will always be executed sequentially and in the correct order.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

