### PR TITLE
ADD FXIOS-9860 [Native Error Pages]-NIC reload action using REDUX

### DIFF
--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -83,7 +83,7 @@ final class NativeErrorPageViewController: UIViewController,
     }
 
     private lazy var reloadButton: PrimaryRoundedButton = .build { button in
-        button.addTarget(self, action: #selector(self.didTapSubmit), for: .touchUpInside)
+        button.addTarget(self, action: #selector(self.didTapReload), for: .touchUpInside)
         button.isEnabled = true
     }
 
@@ -221,8 +221,14 @@ final class NativeErrorPageViewController: UIViewController,
         reloadButton.applyTheme(theme: theme)
     }
 
-    // TODO: FXIOS-9860 #21645 Integration with Redux - reload button
     @objc
-    private func didTapSubmit() {
+    private func didTapReload() {
+        store.dispatch(
+            GeneralBrowserAction(
+                isNativeErrorPage: true,
+                windowUUID: windowUUID,
+                actionType: GeneralBrowserActionType.reloadWebsite
+            )
+        )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -80,6 +80,18 @@ final class BrowserViewControllerStateTests: XCTestCase {
         XCTAssertEqual(newState.displayView, .passwordGenerator)
     }
 
+    func testReloadWebsiteAction() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.navigateTo)
+
+        let action = getAction(for: .reloadWebsite)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.navigateTo, .reload)
+    }
+
     // MARK: - Private
     private func createSubject() -> BrowserViewControllerState {
         return BrowserViewControllerState(windowUUID: .XCTestDefaultUUID)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9860)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21645)

## :bulb: Description
Added GeneralBrowserAction actionType.reload for reload button on new error page.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

