### PR TITLE
Bugfix FXIOS-9991 - Auto-Completion of website URL requires multiple deletions to enter desired URL on some devices

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -302,9 +302,7 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
 
          return {
              // If calling again, invalidate the last timer.
-             if let timer = timer {
-                 timer.invalidate()
-             }
+             if let timer { timer.invalidate() }
              timer = Timer(
                  timeInterval: delay,
                  target: callback,

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -97,9 +97,8 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         notifyTextChanged = { [self] in
             guard urlTextField.isEditing else { return }
 
-            urlTextField.text = urlTextField.text?.lowercased()
-            urlAbsolutePath = urlTextField.text
-            delegate?.locationViewDidEnterText(urlTextField.text ?? "")
+            urlAbsolutePath = urlTextField.text?.lowercased()
+            delegate?.locationViewDidEnterText(urlAbsolutePath ?? "")
         }
     }
 
@@ -243,9 +242,8 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
     private func updateUIForSearchEngineDisplay() {
         removeContainerIcons()
         iconContainerStackView.addArrangedSubview(searchEngineContentView)
-        urlTextFieldLeadingConstraint?.constant = UX.horizontalSpace
-        iconContainerStackViewLeadingConstraint?.constant = UX.horizontalSpace
         updateURLTextFieldLeadingConstraint(constant: UX.horizontalSpace)
+        iconContainerStackViewLeadingConstraint?.constant = UX.horizontalSpace
         updateGradient()
     }
 
@@ -253,7 +251,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         guard !isEditing else { return }
         removeContainerIcons()
         iconContainerStackView.addArrangedSubview(lockIconButton)
-        urlTextFieldLeadingConstraint?.constant = 0
+        updateURLTextFieldLeadingConstraint()
         iconContainerStackViewLeadingConstraint?.constant = 0
         updateGradient()
     }

--- a/firefox-ios/Client/Frontend/Browser/SearchLoader.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchLoader.swift
@@ -14,7 +14,7 @@ private let URLBeforePathRegex = try? NSRegularExpression(pattern: "^https?://([
  * Shared data source for the SearchViewController and the URLBar domain completion.
  * Since both of these use the same SQL query, we can perform the query once and dispatch the results.
  */
-class SearchLoader: Loader<Cursor<Site>, SearchViewModel>, FeatureFlaggable {
+final class SearchLoader: Loader<Cursor<Site>, SearchViewModel>, FeatureFlaggable {
     fileprivate let profile: Profile
     fileprivate let autocompleteView: Autocompletable
     private let logger: Logger


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9991)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21941)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR will:
- Fix an issue where `urlTextField.text` was accessed multiple times, potentially leading to inconsistent values. Update the code to compute the lowercase value once and use it consistently, ensuring reliable behavior.
- Simplify some code.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

