### PR TITLE
Bugfix FXIOS-10248 - When retyping a URL from history, the typed text cannot be seen in the address bar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -137,14 +137,7 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
 
         let suggestionText = String(suggestion.dropFirst(normalized.count))
         setMarkedText(suggestionText, selectedRange: NSRange())
-
-        // Only call forceResetCursor() if `hideCursor` changes.
-        // Because forceResetCursor() auto accept iOS user's text replacement
-        // (e.g. mu->μ) which makes user unable to type "mu".
-        if !hideCursor {
-            hideCursor = true
-            forceResetCursor()
-        }
+        hideCursor = true
     }
 
     // MARK: - ThemeApplicable


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10248)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22425)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Found out that calling `forceResetCursor()` was causing problems as it positioned the cursor to the end of the `urlTextField` hiding the text.
- Removed the call to `forceResetCursor` to solve the issue.
- Didn't see any side effects.

### Video
https://github.com/user-attachments/assets/716cb2a8-e1b2-4bf8-8728-13f30aabe453

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

