### PR TITLE
Fix FXIOS-10234 - Only send address ping when section is valid

### DIFF
--- a/firefox-ios/Client/Assets/CC_Script/FormAutofillChild.ios.sys.mjs
+++ b/firefox-ios/Client/Assets/CC_Script/FormAutofillChild.ios.sys.mjs
@@ -110,6 +110,13 @@ export class FormAutofillChild {
       return;
     }
 
+    // Since iOS doesn't support cross frame autofill,
+    // we should only call the autofill callback if the section is valid.
+    // TODO(issam): This will change when we have cross frame fill support.
+    if (!this.activeSection.isValidSection()) {
+      return;
+    }
+
     const fieldNamesWithValues = this.transformToFieldNamesWithValues(
       this.activeSection.fieldDetails
     );


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10234)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22400)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Adds check for `isValidSection` so we don't show the accessory view when the formautofill section is not valid.
- Manually adds changes from [Bug 1923191](https://bugzilla.mozilla.org/show_bug.cgi?id=1923191) and not waiting for the automated script.

### Current behaviour


https://github.com/user-attachments/assets/664a445a-eaf5-4a23-80b6-fd16d16526d9


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~Wrote unit tests and/or ensured the tests suite is passing~
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed, I updated documentation / comments for complex code and public methods~
- [ ] ~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~

