### PR TITLE
Bugfix FXIOS-10211 Fix debug-build crash when disabling content blocker

### DIFF
--- a/firefox-ios/Client/ContentBlocker/ContentBlocker+Safelist.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker+Safelist.swift
@@ -31,7 +31,7 @@ extension ContentBlocker {
             return ""
         }
         // Note that * is added to the front of domains, so foo.com becomes *foo.com
-        let list = "'*" + safelistedDomains.domainSet.joined(separator: "','*") + "'"
+        let list = "\"*" + safelistedDomains.domainSet.joined(separator: "\",\"*") + "\""
 
         let script =
         """


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10211)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22352)

## :bulb: Description

Debug builds were hitting an `assertionFailure` in some scenarios during content blocking loading.

The root problem was that the safelist JSON script was recently changed to use literal quotes for readability and to avoid needing to parse and update the string at runtime (to replace ' with "), but the quotes around the domains  were not updated, so the mismatch was causing a parsing error.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

