### PR TITLE
Bugfix FXIOS-0000 Restore missing Focus SPM packages

### DIFF
--- a/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
           "version": null
         }
       },
+        {
+        "package": "Glean",
+        "repositoryURL": "https://github.com/mozilla/glean-swift",
+        "state": {
+          "branch": null,
+          "revision": "51794f8b74c55ebde6d1502b641eacc19176e139",
+          "version": "61.2.0"
+        }
+      },
       {
         "package": "Kingfisher",
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
@@ -35,6 +44,15 @@
           "branch": null,
           "revision": "2ef543ee21d63734e1c004ad6c870255e8716c50",
           "version": "7.12.0"
+        }
+      },
+        {
+        "package": "MozillaRustComponentsSwift",
+        "repositoryURL": "https://github.com/mozilla/rust-components-swift",
+        "state": {
+          "branch": null,
+          "revision": "e535bbe6d66996f32d0e4f632e9d8588372cd489",
+          "version": "133.0.20241009050322"
         }
       },
       {


### PR DESCRIPTION
## :scroll: Tickets
n/a

## :bulb: Description

Fix Focus SPM packages removed incorrectly during Sentry downgrade. 

https://mozilla.slack.com/archives/C05C9RET70F/p1728920723347869

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

