### PR TITLE
Bugfix FXIOS-10214 Fix Javascript alert callback

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -40,13 +40,16 @@ protocol JSAlertInfo {
 struct MessageAlert: JSAlertInfo {
     let message: String
     let frame: WKFrameInfo
+    let completionHandler: (() -> Void)?
 
     func alertController() -> JSPromptAlertController {
         let alertController = JSPromptAlertController(
             title: titleForJavaScriptPanelInitiatedByFrame(frame),
             message: message,
             preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: .OKString, style: .default))
+        alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
+            completionHandler?()
+        })
         alertController.alertInfo = self
         return alertController
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -57,14 +57,14 @@ extension BrowserViewController: WKUIDelegate {
         initiatedByFrame frame: WKFrameInfo,
         completionHandler: @escaping () -> Void
     ) {
-        let messageAlert = MessageAlert(message: message, frame: frame)
+        let messageAlert = MessageAlert(message: message, frame: frame, completionHandler: {
+            completionHandler()
+            self.logger.log("Javascript message alert was completed.", level: .info, category: .webview)
+        })
         if shouldDisplayJSAlertForWebView(webView) {
             logger.log("Javascript message alert will be presented.", level: .info, category: .webview)
 
-            present(messageAlert.alertController(), animated: true) {
-                completionHandler()
-                self.logger.log("Javascript message alert was completed.", level: .info, category: .webview)
-            }
+            present(messageAlert.alertController(), animated: true)
         } else if let promptingTab = tabManager[webView] {
             logger.log("Javascript message alert is queued.", level: .info, category: .webview)
 
@@ -961,7 +961,7 @@ private extension BrowserViewController {
 
     func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {
         // Only display a JS Alert if we are selected and there isn't anything being shown
-        return ((tabManager.selectedTab == nil ? false : tabManager.selectedTab!.webView == webView))
+        return (tabManager.selectedTab == nil ? false : tabManager.selectedTab!.webView == webView)
             && (self.presentedViewController == nil)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10214)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22358)

## :bulb: Description

Fixes incorrect WebKit callback which was calling into completionHandler too early (upon JS alert presentation, instead of dismissal). This fixes a crash that could occur in some JS code, as well as potential other bugs.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

