### PR TITLE
Bugfix FXIOS-9407 Open external links in last browsing mode

### DIFF
--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -138,6 +138,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         performActionFor shortcutItem: UIApplicationShortcutItem,
         completionHandler: @escaping (Bool) -> Void
     ) {
+        routeBuilder.configure(
+            isPrivate: UserDefaults.standard.bool(
+                forKey: PrefsKeys.LastSessionWasPrivate
+            ),
+            prefs: profile.prefs
+        )
+        
         guard let route = routeBuilder.makeRoute(shortcutItem: shortcutItem,
                                                  tabSetting: NewTabAccessors.getNewTabPage(profile.prefs))
         else { return }

--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -144,7 +144,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             ),
             prefs: profile.prefs
         )
-        
+
         guard let route = routeBuilder.makeRoute(shortcutItem: shortcutItem,
                                                  tabSetting: NewTabAccessors.getNewTabPage(profile.prefs))
         else { return }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -242,8 +242,8 @@ class BrowserCoordinator: BaseCoordinator,
 
         logger.log("Handling a route", level: .info, category: .coordinator)
         switch route {
-        case let .searchQuery(query):
-            handle(query: query)
+        case let .searchQuery(query, isPrivate):
+            handle(query: query, isPrivate: isPrivate)
 
         case let .search(url, isPrivate, options):
             handle(url: url, isPrivate: isPrivate, options: options)
@@ -320,8 +320,8 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
-    private func handle(query: String) {
-        browserViewController.handle(query: query)
+    private func handle(query: String, isPrivate: Bool) {
+        browserViewController.handle(query: query, isPrivate: isPrivate)
     }
 
     private func handle(url: URL?, isPrivate: Bool, options: Set<Route.SearchOptions>? = nil) {

--- a/firefox-ios/Client/Coordinators/Router/Route.swift
+++ b/firefox-ios/Client/Coordinators/Router/Route.swift
@@ -125,11 +125,5 @@ enum Route: Equatable {
     enum SearchOptions: Equatable {
         /// An option to focus the user's attention on the location field of the search interface.
         case focusLocationField
-
-        /// An option to switch to a normal search mode.
-        case switchToNormalMode
-
-        /// An option to switch to a privacy mode that may hide or obscure search results and prevent data sharing.
-        case switchToPrivacyMode
     }
 }

--- a/firefox-ios/Client/Coordinators/Router/Route.swift
+++ b/firefox-ios/Client/Coordinators/Router/Route.swift
@@ -22,10 +22,13 @@ enum Route: Equatable {
     ///   - tabId: A string representing the identifier of the tab where the search should be performed.
     case searchURL(url: URL?, tabId: String)
 
-    /// Represents a search route that takes a query string.
+    /// Represents a search route that takes a query string a boolean value indicating whether the search
+    /// is private or not.
     ///
-    /// - Parameter query: A string representing the query to be searched.
-    case searchQuery(query: String)
+    /// - Parameters:
+    ///   - query: A string representing the query to be searched and.
+    ///   - isPrivate: A boolean value indicating whether the search is private or not.
+    case searchQuery(query: String, isPrivate: Bool)
 
     /// Represents a route for sending Glean data.
     ///

--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -69,7 +69,7 @@ final class RouteBuilder {
                 }
 
             case .openText:
-                return .searchQuery(query: urlScanner.value(query: "text") ?? "")
+                return .searchQuery(query: urlScanner.value(query: "text") ?? "", isPrivate: isPrivate)
 
             case .glean:
                 return .glean(url: url)
@@ -90,7 +90,7 @@ final class RouteBuilder {
                 // Widget Quick links - medium - open copied url
                 if !UIPasteboard.general.hasURLs {
                     let searchText = UIPasteboard.general.string ?? ""
-                    return .searchQuery(query: searchText)
+                    return .searchQuery(query: searchText, isPrivate: isPrivate)
                 } else {
                     let url = UIPasteboard.general.url
                     return .search(url: url, isPrivate: isPrivate)

--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -179,7 +179,7 @@ final class RouteBuilder {
             return .search(url: nil, isPrivate: true, options: options)
         case .openLastBookmark:
             if let urlToOpen = (shortcutItem.userInfo?[QuickActionInfos.tabURLKey] as? String)?.asURL {
-                return .search(url: urlToOpen, isPrivate: false, options: [.switchToNormalMode])
+                return .search(url: urlToOpen, isPrivate: isPrivate)
             } else {
                 return nil
             }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2351,8 +2351,8 @@ class BrowserViewController: UIViewController,
                                     topTabsVisible: UIDevice.current.userInterfaceIdiom == .pad)
     }
 
-    func handle(query: String) {
-        openBlankNewTab(focusLocationField: false)
+    func handle(query: String, isPrivate: Bool) {
+        openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
         if isToolbarRefactorEnabled {
             openBrowser(searchTerm: query)
         } else {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2362,9 +2362,6 @@ class BrowserViewController: UIViewController,
 
     func handle(url: URL?, isPrivate: Bool, options: Set<Route.SearchOptions>? = nil) {
         if let url = url {
-            if options?.contains(.switchToNormalMode) == true {
-                switchToPrivacyMode(isPrivate: false)
-            }
             switchToTabForURLOrOpen(url, isPrivate: isPrivate)
         } else {
             openBlankNewTab(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -370,7 +370,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         subject.browserViewController = mbvc
         subject.browserHasLoaded()
 
-        let result = testCanHandleAndHandle(subject, route: .searchQuery(query: query))
+        let result = testCanHandleAndHandle(subject, route: .searchQuery(query: query, isPrivate: false))
 
         XCTAssertTrue(result)
         XCTAssertTrue(mbvc.handleQueryCalled)
@@ -401,11 +401,10 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         subject.browserHasLoaded()
 
         let result = testCanHandleAndHandle(subject, route: .search(url: URL(string: "https://example.com")!,
-                                                                    isPrivate: false,
-                                                                    options: [.switchToNormalMode]))
+                                                                    isPrivate: false))
 
         XCTAssertTrue(result)
-        XCTAssertTrue(mbvc.switchToPrivacyModeCalled)
+        XCTAssertFalse(mbvc.switchToPrivacyModeCalled)
         XCTAssertFalse(mbvc.switchToPrivacyModeIsPrivate)
         XCTAssertTrue(mbvc.switchToTabForURLOrOpenCalled)
         XCTAssertEqual(mbvc.switchToTabForURLOrOpenURL, URL(string: "https://example.com")!)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -262,7 +262,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .searchQuery(query: "test search text"))
+        XCTAssertEqual(route, .searchQuery(query: "test search text", isPrivate: false))
     }
 
     func testWidgetSmallQuicklinkOpenCopiedWithUrl() {
@@ -344,7 +344,7 @@ class RouteTests: XCTestCase {
 
         let route = subject.makeRoute(url: url)
 
-        XCTAssertEqual(route, .searchQuery(query: "google"))
+        XCTAssertEqual(route, .searchQuery(query: "google", isPrivate: false))
     }
 
     // MARK: - AppAction

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShortcutRouteTests.swift
@@ -38,8 +38,7 @@ final class ShortcutRouteTests: XCTestCase {
         let route = subject.makeRoute(shortcutItem: shortcutItem, tabSetting: .blankPage)
 
         XCTAssertEqual(route, .search(url: URL(string: "https://www.example.com"),
-                                      isPrivate: false,
-                                      options: [.switchToNormalMode]))
+                                      isPrivate: false))
     }
 
     // FXIOS-8107: Disabled test as history highlights has been disabled to fix app hangs / slowness

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -78,7 +78,7 @@ class MockBrowserViewController: BrowserViewController {
         openBlankNewTabCount += 1
     }
 
-    override func handle(query: String) {
+    override func handle(query: String, isPrivate: Bool) {
         handleQueryCalled = true
         handleQuery = query
         handleQueryCount += 1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9407)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20832)

## :bulb: Description
- The following methods of opening external links will now open in the last browsing mode (regular or private)
  - "Go to copied link" widget's (small and medium sizes)
  - "Search in Firefox" ShareTo extension action (when searching for text)
  - "Open last bookmark" home screen quick action (unless the webpage is already opened, then it switches to that tab - preferring regular over private browsing)

### 📝 Discussion
- External links opened utilizing the `.searchQuery` route always open in a new tab, whereas external links opened utilizing the `.search` route always check to see if that webpage is open in another tab and switches to it (preferring regular over private browsing) before opening a new tab in the last browsing mode
- When “Close Private Tabs” is enabled, closing the app while in private browsing does not change the “lastSessionWasPrivate” pref back to false, and I would if it should? This can cause external links to open in private browsing from a cold start of the app.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

