### PR TITLE
Refactored MTE-3645 - url strings with single path identifier

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -133,7 +133,7 @@ class ActivityStreamTest: BaseTestCase {
             waitForExistence(topSitesCells.staticTexts[newTopSiteiOS15["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
         }
 
-        waitForExistence(app.buttons["urlBar-cancel"])
+        waitForExistence(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
@@ -206,7 +206,7 @@ class ActivityStreamTest: BaseTestCase {
 
         // The website is open
         mozWaitForElementToNotExist(TopSiteCellgroup)
-        waitForValueContains(app.textFields["url"], value: "wikipedia.org")
+        waitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "wikipedia.org")
     }
 
     // Smoketest

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
@@ -9,7 +9,7 @@ let testBasicHTTPAuthURL = "https://jigsaw.w3.org/HTTP/Basic/"
 class AuthenticationTest: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2360560
     func testBasicHTTPAuthenticationPromptVisible() {
-        mozWaitForElementToExist(app.textFields["url"])
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
         navigator.nowAt(NewTabScreen)
         navigator.openURL(testBasicHTTPAuthURL)
         mozWaitForElementToExist(app.staticTexts["Authentication required"], timeout: 100)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -320,7 +320,7 @@ class BaseTestCase: XCTestCase {
     func loadWebPage(_ url: String, waitForLoadToFinish: Bool = true, file: String = #file, line: UInt = #line) {
         let app = XCUIApplication()
         UIPasteboard.general.string = url
-        app.textFields["url"].press(forDuration: 2.0)
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].press(forDuration: 2.0)
         app.tables["Context Menu"].cells[AccessibilityIdentifiers.Photon.pasteAndGoAction].firstMatch.tap()
 
         if waitForLoadToFinish {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -124,7 +124,7 @@ class BookmarksTests: BaseTestCase {
     // Smoketest
     func testBookmarksAwesomeBar() {
         XCTExpectFailure("The app was not launched", strict: false) {
-            mozWaitForElementToExist(app.textFields["url"], timeout: TIMEOUT_LONG)
+            mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], timeout: TIMEOUT_LONG)
         }
         typeOnSearchBar(text: "www.google")
         mozWaitForElementToExist(app.tables["SiteTable"])
@@ -165,7 +165,7 @@ class BookmarksTests: BaseTestCase {
         addNewBookmark()
         // Verify that clicking on bookmark opens the website
         app.tables["Bookmarks List"].cells.element(boundBy: 1).tap()
-        mozWaitForElementToExist(app.textFields["url"])
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306914
@@ -269,8 +269,8 @@ class BookmarksTests: BaseTestCase {
     }
 
     private func typeOnSearchBar(text: String) {
-        mozWaitForElementToExist(app.textFields["url"])
-        app.textFields["url"].tap()
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
         app.textFields["address"].typeText(text)
     }
 
@@ -279,7 +279,7 @@ class BookmarksTests: BaseTestCase {
     func testBookmarkLibraryAddDeleteBookmark() {
         // Verify that there are only 1 cell (desktop bookmark folder)
         XCTExpectFailure("The app was not launched", strict: false) {
-            mozWaitForElementToExist(app.textFields["url"], timeout: TIMEOUT_LONG)
+            mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], timeout: TIMEOUT_LONG)
         }
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -12,12 +12,15 @@ let PDF_website = [
     "bookmarkLabel": "https://storage.googleapis.com/mobile_test_assets/public/pdf-test.pdf",
     "longUrlValue": "http://www.education.gov.yk.ca/"
 ]
+
 class BrowsingPDFTests: BaseTestCase {
+    let url = XCUIApplication().textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+
     // https://mozilla.testrail.io/index.php?/cases/view/2307116
     func testOpenPDFViewer() {
         navigator.openURL(PDF_website["url"]!)
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
+        mozWaitForValueContains(url, value: PDF_website["pdfValue"]!)
         // Swipe Up and Down
         app.swipeUp()
         mozWaitForElementToExist(app.staticTexts["1 of 1"])
@@ -34,12 +37,12 @@ class BrowsingPDFTests: BaseTestCase {
         // Click on a link on the pdf and check that the website is shown
         app.links.element(boundBy: 0).tapOnApp()
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: PDF_website["urlValue"]!)
+        mozWaitForValueContains(url, value: PDF_website["urlValue"]!)
         mozWaitForElementToExist(app.staticTexts["Education and schools"])
 
         // Go back to pdf view
         app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
-        mozWaitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
+        mozWaitForValueContains(url, value: PDF_website["pdfValue"]!)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307118
@@ -97,7 +100,7 @@ class BrowsingPDFTests: BaseTestCase {
             .element(boundBy: 0)
         pdfTopSite.tap()
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: PDF_website["pdfValue"]!)
+        mozWaitForValueContains(url, value: PDF_website["pdfValue"]!)
 
         // Remove pdf pinned site
         navigator.performAction(Action.OpenNewTabFromTabTray)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
@@ -9,7 +9,7 @@ class ClipBoardTests: BaseTestCase {
 
     // Check for test url in the browser
     func checkUrl() {
-        let urlTextField = app.textFields["url"]
+        let urlTextField = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
         mozWaitForValueContains(urlTextField, value: "www.example")
     }
 
@@ -38,7 +38,7 @@ class ClipBoardTests: BaseTestCase {
                     allowBtn.tap()
                 }
 
-                var value = app.textFields["url"].value as! String
+                var value = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
                 if value.hasPrefix("http") == false {
                     value = "http://\(value)"
                 }
@@ -103,13 +103,13 @@ class ClipBoardTests: BaseTestCase {
 //        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
 //        navigator.createNewTab()
 //        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-//        app.textFields["url"].press(forDuration: 3)
+//        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].press(forDuration: 3)
 //        mozWaitForElementToExist(app.tables["Context Menu"])
 //        mozWaitForElementToExist(
 //            app.tables["Context Menu"].otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction]
 //        )
 //        app.tables["Context Menu"].otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction].tap()
-//        mozWaitForElementToExist(app.textFields["url"])
-//        mozWaitForValueContains(app.textFields["url"], value: "www.example.com")
+//        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
+//        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "www.example.com")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
@@ -223,7 +223,7 @@ class DownloadsTests: BaseTestCase {
 
         // Remove private data once the switch to remove downloaded files is enabled
         navigator.goto(NewTabScreen)
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(ClearPrivateDataSettings)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -107,9 +107,9 @@ class DragAndDropTests: BaseTestCase {
             )
             checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
             if !iPad() {
+                let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
                 XCTAssert(
-                    secondWebsite.url.contains(app.textFields["url"].value! as! String),
-                    "The tab has not been dropped correctly"
+                    secondWebsite.url.contains(url.value! as! String), "The tab has not been dropped correctly"
                 ) } else {
                     XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
                 }
@@ -135,9 +135,9 @@ class DragAndDropTests: BaseTestCase {
             checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: homeTabName)
             // Check that focus is kept on last website open
             if !iPad() {
+                let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
                 XCTAssert(
-                    secondWebsite.url.contains(app.textFields["url"].value! as! String),
-                    "The tab has not been dropped correctly"
+                    secondWebsite.url.contains(url.value! as! String), "The tab has not been dropped correctly"
                 ) } else {
                     XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
                 }
@@ -266,7 +266,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
         // Check that focus is kept on last website open
         XCTAssert(
-            secondWebsite.url.contains(app.textFields["url"].value! as! String),
+            secondWebsite.url.contains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value! as! String),
             "The tab has not been dropped correctly"
         )
     }
@@ -302,7 +302,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         mozWaitForElementToExist(searchField)
 
         // DragAndDrop the url for only one second so that the TP menu is not shown and the search box is not covered
-        app.textFields["url"].press(forDuration: 1, thenDragTo: searchField)
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].press(forDuration: 1, thenDragTo: searchField)
 
         // Verify that the text in the search field is the same as the text in the url text field
         searchField.tap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ExperimentIntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ExperimentIntegrationTests.swift
@@ -69,7 +69,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
 
         wait(forElement: surveyLink.element, timeout: TIMEOUT_LONG)
         surveyLink.element.tap()
-        mozWaitForValueContains(app.textFields["url"], value: "survey")
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "survey")
     }
 
     func testMessageNoThanksNavigatesCorrectly() throws {
@@ -99,7 +99,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
 
         wait(forElement: surveyLink.element, timeout: TIMEOUT_LONG)
         surveyLink.element.tap()
-        mozWaitForValueContains(app.textFields["url"], value: "survey")
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "survey")
     }
 
     func testHomeScreenMessageNavigatesCorrectly() throws {
@@ -109,7 +109,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
 
         wait(forElement: surveyLink.element, timeout: TIMEOUT_LONG)
         surveyLink.element.tap()
-        mozWaitForValueContains(app.textFields["url"], value: "survey")
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "survey")
     }
 
     func testHomeScreenMessageDismissesCorrectly() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FakespotTests.swift
@@ -184,7 +184,7 @@ class FakespotTests: BaseTestCase {
         app.buttons[shoppingIdentifier.turnOffButton].tap()
         // The 'Review quality check' bottom sheet/sidebar closes
         mozWaitForElementToNotExist(app.staticTexts[AccessibilityIdentifiers.Shopping.sheetHeaderTitle])
-        mozWaitForValueContains(app.textFields["url"], value: "www.amazon.com")
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "www.amazon.com")
         // In a new tab, navigate to a product detail page on amazon.com
         navigator.performAction(Action.OpenNewTabFromTabTray)
         reachReviewChecker()
@@ -270,7 +270,7 @@ class FakespotTests: BaseTestCase {
 
     private func validateMozillaSupportWebpage(_ webpageTitle: String, _ url: String) {
         mozWaitForElementToExist(app.staticTexts[webpageTitle])
-        mozWaitForValueContains(app.textFields["url"], value: url)
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: url)
         let numTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual(numTab, "2")
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -174,7 +174,7 @@ class FindInPageTests: BaseTestCase {
         openFindInPageFromMenu(openSite: userState.url!)
 
         // Before reloading, it is necessary to hide the keyboard
-        app.textFields["url"].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
         app.textFields["address"].typeText("\n")
 
         // Once the page is reloaded the search bar should not appear

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -404,7 +404,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.noop(to: HomePanel_TopSites)
 
         screenState.backAction = {
-            app.buttons["urlBar-cancel"].tap()
+            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
         }
         screenState.dismissOnUse = true
     }
@@ -464,7 +464,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         }
 
         screenState.gesture(forAction: Action.CloseURLBarOpen, transitionTo: HomePanelsScreen) {_ in
-            app.buttons["urlBar-cancel"].tap()
+            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
         }
     }
 
@@ -932,9 +932,9 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     func makeURLBarAvailable(_ screenState: MMScreenStateNode<FxUserState>) {
-        screenState.tap(app.textFields["url"], to: URLBarOpen)
+        screenState.tap(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], to: URLBarOpen)
         screenState.gesture(to: URLBarLongPressMenu) {
-            app.textFields["url"].press(forDuration: 1.0)
+            app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].press(forDuration: 1.0)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -371,7 +371,8 @@ class HistoryTests: BaseTestCase {
         urlBarForwardButton.press(forDuration: 1)
         mozWaitForElementToExist(app.tables.staticTexts["The Book of Mozilla"])
         app.tables.staticTexts["The Book of Mozilla"].tap()
-        mozWaitForValueContains(app.textFields["url"], value: "test-fixture/test-mozilla-book.html")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: "test-fixture/test-mozilla-book.html")
     }
 
     // Private function created to select desired option from the "Clear Recent History" list
@@ -387,7 +388,8 @@ class HistoryTests: BaseTestCase {
         // Workaround as the item does not appear if there is only that tab open
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
+        let cancelButton = app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton]
+        mozWaitForElementToExist(cancelButton, timeout: TIMEOUT_LONG)
         navigator.performAction(Action.CloseURLBarOpen)
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
@@ -421,7 +423,7 @@ class HistoryTests: BaseTestCase {
     }
 
     private func closeKeyboard() {
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -93,7 +93,7 @@ class HomePageSettingsUITests: BaseTestCase {
         mozWaitForElementToExist(homePageMenuItem)
         homePageMenuItem.tap()
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: "example")
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "example")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339258
@@ -134,7 +134,7 @@ class HomePageSettingsUITests: BaseTestCase {
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         navigator.performAction(Action.GoToHomePage)
-        mozWaitForElementToExist(app.textFields["url"])
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
 
         // Now after setting History, make sure FF home is set
         navigator.goto(SettingsScreen)
@@ -161,8 +161,8 @@ class HomePageSettingsUITests: BaseTestCase {
 
         // Workaround needed after Xcode 11.3 update Issue 5937
         // Lets check only that website is open
-        mozWaitForElementToExist(app.textFields["url"])
-        mozWaitForValueContains(app.textFields["url"], value: "mozilla")
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "mozilla")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339489
@@ -222,7 +222,7 @@ class HomePageSettingsUITests: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.nowAt(NewTabScreen)
         if !iPad() {
-            mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
             navigator.performAction(Action.CloseURLBarOpen)
         }
         mozWaitForElementToExist(
@@ -268,14 +268,14 @@ class HomePageSettingsUITests: BaseTestCase {
         mozWaitForElementToNotExist(
             app.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.bookmarks]
         )
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.ToggleRecentlySaved)
         navigator.nowAt(HomeSettings)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         if !iPad() {
-            mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
             navigator.performAction(Action.CloseURLBarOpen)
         }
         checkBookmarks()
@@ -325,7 +325,7 @@ class HomePageSettingsUITests: BaseTestCase {
 //                .staticTexts[urlMozillaLabel].exists
 //        )
 //        if !iPad() {
-//            mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: 3)
+//            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton], timeout: 3)
 //            navigator.performAction(Action.CloseURLBarOpen)
 //        }
 //        navigator.nowAt(NewTabScreen)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -7,7 +7,7 @@ import Common
 
 class JumpBackInTests: BaseTestCase {
     func closeKeyboard() {
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
@@ -108,7 +108,7 @@ class JumpBackInTests: BaseTestCase {
 //        app.cells["JumpBackInCell"].staticTexts["Twitter"].tap()
 //
 //        // The view is switched to the twitter tab
-//        let url = app.textFields["url"].value as! String
+//        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
 //        XCTAssertEqual(url, "twitter.com/i/flow/login")
 //
 //        // Open a new tab in normal browsing

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -24,8 +24,8 @@ class NavigationTest: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2441488
     func testNavigation() {
         let urlPlaceholder = "Search or enter address"
-        mozWaitForElementToExist(app.textFields["url"])
-        let defaultValuePlaceholder = app.textFields["url"].placeholderValue!
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
+        let defaultValuePlaceholder = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].placeholderValue!
 
         // Check the url placeholder text and that the back and forward buttons are disabled
         XCTAssert(urlPlaceholder == defaultValuePlaceholder)
@@ -33,28 +33,29 @@ class NavigationTest: BaseTestCase {
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
         if iPad() {
-            app.textFields["url"].tap()
+            app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
             // Once an url has been open, the back button is enabled but not the forward button
             navigator.performAction(Action.CloseURLBarOpen)
             navigator.nowAt(NewTabScreen)
         }
         navigator.openURL(path(forTestPage: "test-example.html"))
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: "test-example.html")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: "test-example.html")
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
         // Once a second url is open, back button is enabled but not the forward one till we go back to url_1
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: "test-mozilla-org.html")
+        mozWaitForValueContains(url, value: "test-mozilla-org.html")
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
         // Go back to previous visited web site
         app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
 
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: "test-example.html")
+        mozWaitForValueContains(url, value: "test-example.html")
 
         if iPad() {
             app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].tap()
@@ -64,7 +65,7 @@ class NavigationTest: BaseTestCase {
             app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].tap()
         }
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: "test-mozilla-org")
+        mozWaitForValueContains(url, value: "test-mozilla-org")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441489
@@ -136,7 +137,8 @@ class NavigationTest: BaseTestCase {
         navigator.goto(TabTray)
         navigator.openURL(website_1["url"]!)
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: website_1["value"]!)
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: website_1["value"]!)
         let topElement = app.links["Mozilla"].firstMatch
         let bottomElement = app.webViews.links.staticTexts["Legal"]
 
@@ -164,13 +166,14 @@ class NavigationTest: BaseTestCase {
     func testCopyLink() {
         longPressLinkOptions(optionSelected: "Copy Link")
         navigator.goto(NewTabScreen)
-        app.textFields["url"].press(forDuration: 2)
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].press(forDuration: 2)
 
         mozWaitForElementToExist(app.tables["Context Menu"])
         app.tables.otherElements[AccessibilityIdentifiers.Photon.pasteAction].tap()
         app.buttons["Go"].tap()
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: website_2["moreLinkLongPressInfo"]!)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441497
@@ -179,14 +182,15 @@ class NavigationTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         longPressLinkOptions(optionSelected: "Copy Link")
         navigator.goto(NewTabScreen)
-        mozWaitForElementToExist(app.textFields["url"])
-        app.textFields["url"].press(forDuration: 2)
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].press(forDuration: 2)
 
         app.tables.otherElements[AccessibilityIdentifiers.Photon.pasteAction].tap()
         mozWaitForElementToExist(app.buttons["Go"])
         app.buttons["Go"].tap()
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: website_2["moreLinkLongPressInfo"]!)
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: website_2["moreLinkLongPressInfo"]!)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441923
@@ -226,11 +230,11 @@ class NavigationTest: BaseTestCase {
             waitUntilPageLoad()
             mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
 
-            app.textFields["url"].press(forDuration: 3)
+            app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].press(forDuration: 3)
             app.tables.otherElements[StandardImageIdentifiers.Large.link].tap()
 
             sleep(2)
-            app.textFields["url"].tap()
+            app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
             // Since the textField value appears all selected first time is clicked
             // this workaround is necessary
             mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
@@ -284,7 +288,8 @@ class NavigationTest: BaseTestCase {
         // Tap on the just downloaded link to check that the web page is loaded
         app.tables.cells.staticTexts["example-domains.html"].tap()
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: "example-domains.html")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: "example-domains.html")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441499
@@ -344,7 +349,7 @@ class NavigationTest: BaseTestCase {
 //
 //        // Check that there are no pop ups
 //        navigator.openURL(popUpTestUrl)
-//        mozWaitForValueContains(app.textFields["url"], value: "blocker.html")
+//        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "blocker.html")
 //        mozWaitForElementToExist(app.webViews.staticTexts["Blocked Element"])
 //
 //        let numTabs = app.buttons["Show Tabs"].value
@@ -361,7 +366,7 @@ class NavigationTest: BaseTestCase {
 //        // Check that now pop ups are shown, two sites loaded
 //        navigator.openURL(popUpTestUrl)
 //        waitUntilPageLoad()
-//        mozWaitForValueContains(app.textFields["url"], value: "example.com")
+//        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "example.com")
 //        let numTabsAfter = app.buttons["Show Tabs"].value
 //        XCTAssertNotEqual("1", numTabsAfter as? String, "Several tabs are open")
     }
@@ -422,7 +427,7 @@ class NavigationTest: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2441775
     // Smoketest
     func testURLBar() {
-        let urlBar = app.textFields["url"]
+        let urlBar = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
         mozWaitForElementToExist(urlBar)
         urlBar.tap()
 
@@ -502,7 +507,8 @@ class NavigationTest: BaseTestCase {
         backButton.tap()
         waitUntilPageLoad()
         if #available(iOS 16, *) {
-            mozWaitForValueContains(app.textFields["url"], value: "test-example.html")
+            let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+            mozWaitForValueContains(url, value: "test-example.html")
             XCTAssertTrue(backButton.isHittable, "Back button is not hittable")
             XCTAssertTrue(backButton.isEnabled, "Back button is disabled")
             backButton.tap()
@@ -542,7 +548,7 @@ class NavigationTest: BaseTestCase {
         waitUntilPageLoad()
         // Sometimes first tap is not working on iPad
         if iPad() {
-            if let urlTextField =  app.textFields["url"].value as? String,
+            if let urlTextField =  app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as? String,
                urlTextField == "ultimateqa.com/dummy-automation-websites" {
                 app.links["SauceDemo.com"].firstMatch.tap(force: true)
             }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
@@ -45,7 +45,7 @@ class NewTabSettingsTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         navigator.performAction(Action.SelectNewTabAsBlankPage)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         mozWaitForElementToNotExist(
@@ -80,7 +80,7 @@ class NewTabSettingsTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         // Check that website is open
         mozWaitForElementToExist(app.webViews.firstMatch, timeout: TIMEOUT_LONG)
-        mozWaitForValueContains(app.textFields["url"], value: "mozilla")
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "mozilla")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307030
@@ -142,10 +142,11 @@ class NewTabSettingsTest: BaseTestCase {
         // Open new page and check that the custom url is used and he keyboard is not raised up
         navigator.performAction(Action.OpenNewTabFromTabTray)
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: "mozilla")
-        XCTAssertFalse(app.textFields["url"].isSelected, "The URL has the focus")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: "mozilla")
+        XCTAssertFalse(url.isSelected, "The URL has the focus")
         XCTAssertFalse(app.keyboards.element.isVisible(), "The keyboard is shown")
-        app.textFields["url"].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
 
         validateKeyboardIsRaisedAndDismissed()
 
@@ -153,10 +154,10 @@ class NewTabSettingsTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        mozWaitForValueContains(app.textFields["url"], value: "mozilla")
-        XCTAssertFalse(app.textFields["url"].isSelected, "The URL has the focus")
+        mozWaitForValueContains(url, value: "mozilla")
+        XCTAssertFalse(url.isSelected, "The URL has the focus")
         XCTAssertFalse(app.keyboards.element.isVisible(), "The keyboard is shown")
-        app.textFields["url"].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
 
         validateKeyboardIsRaisedAndDismissed()
     }
@@ -167,11 +168,12 @@ class NewTabSettingsTest: BaseTestCase {
         XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
         XCTAssertTrue(app.keyboards.element.isVisible(), "The keyboard is not shown")
         // Tap the back button
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)
         // The keyboard is dismissed and the URL is unfocused
-        mozWaitForElementToExist(app.textFields["url"])
-        XCTAssertFalse(app.textFields["url"].isSelected, "The URL has the focus")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForElementToExist(url)
+        XCTAssertFalse(url.isSelected, "The URL has the focus")
         XCTAssertFalse(app.keyboards.element.isVisible(), "The keyboard is shown")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
@@ -92,7 +92,7 @@ class OnboardingTests: BaseTestCase {
         waitUntilPageLoad()
 
         // Extract version number from url
-        let url = app.textFields["url"].value
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value
         let textUrl = String(describing: url)
         let start = textUrl.index(textUrl.startIndex, offsetBy: 43)
         let end = textUrl.index(textUrl.startIndex, offsetBy: 48)
@@ -102,7 +102,7 @@ class OnboardingTests: BaseTestCase {
 
         mozWaitForElementToExist(app.staticTexts[releaseVersion])
         mozWaitForValueContains(
-            app.textFields["url"],
+            app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url],
             value: "www.mozilla.org/en-US/firefox/ios/" + releaseVersion + "/releasenotes/"
         )
         mozWaitForElementToExist(app.staticTexts["Release Notes"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
@@ -12,10 +12,11 @@ class OpeningScreenTests: BaseTestCase {
         // Close the app from app switcher. Relaunch the app
         closeFromAppSwitcherAndRelaunch()
         // After re-launching the app, the last visited page is displayed
-        mozWaitForValueContains(app.textFields["url"], value: "test-mozilla-org")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: "test-mozilla-org")
         // Background and restore Firefox
         restartInBackground()
         // After re-launching the app, the last visited page is displayed
-        mozWaitForValueContains(app.textFields["url"], value: "test-mozilla-org")
+        mozWaitForValueContains(url, value: "test-mozilla-org")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -125,7 +125,8 @@ class PhotonActionSheetTests: BaseTestCase {
         openNewShareSheet()
         app.buttons["Cancel"].tap()
         // User is back to the BrowserTab where the sharesheet was launched
-        mozWaitForElementToExist(app.textFields["url"])
-        mozWaitForValueContains(app.textFields["url"], value: "example.com/")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForElementToExist(url)
+        mozWaitForValueContains(url, value: "example.com/")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
@@ -41,6 +41,7 @@ class PocketTests: BaseTestCase {
         app.collectionViews.scrollViews.cells[AccessibilityIdentifiers.FirefoxHomepage.Pocket.itemCell].firstMatch.tap()
         waitUntilPageLoad()
         // The url textField is not empty
-        XCTAssertNotEqual(app.textFields["url"].value as! String, "", "The url textField is empty")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        XCTAssertNotEqual(url.value as! String, "", "The url textField is empty")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -34,7 +34,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 
         navigator.openURL(url2)
-        mozWaitForValueContains(app.textFields["url"], value: "mozilla")
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "mozilla")
         navigator.goto(LibraryPanel_History)
         mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
         mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView].staticTexts[url1And3Label])
@@ -68,7 +68,8 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.goto(URLBarOpen)
         waitUntilPageLoad()
         navigator.openURL(url3)
-        mozWaitForValueContains(app.textFields["url"], value: "test-example")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: "test-example")
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         navigator.goto(TabTray)
@@ -200,7 +201,7 @@ class PrivateBrowsingTest: BaseTestCase {
         for _ in 1...4 {
             navigator.createNewTab()
             if app.keyboards.element.isVisible() && !iPad() {
-                mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+                mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
                 navigator.performAction(Action.CloseURLBarOpen)
             }
         }
@@ -304,8 +305,8 @@ class PrivateBrowsingTestIphone: IphoneOnlyTestCase {
 
         // Check that the tab has changed
         waitUntilPageLoad()
-        mozWaitForElementToExist(app.textFields["url"])
-        mozWaitForValueContains(app.textFields["url"], value: "iana")
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "iana")
         mozWaitForElementToExist(app.links["RFC 2606"])
         mozWaitForElementToExist(app.buttons["Show Tabs"])
         let numPrivTab = app.buttons["Show Tabs"].value as? String

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
@@ -52,7 +52,7 @@ class ReadingListTests: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
@@ -76,7 +76,7 @@ class ReadingListTests: BaseTestCase {
         // Check that it appears on regular mode
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
@@ -106,7 +106,7 @@ private func createTestGraph(for test: XCTestCase, with app: XCUIApplication) ->
 
     map.addScreenState(FirstRun) { screenState in
         screenState.noop(to: BrowserTab)
-        screenState.tap(app.textFields["url"], to: URLBarOpen)
+        screenState.tap(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], to: URLBarOpen)
     }
 
     map.addScreenState(WebPageLoading) { screenState in
@@ -120,15 +120,15 @@ private func createTestGraph(for test: XCTestCase, with app: XCUIApplication) ->
 
     map.addScreenState(BrowserTab) { screenState in
         screenState.onEnter { userState in
-            userState.url = app.textFields["url"].value as? String
+            userState.url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as? String
         }
 
         screenState.tap(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], to: BrowserTabMenu)
-        screenState.tap(app.textFields["url"], to: URLBarOpen)
+        screenState.tap(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], to: URLBarOpen)
 
         screenState.gesture(forAction: TestActions.LoadURLByPasting, TestActions.LoadURL) { userState in
             UIPasteboard.general.string = userState.url ?? defaultURL
-            app.textFields["url"].press(forDuration: 1.0)
+            app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].press(forDuration: 1.0)
             app.tables["Context Menu"].cells[AccessibilityIdentifiers.Photon.pasteAndGoAction].tap()
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -51,7 +51,7 @@ class SearchTests: BaseTestCase {
         mozWaitForElementToExist(app.tables["SiteTable"].cells.firstMatch)
 
         // Disable Search suggestion
-        app.buttons["urlBar-cancel"].tap()
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
 
         waitForTabsButton()
         app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].tap()
@@ -66,14 +66,14 @@ class SearchTests: BaseTestCase {
         mozWaitForElementToNotExist(app.tables["SiteTable"].cells.firstMatch)
 
         // Verify that previous choice is remembered
-        app.buttons["urlBar-cancel"].tap()
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
         navigator.nowAt(HomePanelsScreen)
         waitForTabsButton()
 
         typeOnSearchBar(text: "foobar")
         mozWaitForElementToNotExist(app.tables["SiteTable"].cells[SuggestedSite])
 
-        app.buttons["urlBar-cancel"].tap()
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
         waitForTabsButton()
         app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].tap()
         navigator.nowAt(BrowserTabMenu)
@@ -131,15 +131,15 @@ class SearchTests: BaseTestCase {
         app.menuItems["Select All"].tap()
         mozWaitForElementToExist(app.menuItems["Copy"])
         app.menuItems["Copy"].tap()
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
-        app.buttons["urlBar-cancel"].tap()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
 
         navigator.nowAt(HomePanelsScreen)
         mozWaitForElementToExist(
             app.collectionViews.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         )
-        mozWaitForElementToExist(app.textFields["url"])
-        app.textFields["url"].tap()
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
         mozWaitForElementToExist(app.textFields["address"])
         app.textFields["address"].tap()
 
@@ -152,7 +152,8 @@ class SearchTests: BaseTestCase {
         waitUntilPageLoad()
 
         // Check that the website is loaded
-        mozWaitForValueContains(app.textFields["url"], value: "www.mozilla.org")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: "www.mozilla.org")
         waitUntilPageLoad()
 
         // Go back, write part of moz, check the autocompletion
@@ -176,7 +177,8 @@ class SearchTests: BaseTestCase {
 
         navigator.openURL("foo bar")
         mozWaitForElementToExist(app.webViews.firstMatch)
-        mozWaitForValueContains(app.textFields["url"], value: searchEngine.lowercased())
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: searchEngine.lowercased())
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306940
@@ -224,7 +226,8 @@ class SearchTests: BaseTestCase {
         mozWaitForElementToExist(app.menuItems["Search with Firefox"])
         app.menuItems["Search with Firefox"].tap()
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: "google")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: "google")
         // Now there should be two tabs open
         let numTab = app.buttons["Show Tabs"].value as? String
         XCTAssertEqual("2", numTab)
@@ -234,11 +237,12 @@ class SearchTests: BaseTestCase {
     // Smoketest
     func testSearchStartAfterTypingTwoWords() {
         navigator.goto(URLBarOpen)
-        mozWaitForElementToExist(app.textFields["url"])
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
         app.typeText("foo bar")
         app.typeText(XCUIKeyboardKey.return.rawValue)
-        mozWaitForElementToExist(app.textFields["url"])
-        mozWaitForValueContains(app.textFields["url"], value: "google")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForElementToExist(url)
+        mozWaitForValueContains(url, value: "google")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306943
@@ -322,7 +326,7 @@ class SearchTests: BaseTestCase {
             let menuSettingsButton = app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton]
             scrollToElement(customizeHomepage)
             mozWaitForElementToExist(customizeHomepage)
-            let urlBar = app.textFields["url"]
+            let urlBar = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
             XCTAssertTrue(urlBar.isBelow(element: customizeHomepage))
             XCTAssertTrue(urlBar.isAbove(element: menuSettingsButton))
 
@@ -352,7 +356,7 @@ class SearchTests: BaseTestCase {
             app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
 
             // The focused is dismissed from the URL bar
-            let addressBar = app.textFields["url"]
+            let addressBar = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
             XCTAssertFalse(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -29,7 +29,8 @@ class SettingsTests: BaseTestCase {
         helpMenu.tap()
 
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: "support.mozilla.org")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: "support.mozilla.org")
         mozWaitForElementToExist(app.webViews.staticTexts["Firefox for iOS Support"])
 
         let numTabs = app.buttons["Show Tabs"].value

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SiteLoadTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SiteLoadTest.swift
@@ -30,7 +30,7 @@ class SiteLoadTest: BaseTestCase {
             mozWaitForElementToExist(app.alerts.buttons["OK"])
             app.alerts.buttons["OK"].tap()
             navigator.goto(BrowserTab)
-            mozWaitForElementToExist(app.textFields["url"])
+            mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
             counter += 1
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
@@ -21,15 +21,15 @@ class ThirdPartySearchTest: BaseTestCase {
         app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
 
         // Perform a search using a custom search engine
-        app.textFields["url"].tap()
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         UIPasteboard.general.string = "window"
         app.textFields.firstMatch.press(forDuration: 1)
         app.staticTexts["Paste"].tap()
         app.scrollViews.otherElements.buttons["Mozilla Engine search"].tap()
         waitUntilPageLoad()
 
-        var url = app.textFields["url"].value as! String
+        var url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
         if url.hasPrefix("https://") == false {
             url = "https://\(url)"
         }
@@ -48,13 +48,13 @@ class ThirdPartySearchTest: BaseTestCase {
         dismissSearchScreen()
 
         // Perform a search to check
-        app.textFields["url"].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
         app.textFields.firstMatch.typeText("window\n")
 
         waitUntilPageLoad()
 
         // Ensure that the default search is MDN
-        var url = app.textFields["url"].value as! String
+        var url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
         if url.hasPrefix("https://") == false {
             url = "https://\(url)"
         }
@@ -69,16 +69,16 @@ class ThirdPartySearchTest: BaseTestCase {
         app.navigationBars["Search"].buttons["Settings"].tap()
         mozWaitForElementToExist(app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem])
         app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
-        app.textFields["url"].tap()
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         UIPasteboard.general.string = "window"
         app.textFields.firstMatch.press(forDuration: 1)
         app.staticTexts["Paste"].tap()
         mozWaitForElementToExist(app.scrollViews.otherElements.buttons["Mozilla Engine search"])
 
         // Need to go step by step to Search Settings. The ScreenGraph will fail to go to the Search Settings Screen
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"])
-        app.buttons["urlBar-cancel"].tap()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].tap()
         app.tables["Context Menu"].otherElements["Settings"].tap()
@@ -91,9 +91,9 @@ class ThirdPartySearchTest: BaseTestCase {
             dismissSearchScreen()
 
             // Perform a search to check
-            mozWaitForElementToExist(app.textFields["url"])
-            app.textFields["url"].tap()
-            mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+            mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
+            app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
             UIPasteboard.general.string = "window"
             app.textFields.firstMatch.press(forDuration: 1)
             app.staticTexts["Paste"].tap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarMenuTests.swift
@@ -47,7 +47,7 @@ class ToolbarMenuTests: BaseTestCase {
         XCUIDevice.shared.orientation = .landscapeLeft
         mozWaitForElementToExist(hamburgerMenu)
         mozWaitForElementToNotExist(app.tables["Context Menu"])
-        mozWaitForElementToExist(app.textFields["url"])
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
         mozWaitForElementToExist(app.webViews["contentView"])
         if iPad() {
             mozWaitForElementToExist(bookmarksButton)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -31,8 +31,8 @@ class ToolbarTests: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
         let urlPlaceholder = "Search or enter address"
-        XCTAssert(app.textFields["url"].exists)
-        let defaultValuePlaceholder = app.textFields["url"].placeholderValue!
+        XCTAssert(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].exists)
+        let defaultValuePlaceholder = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].placeholderValue!
 
         // Check the url placeholder text and that the back and forward buttons are disabled
         XCTAssertTrue(urlPlaceholder == defaultValuePlaceholder, "The placeholder does not show the correct value")
@@ -43,14 +43,15 @@ class ToolbarTests: BaseTestCase {
         navigator.openURL(website1["url"]!)
         waitUntilPageLoad()
         mozWaitForElementToExist(app.webViews.links["Mozilla"], timeout: 10)
-        let valueMozilla = app.textFields["url"].value as! String
+        let valueMozilla = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
         XCTAssertEqual(valueMozilla, urlValueLong)
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].isEnabled)
         navigator.openURL(website2)
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: "localhost:\(serverPort)")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        mozWaitForValueContains(url, value: "localhost:\(serverPort)")
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
@@ -80,11 +81,11 @@ class ToolbarTests: BaseTestCase {
         waitUntilPageLoad()
         waitForTabsButton()
         mozWaitForElementToExist(app.webViews.links["Mozilla"], timeout: 10)
-        let valueMozilla = app.textFields["url"].value as! String
+        let valueMozilla = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
         XCTAssertEqual(valueMozilla, urlValueLong)
 
         // Simulate pressing on backspace key should remove the text
-        app.textFields["url"].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
         app.textFields["address"].typeText("\u{8}")
 
         let value = app.textFields["address"].value

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -75,7 +75,7 @@ class TopTabsTest: BaseTestCase {
 
         mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
         app.cells.staticTexts[urlLabel].firstMatch.tap()
-        let valueMozilla = app.textFields["url"].value as! String
+        let valueMozilla = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
         XCTAssertEqual(valueMozilla, urlValueLong)
 
         navigator.nowAt(BrowserTab)
@@ -84,7 +84,7 @@ class TopTabsTest: BaseTestCase {
 
         mozWaitForElementToExist(app.cells.staticTexts[urlLabelExample])
         app.cells.staticTexts[urlLabelExample].firstMatch.tap()
-        let value = app.textFields["url"].value as! String
+        let value = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
         XCTAssertEqual(value, urlValueLongExample)
     }
 
@@ -170,7 +170,8 @@ class TopTabsTest: BaseTestCase {
     // Smoketest
     func testCloseAllTabsPrivateModeUndo() {
         navigator.goto(URLBarOpen)
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
+        let cancelButton = app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton]
+        mozWaitForElementToExist(cancelButton, timeout: TIMEOUT_LONG)
         navigator.back()
         // A different tab than home is open to do the proper checks
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -329,7 +330,7 @@ class TopTabsTest: BaseTestCase {
         for _ in 1...10 {
             navigator.createNewTab()
             if app.keyboards.element.isVisible() && !iPad() {
-                mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+                mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
                 navigator.performAction(Action.CloseURLBarOpen)
             }
         }
@@ -426,7 +427,7 @@ class TopTabsTest: BaseTestCase {
         for _ in 1...4 {
             navigator.createNewTab()
             if app.keyboards.element.isVisible() && !iPad() {
-                mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+                mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
                 navigator.performAction(Action.CloseURLBarOpen)
             }
         }
@@ -448,7 +449,7 @@ class TopTabsTest: BaseTestCase {
         for _ in 1...nrOfTabs {
             navigator.createNewTab()
             if app.keyboards.element.isVisible() && !iPad() {
-                mozWaitForElementToExist(app.buttons["urlBar-cancel"])
+                mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
                 navigator.performAction(Action.CloseURLBarOpen)
             }
         }
@@ -572,7 +573,7 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
 
         // Check that the tab has changed
         waitUntilPageLoad()
-        mozWaitForValueContains(app.textFields["url"], value: "iana")
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "iana")
         XCTAssertTrue(app.links["RFC 2606"].exists)
         mozWaitForElementToExist(app.buttons["Show Tabs"])
         let numTab = app.buttons["Show Tabs"].value as? String
@@ -596,8 +597,8 @@ class TopTabsTestIphone: IphoneOnlyTestCase {
 
         // Check that the tab has changed to the new open one and that the user is in private mode
         waitUntilPageLoad()
-        mozWaitForElementToExist(app.textFields["url"])
-        mozWaitForValueContains(app.textFields["url"], value: "iana")
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "iana")
         navigator.goto(TabTray)
         XCTAssertTrue(app.buttons["privateModeLarge"].isEnabled)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -75,7 +75,8 @@ class TrackingProtectionTests: BaseTestCase {
     // Smoketest
     func testStandardProtectionLevel() {
         navigator.goto(URLBarOpen)
-        mozWaitForElementToExist(app.buttons["urlBar-cancel"], timeout: TIMEOUT_LONG)
+        let cancelButton = app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton]
+        mozWaitForElementToExist(cancelButton, timeout: TIMEOUT_LONG)
         navigator.back()
         navigator.goto(TrackingProtectionSettings)
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
@@ -8,6 +8,7 @@ class URLValidationTests: BaseTestCase {
     let urlTypes = ["www.mozilla.org", "www.mozilla.org/", "https://www.mozilla.org", "www.mozilla.org/en", "www.mozilla.org/en-",
                     "www.mozilla.org/en-US", "https://www.mozilla.org/", "https://www.mozilla.org/en", "https://www.mozilla.org/en-US"]
     let urlHttpTypes = ["http://example.com", "http://example.com/"]
+    let url = XCUIApplication().textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
 
     override func setUp() {
         super.setUp()
@@ -27,7 +28,7 @@ class URLValidationTests: BaseTestCase {
             waitUntilPageLoad()
             mozWaitForElementToExist(app.otherElements.staticTexts["Mozilla"])
             mozWaitForElementToExist(app.buttons["Menu"])
-            mozWaitForValueContains(app.textFields["url"], value: "www.mozilla.org/en-US/")
+            mozWaitForValueContains(url, value: "www.mozilla.org/en-US/")
             clearURL()
         }
 
@@ -35,7 +36,7 @@ class URLValidationTests: BaseTestCase {
             navigator.openURL(i)
             waitUntilPageLoad()
             mozWaitForElementToExist(app.otherElements.staticTexts["Example Domain"])
-            mozWaitForValueContains(app.textFields["url"], value: "example.com/")
+            mozWaitForValueContains(url, value: "example.com/")
             clearURL()
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
@@ -33,7 +33,7 @@ class UrlBarTests: BaseTestCase {
         // Visit any website and select the URL bar
         navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
         waitUntilPageLoad()
-        app.textFields["url"].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
         // The keyboard is brought up.
         let addressBar = app.textFields["address"]
         XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
@@ -45,7 +45,8 @@ class UrlBarTests: BaseTestCase {
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         // The URL bar is empty on the new tab
-        XCTAssertEqual(app.textFields["url"].value as! String, "Search or enter address")
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+        XCTAssertEqual(url.value as! String, "Search or enter address")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306887
@@ -54,7 +55,7 @@ class UrlBarTests: BaseTestCase {
         // Type a search term and hit "go"
         typeSearchTermAndHitGo(searchTerm: "Firefox")
         // The search is conducted correctly trough the default search engine
-        mozWaitForValueContains(app.textFields["url"], value: "google")
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "google")
         // Add a custom search engine and add it as default search engine
         navigator.goto(SearchSettings)
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
@@ -68,7 +69,7 @@ class UrlBarTests: BaseTestCase {
         tapUrlBarValidateKeyboardAndIcon()
         typeSearchTermAndHitGo(searchTerm: "Firefox")
         // The search is conducted correctly trough the default search engine
-        mozWaitForValueContains(app.textFields["url"], value: "bing")
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "bing")
     }
 
     private func tapUrlBarValidateKeyboardAndIcon() {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3645

## :bulb: Description
Right now we have over 100 places where we use “url” string instead of using an identifier. 
This will cause a lot of updates when the element will change with the toolbar refactor.
Adding the identifier for all the strings so when the time comes we will only have to change the string in one place.
