### PR TITLE
Bugfix MTE-3686 testTopSitesShiftAfterRemovingOne fails intermittently

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -167,6 +167,8 @@ class ActivityStreamTest: BaseTestCase {
             mozWaitForElementToNotExist(app.staticTexts[topSiteFirstCell])
         }
 
+        mozWaitForElementToExist(allTopSites.staticTexts[topSiteSecondCell])
+        mozWaitForElementToNotExist(allTopSites.staticTexts[topSiteFirstCell])
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 4)
 
         // Check top site in first cell now


### PR DESCRIPTION
## :scroll: Ticketse
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MT-3686)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
`testTopSitesShiftAfterRemovingOne` fails intermittently due to the list of top sites don't update immediately after a site is removed. Let's ensure the removed site is no longer be seen before counting the number of top sites.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

