### PR TITLE
Bugfix FXIOS-8948 Fix toolbar a11y labels

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -10,7 +10,6 @@ class PrivateModeButton: ToggleButton, PrivateModeUI {
     override init(frame: CGRect) {
         super.init(frame: frame)
         accessibilityLabel = .TabTrayToggleAccessibilityLabel
-        accessibilityHint = .TabTrayToggleAccessibilityHint
         let maskImage = UIImage(named: StandardImageIdentifiers.Large.privateMode)?
             .withRenderingMode(.alwaysTemplate)
         setImage(maskImage, for: [])

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -31,9 +31,9 @@ class AddressToolbarContainerModel: Equatable {
 
         let locationViewState = LocationViewState(
             searchEngineImageViewA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.searchEngine,
-            searchEngineImageViewA11yLabel: .AddressToolbar.PrivacyAndSecuritySettingsA11yLabel,
+            searchEngineImageViewA11yLabel: .AddressToolbar.SearchEngineA11yLabel,
             lockIconButtonA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon,
-            lockIconButtonA11yLabel: .AddressToolbar.SearchEngineA11yLabel,
+            lockIconButtonA11yLabel: .AddressToolbar.PrivacyAndSecuritySettingsA11yLabel,
             urlTextFieldPlaceholder: .AddressToolbar.LocationPlaceholder,
             urlTextFieldA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField,
             urlTextFieldA11yLabel: .AddressToolbar.LocationA11yLabel,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -12,6 +12,7 @@ class AddressToolbarContainerModel: Equatable {
     let browserActions: [ToolbarElement]
 
     let borderPosition: AddressToolbarBorderPosition?
+    let searchEngineName: String?
     let searchEngineImage: UIImage?
     let searchEngines: SearchEngines
     let lockIconImageName: String?
@@ -31,7 +32,10 @@ class AddressToolbarContainerModel: Equatable {
 
         let locationViewState = LocationViewState(
             searchEngineImageViewA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.searchEngine,
-            searchEngineImageViewA11yLabel: .AddressToolbar.SearchEngineA11yLabel,
+            searchEngineImageViewA11yLabel: String(
+                format: .AddressToolbar.SearchEngineA11yLabel,
+                searchEngineName ?? ""
+            ),
             lockIconButtonA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon,
             lockIconButtonA11yLabel: .AddressToolbar.PrivacyAndSecuritySettingsA11yLabel,
             urlTextFieldPlaceholder: .AddressToolbar.LocationPlaceholder,
@@ -79,6 +83,7 @@ class AddressToolbarContainerModel: Equatable {
                                                                       isShowingTopTabs: state.isShowingTopTabs,
                                                                       windowUUID: windowUUID)
         self.windowUUID = windowUUID
+        self.searchEngineName = profile.searchEngines.defaultEngine?.shortName
         self.searchEngineImage = profile.searchEngines.defaultEngine?.image
         self.searchEngines = profile.searchEngines
         self.lockIconImageName = state.addressToolbar.lockIconImageName

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
@@ -54,7 +54,6 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
         button.layer.cornerRadius = button.frame.size.width / 2
         button.addTarget(self, action: #selector(self?.switchMode), for: .touchUpInside)
         button.accessibilityLabel = .TabTrayToggleAccessibilityLabel
-        button.accessibilityHint = .TabTrayToggleAccessibilityHint
         button.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton
     }
 

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomepageHeaderCell.swift
@@ -115,5 +115,8 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
         let privateModeButtonTintColor = viewModel.isPrivate ? theme.colors.layer2 : theme.colors.iconPrimary
         privateModeButton.imageView?.tintColor = privateModeButtonTintColor
         privateModeButton.backgroundColor = viewModel.isPrivate ? .white : .clear
+        privateModeButton.accessibilityValue = viewModel.isPrivate ?
+            .TabTrayToggleAccessibilityValueOn :
+            .TabTrayToggleAccessibilityValueOff
     }
 }

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -6120,11 +6120,6 @@ extension String {
         tableName: "PrivateBrowsing",
         value: "Private browsing",
         comment: "Accessibility label for toggling on/off private mode")
-    public static let TabTrayToggleAccessibilityHint = MZLocalizedString(
-        key: "Turns private mode on or off",
-        tableName: "PrivateBrowsing",
-        value: nil,
-        comment: "Accessiblity hint for toggling on/off private mode")
     public static let TabTrayToggleAccessibilityValueOn = MZLocalizedString(
         key: "On",
         tableName: "PrivateBrowsing",
@@ -7142,6 +7137,11 @@ extension String {
                 tableName: "PrivateBrowsing",
                 value: nil,
                 comment: "Accessibility label for toggling on/off private mode")
+            public static let TabTrayToggleAccessibilityHint = MZLocalizedString(
+                key: "Turns private mode on or off",
+                tableName: "PrivateBrowsing",
+                value: nil,
+                comment: "Accessiblity hint for toggling on/off private mode")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8948)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19758)

## :bulb: Description
- Add "on" / "off" a11y value for the private mode toggle on the homepage
- Remove redundant a11y hint from the private mode toggle on the homepage and in the top tabs controller
- Swap the "lock" and "search engine" a11y labels, since they were mismatched
- Include search engine name argument to a11y label

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

