### PR TITLE
 Add FXIOS-10159 [Homepage] New feature flag for the rebuild

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -21,6 +21,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case feltPrivacyFeltDeletion
     case firefoxSuggestFeature
     case historyHighlights
+    case homepageRebuild
     case inactiveTabs
     case isToolbarCFREnabled
     case jumpBackIn
@@ -46,6 +47,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     var debugKey: String? {
         switch self {
         case .closeRemoteTabs,
+                .homepageRebuild,
                 .microsurvey,
                 .menuRefactor,
                 .nativeErrorPage:
@@ -90,6 +92,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .fakespotBackInStock,
                 .fakespotFeature,
                 .fakespotProductAds,
+                .homepageRebuild,
                 .isToolbarCFREnabled,
                 .loginAutofill,
                 .microsurvey,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -32,6 +32,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
+                    with: .homepageRebuild,
+                    titleText: format(string: "Enable New Homepage"),
+                    statusText: format(string: "Toggle to use the new homepage")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .microsurvey,
                     titleText: format(string: "Enable Microsurvey"),
                     statusText: format(string: "Toggle to reset microsurvey expiration")

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -32,18 +32,18 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
-                    with: .homepageRebuild,
-                    titleText: format(string: "Enable New Homepage"),
-                    statusText: format(string: "Toggle to use the new homepage")
-                ) { [weak self] _ in
-                    self?.reloadView()
-                },
-                FeatureFlagsBoolSetting(
                     with: .microsurvey,
                     titleText: format(string: "Enable Microsurvey"),
                     statusText: format(string: "Toggle to reset microsurvey expiration")
                 ) { [weak self] _ in
                     UserDefaults.standard.set(nil, forKey: "\(GleanPlumbMessageStore.rootKey)\("homepage-microsurvey-message")")
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .homepageRebuild,
+                    titleText: format(string: "Enable New Homepage"),
+                    statusText: format(string: "Toggle to use the new homepage")
+                ) { [weak self] _ in
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -46,6 +46,9 @@ final class NimbusFeatureFlagLayer {
         case .fakespotBackInStock:
             return checkProductBackInStockFakespotFeature(from: nimbus)
 
+        case .homepageRebuild:
+            return checkHomepageFeature(from: nimbus)
+
         case .inactiveTabs:
             return checkTabTrayFeature(for: featureID, from: nimbus)
 
@@ -146,6 +149,11 @@ final class NimbusFeatureFlagLayer {
         guard let status = config.sectionsEnabled[nimbusID] else { return false }
 
         return status
+    }
+
+    private func checkHomepageFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.homepageRebuildFeature.value()
+        return config.enabled
     }
 
     private func checkNimbusForContextualHintsFeature(

--- a/firefox-ios/nimbus-features/homepageRebuildFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRebuildFeature.yaml
@@ -1,0 +1,18 @@
+# The configuration for the homepageRebuildFeature feature
+features:
+  homepage-rebuild-feature:
+    description: >
+      This feature is for managing the roll out of the Homepage rebuild feature
+    variables:
+      enabled:
+        description: >
+          If true,enables the feature
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: false

--- a/firefox-ios/nimbus-features/homepageRebuildFeature.yaml
+++ b/firefox-ios/nimbus-features/homepageRebuildFeature.yaml
@@ -6,7 +6,7 @@ features:
     variables:
       enabled:
         description: >
-          If true,enables the feature
+          If true, enables the feature
         type: Boolean
         default: false
     defaults:

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -22,6 +22,7 @@ include:
   - nimbus-features/firefoxSuggestFeature.yaml
   - nimbus-features/generalFeatures.yaml
   - nimbus-features/gleanServerKnobs.yaml
+  - nimbus-features/homepageRebuildFeature.yaml
   - nimbus-features/homescreenFeature.yaml
   - nimbus-features/menuRefactorFeature.yaml
   - nimbus-features/messagingFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10159)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22261)

## :bulb: Description
Add feature flag for `homepageRebuild`
Added toggle setting in debug menu (default is false)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
| Debug Menu |
| --- |
| <img src="https://github.com/user-attachments/assets/956d8f88-1811-4b06-86fb-f4cbe1461ad7" width="250"> |