### PR TITLE
Add FXIOS-10162 [Homepage] Header section

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -836,7 +836,7 @@
 		8A88815A2B20FFE0009635AE /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A8881592B20FFE0009635AE /* GCDWebServers */; };
 		8A88815C2B2103AD009635AE /* WebEngine in Frameworks */ = {isa = PBXBuildFile; productRef = 8A88815B2B2103AD009635AE /* WebEngine */; };
 		8A88815E2B21071E009635AE /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A88815D2B21071E009635AE /* GCDWebServers */; };
-		8A8917692B57283B008B01EA /* HomepageHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8917682B57283B008B01EA /* HomepageHeaderCell.swift */; };
+		8A8917692B57283B008B01EA /* LegacyHomepageHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8917682B57283B008B01EA /* LegacyHomepageHeaderCell.swift */; };
 		8A8BAE122B2107E400D774EB /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A8BAE112B2107E400D774EB /* GCDWebServers */; };
 		8A8BAE142B21110000D774EB /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A8BAE132B21110000D774EB /* GCDWebServers */; };
 		8A8BAE162B2119E600D774EB /* InternalURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8BAE152B2119E600D774EB /* InternalURL.swift */; };
@@ -918,6 +918,7 @@
 		8ABE9F1B2CB4620A0080E1DF /* RemoteSettingsFetchConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = 8AF4E76D2C41D86100BAD91C /* RemoteSettingsFetchConfig.json */; };
 		8ABE9F1D2CB462730080E1DF /* RemoteSettingsFetchConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABE9F1C2CB462730080E1DF /* RemoteSettingsFetchConfigTests.swift */; };
 		8ABE9F1E2CB462CA0080E1DF /* RemoteSettingsFetchConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = 8AF4E76D2C41D86100BAD91C /* RemoteSettingsFetchConfig.json */; };
+		8ABDBAA62CB6BF6600B51F63 /* HomepageHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABDBAA52CB6BF6600B51F63 /* HomepageHeaderCell.swift */; };
 		8AC1065F28D0CD700013263A /* OpenQLPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */; };
 		8AC225662B6D403200CDA7FD /* HomepageTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC225642B6D3FA400CDA7FD /* HomepageTelemetryTests.swift */; };
 		8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */; };
@@ -6982,7 +6983,7 @@
 		8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabsStoreTests.swift; sourceTree = "<group>"; };
 		8A87AEE02C1B4D17007428B2 /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
 		8A880C432C63CFE200B77F23 /* MockLoginViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoginViewModelDelegate.swift; sourceTree = "<group>"; };
-		8A8917682B57283B008B01EA /* HomepageHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageHeaderCell.swift; sourceTree = "<group>"; };
+		8A8917682B57283B008B01EA /* LegacyHomepageHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHomepageHeaderCell.swift; sourceTree = "<group>"; };
 		8A8BAE152B2119E600D774EB /* InternalURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalURL.swift; sourceTree = "<group>"; };
 		8A8DDEBE276259A900E7B97A /* RatingPromptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManager.swift; sourceTree = "<group>"; };
 		8A93080827BFE88F0052167D /* PhotonActionSheetContainerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetContainerCell.swift; sourceTree = "<group>"; };
@@ -7060,6 +7061,7 @@
 		8ABCFEA22B45C36100C2988A /* PrivateBrowsingTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTelemetry.swift; sourceTree = "<group>"; };
 		8ABCFEA42B45CAC300C2988A /* PrivateBrowsingTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTelemetryTests.swift; sourceTree = "<group>"; };
 		8ABE9F1C2CB462730080E1DF /* RemoteSettingsFetchConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSettingsFetchConfigTests.swift; sourceTree = "<group>"; };
+		8ABDBAA52CB6BF6600B51F63 /* HomepageHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageHeaderCell.swift; sourceTree = "<group>"; };
 		8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenQLPreviewHelper.swift; sourceTree = "<group>"; };
 		8AC225642B6D3FA400CDA7FD /* HomepageTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageTelemetryTests.swift; sourceTree = "<group>"; };
 		8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
@@ -10938,6 +10940,7 @@
 		8A7D08E12CAAF79F0035999C /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
+				8ABDBAA42CB6BF3A00B51F63 /* View */,
 				8A7D08E22CAAF7C30035999C /* HomepageViewController.swift */,
 				8AA0A6622CAC40AA00AC7EB3 /* HomepageDiffableDataSource.swift */,
 				8AA0A6642CAC6B7100AC7EB3 /* HomepageSectionLayoutProvider.swift */,
@@ -11142,7 +11145,7 @@
 			isa = PBXGroup;
 			children = (
 				1D69FF8C27B17285001F660E /* HomeLogoHeaderCell.swift */,
-				8A8917682B57283B008B01EA /* HomepageHeaderCell.swift */,
+				8A8917682B57283B008B01EA /* LegacyHomepageHeaderCell.swift */,
 				8AB8573627D951640075C173 /* HomeLogoHeaderViewModel.swift */,
 			);
 			path = LogoHeader;
@@ -11165,6 +11168,14 @@
 				8AEAD9F42C3D7BA9001A2C5A /* FeatureFlagsDebugViewController.swift */,
 			);
 			path = FeatureFlags;
+			sourceTree = "<group>";
+		};
+		8ABDBAA42CB6BF3A00B51F63 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				8ABDBAA52CB6BF6600B51F63 /* HomepageHeaderCell.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		8AC225632B6D3F9600CDA7FD /* Telemetry */ = {
@@ -15436,7 +15447,7 @@
 				5AA0CC662A4B8F6100014E2A /* PasswordManagerCoordinator.swift in Sources */,
 				8A7368AD27924AAF005D7704 /* CanRemoveQuickActionBookmark.swift in Sources */,
 				C2296FCC2A601C190046ECA6 /* IntensityVisualEffectView.swift in Sources */,
-				8A8917692B57283B008B01EA /* HomepageHeaderCell.swift in Sources */,
+				8A8917692B57283B008B01EA /* LegacyHomepageHeaderCell.swift in Sources */,
 				8ADC2A102A33758E00543DAA /* FxALaunchParams.swift in Sources */,
 				D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */,
 				E17496382991A2720096900A /* AdaptiveStack.swift in Sources */,
@@ -15512,6 +15523,7 @@
 				C88E7A602A05551B0072E638 /* NimbusOnboardingFeatureLayerProtocol.swift in Sources */,
 				8CFD56882AAF057D003157A6 /* SwitchFakespotProduction.swift in Sources */,
 				C40046FA1CF8E0B200B08303 /* BackForwardListAnimator.swift in Sources */,
+				8ABDBAA62CB6BF6600B51F63 /* HomepageHeaderCell.swift in Sources */,
 				8AD0110F2CB4314B00368BF3 /* HeaderAction.swift in Sources */,
 				8CE1E4372B8C76C80026530B /* LoginAutofillView.swift in Sources */,
 				DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -31,8 +31,8 @@ class TabManagerMiddleware {
             self.resovleTabPanelViewActions(action: action, state: state)
         } else if let action = action as? MainMenuAction {
             self.resolveMainMenuActions(with: action, appState: state)
-        } else if let action = action as? HomepageAction {
-            self.resolveHomepageActions(with: action)
+        } else if let action = action as? HeaderAction {
+            self.resolveHomepageHeaderActions(with: action)
         }
     }
 
@@ -692,7 +692,7 @@ class TabManagerMiddleware {
         }
     }
 
-    private func resolveHomepageActions(with action: HomepageAction) {
+    private func resolveHomepageHeaderActions(with action: HeaderAction) {
         switch action.actionType {
         case HeaderActionType.toggleHomepageMode:
             tabManager(for: action.windowUUID).switchPrivacyMode()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -32,7 +32,7 @@ class TabManagerMiddleware {
         } else if let action = action as? MainMenuAction {
             self.resolveMainMenuActions(with: action, appState: state)
         } else if let action = action as? HomepageAction {
-            self.resolveHomepageActions(with: action, appState: state)
+            self.resolveHomepageActions(with: action)
         }
     }
 
@@ -692,7 +692,7 @@ class TabManagerMiddleware {
         }
     }
 
-    private func resolveHomepageActions(with action: HomepageAction, appState: AppState) {
+    private func resolveHomepageActions(with action: HomepageAction) {
         switch action.actionType {
         case HeaderActionType.toggleHomepageMode:
             tabManager(for: action.windowUUID).switchPrivacyMode()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -31,6 +31,8 @@ class TabManagerMiddleware {
             self.resovleTabPanelViewActions(action: action, state: state)
         } else if let action = action as? MainMenuAction {
             self.resolveMainMenuActions(with: action, appState: state)
+        } else if let action = action as? HomepageAction {
+            self.resolveHomepageActions(with: action, appState: state)
         }
     }
 
@@ -687,6 +689,15 @@ class TabManagerMiddleware {
                 isChangedUA: selectedTab.changedUserAgent,
                 isPrivate: selectedTab.isPrivate
             )
+        }
+    }
+
+    private func resolveHomepageActions(with action: HomepageAction, appState: AppState) {
+        switch action.actionType {
+        case HeaderActionType.toggleHomepageMode:
+            tabManager(for: action.windowUUID).switchPrivacyMode()
+        default:
+            break
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -16,58 +16,18 @@ final class HomepageDiffableDataSource:
         case pocket
     }
 
-    // TODO: FXIOS-10162 Update item type depending section data
-    struct HomeItem: Hashable {
-        let id: UUID
-        let title: String
+    enum HomeItem: Hashable {
+        case header
     }
 
     func applyInitialSnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeItem>()
 
         snapshot.appendSections([.header, .topSites, .pocket])
-
-        // TODO: FXIOS-10162 Remove the dummy data and start implementing using the header section
-        let items = [
-            HomeItem(id: UUID(), title: "First"),
-            HomeItem(id: UUID(), title: "Second"),
-            HomeItem(id: UUID(), title: "Third")
-        ]
-
-        let items2 = [
-            HomeItem(id: UUID(), title: "First"),
-            HomeItem(id: UUID(), title: "Second"),
-        ]
-
-        let items3 = [
-            HomeItem(id: UUID(), title: "First"),
-        ]
-
-        snapshot.appendItems(items, toSection: .header)
-        snapshot.appendItems(items2, toSection: .topSites)
-        snapshot.appendItems(items3, toSection: .pocket)
+        snapshot.appendItems([.header], toSection: .header)
+        snapshot.appendItems([], toSection: .topSites)
+        snapshot.appendItems([], toSection: .pocket)
 
         apply(snapshot, animatingDifferences: true)
-    }
-
-    func updateHeaderSection() {
-        var updatedSnapshot = snapshot()
-
-        if !updatedSnapshot.sectionIdentifiers.contains(.header) {
-            updatedSnapshot.appendSections([.header])
-        }
-
-        let currentItems = updatedSnapshot.itemIdentifiers(inSection: .header)
-
-        updatedSnapshot.deleteItems(currentItems)
-
-        // TODO: FXIOS-10162 Remove the dummy data and start implementing using the header section
-        let newItems = [
-            HomeItem(id: UUID(), title: "Fourth"),
-        ]
-
-        updatedSnapshot.appendItems(newItems, toSection: .header)
-
-        apply(updatedSnapshot, animatingDifferences: true)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -7,6 +7,22 @@ import Common
 
 /// Holds section layout logic for the new homepage as part of the rebuild project
 final class HomepageSectionLayoutProvider {
+    struct UX {
+        static let bottomSpacing: CGFloat = 30
+        static let standardInset: CGFloat = 16
+        static let iPadInset: CGFloat = 50
+
+        static func leadingInset(
+            traitCollection: UITraitCollection,
+            interfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+        ) -> CGFloat {
+            guard interfaceIdiom != .phone else { return standardInset }
+
+            // Handles multitasking on iPad
+            return traitCollection.horizontalSizeClass == .regular ? iPadInset : standardInset
+        }
+    }
+
     private var logger: Logger
 
     init(logger: Logger = DefaultLogger.shared) {
@@ -23,22 +39,46 @@ final class HomepageSectionLayoutProvider {
                 )
                 return nil
             }
-            return self.createLayoutSection(for: section)
+            return self.createLayoutSection(for: section, with: environment.traitCollection)
         }
     }
 
     // TODO: FXIOS-10162 - Update layout section with appropriate views + integrate with redux
     private func createLayoutSection(
-        for section: HomepageSection
+        for section: HomepageSection,
+        with traitCollection: UITraitCollection
     ) -> NSCollectionLayoutSection {
         switch section {
         case .header:
-            return createDefaultSectionLayout()
+            return createHeaderSectionLayout(for: traitCollection)
         case .topSites:
             return createFirstSectionLayout()
         case .pocket:
             return createDefaultSectionLayout()
         }
+    }
+
+    private func createHeaderSectionLayout(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                              heightDimension: .estimated(100))
+
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                               heightDimension: .estimated(100))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
+
+        let section = NSCollectionLayoutSection(group: group)
+
+        let leadingInset = UX.leadingInset(traitCollection: traitCollection)
+
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: UX.standardInset,
+            leading: leadingInset,
+            bottom: UX.bottomSpacing,
+            trailing: leadingInset)
+
+        return section
     }
 
     // TODO: FXIOS-10165 - Update with proper top sites section layout

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -194,7 +194,6 @@ final class HomepageViewController: UIViewController,
             guard let headerCell = cell as? HomepageHeaderCell else {
                 return UICollectionViewCell()
             }
-            // TODO: FXIOS-10259 - Update with felt privacy feature flags or confirm we can remove the isPrivate check
             headerCell.configure(
                 headerState: homepageState.headerState,
                 showiPadSetup: shouldUseiPadSetup()

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -100,8 +100,6 @@ final class HomepageViewController: UIViewController,
         homepageState = state
         if homepageState.loadInitialData {
             dataSource?.applyInitialSnapshot()
-        } else if homepageState.headerState.showHeader {
-            dataSource?.updateHeaderSection()
         }
     }
 
@@ -143,8 +141,7 @@ final class HomepageViewController: UIViewController,
     private func configureCollectionView() {
         let collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: layoutConfiguration)
 
-        // TODO: FXIOS-10162 - Update with proper cells
-        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "cell")
+        collectionView.register(HomepageHeaderCell.self, forCellWithReuseIdentifier: HomepageHeaderCell.cellIdentifier)
 
         collectionView.keyboardDismissMode = .onDrag
         collectionView.showsVerticalScrollIndicator = false
@@ -179,12 +176,7 @@ final class HomepageViewController: UIViewController,
         for item: HomepageDiffableDataSource.HomeItem,
         at indexPath: IndexPath
     ) -> UICollectionViewCell {
-        // TODO: FXIOS-10162 - Dummy collection cells, to update with proper cells
-        guard let section = HomepageSection(rawValue: indexPath.section),
-              let cell: UICollectionViewCell = collectionView?.dequeueReusableCell(
-                withReuseIdentifier: "cell",
-                for: indexPath
-              ) else {
+        guard let section = HomepageSection(rawValue: indexPath.section) else {
             self.logger.log(
                 "Section should not have been nil, something went wrong",
                 level: .fatal,
@@ -193,41 +185,45 @@ final class HomepageViewController: UIViewController,
             return UICollectionViewCell()
         }
 
-        cell.contentView.subviews.forEach { $0.removeFromSuperview() }
-        cell.contentView.backgroundColor = getBackgroundColor(for: section)
-
-        let label = UILabel(frame: cell.contentView.bounds)
-        label.textAlignment = .center
-        label.text = item.title
-        label.textColor = .white
-        cell.contentView.addSubview(label)
-
-        return cell
-    }
-
-    private func getBackgroundColor(for section: HomepageSection) -> UIColor {
         switch section {
         case .header:
-            return .systemPink
-        case .topSites:
-            return .systemGreen
-        case .pocket:
-            return .systemPurple
+            let cell = collectionView?.dequeueReusableCell(
+                withReuseIdentifier: HomepageHeaderCell.cellIdentifier,
+                for: indexPath
+            )
+            guard let headerCell = cell as? HomepageHeaderCell else {
+                return UICollectionViewCell()
+            }
+            // TODO: FXIOS-10259 - Update with felt privacy feature flags or confirm we can remove the isPrivate check
+            headerCell.configure(
+                headerState: homepageState.headerState,
+                showiPadSetup: shouldUseiPadSetup()
+            ) { [weak self] in
+                guard let self else { return }
+                store.dispatch(
+                    HeaderAction(
+                        windowUUID: self.windowUUID,
+                        actionType: HeaderActionType.toggleHomepageMode
+                    )
+                )
+            }
+            headerCell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+            return headerCell
+        default:
+            return UICollectionViewCell()
         }
     }
 
     // MARK: UICollectionViewDelegate
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        if let selectedItem = dataSource?.itemIdentifier(for: indexPath) {
-            // TODO: FXIOS-10162 - Dummy trigger to update with proper triggers
-            if selectedItem.title == "First" {
-                store.dispatch(
-                    HeaderAction(
-                        windowUUID: windowUUID,
-                        actionType: HeaderActionType.updateHeader
-                    )
-                )
-            }
+        // TODO: FXIOS-10162 - Dummy trigger to update with proper triggers
+
+        guard let section = HomepageSection(rawValue: indexPath.section) else {
+            return
+        }
+        switch section {
+        default:
+            return
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderAction.swift
@@ -13,5 +13,5 @@ final class HeaderAction: Action {
 }
 
 enum HeaderActionType: ActionType {
-    case updateHeader
+    case toggleHomepageMode
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderState.swift
@@ -8,21 +8,25 @@ import Redux
 
 struct HeaderState: StateType, Equatable {
     var windowUUID: WindowUUID
-    var showHeader: Bool
+    var isPrivate: Bool
+    var showPrivateModeToggle: Bool
 
     init(windowUUID: WindowUUID) {
         self.init(
             windowUUID: windowUUID,
-            showHeader: false
+            isPrivate: false,
+            showPrivateModeToggle: false
         )
     }
 
     private init(
         windowUUID: WindowUUID,
-        showHeader: Bool
+        isPrivate: Bool,
+        showPrivateModeToggle: Bool
     ) {
         self.windowUUID = windowUUID
-        self.showHeader = showHeader
+        self.isPrivate = isPrivate
+        self.showPrivateModeToggle = showPrivateModeToggle
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -30,20 +34,23 @@ struct HeaderState: StateType, Equatable {
         else {
             return HeaderState(
                 windowUUID: state.windowUUID,
-                showHeader: false
+                isPrivate: state.isPrivate,
+                showPrivateModeToggle: state.showPrivateModeToggle
             )
         }
 
         switch action.actionType {
-        case HeaderActionType.updateHeader:
+        case HomepageActionType.initialize:
             return HeaderState(
                 windowUUID: state.windowUUID,
-                showHeader: true
+                isPrivate: false,
+                showPrivateModeToggle: true
             )
         default:
             return HeaderState(
                 windowUUID: state.windowUUID,
-                showHeader: false
+                isPrivate: state.isPrivate,
+                showPrivateModeToggle: state.showPrivateModeToggle
             )
         }
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderState.swift
@@ -41,6 +41,7 @@ struct HeaderState: StateType, Equatable {
 
         switch action.actionType {
         case HomepageActionType.initialize:
+            // TODO: FXIOS-10259 - Update with felt privacy feature flags or confirm we can remove the showPrivateModeToggle check
             return HeaderState(
                 windowUUID: state.windowUUID,
                 isPrivate: false,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HeaderState.swift
@@ -41,7 +41,8 @@ struct HeaderState: StateType, Equatable {
 
         switch action.actionType {
         case HomepageActionType.initialize:
-            // TODO: FXIOS-10259 - Update with felt privacy feature flags or confirm we can remove the showPrivateModeToggle check
+            // TODO: FXIOS-10259 - Update with felt privacy feature flags 
+            // or confirm we can remove the showPrivateModeToggle check
             return HeaderState(
                 windowUUID: state.windowUUID,
                 isPrivate: false,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -62,12 +62,6 @@ struct HomepageState: ScreenState, Equatable {
                 loadInitialData: true,
                 headerState: HeaderState.reducer(state.headerState, action)
             )
-        case HeaderActionType.updateHeader:
-            return HomepageState(
-                windowUUID: state.windowUUID,
-                loadInitialData: false,
-                headerState: HeaderState.reducer(state.headerState, action)
-            )
         default:
             return HomepageState(
                 windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/View/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/View/HomepageHeaderCell.swift
@@ -83,8 +83,8 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
         self.headerState = headerState
         self.action = action
         setupView(with: showiPadSetup)
-        logoHeaderCell.configure(with: headerState.isPrivate)
-        privateModeButton.isHidden = !headerState.showPrivateModeToggle
+        logoHeaderCell.configure(with: showiPadSetup)
+        privateModeButton.isHidden = showiPadSetup || !headerState.showPrivateModeToggle
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/View/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/View/HomepageHeaderCell.swift
@@ -6,27 +6,6 @@ import Foundation
 import UIKit
 import Common
 
-struct HomepageHeaderCellViewModel {
-    var showiPadSetup: Bool
-    var showPrivateModeToggle: Bool
-    var isPrivate: Bool
-
-    private var action: (() -> Void)
-    private var homepageTelemetry = HomepageTelemetry()
-
-    init(isPrivate: Bool, showiPadSetup: Bool, showPrivateModeToggle: Bool, action: @escaping () -> Void) {
-        self.isPrivate = isPrivate
-        self.showiPadSetup = showiPadSetup
-        self.showPrivateModeToggle = showPrivateModeToggle
-        self.action = action
-    }
-
-    func switchMode() {
-        action()
-        homepageTelemetry.sendHomepageTappedTelemetry(enteringPrivateMode: !isPrivate)
-    }
-}
-
 // Header for the homepage in both normal and private mode
 // Contains the firefox logo and the private browsing shortcut button
 class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
@@ -36,7 +15,8 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
         static let circleSize = CGRect(width: 40, height: 40)
     }
 
-    var viewModel: HomepageHeaderCellViewModel?
+    private var headerState: HeaderState?
+    private var action: (() -> Void)?
 
     private lazy var stackContainer: UIStackView = .build { stackView in
         stackView.axis = .horizontal
@@ -95,26 +75,32 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
         NSLayoutConstraint.activate(logoConstraints)
     }
 
-    func configure(with viewModel: HomepageHeaderCellViewModel) {
-        self.viewModel = viewModel
-        setupView(with: viewModel.showiPadSetup)
-        logoHeaderCell.configure(with: viewModel.showiPadSetup)
-        privateModeButton.isHidden = !viewModel.showPrivateModeToggle
+    func configure(
+        headerState: HeaderState,
+        showiPadSetup: Bool,
+        action: @escaping () -> Void
+    ) {
+        self.headerState = headerState
+        self.action = action
+        setupView(with: showiPadSetup)
+        logoHeaderCell.configure(with: headerState.isPrivate)
+        privateModeButton.isHidden = !headerState.showPrivateModeToggle
     }
 
     @objc
     private func switchMode() {
-        viewModel?.switchMode()
+        // TODO: FXIOS-10171 - Add Telemetry for toggle, to live in homepage middleware
+        action?()
     }
 
     // MARK: - ThemeApplicable
     func applyTheme(theme: Theme) {
+        guard let isPrivateHomepage = headerState?.isPrivate else { return }
         logoHeaderCell.applyTheme(theme: theme)
-        guard let viewModel else { return }
-        let privateModeButtonTintColor = viewModel.isPrivate ? theme.colors.layer2 : theme.colors.iconPrimary
+        let privateModeButtonTintColor = isPrivateHomepage ? theme.colors.layer2 : theme.colors.iconPrimary
         privateModeButton.imageView?.tintColor = privateModeButtonTintColor
-        privateModeButton.backgroundColor = viewModel.isPrivate ? .white : .clear
-        privateModeButton.accessibilityValue = viewModel.isPrivate ?
+        privateModeButton.backgroundColor = isPrivateHomepage ? .white : .clear
+        privateModeButton.accessibilityValue = isPrivateHomepage ?
             .TabTrayToggleAccessibilityValueOn :
             .TabTrayToggleAccessibilityValueOff
     }

--- a/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
@@ -27,7 +27,7 @@ enum HomepageSectionType: Int, CaseIterable {
 
     var cellIdentifier: String {
         switch self {
-        case .homepageHeader: return HomepageHeaderCell.cellIdentifier
+        case .homepageHeader: return LegacyHomepageHeaderCell.cellIdentifier
         case .messageCard: return HomepageMessageCardCell.cellIdentifier
         // Top sites has more than 1 cell type, dequeuing is done through FxHomeSectionHandler protocol
         case .topSites: return ""
@@ -42,7 +42,7 @@ enum HomepageSectionType: Int, CaseIterable {
     }
 
     static var cellTypes: [ReusableCell.Type] {
-        return [HomepageHeaderCell.self,
+        return [LegacyHomepageHeaderCell.self,
                 HomepageMessageCardCell.self,
                 TopSiteItemCell.self,
                 EmptyTopSiteCell.self,

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/HomeLogoHeaderViewModel.swift
@@ -73,7 +73,7 @@ extension HomepageHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 
 extension HomepageHeaderViewModel: HomepageSectionHandler {
     func configure(_ cell: UICollectionViewCell, at indexPath: IndexPath) -> UICollectionViewCell {
-        guard let headerCell = cell as? HomepageHeaderCell else { return UICollectionViewCell() }
+        guard let headerCell = cell as? LegacyHomepageHeaderCell else { return UICollectionViewCell() }
         headerCell.configure(
             with: HomepageHeaderCellViewModel(
                 isPrivate: false,

--- a/firefox-ios/Client/Frontend/Home/LogoHeader/LegacyHomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/LogoHeader/LegacyHomepageHeaderCell.swift
@@ -1,0 +1,121 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import UIKit
+import Common
+
+struct HomepageHeaderCellViewModel {
+    var showiPadSetup: Bool
+    var showPrivateModeToggle: Bool
+    var isPrivate: Bool
+
+    private var action: (() -> Void)
+    private var homepageTelemetry = HomepageTelemetry()
+
+    init(isPrivate: Bool, showiPadSetup: Bool, showPrivateModeToggle: Bool, action: @escaping () -> Void) {
+        self.isPrivate = isPrivate
+        self.showiPadSetup = showiPadSetup
+        self.showPrivateModeToggle = showPrivateModeToggle
+        self.action = action
+    }
+
+    func switchMode() {
+        action()
+        homepageTelemetry.sendHomepageTappedTelemetry(enteringPrivateMode: !isPrivate)
+    }
+}
+
+// Header for the homepage in both normal and private mode
+// Contains the firefox logo and the private browsing shortcut button
+class LegacyHomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
+    enum UX {
+        static let iPhoneTopConstant: CGFloat = 16
+        static let iPadTopConstant: CGFloat = 54
+        static let circleSize = CGRect(width: 40, height: 40)
+    }
+
+    var viewModel: HomepageHeaderCellViewModel?
+
+    private lazy var stackContainer: UIStackView = .build { stackView in
+        stackView.axis = .horizontal
+    }
+
+    private lazy var logoHeaderCell: HomeLogoHeaderCell = {
+        let logoHeader = HomeLogoHeaderCell()
+        return logoHeader
+    }()
+
+    private lazy var privateModeButton: UIButton = .build { [weak self] button in
+        let maskImage = UIImage(named: StandardImageIdentifiers.Large.privateMode)?.withRenderingMode(.alwaysTemplate)
+        button.setImage(maskImage, for: .normal)
+        button.frame = UX.circleSize
+        button.layer.cornerRadius = button.frame.size.width / 2
+        button.addTarget(self, action: #selector(self?.switchMode), for: .touchUpInside)
+        button.accessibilityLabel = .TabTrayToggleAccessibilityLabel
+        button.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton
+    }
+
+    // MARK: - Initializers
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI Setup
+
+    private func setupView(with showiPadSetup: Bool) {
+        stackContainer.addArrangedSubview(logoHeaderCell.contentView)
+        stackContainer.addArrangedSubview(privateModeButton)
+        contentView.addSubview(stackContainer)
+
+        setupConstraints(for: showiPadSetup)
+    }
+
+    private var logoConstraints = [NSLayoutConstraint]()
+
+    private func setupConstraints(for iPadSetup: Bool) {
+        NSLayoutConstraint.deactivate(logoConstraints)
+        let topAnchorConstant = iPadSetup ? UX.iPadTopConstant : UX.iPhoneTopConstant
+        logoConstraints = [
+            stackContainer.topAnchor.constraint(equalTo: contentView.topAnchor, constant: topAnchorConstant),
+            stackContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            stackContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            stackContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).priority(.defaultLow),
+
+            privateModeButton.widthAnchor.constraint(equalToConstant: UX.circleSize.width),
+            privateModeButton.centerYAnchor.constraint(equalTo: stackContainer.centerYAnchor),
+            logoHeaderCell.contentView.centerYAnchor.constraint(equalTo: stackContainer.centerYAnchor)
+        ]
+
+        NSLayoutConstraint.activate(logoConstraints)
+    }
+
+    func configure(with viewModel: HomepageHeaderCellViewModel) {
+        self.viewModel = viewModel
+        setupView(with: viewModel.showiPadSetup)
+        logoHeaderCell.configure(with: viewModel.showiPadSetup)
+        privateModeButton.isHidden = !viewModel.showPrivateModeToggle
+    }
+
+    @objc
+    private func switchMode() {
+        viewModel?.switchMode()
+    }
+
+    // MARK: - ThemeApplicable
+    func applyTheme(theme: Theme) {
+        logoHeaderCell.applyTheme(theme: theme)
+        guard let viewModel else { return }
+        let privateModeButtonTintColor = viewModel.isPrivate ? theme.colors.layer2 : theme.colors.iconPrimary
+        privateModeButton.imageView?.tintColor = privateModeButtonTintColor
+        privateModeButton.backgroundColor = viewModel.isPrivate ? .white : .clear
+        privateModeButton.accessibilityValue = viewModel.isPrivate ?
+            .TabTrayToggleAccessibilityValueOn :
+            .TabTrayToggleAccessibilityValueOff
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -89,8 +89,8 @@ final class PrivateHomepageViewController:
         return messageCard
     }()
 
-    private lazy var homepageHeaderCell: HomepageHeaderCell = {
-        let header = HomepageHeaderCell()
+    private lazy var homepageHeaderCell: LegacyHomepageHeaderCell = {
+        let header = LegacyHomepageHeaderCell()
         header.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         header.configure(with: headerViewModel)
         return header

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -38,35 +38,8 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot.numberOfSections, 3)
         XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites, .pocket])
 
-        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 3)
-        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .topSites).count, 2)
-        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .pocket).count, 1)
-    }
-
-    // MARK: - updateHeaderSection
-    func test_updateHeaderSection_hasCorrectData() throws {
-        let dataSource = try XCTUnwrap(diffableDataSource)
-
-        dataSource.applyInitialSnapshot()
-        dataSource.updateHeaderSection()
-
-        let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfSections, 3)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites, .pocket])
-
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
-        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .topSites).count, 2)
-        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .pocket).count, 1)
-    }
-
-    func test_updateHeaderSection_withoutInitialSection_hasCorrectData() throws {
-        let dataSource = try XCTUnwrap(diffableDataSource)
-
-        dataSource.updateHeaderSection()
-
-        let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfSections, 1)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header])
-        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
+        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .topSites).count, 0)
+        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .pocket).count, 0)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HeaderStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HeaderStateTests.swift
@@ -8,47 +8,29 @@ import XCTest
 @testable import Client
 
 final class HeaderStateTests: XCTestCase {
-    func testInitialization() {
-        let initialState = createSubject()
-
-        XCTAssertFalse(initialState.showHeader)
-    }
-
-    func test_windowUUID_returnsValidUUID() {
+    func tests_initialState_returnsExpectedState() {
         let initialState = createSubject()
 
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(initialState.isPrivate)
+        XCTAssertFalse(initialState.showPrivateModeToggle)
     }
 
-    func test_different_windowUUID_returnsDefaultState() {
+    func test_initializeAction_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = headerReducer()
 
         let newState = reducer(
             initialState,
-            HeaderAction(
-                windowUUID: .DefaultUITestingUUID,
-                actionType: HeaderActionType.updateHeader
+            HomepageAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.initialize
             )
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertFalse(newState.showHeader)
-    }
-
-    func test_updateHeader_returnsTrue() {
-        let initialState = createSubject()
-        let reducer = headerReducer()
-
-        let newState = reducer(
-            initialState,
-            HeaderAction(
-                windowUUID: .XCTestDefaultUUID,
-                actionType: HeaderActionType.updateHeader
-            )
-        )
-
-        XCTAssertTrue(newState.showHeader)
+        XCTAssertFalse(newState.isPrivate)
+        XCTAssertTrue(newState.showPrivateModeToggle)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
@@ -8,35 +8,14 @@ import XCTest
 @testable import Client
 
 final class HomepageStateTests: XCTestCase {
-    func testInitialization() {
+    func tests_initialState_returnsExpectedState() {
         let initialState = createSubject()
 
         XCTAssertFalse(initialState.loadInitialData)
-    }
-
-    func test_windowUUID_returnsValidUUID() {
-        let initialState = createSubject()
-
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
     }
 
-    func test_different_windowUUID_returnsDefaultState() {
-        let initialState = createSubject()
-        let reducer = homepageReducer()
-
-        let newState = reducer(
-            initialState,
-            HeaderAction(
-                windowUUID: .DefaultUITestingUUID,
-                actionType: HeaderActionType.updateHeader
-            )
-        )
-
-        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertFalse(newState.loadInitialData)
-    }
-
-    func test_initializeData_returnsTrue() {
+    func test_initializeAction_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = homepageReducer()
 
@@ -48,22 +27,10 @@ final class HomepageStateTests: XCTestCase {
             )
         )
 
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertTrue(newState.loadInitialData)
-    }
-
-    func test_updateHeader_returnsTrue() {
-        let initialState = createSubject()
-        let reducer = homepageReducer()
-
-        let newState = reducer(
-            initialState,
-            HeaderAction(
-                windowUUID: .XCTestDefaultUUID,
-                actionType: HeaderActionType.updateHeader
-            )
-        )
-
-        XCTAssertTrue(newState.headerState.showHeader)
+        XCTAssertFalse(newState.headerState.isPrivate)
+        XCTAssertTrue(newState.headerState.showPrivateModeToggle)
     }
 
     // MARK: - Private


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10162)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22264)

## :bulb: Description
Add header section to homepage
* Rename current header cell to `LegacyHomepageHeaderCell` and created new `HomepageHeaderCell`
* Also updated the private mode toggle for both normal + private to use the redux pattern, now that tab tray refactor is enabled. After user taps on button, we dispatch an action that gets received and handled by the tab manager middleware.
* Goodbye skittles 👋 , will update the snapshots and collection layout as I add in each section

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
**iPhone**

https://github.com/user-attachments/assets/e6faca8d-31df-4580-958b-a6f840240ea0

**iPad**

https://github.com/user-attachments/assets/8535d334-b1c3-419d-9536-a17f0ea577d8