### PR TITLE
Bugfix FXIOS-9881 Fix Tab Tray Drag and Drop not working/updating properly when inactive tabs were present

### DIFF
--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -510,7 +510,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
 
     // MARK: - Move tabs
     func reorderTabs(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {
-        let currentTabs = privateMode ? privateTabs : normalTabs
+        let currentTabs = privateMode ? privateTabs : normalActiveTabs
 
         guard visibleFromIndex < currentTabs.count, visibleToIndex < currentTabs.count else { return }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9881)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21674)

## :bulb: Description
Switched the reorder method to use `normalActiveTabs` instead of `normalTabs`. Using normalTabs was causing issues with moving the tabs in the tab tray when there were inactive tabs present because normalTabs includes activeTabs and inactiveTabs.

For ease of testing you can set the debug menu value to more than 10 seconds on line 436 of Tab.swift

## Video
https://github.com/user-attachments/assets/2a17dd9a-00f1-4b12-978f-f7370f51ffb8



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

