### PR TITLE
Refactor FXIOS-7301 - Remove 2 closure_body_length violation from ContentBlockerSettingViewController.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -50,10 +50,6 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
         linkButton.isHidden = currentBlockingStrength == .strict
     }
 
-    private func setupLinkButtonVisibility(option: BlockingStrength) {
-        self.linkButton.isHidden = option == .strict
-    }
-
     override func didRotate(from fromInterfaceOrientation: UIInterfaceOrientation) {
         tableView.reloadData()
     }

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -71,6 +71,10 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
                     TabContentBlocker.prefsChanged()
                     self.tableView.reloadData()
 
+                    if option == .strict {
+                        self.linkButton.isHidden = true
+                    }
+
                     let extras = [
                         TelemetryWrapper.EventExtraKey.preference.rawValue: "ETP-strength",
                         TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: option.rawValue
@@ -83,7 +87,6 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
                     )
 
                     if option == .strict {
-                        self.linkButton.isHidden = true
                         TelemetryWrapper.recordEvent(
                             category: .action,
                             method: .tap,

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -76,7 +76,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
                     TabContentBlocker.prefsChanged()
                     self.tableView.reloadData()
 
-                    self.setupLinkButtonVisibility(option: option)
+                    self.linkButton.isHidden = option == .strict
 
                     self.recordEventOnChecked(option: option)
                 })

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -75,32 +75,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
                         self.linkButton.isHidden = true
                     }
 
-                    let extras = [
-                        TelemetryWrapper.EventExtraKey.preference.rawValue: "ETP-strength",
-                        TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: option.rawValue
-                    ]
-                    TelemetryWrapper.recordEvent(
-                        category: .action,
-                        method: .change,
-                        object: .setting,
-                        extras: extras
-                    )
-
-                    if option == .strict {
-                        TelemetryWrapper.recordEvent(
-                            category: .action,
-                            method: .tap,
-                            object: .trackingProtectionMenu,
-                            extras: [TelemetryWrapper.EventExtraKey.etpSetting.rawValue: option.rawValue]
-                        )
-                    } else {
-                        TelemetryWrapper.recordEvent(
-                            category: .action,
-                            method: .tap,
-                            object: .trackingProtectionMenu,
-                            extras: [TelemetryWrapper.EventExtraKey.etpSetting.rawValue: "standard"]
-                        )
-                    }
+                    self.recordEventOnChecked(option: option)
                 })
 
             let uuid = windowUUID

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -47,7 +47,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
         super.viewDidLoad()
         applyTheme()
         setupNotifications(forObserver: self, observing: [UIContentSizeCategory.didChangeNotification])
-        setupLinkButtonVisibility(option: currentBlockingStrength)
+        linkButton.isHidden = currentBlockingStrength == .strict
     }
 
     private func setupLinkButtonVisibility(option: BlockingStrength) {

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -50,6 +50,10 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
         setupNotifications(forObserver: self, observing: [UIContentSizeCategory.didChangeNotification])
     }
 
+    private func setupLinkButtonVisibility(option: BlockingStrength) {
+        self.linkButton.isHidden = option == .strict
+    }
+
     override func didRotate(from fromInterfaceOrientation: UIInterfaceOrientation) {
         tableView.reloadData()
     }

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -76,7 +76,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
                     TabContentBlocker.prefsChanged()
                     self.tableView.reloadData()
 
-                    self.linkButton.isHidden = option == .strict
+                    self.setupLinkButtonVisibility(option: option)
 
                     self.recordEventOnChecked(option: option)
                 })

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -173,7 +173,6 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
             linkButton.configure(viewModel: linkButtonViewModel)
 
             linkButton.addTarget(self, action: #selector(moreInfoTapped), for: .touchUpInside)
-            linkButton.isHidden = false
 
             defaultFooter.stackView.addArrangedSubview(linkButton)
 

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -29,6 +29,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
         super.init(style: .grouped, windowUUID: windowUUID)
 
         self.title = .SettingsTrackingProtectionSectionName
+        self.linkButton.isHidden = currentBlockingStrength == .strict
 
         if !isShownFromSettings {
             navigationItem.rightBarButtonItem = UIBarButtonItem(

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -151,6 +151,35 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
         return [firstSection, secondSection]
     }
 
+    private func recordEventOnChecked(option: BlockingStrength) {
+        let extras = [
+            TelemetryWrapper.EventExtraKey.preference.rawValue: "ETP-strength",
+            TelemetryWrapper.EventExtraKey.preferenceChanged.rawValue: option.rawValue
+        ]
+        TelemetryWrapper.recordEvent(
+            category: .action,
+            method: .change,
+            object: .setting,
+            extras: extras
+        )
+
+        if option == .strict {
+            TelemetryWrapper.recordEvent(
+                category: .action,
+                method: .tap,
+                object: .trackingProtectionMenu,
+                extras: [TelemetryWrapper.EventExtraKey.etpSetting.rawValue: option.rawValue]
+            )
+        } else {
+            TelemetryWrapper.recordEvent(
+                category: .action,
+                method: .tap,
+                object: .trackingProtectionMenu,
+                extras: [TelemetryWrapper.EventExtraKey.etpSetting.rawValue: "standard"]
+            )
+        }
+    }
+
     // The first section header gets a More Info link
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let _defaultFooter = super.tableView(

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -29,7 +29,6 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
         super.init(style: .grouped, windowUUID: windowUUID)
 
         self.title = .SettingsTrackingProtectionSectionName
-        self.linkButton.isHidden = currentBlockingStrength == .strict
 
         if !isShownFromSettings {
             navigationItem.rightBarButtonItem = UIBarButtonItem(
@@ -48,6 +47,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
         super.viewDidLoad()
         applyTheme()
         setupNotifications(forObserver: self, observing: [UIContentSizeCategory.didChangeNotification])
+        setupLinkButtonVisibility(option: currentBlockingStrength)
     }
 
     private func setupLinkButtonVisibility(option: BlockingStrength) {

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -71,9 +71,7 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
                     TabContentBlocker.prefsChanged()
                     self.tableView.reloadData()
 
-                    if option == .strict {
-                        self.linkButton.isHidden = true
-                    }
+                    self.linkButton.isHidden = option == .strict
 
                     self.recordEventOnChecked(option: option)
                 })


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 2 `closure_body_length` violations from the `ContentBlockerSettingViewController.swift` file. It extracts the telemetry logic to a new function.

I’ve noticed a potential bug with the `self.linkButton.isHidden = true` logic when selecting the "strict" option. This line should hide the "Learn more" button in the footer of the first section, but it doesn’t seem to work. I’ve observed the same behavior on the main branch as well. Could someone confirm if this is indeed a bug?

Below is a screenshot of the button that should be hidden when strict mode is selected.

![Screenshot 2024-09-30 at 19 10 04](https://github.com/user-attachments/assets/c4c79cb1-9c33-4529-b31d-9b6dd11e356c)

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

