### PR TITLE
Add FXIOS-10163 [Homepage] Initial redux implementation

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -712,7 +712,6 @@
 		8A36BE2C29EDE16C00AC1C5C /* ContentContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */; };
 		8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewProviderTests.swift */; };
 		8A395552299AF83400B2AFBB /* UIControl+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A395551299AF83300B2AFBB /* UIControl+Extension.swift */; };
-		8A3EE51E2CAF314C0010CC8D /* HomepageStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EE51D2CAF314C0010CC8D /* HomepageStateTests.swift */; };
 		8A3EF7F02A2FCF3100796E3A /* HiddenSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF7EF2A2FCF3100796E3A /* HiddenSettings.swift */; };
 		8A3EF7F22A2FCF4000796E3A /* DeleteExportedDataSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF7F12A2FCF4000796E3A /* DeleteExportedDataSetting.swift */; };
 		8A3EF7F42A2FCF5700796E3A /* ExportBrowserDataSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF7F32A2FCF5700796E3A /* ExportBrowserDataSetting.swift */; };
@@ -747,6 +746,8 @@
 		8A4EA0DD2C0117F200E4E4F1 /* MicrosurveyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4EA0DC2C0117F200E4E4F1 /* MicrosurveyModel.swift */; };
 		8A5038142A5DFCE000A1B02A /* MockBrowserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5038132A5DFCE000A1B02A /* MockBrowserProfile.swift */; };
 		8A5189C92C1B614E00CDB668 /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A87AEE02C1B4D17007428B2 /* SearchViewModelTests.swift */; };
+		8A552AC72CB43AB400564C98 /* HomepageStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */; };
+		8A552AC82CB43AB400564C98 /* HeaderStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */; };
 		8A55E8042BFBA9BE006DBD85 /* MicrosurveyCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E5F3D2BFBA49400DE052B /* MicrosurveyCoordinatorTests.swift */; };
 		8A5604F629DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */; };
 		8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */; };
@@ -907,7 +908,6 @@
 		8ACE9BFB2A54A010001E7A73 /* ExpandButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */; };
 		8AD0110D2CB42FE700368BF3 /* HeaderState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD0110C2CB42FE700368BF3 /* HeaderState.swift */; };
 		8AD0110F2CB4314B00368BF3 /* HeaderAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD0110E2CB4314B00368BF3 /* HeaderAction.swift */; };
-		8AD011112CB4340100368BF3 /* HeaderStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD011102CB4340100368BF3 /* HeaderStateTests.swift */; };
 		8AD08D1527E9198E00B8E907 /* TabsTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */; };
 		8AD08D1727E91AC800B8E907 /* TabsTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsTelemetryTests.swift */; };
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
@@ -6827,7 +6827,6 @@
 		8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentContainerTests.swift; sourceTree = "<group>"; };
 		8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintViewProviderTests.swift; sourceTree = "<group>"; };
 		8A395551299AF83300B2AFBB /* UIControl+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+Extension.swift"; sourceTree = "<group>"; };
-		8A3EE51D2CAF314C0010CC8D /* HomepageStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageStateTests.swift; sourceTree = "<group>"; };
 		8A3EF7EF2A2FCF3100796E3A /* HiddenSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenSettings.swift; sourceTree = "<group>"; };
 		8A3EF7F12A2FCF4000796E3A /* DeleteExportedDataSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteExportedDataSetting.swift; sourceTree = "<group>"; };
 		8A3EF7F32A2FCF5700796E3A /* ExportBrowserDataSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportBrowserDataSetting.swift; sourceTree = "<group>"; };
@@ -6862,6 +6861,8 @@
 		8A4EA0DC2C0117F200E4E4F1 /* MicrosurveyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyModel.swift; sourceTree = "<group>"; };
 		8A5038132A5DFCE000A1B02A /* MockBrowserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBrowserProfile.swift; sourceTree = "<group>"; };
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
+		8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomepageStateTests.swift; sourceTree = "<group>"; };
+		8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderStateTests.swift; sourceTree = "<group>"; };
 		8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleViewModel.swift; sourceTree = "<group>"; };
@@ -7030,7 +7031,6 @@
 		8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandButtonState.swift; sourceTree = "<group>"; };
 		8AD0110C2CB42FE700368BF3 /* HeaderState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderState.swift; sourceTree = "<group>"; };
 		8AD0110E2CB4314B00368BF3 /* HeaderAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderAction.swift; sourceTree = "<group>"; };
-		8AD011102CB4340100368BF3 /* HeaderStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderStateTests.swift; sourceTree = "<group>"; };
 		8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsTelemetry.swift; sourceTree = "<group>"; };
 		8AD08D1627E91AC800B8E907 /* TabsTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsTelemetryTests.swift; sourceTree = "<group>"; };
 		8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetViewModel.swift; sourceTree = "<group>"; };
@@ -10511,9 +10511,9 @@
 		8A00BD852CAB3FC200680AF9 /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
+				8A552AC22CB43A7000564C98 /* Redux */,
 				8A00BD862CAB3FE500680AF9 /* HomepageViewControllerTests.swift */,
-				8AA0A6662CAC745300AC7EB3 /* HomepageDiffableDataSourceTests.swift
-				8A3EE51C2CAF31390010CC8D /* Redux */,
+				8AA0A6662CAC745300AC7EB3 /* HomepageDiffableDataSourceTests.swift */,
 			);
 			path = "Homepage Rebuild";
 			sourceTree = "<group>";
@@ -10665,15 +10665,6 @@
 			path = Wrapper;
 			sourceTree = "<group>";
 		};
-		8A3EE51C2CAF31390010CC8D /* Redux */ = {
-			isa = PBXGroup;
-			children = (
-				8A3EE51D2CAF314C0010CC8D /* HomepageStateTests.swift */,
-				8AD011102CB4340100368BF3 /* HeaderStateTests.swift */,
-			);
-			path = Redux;
-			sourceTree = "<group>";
-		};
 		8A3EF7ED2A2FCEC900796E3A /* Main */ = {
 			isa = PBXGroup;
 			children = (
@@ -10734,6 +10725,15 @@
 				8AAAB0582C1B723F008830B3 /* MockRustFirefoxSuggest.swift */,
 			);
 			path = Search;
+			sourceTree = "<group>";
+		};
+		8A552AC22CB43A7000564C98 /* Redux */ = {
+			isa = PBXGroup;
+			children = (
+				8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */,
+				8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */,
+			);
+			path = Redux;
 			sourceTree = "<group>";
 		};
 		8A590C5F28C122FF0032F1AA /* OpenInHelper */ = {
@@ -14917,8 +14917,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				4590912E2A2E4F7700061F0C /* AutopushTests.swift in Sources */,
-				8AD011112CB4340100368BF3 /* HeaderStateTests.swift in Sources */,
-				8A3EE51E2CAF314C0010CC8D /* HomepageStateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -16368,6 +16366,7 @@
 				8A5604F629DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift in Sources */,
 				630FE1342C7FB42500D9D6B2 /* NativeErrorPageMockModel.swift in Sources */,
 				C807CCCC28367446008E6A5A /* FeatureFlagManagerTests.swift in Sources */,
+				8A552AC72CB43AB400564C98 /* HomepageStateTests.swift in Sources */,
 				8A5C3BC5282ABF8E003A8CCF /* LegacyRemoteTabsPanelTests.swift in Sources */,
 				8AABBD032A001CBC0089941E /* MockApplicationHelper.swift in Sources */,
 				8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */,
@@ -16402,6 +16401,7 @@
 				21FA8FAE2AE856460013B815 /* TabsCoordinatorTests.swift in Sources */,
 				E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */,
 				5AF6254328A57A4600A90253 /* HistoryHighlightsDataAdaptorTests.swift in Sources */,
+				8A552AC82CB43AB400564C98 /* HeaderStateTests.swift in Sources */,
 				8A7AF0C72C9A119A009691B5 /* TabPeekStateTests.swift in Sources */,
 				0AFF7F642C7784D600265214 /* MockDataCleaner.swift in Sources */,
 				8AE80BAD2891957C00BC12EA /* TopSitesDimensionTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -712,6 +712,7 @@
 		8A36BE2C29EDE16C00AC1C5C /* ContentContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */; };
 		8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewProviderTests.swift */; };
 		8A395552299AF83400B2AFBB /* UIControl+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A395551299AF83300B2AFBB /* UIControl+Extension.swift */; };
+		8A3EE51E2CAF314C0010CC8D /* HomepageStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EE51D2CAF314C0010CC8D /* HomepageStateTests.swift */; };
 		8A3EF7F02A2FCF3100796E3A /* HiddenSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF7EF2A2FCF3100796E3A /* HiddenSettings.swift */; };
 		8A3EF7F22A2FCF4000796E3A /* DeleteExportedDataSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF7F12A2FCF4000796E3A /* DeleteExportedDataSetting.swift */; };
 		8A3EF7F42A2FCF5700796E3A /* ExportBrowserDataSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF7F32A2FCF5700796E3A /* ExportBrowserDataSetting.swift */; };
@@ -904,6 +905,9 @@
 		8ACA8F74291987AE00D3075D /* AccountSyncHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F73291987AE00D3075D /* AccountSyncHandlerTests.swift */; };
 		8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */; };
 		8ACE9BFB2A54A010001E7A73 /* ExpandButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */; };
+		8AD0110D2CB42FE700368BF3 /* HeaderState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD0110C2CB42FE700368BF3 /* HeaderState.swift */; };
+		8AD0110F2CB4314B00368BF3 /* HeaderAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD0110E2CB4314B00368BF3 /* HeaderAction.swift */; };
+		8AD011112CB4340100368BF3 /* HeaderStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD011102CB4340100368BF3 /* HeaderStateTests.swift */; };
 		8AD08D1527E9198E00B8E907 /* TabsTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */; };
 		8AD08D1727E91AC800B8E907 /* TabsTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD08D1627E91AC800B8E907 /* TabsTelemetryTests.swift */; };
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
@@ -964,6 +968,8 @@
 		8AF10D8F29D774090086351D /* SceneSetupHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF10D8E29D774090086351D /* SceneSetupHelper.swift */; };
 		8AF10D9129D7761A0086351D /* MockLaunchScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */; };
 		8AF2D0FC2A5F272A00C7DD69 /* ComponentLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = 8AF2D0FB2A5F272A00C7DD69 /* ComponentLibrary */; };
+		8AF347DE2CADD1B200624036 /* HomepageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF347DD2CADD1B200624036 /* HomepageState.swift */; };
+		8AF347E02CADD1C300624036 /* HomepageAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF347DF2CADD1C300624036 /* HomepageAction.swift */; };
 		8AF3B15A2AF99B86009BB262 /* HistoryPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF3B1592AF99B86009BB262 /* HistoryPanelTests.swift */; };
 		8AF3B15C2AF99C77009BB262 /* ReadingListPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF3B15B2AF99C77009BB262 /* ReadingListPanelTests.swift */; };
 		8AF3B15E2AF99D2F009BB262 /* DownloadsPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF3B15D2AF99D2F009BB262 /* DownloadsPanelTests.swift */; };
@@ -6821,6 +6827,7 @@
 		8A36BE2A29EDE16700AC1C5C /* ContentContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentContainerTests.swift; sourceTree = "<group>"; };
 		8A37C79E28DA4BA600B1FAD4 /* ContextualHintViewProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualHintViewProviderTests.swift; sourceTree = "<group>"; };
 		8A395551299AF83300B2AFBB /* UIControl+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+Extension.swift"; sourceTree = "<group>"; };
+		8A3EE51D2CAF314C0010CC8D /* HomepageStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageStateTests.swift; sourceTree = "<group>"; };
 		8A3EF7EF2A2FCF3100796E3A /* HiddenSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenSettings.swift; sourceTree = "<group>"; };
 		8A3EF7F12A2FCF4000796E3A /* DeleteExportedDataSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteExportedDataSetting.swift; sourceTree = "<group>"; };
 		8A3EF7F32A2FCF5700796E3A /* ExportBrowserDataSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportBrowserDataSetting.swift; sourceTree = "<group>"; };
@@ -7021,6 +7028,9 @@
 		8ACA8F7529198D6400D3075D /* ThrottlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrottlerTests.swift; sourceTree = "<group>"; };
 		8ACD3B972BA8EA8300E73E9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandButtonState.swift; sourceTree = "<group>"; };
+		8AD0110C2CB42FE700368BF3 /* HeaderState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderState.swift; sourceTree = "<group>"; };
+		8AD0110E2CB4314B00368BF3 /* HeaderAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderAction.swift; sourceTree = "<group>"; };
+		8AD011102CB4340100368BF3 /* HeaderStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderStateTests.swift; sourceTree = "<group>"; };
 		8AD08D1427E9198E00B8E907 /* TabsTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsTelemetry.swift; sourceTree = "<group>"; };
 		8AD08D1627E91AC800B8E907 /* TabsTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsTelemetryTests.swift; sourceTree = "<group>"; };
 		8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetViewModel.swift; sourceTree = "<group>"; };
@@ -7082,6 +7092,8 @@
 		8AF10D8929D713F50086351D /* LaunchScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenViewModelTests.swift; sourceTree = "<group>"; };
 		8AF10D8E29D774090086351D /* SceneSetupHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneSetupHelper.swift; sourceTree = "<group>"; };
 		8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchScreenManager.swift; sourceTree = "<group>"; };
+		8AF347DD2CADD1B200624036 /* HomepageState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageState.swift; sourceTree = "<group>"; };
+		8AF347DF2CADD1C300624036 /* HomepageAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageAction.swift; sourceTree = "<group>"; };
 		8AF3B1592AF99B86009BB262 /* HistoryPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryPanelTests.swift; sourceTree = "<group>"; };
 		8AF3B15B2AF99C77009BB262 /* ReadingListPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListPanelTests.swift; sourceTree = "<group>"; };
 		8AF3B15D2AF99D2F009BB262 /* DownloadsPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsPanelTests.swift; sourceTree = "<group>"; };
@@ -10500,7 +10512,8 @@
 			isa = PBXGroup;
 			children = (
 				8A00BD862CAB3FE500680AF9 /* HomepageViewControllerTests.swift */,
-				8AA0A6662CAC745300AC7EB3 /* HomepageDiffableDataSourceTests.swift */,
+				8AA0A6662CAC745300AC7EB3 /* HomepageDiffableDataSourceTests.swift
+				8A3EE51C2CAF31390010CC8D /* Redux */,
 			);
 			path = "Homepage Rebuild";
 			sourceTree = "<group>";
@@ -10650,6 +10663,15 @@
 				8A359EF22A1FD449004A5BB7 /* AdjustWrapper.swift */,
 			);
 			path = Wrapper;
+			sourceTree = "<group>";
+		};
+		8A3EE51C2CAF31390010CC8D /* Redux */ = {
+			isa = PBXGroup;
+			children = (
+				8A3EE51D2CAF314C0010CC8D /* HomepageStateTests.swift */,
+				8AD011102CB4340100368BF3 /* HeaderStateTests.swift */,
+			);
+			path = Redux;
 			sourceTree = "<group>";
 		};
 		8A3EF7ED2A2FCEC900796E3A /* Main */ = {
@@ -10830,6 +10852,7 @@
 				8A7D08E22CAAF7C30035999C /* HomepageViewController.swift */,
 				8AA0A6622CAC40AA00AC7EB3 /* HomepageDiffableDataSource.swift */,
 				8AA0A6642CAC6B7100AC7EB3 /* HomepageSectionLayoutProvider.swift */,
+				8AF347DC2CADD0E100624036 /* Redux */,
 			);
 			path = "Homepage Rebuild";
 			sourceTree = "<group>";
@@ -11295,6 +11318,17 @@
 				8AEDB11429F9F00400F2A53B /* SceneContainer.swift */,
 			);
 			path = Scene;
+			sourceTree = "<group>";
+		};
+		8AF347DC2CADD0E100624036 /* Redux */ = {
+			isa = PBXGroup;
+			children = (
+				8AD0110C2CB42FE700368BF3 /* HeaderState.swift */,
+				8AD0110E2CB4314B00368BF3 /* HeaderAction.swift */,
+				8AF347DD2CADD1B200624036 /* HomepageState.swift */,
+				8AF347DF2CADD1C300624036 /* HomepageAction.swift */,
+			);
+			path = Redux;
 			sourceTree = "<group>";
 		};
 		8AF4E76A2C41D60A00BAD91C /* RemoteSettingsData */ = {
@@ -14883,6 +14917,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4590912E2A2E4F7700061F0C /* AutopushTests.swift in Sources */,
+				8AD011112CB4340100368BF3 /* HeaderStateTests.swift in Sources */,
+				8A3EE51E2CAF314C0010CC8D /* HomepageStateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -15239,6 +15275,7 @@
 				E17BE4C42A94BA6900C5124E /* FakespotHighlightGroupView.swift in Sources */,
 				C825E9832832A425006CB811 /* NimbusSearchBarLayer.swift in Sources */,
 				E1FC23F12A8629380089E14D /* FakespotReliabilityCardView.swift in Sources */,
+				8AF347DE2CADD1B200624036 /* HomepageState.swift in Sources */,
 				C8DC90C92A0675E70008832B /* MarkupParsingUtility.swift in Sources */,
 				CA03B26A247F1D9E00382B62 /* BreachAlertsClient.swift in Sources */,
 				8A3EF8072A2FCFF700796E3A /* SentryIDSetting.swift in Sources */,
@@ -15370,6 +15407,7 @@
 				C88E7A602A05551B0072E638 /* NimbusOnboardingFeatureLayerProtocol.swift in Sources */,
 				8CFD56882AAF057D003157A6 /* SwitchFakespotProduction.swift in Sources */,
 				C40046FA1CF8E0B200B08303 /* BackForwardListAnimator.swift in Sources */,
+				8AD0110F2CB4314B00368BF3 /* HeaderAction.swift in Sources */,
 				8CE1E4372B8C76C80026530B /* LoginAutofillView.swift in Sources */,
 				DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */,
 				D81E45131F82C56D004EFFBA /* NewTabContentSettingsViewController.swift in Sources */,
@@ -15488,6 +15526,7 @@
 				219A0FDB2ACCCFFC009A6D1A /* InactiveTabsSectionManager.swift in Sources */,
 				B2981F8A2B71AD7A00132C1B /* AutofillAccessoryViewButtonItem.swift in Sources */,
 				211F00AC27F4D918001D9189 /* HistoryPanel+Search.swift in Sources */,
+				8AF347E02CADD1C300624036 /* HomepageAction.swift in Sources */,
 				96EB6C3827D821B800A9D159 /* HistoryPanelViewModel.swift in Sources */,
 				8A4490922BF3BC2700E7E682 /* MicrosurveyPromptView.swift in Sources */,
 				AB52ED3B2A0E8873001067F5 /* UserConversionMetrics.swift in Sources */,
@@ -15848,6 +15887,7 @@
 				437A9B6A2681257F00FB41C1 /* LegacyInactiveTabViewModel.swift in Sources */,
 				C838FD5E289981240068F60B /* WallpaperURLProvider.swift in Sources */,
 				E18259DB29AEB34900E6BE76 /* OnboardingNotificationCardHelper.swift in Sources */,
+				8AD0110D2CB42FE700368BF3 /* HeaderState.swift in Sources */,
 				D0B9483422A03468002F4AA1 /* BookmarkDetailPanel.swift in Sources */,
 				968BD7EB27DFF0F8003148B3 /* ASGroup.swift in Sources */,
 				392ED7E41D0AEF56009D9B62 /* NewTabAccessors.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -128,7 +128,8 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     func showHomepage() {
-        let homepageController = HomepageViewController(windowUUID: windowUUID)
+        let homepageController = self.homepageViewController ?? HomepageViewController(windowUUID: windowUUID)
+
         guard browserViewController.embedContent(homepageController) else {
             logger.log("Unable to embed new homepage", level: .debug, category: .coordinator)
             return

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -27,7 +27,7 @@ final class HomepageSectionLayoutProvider {
         }
     }
 
-    // TODO: FXIOS-10163 - Update layout section with appropriate views + integrate with redux
+    // TODO: FXIOS-10162 - Update layout section with appropriate views + integrate with redux
     private func createLayoutSection(
         for section: HomepageSection
     ) -> NSCollectionLayoutSection {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -6,15 +6,11 @@ import Foundation
 import Common
 import Redux
 
-<<<<<<< HEAD:firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
-final class HomepageViewController: UIViewController, ContentContainable, Themeable {
-=======
-final class NewHomepageViewController: UIViewController,
-                                       UICollectionViewDelegate,
-                                       ContentContainable,
-                                       Themeable,
-                                       StoreSubscriber {
->>>>>>> 1451919a81 (add initial redux):firefox-ios/Client/Frontend/Home/Homepage Rebuild/NewHomepageViewController.swift
+final class HomepageViewController: UIViewController,
+                                    UICollectionViewDelegate,
+                                    ContentContainable,
+                                    Themeable,
+                                    StoreSubscriber {
     // MARK: - Typealiases
     typealias SubscriberStateType = HomepageState
     private typealias a11y = AccessibilityIdentifiers.FirefoxHomepage
@@ -147,7 +143,7 @@ final class NewHomepageViewController: UIViewController,
     private func configureCollectionView() {
         let collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: layoutConfiguration)
 
-        // TODO: FXIOS-10163 - Update with proper cells
+        // TODO: FXIOS-10162 - Update with proper cells
         collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "cell")
 
         collectionView.keyboardDismissMode = .onDrag
@@ -183,7 +179,7 @@ final class NewHomepageViewController: UIViewController,
         for item: HomepageDiffableDataSource.HomeItem,
         at indexPath: IndexPath
     ) -> UICollectionViewCell {
-        // TODO: FXIOS-10163 - Dummy collection cells, to update with proper cells
+        // TODO: FXIOS-10162 - Dummy collection cells, to update with proper cells
         guard let section = HomepageSection(
             rawValue: indexPath.section
         ), let cell: UICollectionViewCell = collectionView?.dequeueReusableCell(
@@ -193,7 +189,7 @@ final class NewHomepageViewController: UIViewController,
             self.logger.log(
                 "Section should not have been nil, something went wrong",
                 level: .fatal,
-                category: .newHomepage
+                category: .homepage
             )
             return UICollectionViewCell()
         }
@@ -224,7 +220,7 @@ final class NewHomepageViewController: UIViewController,
     // MARK: UICollectionViewDelegate
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if let selectedItem = dataSource?.itemIdentifier(for: indexPath) {
-            // TODO: FXIOS-10163 - Dummy trigger to update with proper triggers
+            // TODO: FXIOS-10162 - Dummy trigger to update with proper triggers
             if selectedItem.title == "First" {
                 store.dispatch(
                     HeaderAction(

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -180,12 +180,11 @@ final class HomepageViewController: UIViewController,
         at indexPath: IndexPath
     ) -> UICollectionViewCell {
         // TODO: FXIOS-10162 - Dummy collection cells, to update with proper cells
-        guard let section = HomepageSection(
-            rawValue: indexPath.section
-        ), let cell: UICollectionViewCell = collectionView?.dequeueReusableCell(
-            withReuseIdentifier: "cell",
-            for: indexPath
-        ) else {
+        guard let section = HomepageSection(rawValue: indexPath.section),
+              let cell: UICollectionViewCell = collectionView?.dequeueReusableCell(
+                withReuseIdentifier: "cell",
+                for: indexPath
+              ) else {
             self.logger.log(
                 "Section should not have been nil, something went wrong",
                 level: .fatal,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderAction.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Redux
+
+final class HeaderAction: Action {
+    override init(windowUUID: WindowUUID, actionType: any ActionType) {
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
+
+enum HeaderActionType: ActionType {
+    case updateHeader
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderState.swift
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Redux
+
+struct HeaderState: StateType, Equatable {
+    var windowUUID: WindowUUID
+    var showHeader: Bool
+
+    init(windowUUID: WindowUUID) {
+        self.init(windowUUID: windowUUID,
+                  showHeader: false)
+    }
+
+    private init(
+        windowUUID: WindowUUID,
+        showHeader: Bool
+    ) {
+        self.windowUUID = windowUUID
+        self.showHeader = showHeader
+    }
+
+    static let reducer: Reducer<Self> = { state, action in
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
+        else {
+            return HeaderState(
+                windowUUID: state.windowUUID,
+                showHeader: state.showHeader
+            )
+        }
+
+        switch action.actionType {
+        case HeaderActionType.updateHeader:
+            return HeaderState(
+                windowUUID: state.windowUUID,
+                showHeader: true
+            )
+        default:
+            return HeaderState(
+                windowUUID: state.windowUUID,
+                showHeader: false
+            )
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderState.swift
@@ -11,8 +11,10 @@ struct HeaderState: StateType, Equatable {
     var showHeader: Bool
 
     init(windowUUID: WindowUUID) {
-        self.init(windowUUID: windowUUID,
-                  showHeader: false)
+        self.init(
+            windowUUID: windowUUID,
+            showHeader: false
+        )
     }
 
     private init(
@@ -28,7 +30,7 @@ struct HeaderState: StateType, Equatable {
         else {
             return HeaderState(
                 windowUUID: state.windowUUID,
-                showHeader: state.showHeader
+                showHeader: false
             )
         }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+
+final class HomepageAction: Action {
+    override init(windowUUID: WindowUUID, actionType: any ActionType) {
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
+
+enum HomepageActionType: ActionType {
+    case initialize
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -30,14 +30,14 @@ struct HomepageState: ScreenState, Equatable {
     init(windowUUID: WindowUUID) {
         self.init(
             windowUUID: windowUUID,
-            loadInitialData: false
+            loadInitialData: false,
             headerState: HeaderState(windowUUID: windowUUID)
         )
     }
 
     private init(
         windowUUID: WindowUUID,
-        loadInitialData: Bool
+        loadInitialData: Bool,
         headerState: HeaderState
     ) {
         self.windowUUID = windowUUID
@@ -50,7 +50,7 @@ struct HomepageState: ScreenState, Equatable {
         else {
             return HomepageState(
                 windowUUID: state.windowUUID,
-                loadInitialData: false
+                loadInitialData: false,
                 headerState: HeaderState.reducer(state.headerState, action)
             )
         }
@@ -59,19 +59,19 @@ struct HomepageState: ScreenState, Equatable {
         case HomepageActionType.initialize:
             return HomepageState(
                 windowUUID: state.windowUUID,
-                loadInitialData: true
+                loadInitialData: true,
                 headerState: HeaderState.reducer(state.headerState, action)
             )
         case HeaderActionType.updateHeader:
             return HomepageState(
                 windowUUID: state.windowUUID,
-                loadInitialData: false
+                loadInitialData: false,
                 headerState: HeaderState.reducer(state.headerState, action)
             )
         default:
             return HomepageState(
                 windowUUID: state.windowUUID,
-                loadInitialData: false
+                loadInitialData: false,
                 headerState: HeaderState.reducer(state.headerState, action)
             )
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+
+struct HomepageState: ScreenState, Equatable {
+    var windowUUID: WindowUUID
+    var loadInitialData: Bool
+    var headerState: HeaderState
+
+    init(appState: AppState, uuid: WindowUUID) {
+        guard let homepageState = store.state.screenState(
+            HomepageState.self,
+            for: .homepage,
+            window: uuid
+        ) else {
+            self.init(windowUUID: uuid)
+            return
+        }
+
+        self.init(
+            windowUUID: homepageState.windowUUID,
+            loadInitialData: homepageState.loadInitialData,
+            headerState: homepageState.headerState
+        )
+    }
+
+    init(windowUUID: WindowUUID) {
+        self.init(
+            windowUUID: windowUUID,
+            loadInitialData: false
+            headerState: HeaderState(windowUUID: windowUUID)
+        )
+    }
+
+    private init(
+        windowUUID: WindowUUID,
+        loadInitialData: Bool
+        headerState: HeaderState
+    ) {
+        self.windowUUID = windowUUID
+        self.loadInitialData = loadInitialData
+        self.headerState = headerState
+    }
+
+    static let reducer: Reducer<Self> = { state, action in
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
+        else {
+            return HomepageState(
+                windowUUID: state.windowUUID,
+                loadInitialData: false
+                headerState: HeaderState.reducer(state.headerState, action)
+            )
+        }
+
+        switch action.actionType {
+        case HomepageActionType.initialize:
+            return HomepageState(
+                windowUUID: state.windowUUID,
+                loadInitialData: true
+                headerState: HeaderState.reducer(state.headerState, action)
+            )
+        case HeaderActionType.updateHeader:
+            return HomepageState(
+                windowUUID: state.windowUUID,
+                loadInitialData: false
+                headerState: HeaderState.reducer(state.headerState, action)
+            )
+        default:
+            return HomepageState(
+                windowUUID: state.windowUUID,
+                loadInitialData: false
+                headerState: HeaderState.reducer(state.headerState, action)
+            )
+        }
+    }
+}

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
@@ -21,6 +21,7 @@ class ScreenAction: Action {
 enum AppScreen {
     case browserViewController
     case onboardingViewController
+    case homepage
     case themeSettings
     case tabsTray
     case tabsPanel

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
@@ -9,6 +9,7 @@ import ToolbarKit
 
 enum AppScreenState: Equatable {
     case browserViewController(BrowserViewControllerState)
+    case homepage(HomepageState)
     case mainMenu(MainMenuState)
     case mainMenuDetails(MainMenuDetailsState)
     case microsurvey(MicrosurveyState)
@@ -25,6 +26,8 @@ enum AppScreenState: Equatable {
         switch state {
         case .browserViewController(let state):
             return .browserViewController(BrowserViewControllerState.reducer(state, action))
+        case .homepage(let state):
+            return .homepage(HomepageState.reducer(state, action))
         case .mainMenu(let state):
             return .mainMenu(MainMenuState.reducer(state, action))
         case .mainMenuDetails(let state):
@@ -54,6 +57,7 @@ enum AppScreenState: Equatable {
     var associatedAppScreen: AppScreen {
         switch self {
         case .browserViewController: return .browserViewController
+        case .homepage: return .homepage
         case .mainMenu: return .mainMenu
         case .mainMenuDetails: return .mainMenuDetails
         case .microsurvey: return .microsurvey
@@ -71,6 +75,7 @@ enum AppScreenState: Equatable {
     var windowUUID: WindowUUID? {
         switch self {
         case .browserViewController(let state): return state.windowUUID
+        case .homepage(let state): return state.windowUUID
         case .mainMenu(let state): return state.windowUUID
         case .mainMenuDetails(let state): return state.windowUUID
         case .microsurvey(let state): return state.windowUUID
@@ -122,6 +127,8 @@ struct ActiveScreensState: Equatable {
             switch action.screen {
             case .browserViewController:
                 screens.append(.browserViewController(BrowserViewControllerState(windowUUID: uuid)))
+            case .homepage:
+                screens.append(.homepage(HomepageState(windowUUID: uuid)))
             case .mainMenu:
                 screens.append(.mainMenu(MainMenuState(windowUUID: uuid)))
             case .mainMenuDetails:

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -20,6 +20,7 @@ struct AppState: StateType {
             .compactMap {
                 switch ($0, screen) {
                 case (.browserViewController(let state), .browserViewController): return state as? S
+                case (.homepage(let state), .homepage): return state as? S
                 case (.mainMenu(let state), .mainMenu): return state as? S
                 case (.mainMenuDetails(let state), .mainMenuDetails): return state as? S
                 case (.microsurvey(let state), .microsurvey): return state as? S

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HeaderStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HeaderStateTests.swift
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+final class HeaderStateTests: XCTestCase {
+//    func testInitialization() {
+//        let initialState = createSubject()
+//
+//        XCTAssertFalse(initialState.showHeader)
+//    }
+//
+//    func test_windowUUID() {
+//        let initialState = createSubject()
+//
+//        XCTAssertFalse(initialState.showHeader)
+//    }
+//
+//    func testUpdatingCurrentHeader() {
+//        let initialState = createSubject()
+//        let reducer = headerReducer()
+//
+//        let newState = reducer(
+//            initialState,
+//            HeaderAction(
+//                windowUUID: .XCTestDefaultUUID,
+//                actionType: HeaderActionType.updateHeader
+//            )
+//        )
+//
+//        XCTAssertTrue(newState.showHeader)
+//    }
+//
+//    // MARK: - Private
+//    private func createSubject() -> HeaderState {
+//        return HeaderState(windowUUID: .XCTestDefaultUUID)
+//    }
+//
+//    private func headerReducer() -> Reducer<HeaderState> {
+//        return HeaderState.reducer
+//    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HeaderStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HeaderStateTests.swift
@@ -2,42 +2,61 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Redux
 import XCTest
 
+@testable import Client
+
 final class HeaderStateTests: XCTestCase {
-//    func testInitialization() {
-//        let initialState = createSubject()
-//
-//        XCTAssertFalse(initialState.showHeader)
-//    }
-//
-//    func test_windowUUID() {
-//        let initialState = createSubject()
-//
-//        XCTAssertFalse(initialState.showHeader)
-//    }
-//
-//    func testUpdatingCurrentHeader() {
-//        let initialState = createSubject()
-//        let reducer = headerReducer()
-//
-//        let newState = reducer(
-//            initialState,
-//            HeaderAction(
-//                windowUUID: .XCTestDefaultUUID,
-//                actionType: HeaderActionType.updateHeader
-//            )
-//        )
-//
-//        XCTAssertTrue(newState.showHeader)
-//    }
-//
-//    // MARK: - Private
-//    private func createSubject() -> HeaderState {
-//        return HeaderState(windowUUID: .XCTestDefaultUUID)
-//    }
-//
-//    private func headerReducer() -> Reducer<HeaderState> {
-//        return HeaderState.reducer
-//    }
+    func testInitialization() {
+        let initialState = createSubject()
+
+        XCTAssertFalse(initialState.showHeader)
+    }
+
+    func test_windowUUID_returnsValidUUID() {
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
+    }
+
+    func test_different_windowUUID_returnsDefaultState() {
+        let initialState = createSubject()
+        let reducer = headerReducer()
+
+        let newState = reducer(
+            initialState,
+            HeaderAction(
+                windowUUID: .DefaultUITestingUUID,
+                actionType: HeaderActionType.updateHeader
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(newState.showHeader)
+    }
+
+    func test_updateHeader_returnsTrue() {
+        let initialState = createSubject()
+        let reducer = headerReducer()
+
+        let newState = reducer(
+            initialState,
+            HeaderAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HeaderActionType.updateHeader
+            )
+        )
+
+        XCTAssertTrue(newState.showHeader)
+    }
+
+    // MARK: - Private
+    private func createSubject() -> HeaderState {
+        return HeaderState(windowUUID: .XCTestDefaultUUID)
+    }
+
+    private func headerReducer() -> Reducer<HeaderState> {
+        return HeaderState.reducer
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
@@ -8,39 +8,70 @@ import XCTest
 @testable import Client
 
 final class HomepageStateTests: XCTestCase {
-//    func testInitialization() {
-//        let initialState = createSubject()
-//
-//        XCTAssertFalse(initialState.showHeader)
-//    }
-//
-//    func test_windowUUID() {
-//        let initialState = createSubject()
-//
-//        XCTAssertFalse(initialState.showHeader)
-//    }
-//
-//    func testUpdatingCurrentHeader() {
-//        let initialState = createSubject()
-//        let reducer = homepageReducer()
-//
-//        let newState = reducer(
-//            initialState,
-//            HomepageAction(
-//                windowUUID: .XCTestDefaultUUID,
-//                actionType: HomepageActionType.updateHeader
-//            )
-//        )
-//
-//        XCTAssertTrue(newState.showHeader)
-//    }
-//
-//    // MARK: - Private
-//    private func createSubject() -> HomepageState {
-//        return HomepageState(windowUUID: .XCTestDefaultUUID)
-//    }
-//
-//    private func homepageReducer() -> Reducer<HomepageState> {
-//        return HomepageState.reducer
-//    }
+    func testInitialization() {
+        let initialState = createSubject()
+
+        XCTAssertFalse(initialState.loadInitialData)
+    }
+
+    func test_windowUUID_returnsValidUUID() {
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
+    }
+
+    func test_different_windowUUID_returnsDefaultState() {
+        let initialState = createSubject()
+        let reducer = homepageReducer()
+
+        let newState = reducer(
+            initialState,
+            HeaderAction(
+                windowUUID: .DefaultUITestingUUID,
+                actionType: HeaderActionType.updateHeader
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(newState.loadInitialData)
+    }
+
+    func test_initializeData_returnsTrue() {
+        let initialState = createSubject()
+        let reducer = homepageReducer()
+
+        let newState = reducer(
+            initialState,
+            HomepageAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.initialize
+            )
+        )
+
+        XCTAssertTrue(newState.loadInitialData)
+    }
+
+    func test_updateHeader_returnsTrue() {
+        let initialState = createSubject()
+        let reducer = homepageReducer()
+
+        let newState = reducer(
+            initialState,
+            HeaderAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HeaderActionType.updateHeader
+            )
+        )
+
+        XCTAssertTrue(newState.headerState.showHeader)
+    }
+
+    // MARK: - Private
+    private func createSubject() -> HomepageState {
+        return HomepageState(windowUUID: .XCTestDefaultUUID)
+    }
+
+    private func homepageReducer() -> Reducer<HomepageState> {
+        return HomepageState.reducer
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+final class HomepageStateTests: XCTestCase {
+//    func testInitialization() {
+//        let initialState = createSubject()
+//
+//        XCTAssertFalse(initialState.showHeader)
+//    }
+//
+//    func test_windowUUID() {
+//        let initialState = createSubject()
+//
+//        XCTAssertFalse(initialState.showHeader)
+//    }
+//
+//    func testUpdatingCurrentHeader() {
+//        let initialState = createSubject()
+//        let reducer = homepageReducer()
+//
+//        let newState = reducer(
+//            initialState,
+//            HomepageAction(
+//                windowUUID: .XCTestDefaultUUID,
+//                actionType: HomepageActionType.updateHeader
+//            )
+//        )
+//
+//        XCTAssertTrue(newState.showHeader)
+//    }
+//
+//    // MARK: - Private
+//    private func createSubject() -> HomepageState {
+//        return HomepageState(windowUUID: .XCTestDefaultUUID)
+//    }
+//
+//    private func homepageReducer() -> Reducer<HomepageState> {
+//        return HomepageState.reducer
+//    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10163)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22265)

## :bulb: Description
* Add initial redux foundation for homepage
* Created main `HomepageState` for the parent state
* Created example substate `HeaderState` for the child section states
* Add two type of actions `initialize` and `updateHeader` for demo purposes in how we can dispatch an action and have that update the collection view

Overall, added code to demonstrate an action taken and how the header section updates based on that action. 
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Testing Steps
* Turn on the new homepage with feature flags
* View the new homepage by adding a new tab
* Confirm that the initial sections are loaded
* Tap on either "First" cell and view the changes in the sections 

https://github.com/user-attachments/assets/0ee9b135-ac13-4a5b-a204-bd31170fabf2
