### PR TITLE
Add FXIOS-21837 [Onboarding] Add advance card to open iOS FX settings action in main onboarding flow

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/IntroViewController.swift
@@ -338,6 +338,9 @@ extension IntroViewController: OnboardingCardDelegate {
                 selector: #selector(dismissPrivacyPolicyViewController))
         case .openIosFxSettings:
             DefaultApplicationHelper().openSettings()
+            advance(numberOfPages: 1, from: cardName) {
+                self.showNextPageCompletionForLastCard()
+            }
         case .endOnboarding:
             closeOnboarding()
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Mocks/MockOnboardingCardDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Mocks/MockOnboardingCardDelegate.swift
@@ -59,6 +59,7 @@ class MockOnboardinCardDelegateController: UIViewController,
                                  completion: {})
         case .openIosFxSettings:
             DefaultApplicationHelper().openSettings()
+            showNextPage(numberOfCards: 1, from: cardName, completionIfLastCard: {})
         case .endOnboarding:
             self.action = .endOnboarding
         }

--- a/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
@@ -425,7 +425,7 @@ enums:
           Will request to allow notifications from the user
       set-default-browser:
         description: >
-          Will send the user to settings to set Firefox as their default browser
+          Will send the user to settings to set Firefox as their default browser and advance to next card
       open-instructions-popup:
         description: >
           Will open up a popup with instructions for something


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/OMC-965)

## :bulb: Description
After discussion with product, we want to update the recently added open-ios-fx-setting action to include advancing to the next card.

_**We would like to backport this to 131.1 if possible.**_

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

