### PR TITLE
Bugfix FXIOS-10249 FXIOS-10290 [Toolbar redesign] Prevent cleared url string from reappearing

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -453,17 +453,11 @@ class BrowserViewController: UIViewController,
         view.layoutSubviews()
 
         if let tab = tabManager.selectedTab,
-           let webView = tab.webView {
+           let webView = tab.webView,
+           !isToolbarRefactorEnabled {
             updateURLBarDisplayURL(tab)
-
-            if isToolbarRefactorEnabled {
-                dispatchBackForwardToolbarAction(canGoBack: webView.canGoBack,
-                                                 canGoForward: webView.canGoForward,
-                                                 windowUUID: windowUUID)
-            } else {
-                navigationToolbar.updateBackStatus(webView.canGoBack)
-                navigationToolbar.updateForwardStatus(webView.canGoForward)
-            }
+            navigationToolbar.updateBackStatus(webView.canGoBack)
+            navigationToolbar.updateForwardStatus(webView.canGoForward)
         }
     }
 
@@ -2340,14 +2334,16 @@ class BrowserViewController: UIViewController,
     /// This requires an update of the toolbars.
     private func updateToolbarStateTraitCollectionIfNecessary(_ newCollection: UITraitCollection) {
         let showTopTabs = ToolbarHelper().shouldShowTopTabs(for: newCollection)
+        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: newCollection)
 
         // Only dispatch action when the value of top tabs being shown is different from what is saved in the state
         // to avoid having the toolbar re-displayed
         guard let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID),
-              toolbarState.isShowingTopTabs != showTopTabs
+              toolbarState.isShowingTopTabs != showTopTabs || toolbarState.isShowingNavigationToolbar != showNavToolbar
         else { return }
 
         let action = ToolbarAction(
+            isShowingNavigationToolbar: showNavToolbar,
             isShowingTopTabs: showTopTabs,
             windowUUID: windowUUID,
             actionType: ToolbarActionType.traitCollectionDidChange

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -339,7 +339,7 @@ struct AddressBarState: StateType, Equatable {
                 pageActions: pageActions(action: toolbarAction, addressBarState: state, isEditing: false),
                 browserActions: browserActions(action: toolbarAction, addressBarState: state),
                 borderPosition: state.borderPosition,
-                url: state.url,
+                url: toolbarAction.url ?? state.url,
                 searchTerm: nil,
                 lockIconImageName: state.lockIconImageName,
                 isEditing: false,
@@ -379,6 +379,25 @@ struct AddressBarState: StateType, Equatable {
                 lockIconImageName: state.lockIconImageName,
                 isEditing: state.isEditing,
                 isScrollingDuringEdit: true,
+                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+                isLoading: state.isLoading,
+                readerModeState: state.readerModeState
+            )
+
+        case ToolbarActionType.clearSearch:
+            guard let toolbarAction = action as? ToolbarAction else { return state }
+
+            return AddressBarState(
+                windowUUID: state.windowUUID,
+                navigationActions: state.navigationActions,
+                pageActions: state.pageActions,
+                browserActions: state.browserActions,
+                borderPosition: state.borderPosition,
+                url: nil,
+                searchTerm: nil,
+                lockIconImageName: state.lockIconImageName,
+                isEditing: state.isEditing,
+                isScrollingDuringEdit: state.isScrollingDuringEdit,
                 shouldSelectSearchTerm: state.shouldSelectSearchTerm,
                 isLoading: state.isLoading,
                 readerModeState: state.readerModeState

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -84,6 +84,7 @@ enum ToolbarActionType: ActionType {
     case searchEngineDidChange
     case navigationButtonDoubleTapped
     case navigationHintFinishedPresenting
+    case clearSearch
 }
 
 class ToolbarMiddlewareAction: Action {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -15,7 +15,7 @@ final class ToolbarMiddleware: FeatureFlaggable {
 
     init(profile: Profile = AppContainer.shared.resolve(),
          manager: ToolbarManager = DefaultToolbarManager(),
-         windowManager: WindowManager = AppContainer.shared.resolve() as WindowManager,
+         windowManager: WindowManager = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.manager = manager

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -9,14 +9,17 @@ import ToolbarKit
 final class ToolbarMiddleware: FeatureFlaggable {
     private let profile: Profile
     private let manager: ToolbarManager
+    private let windowManager: WindowManager
     private let logger: Logger
     private let toolbarTelemetry = ToolbarTelemetry()
 
     init(profile: Profile = AppContainer.shared.resolve(),
          manager: ToolbarManager = DefaultToolbarManager(),
+         windowManager: WindowManager = AppContainer.shared.resolve() as WindowManager,
          logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.manager = manager
+        self.windowManager = windowManager
         self.logger = logger
     }
 
@@ -409,6 +412,6 @@ final class ToolbarMiddleware: FeatureFlaggable {
     }
 
     private func tabManager(for uuid: WindowUUID) -> TabManager {
-        return (AppContainer.shared.resolve() as WindowManager).tabManager(for: uuid)
+        return windowManager.tabManager(for: uuid)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -409,13 +409,6 @@ final class ToolbarMiddleware: FeatureFlaggable {
     }
 
     private func tabManager(for uuid: WindowUUID) -> TabManager {
-        let windowManager: WindowManager = AppContainer.shared.resolve()
-        guard uuid != .unavailable else {
-            assertionFailure()
-            logger.log("Unexpected or unavailable window UUID for requested TabManager.", level: .fatal, category: .tabs)
-            return windowManager.allWindowTabManagers().first!
-        }
-
-        return windowManager.tabManager(for: uuid)
+        return (AppContainer.shared.resolve() as WindowManager).tabManager(for: uuid)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -111,7 +111,7 @@ struct ToolbarState: ScreenState, Equatable {
             ToolbarActionType.didSetTextInLocationView, ToolbarActionType.didPasteSearchTerm,
             ToolbarActionType.didStartEditingUrl, ToolbarActionType.cancelEdit,
             ToolbarActionType.didScrollDuringEdit, ToolbarActionType.websiteLoadingStateDidChange,
-            ToolbarActionType.searchEngineDidChange:
+            ToolbarActionType.searchEngineDidChange, ToolbarActionType.clearSearch:
             return handleToolbarUpdates(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -289,7 +289,7 @@ struct ToolbarState: ScreenState, Equatable {
             isPrivateMode: state.isPrivateMode,
             addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
             navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
-            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingNavigationToolbar: toolbarAction.isShowingNavigationToolbar ?? state.isShowingNavigationToolbar,
             isShowingTopTabs: toolbarAction.isShowingTopTabs ?? state.isShowingTopTabs,
             canGoBack: state.canGoBack,
             canGoForward: state.canGoForward,

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -411,9 +411,9 @@ class LegacyHomepageViewController:
         if featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly),
            let toolbarState,
            toolbarState.addressToolbar.isEditing {
-            // When the user scrolls the homepage we cancel edit mode
+            // When the user scrolls the homepage (not overlaid on a webpage when searching) we cancel edit mode
             // On a website we just dismiss the keyboard
-            if toolbarState.addressToolbar.url == nil {
+            if toolbarState.addressToolbar.url == nil && tabManager.selectedTab?.isFxHomeTab == true {
                 let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.cancelEdit)
                 store.dispatch(action)
             } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket FXIOS-10249](https://mozilla-hub.atlassian.net/browse/FXIOS-10249)
[Github issue 22427](https://github.com/mozilla-mobile/firefox-ios/issues/22427)
[Jira ticket FXIOS-10290](https://mozilla-hub.atlassian.net/browse/FXIOS-10290)
[Github issue 22540](https://github.com/mozilla-mobile/firefox-ios/issues/22540)



## :bulb: Description
- Prevent cleared url string from reappearing in address bar when toolbar state updates (on scroll) while searching with a webpage loaded

### 📝 Notes
- We now clear the `url` state from `AddressBarState` when pressing the "X" button in the address bar to clear the text
- Because the `url'` state is responsible for what is displayed in the address bar, when we cancel editing the address bar text via the back button (to go back to a webpage) we must update the `url` state to the selected tab's url

### 📹 Videos

https://github.com/user-attachments/assets/6d30c52f-649a-47b2-9ee2-dda9ffb563a3



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

