### PR TITLE
Refactor FXIOS-10206 [Unified Search] Separate the toolbar's search engine image into its own class

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -10,10 +10,8 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
     private enum UX {
         static let horizontalSpace: CGFloat = 8
         static let gradientViewWidth: CGFloat = 40
-        static let searchEngineImageViewCornerRadius: CGFloat = 4
         static let iconContainerCornerRadius: CGFloat = 8
         static let lockIconImageViewSize = CGSize(width: 40, height: 24)
-        static let searchEngineImageViewSize = CGSize(width: 24, height: 24)
     }
 
     private var urlAbsolutePath: String?

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -397,6 +397,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         urlTextFieldColor = colors.textPrimary
         urlTextFieldSubdomainColor = colors.textSecondary
         gradientLayer.colors = colors.layerGradientURL.cgColors.reversed()
+        searchEngineContentView.applyTheme(theme: theme)
         iconContainerBackgroundView.backgroundColor = colors.layerSearch
         lockIconButton.tintColor = colors.iconPrimary
         lockIconButton.backgroundColor = colors.layerSearch

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -56,29 +56,22 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
     private var iconContainerStackViewLeadingConstraint: NSLayoutConstraint?
     private var lockIconWidthAnchor: NSLayoutConstraint?
 
+    // MARK: - Search Engine / Lock Image
     private lazy var iconContainerStackView: UIStackView = .build { view in
         view.axis = .horizontal
         view.alignment = .center
         view.distribution = .fill
     }
-
-    private lazy var searchEngineContentView: UIView = .build()
-
     private lazy var iconContainerBackgroundView: UIView = .build { view in
         view.layer.cornerRadius = UX.iconContainerCornerRadius
     }
-
-    private lazy var searchEngineImageView: UIImageView = .build { imageView in
-        imageView.contentMode = .scaleAspectFit
-        imageView.layer.cornerRadius = UX.searchEngineImageViewCornerRadius
-        imageView.isAccessibilityElement = true
-    }
-
+    private lazy var searchEngineContentView: SearchEngineView = .build()
     private lazy var lockIconButton: UIButton = .build { button in
         button.contentMode = .scaleAspectFit
         button.addTarget(self, action: #selector(self.didTapLockIcon), for: .touchUpInside)
     }
 
+    // MARK: - URL Text Field
     private lazy var urlTextField: LocationTextField = .build { [self] urlTextField in
         urlTextField.backgroundColor = .clear
         urlTextField.font = FXFontStyles.Regular.body.scaledFont()
@@ -118,7 +111,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
     }
 
     func configure(_ state: LocationViewState, delegate: LocationViewDelegate, isUnifiedSearchEnabled: Bool) {
-        searchEngineImageView.image = state.searchEngineImage
+        searchEngineContentView.configure(state, delegate: delegate, isUnifiedSearchEnabled: isUnifiedSearchEnabled)
         configureLockIconButton(state)
         configureURLTextField(state)
         configureA11y(state)
@@ -155,7 +148,6 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
 
         addSubviews(urlTextField, iconContainerStackView, gradientView)
         iconContainerStackView.addSubview(iconContainerBackgroundView)
-        searchEngineContentView.addSubview(searchEngineImageView)
         iconContainerStackView.addArrangedSubview(searchEngineContentView)
 
         urlTextFieldLeadingConstraint = urlTextField.leadingAnchor.constraint(
@@ -179,15 +171,6 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
             iconContainerBackgroundView.bottomAnchor.constraint(equalTo: urlTextField.bottomAnchor),
             iconContainerBackgroundView.leadingAnchor.constraint(lessThanOrEqualTo: urlTextField.leadingAnchor),
             iconContainerBackgroundView.trailingAnchor.constraint(equalTo: iconContainerStackView.trailingAnchor),
-
-            searchEngineImageView.heightAnchor.constraint(equalToConstant: UX.searchEngineImageViewSize.height),
-            searchEngineImageView.widthAnchor.constraint(equalToConstant: UX.searchEngineImageViewSize.width),
-            searchEngineImageView.leadingAnchor.constraint(equalTo: searchEngineContentView.leadingAnchor),
-            searchEngineImageView.trailingAnchor.constraint(equalTo: searchEngineContentView.trailingAnchor),
-            searchEngineImageView.topAnchor.constraint(greaterThanOrEqualTo: searchEngineContentView.topAnchor),
-            searchEngineImageView.bottomAnchor.constraint(lessThanOrEqualTo: searchEngineContentView.bottomAnchor),
-            searchEngineImageView.centerXAnchor.constraint(equalTo: searchEngineContentView.centerXAnchor),
-            searchEngineImageView.centerYAnchor.constraint(equalTo: searchEngineContentView.centerYAnchor),
 
             lockIconButton.heightAnchor.constraint(equalToConstant: UX.lockIconImageViewSize.height),
             lockIconButton.widthAnchor.constraint(equalToConstant: UX.lockIconImageViewSize.width),
@@ -401,11 +384,6 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         lockIconButton.accessibilityIdentifier = state.lockIconButtonA11yId
         lockIconButton.accessibilityLabel = state.lockIconButtonA11yLabel
 
-        searchEngineImageView.accessibilityIdentifier = state.searchEngineImageViewA11yId
-        searchEngineImageView.accessibilityLabel = state.searchEngineImageViewA11yLabel
-        searchEngineImageView.largeContentTitle = state.searchEngineImageViewA11yLabel
-        searchEngineImageView.largeContentImage = nil
-
         urlTextField.accessibilityIdentifier = state.urlTextFieldA11yId
         urlTextField.accessibilityLabel = state.urlTextFieldA11yLabel
     }
@@ -421,7 +399,6 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         urlTextFieldColor = colors.textPrimary
         urlTextFieldSubdomainColor = colors.textSecondary
         gradientLayer.colors = colors.layerGradientURL.cgColors.reversed()
-        searchEngineImageView.backgroundColor = colors.layer2
         iconContainerBackgroundView.backgroundColor = colors.layerSearch
         lockIconButton.tintColor = colors.iconPrimary
         lockIconButton.backgroundColor = colors.layerSearch

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView.swift
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+
+final class SearchEngineView: UIView, ThemeApplicable {
+    // MARK: - Properties
+    private enum UX {
+        static let horizontalSpace: CGFloat = 8
+        static let gradientViewWidth: CGFloat = 40
+        static let searchEngineImageViewCornerRadius: CGFloat = 4
+        static let iconContainerCornerRadius: CGFloat = 8
+        static let lockIconImageViewSize = CGSize(width: 40, height: 24)
+        static let searchEngineImageViewSize = CGSize(width: 24, height: 24)
+    }
+
+    private weak var delegate: LocationViewDelegate? // TODO Needed for FXIOS-10191
+    private var isUnifiedSearchEnabled: Bool = false
+
+    private lazy var searchEngineImageView: UIImageView = .build { imageView in
+        imageView.contentMode = .scaleAspectFit
+        imageView.layer.cornerRadius = UX.searchEngineImageViewCornerRadius
+        imageView.isAccessibilityElement = true
+    }
+
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(_ state: LocationViewState, delegate: LocationViewDelegate, isUnifiedSearchEnabled: Bool) {
+        searchEngineImageView.image = state.searchEngineImage
+        configureA11y(state)
+        self.delegate = delegate
+        self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
+    }
+
+    // MARK: - Layout
+
+    private func setupLayout() {
+        translatesAutoresizingMaskIntoConstraints = true
+        addSubviews(searchEngineImageView)
+
+        NSLayoutConstraint.activate([
+            searchEngineImageView.heightAnchor.constraint(equalToConstant: UX.searchEngineImageViewSize.height),
+            searchEngineImageView.widthAnchor.constraint(equalToConstant: UX.searchEngineImageViewSize.width),
+            searchEngineImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            searchEngineImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            searchEngineImageView.topAnchor.constraint(greaterThanOrEqualTo: self.topAnchor),
+            searchEngineImageView.bottomAnchor.constraint(lessThanOrEqualTo: self.bottomAnchor),
+            searchEngineImageView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            searchEngineImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+        ])
+    }
+
+    // MARK: - Accessibility
+
+    private func configureA11y(_ state: LocationViewState) {
+        searchEngineImageView.accessibilityIdentifier = state.searchEngineImageViewA11yId
+        searchEngineImageView.accessibilityLabel = state.searchEngineImageViewA11yLabel
+        searchEngineImageView.largeContentTitle = state.searchEngineImageViewA11yLabel
+        searchEngineImageView.largeContentImage = nil
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        let colors = theme.colors
+        searchEngineImageView.backgroundColor = colors.layer2
+    }
+}

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView.swift
@@ -13,7 +13,7 @@ final class SearchEngineView: UIView, ThemeApplicable {
     }
 
     private weak var delegate: LocationViewDelegate? // TODO Needed for FXIOS-10191
-    private var isUnifiedSearchEnabled: Bool = false
+    private var isUnifiedSearchEnabled = false
 
     private lazy var searchEngineImageView: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView.swift
@@ -8,11 +8,7 @@ import Common
 final class SearchEngineView: UIView, ThemeApplicable {
     // MARK: - Properties
     private enum UX {
-        static let horizontalSpace: CGFloat = 8
-        static let gradientViewWidth: CGFloat = 40
         static let searchEngineImageViewCornerRadius: CGFloat = 4
-        static let iconContainerCornerRadius: CGFloat = 8
-        static let lockIconImageViewSize = CGSize(width: 40, height: 24)
         static let searchEngineImageViewSize = CGSize(width: 24, height: 24)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10206)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22342)

## :bulb: Description
This PR refactors the toolbar's search engine image view and its parent container view into its own class. (This should not cause any UI/UX changes; I simply moved code around.)

This will make it easier to swap out this view with the new unified search drop-down image view (a future task).

### Accessibility check:

Checked the accessibility inspector Voice Over and I get the following, which appears to be the same order as on main:
_"Back Button" > "Image" (search engine) > "Address and Search"_

Dynamic Type also remains unchanged:

<img width="200" alt="Screenshot 2024-10-02 at 12 09 44 PM" src="https://github.com/user-attachments/assets/d12bef5d-8b1e-4beb-af51-4f005dd635cc">

### Demo:
#### Search engine icon:
<img width="382" alt="Screenshot 2024-10-02 at 11 34 03 AM" src="https://github.com/user-attachments/assets/98d24700-c02d-4f75-a3a4-87f206e3305d">

<img width="892" alt="Screenshot 2024-10-02 at 11 34 09 AM" src="https://github.com/user-attachments/assets/db6a46d8-fe1e-469f-b806-87e32dc18453">

#### Lock icon:
<img width="386" alt="Screenshot 2024-10-02 at 11 34 38 AM" src="https://github.com/user-attachments/assets/f0b04740-970d-4eb5-9f9a-cf8ab6cd08df">
<img width="911" alt="Screenshot 2024-10-02 at 11 34 45 AM" src="https://github.com/user-attachments/assets/fddef35a-af5f-4762-8f42-71ddc36b9854">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

