### PR TITLE
Bugfix FXIOS-10267 ⁃ Left margin for icons, in menu cells is too wide

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuCell.swift
@@ -11,12 +11,11 @@ public class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
         static let contentMargin: CGFloat = 10
         static let iconSize: CGFloat = 24
         static let largeIconSize: CGFloat = 48
-        static let iconMargin: CGFloat = 25
         static let contentSpacing: CGFloat = 2
     }
 
     private var separatorInsetSize: CGFloat {
-        return UX.contentMargin + UX.iconSize + UX.iconMargin + UX.contentSpacing
+        return UX.contentMargin * 2 + UX.iconSize
     }
 
     // MARK: - UI Elements
@@ -73,7 +72,7 @@ public class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
         contentStackView.addArrangedSubview(titleLabel)
         contentStackView.addArrangedSubview(descriptionLabel)
         NSLayoutConstraint.activate([
-            icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.iconMargin),
+            icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.contentMargin),
             icon.centerYAnchor.constraint(equalTo: centerYAnchor),
 
             contentStackView.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: UX.contentMargin),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10267)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22479)

## :bulb: Description
Fixed the icon margin for Menu cells

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

