### PR TITLE
Bugfix FXIOS-10155 redux bug

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -122,8 +122,6 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             return BrowserViewControllerState.reduceStateForFakeSpotAction(action: action, state: state)
         } else if let action = action as? MicrosurveyPromptAction {
             return BrowserViewControllerState.reduceStateForMicrosurveyAction(action: action, state: state)
-//        } else if let action = action as? PrivateModeAction {
-//            return BrowserViewControllerState.reduceStateForPrivateModeAction(action: action, state: state)
         } else if let action = action as? GeneralBrowserAction {
             return BrowserViewControllerState.reduceStateForGeneralBrowserAction(action: action, state: state)
         } else {
@@ -159,35 +157,6 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             browserViewType: state.browserViewType,
             microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
     }
-
-//    static func reduceStateForPrivateModeAction(action: PrivateModeAction,
-//                                                state: BrowserViewControllerState) -> BrowserViewControllerState {
-//        switch action.actionType {
-////        case PrivateModeActionType.privateModeUpdated:
-////            let privacyState = action.isPrivate ?? false
-////            var browserViewType = state.browserViewType
-////            if browserViewType != .webview && browserViewType != .nativeErrorPage {
-////                browserViewType = privacyState ? .privateHomepage : .normalHomepage
-////            }
-////            return BrowserViewControllerState(
-////                searchScreenState: SearchScreenState(inPrivateMode: privacyState),
-////                showDataClearanceFlow: privacyState,
-////                fakespotState: state.fakespotState,
-////                windowUUID: state.windowUUID,
-////                reloadWebView: true,
-////                browserViewType: browserViewType,
-////                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
-//        default:
-//            return BrowserViewControllerState(
-//                searchScreenState: state.searchScreenState,
-//                showDataClearanceFlow: state.showDataClearanceFlow,
-//                fakespotState: state.fakespotState,
-//                windowUUID: state.windowUUID,
-//                reloadWebView: state.reloadWebView,
-//                browserViewType: state.browserViewType,
-//                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
-//        }
-//    }
 
     static func reduceStateForGeneralBrowserAction(action: GeneralBrowserAction,
                                                    state: BrowserViewControllerState) -> BrowserViewControllerState {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -122,8 +122,8 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             return BrowserViewControllerState.reduceStateForFakeSpotAction(action: action, state: state)
         } else if let action = action as? MicrosurveyPromptAction {
             return BrowserViewControllerState.reduceStateForMicrosurveyAction(action: action, state: state)
-        } else if let action = action as? PrivateModeAction {
-            return BrowserViewControllerState.reduceStateForPrivateModeAction(action: action, state: state)
+//        } else if let action = action as? PrivateModeAction {
+//            return BrowserViewControllerState.reduceStateForPrivateModeAction(action: action, state: state)
         } else if let action = action as? GeneralBrowserAction {
             return BrowserViewControllerState.reduceStateForGeneralBrowserAction(action: action, state: state)
         } else {
@@ -160,34 +160,34 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
     }
 
-    static func reduceStateForPrivateModeAction(action: PrivateModeAction,
-                                                state: BrowserViewControllerState) -> BrowserViewControllerState {
-        switch action.actionType {
-        case PrivateModeActionType.privateModeUpdated:
-            let privacyState = action.isPrivate ?? false
-            var browserViewType = state.browserViewType
-            if browserViewType != .webview && browserViewType != .nativeErrorPage {
-                browserViewType = privacyState ? .privateHomepage : .normalHomepage
-            }
-            return BrowserViewControllerState(
-                searchScreenState: SearchScreenState(inPrivateMode: privacyState),
-                showDataClearanceFlow: privacyState,
-                fakespotState: state.fakespotState,
-                windowUUID: state.windowUUID,
-                reloadWebView: true,
-                browserViewType: browserViewType,
-                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
-        default:
-            return BrowserViewControllerState(
-                searchScreenState: state.searchScreenState,
-                showDataClearanceFlow: state.showDataClearanceFlow,
-                fakespotState: state.fakespotState,
-                windowUUID: state.windowUUID,
-                reloadWebView: state.reloadWebView,
-                browserViewType: state.browserViewType,
-                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
-        }
-    }
+//    static func reduceStateForPrivateModeAction(action: PrivateModeAction,
+//                                                state: BrowserViewControllerState) -> BrowserViewControllerState {
+//        switch action.actionType {
+////        case PrivateModeActionType.privateModeUpdated:
+////            let privacyState = action.isPrivate ?? false
+////            var browserViewType = state.browserViewType
+////            if browserViewType != .webview && browserViewType != .nativeErrorPage {
+////                browserViewType = privacyState ? .privateHomepage : .normalHomepage
+////            }
+////            return BrowserViewControllerState(
+////                searchScreenState: SearchScreenState(inPrivateMode: privacyState),
+////                showDataClearanceFlow: privacyState,
+////                fakespotState: state.fakespotState,
+////                windowUUID: state.windowUUID,
+////                reloadWebView: true,
+////                browserViewType: browserViewType,
+////                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
+//        default:
+//            return BrowserViewControllerState(
+//                searchScreenState: state.searchScreenState,
+//                showDataClearanceFlow: state.showDataClearanceFlow,
+//                fakespotState: state.fakespotState,
+//                windowUUID: state.windowUUID,
+//                reloadWebView: state.reloadWebView,
+//                browserViewType: state.browserViewType,
+//                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action))
+//        }
+//    }
 
     static func reduceStateForGeneralBrowserAction(action: GeneralBrowserAction,
                                                    state: BrowserViewControllerState) -> BrowserViewControllerState {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1269,6 +1269,7 @@ class BrowserViewController: UIViewController,
         guard contentContainer.canAdd(content: viewController) else { return false }
 
         addChild(viewController)
+        viewController.willMove(toParent: self)
         contentContainer.add(content: viewController)
         viewController.didMove(toParent: self)
         statusBarOverlay.resetState(isHomepage: contentContainer.hasHomepage)
@@ -3683,7 +3684,8 @@ extension BrowserViewController: TabManagerDelegate {
 
         scrollController.tab = selectedTab
 
-        if let webView = selectedTab.webView {
+        if !selectedTab.isFxHomeTab,
+           let webView = selectedTab.webView {
             webView.accessibilityLabel = .WebViewAccessibilityLabel
             webView.accessibilityIdentifier = "contentView"
             webView.accessibilityElementsHidden = false

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -625,8 +625,6 @@ class BrowserViewController: UIViewController,
     }
 
     func newState(state: BrowserViewControllerState) {
-        guard let self else { return }
-
         browserViewControllerState = state
 
         // opens or close sidebar/bottom sheet to match the saved state

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -625,42 +625,40 @@ class BrowserViewController: UIViewController,
     }
 
     func newState(state: BrowserViewControllerState) {
-        ensureMainThread { [weak self] in
-            guard let self else { return }
+        guard let self else { return }
 
-            browserViewControllerState = state
+        browserViewControllerState = state
 
-            // opens or close sidebar/bottom sheet to match the saved state
-            if state.fakespotState.isOpen {
-                let productURL = isToolbarRefactorEnabled ?
-                    store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID)?.addressToolbar.url :
-                    urlBar.currentURL
-                guard let productURL else { return }
-                handleFakespotFlow(productURL: productURL)
-            } else if !state.fakespotState.isOpen {
-                dismissFakespotIfNeeded()
-            }
-
-            if state.reloadWebView {
-                updateContentInHomePanel(state.browserViewType)
-            }
-
-            setupMiddleButtonStatus(isLoading: false)
-
-            if let toast = state.toast {
-                self.showToastType(toast: toast)
-            }
-
-            if state.showOverlay == true {
-                overlayManager.openNewTab(url: nil, newTabSettings: newTabSettings)
-            } else if state.showOverlay == false {
-                overlayManager.cancelEditing(shouldCancelLoading: false)
-            }
-
-            executeNavigationAndDisplayActions()
-
-            handleMicrosurvey(state: state)
+        // opens or close sidebar/bottom sheet to match the saved state
+        if state.fakespotState.isOpen {
+            let productURL = isToolbarRefactorEnabled ?
+                store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID)?.addressToolbar.url :
+                urlBar.currentURL
+            guard let productURL else { return }
+            handleFakespotFlow(productURL: productURL)
+        } else if !state.fakespotState.isOpen {
+            dismissFakespotIfNeeded()
         }
+
+        if state.reloadWebView {
+            updateContentInHomePanel(state.browserViewType)
+        }
+
+        setupMiddleButtonStatus(isLoading: false)
+
+        if let toast = state.toast {
+            self.showToastType(toast: toast)
+        }
+
+        if state.showOverlay == true {
+            overlayManager.openNewTab(url: nil, newTabSettings: newTabSettings)
+        } else if state.showOverlay == false {
+            overlayManager.cancelEditing(shouldCancelLoading: false)
+        }
+
+        executeNavigationAndDisplayActions()
+
+        handleMicrosurvey(state: state)
     }
 
     private func showToastType(toast: ToastType) {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -67,6 +67,7 @@ class DefaultOverlayModeManager: OverlayModeManager {
     }
 
     func finishEditing(shouldCancelLoading: Bool) {
+        guard inOverlayMode else { return }
         leaveOverlayMode(reason: .finished, shouldCancelLoading: shouldCancelLoading)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -54,18 +54,6 @@ final class BrowserViewControllerStateTests: XCTestCase {
         XCTAssertEqual(newState.displayView, .dataClearance)
     }
 
-    func testPrivateModeAction() {
-        let initialState = createSubject()
-        let reducer = browserViewControllerReducer()
-
-        XCTAssertEqual(initialState.browserViewType, .normalHomepage)
-
-        let action = getPrivateModeAction(isPrivate: true, for: .privateModeUpdated)
-        let newState = reducer(initialState, action)
-
-        XCTAssertEqual(newState.browserViewType, .privateHomepage)
-    }
-
     func testUpdateSelectedTabAction() {
         let initialState = createSubject()
         let reducer = browserViewControllerReducer()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -140,7 +140,7 @@ class CreditCardsTests: BaseTestCase {
             navigator.openURL("https://checkout.stripe.dev/preview")
             waitUntilPageLoad()
             // The autofill option (Use saved card prompt) is not displayed
-            let cardNumber = app.webViews["contentView"].webViews.textFields["Card number"]
+            let cardNumber = app.webViews["Web content"].textFields["Card number"]
             app.swipeUp()
             app.swipeUp()
             mozWaitForElementToExist(cardNumber)
@@ -166,12 +166,12 @@ class CreditCardsTests: BaseTestCase {
             waitForExistence(app.buttons["Done"])
             app.buttons["Done"].tap()
             app.swipeUp()
-            mozWaitForElementToExist(app.webViews["contentView"].webViews.staticTexts["Explore Checkout"], timeout: TIMEOUT)
+            mozWaitForElementToExist(app.webViews["Web content"].staticTexts["Explore Checkout"], timeout: TIMEOUT)
             mozWaitForElementToExist(cardNumber)
             cardNumber.tapOnApp()
             // The autofill option (Use saved card prompt) is displayed
             if !app.buttons[useSavedCard].exists {
-                app.webViews["contentView"].webViews.textFields["Full name on card"].tapOnApp()
+                app.webViews["Web content"].textFields["Full name on card"].tapOnApp()
             }
             mozWaitForElementToExist(app.buttons[useSavedCard])
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10155)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22258)

## :bulb: Description
The recent refactor to how redux actions execute surfaced a race condition where the webview was overwriting and removing the home page. This was previously happening in the opposite order so it wasn't causuing any obvious issues. I added a check to only update the webview when it is not the home page. 
I also cleaned up some unneded code as it was adding a lot of noise to the logs and making it difficult to debug. I think this code became unneded as more of BVC's logic is being routed through redux. 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

