### PR TITLE
Add FXIOS-10190 [Unified Search] Unified Search feature flag to Swift code

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -38,6 +38,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case searchHighlights
     case splashScreen
     case tabTrayRefactor
+    case unifiedSearch
     case toolbarRefactor
     case toolbarOneTapNewTab
     case toolbarNavigationHint
@@ -108,6 +109,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .searchHighlights,
                 .splashScreen,
                 .tabTrayRefactor,
+                .unifiedSearch,
                 .toolbarRefactor,
                 .toolbarOneTapNewTab,
                 .toolbarNavigationHint,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -127,6 +127,9 @@ class BrowserViewController: UIViewController,
     var isToolbarRefactorEnabled: Bool {
         return featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly)
     }
+    var isUnifiedSearchEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.unifiedSearch, checking: .buildOnly)
+    }
     var isOneTapNewTabEnabled: Bool {
         return featureFlags.isFeatureEnabled(.toolbarOneTapNewTab, checking: .buildOnly)
     }

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -91,6 +91,9 @@ final class NimbusFeatureFlagLayer {
         case .toolbarRefactor:
             return checkToolbarRefactorFeature(from: nimbus)
 
+        case .unifiedSearch:
+            return checkUnifiedSearchFeature(from: nimbus)
+
         case .toolbarOneTapNewTab:
             return checkToolbarOneTapNewTabFeature(from: nimbus)
 
@@ -180,6 +183,11 @@ final class NimbusFeatureFlagLayer {
     private func checkToolbarRefactorFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.toolbarRefactorFeature.value()
         return config.enabled
+    }
+
+    private func checkUnifiedSearchFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.toolbarRefactorFeature.value()
+        return config.unifiedSearch
     }
 
     private func checkToolbarOneTapNewTabFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -19,7 +19,7 @@ features:
           If true, enables the navigation contextual hint.
         type: Boolean
         default: false
-      unified_search_enabled:
+      unified_search:
         description: >
           Enables the unified search feature
         type: Boolean
@@ -29,13 +29,13 @@ features:
       - channel: beta
         value:
           enabled: false
-          unified_search_enabled: false
+          unified_search: false
           one_tap_new_tab: false
           navigation_hint: false
       - channel: developer
         value:
-          enabled: false
-          unified_search_enabled: false
+          enabled: true
+          unified_search: true
           one_tap_new_tab: false
           navigation_hint: false
 

--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -34,8 +34,8 @@ features:
           navigation_hint: false
       - channel: developer
         value:
-          enabled: true
-          unified_search: true
+          enabled: false
+          unified_search: false
           one_tap_new_tab: false
           navigation_hint: false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10190)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22306)

## :bulb: Description
This PR:
* updates the existing unified search flag naming in the YAML (for consistency with other variables), and 
* updates our project code to us the new variable

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

