### PR TITLE
Fix FXIOS-9525 - Adjust edit address view when keyboard is shown/hidden

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 import WebKit
 import SwiftUI
 import Common
+import Shared
 import struct MozillaAppServices.UpdatableAddressFields
 
 class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler, Themeable {
@@ -55,6 +56,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
         setupWebView()
         setupRemoveButton()
         listenForThemeChange(view)
+        KeyboardHelper.defaultHelper.addDelegate(self)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -78,6 +80,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
         guard let webView else { return }
         view.addSubview(stackView)
         stackView.addArrangedSubview(webView)
+        stackView.isLayoutMarginsRelativeArrangement = true
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -200,6 +203,20 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
         ))
 
         self.present(alertController, animated: true, completion: nil)
+    }
+}
+
+// MARK: - KeyboardHelperDelegate
+extension EditAddressViewController: KeyboardHelperDelegate {
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
+        let coveredHeight = state.intersectionHeightForView(view)
+        // Adjust stackView's bottom inset when the keyboard appears
+        stackView.layoutMargins.bottom = coveredHeight
+    }
+
+    func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
+        // Reset the bottom inset when the keyboard hides
+        stackView.layoutMargins.bottom = 0
     }
 }
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -209,7 +209,7 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
         let coveredHeight = state.intersectionHeightForView(view)
         // Adjust stackView's bottom inset when the keyboard appears
-        stackView.layoutMargins.bottom = coveredHeight
+        stackView.layoutMargins.bottom = removeButton.isHidden ? 0 : coveredHeight
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -9,7 +9,7 @@ import Common
 import Shared
 import struct MozillaAppServices.UpdatableAddressFields
 
-class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler, Themeable {
+class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler, Themeable, KeyboardHelperDelegate {
     private lazy var removeButton: RemoveAddressButton = {
         let button = RemoveAddressButton()
         button.setTitle(.Addresses.Settings.Edit.RemoveAddressButtonTitle, for: .normal)
@@ -204,10 +204,8 @@ class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScrip
 
         self.present(alertController, animated: true, completion: nil)
     }
-}
 
-// MARK: - KeyboardHelperDelegate
-extension EditAddressViewController: KeyboardHelperDelegate {
+    // MARK: - KeyboardHelperDelegate
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
         let coveredHeight = state.intersectionHeightForView(view)
         // Adjust stackView's bottom inset when the keyboard appears

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -9,7 +9,11 @@ import Common
 import Shared
 import struct MozillaAppServices.UpdatableAddressFields
 
-class EditAddressViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler, Themeable, KeyboardHelperDelegate {
+class EditAddressViewController: UIViewController,
+                                 WKNavigationDelegate,
+                                 WKScriptMessageHandler,
+                                 Themeable,
+                                 KeyboardHelperDelegate {
     private lazy var removeButton: RemoveAddressButton = {
         let button = RemoveAddressButton()
         button.setTitle(.Addresses.Settings.Edit.RemoveAddressButtonTitle, for: .normal)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9525)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Adjusts stack bottom margin when keyboard is shown/hidden.

⚠️ For more context [see thread in Jira](https://mozilla-hub.atlassian.net/browse/FXIOS-9525?focusedCommentId=947250)

## Behaviour After Fix

### iPhone
https://github.com/user-attachments/assets/64eb58e5-f1f2-4f86-a22e-b5c8a827e044
### iPad
https://github.com/user-attachments/assets/e212c704-476e-4344-a3b1-38144d60fb10



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~Wrote unit tests and/or ensured the tests suite is passing~
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed, I updated documentation / comments for complex code and public methods~
- [ ] ~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~

