### PR TITLE
Bugfix MTE-3671 Ensure button shows up before tapping in microsurvey

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -39,6 +39,7 @@ final class MicrosurveyTests: BaseTestCase {
 
     func testCloseButtonDismissesMicrosurveyPrompt() {
         generateTriggerForMicrosurvey()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton])
         app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].tap()
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton])
         mozWaitForElementToNotExist(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo])
@@ -68,6 +69,7 @@ final class MicrosurveyTests: BaseTestCase {
     func testCloseButtonDismissesSurveyAndPrompt() {
         generateTriggerForMicrosurvey()
         let continueButton = app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton]
+        mozWaitForElementToExist(continueButton)
         continueButton.tap()
 
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Microsurvey.Survey.closeButton])
@@ -94,9 +96,11 @@ final class MicrosurveyTests: BaseTestCase {
             mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.Browser.TopTabs.collectionView])
         }
         if !iPad() {
+            mozWaitForElementToExist(homepageToggleButtonIphone)
             homepageToggleButtonIphone.tap()
             mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView])
         } else {
+            mozWaitForElementToExist(homepageToggleButtonIpad)
             homepageToggleButtonIpad.tap()
             mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.Browser.TopTabs.collectionView])
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3671)

## :bulb: Description
`testCloseButtonDismissesMicrosurveyPrompt` fails intermittently. The test attempts to tap `closeButton` before the button is available.

iOS 15: https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/firefox-ios-iphone-iOS-15/result_111/firefox-ios/build/reports/index.html

Let's ensure this button and a few others are available before tapping.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

