### PR TITLE
Bugfix FXIOS-10115 [Unit Tests] Clean up RustPlaces in teardown

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustPlacesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustPlacesTests.swift
@@ -26,6 +26,12 @@ class RustPlacesTests: XCTestCase {
         _ = places.reopenIfClosed()
     }
 
+    override func tearDown() {
+        _ = places.forceClose()
+        places = nil
+        super.tearDown()
+    }
+
     /**
         Basic "smoke tests" of the history metadata. Robust test suite exists within the library itself.
      */


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10115)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Although these were not failing in Bitrise from what I can tell, these were making it difficult to run test suites multiple times locally. After properly closing the database and cleaning up, the issue should no longer exists. 

In general, these tests could use a bit of an overhaul, but this solves the issue for now.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

