### PR TITLE
Add EXP-4788: Add studies toggle checkbox verification to experiment integration tests.

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ExperimentIntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ExperimentIntegrationTests.swift
@@ -51,7 +51,6 @@ final class ExperimentIntegrationTests: BaseTestCase {
             return false
         }
     }
-
     func testVerifyExperimentEnrolled() throws {
         navigator.goto(SettingsScreen)
 
@@ -132,8 +131,9 @@ final class ExperimentIntegrationTests: BaseTestCase {
         let studiesToggle = app.switches.matching(
             NSPredicate(format: "identifier CONTAINS 'settings.studiesToggle'")
         )
-
+        XCTAssertEqual(studiesToggle.element.value as? String, "1")
         studiesToggle.element.tap()
+        XCTAssertEqual(studiesToggle.element.value as? String, "0")
         XCTAssertFalse(checkExperimentEnrollment(experimentName: experimentName))
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-4788)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This checks the value of the studies element before and after tapping it to disable it. 

## :pencil: Checklist
You have to check all boxes before merging
- [✅] Filled in the above information (tickets numbers and description of your work)
- [✅] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

