### PR TITLE
Bugfix MTE-3550 Eliminating deprecated commands from Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,6 @@
 queue_rules:
   - name: default
-    conditions:
+    queue_conditions:
       - check-success=Bitrise
 
 pull_request_rules:
@@ -22,7 +22,7 @@ pull_request_rules:
         type: APPROVE
         message: Github-action[bot] 💪
       queue:
-        method: rebase
+        merge_method: rebase
         name: default
   - name: Rust Component Upgrade - Auto Merge
     conditions:
@@ -35,7 +35,7 @@ pull_request_rules:
         type: APPROVE
         message: Github-action[bot] 💪
       queue:
-        method: rebase
+        merge_method: rebase
         name: default
   - name: L10N - Auto Merge
     conditions:
@@ -48,7 +48,7 @@ pull_request_rules:
         type: APPROVE
         message: LGTM 😎
       queue:
-        method: rebase
+        merge_method: rebase
         name: default
   - name: Needs landing - Rebase
     conditions:
@@ -59,7 +59,7 @@ pull_request_rules:
       - label!=Do Not Merge ⛔️
     actions:
       queue:
-        method: rebase
+        merge_method: rebase
         name: default
   - name: Needs landing - Squash
     conditions:
@@ -70,5 +70,5 @@ pull_request_rules:
       - label!=Do Not Merge ⛔️
     actions:
       queue:
-        method: squash
+        merge_method: squash
         name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,7 @@ queue_rules:
   - name: squash-queue
     queue_conditions:
       - check-success=Bitrise
-    merge_method: rebase
+    merge_method: squash
 
 pull_request_rules:
   - name: Resolve conflict
@@ -27,7 +27,7 @@ pull_request_rules:
         type: APPROVE
         message: Github-action[bot] 💪
       queue:
-        name: rebase_queue
+        name: rebase-queue
   - name: Rust Component Upgrade - Auto Merge
     conditions:
       - author=github-actions[bot]
@@ -39,7 +39,7 @@ pull_request_rules:
         type: APPROVE
         message: Github-action[bot] 💪
       queue:
-        name: rebase_queue
+        name: rebase-queue
   - name: L10N - Auto Merge
     conditions:
       - author=github-actions[bot]
@@ -51,7 +51,7 @@ pull_request_rules:
         type: APPROVE
         message: LGTM 😎
       queue:
-        name: rebase_queue
+        name: rebase-queue
   - name: Needs landing - Rebase
     conditions:
       - check-success=Bitrise
@@ -61,7 +61,7 @@ pull_request_rules:
       - label!=Do Not Merge ⛔️
     actions:
       queue:
-        name: rebase_queue
+        name: rebase-queue
   - name: Needs landing - Squash
     conditions:
       - check-success=Bitrise
@@ -71,4 +71,4 @@ pull_request_rules:
       - label!=Do Not Merge ⛔️
     actions:
       queue:
-        name: squash_queue
+        name: squash-queue

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,12 @@
 queue_rules:
-  - name: default
+  - name: rebase-queue
     queue_conditions:
       - check-success=Bitrise
+    merge_method: rebase
+  - name: squash-queue
+    queue_conditions:
+      - check-success=Bitrise
+    merge_method: rebase
 
 pull_request_rules:
   - name: Resolve conflict
@@ -22,8 +27,7 @@ pull_request_rules:
         type: APPROVE
         message: Github-action[bot] 💪
       queue:
-        merge_method: rebase
-        name: default
+        name: rebase_queue
   - name: Rust Component Upgrade - Auto Merge
     conditions:
       - author=github-actions[bot]
@@ -35,8 +39,7 @@ pull_request_rules:
         type: APPROVE
         message: Github-action[bot] 💪
       queue:
-        merge_method: rebase
-        name: default
+        name: rebase_queue
   - name: L10N - Auto Merge
     conditions:
       - author=github-actions[bot]
@@ -48,8 +51,7 @@ pull_request_rules:
         type: APPROVE
         message: LGTM 😎
       queue:
-        merge_method: rebase
-        name: default
+        name: rebase_queue
   - name: Needs landing - Rebase
     conditions:
       - check-success=Bitrise
@@ -59,8 +61,7 @@ pull_request_rules:
       - label!=Do Not Merge ⛔️
     actions:
       queue:
-        merge_method: rebase
-        name: default
+        name: rebase_queue
   - name: Needs landing - Squash
     conditions:
       - check-success=Bitrise
@@ -70,5 +71,4 @@ pull_request_rules:
       - label!=Do Not Merge ⛔️
     actions:
       queue:
-        merge_method: squash
-        name: default
+        name: squash_queue

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,12 @@
 queue_rules:
-  - name: default
+  - name: rebase-queue
     queue_conditions:
       - check-success=Bitrise
+    merge_method: rebase  
+  - name: squash-queue
+    queue_conditions:
+      - check-success=Bitrise
+    merge_method: squash
 
 pull_request_rules:
   - name: Resolve conflict
@@ -22,7 +27,7 @@ pull_request_rules:
         type: APPROVE
         message: Github-action[bot] 💪
       queue:
-        name: default
+        name: rebase-queue
   - name: Rust Component Upgrade - Auto Merge
     conditions:
       - author=github-actions[bot]
@@ -34,7 +39,7 @@ pull_request_rules:
         type: APPROVE
         message: Github-action[bot] 💪
       queue:
-        name: default
+        name: rebase-queue
   - name: L10N - Auto Merge
     conditions:
       - author=github-actions[bot]
@@ -46,7 +51,7 @@ pull_request_rules:
         type: APPROVE
         message: LGTM 😎
       queue:
-        name: default
+        name: rebase-queue
   - name: Needs landing - Rebase
     conditions:
       - check-success=Bitrise
@@ -56,7 +61,7 @@ pull_request_rules:
       - label!=Do Not Merge ⛔️
     actions:
       queue:
-        name: default
+        name: rebase-queue
   - name: Needs landing - Squash
     conditions:
       - check-success=Bitrise
@@ -66,4 +71,4 @@ pull_request_rules:
       - label!=Do Not Merge ⛔️
     actions:
       queue:
-        name: default
+        name: squash-queue

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,12 +1,7 @@
 queue_rules:
-  - name: rebase-queue
+  - name: default
     queue_conditions:
       - check-success=Bitrise
-    merge_method: rebase
-  - name: squash-queue
-    queue_conditions:
-      - check-success=Bitrise
-    merge_method: squash
 
 pull_request_rules:
   - name: Resolve conflict
@@ -27,7 +22,7 @@ pull_request_rules:
         type: APPROVE
         message: Github-action[bot] 💪
       queue:
-        name: rebase-queue
+        name: default
   - name: Rust Component Upgrade - Auto Merge
     conditions:
       - author=github-actions[bot]
@@ -39,7 +34,7 @@ pull_request_rules:
         type: APPROVE
         message: Github-action[bot] 💪
       queue:
-        name: rebase-queue
+        name: default
   - name: L10N - Auto Merge
     conditions:
       - author=github-actions[bot]
@@ -51,7 +46,7 @@ pull_request_rules:
         type: APPROVE
         message: LGTM 😎
       queue:
-        name: rebase-queue
+        name: default
   - name: Needs landing - Rebase
     conditions:
       - check-success=Bitrise
@@ -61,7 +56,7 @@ pull_request_rules:
       - label!=Do Not Merge ⛔️
     actions:
       queue:
-        name: rebase-queue
+        name: default
   - name: Needs landing - Squash
     conditions:
       - check-success=Bitrise
@@ -71,4 +66,4 @@ pull_request_rules:
       - label!=Do Not Merge ⛔️
     actions:
       queue:
-        name: squash-queue
+        name: default


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3550)

## :bulb: Description
`merge` commands under `pull_request_rules` will be removed on Oct 2024. We should use the [Queue Rules](https://docs.mergify.com/configuration/file-format/#queue-rules). I determined that `merge_method` Queue Rule should be what we need.

I have not tested this change. Let me find out how to do so.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

