### PR TITLE
Bugfix MTE-3546 Update "Private browing" label for button

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -317,7 +317,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
         if isTablet {
             screenState.tap(
-                app.buttons["Private Mode"],
+                app.buttons[AccessibilityIdentifiers.Browser.TopTabs.privateModeButton],
                 forAction: Action.TogglePrivateModeFromTabBarNewTab
             ) { userState in
                 userState.isPrivate = !userState.isPrivate
@@ -447,7 +447,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(HomePanelsScreen) { screenState in
         if isTablet {
             screenState.tap(
-                app.buttons["Private Mode"],
+                app.buttons[AccessibilityIdentifiers.Browser.TopTabs.privateModeButton],
                 forAction: Action.TogglePrivateModeFromTabBarHomePanel
             ) { userState in
                 userState.isPrivate = !userState.isPrivate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3546)

## :bulb: Description
`testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad` fails due to the label for the "private browsing" button has been updated (https://github.com/mozilla-mobile/firefox-ios/pull/22174/files). Instead of hard-coding the string, we should use the `AccessibilityIdentifiers` going forward.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

