### PR TITLE
Bugfix FXIOS-9989 Fix incorrect toolbar display

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -902,6 +902,8 @@ class BrowserViewController: UIViewController,
         if !isToolbarRefactorEnabled {
             urlBar.searchEnginesDidUpdate()
         }
+
+        updateToolbarStateForTraitCollection(traitCollection)
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9989)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21939)

## :bulb: Description
- Display toolbars correctly after returning from a full screen modal where the device orientation was changed
- Applies to the new and old address/navigation toolbars

### 📝 Discussion 
- BVC was not receiving `traitCollectionDidChange` updates because it was no longer in the view hierarchy (receiving lifecycle events) when a full-screen view controller is presented on top of it. 
- Resolution was to update toolbar display states in BVC's `viewWillAppear`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

