### PR TITLE
Bugfix MTE-3547 testOpenExternalLink taps on only one link

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -531,14 +531,14 @@ class NavigationTest: BaseTestCase {
     private func validateExternalLink(isPrivate: Bool = false) {
         navigator.openURL("ultimateqa.com/dummy-automation-websites")
         waitUntilPageLoad()
-        scrollToElement(app.links["SauceDemo.com"])
-        app.links["SauceDemo.com"].tap(force: true)
+        scrollToElement(app.links["SauceDemo.com"].firstMatch)
+        app.links["SauceDemo.com"].firstMatch.tap(force: true)
         waitUntilPageLoad()
         // Sometimes first tap is not working on iPad
         if iPad() {
             if let urlTextField =  app.textFields["url"].value as? String,
                urlTextField == "ultimateqa.com/dummy-automation-websites" {
-                app.links["SauceDemo.com"].tap(force: true)
+                app.links["SauceDemo.com"].firstMatch.tap(force: true)
             }
         }
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3547)

## :bulb: Description
`testOpenExternalLink` fails because the external site contains two identical links. The test is unable to tap on more than one.

This change specifies that only the first link is tapped.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

