### PR TITLE
Add FXIOS-10208 [Unified Search] Swap to placeholder search engine image view view when isUnifiedSearchEnabled

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -63,7 +63,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
     private lazy var iconContainerBackgroundView: UIView = .build { view in
         view.layer.cornerRadius = UX.iconContainerCornerRadius
     }
-    private lazy var searchEngineContentView: SearchEngineView = .build()
+    private lazy var searchEngineContentView: SearchEngineView = PlainSearchEngineView()
     private lazy var lockIconButton: UIButton = .build { button in
         button.contentMode = .scaleAspectFit
         button.addTarget(self, action: #selector(self.didTapLockIcon), for: .touchUpInside)
@@ -109,7 +109,6 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
     }
 
     func configure(_ state: LocationViewState, delegate: LocationViewDelegate, isUnifiedSearchEnabled: Bool) {
-        searchEngineContentView.configure(state, delegate: delegate, isUnifiedSearchEnabled: isUnifiedSearchEnabled)
         configureLockIconButton(state)
         configureURLTextField(state)
         configureA11y(state)
@@ -119,6 +118,11 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
         searchTerm = state.searchTerm
         onLongPress = state.onLongPress
+
+        searchEngineContentView = isUnifiedSearchEnabled
+                                  ? DropDownSearchEngineView()
+                                  : PlainSearchEngineView()
+        searchEngineContentView.configure(state, delegate: delegate)
     }
 
     func setAutocompleteSuggestion(_ suggestion: String?) {
@@ -140,10 +144,6 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
     }
 
     private func setupLayout() {
-        if isUnifiedSearchEnabled {
-            // TODO FXIOS-10193 Update search engine icon for Unified Search
-        }
-
         addSubviews(urlTextField, iconContainerStackView, gradientView)
         iconContainerStackView.addSubview(iconContainerBackgroundView)
         iconContainerStackView.addArrangedSubview(searchEngineContentView)

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -63,7 +63,11 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
     private lazy var iconContainerBackgroundView: UIView = .build { view in
         view.layer.cornerRadius = UX.iconContainerCornerRadius
     }
-    private lazy var searchEngineContentView: SearchEngineView = PlainSearchEngineView()
+    // TODO FXIOS-10210 Once the Unified Search experiment is complete, we will only need to use `DropDownSearchEngineView`
+    // and we can remove `PlainSearchEngineView` from the project.
+    private lazy var plainSearchEngineView: PlainSearchEngineView = .build()
+    private lazy var dropDownSearchEngineView: DropDownSearchEngineView = .build()
+    private lazy var searchEngineContentView: SearchEngineView = plainSearchEngineView
     private lazy var lockIconButton: UIButton = .build { button in
         button.contentMode = .scaleAspectFit
         button.addTarget(self, action: #selector(self.didTapLockIcon), for: .touchUpInside)
@@ -109,6 +113,13 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
     }
 
     func configure(_ state: LocationViewState, delegate: LocationViewDelegate, isUnifiedSearchEnabled: Bool) {
+        // TODO FXIOS-10210 Once the Unified Search experiment is complete, we won't need this extra layout logic and can
+        // simply use the `.build` method on `DropDownSearchEngineView` on `LocationView`'s init.
+        searchEngineContentView = isUnifiedSearchEnabled
+                                  ? dropDownSearchEngineView
+                                  : plainSearchEngineView
+        searchEngineContentView.configure(state, delegate: delegate)
+
         configureLockIconButton(state)
         configureURLTextField(state)
         configureA11y(state)
@@ -118,11 +129,6 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
         searchTerm = state.searchTerm
         onLongPress = state.onLongPress
-
-        searchEngineContentView = isUnifiedSearchEnabled
-                                  ? DropDownSearchEngineView()
-                                  : PlainSearchEngineView()
-        searchEngineContentView.configure(state, delegate: delegate)
     }
 
     func setAutocompleteSuggestion(_ suggestion: String?) {
@@ -148,8 +154,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         iconContainerStackView.addSubview(iconContainerBackgroundView)
         iconContainerStackView.addArrangedSubview(searchEngineContentView)
 
-        urlTextFieldLeadingConstraint = urlTextField.leadingAnchor.constraint(
-            equalTo: iconContainerStackView.trailingAnchor)
+        urlTextFieldLeadingConstraint = urlTextField.leadingAnchor.constraint(equalTo: iconContainerStackView.trailingAnchor)
         urlTextFieldLeadingConstraint?.isActive = true
 
         iconContainerStackViewLeadingConstraint = iconContainerStackView.leadingAnchor.constraint(equalTo: leadingAnchor)

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView/DropDownSearchEngineView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView/DropDownSearchEngineView.swift
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+
+// TODO FXIOS-10193 This file is a placeholder stub for FXIOS-10193 customization
+/// A view which contains a search engine icon and a drop down arrow. Supports tapping actions which call the appropriate
+/// method on the `LocationViewDelegate`.
+final class DropDownSearchEngineView: UIView, SearchEngineView, ThemeApplicable {
+    // MARK: - Properties
+    private enum UX {
+        static let cornerRadius: CGFloat = 4
+        static let dropDownMargin: CGFloat = 4
+        static let imageViewMargin: CGFloat = 2
+        static let imageViewSize = CGSize(width: 24, height: 24)
+        static let downArrowSize = CGSize(width: 8, height: 8)
+    }
+
+    private weak var delegate: LocationViewDelegate? // TODO FXIOS-10193 Notify delegate on tap (add selector)
+
+    private lazy var searchEngineImageView: UIImageView = .build { imageView in
+        imageView.contentMode = .scaleAspectFit
+        imageView.layer.cornerRadius = UX.cornerRadius
+        imageView.isAccessibilityElement = true
+    }
+
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(_ state: LocationViewState, delegate: LocationViewDelegate) {
+        // TODO FXIOS-10193 Load the image into the imageView
+        searchEngineImageView.backgroundColor = UIColor.red // Placeholder
+        configureA11y(state)
+        self.delegate = delegate
+    }
+
+    // MARK: - Layout
+
+    private func setupLayout() {
+        translatesAutoresizingMaskIntoConstraints = true
+        addSubviews(searchEngineImageView)
+
+        // TODO FXIOS-10193 Add subviews to create the new button with the drop-down arrow
+        //
+        //
+        //
+
+        NSLayoutConstraint.activate([
+            searchEngineImageView.heightAnchor.constraint(equalToConstant: UX.imageViewSize.height),
+            searchEngineImageView.widthAnchor.constraint(equalToConstant: UX.imageViewSize.width),
+            searchEngineImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            searchEngineImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            searchEngineImageView.topAnchor.constraint(greaterThanOrEqualTo: self.topAnchor),
+            searchEngineImageView.bottomAnchor.constraint(lessThanOrEqualTo: self.bottomAnchor),
+            searchEngineImageView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            searchEngineImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+        ])
+    }
+
+    // MARK: - Accessibility
+
+    private func configureA11y(_ state: LocationViewState) {
+        // TODO FXIOS-10193 Enforce correct accessibility identifiers after finalizing the UI for DropDownSearchEngineView
+        // e.g.) Old code, may need updating:
+        // searchEngineImageView.accessibilityIdentifier = state.searchEngineImageViewA11yId
+        // searchEngineImageView.accessibilityLabel = state.searchEngineImageViewA11yLabel
+        // searchEngineImageView.largeContentTitle = state.searchEngineImageViewA11yLabel
+        // searchEngineImageView.largeContentImage = nil
+    }
+
+    // MARK: - Selectors
+
+    // TODO FXIOS-10193 Add selector action method to bubble up tap of this view to the delegate
+    // TODO FXIOS-10191 Actual selector implementation to come later.
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        // TODO FXIOS-10193 Apply theme to new subviews
+        // e.g.)  Old code, may need updating:
+        // let colors = theme.colors
+        // searchEngineImageView.backgroundColor = colors.layer2
+    }
+}

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView/PlainSearchEngineView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView/PlainSearchEngineView.swift
@@ -5,19 +5,17 @@
 import UIKit
 import Common
 
-final class SearchEngineView: UIView, ThemeApplicable {
+/// A wrapped UIImageView which displays a plain search engine icon with no tapping features.
+final class PlainSearchEngineView: UIView, SearchEngineView, ThemeApplicable {
     // MARK: - Properties
     private enum UX {
-        static let searchEngineImageViewCornerRadius: CGFloat = 4
-        static let searchEngineImageViewSize = CGSize(width: 24, height: 24)
+        static let cornerRadius: CGFloat = 4
+        static let imageViewSize = CGSize(width: 24, height: 24)
     }
-
-    private weak var delegate: LocationViewDelegate? // TODO Needed for FXIOS-10191
-    private var isUnifiedSearchEnabled = false
 
     private lazy var searchEngineImageView: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
-        imageView.layer.cornerRadius = UX.searchEngineImageViewCornerRadius
+        imageView.layer.cornerRadius = UX.cornerRadius
         imageView.isAccessibilityElement = true
     }
 
@@ -31,11 +29,9 @@ final class SearchEngineView: UIView, ThemeApplicable {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(_ state: LocationViewState, delegate: LocationViewDelegate, isUnifiedSearchEnabled: Bool) {
+    func configure(_ state: LocationViewState, delegate: LocationViewDelegate) {
         searchEngineImageView.image = state.searchEngineImage
         configureA11y(state)
-        self.delegate = delegate
-        self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
     }
 
     // MARK: - Layout
@@ -45,8 +41,8 @@ final class SearchEngineView: UIView, ThemeApplicable {
         addSubviews(searchEngineImageView)
 
         NSLayoutConstraint.activate([
-            searchEngineImageView.heightAnchor.constraint(equalToConstant: UX.searchEngineImageViewSize.height),
-            searchEngineImageView.widthAnchor.constraint(equalToConstant: UX.searchEngineImageViewSize.width),
+            searchEngineImageView.heightAnchor.constraint(equalToConstant: UX.imageViewSize.height),
+            searchEngineImageView.widthAnchor.constraint(equalToConstant: UX.imageViewSize.width),
             searchEngineImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             searchEngineImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             searchEngineImageView.topAnchor.constraint(greaterThanOrEqualTo: self.topAnchor),

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView/SearchEngineView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView/SearchEngineView.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+/// Protocol for a view which displays the current search engine inside the toolbar.
+protocol SearchEngineView: UIView {
+    func configure(_ state: LocationViewState, delegate: LocationViewDelegate)
+}

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView/SearchEngineView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView/SearchEngineView.swift
@@ -3,8 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
+import Common
 
 /// Protocol for a view which displays the current search engine inside the toolbar.
 protocol SearchEngineView: UIView {
     func configure(_ state: LocationViewState, delegate: LocationViewDelegate)
+    func applyTheme(theme: Theme)
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10208)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22346)

## :bulb: Description
_**NOTE:** This PR is for the Unified Search project, which is only active when _both_ the toolbar refactor and `unified_search` are enabled._

This PR adds functionality to swap between two different container views for the search engine graphic that displays in the toolbar refactor.

The `DropDownSearchEngineView` class is mostly a stub for now. In the [FXIOS-10193 ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10193), `DropDownSearchEngineView` will be used to implement the new search engine drop down UI/UX for Unified Search.

When both the toolbar refactor and `unified_search` are enabled, you will currently see a red placeholder graphic:
<img width="200" alt="Screenshot 2024-10-02 at 1 30 56 PM" src="https://github.com/user-attachments/assets/c90ec3c7-ec83-4692-afa8-db8845c9fed4">

This PR provides just enough setup so that the [FXIOS-10193 ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10193) can be passed off to another developer later if required by current timelines.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

