### PR TITLE
Add FXIOS-10191 [Unified Search] Bubble up search engine tap event to BrowserViewController

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarDelegate.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarDelegate.swift
@@ -17,4 +17,5 @@ public protocol AddressToolbarDelegate: AnyObject {
                                  with contextualHintType: String)
     func addressToolbarDidBeginDragInteraction()
     func addressToolbarDidProvideItemsForDragInteraction()
+    func addressToolbarDidTapSearchEngine(_ searchEngineView: UIView)
 }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -332,7 +332,7 @@ public class BrowserAddressToolbar: UIView,
     }
 
     func locationViewDidTapSearchEngine<T: SearchEngineView>(_ searchEngine: T) {
-            // TODO: FXIOS-10191 - To be implemented
+        toolbarDelegate?.addressToolbarDidTapSearchEngine(searchEngine)
     }
 
     func locationViewAccessibilityActions() -> [UIAccessibilityCustomAction]? {

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView/DropDownSearchEngineView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/SearchEngineView/DropDownSearchEngineView.swift
@@ -93,7 +93,6 @@ final class DropDownSearchEngineView: UIView, SearchEngineView, ThemeApplicable 
     @objc
     private func didTapSearchEngine() {
         delegate?.locationViewDidTapSearchEngine(self)
-        // TODO FXIOS-10191 Actual selector implementation to come later.
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3186,6 +3186,10 @@ class BrowserViewController: UIViewController,
     func addressToolbarDidBeginDragInteraction() {
         dismissVisibleMenus()
     }
+
+    func addressToolbarDidTapSearchEngine(_ searchEngineView: UIView) {
+        // TODO FXIOS-10273 Use coordinator to handle search engine bottom sheet display
+    }
 }
 
 extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -17,6 +17,7 @@ protocol AddressToolbarContainerDelegate: AnyObject {
     func addressToolbarDidEnterOverlayMode(_ view: UIView)
     func addressToolbar(_ view: UIView, didLeaveOverlayModeForReason: URLBarLeaveOverlayModeReason)
     func addressToolbarDidBeginDragInteraction()
+    func addressToolbarDidTapSearchEngine(_ searchEngineView: UIView)
 }
 
 final class AddressToolbarContainer: UIView,
@@ -287,6 +288,10 @@ final class AddressToolbarContainer: UIView,
 
     func openBrowser(searchTerm: String) {
         delegate?.openBrowser(searchTerm: searchTerm)
+    }
+
+    func addressToolbarDidTapSearchEngine(_ searchEngineView: UIView) {
+        delegate?.addressToolbarDidTapSearchEngine(searchEngineView)
     }
 
     func openSuggestions(searchTerm: String) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10191)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22308)

## :bulb: Description
### Background
This PR is for the [Unified Search project](https://mozilla-hub.atlassian.net/browse/FXIOS-4066), which adds a drop-down search engine icon to the toolbar refactor. This icon is tappable and will eventually allow the user to choose an alternative search engine from a bottom sheet / popover.

### PR
Since ToolbarKit cannot access the Redux store, we need to bubble up the search engine tap event through the delegate chain to the BrowserViewController. 

TODO is for adding a Coordinator in a separate task for displaying the search engine selection bottom sheet.

### Testing Notes
Enable both the toolbar refactor and the `unified_search` flag to see the new drop-down search engine button in the toolbar.

You can add a print statement or breakpoint to BrowserViewController.swift line 3192 to test this code.

<img width="400" alt="Screenshot 2024-10-11 at 4 15 21 PM" src="https://github.com/user-attachments/assets/74b7d763-f849-43c1-a385-e09e6a108e72">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

