### PR TITLE
Bugfix FXIOS-10173 - Crash in HomepageViewController's Collection View

### DIFF
--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -229,8 +229,8 @@ extension TopSitesViewModel: TopSitesManagerDelegate {
 extension TopSitesViewModel: HomepageSectionHandler {
     func configure(_ collectionView: UICollectionView,
                    at indexPath: IndexPath) -> UICollectionViewCell {
-        if let cell = collectionView.dequeueReusableCell(cellType: TopSiteItemCell.self, for: indexPath),
-           let contentItem = topSites[safe: indexPath.row] {
+        if let contentItem = topSites[safe: indexPath.row],
+           let cell = collectionView.dequeueReusableCell(cellType: TopSiteItemCell.self, for: indexPath) {
             let textColor = wallpaperManager.currentWallpaper.textColor
 
             cell.configure(contentItem,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10173)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22278)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### Issue:
- The app was crashing due to the order of operations in `configure` method. Specifically, the cell was being dequeued before ensuring that the `contentItem` was safely accessed from the `topSites` array.

### Solution:
- Reordered the conditional statements to first check if `contentItem` is available before attempting to dequeue the cell. This ensures that the cell is only dequeued and configured if valid data is present.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

