### PR TITLE
Bugfix FXIOS-21826 - Incorrect behavior when (re)opening the screen

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -58,8 +58,8 @@ class StartAtHomeHelper: FeatureFlaggable {
             timeSinceLastActivity = dateComponents.hour ?? 0
             timeToOpenNewHome = 4
         } else if setting == .always {
-            timeSinceLastActivity = dateComponents.second ?? 0
-            timeToOpenNewHome = 5
+            // When "always", time to open new home should be immediate, no delay
+            return true
         }
 
         return timeSinceLastActivity >= timeToOpenNewHome

--- a/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -44,26 +44,23 @@ class StartAtHomeHelper: FeatureFlaggable {
     /// the user's last activity and whether, based on their settings, Start at Home feature
     /// should perform its function.
     public func shouldStartAtHome() -> Bool {
-        let setting = startAtHomeSetting
-        guard setting != .disabled else { return false }
+            let setting = startAtHomeSetting
 
-        let lastActiveTimestamp = UserDefaults.standard.object(forKey: "LastActiveTimestamp") as? Date ?? Date()
-        let dateComponents = Calendar.current.dateComponents([.hour, .second],
-                                                             from: lastActiveTimestamp,
-                                                             to: Date())
-        var timeSinceLastActivity = 0
-        var timeToOpenNewHome = 0
+            let lastActiveTimestamp = UserDefaults.standard.object(forKey: "LastActiveTimestamp") as? Date ?? Date()
+            let dateComponents = Calendar.current.dateComponents([.hour, .second],
+                                                                 from: lastActiveTimestamp,
+                                                                 to: Date())
 
-        if setting == .afterFourHours {
-            timeSinceLastActivity = dateComponents.hour ?? 0
-            timeToOpenNewHome = 4
-        } else if setting == .always {
-            // When "always", time to open new home should be immediate, no delay
-            return true
+            switch setting {
+            case .afterFourHours:
+                return 4 >= dateComponents.hour ?? 0
+            case .always:
+                // When "always", time to open new home should be immediate, no delay
+                return true
+            case .disabled:
+                return false
+            }
         }
-
-        return timeSinceLastActivity >= timeToOpenNewHome
-    }
 
     /// Looks to see if the user already has a homepage tab open (as per their preferences)
     /// and, if they do, returns that tab, in order to avoid opening multiple duplicate

--- a/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -44,23 +44,23 @@ class StartAtHomeHelper: FeatureFlaggable {
     /// the user's last activity and whether, based on their settings, Start at Home feature
     /// should perform its function.
     public func shouldStartAtHome() -> Bool {
-            let setting = startAtHomeSetting
+        let setting = startAtHomeSetting
 
-            let lastActiveTimestamp = UserDefaults.standard.object(forKey: "LastActiveTimestamp") as? Date ?? Date()
-            let dateComponents = Calendar.current.dateComponents([.hour, .second],
-                                                                 from: lastActiveTimestamp,
-                                                                 to: Date())
+        let lastActiveTimestamp = UserDefaults.standard.object(forKey: "LastActiveTimestamp") as? Date ?? Date()
+        let dateComponents = Calendar.current.dateComponents([.hour, .second],
+                                                             from: lastActiveTimestamp,
+                                                             to: Date())
 
-            switch setting {
-            case .afterFourHours:
-                return 4 >= dateComponents.hour ?? 0
-            case .always:
-                // When "always", time to open new home should be immediate, no delay
-                return true
-            case .disabled:
-                return false
-            }
+        switch setting {
+        case .afterFourHours:
+            return 4 >= dateComponents.hour ?? 0
+        case .always:
+            // When "always", time to open new home should be immediate, no delay
+            return true
+        case .disabled:
+            return false
         }
+    }
 
     /// Looks to see if the user already has a homepage tab open (as per their preferences)
     /// and, if they do, returns that tab, in order to avoid opening multiple duplicate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9941)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21826)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
It seems more appropriate to immediately return true for redirection to home page based on what the issue describes as a bug.
var timeSinceLastActivity = 0
        var timeToOpenNewHome = 0

        if setting == .afterFourHours {
            timeSinceLastActivity = dateComponents.hour ?? 0
            timeToOpenNewHome = 4
        } else if setting == .always {
            // When "always", time to open new home should be immediate, no delay
            return true
        }

        return timeSinceLastActivity >= timeToOpenNewHome
    }

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

