### PR TITLE
Bugfix FXIOS-10272 [Favicon Refactor] Add Accept header when scraping HTML for favicons

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/HTMLDataRequest.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/HTMLDataRequest.swift
@@ -14,12 +14,17 @@ struct DefaultHTMLDataRequest: HTMLDataRequest {
 
         // swiftlint:disable line_length
         static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15"
+        static let accept = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
         // swiftlint:enable line_length
     }
 
     func fetchDataForURL(_ url: URL) async throws -> Data {
         let configuration = URLSessionConfiguration.ephemeral
-        configuration.httpAdditionalHeaders = ["User-Agent": RequestConstants.userAgent]
+        // Some websites (e.g. crates.io as a search engine) respond with 404 if we are missing the Accept header
+        configuration.httpAdditionalHeaders = [
+            "User-Agent": RequestConstants.userAgent,
+            "Accept": RequestConstants.accept
+        ]
         configuration.timeoutIntervalForRequest = RequestConstants.timeout
         configuration.multipathServiceType = .handover
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10272)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22493)

## :bulb: Description
When we attempt to get the favicon URL for some search engines (e.g. crates.io), we get a 404 response because we were missing the `Accept` HTTP header. After adding the `Accept` header to our HTML processing requests, these sites now correctly return a response.

Without this, crates.io will always show a "C" letter favicon.

**NOTE**: Another alternative would have been to remove the search terms from the `siteURL`s for search engines (e.g. just use the base URL) when requesting favicons.

**How to test:**
- Fresh install the app
- Navigate to Settings > Search > Add Search Engine
- Add a custom search engine for crates.io with this query string: `https://crates.io/search?q=%s`
- Tap `Save`
- Observe the favicon that appears after the search engine has been added

<img width="400" alt="Screenshot 2024-10-10 at 2 31 08 PM" src="https://github.com/user-attachments/assets/f0e7e038-835e-4bb3-9edc-aebefd0f6748">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

