### PR TITLE
Update EXP-4788: Add wait and fix timeouts and ios version for testing.

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests/conftest.py
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests/conftest.py
@@ -12,14 +12,9 @@ import time
 import pytest
 import requests
 
-## MUST REMOVE WHEN SYNCINTEGRATIONTEST FOLDER IS MOVED
-import sys
-
-sys.path.append("../../")
-
 from ExperimentIntegrationTests.models.models import TelemetryModel
-from SyncIntegrationTests.xcodebuild import XCodeBuild
-from SyncIntegrationTests.xcrun import XCRun
+from ExperimentIntegrationTests.xcodebuild import XCodeBuild
+from ExperimentIntegrationTests.xcrun import XCRun
 
 KLAATU_SERVER_URL = "http://localhost:1378"
 KLAATU_LOCAL_SERVER_URL = "http://localhost:1378"

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests/xcodebuild.py
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests/xcodebuild.py
@@ -1,44 +1,47 @@
 import logging
-import os
 import subprocess
+from pathlib import Path
 
 from .xcrun import XCRun
 
-here = os.path.dirname(__file__)
+here = Path(__file__).resolve()
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
 class XCodeBuild(object):
-    binary = 'xcodebuild'
-    destination = 'platform=iOS Simulator,name=iPhone 15,OS=17.4'
+    binary = "xcodebuild"
+    destination = "platform=iOS Simulator,name=iPhone 15,OS=17.5"
     logger = logging.getLogger()
-    scheme = 'Fennec'
-    testPlan = 'SyncIntegrationTestPlan'
+    scheme = "Fennec"
+    testPlan = "SyncIntegrationTestPlan"
     xcrun = XCRun()
 
     def __init__(self, log, **kwargs):
         self.scheme = kwargs.get("scheme", self.scheme)
         self.testPlan = kwargs.get("test_plan", self.testPlan)
         self.log = log
+        self.firefox_app_path = next(
+            Path("/Users").glob(
+                "**/Library/Developer/Xcode/DerivedData/Client-*/Build/Products/Fennec_Testing-*/Client.app"  # noqa
+            )
+        )
 
     def install(self, boot=True):
-        command = "find ~/Library/Developer/Xcode/DerivedData/Client-*/Build/Products/Fennec-* -type d -iname 'Client.app'"
-        path = subprocess.check_output(command, shell=True, universal_newlines=True)
         if boot:
             self.xcrun.boot()
         try:
             out = subprocess.check_output(
-                f"xcrun simctl install booted {path}",
-                cwd=os.pardir,
+                f"xcrun simctl install booted {self.firefox_app_path}",
+                cwd=f"{here.parent}",
                 stderr=subprocess.STDOUT,
                 universal_newlines=True,
-                shell=True
+                shell=True,
             )
         except subprocess.CalledProcessError as e:
             out = e.output
             raise
         finally:
-            with open(self.log, 'w') as f:
+            with open(self.log, "w") as f:
                 f.write(out)
 
     def test(self, identifier, build=True, erase=True):
@@ -49,23 +52,23 @@ class XCodeBuild(object):
             run_args = "test-without-building"
         args = [
             self.binary,
-            f'{run_args}',
-            '-scheme', self.scheme,
-            '-destination', self.destination,
-            '-only-testing:{}'.format(identifier),
-            '-testPlan', self.testPlan]
-        self.logger.info('Running: {}'.format(' '.join(args)))
+            f"{run_args}",
+            "-scheme",
+            self.scheme,
+            "-destination",
+            self.destination,
+            "-only-testing:{}".format(identifier),
+            "-testPlan",
+            self.testPlan,
+        ]
+        self.logger.info("Running: {}".format(" ".join(args)))
         try:
             out = subprocess.check_output(
-                args,
-                cwd=os.chdir("../../.."),
-                stderr=subprocess.STDOUT,
-                universal_newlines=True)
+                args, cwd=f"{here.parents[3]}", stderr=subprocess.STDOUT, universal_newlines=True
+            )
         except subprocess.CalledProcessError as e:
             out = e.output
             raise
         finally:
-            with open(self.log, 'w') as f:
+            with open(self.log, "w") as f:
                 f.write(out)
-            os.chdir("firefox-ios-tests/Tests/SyncIntegrationTests")
-

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests/xcrun.py
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests/xcrun.py
@@ -1,0 +1,29 @@
+import logging
+import os
+import subprocess
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+
+class XCRun(object):
+    binary = "xcrun"
+    logger = logging.getLogger()
+
+    def _run(self, *args):
+        args = [self.binary, "simctl"] + list(args)
+        self.logger.info("Running: {}".format(" ".join(args)))
+        subprocess.check_call(args)
+
+    def boot(self, device="iPhone 15"):
+        ios_device = os.environ.get("SIMULATOR_UDID", device)
+        self._run("boot", ios_device)
+
+    def install(self, device="all"):
+        self._run("install", device)
+
+    def shutdown(self, device="all"):
+        self._run("shutdown", device)
+
+    def erase(self, device="all"):
+        self.shutdown(device)
+        self._run("erase", device)

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/xcodebuild.py
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/xcodebuild.py
@@ -10,7 +10,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 class XCodeBuild(object):
     binary = 'xcodebuild'
-    destination = 'platform=iOS Simulator,name=iPhone 15,OS=17.4'
+    destination = 'platform=iOS Simulator,name=iPhone 15,OS=17.5'
     logger = logging.getLogger()
     scheme = 'Fennec'
     testPlan = 'SyncIntegrationTestPlan'
@@ -22,7 +22,7 @@ class XCodeBuild(object):
         self.log = log
 
     def install(self, boot=True):
-        command = "find ~/Library/Developer/Xcode/DerivedData/Client-*/Build/Products/Fennec-* -type d -iname 'Client.app'"
+        command = "find ~/Library/Developer/Xcode/DerivedData/Client-*/Build/Products/Fennec_Testing-* -type d -iname 'Client.app'"
         path = subprocess.check_output(command, shell=True, universal_newlines=True)
         if boot:
             self.xcrun.boot()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ExperimentIntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ExperimentIntegrationTests.swift
@@ -11,7 +11,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
     override func setUpApp() {
         app.activate()
         let closeButton = app.buttons["CloseButton"]
-        if closeButton.waitForExistence(timeout: TIMEOUT_LONG) {
+        if closeButton.waitForExistence(timeout: TIMEOUT) {
             closeButton.tap()
         }
         super.setUpScreenGraph()
@@ -131,6 +131,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
         let studiesToggle = app.switches.matching(
             NSPredicate(format: "identifier CONTAINS 'settings.studiesToggle'")
         )
+        wait(forElement: studiesToggle.element, timeout: TIMEOUT)
         XCTAssertEqual(studiesToggle.element.value as? String, "1")
         studiesToggle.element.tap()
         XCTAssertEqual(studiesToggle.element.value as? String, "0")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-4788)


## :bulb: Description
This updates the asserts I added previously. There were intermittent failures where the switch toggle would report as blank, I added a wait so that the switch can be correctly queried for its value.

I also changed the iOS version that the Experiment Integration tests use to match what we currently support.

## :pencil: Checklist
You have to check all boxes before merging
- [✅] Filled in the above information (tickets numbers and description of your work)
- [✅] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [✅] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

