### PR TITLE
Bugfix FXIOS-9818 [Unit Tests] Resolve flaky PocketDataAdaptorTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Pocket/PocketDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Pocket/PocketDataAdaptorTests.swift
@@ -6,6 +6,7 @@ import XCTest
 @testable import Client
 
 class PocketDataAdaptorTests: XCTestCase {
+    private let sleepTime: UInt64 = 1 * NSEC_PER_SEC
     var mockNotificationCenter: MockNotificationCenter!
     var mockPocketAPI: MockPocketAPI!
 
@@ -21,14 +22,15 @@ class PocketDataAdaptorTests: XCTestCase {
         mockPocketAPI = nil
     }
 
-    func testEmptyData() {
+    func testEmptyData() async throws {
         mockPocketAPI = MockPocketAPI(result: .success([]))
         let subject = createSubject()
         let data = subject.getPocketData()
+        try await Task.sleep(nanoseconds: sleepTime)
         XCTAssertEqual(data.count, 0, "Data should be null")
     }
 
-    func testGetPocketData() {
+    func testGetPocketData() async throws {
         let stories: [PocketFeedStory] = [
             .make(title: "feed1"),
             .make(title: "feed2"),
@@ -37,6 +39,7 @@ class PocketDataAdaptorTests: XCTestCase {
         mockPocketAPI = MockPocketAPI(result: .success(stories))
         let subject = createSubject()
         let data = subject.getPocketData()
+        try await Task.sleep(nanoseconds: sleepTime)
         XCTAssertEqual(data.count, 3, "Data should contain three pocket stories")
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9818)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21565)

## :bulb: Description
Adding sleep confirms that the task has finished and no longer throws an error for memory leaks. These tests will most likely go away during the homepage rebuild work, but hoping this fix should address the flakiness that we see for these tests.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

