### PR TITLE
Bugfix FXIOS-10131 NSInconsistencyException thrown for invalid section definition

### DIFF
--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -289,11 +289,6 @@ class LegacyHomepageViewController:
     }
 
     func createLayout() -> UICollectionViewLayout {
-        let zeroLayoutSize = NSCollectionLayoutSize(widthDimension: .absolute(0.0), heightDimension: .absolute(0.0))
-        let emptyGroup = NSCollectionLayoutGroup.horizontal(layoutSize: zeroLayoutSize,
-                                                            subitems: [NSCollectionLayoutItem(layoutSize: zeroLayoutSize)])
-        let emptyDefaultLayoutSection = NSCollectionLayoutSection(group: emptyGroup)
-
         // swiftlint: disable line_length
         let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment)
             -> NSCollectionLayoutSection? in
@@ -302,8 +297,14 @@ class LegacyHomepageViewController:
                   let viewModel = self.viewModel.getSectionViewModel(shownSection: sectionIndex),
                   viewModel.shouldShow
             // Returning a default section to prevent the app to crash with invalid section definition
-            else { return emptyDefaultLayoutSection }
-            self.logger.log(
+            else {
+                let shownSection = self?.viewModel.shownSections[safe: sectionIndex]
+                self?.logger.log("The current section index: \(sectionIndex) didn't load a valid section. The associated section type if present is: \(String(describing: shownSection))",
+                                 level: .fatal,
+                                 category: .legacyHomepage)
+                return Self.makeEmptyLayoutSection()
+            }
+            logger.log(
                 "Section \(viewModel.sectionType) is going to show",
                 level: .debug,
                 category: .legacyHomepage
@@ -314,6 +315,16 @@ class LegacyHomepageViewController:
             )
         }
         return layout
+    }
+
+    // making the method static so in the create layout we return always a valid layout
+    // even when self is nil to avoid app crash
+    private static func makeEmptyLayoutSection() -> NSCollectionLayoutSection {
+        let zeroLayoutSize = NSCollectionLayoutSize(widthDimension: .absolute(0.0),
+                                                    heightDimension: .absolute(0.0))
+        let emptyGroup = NSCollectionLayoutGroup.horizontal(layoutSize: zeroLayoutSize,
+                                                            subitems: [NSCollectionLayoutItem(layoutSize: zeroLayoutSize)])
+        return NSCollectionLayoutSection(group: emptyGroup)
     }
 
     // MARK: Long press

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -301,6 +301,7 @@ class LegacyHomepageViewController:
             guard let self,
                   let viewModel = self.viewModel.getSectionViewModel(shownSection: sectionIndex),
                   viewModel.shouldShow
+            // Returning a default section to prevent the app to crash with invalid section definition
             else { return emptyDefaultLayoutSection }
             self.logger.log(
                 "Section \(viewModel.sectionType) is going to show",

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -289,13 +289,19 @@ class LegacyHomepageViewController:
     }
 
     func createLayout() -> UICollectionViewLayout {
-        // swiftlint:disable line_length
-        let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
-        // swiftlint:enable line_length
-            guard let self = self,
+        let zeroLayoutSize = NSCollectionLayoutSize(widthDimension: .absolute(0.0), heightDimension: .absolute(0.0))
+        let emptyGroup = NSCollectionLayoutGroup.horizontal(layoutSize: zeroLayoutSize,
+                                                            subitems: [NSCollectionLayoutItem(layoutSize: zeroLayoutSize)])
+        let emptyDefaultLayoutSection = NSCollectionLayoutSection(group: emptyGroup)
+
+        // swiftlint: disable line_length
+        let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment)
+            -> NSCollectionLayoutSection? in
+        // swiftlint: enable line_length
+            guard let self,
                   let viewModel = self.viewModel.getSectionViewModel(shownSection: sectionIndex),
                   viewModel.shouldShow
-            else { return nil }
+            else { return emptyDefaultLayoutSection }
             self.logger.log(
                 "Section \(viewModel.sectionType) is going to show",
                 level: .debug,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10131)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22203)

## :bulb: Description
@OrlaM i narrowed down that exception we have on [sentry](https://mozilla.sentry.io/issues/3081363675/events/65c8739c880f4c238abb5eeb0369f9e1/?environment=Production&project=6176941&query=release%3Aorg.mozilla.ios.Firefox%40130.1&referrer=previous-event) and by looking ad the breadcrumbs i think it could be related to the `LegacyHomePageViewController` having not synced data between the collection view data source and the view models. I can only recreate an error like that if i try to return nil from the section provider in the `LegacyHomePageViewController`.  The system closure support returning a nil value but when returning actually the application crashes, so i thought that we could just return a default section in case there is data race between view model and collection view data soruce.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

