### PR TITLE
Bugfix FXIOS-10230 [Accesibility] When the address bar on the homepage is unselected, for the text 'Search or enter an address,' we should use the Text/Secondary colour

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -158,6 +158,11 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
             textColor = colors.textPrimary
         }
 
+        attributedPlaceholder = NSAttributedString(
+            string: placeholder ?? "",
+            attributes: [NSAttributedString.Key.foregroundColor: colors.textSecondary]
+        )
+
         tintClearButton()
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10230)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22380)

## :bulb: Description
Sets the toolbar placeholder color
![Simulator Screenshot - iPhone 15 Pro Max - 2024-10-07 at 11 51 27](https://github.com/user-attachments/assets/e592db00-9b53-41ff-9a4a-0aec47ff1278)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

