### PR TITLE
Add FXIOS-10065 ⁃ Add accessibility strings/hints/labels to MenuElements in MenuConfigurationUtility

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
@@ -20,6 +20,7 @@ public final class HeaderView: UIView, ThemeApplicable {
     }
 
     public var closeButtonCallback: (() -> Void)?
+    public var mainButtonCallback: (() -> Void)?
 
     private var faviconHeightConstraint: NSLayoutConstraint?
     private var faviconWidthConstraint: NSLayoutConstraint?
@@ -52,6 +53,11 @@ public final class HeaderView: UIView, ThemeApplicable {
         button.addTarget(self, action: #selector(self.closeButtonTapped), for: .touchUpInside)
     }
 
+    private lazy var mainButton: UIButton = .build { button in
+        button.backgroundColor = .clear
+        button.addTarget(self, action: #selector(self.mainButtonTapped), for: .touchUpInside)
+    }
+
     private var iconMask: UIView = .build { view in
         view.backgroundColor = .clear
     }
@@ -70,7 +76,7 @@ public final class HeaderView: UIView, ThemeApplicable {
     private func setupLayout() {
         headerLabelsContainer.addArrangedSubview(titleLabel)
         headerLabelsContainer.addArrangedSubview(subtitleLabel)
-        addSubviews(iconMask, favicon, headerLabelsContainer, closeButton, horizontalLine)
+        addSubviews(mainButton, iconMask, favicon, headerLabelsContainer, closeButton, horizontalLine)
         NSLayoutConstraint.activate([
             favicon.leadingAnchor.constraint(
                 equalTo: self.leadingAnchor,
@@ -108,14 +114,30 @@ public final class HeaderView: UIView, ThemeApplicable {
             iconMask.widthAnchor.constraint(equalToConstant: UX.maskFaviconImageSize),
             iconMask.heightAnchor.constraint(equalToConstant: UX.maskFaviconImageSize),
             iconMask.centerXAnchor.constraint(equalTo: favicon.centerXAnchor),
-            iconMask.centerYAnchor.constraint(equalTo: favicon.centerYAnchor)
+            iconMask.centerYAnchor.constraint(equalTo: favicon.centerYAnchor),
+
+            mainButton.leadingAnchor.constraint(equalTo: iconMask.leadingAnchor),
+            mainButton.trailingAnchor.constraint(equalTo: headerLabelsContainer.trailingAnchor),
+            mainButton.topAnchor.constraint(equalTo: headerLabelsContainer.topAnchor),
+            mainButton.bottomAnchor.constraint(equalTo: headerLabelsContainer.bottomAnchor)
         ])
     }
 
-    public func setupAccessibility(closeButtonA11yLabel: String, closeButtonA11yId: String) {
+    public func setupAccessibility(closeButtonA11yLabel: String,
+                                   closeButtonA11yId: String,
+                                   mainButtonA11yLabel: String? = nil,
+                                   mainButtonA11yId: String? = nil) {
         let closeButtonViewModel = CloseButtonViewModel(a11yLabel: closeButtonA11yLabel,
                                                         a11yIdentifier: closeButtonA11yId)
         closeButton.configure(viewModel: closeButtonViewModel)
+        if let mainButtonA11yLabel, let mainButtonA11yId {
+            titleLabel.isAccessibilityElement = false
+            subtitleLabel.isAccessibilityElement = false
+            mainButton.accessibilityIdentifier = mainButtonA11yId
+            mainButton.accessibilityLabel = mainButtonA11yLabel
+        } else {
+            mainButton.isAccessibilityElement = false
+        }
     }
 
     public func setupDetails(subtitle: String, title: String, icon: FaviconImageViewModel) {
@@ -158,6 +180,11 @@ public final class HeaderView: UIView, ThemeApplicable {
     @objc
     func closeButtonTapped() {
         closeButtonCallback?()
+    }
+
+    @objc
+    func mainButtonTapped() {
+        mainButtonCallback?()
     }
 
     public func applyTheme(theme: Theme) {

--- a/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
@@ -17,7 +17,7 @@ public final class NavigationHeaderView: UIView {
     public var backToMainMenuCallback: (() -> Void)?
     public var dismissMenuCallback: (() -> Void)?
 
-    let siteTitleLabel: UILabel = .build { label in
+    let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         label.font = FXFontStyles.Regular.headline.scaledFont()
@@ -53,7 +53,7 @@ public final class NavigationHeaderView: UIView {
 
     // MARK: View Setup
     private func setupView() {
-        addSubviews(siteTitleLabel, backButton, closeButton, horizontalLine)
+        addSubviews(titleLabel, backButton, closeButton, horizontalLine)
 
         NSLayoutConstraint.activate([
             backButton.leadingAnchor.constraint(
@@ -62,15 +62,15 @@ public final class NavigationHeaderView: UIView {
             ),
             backButton.centerYAnchor.constraint(equalTo: centerYAnchor),
 
-            siteTitleLabel.topAnchor.constraint(
+            titleLabel.topAnchor.constraint(
                 equalTo: topAnchor,
                 constant: UX.baseDistance
             ),
-            siteTitleLabel.bottomAnchor.constraint(
+            titleLabel.bottomAnchor.constraint(
                 equalTo: bottomAnchor,
                 constant: -UX.baseDistance
             ),
-            siteTitleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
 
             closeButton.trailingAnchor.constraint(
                 equalTo: trailingAnchor,
@@ -99,7 +99,7 @@ public final class NavigationHeaderView: UIView {
     }
 
     public func setViews(with title: String, and backButtonText: String) {
-        siteTitleLabel.text = title
+        titleLabel.text = title
         backButton.setTitle(backButtonText, for: .normal)
     }
 
@@ -122,6 +122,6 @@ public final class NavigationHeaderView: UIView {
         backButton.tintColor = theme.colors.iconAction
         backButton.setTitleColor(theme.colors.textAccent, for: .normal)
         horizontalLine.backgroundColor = theme.colors.borderPrimary
-        siteTitleLabel.textColor = theme.colors.textPrimary
+        titleLabel.textColor = theme.colors.textPrimary
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
@@ -23,6 +23,7 @@ public final class NavigationHeaderView: UIView {
         label.font = FXFontStyles.Regular.headline.scaledFont()
         label.numberOfLines = 2
         label.accessibilityTraits.insert(.header)
+        label.isAccessibilityElement = false
     }
 
     private lazy var closeButton: CloseButton = .build { button in
@@ -35,6 +36,7 @@ public final class NavigationHeaderView: UIView {
             .withRenderingMode(.alwaysTemplate),
                         for: .normal)
         button.titleLabel?.font = FXFontStyles.Regular.body.scaledFont()
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
         button.addTarget(self, action: #selector(self.backButtonTapped), for: .touchUpInside)
     }
 
@@ -60,9 +62,6 @@ public final class NavigationHeaderView: UIView {
             ),
             backButton.centerYAnchor.constraint(equalTo: centerYAnchor),
 
-            siteTitleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            siteTitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
-            siteTitleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
             siteTitleLabel.topAnchor.constraint(
                 equalTo: topAnchor,
                 constant: UX.baseDistance
@@ -71,6 +70,7 @@ public final class NavigationHeaderView: UIView {
                 equalTo: bottomAnchor,
                 constant: -UX.baseDistance
             ),
+            siteTitleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
 
             closeButton.trailingAnchor.constraint(
                 equalTo: trailingAnchor,
@@ -85,6 +85,17 @@ public final class NavigationHeaderView: UIView {
             horizontalLine.bottomAnchor.constraint(equalTo: bottomAnchor),
             horizontalLine.heightAnchor.constraint(equalToConstant: UX.separatorHeight)
         ])
+    }
+
+    public func setupAccessibility(closeButtonA11yLabel: String,
+                                   closeButtonA11yId: String,
+                                   backButtonA11yLabel: String,
+                                   backButtonA11yId: String) {
+        let closeButtonViewModel = CloseButtonViewModel(a11yLabel: closeButtonA11yLabel,
+                                                        a11yIdentifier: closeButtonA11yId)
+        closeButton.configure(viewModel: closeButtonViewModel)
+        backButton.accessibilityIdentifier = backButtonA11yId
+        backButton.accessibilityLabel = backButtonA11yLabel
     }
 
     public func setViews(with title: String, and backButtonText: String) {

--- a/BrowserKit/Sources/MenuKit/MenuCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuCell.swift
@@ -49,10 +49,14 @@ public class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
     public func configureCellWith(model: MenuElement) {
         self.model = model
         self.titleLabel.text = model.title
-        self.descriptionLabel.text = model.a11yLabel // TODO: to be updated with the correct value
+        self.descriptionLabel.text = model.description
         self.icon.image = UIImage(named: model.iconName)?.withRenderingMode(.alwaysTemplate)
         self.accessoryArrowView.image =
         UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
+        self.isAccessibilityElement = true
+        self.accessibilityIdentifier = model.a11yId
+        self.accessibilityLabel = model.a11yLabel
+        self.accessibilityHint = model.a11yHint
         setupView()
     }
 

--- a/BrowserKit/Sources/MenuKit/MenuDetailView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuDetailView.swift
@@ -44,6 +44,16 @@ public final class MenuDetailView: UIView,
         ])
     }
 
+    public func setupAccessibilityIdentifiers(closeButtonA11yLabel: String,
+                                              closeButtonA11yId: String,
+                                              backButtonA11yLabel: String,
+                                              backButtonA11yId: String) {
+        detailHeaderView.setupAccessibility(closeButtonA11yLabel: closeButtonA11yLabel,
+                                            closeButtonA11yId: closeButtonA11yId,
+                                            backButtonA11yLabel: backButtonA11yLabel,
+                                            backButtonA11yId: backButtonA11yId)
+    }
+
     // MARK: - Interface
     public func reloadTableView(with data: [MenuSection]) {
         tableView.reloadTableView(with: data)

--- a/BrowserKit/Sources/MenuKit/MenuElement.swift
+++ b/BrowserKit/Sources/MenuKit/MenuElement.swift
@@ -6,6 +6,7 @@ import UIKit
 
 public struct MenuElement: Equatable {
     let title: String
+    let description: String?
     let iconName: String
     let isEnabled: Bool
     let isActive: Bool
@@ -19,6 +20,7 @@ public struct MenuElement: Equatable {
     // for the struct will be internal and can not be used outside of MenuKit
     public init(
         title: String,
+        description: String? = nil,
         iconName: String,
         isEnabled: Bool,
         isActive: Bool,
@@ -29,6 +31,7 @@ public struct MenuElement: Equatable {
         action: (() -> Void)?
     ) {
         self.title = title
+        self.description = description
         self.iconName = iconName
         self.isEnabled = isEnabled
         self.isActive = isActive
@@ -41,6 +44,7 @@ public struct MenuElement: Equatable {
 
     public static func == (lhs: MenuElement, rhs: MenuElement) -> Bool {
         return lhs.title == rhs.title &&
+        lhs.description == rhs.description &&
         lhs.iconName == rhs.iconName &&
         lhs.isEnabled == rhs.isEnabled &&
         lhs.isActive == rhs.isActive &&

--- a/BrowserKit/Sources/MenuKit/MenuMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuMainView.swift
@@ -48,6 +48,20 @@ public final class MenuMainView: UIView,
                                        icon: icon)
     }
 
+    public func setupAccessibilityIdentifiers(closeButtonA11yLabel: String,
+                                              closeButtonA11yId: String,
+                                              mainButtonA11yLabel: String,
+                                              mainButtonA11yId: String,
+                                              menuA11yId: String,
+                                              menuA11yLabel: String) {
+        accountHeaderView.setupAccessibility(closeButtonA11yLabel: closeButtonA11yLabel,
+                                             closeButtonA11yId: closeButtonA11yId,
+                                             mainButtonA11yLabel: mainButtonA11yLabel,
+                                             mainButtonA11yId: mainButtonA11yId)
+        tableView.accessibilityIdentifier = menuA11yId
+        tableView.accessibilityLabel = menuA11yLabel
+    }
+
     // MARK: - Interface
     public func reloadTableView(with data: [MenuSection]) {
         tableView.reloadTableView(with: data)

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -72,6 +72,45 @@ public struct AccessibilityIdentifiers {
         static let actionButton = "ContextualHints.ActionButton"
     }
 
+    struct MainMenu {
+        struct HeaderView {
+            static let mainButton = "MainMenu.MainButton"
+            static let closeButton = "MainMenu.CloseMenuButton"
+        }
+
+        struct NavigationHeaderView {
+            static let backButton = "MainMenu.BackButton"
+            static let closeButton = "MainMenu.CloseMenuButton"
+        }
+
+        static let mainMenu = "MainMenu.Menu"
+        static let newTab = "MainMenu.NewTab"
+        static let newPrivateTab = "MainMenu.NewPrivateTab"
+        static let switchToDesktopSite = "MainMenu.SwitchToDesktopSite"
+        static let findInPage = "MainMenu.FindInPage"
+        static let tools = "MainMenu.Tools"
+        static let save = "MainMenu.Save"
+        static let bookmarks = "MainMenu.Bookmarks"
+        static let history = "MainMenu.History"
+        static let downloads = "MainMenu.Downloads"
+        static let passwords = "MainMenu.Passwords"
+        static let getHelp = "MainMenu.GetHelp"
+        static let settings = "MainMenu.Settings"
+        static let whatsNew = "MainMenu.WhatsNew"
+        static let customizeHomepage = "MainMenu.CustomizeHomepage"
+        static let saveAsPDF = "MainMenu.SaveAsPDF"
+        static let saveToReadingList = "MainMenu.SaveToReadingList"
+        static let addToHomeScreen = "MainMenu.AddToHomeScreen"
+        static let addToShortcuts = "MainMenu.AddToShortcuts"
+        static let bookmarkThisPage = "MainMenu.BookmarkThisPage"
+        static let share = "MainMenu.Share"
+        static let print = "MainMenu.Print"
+        static let reportBrokenSite = "MainMenu.ReportBrokenSite"
+        static let readerViewOn = "MainMenu.ReaderViewOn"
+        static let nightModeOn = "MainMenu.NightModeOn"
+        static let zoom = "MainMenu.Zoom"
+    }
+
     struct EnhancedTrackingProtection {
         struct MainScreen {
             static let clearCookiesButton = "TrackingProtection.ClearCookiesButton"

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -69,7 +69,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.newTab,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.NewTabMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.AccessibilityLabels.NewTabMenuItemAccessibilityLabel,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.newTab,
                 action: {
@@ -87,7 +87,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.newPrivateTab,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.NewPrivateTabMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.AccessibilityLabels.NewPrivateTabMenuItemAccessibilityLabel,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.newPrivateTab,
                 action: {
@@ -118,7 +118,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.deviceDesktop,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.SwitchToDesktopMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.AccessibilityLabels.SwitchToDesktopMenuItemAccessibilityLabel,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.switchToDesktopSite,
                     action: {
@@ -135,7 +135,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.findInPage,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.FindInPageMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.AccessibilityLabels.FindInPageMenuItemAccessibilityLabel,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.findInPage,
                     action: {
@@ -150,13 +150,12 @@ struct MainMenuConfigurationUtility: Equatable {
                 ),
                 MenuElement(
                     title: .MainMenu.ToolsSection.Tools,
-                    description: .MainMenu.ToolsSection.Description,
                     iconName: Icons.tools,
                     isEnabled: true,
                     isActive: false,
                     hasSubmenu: true,
-                    a11yLabel: .MainMenu.ToolsMenuItemAccessibilityLabel,
-                    a11yHint: .MainMenu.ToolsMenuItemAccessibilityHint,
+                    a11yLabel: .MainMenu.AccessibilityLabels.ToolsMenuItemAccessibilityLabel,
+                    a11yHint: .MainMenu.AccessibilityLabels.ToolsMenuItemAccessibilityHint,
                     a11yId: AccessibilityIdentifiers.MainMenu.tools,
                     action: {
                         store.dispatch(
@@ -171,13 +170,12 @@ struct MainMenuConfigurationUtility: Equatable {
                 ),
                 MenuElement(
                     title: .MainMenu.ToolsSection.Save,
-                    description: .MainMenu.Submenus.Save.Description,
                     iconName: Icons.save,
                     isEnabled: true,
                     isActive: false,
                     hasSubmenu: true,
-                    a11yLabel: .MainMenu.SaveMenuItemAccessibilityLabel,
-                    a11yHint: .MainMenu.SaveMenuItemAccessibilityHint,
+                    a11yLabel: .MainMenu.AccessibilityLabels.SaveMenuItemAccessibilityLabel,
+                    a11yHint: .MainMenu.AccessibilityLabels.SaveMenuItemAccessibilityHint,
                     a11yId: AccessibilityIdentifiers.MainMenu.save,
                     action: {
                         store.dispatch(
@@ -224,7 +222,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.zoom,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.ZoomMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.AccessibilityLabels.ZoomMenuItemAccessibilityLabel,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.zoom,
                         action: {
@@ -241,7 +239,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.readerViewOn,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.TurnOnReaderViewMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.AccessibilityLabels.TurnOnReaderViewMenuItemAccessibilityLabel,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.readerViewOn,
                         action: {
@@ -258,7 +256,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.nightModeOn,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.TurnOnNightModeMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.AccessibilityLabels.TurnOnNightModeMenuItemAccessibilityLabel,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.nightModeOn,
                         action: {
@@ -275,7 +273,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.reportBrokenSite,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.ReportBrokenSiteMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.AccessibilityLabels.ReportBrokenSiteMenuItemAccessibilityLabel,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.reportBrokenSite,
                         action: {
@@ -296,7 +294,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.print,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.PrintMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.AccessibilityLabels.PrintMenuItemAccessibilityLabel,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.print,
                         action: {
@@ -313,7 +311,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.share,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.ShareMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.AccessibilityLabels.ShareMenuItemAccessibilityLabel,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.share,
                         action: {
@@ -338,7 +336,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.bookmarkThisPage,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.BookmarkThisPageMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.AccessibilityLabels.BookmarkThisPageMenuItemAccessibilityLabel,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.bookmarkThisPage,
                     action: {
@@ -355,7 +353,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.addToShortcuts,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.AddToShortcutsMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.AccessibilityLabels.AddToShortcutsMenuItemAccessibilityLabel,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.addToShortcuts,
                     action: {
@@ -372,7 +370,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.addToHomeScreen,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.AddToHomeScreenMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.AccessibilityLabels.AddToHomeScreenMenuItemAccessibilityLabel,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.addToHomeScreen,
                     action: {
@@ -389,7 +387,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.saveToReadingList,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.SaveToReadingListMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.AccessibilityLabels.SaveToReadingListMenuItemAccessibilityLabel,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.saveToReadingList,
                     action: {
@@ -406,7 +404,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.saveAsPDF,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.SaveAsPDFMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.AccessibilityLabels.SaveAsPDFMenuItemAccessibilityLabel,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.saveAsPDF,
                     action: {
@@ -430,7 +428,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.bookmarks,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.BookmarksMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.AccessibilityLabels.BookmarksMenuItemAccessibilityLabel,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.bookmarks,
                 action: {
@@ -448,7 +446,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.history,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.HistoryMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.AccessibilityLabels.HistoryMenuItemAccessibilityLabel,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.history,
                 action: {
@@ -466,7 +464,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.downloads,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.DownloadsMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.AccessibilityLabels.DownloadsMenuItemAccessibilityLabel,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.downloads,
                 action: {
@@ -484,7 +482,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.passwords,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.PasswordsMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.AccessibilityLabels.PasswordsMenuItemAccessibilityLabel,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.passwords,
                 action: {
@@ -511,7 +509,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.customizeHomepage,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.CustomizeHomepageMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.AccessibilityLabels.CustomizeHomepageMenuItemAccessibilityLabel,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.customizeHomepage,
                 action: {
@@ -532,7 +530,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.whatsNew,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.NewInMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.AccessibilityLabels.NewInMenuItemAccessibilityLabel,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.whatsNew,
                 action: {
@@ -553,7 +551,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.getHelp,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.GetHelpMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.AccessibilityLabels.GetHelpMenuItemAccessibilityLabel,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.getHelp,
                 action: {
@@ -571,7 +569,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.settings,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.SettingsMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.AccessibilityLabels.SettingsMenuItemAccessibilityLabel,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.settings,
                 action: {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -69,7 +69,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.newTab,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.AccessibilityLabels.NewTabMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.TabsSection.AccessibilityLabels.NewTab,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.newTab,
                 action: {
@@ -87,7 +87,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.newPrivateTab,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.AccessibilityLabels.NewPrivateTabMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.TabsSection.AccessibilityLabels.NewPrivateTab,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.newPrivateTab,
                 action: {
@@ -118,7 +118,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.deviceDesktop,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.AccessibilityLabels.SwitchToDesktopMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.ToolsSection.AccessibilityLabels.SwitchToDesktopSite,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.switchToDesktopSite,
                     action: {
@@ -135,7 +135,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.findInPage,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.AccessibilityLabels.FindInPageMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.ToolsSection.AccessibilityLabels.FindInPage,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.findInPage,
                     action: {
@@ -154,8 +154,8 @@ struct MainMenuConfigurationUtility: Equatable {
                     isEnabled: true,
                     isActive: false,
                     hasSubmenu: true,
-                    a11yLabel: .MainMenu.AccessibilityLabels.ToolsMenuItemAccessibilityLabel,
-                    a11yHint: .MainMenu.AccessibilityLabels.ToolsMenuItemAccessibilityHint,
+                    a11yLabel: .MainMenu.ToolsSection.AccessibilityLabels.Tools,
+                    a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.tools,
                     action: {
                         store.dispatch(
@@ -174,8 +174,8 @@ struct MainMenuConfigurationUtility: Equatable {
                     isEnabled: true,
                     isActive: false,
                     hasSubmenu: true,
-                    a11yLabel: .MainMenu.AccessibilityLabels.SaveMenuItemAccessibilityLabel,
-                    a11yHint: .MainMenu.AccessibilityLabels.SaveMenuItemAccessibilityHint,
+                    a11yLabel: .MainMenu.ToolsSection.AccessibilityLabels.Save,
+                    a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.save,
                     action: {
                         store.dispatch(
@@ -222,7 +222,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.zoom,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.AccessibilityLabels.ZoomMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.Submenus.Tools.AccessibilityLabels.Zoom,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.zoom,
                         action: {
@@ -239,7 +239,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.readerViewOn,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.AccessibilityLabels.TurnOnReaderViewMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.Submenus.Tools.AccessibilityLabels.ReaderViewOn,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.readerViewOn,
                         action: {
@@ -256,7 +256,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.nightModeOn,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.AccessibilityLabels.TurnOnNightModeMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.Submenus.Tools.AccessibilityLabels.NightModeOn,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.nightModeOn,
                         action: {
@@ -273,7 +273,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.reportBrokenSite,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.AccessibilityLabels.ReportBrokenSiteMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.Submenus.Tools.AccessibilityLabels.ReportBrokenSite,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.reportBrokenSite,
                         action: {
@@ -294,7 +294,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.print,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.AccessibilityLabels.PrintMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.Submenus.Tools.AccessibilityLabels.Print,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.print,
                         action: {
@@ -311,7 +311,7 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.share,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: .MainMenu.AccessibilityLabels.ShareMenuItemAccessibilityLabel,
+                        a11yLabel: .MainMenu.Submenus.Tools.AccessibilityLabels.Share,
                         a11yHint: "",
                         a11yId: AccessibilityIdentifiers.MainMenu.share,
                         action: {
@@ -336,7 +336,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.bookmarkThisPage,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.AccessibilityLabels.BookmarkThisPageMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.Submenus.Save.AccessibilityLabels.BookmarkThisPage,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.bookmarkThisPage,
                     action: {
@@ -353,7 +353,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.addToShortcuts,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.AccessibilityLabels.AddToShortcutsMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.Submenus.Save.AccessibilityLabels.AddToShortcuts,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.addToShortcuts,
                     action: {
@@ -370,7 +370,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.addToHomeScreen,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.AccessibilityLabels.AddToHomeScreenMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.Submenus.Save.AccessibilityLabels.AddToHomeScreen,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.addToHomeScreen,
                     action: {
@@ -387,7 +387,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.saveToReadingList,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.AccessibilityLabels.SaveToReadingListMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.Submenus.Save.AccessibilityLabels.SaveToReadingList,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.saveToReadingList,
                     action: {
@@ -404,7 +404,7 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.saveAsPDF,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: .MainMenu.AccessibilityLabels.SaveAsPDFMenuItemAccessibilityLabel,
+                    a11yLabel: .MainMenu.Submenus.Save.AccessibilityLabels.SaveAsPDF,
                     a11yHint: "",
                     a11yId: AccessibilityIdentifiers.MainMenu.saveAsPDF,
                     action: {
@@ -428,7 +428,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.bookmarks,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.AccessibilityLabels.BookmarksMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.PanelLinkSection.AccessibilityLabels.Bookmarks,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.bookmarks,
                 action: {
@@ -446,7 +446,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.history,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.AccessibilityLabels.HistoryMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.PanelLinkSection.AccessibilityLabels.History,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.history,
                 action: {
@@ -464,7 +464,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.downloads,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.AccessibilityLabels.DownloadsMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.PanelLinkSection.AccessibilityLabels.Downloads,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.downloads,
                 action: {
@@ -482,7 +482,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.passwords,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.AccessibilityLabels.PasswordsMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.PanelLinkSection.AccessibilityLabels.Passwords,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.passwords,
                 action: {
@@ -509,7 +509,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.customizeHomepage,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.AccessibilityLabels.CustomizeHomepageMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.OtherToolsSection.AccessibilityLabels.CustomizeHomepage,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.customizeHomepage,
                 action: {
@@ -530,7 +530,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.whatsNew,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.AccessibilityLabels.NewInMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.OtherToolsSection.AccessibilityLabels.WhatsNew,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.whatsNew,
                 action: {
@@ -551,7 +551,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.getHelp,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.AccessibilityLabels.GetHelpMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.OtherToolsSection.AccessibilityLabels.GetHelp,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.getHelp,
                 action: {
@@ -569,7 +569,7 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.settings,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: .MainMenu.AccessibilityLabels.SettingsMenuItemAccessibilityLabel,
+                a11yLabel: .MainMenu.OtherToolsSection.AccessibilityLabels.Settings,
                 a11yHint: "",
                 a11yId: AccessibilityIdentifiers.MainMenu.settings,
                 action: {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -69,9 +69,9 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.newTab,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: "",
+                a11yLabel: .MainMenu.NewTabMenuItemAccessibilityLabel,
                 a11yHint: "",
-                a11yId: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.newTab,
                 action: {
                     store.dispatch(
                         MainMenuAction(
@@ -87,9 +87,9 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.newPrivateTab,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: "",
+                a11yLabel: .MainMenu.NewPrivateTabMenuItemAccessibilityLabel,
                 a11yHint: "",
-                a11yId: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.newPrivateTab,
                 action: {
                     store.dispatch(
                         MainMenuAction(
@@ -118,9 +118,9 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.deviceDesktop,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: "",
+                    a11yLabel: .MainMenu.SwitchToDesktopMenuItemAccessibilityLabel,
                     a11yHint: "",
-                    a11yId: "",
+                    a11yId: AccessibilityIdentifiers.MainMenu.switchToDesktopSite,
                     action: {
                         store.dispatch(
                             MainMenuAction(
@@ -135,9 +135,9 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.findInPage,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: "",
+                    a11yLabel: .MainMenu.FindInPageMenuItemAccessibilityLabel,
                     a11yHint: "",
-                    a11yId: "",
+                    a11yId: AccessibilityIdentifiers.MainMenu.findInPage,
                     action: {
                         store.dispatch(
                             MainMenuAction(
@@ -150,13 +150,14 @@ struct MainMenuConfigurationUtility: Equatable {
                 ),
                 MenuElement(
                     title: .MainMenu.ToolsSection.Tools,
+                    description: .MainMenu.ToolsSection.Description,
                     iconName: Icons.tools,
                     isEnabled: true,
                     isActive: false,
                     hasSubmenu: true,
-                    a11yLabel: "",
-                    a11yHint: "",
-                    a11yId: "",
+                    a11yLabel: .MainMenu.ToolsMenuItemAccessibilityLabel,
+                    a11yHint: .MainMenu.ToolsMenuItemAccessibilityHint,
+                    a11yId: AccessibilityIdentifiers.MainMenu.tools,
                     action: {
                         store.dispatch(
                             MainMenuAction(
@@ -170,13 +171,14 @@ struct MainMenuConfigurationUtility: Equatable {
                 ),
                 MenuElement(
                     title: .MainMenu.ToolsSection.Save,
+                    description: .MainMenu.Submenus.Save.Description,
                     iconName: Icons.save,
                     isEnabled: true,
                     isActive: false,
                     hasSubmenu: true,
-                    a11yLabel: "",
-                    a11yHint: "",
-                    a11yId: "",
+                    a11yLabel: .MainMenu.SaveMenuItemAccessibilityLabel,
+                    a11yHint: .MainMenu.SaveMenuItemAccessibilityHint,
+                    a11yId: AccessibilityIdentifiers.MainMenu.save,
                     action: {
                         store.dispatch(
                             MainMenuAction(
@@ -222,9 +224,9 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.zoom,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: "",
+                        a11yLabel: .MainMenu.ZoomMenuItemAccessibilityLabel,
                         a11yHint: "",
-                        a11yId: "",
+                        a11yId: AccessibilityIdentifiers.MainMenu.zoom,
                         action: {
                             store.dispatch(
                                 MainMenuAction(
@@ -239,9 +241,9 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.readerViewOn,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: "",
+                        a11yLabel: .MainMenu.TurnOnReaderViewMenuItemAccessibilityLabel,
                         a11yHint: "",
-                        a11yId: "",
+                        a11yId: AccessibilityIdentifiers.MainMenu.readerViewOn,
                         action: {
                             store.dispatch(
                                 MainMenuAction(
@@ -256,9 +258,9 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.nightModeOn,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: "",
+                        a11yLabel: .MainMenu.TurnOnNightModeMenuItemAccessibilityLabel,
                         a11yHint: "",
-                        a11yId: "",
+                        a11yId: AccessibilityIdentifiers.MainMenu.nightModeOn,
                         action: {
                             store.dispatch(
                                 MainMenuAction(
@@ -273,9 +275,9 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.reportBrokenSite,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: "",
+                        a11yLabel: .MainMenu.ReportBrokenSiteMenuItemAccessibilityLabel,
                         a11yHint: "",
-                        a11yId: "",
+                        a11yId: AccessibilityIdentifiers.MainMenu.reportBrokenSite,
                         action: {
                             store.dispatch(
                                 MainMenuAction(
@@ -294,9 +296,9 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.print,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: "",
+                        a11yLabel: .MainMenu.PrintMenuItemAccessibilityLabel,
                         a11yHint: "",
-                        a11yId: "",
+                        a11yId: AccessibilityIdentifiers.MainMenu.print,
                         action: {
                             store.dispatch(
                                 MainMenuAction(
@@ -311,9 +313,9 @@ struct MainMenuConfigurationUtility: Equatable {
                         iconName: Icons.share,
                         isEnabled: true,
                         isActive: false,
-                        a11yLabel: "",
+                        a11yLabel: .MainMenu.ShareMenuItemAccessibilityLabel,
                         a11yHint: "",
-                        a11yId: "",
+                        a11yId: AccessibilityIdentifiers.MainMenu.share,
                         action: {
                             store.dispatch(
                                 MainMenuAction(
@@ -336,9 +338,9 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.bookmarkThisPage,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: "",
+                    a11yLabel: .MainMenu.BookmarkThisPageMenuItemAccessibilityLabel,
                     a11yHint: "",
-                    a11yId: "",
+                    a11yId: AccessibilityIdentifiers.MainMenu.bookmarkThisPage,
                     action: {
                         store.dispatch(
                             MainMenuAction(
@@ -353,9 +355,9 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.addToShortcuts,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: "",
+                    a11yLabel: .MainMenu.AddToShortcutsMenuItemAccessibilityLabel,
                     a11yHint: "",
-                    a11yId: "",
+                    a11yId: AccessibilityIdentifiers.MainMenu.addToShortcuts,
                     action: {
                         store.dispatch(
                             MainMenuAction(
@@ -370,9 +372,9 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.addToHomeScreen,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: "",
+                    a11yLabel: .MainMenu.AddToHomeScreenMenuItemAccessibilityLabel,
                     a11yHint: "",
-                    a11yId: "",
+                    a11yId: AccessibilityIdentifiers.MainMenu.addToHomeScreen,
                     action: {
                         store.dispatch(
                             MainMenuAction(
@@ -387,9 +389,9 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.saveToReadingList,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: "",
+                    a11yLabel: .MainMenu.SaveToReadingListMenuItemAccessibilityLabel,
                     a11yHint: "",
-                    a11yId: "",
+                    a11yId: AccessibilityIdentifiers.MainMenu.saveToReadingList,
                     action: {
                         store.dispatch(
                             MainMenuAction(
@@ -404,9 +406,9 @@ struct MainMenuConfigurationUtility: Equatable {
                     iconName: Icons.saveAsPDF,
                     isEnabled: true,
                     isActive: false,
-                    a11yLabel: "",
+                    a11yLabel: .MainMenu.SaveAsPDFMenuItemAccessibilityLabel,
                     a11yHint: "",
-                    a11yId: "",
+                    a11yId: AccessibilityIdentifiers.MainMenu.saveAsPDF,
                     action: {
                         store.dispatch(
                             MainMenuAction(
@@ -428,9 +430,9 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.bookmarks,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: "",
+                a11yLabel: .MainMenu.BookmarksMenuItemAccessibilityLabel,
                 a11yHint: "",
-                a11yId: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.bookmarks,
                 action: {
                     store.dispatch(
                         MainMenuAction(
@@ -446,9 +448,9 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.history,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: "",
+                a11yLabel: .MainMenu.HistoryMenuItemAccessibilityLabel,
                 a11yHint: "",
-                a11yId: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.history,
                 action: {
                     store.dispatch(
                         MainMenuAction(
@@ -464,9 +466,9 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.downloads,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: "",
+                a11yLabel: .MainMenu.DownloadsMenuItemAccessibilityLabel,
                 a11yHint: "",
-                a11yId: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.downloads,
                 action: {
                     store.dispatch(
                         MainMenuAction(
@@ -482,9 +484,9 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.passwords,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: "",
+                a11yLabel: .MainMenu.PasswordsMenuItemAccessibilityLabel,
                 a11yHint: "",
-                a11yId: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.passwords,
                 action: {
                     store.dispatch(
                         MainMenuAction(
@@ -509,9 +511,9 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.customizeHomepage,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: "",
+                a11yLabel: .MainMenu.CustomizeHomepageMenuItemAccessibilityLabel,
                 a11yHint: "",
-                a11yId: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.customizeHomepage,
                 action: {
                     store.dispatch(
                         MainMenuAction(
@@ -530,9 +532,9 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.whatsNew,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: "",
+                a11yLabel: .MainMenu.NewInMenuItemAccessibilityLabel,
                 a11yHint: "",
-                a11yId: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.whatsNew,
                 action: {
                     store.dispatch(
                         MainMenuAction(
@@ -551,9 +553,9 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.getHelp,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: "",
+                a11yLabel: .MainMenu.GetHelpMenuItemAccessibilityLabel,
                 a11yHint: "",
-                a11yId: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.getHelp,
                 action: {
                     store.dispatch(
                         MainMenuAction(
@@ -569,9 +571,9 @@ struct MainMenuConfigurationUtility: Equatable {
                 iconName: Icons.settings,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: "",
+                a11yLabel: .MainMenu.SettingsMenuItemAccessibilityLabel,
                 a11yHint: "",
-                a11yId: "",
+                a11yId: AccessibilityIdentifiers.MainMenu.settings,
                 action: {
                     store.dispatch(
                         MainMenuAction(

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuDetailViewController.swift
@@ -89,9 +89,9 @@ class MainMenuDetailViewController: UIViewController,
 
     private func setupAccessibilityIdentifiers() {
         submenuContent.setupAccessibilityIdentifiers(
-            closeButtonA11yLabel: .MainMenu.Account.CloseButtonAccessibilityLabel,
+            closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButtonAccessibilityLabel,
             closeButtonA11yId: AccessibilityIdentifiers.MainMenu.NavigationHeaderView.closeButton,
-            backButtonA11yLabel: .MainMenu.Account.BackButtonAccessibilityLabel,
+            backButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.BackButtonAccessibilityLabel,
             backButtonA11yId: AccessibilityIdentifiers.MainMenu.NavigationHeaderView.backButton)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuDetailViewController.swift
@@ -89,9 +89,9 @@ class MainMenuDetailViewController: UIViewController,
 
     private func setupAccessibilityIdentifiers() {
         submenuContent.setupAccessibilityIdentifiers(
-            closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButtonAccessibilityLabel,
+            closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButton,
             closeButtonA11yId: AccessibilityIdentifiers.MainMenu.NavigationHeaderView.closeButton,
-            backButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.BackButtonAccessibilityLabel,
+            backButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.BackButton,
             backButtonA11yId: AccessibilityIdentifiers.MainMenu.NavigationHeaderView.backButton)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuDetailViewController.swift
@@ -61,6 +61,7 @@ class MainMenuDetailViewController: UIViewController,
         submenuContent.detailHeaderView.dismissMenuCallback = { [weak self] in
             self?.coordinator?.dismissMenuModal(animated: true)
         }
+        setupAccessibilityIdentifiers()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -84,6 +85,14 @@ class MainMenuDetailViewController: UIViewController,
             submenuContent.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             submenuContent.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
+    }
+
+    private func setupAccessibilityIdentifiers() {
+        submenuContent.setupAccessibilityIdentifiers(
+            closeButtonA11yLabel: .MainMenu.Account.CloseButtonAccessibilityLabel,
+            closeButtonA11yId: AccessibilityIdentifiers.MainMenu.NavigationHeaderView.closeButton,
+            backButtonA11yLabel: .MainMenu.Account.BackButtonAccessibilityLabel,
+            backButtonA11yId: AccessibilityIdentifiers.MainMenu.NavigationHeaderView.backButton)
     }
 
     private func setupTableView() {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -195,12 +195,12 @@ class MainMenuViewController: UIViewController,
 
     private func setupAccessibilityIdentifiers() {
         menuContent.setupAccessibilityIdentifiers(
-            closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButtonAccessibilityLabel,
+            closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButton,
             closeButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.closeButton,
-            mainButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.MainButtonAccessibilityLabel,
+            mainButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.MainButton,
             mainButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.mainButton,
             menuA11yId: AccessibilityIdentifiers.MainMenu.mainMenu,
-            menuA11yLabel: .MainMenu.AccessibilityLabels.MainMenuAccessibilityLabel)
+            menuA11yLabel: .MainMenu.TabsSection.AccessibilityLabels.MainMenu)
     }
 
     // MARK: - UIAdaptivePresentationControllerDelegate

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -73,6 +73,8 @@ class MainMenuViewController: UIViewController,
         menuContent.accountHeaderView.closeButtonCallback = { [weak self] in
             self?.coordinator?.dismissMenuModal(animated: true)
         }
+
+        setupAccessibilityIdentifiers()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -189,6 +191,16 @@ class MainMenuViewController: UIViewController,
     ) -> UISheetPresentationController.Detent.Identifier? {
         guard let sheetController = presentedController as? UISheetPresentationController else { return nil }
         return sheetController.selectedDetentIdentifier
+    }
+
+    private func setupAccessibilityIdentifiers() {
+        menuContent.setupAccessibilityIdentifiers(
+            closeButtonA11yLabel: .MainMenu.Account.CloseButtonAccessibilityLabel,
+            closeButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.closeButton,
+            mainButtonA11yLabel: .MainMenu.Account.MainButtonAccessibilityLabel,
+            mainButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.mainButton,
+            menuA11yId: AccessibilityIdentifiers.MainMenu.mainMenu,
+            menuA11yLabel: .MainMenu.MainMenuAccessibilityLabel)
     }
 
     // MARK: - UIAdaptivePresentationControllerDelegate

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -195,12 +195,12 @@ class MainMenuViewController: UIViewController,
 
     private func setupAccessibilityIdentifiers() {
         menuContent.setupAccessibilityIdentifiers(
-            closeButtonA11yLabel: .MainMenu.Account.CloseButtonAccessibilityLabel,
+            closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButtonAccessibilityLabel,
             closeButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.closeButton,
-            mainButtonA11yLabel: .MainMenu.Account.MainButtonAccessibilityLabel,
+            mainButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.MainButtonAccessibilityLabel,
             mainButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.mainButton,
             menuA11yId: AccessibilityIdentifiers.MainMenu.mainMenu,
-            menuA11yLabel: .MainMenu.MainMenuAccessibilityLabel)
+            menuA11yLabel: .MainMenu.AccessibilityLabels.MainMenuAccessibilityLabel)
     }
 
     // MARK: - UIAdaptivePresentationControllerDelegate

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3897,7 +3897,163 @@ extension String {
                 tableName: "MainMenu",
                 value: "Syncing paused",
                 comment: "On the main menu, at the top, when the user is signed in but there was an error syncing. The description subtitle for the sync error state.")
+            public static let CloseButtonAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.Account.CloseButton.AccessibilityLabel.v133",
+                tableName: "MainMenu",
+                value: "Close",
+                comment: "The accessibility label for the close button in the Main menu.")
+            public static let MainButtonAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.Account.MainButton.AccessibilityLabel.v133",
+                tableName: "MainMenu",
+                value: "Sign in to sync passwords, tabs, and more",
+                comment: "The accessibility label for the sign in button in the Main menu header view.")
+            public static let BackButtonAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.Account.BackButton.AccessibilityLabel.v133",
+                tableName: "MainMenu",
+                value: "Back",
+                comment: "The accessibility label for the back button in the Main menu header navigation view.")
         }
+
+        public static let MainMenuAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.MainMenu.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Main Menu",
+            comment: "The accessibility label for the Main Menu.")
+        public static let NewTabMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.NewTabMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "New tab",
+            comment: "The accessibility label for the Main Menu New Tab item.")
+        public static let NewPrivateTabMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.NewPrivateTabMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "New private tab",
+            comment: "The accessibility label for the Main Menu New Private Tab item.")
+        public static let SwitchToDesktopMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.SwitchToDesktopMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Switch to desktop site",
+            comment: "The accessibility label for the Main Menu Switch to desktop site item.")
+        public static let FindInPageMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.FindInPageMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Find in page",
+            comment: "The accessibility label for the Main Menu Find in page item.")
+        public static let ToolsMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.ToolsMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Tools",
+            comment: "The accessibility label for the Main Menu Tools item.")
+        public static let ToolsMenuItemAccessibilityHint = MZLocalizedString(
+            key: "MainMenu.ToolsMenuItem.AccessibilityHint.v133",
+            tableName: "MainMenu",
+            value: "Zoom, Reader View, Translate, Review Checker",
+            comment: "The accessibility hint for the Main Menu Tools item.")
+        public static let SaveMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.SaveMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Save",
+            comment: "The accessibility label for the Main Menu Save item.")
+        public static let SaveMenuItemAccessibilityHint = MZLocalizedString(
+            key: "MainMenu.SaveMenuItem.AccessibilityHint.v133",
+            tableName: "MainMenu",
+            value: "Add bookmark, Shortcut, Home, Collection",
+            comment: "The accessibility hint for the Main Menu Save item.")
+        public static let BookmarksMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.BookmarksMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Bookmarks",
+            comment: "The accessibility label for the Main Menu Bookmarks item.")
+        public static let HistoryMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.HistoryMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "History",
+            comment: "The accessibility label for the Main Menu History item.")
+        public static let DownloadsMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.DownloadsMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Downloads",
+            comment: "The accessibility label for the Main Menu Downloads item.")
+        public static let PasswordsMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.PasswordsMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Passwords",
+            comment: "The accessibility label for the Main Menu Passwords item.")
+        public static let GetHelpMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.GetHelpMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "GetHelp",
+            comment: "The accessibility label for the Main Menu GetHelp item.")
+        public static let SettingsMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.SettingsMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Settings",
+            comment: "The accessibility label for the Main Menu Settings item.")
+        public static let ZoomMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.ZoomMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Zoom at %@",
+            comment: "The accessibility label for the Main Menu Zoom item.")
+        public static let TurnOnReaderViewMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.TurnOnReaderViewMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Turn on reader view",
+            comment: "The accessibility label for the Main Menu Turn On Reader View item.")
+        public static let TurnOnNightModeMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.TurnOnNightModeMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Turn on night mode",
+            comment: "The accessibility label for the Main Menu Turn On Night Mode item.")
+        public static let PrintMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.PrintMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Print",
+            comment: "The accessibility label for the Main Menu Print item.")
+        public static let ShareMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.ShareMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Share",
+            comment: "The accessibility label for the Main Menu Share item.")
+        public static let ReportBrokenSiteMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.ReportBrokenSiteMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Report broken site",
+            comment: "The accessibility label for the Main Menu Report Broken Site item.")
+        public static let BookmarkThisPageMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.BookmarkThisPageMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Bookmark this page",
+            comment: "The accessibility label for the Main Menu Bookmark This Page item.")
+        public static let AddToShortcutsMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.AddToShortcutsMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Add to shortcuts",
+            comment: "The accessibility label for the Main Menu Add To Shortcuts item.")
+        public static let AddToHomeScreenMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.AddToHomeScreenMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Add to home screen",
+            comment: "The accessibility label for the Main Menu Add To Home Screen item.")
+        public static let SaveToReadingListMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.SaveToReadingListMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Save to reading list",
+            comment: "The accessibility label for the Main Menu Save To Reading List item.")
+        public static let SaveAsPDFMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.SaveAsPDFMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "Save as PDF",
+            comment: "The accessibility label for the Main Menu Save As PDF item.")
+        public static let CustomizeHomepageMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.CustomizeHomepageMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: " Customize Homepage",
+            comment: "The accessibility label for the Main Menu Customize Homepage item.")
+        public static let NewInMenuItemAccessibilityLabel = MZLocalizedString(
+            key: "MainMenu.NewInMenuItem.AccessibilityLabel.v133",
+            tableName: "MainMenu",
+            value: "New in %@",
+            comment: "The accessibility label for the Main Menu New In item.")
 
         public struct TabsSection {
             public static let NewTab = MZLocalizedString(
@@ -3913,6 +4069,11 @@ extension String {
         }
 
         public struct ToolsSection {
+            public static let Description = MZLocalizedString(
+                key: "MainMenu.ToolsSection.Tools.Subtitle.v133",
+                tableName: "MainMenu",
+                value: "Zoom, Reader View, Translate, Review Checker",
+                comment: "On the main menu, the description/subtitle for the Tools section.")
             public static let SwitchToDesktopSite = MZLocalizedString(
                 key: "MainMenu.ToolsSection.SwitchToDesktopSite.Title.v131",
                 tableName: "MainMenu",
@@ -4061,6 +4222,11 @@ extension String {
             }
 
             public struct Save {
+                public static let Description = MZLocalizedString(
+                    key: "MainMenu.SaveSection.Save.Subtitle.v133",
+                    tableName: "MainMenu",
+                    value: "Add Bookmark, Shortcut, Home, Reading List, PDF",
+                    comment: "On the main menu, the description/subtitle for the Save section.")
                 public static let BookmarkThisPage = MZLocalizedString(
                     key: "MainMenu.Submenus.Save.BookmarkThisPage.Title.v131",
                     tableName: "MainMenu",

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3899,165 +3899,22 @@ extension String {
                 comment: "On the main menu, at the top, when the user is signed in but there was an error syncing. The description subtitle for the sync error state.")
 
             public struct AccessibilityLabels {
-                public static let CloseButtonAccessibilityLabel = MZLocalizedString(
-                    key: "MainMenu.Account.AccessibilityLabels.CloseButton.AccessibilityLabel.v132",
+                public static let CloseButton = MZLocalizedString(
+                    key: "MainMenu.Account.AccessibilityLabels.CloseButton.v132",
                     tableName: "MainMenu",
                     value: "Close",
                     comment: "The accessibility label for the close button in the Main menu.")
-                public static let MainButtonAccessibilityLabel = MZLocalizedString(
-                    key: "MainMenu.Account.AccessibilityLabels.MainButton.AccessibilityLabel.v132",
+                public static let MainButton = MZLocalizedString(
+                    key: "MainMenu.Account.AccessibilityLabels.MainButton.v132",
                     tableName: "MainMenu",
                     value: "Sign in to sync passwords, tabs, and more",
                     comment: "The accessibility label for the sign in button in the Main menu header view.")
-                public static let BackButtonAccessibilityLabel = MZLocalizedString(
-                    key: "MainMenu.Account.AccessibilityLabels.BackButton.AccessibilityLabel.v132",
+                public static let BackButton = MZLocalizedString(
+                    key: "MainMenu.Account.AccessibilityLabels.BackButton.v132",
                     tableName: "MainMenu",
                     value: "Back",
                     comment: "The accessibility label for the back button in the Main menu header navigation view.")
             }
-        }
-
-        public struct AccessibilityLabels {
-            public static let MainMenuAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.MainMenu.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Main Menu",
-                comment: "The accessibility label for the Main Menu.")
-            public static let NewTabMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.NewTabMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "New tab",
-                comment: "The accessibility label for the Main Menu New Tab item.")
-            public static let NewPrivateTabMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.NewPrivateTabMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "New private tab",
-                comment: "The accessibility label for the Main Menu New Private Tab item.")
-            public static let SwitchToDesktopMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.SwitchToDesktopMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Switch to desktop site",
-                comment: "The accessibility label for the Main Menu Switch to desktop site item.")
-            public static let FindInPageMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.FindInPageMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Find in page",
-                comment: "The accessibility label for the Main Menu Find in page item.")
-            public static let ToolsMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.ToolsMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Tools",
-                comment: "The accessibility label for the Main Menu Tools item.")
-            public static let ToolsMenuItemAccessibilityHint = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.ToolsMenuItem.AccessibilityHint.v132",
-                tableName: "MainMenu",
-                value: "Zoom, Reader View, Translate, Review Checker",
-                comment: "The accessibility hint for the Main Menu Tools item.")
-            public static let SaveMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.SaveMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Save",
-                comment: "The accessibility label for the Main Menu Save item.")
-            public static let SaveMenuItemAccessibilityHint = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.SaveMenuItem.AccessibilityHint.v132",
-                tableName: "MainMenu",
-                value: "Add bookmark, Shortcut, Home, Collection",
-                comment: "The accessibility hint for the Main Menu Save item.")
-            public static let BookmarksMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.BookmarksMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Bookmarks",
-                comment: "The accessibility label for the Main Menu Bookmarks item.")
-            public static let HistoryMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.HistoryMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "History",
-                comment: "The accessibility label for the Main Menu History item.")
-            public static let DownloadsMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.DownloadsMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Downloads",
-                comment: "The accessibility label for the Main Menu Downloads item.")
-            public static let PasswordsMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.PasswordsMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Passwords",
-                comment: "The accessibility label for the Main Menu Passwords item.")
-            public static let GetHelpMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.GetHelpMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "GetHelp",
-                comment: "The accessibility label for the Main Menu GetHelp item.")
-            public static let SettingsMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.SettingsMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Settings",
-                comment: "The accessibility label for the Main Menu Settings item.")
-            public static let ZoomMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.ZoomMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Zoom at %@",
-                comment: "The accessibility label for the Main Menu Zoom item.")
-            public static let TurnOnReaderViewMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.TurnOnReaderViewMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Turn on reader view",
-                comment: "The accessibility label for the Main Menu Turn On Reader View item.")
-            public static let TurnOnNightModeMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.TurnOnNightModeMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Turn on night mode",
-                comment: "The accessibility label for the Main Menu Turn On Night Mode item.")
-            public static let PrintMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.PrintMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Print",
-                comment: "The accessibility label for the Main Menu Print item.")
-            public static let ShareMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.ShareMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Share",
-                comment: "The accessibility label for the Main Menu Share item.")
-            public static let ReportBrokenSiteMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.ReportBrokenSiteMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Report broken site",
-                comment: "The accessibility label for the Main Menu Report Broken Site item.")
-            public static let BookmarkThisPageMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.BookmarkThisPageMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Bookmark this page",
-                comment: "The accessibility label for the Main Menu Bookmark This Page item.")
-            public static let AddToShortcutsMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.AddToShortcutsMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Add to shortcuts",
-                comment: "The accessibility label for the Main Menu Add To Shortcuts item.")
-            public static let AddToHomeScreenMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.AddToHomeScreenMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Add to home screen",
-                comment: "The accessibility label for the Main Menu Add To Home Screen item.")
-            public static let SaveToReadingListMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.SaveToReadingListMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Save to reading list",
-                comment: "The accessibility label for the Main Menu Save To Reading List item.")
-            public static let SaveAsPDFMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.SaveAsPDFMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "Save as PDF",
-                comment: "The accessibility label for the Main Menu Save As PDF item.")
-            public static let CustomizeHomepageMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.CustomizeHomepageMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: " Customize Homepage",
-                comment: "The accessibility label for the Main Menu Customize Homepage item.")
-            public static let NewInMenuItemAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.AccessibilityLabels.NewInMenuItem.AccessibilityLabel.v132",
-                tableName: "MainMenu",
-                value: "New in %@",
-                comment: "The accessibility label for the Main Menu New In item.")
         }
 
         public struct TabsSection {
@@ -4071,6 +3928,24 @@ extension String {
                 tableName: "MainMenu",
                 value: "New Private Tab",
                 comment: "On the main menu, the title for the action that will create a new private tab.")
+
+            public struct AccessibilityLabels {
+                public static let MainMenu = MZLocalizedString(
+                    key: "MainMenu.AccessibilityLabels.MainMenu.v132",
+                    tableName: "MainMenu",
+                    value: "Main Menu",
+                    comment: "The accessibility label for the Main Menu.")
+                public static let NewTab = MZLocalizedString(
+                    key: "MainMenu.TabsSection.AccessibilityLabels.NewTab.v132",
+                    tableName: "MainMenu",
+                    value: "New tab",
+                    comment: "On the main menu, the accessibility label for the action that will create a new, non-private, tab.")
+                public static let NewPrivateTab = MZLocalizedString(
+                    key: "MainMenu.TabsSection.AccessibilityLabels.NewPrivateTab.v132",
+                    tableName: "MainMenu",
+                    value: "New private tab",
+                    comment: "On the main menu, the accessibility label for the action that will create a new private tab.")
+            }
         }
 
         public struct ToolsSection {
@@ -4099,6 +3974,34 @@ extension String {
                 tableName: "MainMenu",
                 value: "Save",
                 comment: "On the main menu, the title for the action that will take the user to the Save submenu in the menu.")
+
+            public struct AccessibilityLabels {
+                public static let SwitchToDesktopSite = MZLocalizedString(
+                    key: "MainMenu.ToolsSection.AccessibilityLabels.SwitchToDesktopSite.v132",
+                    tableName: "MainMenu",
+                    value: "Switch to desktop site",
+                    comment: "On the main menu, the accessibility label for the action that will switch a site from mobile version to the desktop version, if available.")
+                public static let SwitchToMobileSite = MZLocalizedString(
+                    key: "MainMenu.ToolsSection.AccessibilityLabels.SwitchToMobileSite.v132",
+                    tableName: "MainMenu",
+                    value: "Switch to mobile site",
+                    comment: "On the main menu, the accessibility label for the action that will switch a site from the desktop version to the mobile version.")
+                public static let FindInPage = MZLocalizedString(
+                    key: "MainMenu.ToolsSection.AccessibilityLabels.FindInPage.v132",
+                    tableName: "MainMenu",
+                    value: "Find in page",
+                    comment: "On the main menu, the accessibility label for the action that will bring up the Search menu, so the user can search for a word or a pharse on the current page.")
+                public static let Tools = MZLocalizedString(
+                    key: "MainMenu.ToolsSection.AccessibilityLabels.Tools.v132",
+                    tableName: "MainMenu",
+                    value: "Tools",
+                    comment: "On the main menu, the accessibility label for the action that will take the user to the Tools submenu in the menu.")
+                public static let Save = MZLocalizedString(
+                    key: "MainMenu.ToolsSection.AccessibilityLabels.Save.v132",
+                    tableName: "MainMenu",
+                    value: "Save",
+                    comment: "On the main menu, the accessibility label for the action that will take the user to the Save submenu in the menu.")
+            }
         }
 
         public struct PanelLinkSection {
@@ -4122,6 +4025,29 @@ extension String {
                 tableName: "MainMenu",
                 value: "Passwords",
                 comment: "On the main menu, the title for the action that will take the user to the Passwords panel in the settings screen. Please keep as short as possible, <15 chars of space available.")
+
+            public struct AccessibilityLabels {
+                 public static let Bookmarks = MZLocalizedString(
+                     key: "MainMenu.PanelLinkSection.AccessibilityLabels.Bookmarks.v132",
+                     tableName: "MainMenu",
+                     value: "Bookmarks",
+                     comment: "On the main menu, the accessibility label for the action that will take the user to the Bookmarks panel. Please keep as short as possible, <15 chars of space available.")
+                 public static let History = MZLocalizedString(
+                     key: "MainMenu.PanelLinkSection.AccessibilityLabels.History.v132",
+                     tableName: "MainMenu",
+                     value: "History",
+                     comment: "On the main menu, the accessibility label for the action that will take the user to the History panel. Please keep as short as possible, <15 chars of space available.")
+                 public static let Downloads = MZLocalizedString(
+                     key: "MainMenu.PanelLinkSection.AccessibilityLabels.Downloads.v132",
+                     tableName: "MainMenu",
+                     value: "Downloads",
+                     comment: "On the main menu, the accessibility label for the action that will take the user to the Downloads panel. Please keep as short as possible, <15 chars of space available.")
+                 public static let Passwords = MZLocalizedString(
+                     key: "MainMenu.PanelLinkSection.AccessibilityLabels.Passwords.v132",
+                     tableName: "MainMenu",
+                     value: "Passwords",
+                     comment: "On the main menu, the accessibility label for the action that will take the user to the Passwords panel in the settings screen. Please keep as short as possible, <15 chars of space available.")
+            }
         }
 
         public struct OtherToolsSection {
@@ -4145,6 +4071,29 @@ extension String {
                 tableName: "MainMenu",
                 value: "Get Help",
                 comment: "On the main menu, the title for the action that will take the user to a website to get help from Mozilla.")
+
+            public struct AccessibilityLabels {
+                public static let CustomizeHomepage = MZLocalizedString(
+                    key: "MainMenu.SettingsSection.AccessibilityLabels.CustomizeHomepage.v132",
+                    tableName: "MainMenu",
+                    value: "Customize Homepage",
+                    comment: "On the main menu, the accessibility labels for the action that will take the user to the Customize Homepage section in the settings screen.")
+                public static let WhatsNew = MZLocalizedString(
+                    key: "MainMenu.SettingsSection.AccessibilityLabels.WhatsNew.v132",
+                    tableName: "MainMenu",
+                    value: "New in %@",
+                    comment: "On the main menu, the accessibility labels for the action that will take the user to a What's New in Firefox popup. Placeholder is for the app name.")
+                public static let Settings = MZLocalizedString(
+                    key: "MainMenu.SettingsSection.AccessibilityLabels.Settings.v132",
+                    tableName: "MainMenu",
+                    value: "Settings",
+                    comment: "On the main menu, the accessibility labels for the action that will take the user to the Settings menu.")
+                public static let GetHelp = MZLocalizedString(
+                    key: "MainMenu.SettingsSection.AccessibilityLabels.GetHelp.v132",
+                    tableName: "MainMenu",
+                    value: "Get Help",
+                    comment: "On the main menu, the accessibility labels for the action that will take the user to a website to get help from Mozilla.")
+            }
         }
 
         public struct Submenus {
@@ -4219,6 +4168,79 @@ extension String {
                     tableName: "MainMenu",
                     value: "Report",
                     comment: "On the main menu, a string below the Tool submenu tiitle, indicating what kind of tools are available in that menu. This string is for the Report Broken Site tool.")
+
+                public struct AccessibilityLabels {
+                    public static let Zoom = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.Zoom.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Zoom (%@)",
+                        comment: "On the main menu, in the tools submenu, the accessibility label for the menu component that indicates the current zoom level. Placeholder is for the current zoom level percentage. ")
+                    public static let ZoomSubtitle = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.Zoom.Subtitle.v132",
+                        tableName: "MainMenu",
+                        value: "Zoom",
+                        comment: "On the main menu, a string below the Tool submenu accessibility label, indicating what kind of tools are available in that menu. This string is for the Zoom tool.")
+                    public static let ReaderViewOn = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.ReaderView.On.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Turn on Reader View",
+                        comment: "On the main menu, the accessibility label for the action that will turn the reader view on for the current website.")
+                    public static let ReaderViewOff = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.ReaderView.Off.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Turn off Reader View",
+                        comment: "On the main menu, the accessibility label for the action that will turn the reader view on for the current website.")
+                    public static let ReaderViewSubtitle = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.ReaderView.Subtitle.v132",
+                        tableName: "MainMenu",
+                        value: "Reader View",
+                        comment: "On the main menu, a string below the Tool submenu accessibility label, indicating what kind of tools are available in that menu. This string is for the Reader View tool.")
+                    public static let NightModeOn = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.NightMode.On.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Turn on Night Mode",
+                        comment: "On the main menu, the accessibility label for the action that will turn Night Mode on in the application.")
+                    public static let NightModeOff = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.NightMode.Off.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Turn off Night Mode",
+                        comment: "On the main menu, the accessibility label for the action that will turn Night Mode off in the application.")
+                    public static let NightModeSubtitle = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.NightMode.Subtitle.v132",
+                        tableName: "MainMenu",
+                        value: "Night Mode",
+                        comment: "On the main menu, a string below the Tool submenu accessibility label, indicating what kind of tools are available in that menu. This string is for the Night Mode tool.")
+                    public static let Print = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.Print.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Print",
+                        comment: "On the main menu, the accessibility label for the action that will take the user to the Print module in the application.")
+                    public static let PrintSubtitle = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.Print.Subtitle.v132",
+                        tableName: "MainMenu",
+                        value: "Print",
+                        comment: "On the main menu, a string below the Tool submenu accessibility label, indicating what kind of tools are available in that menu. This string is for the Report Print tool.")
+                    public static let Share = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.Share.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Share",
+                        comment: "On the main menu, the accessibility label for the action that will take the user to the Share module in the application.")
+                    public static let ShareSubtitle = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.Share.Subtitle.v132",
+                        tableName: "MainMenu",
+                        value: "Share",
+                        comment: "On the main menu, a string below the Tool submenu accessibility label, indicating what kind of tools are available in that menu. This string is for the Report Share tool.")
+                    public static let ReportBrokenSite = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.ReportBrokenSite.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Report Broken Site",
+                        comment: "On the main menu, the accessibility label for the action that will take the user to the site where they can report a broken website to our web compatibility team.")
+                    public static let ReportBrokenSiteSubtitle = MZLocalizedString(
+                        key: "MainMenu.Submenus.Tools.AccessibilityLabels.ReportBrokenSite.Subtitle.v132",
+                        tableName: "MainMenu",
+                        value: "Report",
+                        comment: "On the main menu, a string below the Tool submenu accessibility label, indicating what kind of tools are available in that menu. This string is for the Report Broken Site tool.")
+                }
             }
 
             public struct Save {
@@ -4287,6 +4309,74 @@ extension String {
                     tableName: "MainMenu",
                     value: "PDF",
                     comment: "On the main menu, a string below the Save submenu title, indicating what kind of tools are available in that menu. This string is for the Save as PDF tool.")
+
+                public struct AccessibilityLabels {
+                    public static let BookmarkThisPage = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.BookmarkThisPage.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Bookmark This Page",
+                        comment: "On the main menu, in the Save submenu, the accessibility label for the menu component that allows a user to save a bookmark for this particular page..")
+                    public static let BookmarkThisPageSubtitle = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.BookmarkThisPage.Subtitle.v132",
+                        tableName: "MainMenu",
+                        value: "Add Bookmark",
+                        comment: "On the main menu, a string below the Save submenu accessibility label, indicating what kind of tools are available in that menu. This string is for the Bookmarks tool.")
+                    public static let EditBookmark = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.EditBookmark.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Edit Bookmark",
+                        comment: "On the main menu, in the Save submenu, the accessibility label for the menu component that allows a user to edit the bookmark for this particular page.")
+                    public static let AddToShortcuts = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.AddToShortcuts.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Add to Shortcuts",
+                        comment: "On the main menu, in the Save submenu, the accessibility label for the menu component that allows a user to add the current website to the shortcuts on the homepage.")
+                    public static let RemoveFromShortcuts = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.RemoveFromShortcuts.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Remove from Shortcuts",
+                        comment: "On the main menu, in the Save submenu, the accessibility label for the menu component that allows a user to remove the current website from the shortcuts on the homepage.")
+                    public static let AddToShortcutsSubtitle = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.AddToShortcuts.Subtitle.v132",
+                        tableName: "MainMenu",
+                        value: "Shortcut",
+                        comment: "On the main menu, a string below the Save submenu accessibility label, indicating what kind of tools are available in that menu. This string is for the Shortcuts tool.")
+                    public static let AddToHomeScreen = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.AddToHomeScreen.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Add to Home Screen",
+                        comment: "On the main menu, in the Save submenu, the accessibility label for the menu component that allows a user to add a website to the home screen.")
+                    public static let AddToHomeScreenSubtitle = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.AddToHomeScreen.Subtitle.v132",
+                        tableName: "MainMenu",
+                        value: "Home",
+                        comment: "On the main menu, a string below the Save submenu accessibility label, indicating what kind of tools are available in that menu. This string is for the Add to Home screen tool.")
+                    public static let SaveToReadingList = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.SaveToReadingList.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Save to Reading List",
+                        comment: "On the main menu, in the Save submenu, the accessibility label for the menu component that allows the user to add this site to the reading list.")
+                    public static let RemoveFromReadingList = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.RemoveFromReadingList.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Remove from Reading List",
+                        comment: "On the main menu, in the Save submenu, the accessibility label for the menu component that allows the user to remove this site from the reading list.")
+                    public static let SaveToReadingListSubtitle = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.SaveToReadingList.Subtitle.v132",
+                        tableName: "MainMenu",
+                        value: "Reading List",
+                        comment: "On the main menu, a string below the Save submenu accessibility label, indicating what kind of tools are available in that menu. This string is for the Reading List tool.")
+                    public static let SaveAsPDF = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.SaveAsPDF.Title.v132",
+                        tableName: "MainMenu",
+                        value: "Save as PDF",
+                        comment: "On the main menu, in the Save submenu, the title for the menu component that allows the user to use the Save to PDF tool.")
+                    public static let SaveAsPDFSubtitle = MZLocalizedString(
+                        key: "MainMenu.Submenus.Save.AccessibilityLabels.SaveAsPDF.Subtitle.v132",
+                        tableName: "MainMenu",
+                        value: "PDF",
+                        comment: "On the main menu, a string below the Save submenu accessibility label, indicating what kind of tools are available in that menu. This string is for the Save as PDF tool.")
+                }
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3931,7 +3931,7 @@ extension String {
 
             public struct AccessibilityLabels {
                 public static let MainMenu = MZLocalizedString(
-                    key: "MainMenu.AccessibilityLabels.MainMenu.v132",
+                    key: "MainMenu.TabsSection.AccessibilityLabels.MainMenu.v132",
                     tableName: "MainMenu",
                     value: "Main Menu",
                     comment: "The accessibility label for the Main Menu.")

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3897,163 +3897,168 @@ extension String {
                 tableName: "MainMenu",
                 value: "Syncing paused",
                 comment: "On the main menu, at the top, when the user is signed in but there was an error syncing. The description subtitle for the sync error state.")
-            public static let CloseButtonAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.Account.CloseButton.AccessibilityLabel.v133",
-                tableName: "MainMenu",
-                value: "Close",
-                comment: "The accessibility label for the close button in the Main menu.")
-            public static let MainButtonAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.Account.MainButton.AccessibilityLabel.v133",
-                tableName: "MainMenu",
-                value: "Sign in to sync passwords, tabs, and more",
-                comment: "The accessibility label for the sign in button in the Main menu header view.")
-            public static let BackButtonAccessibilityLabel = MZLocalizedString(
-                key: "MainMenu.Account.BackButton.AccessibilityLabel.v133",
-                tableName: "MainMenu",
-                value: "Back",
-                comment: "The accessibility label for the back button in the Main menu header navigation view.")
+
+            public struct AccessibilityLabels {
+                public static let CloseButtonAccessibilityLabel = MZLocalizedString(
+                    key: "MainMenu.Account.AccessibilityLabels.CloseButton.AccessibilityLabel.v132",
+                    tableName: "MainMenu",
+                    value: "Close",
+                    comment: "The accessibility label for the close button in the Main menu.")
+                public static let MainButtonAccessibilityLabel = MZLocalizedString(
+                    key: "MainMenu.Account.AccessibilityLabels.MainButton.AccessibilityLabel.v132",
+                    tableName: "MainMenu",
+                    value: "Sign in to sync passwords, tabs, and more",
+                    comment: "The accessibility label for the sign in button in the Main menu header view.")
+                public static let BackButtonAccessibilityLabel = MZLocalizedString(
+                    key: "MainMenu.Account.AccessibilityLabels.BackButton.AccessibilityLabel.v132",
+                    tableName: "MainMenu",
+                    value: "Back",
+                    comment: "The accessibility label for the back button in the Main menu header navigation view.")
+            }
         }
 
-        public static let MainMenuAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.MainMenu.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Main Menu",
-            comment: "The accessibility label for the Main Menu.")
-        public static let NewTabMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.NewTabMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "New tab",
-            comment: "The accessibility label for the Main Menu New Tab item.")
-        public static let NewPrivateTabMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.NewPrivateTabMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "New private tab",
-            comment: "The accessibility label for the Main Menu New Private Tab item.")
-        public static let SwitchToDesktopMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.SwitchToDesktopMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Switch to desktop site",
-            comment: "The accessibility label for the Main Menu Switch to desktop site item.")
-        public static let FindInPageMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.FindInPageMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Find in page",
-            comment: "The accessibility label for the Main Menu Find in page item.")
-        public static let ToolsMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.ToolsMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Tools",
-            comment: "The accessibility label for the Main Menu Tools item.")
-        public static let ToolsMenuItemAccessibilityHint = MZLocalizedString(
-            key: "MainMenu.ToolsMenuItem.AccessibilityHint.v133",
-            tableName: "MainMenu",
-            value: "Zoom, Reader View, Translate, Review Checker",
-            comment: "The accessibility hint for the Main Menu Tools item.")
-        public static let SaveMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.SaveMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Save",
-            comment: "The accessibility label for the Main Menu Save item.")
-        public static let SaveMenuItemAccessibilityHint = MZLocalizedString(
-            key: "MainMenu.SaveMenuItem.AccessibilityHint.v133",
-            tableName: "MainMenu",
-            value: "Add bookmark, Shortcut, Home, Collection",
-            comment: "The accessibility hint for the Main Menu Save item.")
-        public static let BookmarksMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.BookmarksMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Bookmarks",
-            comment: "The accessibility label for the Main Menu Bookmarks item.")
-        public static let HistoryMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.HistoryMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "History",
-            comment: "The accessibility label for the Main Menu History item.")
-        public static let DownloadsMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.DownloadsMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Downloads",
-            comment: "The accessibility label for the Main Menu Downloads item.")
-        public static let PasswordsMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.PasswordsMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Passwords",
-            comment: "The accessibility label for the Main Menu Passwords item.")
-        public static let GetHelpMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.GetHelpMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "GetHelp",
-            comment: "The accessibility label for the Main Menu GetHelp item.")
-        public static let SettingsMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.SettingsMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Settings",
-            comment: "The accessibility label for the Main Menu Settings item.")
-        public static let ZoomMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.ZoomMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Zoom at %@",
-            comment: "The accessibility label for the Main Menu Zoom item.")
-        public static let TurnOnReaderViewMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.TurnOnReaderViewMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Turn on reader view",
-            comment: "The accessibility label for the Main Menu Turn On Reader View item.")
-        public static let TurnOnNightModeMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.TurnOnNightModeMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Turn on night mode",
-            comment: "The accessibility label for the Main Menu Turn On Night Mode item.")
-        public static let PrintMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.PrintMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Print",
-            comment: "The accessibility label for the Main Menu Print item.")
-        public static let ShareMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.ShareMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Share",
-            comment: "The accessibility label for the Main Menu Share item.")
-        public static let ReportBrokenSiteMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.ReportBrokenSiteMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Report broken site",
-            comment: "The accessibility label for the Main Menu Report Broken Site item.")
-        public static let BookmarkThisPageMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.BookmarkThisPageMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Bookmark this page",
-            comment: "The accessibility label for the Main Menu Bookmark This Page item.")
-        public static let AddToShortcutsMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.AddToShortcutsMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Add to shortcuts",
-            comment: "The accessibility label for the Main Menu Add To Shortcuts item.")
-        public static let AddToHomeScreenMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.AddToHomeScreenMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Add to home screen",
-            comment: "The accessibility label for the Main Menu Add To Home Screen item.")
-        public static let SaveToReadingListMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.SaveToReadingListMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Save to reading list",
-            comment: "The accessibility label for the Main Menu Save To Reading List item.")
-        public static let SaveAsPDFMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.SaveAsPDFMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "Save as PDF",
-            comment: "The accessibility label for the Main Menu Save As PDF item.")
-        public static let CustomizeHomepageMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.CustomizeHomepageMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: " Customize Homepage",
-            comment: "The accessibility label for the Main Menu Customize Homepage item.")
-        public static let NewInMenuItemAccessibilityLabel = MZLocalizedString(
-            key: "MainMenu.NewInMenuItem.AccessibilityLabel.v133",
-            tableName: "MainMenu",
-            value: "New in %@",
-            comment: "The accessibility label for the Main Menu New In item.")
+        public struct AccessibilityLabels {
+            public static let MainMenuAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.MainMenu.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Main Menu",
+                comment: "The accessibility label for the Main Menu.")
+            public static let NewTabMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.NewTabMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "New tab",
+                comment: "The accessibility label for the Main Menu New Tab item.")
+            public static let NewPrivateTabMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.NewPrivateTabMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "New private tab",
+                comment: "The accessibility label for the Main Menu New Private Tab item.")
+            public static let SwitchToDesktopMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.SwitchToDesktopMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Switch to desktop site",
+                comment: "The accessibility label for the Main Menu Switch to desktop site item.")
+            public static let FindInPageMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.FindInPageMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Find in page",
+                comment: "The accessibility label for the Main Menu Find in page item.")
+            public static let ToolsMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.ToolsMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Tools",
+                comment: "The accessibility label for the Main Menu Tools item.")
+            public static let ToolsMenuItemAccessibilityHint = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.ToolsMenuItem.AccessibilityHint.v132",
+                tableName: "MainMenu",
+                value: "Zoom, Reader View, Translate, Review Checker",
+                comment: "The accessibility hint for the Main Menu Tools item.")
+            public static let SaveMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.SaveMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Save",
+                comment: "The accessibility label for the Main Menu Save item.")
+            public static let SaveMenuItemAccessibilityHint = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.SaveMenuItem.AccessibilityHint.v132",
+                tableName: "MainMenu",
+                value: "Add bookmark, Shortcut, Home, Collection",
+                comment: "The accessibility hint for the Main Menu Save item.")
+            public static let BookmarksMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.BookmarksMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Bookmarks",
+                comment: "The accessibility label for the Main Menu Bookmarks item.")
+            public static let HistoryMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.HistoryMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "History",
+                comment: "The accessibility label for the Main Menu History item.")
+            public static let DownloadsMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.DownloadsMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Downloads",
+                comment: "The accessibility label for the Main Menu Downloads item.")
+            public static let PasswordsMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.PasswordsMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Passwords",
+                comment: "The accessibility label for the Main Menu Passwords item.")
+            public static let GetHelpMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.GetHelpMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "GetHelp",
+                comment: "The accessibility label for the Main Menu GetHelp item.")
+            public static let SettingsMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.SettingsMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Settings",
+                comment: "The accessibility label for the Main Menu Settings item.")
+            public static let ZoomMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.ZoomMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Zoom at %@",
+                comment: "The accessibility label for the Main Menu Zoom item.")
+            public static let TurnOnReaderViewMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.TurnOnReaderViewMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Turn on reader view",
+                comment: "The accessibility label for the Main Menu Turn On Reader View item.")
+            public static let TurnOnNightModeMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.TurnOnNightModeMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Turn on night mode",
+                comment: "The accessibility label for the Main Menu Turn On Night Mode item.")
+            public static let PrintMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.PrintMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Print",
+                comment: "The accessibility label for the Main Menu Print item.")
+            public static let ShareMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.ShareMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Share",
+                comment: "The accessibility label for the Main Menu Share item.")
+            public static let ReportBrokenSiteMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.ReportBrokenSiteMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Report broken site",
+                comment: "The accessibility label for the Main Menu Report Broken Site item.")
+            public static let BookmarkThisPageMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.BookmarkThisPageMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Bookmark this page",
+                comment: "The accessibility label for the Main Menu Bookmark This Page item.")
+            public static let AddToShortcutsMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.AddToShortcutsMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Add to shortcuts",
+                comment: "The accessibility label for the Main Menu Add To Shortcuts item.")
+            public static let AddToHomeScreenMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.AddToHomeScreenMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Add to home screen",
+                comment: "The accessibility label for the Main Menu Add To Home Screen item.")
+            public static let SaveToReadingListMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.SaveToReadingListMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Save to reading list",
+                comment: "The accessibility label for the Main Menu Save To Reading List item.")
+            public static let SaveAsPDFMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.SaveAsPDFMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "Save as PDF",
+                comment: "The accessibility label for the Main Menu Save As PDF item.")
+            public static let CustomizeHomepageMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.CustomizeHomepageMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: " Customize Homepage",
+                comment: "The accessibility label for the Main Menu Customize Homepage item.")
+            public static let NewInMenuItemAccessibilityLabel = MZLocalizedString(
+                key: "MainMenu.AccessibilityLabels.NewInMenuItem.AccessibilityLabel.v132",
+                tableName: "MainMenu",
+                value: "New in %@",
+                comment: "The accessibility label for the Main Menu New In item.")
+        }
 
         public struct TabsSection {
             public static let NewTab = MZLocalizedString(
@@ -4069,11 +4074,6 @@ extension String {
         }
 
         public struct ToolsSection {
-            public static let Description = MZLocalizedString(
-                key: "MainMenu.ToolsSection.Tools.Subtitle.v133",
-                tableName: "MainMenu",
-                value: "Zoom, Reader View, Translate, Review Checker",
-                comment: "On the main menu, the description/subtitle for the Tools section.")
             public static let SwitchToDesktopSite = MZLocalizedString(
                 key: "MainMenu.ToolsSection.SwitchToDesktopSite.Title.v131",
                 tableName: "MainMenu",
@@ -4222,11 +4222,6 @@ extension String {
             }
 
             public struct Save {
-                public static let Description = MZLocalizedString(
-                    key: "MainMenu.SaveSection.Save.Subtitle.v133",
-                    tableName: "MainMenu",
-                    value: "Add Bookmark, Shortcut, Home, Reading List, PDF",
-                    comment: "On the main menu, the description/subtitle for the Save section.")
                 public static let BookmarkThisPage = MZLocalizedString(
                     key: "MainMenu.Submenus.Save.BookmarkThisPage.Title.v131",
                     tableName: "MainMenu",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10065)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22061)

## :bulb: Description
Added accessibility strings/hints/labels for Menu
Fixed NavigationHeaderView
Added a button to HeaderView for sign in

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

