### PR TITLE
Bugfix FXIOS-10156 Fix tab tray not scrolling to selected tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -44,6 +44,7 @@ class TabPanelViewAction: Action {
 
 enum TabPanelViewActionType: ActionType {
     case tabPanelDidLoad
+    case tabPanelWillAppear
     case tabPanelDidAppear
     case addNewTab
     case closeTab
@@ -83,6 +84,7 @@ class TabPanelMiddlewareAction: Action {
 
 enum TabPanelMiddlewareActionType: ActionType {
     case didLoadTabPanel
+    case willAppearTabPanel
     case didChangeTabPanel
     case refreshTabs
     case refreshInactiveTabs

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -94,6 +94,14 @@ class TabManagerMiddleware {
                                                   actionType: TabPanelMiddlewareActionType.didLoadTabPanel)
             store.dispatch(action)
 
+        case TabPanelViewActionType.tabPanelWillAppear:
+            let isPrivate = action.panelType == .privateTabs
+            let tabState = self.getTabsDisplayModel(for: isPrivate, shouldScrollToTab: true, uuid: action.windowUUID)
+            let action = TabPanelMiddlewareAction(tabDisplayModel: tabState,
+                                                  windowUUID: action.windowUUID,
+                                                  actionType: TabPanelMiddlewareActionType.willAppearTabPanel)
+            store.dispatch(action)
+
         case TabPanelViewActionType.addNewTab:
             let isPrivateMode = action.panelType == .privateTabs
             addNewTab(with: action.urlRequest, isPrivate: isPrivateMode, for: action.windowUUID)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -92,12 +92,20 @@ struct TabsPanelState: ScreenState, Equatable {
         case TabPanelMiddlewareActionType.didLoadTabPanel,
             TabPanelMiddlewareActionType.didChangeTabPanel:
             guard let tabsModel = action.tabDisplayModel else { return state }
-            let selectedTabIndex = tabsModel.tabs.firstIndex(where: { $0.isSelected })
             return TabsPanelState(windowUUID: state.windowUUID,
                                   isPrivateMode: tabsModel.isPrivateMode,
                                   tabs: tabsModel.tabs,
                                   inactiveTabs: tabsModel.inactiveTabs,
-                                  isInactiveTabsExpanded: tabsModel.isInactiveTabsExpanded,
+                                  isInactiveTabsExpanded: tabsModel.isInactiveTabsExpanded)
+
+        case TabPanelMiddlewareActionType.willAppearTabPanel:
+            guard let tabsModel = action.tabDisplayModel else { return state }
+            let selectedTabIndex = tabsModel.tabs.firstIndex(where: { $0.isSelected })
+            return TabsPanelState(windowUUID: state.windowUUID,
+                                  isPrivateMode: state.isPrivateMode,
+                                  tabs: state.tabs,
+                                  inactiveTabs: state.inactiveTabs,
+                                  isInactiveTabsExpanded: state.isInactiveTabsExpanded,
                                   scrollToIndex: selectedTabIndex)
 
         case TabPanelMiddlewareActionType.refreshTabs:

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -24,6 +24,7 @@ class TabDisplayPanel: UIViewController,
     var tabsState: TabsPanelState
     private let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
+    private var viewHasAppeared = false
 
     // MARK: UI elements
     private lazy var tabDisplayView: TabDisplayView = {
@@ -69,12 +70,13 @@ class TabDisplayPanel: UIViewController,
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        tabDisplayView.layoutIfNeeded()
-
-        let didLoadAction = TabPanelViewAction(panelType: panelType,
-                                               windowUUID: windowUUID,
-                                               actionType: TabPanelViewActionType.tabPanelDidLoad)
-        store.dispatch(didLoadAction)
+        if !viewHasAppeared {
+            tabDisplayView.layoutIfNeeded()
+            store.dispatch(TabPanelViewAction(panelType: panelType,
+                                              windowUUID: windowUUID,
+                                              actionType: TabPanelViewActionType.tabPanelWillAppear))
+            viewHasAppeared = true
+        }
     }
 
     private func setupView() {
@@ -172,6 +174,11 @@ class TabDisplayPanel: UIViewController,
                                         actionType: ScreenActionType.showScreen,
                                         screen: .tabsPanel)
         store.dispatch(screenAction)
+
+        let didLoadAction = TabPanelViewAction(panelType: panelType,
+                                               windowUUID: windowUUID,
+                                               actionType: TabPanelViewActionType.tabPanelDidLoad)
+        store.dispatch(didLoadAction)
 
         let uuid = windowUUID
         store.subscribe(self, transform: {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10156)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22259)

## :bulb: Description
- Fixes an issue where the tab tray would not scroll to the selected tab (if the tab was off-screen) when opened. 
- Issue is resolved when using either the old and new toolbars

### 📝 Discussion
- The issue was caused by the collection view in `TabDisplayView` not being fulled laid out by the time the `TabsPanelState` had an updated `scrollToIndex` ultimately caused by `TabPanelViewActionType.tabPanelDidLoad` dispatched in `TabDisplayPanel`. 
- The issue was resolved by creating and new action `TabPanelViewActionType.tabPanelWillAppear` and dispatching it after the subviews were laid out in `viewWillAppear`
- We also make sure to only dispatch this action once, as `viewWillAppear` can get called multiple times (eg dragging the sheet)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

