### PR TITLE
Bugfix FXIOS-10144 Inactive tabs setting toggle regression [Inactive Tabs]

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -233,7 +233,7 @@ class TabManagerMiddleware {
 
         let tabManager = tabManager(for: uuid)
         var inactiveTabs = [InactiveTabsModel]()
-        for tab in tabManager.inactiveTabs {
+        for tab in tabManager.getInactiveTabs() {
             let inactiveTab = InactiveTabsModel(tabUUID: tab.tabUUID,
                                                 title: tab.displayTitle,
                                                 url: tab.url,

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -87,7 +87,11 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     }
 
     var normalActiveTabs: [Tab] {
-        return normalTabs.filter({ $0.isActive })
+        if isInactiveTabsEnabled {
+            return normalTabs.filter({ $0.isActive })
+        } else {
+            return normalTabs
+        }
     }
 
     var inactiveTabs: [Tab] {
@@ -852,13 +856,13 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
             // If so, handle this gracefully (i.e. close the last private tab should open the most recent normal active tab).
             let viableTabs = removedTab.isPrivate
                                  ? privateTabs
-                                 : normalActiveTabs // We never want to surface an inactive tab
+                                 : normalActiveTabs // We never want to surface an inactive tab, if inactive tabs enabled
             guard !viableTabs.isEmpty else {
                 // If the selected tab is closed, and is private browsing, try to select a recent normal active tab. For all
                 // other cases, open a new normal active tab.
                 if removedTab.isPrivate,
-                   let mostRecentActiveTab = mostRecentTab(inTabs: normalActiveTabs) {
-                    selectTab(mostRecentActiveTab, previous: removedTab)
+                   let mostRecentViableTab = mostRecentTab(inTabs: viableTabs) {
+                    selectTab(mostRecentViableTab, previous: removedTab)
                 } else {
                     selectTab(addTab(), previous: removedTab)
                 }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -861,8 +861,8 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
                 // If the selected tab is closed, and is private browsing, try to select a recent normal active tab. For all
                 // other cases, open a new normal active tab.
                 if removedTab.isPrivate,
-                   let mostRecentViableTab = mostRecentTab(inTabs: viableTabs) {
-                    selectTab(mostRecentViableTab, previous: removedTab)
+                   let mostRecentActiveTab = mostRecentTab(inTabs: normalActiveTabs) {
+                    selectTab(mostRecentActiveTab, previous: removedTab)
                 } else {
                     selectTab(addTab(), previous: removedTab)
                 }

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -98,9 +98,14 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         return tabs.filter { $0.isPrivate }
     }
 
+    var isInactiveTabsEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildAndUser)
+    }
+
     /// This variable returns all normal tabs, sorted chronologically, excluding any home page tabs.
     var recentlyAccessedNormalTabs: [Tab] {
-        var eligibleTabs = normalActiveTabs // Do not include inactive tabs, as they are not "recently" accessed
+        // If inactive tabs are enabled, do not include inactive tabs, as they are not "recently" accessed
+        var eligibleTabs = isInactiveTabsEnabled ? normalActiveTabs : normalTabs
 
         eligibleTabs = eligibleTabs.filter { tab in
             if tab.lastKnownUrl == nil {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -916,7 +916,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable {
             return true
         case (false, false):
             // Two normal tabs are only the same type if they're both active, or both inactive
-            return isInactiveTabsEnabled 
+            return isInactiveTabsEnabled
                 ? self.isActive == otherTab.isActive
                 : true
         default:

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -66,7 +66,7 @@ enum TabUrlType: String {
 
 typealias TabUUID = String
 
-class Tab: NSObject, ThemeApplicable {
+class Tab: NSObject, ThemeApplicable, FeatureFlaggable {
     static let privateModeKey = "PrivateModeKey"
     private var _isPrivate = false
     private(set) var isPrivate: Bool {
@@ -80,16 +80,20 @@ class Tab: NSObject, ThemeApplicable {
         }
     }
 
+    var isInactiveTabsEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildAndUser)
+    }
+
     var isNormal: Bool {
         return !isPrivate
     }
 
     var isNormalActive: Bool {
-        return !isPrivate && isActive
+        return !isPrivate && (isInactiveTabsEnabled ? isActive : true)
     }
 
     var isNormalAndInactive: Bool {
-        return !isPrivate && isInactive
+        return !isPrivate && (isInactiveTabsEnabled ? isInactive : false)
     }
 
     /// The window associated with the tab (where the tab lives and will be displayed).
@@ -912,7 +916,9 @@ class Tab: NSObject, ThemeApplicable {
             return true
         case (false, false):
             // Two normal tabs are only the same type if they're both active, or both inactive
-            return self.isActive == otherTab.isActive
+            return isInactiveTabsEnabled 
+                ? self.isActive == otherTab.isActive
+                : true
         default:
             return false
         }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -23,7 +23,9 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
     var inactiveTabsManager: InactiveTabsManagerProtocol
 
     override var normalActiveTabs: [Tab] {
-        return tabs.filter { !$0.isPrivate && $0.isActive }
+        let inactiveTabs = getInactiveTabs()
+        let activeTabs = tabs.filter { $0.isPrivate == false && !inactiveTabs.contains($0) }
+        return activeTabs
     }
 
     init(profile: Profile,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -761,7 +761,7 @@ class TabManagerTests: XCTestCase {
         XCTAssertEqual(tabManager.selectedIndex, 0)
         XCTAssertEqual(tabManager.selectedTabUUID?.uuidString, privateTab.tabUUID)
 
-        // Remove the last selected private tab
+        // Remove the selected single private tab
         tabManager.removeTab(privateTab)
         try await Task.sleep(nanoseconds: sleepTime)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -9,11 +9,15 @@ import Shared
 @testable import Client
 
 class TabTests: XCTestCase {
+    var mockProfile: MockProfile!
     private var tabDelegate: MockLegacyTabDelegate!
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
     override func setUp() {
         super.setUp()
+        mockProfile = MockProfile()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
+
         // Disable debug flag for faster inactive tabs and perform tests based on the real 14 day time to inactive
         UserDefaults.standard.set(false, forKey: PrefsKeys.FasterInactiveTabsOverride)
     }
@@ -36,14 +40,14 @@ class TabTests: XCTestCase {
 
     func testDisplayTitle_ForHomepageURL() {
         let url = URL(string: "internal://local/about/home")!
-        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
+        let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
         tab.url = url
         let expectedDisplayTitle = String.LegacyAppMenu.AppMenuOpenHomePageTitleString
         XCTAssertEqual(tab.displayTitle, expectedDisplayTitle)
     }
 
     func testTabDoesntLeak() {
-        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
+        let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
         tab.tabDelegate = tabDelegate
         trackForMemoryLeaks(tab)
     }
@@ -52,7 +56,7 @@ class TabTests: XCTestCase {
 
     func testTabIsActive_within14Days() {
         // Tabs use the current date by default, so this one should be considered recent and active on initialization
-        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
+        let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
 
         XCTAssertTrue(tab.isActive)
         XCTAssertFalse(tab.isInactive)
@@ -60,7 +64,7 @@ class TabTests: XCTestCase {
 
     func testTabIsInactive_outside14Days() {
         let lastMonthDate = Date().lastMonth
-        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID, tabCreatedTime: lastMonthDate)
+        let tab = Tab(profile: mockProfile, windowUUID: windowUUID, tabCreatedTime: lastMonthDate)
 
         XCTAssertFalse(tab.isActive)
         XCTAssertTrue(tab.isInactive)
@@ -72,12 +76,12 @@ class TabTests: XCTestCase {
         let lastMonthDate = Date().lastMonth
 
         let privateActiveTab = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             isPrivate: true,
             windowUUID: windowUUID
         )
         let privateInactiveTab = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             isPrivate: true,
             windowUUID: windowUUID,
             tabCreatedTime: lastMonthDate
@@ -90,12 +94,12 @@ class TabTests: XCTestCase {
 
     func testIsSameTypeAs_trueForTwoPrivateTabs_bothActive() {
         let privateActiveTab1 = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             isPrivate: true,
             windowUUID: windowUUID
         )
         let privateActiveTab2 = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             isPrivate: true,
             windowUUID: windowUUID
         )
@@ -108,13 +112,13 @@ class TabTests: XCTestCase {
         let lastMonthDate = Date().lastMonth
 
         let privateInctiveTab1 = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             isPrivate: true,
             windowUUID: windowUUID,
             tabCreatedTime: lastMonthDate
         )
         let privateInactiveTab2 = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             isPrivate: true,
             windowUUID: windowUUID,
             tabCreatedTime: lastMonthDate
@@ -128,16 +132,16 @@ class TabTests: XCTestCase {
         let lastMonthDate = Date().lastMonth
 
         let privateTab = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             isPrivate: true,
             windowUUID: windowUUID
         )
         let normalActiveTab = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             windowUUID: windowUUID
         )
         let normalInactiveTab = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             windowUUID: windowUUID,
             tabCreatedTime: lastMonthDate
         )
@@ -153,11 +157,11 @@ class TabTests: XCTestCase {
         let lastMonthDate = Date().lastMonth
 
         let normalActiveTab = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             windowUUID: windowUUID
         )
         let normalInactiveTab = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             windowUUID: windowUUID,
             tabCreatedTime: lastMonthDate
         )
@@ -169,11 +173,11 @@ class TabTests: XCTestCase {
 
     func testIsSameTypeAs_trueForTwoNormalTabs_bothActive() {
         let normalActiveTab1 = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             windowUUID: windowUUID
         )
         let normalActiveTab2 = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             windowUUID: windowUUID
         )
 
@@ -185,12 +189,12 @@ class TabTests: XCTestCase {
         let lastMonthDate = Date().lastMonth
 
         let normalInctiveTab1 = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             windowUUID: windowUUID,
             tabCreatedTime: lastMonthDate
         )
         let normalInctiveTab2 = Tab(
-            profile: MockProfile(),
+            profile: mockProfile,
             windowUUID: windowUUID,
             tabCreatedTime: lastMonthDate
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10144)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22231)

## :bulb: Description
This change adds back support for the setting to turn off and on Inactive Tabs functionality.

Will make a ticket to suggest better refactoring for this later, I still think the old `getInactiveTabs()` method from before is confusing. 

_P.S. Currently running tests and will push up any fixes needed. Just wanted to get this into review ASAP. Thanks!_

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

