### PR TITLE
Bugfix MTE-3690 "Current selected tab" is now shown on iOS 15

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -365,11 +365,7 @@ class TopTabsTest: BaseTestCase {
         mozWaitForElementToExist(tabsTrayCell.firstMatch)
         app.swipeUp()
         if !iPad() {
-            if #available(iOS 16, *) {
-                XCTAssertEqual(tabsTrayCell.element(boundBy: 3).label, "Homepage. Currently selected tab.")
-            } else {
-                XCTAssertEqual(tabsTrayCell.element(boundBy: 3).label, "Homepage")
-            }
+            XCTAssertEqual(tabsTrayCell.element(boundBy: 3).label, "Homepage. Currently selected tab.")
         } else {
             XCTAssertEqual(tabsTrayCell.element(boundBy: 6).label, "Homepage. Currently selected tab.")
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3690)

## :bulb: Description

`testOpenTabsViewCurrentTabThumbnail` shows that “Currently selected tab” is now shown in the tab tray for currently selected tab for iOS 15 as well.

I have ensured that the test pass on iOS 15, 16, 17 and 18.

https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/firefox-ios-iphone-iOS-15/result_112/firefox-ios/build/reports/index.html

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

