### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from ToolbarState.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -125,23 +125,7 @@ struct ToolbarState: ScreenState, Equatable {
             return handleNumberOfTabsChanged(state: state, action: action)
 
         case ToolbarActionType.toolbarPositionChanged:
-            guard let toolbarPosition = (action as? ToolbarAction)?.toolbarPosition else { return state }
-            let position = addressToolbarPositionFromSearchBarPosition(toolbarPosition)
-            return ToolbarState(
-                windowUUID: state.windowUUID,
-                toolbarPosition: position,
-                isPrivateMode: state.isPrivateMode,
-                addressToolbar: AddressBarState.reducer(state.addressToolbar, action),
-                navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, action),
-                isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-                isShowingTopTabs: state.isShowingTopTabs,
-                canGoBack: state.canGoBack,
-                canGoForward: state.canGoForward,
-                numberOfTabs: state.numberOfTabs,
-                showMenuWarningBadge: state.showMenuWarningBadge,
-                isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-                canShowDataClearanceAction: state.canShowDataClearanceAction,
-                canShowNavigationHint: state.canShowNavigationHint)
+            return handleToolbarPositionChanged(state: state, action: action)
 
         case ToolbarActionType.readerModeStateChanged:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -107,14 +107,10 @@ struct ToolbarState: ScreenState, Equatable {
         case ToolbarActionType.didLoadToolbars:
             return handleDidLoadToolbars(state: state, action: action)
 
-        case ToolbarActionType.borderPositionChanged,
-            ToolbarActionType.urlDidChange,
-            ToolbarActionType.didSetTextInLocationView,
-            ToolbarActionType.didPasteSearchTerm,
-            ToolbarActionType.didStartEditingUrl,
-            ToolbarActionType.cancelEdit,
-            ToolbarActionType.didScrollDuringEdit,
-            ToolbarActionType.websiteLoadingStateDidChange,
+        case ToolbarActionType.borderPositionChanged, ToolbarActionType.urlDidChange,
+            ToolbarActionType.didSetTextInLocationView, ToolbarActionType.didPasteSearchTerm,
+            ToolbarActionType.didStartEditingUrl, ToolbarActionType.cancelEdit,
+            ToolbarActionType.didScrollDuringEdit, ToolbarActionType.websiteLoadingStateDidChange,
             ToolbarActionType.searchEngineDidChange:
             return handleToolbarUpdates(state: state, action: action)
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -344,6 +344,25 @@ struct ToolbarState: ScreenState, Equatable {
             canShowNavigationHint: state.canShowNavigationHint)
     }
 
+    private static func handleTraitCollectionDidChange(state: Self, action: Action) -> ToolbarState {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: state.toolbarPosition,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: toolbarAction.isShowingTopTabs ?? state.isShowingTopTabs,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: state.canShowNavigationHint)
+    }
+
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -338,24 +338,6 @@ struct ToolbarState: ScreenState, Equatable {
             canShowNavigationHint: false)
     }
 
-    private static func handleDefaultActionType(state: Self) -> ToolbarState {
-        return ToolbarState(
-            windowUUID: state.windowUUID,
-            toolbarPosition: state.toolbarPosition,
-            isPrivateMode: state.isPrivateMode,
-            addressToolbar: state.addressToolbar,
-            navigationToolbar: state.navigationToolbar,
-            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-            isShowingTopTabs: state.isShowingTopTabs,
-            canGoBack: state.canGoBack,
-            canGoForward: state.canGoForward,
-            numberOfTabs: state.numberOfTabs,
-            showMenuWarningBadge: state.showMenuWarningBadge,
-            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-            canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint)
-    }
-
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -340,6 +340,25 @@ struct ToolbarState: ScreenState, Equatable {
             canShowNavigationHint: state.canShowNavigationHint)
     }
 
+    private static func handleBackForwardButtonStateChanged(state: Self, action: Action) -> ToolbarState {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: state.toolbarPosition,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: state.isShowingTopTabs,
+            canGoBack: toolbarAction.canGoBack ?? state.canGoBack,
+            canGoForward: toolbarAction.canGoForward ?? state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: state.canShowNavigationHint)
+    }
+
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -324,6 +324,25 @@ struct ToolbarState: ScreenState, Equatable {
             canShowNavigationHint: state.canShowNavigationHint)
     }
 
+    private static func handleShowMenuWarningBadge(state: Self, action: Action) -> ToolbarState {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: state.toolbarPosition,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: state.isShowingTopTabs,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: toolbarAction.showMenuWarningBadge ?? state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: state.canShowNavigationHint)
+    }
+
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -140,22 +140,7 @@ struct ToolbarState: ScreenState, Equatable {
             return handleNavigationButtonDoubleTapped(state: state, action: action)
 
         case ToolbarActionType.navigationHintFinishedPresenting:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-            return ToolbarState(
-                windowUUID: state.windowUUID,
-                toolbarPosition: state.toolbarPosition,
-                isPrivateMode: state.isPrivateMode,
-                addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
-                navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
-                isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-                isShowingTopTabs: state.isShowingTopTabs,
-                canGoBack: state.canGoBack,
-                canGoForward: state.canGoForward,
-                numberOfTabs: state.numberOfTabs,
-                showMenuWarningBadge: state.showMenuWarningBadge,
-                isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-                canShowDataClearanceAction: state.canShowDataClearanceAction,
-                canShowNavigationHint: false)
+            return handleNavigationHintFinishedPresenting(state: state, action: action)
 
         default:
             return ToolbarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -320,6 +320,25 @@ struct ToolbarState: ScreenState, Equatable {
             canShowNavigationHint: state.canShowNavigationHint)
     }
 
+    private static func handleToolbarUpdates(state: Self, action: Action) -> ToolbarState {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: state.toolbarPosition,
+            isPrivateMode: toolbarAction.isPrivate ?? state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
+            isShowingNavigationToolbar: toolbarAction.isShowingNavigationToolbar ?? state.isShowingNavigationToolbar,
+            isShowingTopTabs: toolbarAction.isShowingTopTabs ?? state.isShowingTopTabs,
+            canGoBack: toolbarAction.canGoBack ?? state.canGoBack,
+            canGoForward: toolbarAction.canGoForward ?? state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: state.canShowNavigationHint)
+    }
+
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -116,22 +116,7 @@ struct ToolbarState: ScreenState, Equatable {
             ToolbarActionType.didScrollDuringEdit,
             ToolbarActionType.websiteLoadingStateDidChange,
             ToolbarActionType.searchEngineDidChange:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-            return ToolbarState(
-                windowUUID: state.windowUUID,
-                toolbarPosition: state.toolbarPosition,
-                isPrivateMode: toolbarAction.isPrivate ?? state.isPrivateMode,
-                addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
-                navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
-                isShowingNavigationToolbar: toolbarAction.isShowingNavigationToolbar ?? state.isShowingNavigationToolbar,
-                isShowingTopTabs: toolbarAction.isShowingTopTabs ?? state.isShowingTopTabs,
-                canGoBack: toolbarAction.canGoBack ?? state.canGoBack,
-                canGoForward: toolbarAction.canGoForward ?? state.canGoForward,
-                numberOfTabs: state.numberOfTabs,
-                showMenuWarningBadge: state.showMenuWarningBadge,
-                isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-                canShowDataClearanceAction: state.canShowDataClearanceAction,
-                canShowNavigationHint: state.canShowNavigationHint)
+            return handleToolbarUpdates(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -128,22 +128,7 @@ struct ToolbarState: ScreenState, Equatable {
             return handleToolbarPositionChanged(state: state, action: action)
 
         case ToolbarActionType.readerModeStateChanged:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-            return ToolbarState(
-                windowUUID: state.windowUUID,
-                toolbarPosition: state.toolbarPosition,
-                isPrivateMode: state.isPrivateMode,
-                addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
-                navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
-                isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-                isShowingTopTabs: state.isShowingTopTabs,
-                canGoBack: state.canGoBack,
-                canGoForward: state.canGoForward,
-                numberOfTabs: state.numberOfTabs,
-                showMenuWarningBadge: state.showMenuWarningBadge,
-                isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-                canShowDataClearanceAction: state.canShowDataClearanceAction,
-                canShowNavigationHint: state.canShowNavigationHint)
+            return handleReaderModeStateChanged(state: state, action: action)
 
         case ToolbarActionType.backForwardButtonStateChanged:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -328,6 +328,25 @@ struct ToolbarState: ScreenState, Equatable {
             canShowNavigationHint: state.canShowNavigationHint)
     }
 
+    private static func handleNumberOfTabsChanged(state: Self, action: Action) -> ToolbarState {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: state.toolbarPosition,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: state.isShowingTopTabs,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+            numberOfTabs: toolbarAction.numberOfTabs ?? state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: state.canShowNavigationHint)
+    }
+
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -137,22 +137,7 @@ struct ToolbarState: ScreenState, Equatable {
             return handleTraitCollectionDidChange(state: state, action: action)
 
         case ToolbarActionType.navigationButtonDoubleTapped:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-            return ToolbarState(
-                windowUUID: state.windowUUID,
-                toolbarPosition: state.toolbarPosition,
-                isPrivateMode: state.isPrivateMode,
-                addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
-                navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
-                isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-                isShowingTopTabs: state.isShowingTopTabs,
-                canGoBack: state.canGoBack,
-                canGoForward: state.canGoForward,
-                numberOfTabs: state.numberOfTabs,
-                showMenuWarningBadge: state.showMenuWarningBadge,
-                isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-                canShowDataClearanceAction: state.canShowDataClearanceAction,
-                canShowNavigationHint: true)
+            return handleNavigationButtonDoubleTapped(state: state, action: action)
 
         case ToolbarActionType.navigationHintFinishedPresenting:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -316,6 +316,29 @@ struct ToolbarState: ScreenState, Equatable {
         }
     }
 
+    private static func handleDidLoadToolbars(state: Self, action: Action) -> ToolbarState {
+        guard let toolbarAction = action as? ToolbarAction,
+              let toolbarPosition = toolbarAction.toolbarPosition
+        else { return state }
+
+        let position = addressToolbarPositionFromSearchBarPosition(toolbarPosition)
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: position,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: state.isShowingTopTabs,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: toolbarAction.isNewTabFeatureEnabled ?? state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: toolbarAction.canShowDataClearanceAction ?? state.canShowDataClearanceAction,
+            canShowNavigationHint: state.canShowNavigationHint)
+    }
+
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -336,6 +336,25 @@ struct ToolbarState: ScreenState, Equatable {
             canShowNavigationHint: state.canShowNavigationHint)
     }
 
+    private static func handleReaderModeStateChanged(state: Self, action: Action) -> ToolbarState {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: state.toolbarPosition,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: state.isShowingTopTabs,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: state.canShowNavigationHint)
+    }
+
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -143,21 +143,7 @@ struct ToolbarState: ScreenState, Equatable {
             return handleNavigationHintFinishedPresenting(state: state, action: action)
 
         default:
-            return ToolbarState(
-                windowUUID: state.windowUUID,
-                toolbarPosition: state.toolbarPosition,
-                isPrivateMode: state.isPrivateMode,
-                addressToolbar: state.addressToolbar,
-                navigationToolbar: state.navigationToolbar,
-                isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-                isShowingTopTabs: state.isShowingTopTabs,
-                canGoBack: state.canGoBack,
-                canGoForward: state.canGoForward,
-                numberOfTabs: state.numberOfTabs,
-                showMenuWarningBadge: state.showMenuWarningBadge,
-                isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-                canShowDataClearanceAction: state.canShowDataClearanceAction,
-                canShowNavigationHint: state.canShowNavigationHint)
+            return handleDefaultActionType(state: state)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -139,7 +139,7 @@ struct ToolbarState: ScreenState, Equatable {
             return handleNavigationHintFinishedPresenting(state: state, action: action)
 
         default:
-            return handleDefaultActionType(state: state)
+            return state
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -134,22 +134,7 @@ struct ToolbarState: ScreenState, Equatable {
             return handleBackForwardButtonStateChanged(state: state, action: action)
 
         case ToolbarActionType.traitCollectionDidChange:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-            return ToolbarState(
-                windowUUID: state.windowUUID,
-                toolbarPosition: state.toolbarPosition,
-                isPrivateMode: state.isPrivateMode,
-                addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
-                navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
-                isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-                isShowingTopTabs: toolbarAction.isShowingTopTabs ?? state.isShowingTopTabs,
-                canGoBack: state.canGoBack,
-                canGoForward: state.canGoForward,
-                numberOfTabs: state.numberOfTabs,
-                showMenuWarningBadge: state.showMenuWarningBadge,
-                isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-                canShowDataClearanceAction: state.canShowDataClearanceAction,
-                canShowNavigationHint: state.canShowNavigationHint)
+            return handleTraitCollectionDidChange(state: state, action: action)
 
         case ToolbarActionType.navigationButtonDoubleTapped:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -119,22 +119,7 @@ struct ToolbarState: ScreenState, Equatable {
             return handleToolbarUpdates(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-            return ToolbarState(
-                windowUUID: state.windowUUID,
-                toolbarPosition: state.toolbarPosition,
-                isPrivateMode: state.isPrivateMode,
-                addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
-                navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
-                isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-                isShowingTopTabs: state.isShowingTopTabs,
-                canGoBack: state.canGoBack,
-                canGoForward: state.canGoForward,
-                numberOfTabs: state.numberOfTabs,
-                showMenuWarningBadge: toolbarAction.showMenuWarningBadge ?? state.showMenuWarningBadge,
-                isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-                canShowDataClearanceAction: state.canShowDataClearanceAction,
-                canShowNavigationHint: state.canShowNavigationHint)
+            return handleShowMenuWarningBadge(state: state, action: action)
 
         case ToolbarActionType.numberOfTabsChanged:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -348,6 +348,25 @@ struct ToolbarState: ScreenState, Equatable {
             canShowNavigationHint: state.canShowNavigationHint)
     }
 
+    private static func handleNavigationButtonDoubleTapped(state: Self, action: Action) -> ToolbarState {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: state.toolbarPosition,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: state.isShowingTopTabs,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: true)
+    }
+
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -122,22 +122,7 @@ struct ToolbarState: ScreenState, Equatable {
             return handleShowMenuWarningBadge(state: state, action: action)
 
         case ToolbarActionType.numberOfTabsChanged:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-            return ToolbarState(
-                windowUUID: state.windowUUID,
-                toolbarPosition: state.toolbarPosition,
-                isPrivateMode: state.isPrivateMode,
-                addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
-                navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
-                isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-                isShowingTopTabs: state.isShowingTopTabs,
-                canGoBack: state.canGoBack,
-                canGoForward: state.canGoForward,
-                numberOfTabs: toolbarAction.numberOfTabs ?? state.numberOfTabs,
-                showMenuWarningBadge: state.showMenuWarningBadge,
-                isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-                canShowDataClearanceAction: state.canShowDataClearanceAction,
-                canShowNavigationHint: state.canShowNavigationHint)
+            return handleNumberOfTabsChanged(state: state, action: action)
 
         case ToolbarActionType.toolbarPositionChanged:
             guard let toolbarPosition = (action as? ToolbarAction)?.toolbarPosition else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -332,6 +332,26 @@ struct ToolbarState: ScreenState, Equatable {
             canShowNavigationHint: state.canShowNavigationHint)
     }
 
+    private static func handleToolbarPositionChanged(state: Self, action: Action) -> ToolbarState {
+        guard let toolbarPosition = (action as? ToolbarAction)?.toolbarPosition else { return state }
+        let position = addressToolbarPositionFromSearchBarPosition(toolbarPosition)
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: position,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, action),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, action),
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: state.isShowingTopTabs,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: state.canShowNavigationHint)
+    }
+
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -105,26 +105,7 @@ struct ToolbarState: ScreenState, Equatable {
 
         switch action.actionType {
         case ToolbarActionType.didLoadToolbars:
-            guard let toolbarAction = action as? ToolbarAction,
-                  let toolbarPosition = toolbarAction.toolbarPosition
-            else { return state }
-
-            let position = addressToolbarPositionFromSearchBarPosition(toolbarPosition)
-            return ToolbarState(
-                windowUUID: state.windowUUID,
-                toolbarPosition: position,
-                isPrivateMode: state.isPrivateMode,
-                addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
-                navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
-                isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-                isShowingTopTabs: state.isShowingTopTabs,
-                canGoBack: state.canGoBack,
-                canGoForward: state.canGoForward,
-                numberOfTabs: state.numberOfTabs,
-                showMenuWarningBadge: state.showMenuWarningBadge,
-                isNewTabFeatureEnabled: toolbarAction.isNewTabFeatureEnabled ?? state.isNewTabFeatureEnabled,
-                canShowDataClearanceAction: toolbarAction.canShowDataClearanceAction ?? state.canShowDataClearanceAction,
-                canShowNavigationHint: state.canShowNavigationHint)
+            return handleDidLoadToolbars(state: state, action: action)
 
         case ToolbarActionType.borderPositionChanged,
             ToolbarActionType.urlDidChange,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -352,6 +352,25 @@ struct ToolbarState: ScreenState, Equatable {
             canShowNavigationHint: true)
     }
 
+    private static func handleNavigationHintFinishedPresenting(state: Self, action: Action) -> ToolbarState {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: state.toolbarPosition,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: state.isShowingTopTabs,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: false)
+    }
+
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -131,22 +131,7 @@ struct ToolbarState: ScreenState, Equatable {
             return handleReaderModeStateChanged(state: state, action: action)
 
         case ToolbarActionType.backForwardButtonStateChanged:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-            return ToolbarState(
-                windowUUID: state.windowUUID,
-                toolbarPosition: state.toolbarPosition,
-                isPrivateMode: state.isPrivateMode,
-                addressToolbar: AddressBarState.reducer(state.addressToolbar, toolbarAction),
-                navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, toolbarAction),
-                isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-                isShowingTopTabs: state.isShowingTopTabs,
-                canGoBack: toolbarAction.canGoBack ?? state.canGoBack,
-                canGoForward: toolbarAction.canGoForward ?? state.canGoForward,
-                numberOfTabs: state.numberOfTabs,
-                showMenuWarningBadge: state.showMenuWarningBadge,
-                isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-                canShowDataClearanceAction: state.canShowDataClearanceAction,
-                canShowNavigationHint: state.canShowNavigationHint)
+            return handleBackForwardButtonStateChanged(state: state, action: action)
 
         case ToolbarActionType.traitCollectionDidChange:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -356,6 +356,24 @@ struct ToolbarState: ScreenState, Equatable {
             canShowNavigationHint: false)
     }
 
+    private static func handleDefaultActionType(state: Self) -> ToolbarState {
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: state.toolbarPosition,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: state.addressToolbar,
+            navigationToolbar: state.navigationToolbar,
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: state.isShowingTopTabs,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: state.canShowNavigationHint)
+    }
+
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)
     -> AddressToolbarPosition {
         switch position {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `ToolbarState.swift` file by extracting the toolbar creation logic into separate methods, one for each condition. Initially, I considered creating a single method with optional parameters to handle different cases, but that approach felt complex and less maintainable. Because of it, I preferred to create one method per condition.

The final commit may raise some concerns, as it combines two conditions per line - see the switch case statement, with more than one option grouped. This was necessary to keep the `closure_body_length` under the 30-line limit imposed by rule. If this approach is not acceptable, we might need to consider increasing the line limit for this rule. 

I'd appreciate hearing your suggestions and feedback on this.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

