### PR TITLE
Refactor FXIOS-10122 Revert change to accomodate ease of UI tests and re-enable bypassed UI test

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -323,6 +323,9 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
     /// Note: it is safe to call this with `tab` and `previous` as the same tab, for use in the case
     /// where the index of the tab has changed (such as after deletion).
     override func selectTab(_ tab: Tab?, previous: Tab? = nil) {
+        // Fallback everywhere to selectedTab if no previous tab
+        let previous = previous ?? selectedTab
+
         guard let tab = tab,
               let tabUUID = UUID(uuidString: tab.tabUUID)
         else {
@@ -343,7 +346,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
 
         willSelectTab(url)
 
-        let isPrivateBrowsing = (previous ?? selectedTab)?.isPrivate
+        let isPrivateBrowsing = previous?.isPrivate
         previous?.metadataManager?.updateTimerAndObserving(state: .tabSwitched, isPrivate: isPrivateBrowsing ?? false)
         tab.metadataManager?.updateTimerAndObserving(state: .tabSelected, isPrivate: tab.isPrivate)
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -531,6 +531,11 @@ class NavigationTest: BaseTestCase {
     private func validateExternalLink(isPrivate: Bool = false) {
         navigator.openURL("ultimateqa.com/dummy-automation-websites")
         waitUntilPageLoad()
+        if app.links.matching(identifier: "SauceDemo.com").count > 1 {
+            // If there are more than one match for SauceDemo.com, for some reason the normal tab and the private tab
+            // views are still in the view hierarchy simultaneously. This should not happen unintentionally.
+            XCTFail("Too many matches! Has the UI hierarchy unexpectedly changed? ")
+        }
         scrollToElement(app.links["SauceDemo.com"].firstMatch)
         app.links["SauceDemo.com"].firstMatch.tap(force: true)
         waitUntilPageLoad()
@@ -544,8 +549,6 @@ class NavigationTest: BaseTestCase {
         let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
         mozWaitForElementToExist(tabsButton)
         XCTAssertEqual(tabsButton.value as? String, "2")
-        // We need to close the tabs from regular mode in order to be able to interact with the elements from private tab
-        navigator.performAction(Action.AcceptRemovingAllTabs)
     }
 
     private func openContextMenuForArticleLink() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -532,9 +532,10 @@ class NavigationTest: BaseTestCase {
         navigator.openURL("ultimateqa.com/dummy-automation-websites")
         waitUntilPageLoad()
         if app.links.matching(identifier: "SauceDemo.com").count > 1 {
-            // If there are more than one match for SauceDemo.com, for some reason the normal tab and the private tab
-            // views are still in the view hierarchy simultaneously. This should not happen unintentionally.
-            XCTFail("Too many matches! Has the UI hierarchy unexpectedly changed? ")
+            // If there are multiple matches for "SauceDemo.com", then both the normal tab and the private tab views may be
+            // in the view hierarchy simultaneously. This should not change unintentionally! Check the Debug View Hierarchy.
+            // Note: Additional matches may also appear if the external website updates.
+            XCTFail("Too many matches! Has the UI hierarchy or external website unexpectedly changed?")
         }
         scrollToElement(app.links["SauceDemo.com"].firstMatch)
         app.links["SauceDemo.com"].firstMatch.tap(force: true)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -531,12 +531,12 @@ class NavigationTest: BaseTestCase {
     private func validateExternalLink(isPrivate: Bool = false) {
         navigator.openURL("ultimateqa.com/dummy-automation-websites")
         waitUntilPageLoad()
-        if app.links.matching(identifier: "SauceDemo.com").count > 1 {
-            // If there are multiple matches for "SauceDemo.com", then both the normal tab and the private tab views may be
-            // in the view hierarchy simultaneously. This should not change unintentionally! Check the Debug View Hierarchy.
-            // Note: Additional matches may also appear if the external website updates.
-            XCTFail("Too many matches! Has the UI hierarchy or external website unexpectedly changed?")
-        }
+
+        // If there are multiple matches for "SauceDemo.com", then both the normal tab and the private tab views may be
+        // in the view hierarchy simultaneously. This should not change unintentionally! Check the Debug View Hierarchy.
+        // Note: Additional matches may also appear if the external website updates.
+        XCTAssertEqual(app.links.matching(identifier: "SauceDemo.com").count, 1, "Too many matches")
+
         scrollToElement(app.links["SauceDemo.com"].firstMatch)
         app.links["SauceDemo.com"].firstMatch.tap(force: true)
         waitUntilPageLoad()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
@@ -162,6 +162,12 @@ class ZoomingTests: BaseTestCase {
     }
 
     func zoomIn() {
+        if app.buttons.matching(identifier: AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel).count > 1 {
+            // If there are multiple matches for this element, then both the normal tab and the private tab views may be
+            // in the view hierarchy simultaneously. This should not change unintentionally! Check the Debug View Hierarchy.
+            XCTFail("Too many matches! Has the UI hierarchy unexpectedly changed?")
+        }
+
         for i in 0...3 {
             zoomLevel = app.buttons[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
             let previoustTextSize = bookOfMozillaTxt.frame.size.height

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
@@ -162,11 +162,10 @@ class ZoomingTests: BaseTestCase {
     }
 
     func zoomIn() {
-        if app.buttons.matching(identifier: AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel).count > 1 {
-            // If there are multiple matches for this element, then both the normal tab and the private tab views may be
-            // in the view hierarchy simultaneously. This should not change unintentionally! Check the Debug View Hierarchy.
-            XCTFail("Too many matches! Has the UI hierarchy unexpectedly changed?")
-        }
+        // If there are multiple matches for this element, then both the normal tab and the private tab views may be
+        // in the view hierarchy simultaneously. This should not change unintentionally! Check the Debug View Hierarchy.
+        let viewCount = app.buttons.matching(identifier: AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel).count
+        XCTAssertLessThanOrEqual(viewCount, 1, "Too many matches")
 
         for i in 0...3 {
             zoomLevel = app.buttons[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
@@ -27,21 +27,20 @@ class ZoomingTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306947
     // Smoketest
-    // FIXME FXIOS-10122 Must be addressed
-//    func testZoomingActions() {
-//        // Regular browsing
-//        validateZoomActions()
-//
-//        // Repeat all the steps in private browsing
-//        XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
-//        navigator.nowAt(BrowserTab)
-//        navigator.goto(TabTray)
-//        if !app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].exists {
-//            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
-//        }
-//        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-//        validateZoomActions()
-//    }
+    func testZoomingActions() {
+        // Regular browsing
+        validateZoomActions()
+
+        // Repeat all the steps in private browsing
+        XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
+        navigator.nowAt(BrowserTab)
+        navigator.goto(TabTray)
+        if !app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].exists {
+            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
+        }
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+        validateZoomActions()
+    }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306949
     func testZoomForceCloseFirefox() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10122)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22169)

## :bulb: Description
This is a followup PR reverts a small change and the UI test bypass from PR https://github.com/mozilla-mobile/firefox-ios/pull/22075

As well, this also reverts another UI test bypass that was added in PR https://github.com/mozilla-mobile/firefox-ios/pull/22209

### Additional Info
UI tests will now only have one match (instead of multiple matches) for a `XCUIElementQuery` when both a normal and private tab have been opened. The behaviour revert allows `firstMatch` and `element(boundBy:)` to return the expected private tab element instead of one from the (not visible) normal tab.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

