### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from EditAddressViewController.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -143,7 +143,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
     }
 
     private func unwrapGetCurrentFormDataResult(result: Any?, error: (any Error)?, logger: Logger?) -> [String: Any]? {
-        if let error = error {
+        if let error {
             logger?.log(
                 "JavaScript execution error",
                 level: .warning,

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -97,6 +97,15 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
         performPostLoadActions()
     }
 
+    private func logError(message: String, description: String) {
+        logger.log(
+            message,
+            level: .warning,
+            category: .autofill,
+            description: description
+        )
+    }
+
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {}
 
     func performPostLoadActions() {

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -137,8 +137,10 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
             }
 
             guard let resultDict = result as? [String: Any] else {
-                self?.logError(
-                    message: "Result is nil or not a dictionary",
+                self?.logger.log(
+                    "Result is nil or not a dictionary",
+                    level: .warning,
+                    category: .autofill,
                     description: "Result is nil or not a dictionary"
                 )
                 return

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -129,10 +129,8 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
         guard let webView else { return }
         webView.evaluateJavaScript("getCurrentFormData();") { [weak self] result, error in
             if let error = error {
-                self?.logger.log(
-                    "JavaScript execution error",
-                    level: .warning,
-                    category: .autofill,
+                self?.logError(
+                    message: "JavaScript execution error",
                     description: "JavaScript execution error: \(error.localizedDescription)"
                 )
                 return

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -129,8 +129,10 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
         guard let webView else { return }
         webView.evaluateJavaScript("getCurrentFormData();") { [weak self] result, error in
             if let error = error {
-                self?.logError(
-                    message: "JavaScript execution error",
+                self?.logger.log(
+                    "JavaScript execution error",
+                    level: .warning,
+                    category: .autofill,
                     description: "JavaScript execution error: \(error.localizedDescription)"
                 )
                 return

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -119,23 +119,9 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
     private func getCurrentFormData(completion: @escaping (UpdatableAddressFields) -> Void) {
         guard let webView else { return }
         webView.evaluateJavaScript("getCurrentFormData();") { [weak self] result, error in
-            if let error = error {
-                self?.logger.log(
-                    "JavaScript execution error",
-                    level: .warning,
-                    category: .autofill,
-                    description: "JavaScript execution error: \(error.localizedDescription)"
-                )
-                return
-            }
-
-            guard let resultDict = result as? [String: Any] else {
-                self?.logger.log(
-                    "Result is nil or not a dictionary",
-                    level: .warning,
-                    category: .autofill,
-                    description: "Result is nil or not a dictionary"
-                )
+            guard let resultDict = self?.unwrapGetCurrentFormDataResult(result: result,
+                                                                        error: error,
+                                                                        logger: self?.logger) else {
                 return
             }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -137,10 +137,8 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
             }
 
             guard let resultDict = result as? [String: Any] else {
-                self?.logger.log(
-                    "Result is nil or not a dictionary",
-                    level: .warning,
-                    category: .autofill,
+                self?.logError(
+                    message: "Result is nil or not a dictionary",
                     description: "Result is nil or not a dictionary"
                 )
                 return

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -156,6 +156,30 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
         }
     }
 
+    private func unwrapGetCurrentFormDataResult(result: Any?, error: (any Error)?, logger: Logger?) -> [String: Any]? {
+        if let error = error {
+            logger?.log(
+                "JavaScript execution error",
+                level: .warning,
+                category: .autofill,
+                description: "JavaScript execution error: \(error.localizedDescription)"
+            )
+            return nil
+        }
+
+        guard let result = result as? [String: Any] else {
+            logger?.log(
+                "Result is nil or not a dictionary",
+                level: .warning,
+                category: .autofill,
+                description: "Result is nil or not a dictionary"
+            )
+            return nil
+        }
+
+        return result
+    }
+
     private func evaluateJavaScript(_ jsCode: String) {
         guard let webView else { return }
         webView.evaluateJavaScript(jsCode) { [weak self] result, error in

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -97,15 +97,6 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
         performPostLoadActions()
     }
 
-    private func logError(message: String, description: String) {
-        logger.log(
-            message,
-            level: .warning,
-            category: .autofill,
-            description: description
-        )
-    }
-
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {}
 
     func performPostLoadActions() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `EditAddressViewController.swift` file. It extracts the log register to a new function.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

