### PR TITLE
Bugfix FXIOS-10253 - Keyboard hides in edit mode after rotating the phone a few times

### DIFF
--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -397,28 +397,20 @@ class LegacyHomepageViewController:
 
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         lastContentOffsetY = scrollView.contentOffset.y
+        handleToolbarStateOnScroll()
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         handleScroll(scrollView, isUserInteraction: true)
     }
 
-    private func handleScroll(_ scrollView: UIScrollView, isUserInteraction: Bool) {
-        // We only handle status bar overlay alpha if there's a wallpaper applied on the homepage
-        if WallpaperManager().currentWallpaper.type != .defaultWallpaper {
-            let theme = themeManager.getCurrentTheme(for: windowUUID)
-            statusBarScrollDelegate?.scrollViewDidScroll(scrollView,
-                                                         statusBarFrame: statusBarFrame,
-                                                         theme: theme)
-        }
-
+    private func handleToolbarStateOnScroll() {
         let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID)
 
         // Only dispatch action when user is in edit mode to avoid having the toolbar re-displayed
         if featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly),
            let toolbarState,
-           toolbarState.addressToolbar.isEditing,
-           isUserInteraction {
+           toolbarState.addressToolbar.isEditing {
             // When the user scrolls the homepage we cancel edit mode
             // On a website we just dismiss the keyboard
             if toolbarState.addressToolbar.url == nil {
@@ -428,6 +420,16 @@ class LegacyHomepageViewController:
                 let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.didScrollDuringEdit)
                 store.dispatch(action)
             }
+        }
+    }
+
+    private func handleScroll(_ scrollView: UIScrollView, isUserInteraction: Bool) {
+        // We only handle status bar overlay alpha if there's a wallpaper applied on the homepage
+        if WallpaperManager().currentWallpaper.type != .defaultWallpaper {
+            let theme = themeManager.getCurrentTheme(for: windowUUID)
+            statusBarScrollDelegate?.scrollViewDidScroll(scrollView,
+                                                         statusBarFrame: statusBarFrame,
+                                                         theme: theme)
         }
 
         // this action controls the address toolbar's border position, and to prevent spamming redux with actions for every


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10253)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22441)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- For some reason, when rotating the device, the `scrollViewDidScroll` gets called.
- Extract the code that involves user action for scrolling, in a method and add it `scrollViewWillBeginDragging`.
### Video

https://github.com/user-attachments/assets/cf5e229c-f5a1-4923-9d2a-4596e59a57d0



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

