### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from FakespotState.swift (3/3)

### DIFF
--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -91,11 +91,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleDismiss(state: state)
 
         case FakespotActionType.setAppearanceTo:
-            let isEnabled = action.isOpen ?? state.isOpen
-            var state = state
-            state.isOpen = isEnabled
-            state.sendSurfaceDisplayedTelemetryEvent = !isEnabled
-            return state
+            return handleAppearance(action: action, state: state)
 
         case FakespotActionType.surfaceDisplayedEventSend:
             var state = state

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -175,7 +175,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handleAppearance(action: FakespotAction, state: FakespotState) -> FakespotState {
+    private static func handleAppearance(action: FakespotAction, state: FakespotState) -> FakespotState {
         let isEnabled = action.isOpen ?? state.isOpen
         var state = state
         state.isOpen = isEnabled

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -204,4 +204,14 @@ struct FakespotState: ScreenState, Equatable {
         state.telemetryState[state.currentTabUUID]?.adEvents[productId]?.sendAdsImpressionEvent = false
         return state
     }
+
+    fileprivate static func handleAdsExposure(action: FakespotAction, state: FakespotState) -> FakespotState {
+        guard let productId = action.productId else { return state }
+        var state = state
+        if state.telemetryState[state.currentTabUUID]?.adEvents[productId] == nil {
+            state.telemetryState[state.currentTabUUID]?.adEvents[productId] = AdTelemetryState()
+        }
+        state.telemetryState[state.currentTabUUID]?.adEvents[productId]?.sendAdExposureEvent = false
+        return state
+    }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -94,7 +94,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleAppearance(action: action, state: state)
 
         case FakespotActionType.surfaceDisplayedEventSend:
-            return handleSurfaceDisplayed(state: state)
+            return handleSurfaceDisplayedEvent(state: state)
 
         case FakespotActionType.adsImpressionEventSendFor:
             return handleAdsImpression(action: action, state: state)
@@ -183,7 +183,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    private static func handleSurfaceDisplayed(state: FakespotState) -> FakespotState {
+    private static func handleSurfaceDisplayedEvent(state: FakespotState) -> FakespotState {
         var state = state
         state.sendSurfaceDisplayedTelemetryEvent = false
         return state

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -100,13 +100,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleAdsImpression(action: action, state: state)
 
         case FakespotActionType.adsExposureEventSendFor:
-            guard let productId = action.productId else { return state }
-            var state = state
-            if state.telemetryState[state.currentTabUUID]?.adEvents[productId] == nil {
-                state.telemetryState[state.currentTabUUID]?.adEvents[productId] = AdTelemetryState()
-            }
-            state.telemetryState[state.currentTabUUID]?.adEvents[productId]?.sendAdExposureEvent = false
-            return state
+            return handleAdsExposure(action: action, state: state)
 
         default:
             return state

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -100,7 +100,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleAdsImpressionEvent(action: action, state: state)
 
         case FakespotActionType.adsExposureEventSendFor:
-            return handleAdsExposure(action: action, state: state)
+            return handleAdsExposureEvent(action: action, state: state)
 
         default:
             return state
@@ -199,7 +199,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    private static func handleAdsExposure(action: FakespotAction, state: FakespotState) -> FakespotState {
+    private static func handleAdsExposureEvent(action: FakespotAction, state: FakespotState) -> FakespotState {
         guard let productId = action.productId else { return state }
         var state = state
         if state.telemetryState[state.currentTabUUID]?.adEvents[productId] == nil {

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -200,4 +200,14 @@ struct FakespotState: ScreenState, Equatable {
         state.sendSurfaceDisplayedTelemetryEvent = false
         return state
     }
+
+    fileprivate static func handleAdsImpression(action: FakespotAction, state: FakespotState) -> FakespotState {
+        guard let productId = action.productId else { return state }
+        var state = state
+        if state.telemetryState[state.currentTabUUID]?.adEvents[productId] == nil {
+            state.telemetryState[state.currentTabUUID]?.adEvents[productId] = AdTelemetryState()
+        }
+        state.telemetryState[state.currentTabUUID]?.adEvents[productId]?.sendAdsImpressionEvent = false
+        return state
+    }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -192,4 +192,12 @@ struct FakespotState: ScreenState, Equatable {
         state.sendSurfaceDisplayedTelemetryEvent = true
         return state
     }
+
+    fileprivate static func handleAppearance(action: FakespotAction, state: FakespotState) -> FakespotState {
+        let isEnabled = action.isOpen ?? state.isOpen
+        var state = state
+        state.isOpen = isEnabled
+        state.sendSurfaceDisplayedTelemetryEvent = !isEnabled
+        return state
+    }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -196,4 +196,10 @@ struct FakespotState: ScreenState, Equatable {
         state.sendSurfaceDisplayedTelemetryEvent = !isEnabled
         return state
     }
+
+    fileprivate static func handleSurfaceDisplayed(state: FakespotState) -> FakespotState {
+        var state = state
+        state.sendSurfaceDisplayedTelemetryEvent = false
+        return state
+    }
 }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -183,7 +183,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handleSurfaceDisplayed(state: FakespotState) -> FakespotState {
+    private static func handleSurfaceDisplayed(state: FakespotState) -> FakespotState {
         var state = state
         state.sendSurfaceDisplayedTelemetryEvent = false
         return state

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -97,7 +97,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleSurfaceDisplayedEvent(state: state)
 
         case FakespotActionType.adsImpressionEventSendFor:
-            return handleAdsImpression(action: action, state: state)
+            return handleAdsImpressionEvent(action: action, state: state)
 
         case FakespotActionType.adsExposureEventSendFor:
             return handleAdsExposure(action: action, state: state)
@@ -189,7 +189,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    private static func handleAdsImpression(action: FakespotAction, state: FakespotState) -> FakespotState {
+    private static func handleAdsImpressionEvent(action: FakespotAction, state: FakespotState) -> FakespotState {
         guard let productId = action.productId else { return state }
         var state = state
         if state.telemetryState[state.currentTabUUID]?.adEvents[productId] == nil {

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -97,13 +97,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleSurfaceDisplayed(state: state)
 
         case FakespotActionType.adsImpressionEventSendFor:
-            guard let productId = action.productId else { return state }
-            var state = state
-            if state.telemetryState[state.currentTabUUID]?.adEvents[productId] == nil {
-                state.telemetryState[state.currentTabUUID]?.adEvents[productId] = AdTelemetryState()
-            }
-            state.telemetryState[state.currentTabUUID]?.adEvents[productId]?.sendAdsImpressionEvent = false
-            return state
+            return handleAdsImpression(action: action, state: state)
 
         case FakespotActionType.adsExposureEventSendFor:
             guard let productId = action.productId else { return state }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -94,9 +94,7 @@ struct FakespotState: ScreenState, Equatable {
             return handleAppearance(action: action, state: state)
 
         case FakespotActionType.surfaceDisplayedEventSend:
-            var state = state
-            state.sendSurfaceDisplayedTelemetryEvent = false
-            return state
+            return handleSurfaceDisplayed(state: state)
 
         case FakespotActionType.adsImpressionEventSendFor:
             guard let productId = action.productId else { return state }

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -189,7 +189,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handleAdsImpression(action: FakespotAction, state: FakespotState) -> FakespotState {
+    private static func handleAdsImpression(action: FakespotAction, state: FakespotState) -> FakespotState {
         guard let productId = action.productId else { return state }
         var state = state
         if state.telemetryState[state.currentTabUUID]?.adEvents[productId] == nil {

--- a/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
+++ b/firefox-ios/Client/Frontend/Fakespot/FakespotState.swift
@@ -199,7 +199,7 @@ struct FakespotState: ScreenState, Equatable {
         return state
     }
 
-    fileprivate static func handleAdsExposure(action: FakespotAction, state: FakespotState) -> FakespotState {
+    private static func handleAdsExposure(action: FakespotAction, state: FakespotState) -> FakespotState {
         guard let productId = action.productId else { return state }
         var state = state
         if state.telemetryState[state.currentTabUUID]?.adEvents[productId] == nil {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `FakespotState.swift` file. It extracts to new functions the logic to:
- handle appearance
- handle surface displayed event
- handle ads impression event
- handle ads exposure event

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

