### PR TITLE
Bugfix FXIOS-10137 Address toolbar border in private mode not displayed

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -734,6 +734,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 if isToolbarRefactorEnabled {
                     let action = ToolbarAction(
                         url: tab.url?.displayURL,
+                        isPrivate: tab.isPrivate,
                         canGoBack: tab.canGoBack,
                         canGoForward: tab.canGoForward,
                         windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1892,7 +1892,7 @@ class BrowserViewController: UIViewController,
                 let middlewareAction = ToolbarMiddlewareAction(
                     scrollOffset: scrollController.contentOffset,
                     windowUUID: windowUUID,
-                    actionType: ToolbarMiddlewareActionType.tabModeChanged)
+                    actionType: ToolbarMiddlewareActionType.urlDidChange)
                 store.dispatch(middlewareAction)
             }
             return

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1877,6 +1877,7 @@ class BrowserViewController: UIViewController,
         guard !isToolbarRefactorEnabled else {
             let action = ToolbarAction(
                 url: tab.url?.displayURL,
+                isPrivate: tab.isPrivate,
                 isShowingNavigationToolbar: ToolbarHelper().shouldShowNavigationToolbar(for: traitCollection),
                 canGoBack: tab.canGoBack,
                 canGoForward: tab.canGoForward,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1885,6 +1885,16 @@ class BrowserViewController: UIViewController,
                 windowUUID: windowUUID,
                 actionType: ToolbarActionType.urlDidChange)
             store.dispatch(action)
+
+            if let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID),
+               toolbarState.isPrivateMode != tab.isPrivate {
+                // update toolbar borders
+                let middlewareAction = ToolbarMiddlewareAction(
+                    scrollOffset: scrollController.contentOffset,
+                    windowUUID: windowUUID,
+                    actionType: ToolbarMiddlewareActionType.tabModeChanged)
+                store.dispatch(middlewareAction)
+            }
             return
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -90,15 +90,18 @@ class ToolbarMiddlewareAction: Action {
     let buttonType: ToolbarActionState.ActionType?
     let buttonTapped: UIButton?
     let gestureType: ToolbarButtonGesture?
+    let scrollOffset: CGPoint?
 
     init(buttonType: ToolbarActionState.ActionType? = nil,
          buttonTapped: UIButton? = nil,
          gestureType: ToolbarButtonGesture? = nil,
+         scrollOffset: CGPoint? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
         self.buttonType = buttonType
         self.buttonTapped = buttonTapped
         self.gestureType = gestureType
+        self.scrollOffset = scrollOffset
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
@@ -106,4 +109,5 @@ class ToolbarMiddlewareAction: Action {
 enum ToolbarMiddlewareActionType: ActionType {
     case didTapButton
     case customA11yAction
+    case tabModeChanged // private vs normal tab
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -109,5 +109,5 @@ class ToolbarMiddlewareAction: Action {
 enum ToolbarMiddlewareActionType: ActionType {
     case didTapButton
     case customA11yAction
-    case tabModeChanged // private vs normal tab
+    case urlDidChange
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -53,7 +53,8 @@ final class ToolbarMiddleware: FeatureFlaggable {
             store.dispatch(action)
 
         case GeneralBrowserMiddlewareActionType.websiteDidScroll:
-            updateTopAddressBorderPosition(action: action, state: state)
+            guard let scrollOffset = action.scrollOffset else { return }
+            updateTopAddressBorderPosition(scrollOffset: scrollOffset, windowUUID: action.windowUUID, state: state)
 
         case GeneralBrowserMiddlewareActionType.toolbarPositionChanged:
             updateToolbarPosition(action: action, state: state)
@@ -81,6 +82,10 @@ final class ToolbarMiddleware: FeatureFlaggable {
 
         case ToolbarMiddlewareActionType.didTapButton:
             resolveToolbarMiddlewareButtonTapActions(action: action, state: state)
+
+        case ToolbarMiddlewareActionType.tabModeChanged:
+            guard let scrollOffset = action.scrollOffset else { return }
+            updateTopAddressBorderPosition(scrollOffset: scrollOffset, windowUUID: action.windowUUID, state: state)
 
         default:
             break
@@ -226,11 +231,10 @@ final class ToolbarMiddleware: FeatureFlaggable {
 
     // MARK: - Border
     // For the top placement of the address bar, the border is only visible on scroll. This is due to a design choice.
-    private func updateTopAddressBorderPosition(action: GeneralBrowserMiddlewareAction, state: AppState) {
-        guard let scrollOffset = action.scrollOffset,
-              let toolbarState = state.screenState(ToolbarState.self,
+    private func updateTopAddressBorderPosition(scrollOffset: CGPoint, windowUUID: WindowUUID, state: AppState) {
+        guard let toolbarState = state.screenState(ToolbarState.self,
                                                    for: .toolbar,
-                                                   window: action.windowUUID),
+                                                   window: windowUUID),
               toolbarState.toolbarPosition == .top
         else { return }
 
@@ -242,7 +246,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
 
         let toolbarAction = ToolbarAction(
             addressBorderPosition: addressBorderPosition,
-            windowUUID: action.windowUUID,
+            windowUUID: windowUUID,
             actionType: ToolbarActionType.borderPositionChanged
         )
         store.dispatch(toolbarAction)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -83,7 +83,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
         case ToolbarMiddlewareActionType.didTapButton:
             resolveToolbarMiddlewareButtonTapActions(action: action, state: state)
 
-        case ToolbarMiddlewareActionType.tabModeChanged:
+        case ToolbarMiddlewareActionType.urlDidChange:
             guard let scrollOffset = action.scrollOffset else { return }
             updateTopAddressBorderPosition(scrollOffset: scrollOffset, windowUUID: action.windowUUID, state: state)
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -139,7 +139,7 @@ struct ToolbarState: ScreenState, Equatable {
             return ToolbarState(
                 windowUUID: state.windowUUID,
                 toolbarPosition: state.toolbarPosition,
-                isPrivateMode: state.isPrivateMode,
+                isPrivateMode: toolbarAction.isPrivate ?? state.isPrivateMode,
                 addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
                 navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
                 isShowingNavigationToolbar: toolbarAction.isShowingNavigationToolbar ?? state.isShowingNavigationToolbar,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10137)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22208)

## :bulb: Description
Updates private mode state correctly and updates the address toolbar border when switching tab mode (normal to private and vice versa).
![Simulator Screenshot - iPhone 15 Pro Max - 2024-09-26 at 13 59 09](https://github.com/user-attachments/assets/b5d5948b-5a2e-44e1-84d5-4f1c06c37f3c)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

