### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from UITestAppDelegate.swift (3/3)

### DIFF
--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -163,7 +163,7 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
         UserDefaults.standard.setValue(false, forKey: PrefsKeys.PlacesHistoryMigrationSucceeded)
     }
 
-    fileprivate func configureTabs(_ arg: String, launchArguments: [String]) {
+    private func configureTabs(_ arg: String, launchArguments: [String]) {
         let tabDirectory = "\(self.appRootDir())/profile.profile"
         if launchArguments.contains(LaunchArguments.ClearProfile) {
             fatalError("Clearing profile and loading tabs, not a supported combination.")

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -41,51 +41,7 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
             }
 
             if arg.starts(with: LaunchArguments.LoadTabsStateArchive) {
-                let tabDirectory = "\(self.appRootDir())/profile.profile"
-                if launchArguments.contains(LaunchArguments.ClearProfile) {
-                    fatalError("Clearing profile and loading tabs, not a supported combination.")
-                }
-
-                // Grab the name of file in the bundle's test-fixtures dir, and copy it to the runtime app dir.
-                let filenameArchive = arg.replacingOccurrences(of: LaunchArguments.LoadTabsStateArchive, with: "")
-                let input = URL(
-                    fileURLWithPath: Bundle(for: UITestAppDelegate.self).path(
-                        forResource: filenameArchive,
-                        ofType: nil,
-                        inDirectory: "test-fixtures"
-                    )!
-                )
-                try? FileManager.default.createDirectory(
-                    atPath: tabDirectory,
-                    withIntermediateDirectories: false,
-                    attributes: nil
-                )
-                let outputDir = URL(fileURLWithPath: "\(tabDirectory)/window-data")
-                let outputFile = URL(
-                    fileURLWithPath: "\(tabDirectory)/window-data/window-44BA0B7D-097A-484D-8358-91A6E374451D"
-                )
-                let enumerator = FileManager.default.enumerator(atPath: "\(tabDirectory)/window-data")
-                let filePaths = enumerator?.allObjects as? [String]
-                filePaths?.filter { $0.contains("window-") }.forEach { item in
-                    do {
-                        try FileManager.default.removeItem(
-                            at: URL(fileURLWithPath: "\(tabDirectory)/window-data/\(item)")
-                        )
-                    } catch {
-                        fatalError("Could not remove items at \(tabDirectory)/window-data/\(item): \(error)")
-                    }
-                }
-
-                try? FileManager.default.createDirectory(
-                    at: outputDir,
-                    withIntermediateDirectories: true
-                )
-
-                do {
-                    try FileManager.default.copyItem(at: input, to: outputFile)
-                } catch {
-                    fatalError("Could not copy items at from \(input) to \(outputFile): \(error)")
-                }
+                configureTabs(arg, launchArguments: launchArguments)
             }
         }
 

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -207,6 +207,54 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
         UserDefaults.standard.setValue(false, forKey: PrefsKeys.PlacesHistoryMigrationSucceeded)
     }
 
+    fileprivate func configureTabs(_ arg: String, launchArguments: [String]) {
+        let tabDirectory = "\(self.appRootDir())/profile.profile"
+        if launchArguments.contains(LaunchArguments.ClearProfile) {
+            fatalError("Clearing profile and loading tabs, not a supported combination.")
+        }
+
+        // Grab the name of file in the bundle's test-fixtures dir, and copy it to the runtime app dir.
+        let filenameArchive = arg.replacingOccurrences(of: LaunchArguments.LoadTabsStateArchive, with: "")
+        let input = URL(
+            fileURLWithPath: Bundle(for: UITestAppDelegate.self).path(
+                forResource: filenameArchive,
+                ofType: nil,
+                inDirectory: "test-fixtures"
+            )!
+        )
+        try? FileManager.default.createDirectory(
+            atPath: tabDirectory,
+            withIntermediateDirectories: false,
+            attributes: nil
+        )
+        let outputDir = URL(fileURLWithPath: "\(tabDirectory)/window-data")
+        let outputFile = URL(
+            fileURLWithPath: "\(tabDirectory)/window-data/window-44BA0B7D-097A-484D-8358-91A6E374451D"
+        )
+        let enumerator = FileManager.default.enumerator(atPath: "\(tabDirectory)/window-data")
+        let filePaths = enumerator?.allObjects as? [String]
+        filePaths?.filter { $0.contains("window-") }.forEach { item in
+            do {
+                try FileManager.default.removeItem(
+                    at: URL(fileURLWithPath: "\(tabDirectory)/window-data/\(item)")
+                )
+            } catch {
+                fatalError("Could not remove items at \(tabDirectory)/window-data/\(item): \(error)")
+            }
+        }
+
+        try? FileManager.default.createDirectory(
+            at: outputDir,
+            withIntermediateDirectories: true
+        )
+
+        do {
+            try FileManager.default.copyItem(at: input, to: outputFile)
+        } catch {
+            fatalError("Could not copy items at from \(input) to \(outputFile): \(error)")
+        }
+    }
+
     override func application(
         _ application: UIApplication,
         willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `UITestAppDelegate.swift` file. It is the last part, and in this one I've extracted the tab's configuration into a new function.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

