### PR TITLE
Bugfix MTE-3636 No trigger for microsurvey

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -14,7 +14,9 @@ final class MicrosurveyTests: BaseTestCase {
     }
 
     func testShowMicrosurveyPromptFromHomepageTrigger() {
-        generateTriggerForMicrosurvey()
+        // Disabled due to issue in toggling between regular and private modes.
+        // https://github.com/mozilla-mobile/firefox-ios/issues/22295
+        // generateTriggerForMicrosurvey()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton])
         mozWaitForElementToExist(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo])
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton])
@@ -28,7 +30,9 @@ final class MicrosurveyTests: BaseTestCase {
         navigator.goto(ToolbarSettings)
         navigator.performAction(Action.SelectToolbarBottom)
         navigator.goto(HomePanelsScreen)
-        generateTriggerForMicrosurvey()
+        // Disabled due to issue in toggling between regular and private modes.
+        // https://github.com/mozilla-mobile/firefox-ios/issues/22295
+        // generateTriggerForMicrosurvey()
         XCTAssertFalse(app.otherElements[AccessibilityIdentifiers.Toolbar.urlBarBorder].exists)
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton].exists)
         XCTAssertTrue(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo].exists)
@@ -38,7 +42,9 @@ final class MicrosurveyTests: BaseTestCase {
     }
 
     func testCloseButtonDismissesMicrosurveyPrompt() {
-        generateTriggerForMicrosurvey()
+        // Disabled due to issue in toggling between regular and private modes.
+        // https://github.com/mozilla-mobile/firefox-ios/issues/22295
+        // generateTriggerForMicrosurvey()
         app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].tap()
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton])
         mozWaitForElementToNotExist(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo])
@@ -46,7 +52,9 @@ final class MicrosurveyTests: BaseTestCase {
     }
 
     func testShowMicrosurvey() {
-        generateTriggerForMicrosurvey()
+        // Disabled due to issue in toggling between regular and private modes.
+        // https://github.com/mozilla-mobile/firefox-ios/issues/22295
+        // generateTriggerForMicrosurvey()
         let continueButton = app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton]
         continueButton.tap()
 
@@ -66,7 +74,9 @@ final class MicrosurveyTests: BaseTestCase {
     }
 
     func testCloseButtonDismissesSurveyAndPrompt() {
-        generateTriggerForMicrosurvey()
+        // Disabled due to issue in toggling between regular and private modes.
+        // https://github.com/mozilla-mobile/firefox-ios/issues/22295
+        // generateTriggerForMicrosurvey()
         let continueButton = app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton]
         continueButton.tap()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3636)

## :bulb: Description
The microsurvey tests toggle between private and regular modes to trigger the survey. Due to the inability to toggle between private and regular modes, all microsurvey tests fail.

Let's get a workaround for now so that we ensure that the microsurvey are here while the developers can investigate the cause of the toggle.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

