### PR TITLE
Bugfix FXIOS-10056 [Toolbar redesign] Number in tab button not dimmed

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
@@ -25,14 +25,6 @@ final class TabNumberButton: ToolbarButton {
         label.textAlignment = .center
     }
 
-    override var isHighlighted: Bool {
-        didSet {
-            countLabel.textColor = isHighlighted ?
-            foregroundColorHighlighted :
-            foregroundColorNormal
-        }
-    }
-
     // MARK: - Init
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -48,6 +40,13 @@ final class TabNumberButton: ToolbarButton {
 
         guard let numberOfTabs = element.numberOfTabs else { return }
         updateTabCount(numberOfTabs)
+    }
+
+    override public func updateConfiguration() {
+        super.updateConfiguration()
+
+        // Use image view tint color for tab number label as it gets dimmed when a modal gets displayed
+        countLabel.textColor = imageView?.tintColor ?? configuration?.baseForegroundColor
     }
 
     private func updateTabCount(_ count: Int) {
@@ -66,11 +65,5 @@ final class TabNumberButton: ToolbarButton {
             countLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
             countLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
-    }
-
-    // MARK: - Theming System
-    override func applyTheme(theme: any Theme) {
-        super.applyTheme(theme: theme)
-        countLabel.textColor = theme.colors.iconPrimary
     }
 }

--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -17,10 +17,10 @@ class ToolbarButton: UIButton, ThemeApplicable {
         static let badgeIconSize = CGSize(width: 20, height: 20)
     }
 
-    private(set) var foregroundColorNormal: UIColor = .clear
-    private(set) var foregroundColorHighlighted: UIColor = .clear
-    private(set) var foregroundColorDisabled: UIColor = .clear
-    private(set) var backgroundColorNormal: UIColor = .clear
+    private var foregroundColorNormal: UIColor = .clear
+    private var foregroundColorHighlighted: UIColor = .clear
+    private var foregroundColorDisabled: UIColor = .clear
+    private var backgroundColorNormal: UIColor = .clear
 
     private var badgeImageView: UIImageView?
     private var maskImageView: UIImageView?


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10056)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22035)

## :bulb: Description
Dims the tab number when menu is opened
![Simulator Screenshot - iPhone 15 Pro Max - 2024-09-25 at 18 39 36](https://github.com/user-attachments/assets/893f5736-b96b-40e7-a34e-083b9608a8f0)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

