### PR TITLE
Add FXIOS-9656 - Password Generator - copy generated password on longpress

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
@@ -105,7 +105,7 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
     }
 
     @objc
-    func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+    private func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
         let menuController = UIMenuController.shared
         let copyItem = UIMenuItem(title: .PasswordGenerator.CopyPasswordButtonLabel, action: #selector(copyText(_:)))
         menuController.menuItems = [copyItem]
@@ -113,7 +113,7 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
     }
 
     @objc
-    func copyText(_ sender: Any?) {
+    private func copyText(_ sender: Any?) {
         UIPasteboard.general.string = passwordLabel.text
     }
 

--- a/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
@@ -52,6 +52,11 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
         self.layer.borderWidth = UX.passwordFieldBorderWidth
         self.layer.cornerRadius = UX.passwordFieldCornerRadius
         self.accessibilityIdentifier = AccessibilityIdentifiers.PasswordGenerator.passwordField
+        self.isUserInteractionEnabled = true
+       let longPressGesture = UILongPressGestureRecognizer(
+           target: self,
+           action: #selector(self.handleLongPress(_:)))
+        self.addGestureRecognizer(longPressGesture)
         setupNotifications(forObserver: self,
                            observing: [.DynamicFontChanged])
         setupLayout()
@@ -97,6 +102,19 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
         let rangeOfPassword = (attributedString.string as NSString).range(of: password)
         attributedString.addAttributes([.accessibilitySpeechSpellOut: true], range: rangeOfPassword)
         return attributedString
+    }
+
+    @objc
+    func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+        let menuController = UIMenuController.shared
+        let copyItem = UIMenuItem(title: .PasswordGenerator.CopyPasswordButtonLabel, action: #selector(copyText(_:)))
+        menuController.menuItems = [copyItem]
+        menuController.showMenu(from: passwordLabel, rect: passwordLabel.bounds)
+    }
+
+    @objc
+    func copyText(_ sender: Any?) {
+        UIPasteboard.general.string = passwordLabel.text
     }
 
     func applyTheme(theme: any Common.Theme) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9656)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21259)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
To open the password generator UI, you must open the debug options from the main menu (options made available by clicking on the version number 5 times) and click "Show Password Generator Prompt"

Once the password generator prompt is opened, long pressing on the password gives the option to copy the password.

Note: This branches off of #22119 and will be rebased once that one is merged into main.

Epic: https://mozilla-hub.atlassian.net/browse/FXIOS-8348

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

