### PR TITLE
Fix MTE-3640 - testMultiWindowNewTab test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
@@ -44,6 +44,7 @@ class MultiWindowTests: IpadOnlyTestCase {
         let topSites = AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell
         let homeButtom = AccessibilityIdentifiers.Toolbar.homeButton
         // A new tab is opened in the same window
+        mozWaitForElementToExist(app.collectionViews.cells.matching(identifier: topSites).firstMatch)
         app.collectionViews.cells.matching(identifier: topSites).firstMatch.tap()
         mozWaitForElementToExist(app.buttons[homeButtom])
         app.buttons.matching(identifier: menuButton).element(boundBy: 0).tap()
@@ -53,6 +54,7 @@ class MultiWindowTests: IpadOnlyTestCase {
         let tabButtonSecondWindow = app.buttons.matching(identifier: tabsButtonIdentifier).element(boundBy: 0)
         XCTAssertEqual(tabButtonSecondWindow.value as! String, "2", "Number of tabs opened should be equal to 2")
         // A new tab is opened in the same window
+        mozWaitForElementToExist(app.collectionViews.cells.matching(identifier: topSites).element(boundBy: 6))
         app.collectionViews.cells.matching(identifier: topSites).element(boundBy: 6).tap()
         mozWaitForElementToExist(app.buttons[homeButtom])
         app.buttons.matching(identifier: menuButton).element(boundBy: 1).tap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -28,6 +28,7 @@ class PhotonActionSheetTests: BaseTestCase {
         app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash].tap()
 
         // Check that it has been unpinned
+        // Adding sleep as an workaround until https://github.com/mozilla-mobile/firefox-ios/issues/22323 is fixed
         sleep(5)
         cell.press(forDuration: 2)
         mozWaitForElementToExist(app.tables.cells.otherElements[StandardImageIdentifiers.Large.pin])


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3640

## :bulb: Description
Adding waits to make sure some elements have enough time to load and the test is not selecting the wrong element.

<img width="517" alt="Screenshot 2024-10-02 at 15 42 43" src="https://github.com/user-attachments/assets/b7ec60ad-3ae5-4556-82ce-b476af1fcfa4">
