### PR TITLE
Add FXIOS-10161 [Homepage] Initial diffable datasource + comp layout

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -20,6 +20,9 @@ public enum LoggerCategory: String {
     /// Related to homepage UI and it's data management.
     case homepage
 
+    /// Related to new homepage UI and it's data management for the homepage rebuild project.
+    case newHomepage
+
     /// Related to errors around image fetches, and includes all image types (`SiteImageType`, and general images).
     case images
 

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -850,6 +850,9 @@
 		8A9F0B5827C59E1800FE09AE /* ImageIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */; };
 		8A9F0B5927C5A2AB00FE09AE /* ImageIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */; };
 		8AA020EF2B9A37E500771DE0 /* NimbusSplashScreenFeatureLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA020EE2B9A37E500771DE0 /* NimbusSplashScreenFeatureLayer.swift */; };
+		8AA0A6632CAC40AA00AC7EB3 /* NewHomepageDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0A6622CAC40AA00AC7EB3 /* NewHomepageDiffableDataSource.swift */; };
+		8AA0A6652CAC6B7100AC7EB3 /* NewHomepageCompositionalLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0A6642CAC6B7100AC7EB3 /* NewHomepageCompositionalLayout.swift */; };
+		8AA0A6682CAC747500AC7EB3 /* NewHomepageDiffableDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0A6662CAC745300AC7EB3 /* NewHomepageDiffableDataSourceTests.swift */; };
 		8AA6ADB52742B567004EEE23 /* TelemetryWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */; };
 		8AA7347B28AEDB3100443D24 /* PocketViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */; };
 		8AA8389D2CA2FEFC003FA256 /* StoreTestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA8389C2CA2FEFC003FA256 /* StoreTestUtility.swift */; };
@@ -6962,6 +6965,9 @@
 		8A9E46BC2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStatusBarScrollDelegate.swift; sourceTree = "<group>"; };
 		8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageIdentifiers.swift; sourceTree = "<group>"; };
 		8AA020EE2B9A37E500771DE0 /* NimbusSplashScreenFeatureLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusSplashScreenFeatureLayer.swift; sourceTree = "<group>"; };
+		8AA0A6622CAC40AA00AC7EB3 /* NewHomepageDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewHomepageDiffableDataSource.swift; sourceTree = "<group>"; };
+		8AA0A6642CAC6B7100AC7EB3 /* NewHomepageCompositionalLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewHomepageCompositionalLayout.swift; sourceTree = "<group>"; };
+		8AA0A6662CAC745300AC7EB3 /* NewHomepageDiffableDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewHomepageDiffableDataSourceTests.swift; sourceTree = "<group>"; };
 		8AA6ADB42742B567004EEE23 /* TelemetryWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryWrapperTests.swift; sourceTree = "<group>"; };
 		8AA7347A28AEDB3100443D24 /* PocketViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketViewModelTests.swift; sourceTree = "<group>"; };
 		8AA8389C2CA2FEFC003FA256 /* StoreTestUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTestUtility.swift; sourceTree = "<group>"; };
@@ -10484,6 +10490,7 @@
 			isa = PBXGroup;
 			children = (
 				8A00BD862CAB3FE500680AF9 /* NewHomepageViewControllerTests.swift */,
+				8AA0A6662CAC745300AC7EB3 /* NewHomepageDiffableDataSourceTests.swift */,
 			);
 			path = "Homepage Rebuild";
 			sourceTree = "<group>";
@@ -10811,6 +10818,8 @@
 			isa = PBXGroup;
 			children = (
 				8A7D08E22CAAF7C30035999C /* NewHomepageViewController.swift */,
+				8AA0A6622CAC40AA00AC7EB3 /* NewHomepageDiffableDataSource.swift */,
+				8AA0A6642CAC6B7100AC7EB3 /* NewHomepageCompositionalLayout.swift */,
 			);
 			path = "Homepage Rebuild";
 			sourceTree = "<group>";
@@ -15406,6 +15415,7 @@
 				C8BD87602A0C248000CD803A /* OnboardingButtonsModel.swift in Sources */,
 				0BB5B2881AC0A2B90052877D /* SnackBar.swift in Sources */,
 				E1442FCF294782D9003680B0 /* UIView+Screenshot.swift in Sources */,
+				8AA0A6652CAC6B7100AC7EB3 /* NewHomepageCompositionalLayout.swift in Sources */,
 				8AB8572C27D945FA0075C173 /* TopSitesDataAdaptor.swift in Sources */,
 				C889569A27E8D1AC00E3779E /* LegacyInactiveTabHeader.swift in Sources */,
 				7BEFC6801BFF68C30059C952 /* QuickActions.swift in Sources */,
@@ -16005,6 +16015,7 @@
 				59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */,
 				0A93C8AA2C87070300BEA143 /* TrackingProtectionConnectionStatusView.swift in Sources */,
 				C849E46126B9C39B00260F0B /* EnhancedTrackingProtectionVC.swift in Sources */,
+				8AA0A6632CAC40AA00AC7EB3 /* NewHomepageDiffableDataSource.swift in Sources */,
 				E40FAB0C1A7ABB77009CB80D /* WebServer.swift in Sources */,
 				59A68D66379CFA85C4EAF00B /* TwoLineImageOverlayCell.swift in Sources */,
 				0A49784A2C53E63200B1E82A /* TrackingProtectionViewController.swift in Sources */,
@@ -16353,6 +16364,7 @@
 				C88012232A40E38D00F4D1D6 /* IntroViewControllerTests.swift in Sources */,
 				E16E1C9628BFB2E600EE2EF5 /* WallpaperSettingsViewModelTests.swift in Sources */,
 				E1463D042982D0240074E16E /* NotificationManagerTests.swift in Sources */,
+				8AA0A6682CAC747500AC7EB3 /* NewHomepageDiffableDataSourceTests.swift in Sources */,
 				3B61CD591F2A750800D38DE1 /* PocketFeedTests.swift in Sources */,
 				C8E1BC0A28085AA700C62964 /* NimbusFeatureFlagLayerTests.swift in Sources */,
 				F80D53CF2A09A3350047ED14 /* RustSyncManagerTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/NewHomepageCompositionalLayout.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/NewHomepageCompositionalLayout.swift
@@ -6,7 +6,7 @@ import Foundation
 import Common
 
 /// Holds section layout logic for the new homepage as part of the rebuild project
-class NewHomepageSectionLayoutProvider {
+final class NewHomepageSectionLayoutProvider {
     private var logger: Logger
 
     init(logger: Logger = DefaultLogger.shared) {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/NewHomepageCompositionalLayout.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/NewHomepageCompositionalLayout.swift
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+/// Holds section layout logic for the new homepage as part of the rebuild project
+class NewHomepageSectionLayoutProvider {
+    private var logger: Logger
+
+    init(logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+    }
+
+    func createCompositionalLayout() -> UICollectionViewCompositionalLayout {
+        return UICollectionViewCompositionalLayout { (sectionIndex, environment) -> NSCollectionLayoutSection? in
+            guard let section = HomepageSection(rawValue: sectionIndex) else {
+                self.logger.log(
+                    "Section should not have been nil, something went wrong",
+                    level: .fatal,
+                    category: .newHomepage
+                )
+                return nil
+            }
+            return self.createLayoutSection(for: section)
+        }
+    }
+
+    // TODO: FXIOS-10163 - Update layout section with appropriate views + integrate with redux
+    private func createLayoutSection(
+        for section: HomepageSection
+    ) -> NSCollectionLayoutSection {
+        switch section {
+        case .header:
+            return createDefaultSectionLayout()
+        case .topSites:
+            return createFirstSectionLayout()
+        case .pocket:
+            return createDefaultSectionLayout()
+        }
+    }
+
+    // TODO: FXIOS-10165 - Update with proper top sites section layout
+    private func createFirstSectionLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(100))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 3)
+
+        group.interItemSpacing = .fixed(10)
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
+
+        return section
+    }
+
+    // TODO: FXIOS-10161 - Update with proper section layout
+    private func createDefaultSectionLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        item.contentInsets = NSDirectionalEdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0)
+
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(100))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
+
+        return section
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/NewHomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/NewHomepageDiffableDataSource.swift
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+typealias HomepageSection = NewHomepageDiffableDataSource.HomeSection
+typealias HomepageItem = NewHomepageDiffableDataSource.HomeItem
+
+/// Holds the data source configuration for the new homepage as part of the rebuild project
+class NewHomepageDiffableDataSource:
+    UICollectionViewDiffableDataSource<HomepageSection, HomepageItem> {
+    enum HomeSection: Int, Hashable {
+        case header
+        case topSites
+        case pocket
+    }
+
+    // TODO: FXIOS-10162 Update item type depending section data
+    struct HomeItem: Hashable {
+        let id: UUID
+        let title: String
+    }
+
+    func applyInitialSnapshot() {
+        var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeItem>()
+
+        snapshot.appendSections([.header, .topSites, .pocket])
+
+        // TODO: FXIOS-10162 Remove the dummy data and start implementing using the header section
+        let items = [
+            HomeItem(id: UUID(), title: "First"),
+            HomeItem(id: UUID(), title: "Second"),
+            HomeItem(id: UUID(), title: "Third")
+        ]
+
+        let items2 = [
+            HomeItem(id: UUID(), title: "First"),
+            HomeItem(id: UUID(), title: "Second"),
+        ]
+
+        let items3 = [
+            HomeItem(id: UUID(), title: "First"),
+        ]
+
+        snapshot.appendItems(items, toSection: .header)
+        snapshot.appendItems(items2, toSection: .topSites)
+        snapshot.appendItems(items3, toSection: .pocket)
+
+        apply(snapshot, animatingDifferences: true)
+    }
+
+    func updateHeaderSection() {
+        var updatedSnapshot = snapshot()
+
+        if !updatedSnapshot.sectionIdentifiers.contains(.header) {
+            updatedSnapshot.appendSections([.header])
+        }
+
+        let currentItems = updatedSnapshot.itemIdentifiers(inSection: .header)
+
+        updatedSnapshot.deleteItems(currentItems)
+
+        // TODO: FXIOS-10162 Remove the dummy data and start implementing using the header section
+        let newItems = [
+            HomeItem(id: UUID(), title: "Fourth"),
+        ]
+
+        updatedSnapshot.appendItems(newItems, toSection: .header)
+
+        apply(updatedSnapshot, animatingDifferences: true)
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/NewHomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/NewHomepageDiffableDataSource.swift
@@ -8,7 +8,7 @@ typealias HomepageSection = NewHomepageDiffableDataSource.HomeSection
 typealias HomepageItem = NewHomepageDiffableDataSource.HomeItem
 
 /// Holds the data source configuration for the new homepage as part of the rebuild project
-class NewHomepageDiffableDataSource:
+final class NewHomepageDiffableDataSource:
     UICollectionViewDiffableDataSource<HomepageSection, HomepageItem> {
     enum HomeSection: Int, Hashable {
         case header

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/NewHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/NewHomepageViewController.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Common
 
-class NewHomepageViewController: UIViewController, ContentContainable, Themeable {
+final class NewHomepageViewController: UIViewController, ContentContainable, Themeable {
     // MARK: - Typealiases
     private typealias a11y = AccessibilityIdentifiers.FirefoxHomepage
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/NewHomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/NewHomepageDiffableDataSourceTests.swift
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+final class NewHomepageDiffableDataSourceTests: XCTestCase {
+    var collectionView: UICollectionView?
+    var diffableDataSource: NewHomepageDiffableDataSource?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        let collectionView = try XCTUnwrap(collectionView)
+        diffableDataSource = NewHomepageDiffableDataSource(
+            collectionView: collectionView
+        ) { (collectionView, indexPath, item) -> UICollectionViewCell? in
+            return UICollectionViewCell()
+        }
+    }
+
+    override func tearDown() {
+        diffableDataSource = nil
+        collectionView = nil
+        super.tearDown()
+    }
+
+    // MARK: - applyInitialSnapshot
+    func test_applyInitialSnapshot_hasCorrectData() throws {
+        let dataSource = try XCTUnwrap(diffableDataSource)
+
+        dataSource.applyInitialSnapshot()
+
+        let snapshot = dataSource.snapshot()
+        XCTAssertEqual(snapshot.numberOfSections, 3)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites, .pocket])
+
+        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 3)
+        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .topSites).count, 2)
+        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .pocket).count, 1)
+    }
+
+    // MARK: - updateHeaderSection
+    func test_updateHeaderSection_hasCorrectData() throws {
+        let dataSource = try XCTUnwrap(diffableDataSource)
+
+        dataSource.applyInitialSnapshot()
+        dataSource.updateHeaderSection()
+
+        let snapshot = dataSource.snapshot()
+        XCTAssertEqual(snapshot.numberOfSections, 3)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites, .pocket])
+
+        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
+        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .topSites).count, 2)
+        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .pocket).count, 1)
+    }
+
+    func test_updateHeaderSection_withoutInitialSection_hasCorrectData() throws {
+        let dataSource = try XCTUnwrap(diffableDataSource)
+
+        dataSource.updateHeaderSection()
+
+        let snapshot = dataSource.snapshot()
+        XCTAssertEqual(snapshot.numberOfSections, 1)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header])
+        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10161)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22263)

## :bulb: Description
Add initial setup for diffable datasource and compositional layout. Added dummy / mock data for now which will slowly get replaced in future PRs when we move into adding the different sections

* Add new classes `NewHomepageSectionLayoutProvider` to support compositional layout code and `NewHomepageDiffableDataSource` to separate our diffable data source code
* Add new category for logger to separate `homepage` vs. `newHomepage`
* Add unit tests for diffable, UI tests seem more suitable for compositional layout (will need to check our current homepage UI tests)
* Port over some collectionView properties from original homepage while we are here

## Test Steps
1. Navigate to Fx Homepage (confirm you see the old one)
2. Go to the secret settings menu and find the New Homepage toggle in the `Feature Flags` section
3. Toggle on the feature and open a new tab 
4. Confirm that you see the screenshot below 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
| New Homepage |
| --- |
| <img src="https://github.com/user-attachments/assets/8a078941-26c4-4635-a1e5-236f6603346a" width="250"> |