### PR TITLE
Remove MTE-3549 - workaround for testOpenExternalLink test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -543,13 +543,9 @@ class NavigationTest: BaseTestCase {
         }
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(tabsButton)
-        if !isPrivate {
-            XCTAssertEqual(tabsButton.value as? String, "2")
-        } else {
-            // External link is opened in the same tab on private mode
-            // Change validation after https://github.com/mozilla-mobile/firefox-ios/issues/21773 is fixed
-            XCTAssertEqual(tabsButton.value as? String, "1")
-        }
+        XCTAssertEqual(tabsButton.value as? String, "2")
+        // We need to close the tabs from regular mode in order to be able to interact with the elements from private tab
+        navigator.performAction(Action.AcceptRemovingAllTabs)
     }
 
     private func openContextMenuForArticleLink() {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3549

## :bulb: Description
Issue https://github.com/mozilla-mobile/firefox-ios/issues/21773 has been fixed with https://github.com/mozilla-mobile/firefox-ios/pull/22190
Added an extra line to remove all tabs on regular mode first in order to be able to interact with the private tab:
https://mozilla-hub.atlassian.net/browse/FXIOS-10122
