### PR TITLE
Add FXIOS-9627 [Native Error Page] initial changes for error page handler

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -754,8 +754,21 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
-        if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
-            ErrorPageHelper(certStore: profile.certStore).loadPage(error, forUrl: url, inWebView: webView)
+        if isNativeErrorPage() {
+            if let tab = tabManager[webView], tab === tabManager.selectedTab {
+                guard let errorPageURL = URL(string: "\(InternalURL.baseUrl)/\(InternalURL.Path.errorpage.rawValue)") else { return }
+                let action = GeneralBrowserAction(selectedTabURL: errorPageURL,
+                                                  isPrivateBrowsing: tab.isPrivate,
+                                                  isNativeErrorPage: true,
+                                                  windowUUID: windowUUID,
+                                                  actionType: GeneralBrowserActionType.updateSelectedTab)
+                store.dispatch(action)
+                webView.load(PrivilegedRequest(url: errorPageURL) as URLRequest)
+            }
+        } else {
+            if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
+                ErrorPageHelper(certStore: profile.certStore).loadPage(error, forUrl: url, inWebView: webView)
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1414,7 +1414,7 @@ class BrowserViewController: UIViewController,
 
     // MARK: - Native Error Page
 
-    private func isNativeErrorPage() -> Bool {
+    func isNativeErrorPage() -> Bool {
         featureFlags.isFeatureEnabled(.nativeErrorPage, checking: .buildOnly)
     }
 


### PR DESCRIPTION
…dler.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9627)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21220)

## :bulb: Description
Modified Native error page load on getting error.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

