### PR TITLE
Added FXIOS-10180 Enable flag by default

### DIFF
--- a/firefox-ios/nimbus-features/tabTrayRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/tabTrayRefactorFeature.yaml
@@ -8,11 +8,8 @@ features:
         description: >
           Enables the feature
         type: Boolean
-        default: false
+        default: true
     defaults:
-      - channel: beta
-        value:
-          enabled: true
-      - channel: developer
+      - channel: developer, beta, release
         value:
           enabled: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10180)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22290)

## :bulb: Description
Enable the tab tray flag for all build versions for reals this time 🙈 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

