### PR TITLE
Refactor MTE-3689 "Cannot get from screen" errors

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
@@ -39,7 +39,7 @@ class DataManagementTests: BaseTestCase {
         navigator.goto(WebsiteDataSettings)
         mozWaitForElementToExist(app.tables.otherElements["Website Data"])
         if #available(iOS 17, *) {
-            mozWaitForElementToExist(app.tables.buttons.images["circle"].firstMatch)
+            mozWaitForElementToExist(app.tables.buttons.images["circle"].firstMatch, timeout: TIMEOUT_LONG)
         } else {
             mozWaitForElementToExist(app.tables.buttons.firstMatch)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -932,6 +932,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     func makeURLBarAvailable(_ screenState: MMScreenStateNode<FxUserState>) {
+        // here
         screenState.tap(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], to: URLBarOpen)
         screenState.gesture(to: URLBarLongPressMenu) {
             app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].press(forDuration: 1.0)
@@ -1085,7 +1086,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(BrowserTabMenu) { screenState in
-        sleep(1)
+        sleep(3)
         screenState.tap(
             app.tables.otherElements[StandardImageIdentifiers.Large.settings],
             to: SettingsScreen
@@ -1204,6 +1205,7 @@ extension MMNavigator where T == FxUserState {
         UIPasteboard.general.string = urlString
         userState.url = urlString
         userState.waitForLoading = waitForLoading
+        sleep(3)
         // Using LoadURLByTyping for Intel too on Xcode14
         if #available (iOS 16, *) {
             performAction(Action.LoadURLByTyping)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -385,7 +385,9 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.gesture(forAction: Action.LoadURLByTyping) { userState in
             let url = userState.url ?? defaultURL
             // Workaround BB iOS13 be sure tap happens on url bar
+            sleep(1)
             app.textFields.firstMatch.tap()
+            sleep(1)
             app.textFields.firstMatch.tap()
             app.textFields.firstMatch.typeText(url)
             app.textFields.firstMatch.typeText("\r")
@@ -932,7 +934,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     func makeURLBarAvailable(_ screenState: MMScreenStateNode<FxUserState>) {
-        // here
+        sleep(3)
         screenState.tap(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], to: URLBarOpen)
         screenState.gesture(to: URLBarLongPressMenu) {
             app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].press(forDuration: 1.0)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3689)

## :bulb: Description

Firefox smoke tests on Github Actions have been flaky partly due to the following error messages:
```
Cannot get from NewTabScreen to URLBarOpen. See /Users/runner/work/firefox-ios/firefox-ios/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift:935
```
```
Cannot get from BrowserTabMenu to PageZoom. See /Users/runner/work/firefox-ios/firefox-ios/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift:1160
```
Github Action runner may be slow that the app was not ready for tapping when the action supposed to occur. `mozWait` and `waitFor` commands are not available on the screen graph. Let me try with `sleep()`. It's not an ideal solution, but if this command alleviate the flakiness I'd do it.

Try out this change in Github Actions
https://github.com/mozilla-mobile/firefox-ios/actions/runs/11257779085

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

