### PR TITLE
Add FXIOS-10166 [Homepage] Add Customize Homepage Section

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -10714,6 +10714,13 @@
 			path = PrivateHome;
 			sourceTree = "<group>";
 		};
+		8A1188EF2CBD600400281F9A /* CustomizeHomepage */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = CustomizeHomepage;
+			sourceTree = "<group>";
+		};
 		8A171A6029F82AD90085770E /* Application */ = {
 			isa = PBXGroup;
 			children = (
@@ -11045,6 +11052,7 @@
 		8A7D08E12CAAF79F0035999C /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
+				8A1188EF2CBD600400281F9A /* CustomizeHomepage */,
 				8ABDBAA42CB6BF3A00B51F63 /* View */,
 				8A7D08E22CAAF7C30035999C /* HomepageViewController.swift */,
 				8AA0A6622CAC40AA00AC7EB3 /* HomepageDiffableDataSource.swift */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -10714,13 +10714,6 @@
 			path = PrivateHome;
 			sourceTree = "<group>";
 		};
-		8A1188EF2CBD600400281F9A /* CustomizeHomepage */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = CustomizeHomepage;
-			sourceTree = "<group>";
-		};
 		8A171A6029F82AD90085770E /* Application */ = {
 			isa = PBXGroup;
 			children = (
@@ -11052,7 +11045,6 @@
 		8A7D08E12CAAF79F0035999C /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
-				8A1188EF2CBD600400281F9A /* CustomizeHomepage */,
 				8ABDBAA42CB6BF3A00B51F63 /* View */,
 				8A7D08E22CAAF7C30035999C /* HomepageViewController.swift */,
 				8AA0A6622CAC40AA00AC7EB3 /* HomepageDiffableDataSource.swift */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -22,6 +22,7 @@ class BrowserCoordinator: BaseCoordinator,
                           LibraryCoordinatorDelegate,
                           EnhancedTrackingProtectionCoordinatorDelegate,
                           FakespotCoordinatorDelegate,
+                          HomepageCoordinatorDelegate,
                           ParentCoordinatorDelegate,
                           TabManagerDelegate,
                           TabTrayCoordinatorDelegate,
@@ -130,7 +131,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     func showHomepage() {
         let homepageController = self.homepageViewController ?? HomepageViewController(windowUUID: windowUUID)
-
+        homepageController.parentCoordinator = self
         guard browserViewController.embedContent(homepageController) else {
             logger.log("Unable to embed new homepage", level: .debug, category: .coordinator)
             return

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import UIKit
 
 typealias HomepageSection = HomepageDiffableDataSource.HomeSection
@@ -14,19 +15,29 @@ final class HomepageDiffableDataSource:
         case header
         case topSites
         case pocket
+        case customizeHomepage
     }
 
     enum HomeItem: Hashable {
         case header
+        case customizeHomepage
+
+        static var cellTypes: [ReusableCell.Type] {
+            return [
+                HomepageHeaderCell.self,
+                CustomizeHomepageSectionCell.self
+            ]
+        }
     }
 
     func applyInitialSnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeItem>()
 
-        snapshot.appendSections([.header, .topSites, .pocket])
+        snapshot.appendSections([.header, .topSites, .pocket, .customizeHomepage])
         snapshot.appendItems([.header], toSection: .header)
         snapshot.appendItems([], toSection: .topSites)
         snapshot.appendItems([], toSection: .pocket)
+        snapshot.appendItems([.customizeHomepage], toSection: .customizeHomepage)
 
         apply(snapshot, animatingDifferences: true)
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -11,6 +11,7 @@ final class HomepageSectionLayoutProvider {
         static let bottomSpacing: CGFloat = 30
         static let standardInset: CGFloat = 16
         static let iPadInset: CGFloat = 50
+        static let spacingBetweenSections: CGFloat = 62
 
         static func leadingInset(
             traitCollection: UITraitCollection,
@@ -55,6 +56,8 @@ final class HomepageSectionLayoutProvider {
             return createFirstSectionLayout()
         case .pocket:
             return createDefaultSectionLayout()
+        case .customizeHomepage:
+            return createCustomizeSectionLayout(for: traitCollection)
         }
     }
 
@@ -110,6 +113,25 @@ final class HomepageSectionLayoutProvider {
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
 
+        return section
+    }
+
+    private func createCustomizeSectionLayout(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                              heightDimension: .estimated(100))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                               heightDimension: .estimated(100))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
+
+        let horizontalInsets = UX.leadingInset(traitCollection: traitCollection)
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: UX.spacingBetweenSections,
+            leading: horizontalInsets,
+            bottom: UX.spacingBetweenSections,
+            trailing: horizontalInsets)
         return section
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -6,6 +6,10 @@ import Foundation
 import Common
 import Redux
 
+protocol HomepageCoordinatorDelegate: AnyObject {
+    func showSettings(at destination: Route.SettingsSection)
+}
+
 final class HomepageViewController: UIViewController,
                                     UICollectionViewDelegate,
                                     ContentContainable,
@@ -26,12 +30,19 @@ final class HomepageViewController: UIViewController,
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { return windowUUID }
 
+    // MARK: Navigation variables
+    weak var parentCoordinator: HomepageCoordinatorDelegate?
+
     // MARK: - Private variables
     private var collectionView: UICollectionView?
     private var dataSource: HomepageDiffableDataSource?
     private var layoutConfiguration = HomepageSectionLayoutProvider().createCompositionalLayout()
     private var logger: Logger
     private var homepageState: HomepageState
+
+    private var currentTheme: Theme {
+        themeManager.getCurrentTheme(for: windowUUID)
+    }
 
     // MARK: - Initializers
     init(windowUUID: WindowUUID,
@@ -101,6 +112,9 @@ final class HomepageViewController: UIViewController,
         if homepageState.loadInitialData {
             dataSource?.applyInitialSnapshot()
         }
+        if homepageState.navigateTo == .customizeHomepage {
+            parentCoordinator?.showSettings(at: .homePage)
+        }
     }
 
     func unsubscribeFromRedux() {
@@ -141,7 +155,9 @@ final class HomepageViewController: UIViewController,
     private func configureCollectionView() {
         let collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: layoutConfiguration)
 
-        collectionView.register(HomepageHeaderCell.self, forCellWithReuseIdentifier: HomepageHeaderCell.cellIdentifier)
+        HomepageItem.cellTypes.forEach {
+            collectionView.register($0, forCellWithReuseIdentifier: $0.cellIdentifier)
+        }
 
         collectionView.keyboardDismissMode = .onDrag
         collectionView.showsVerticalScrollIndicator = false
@@ -187,30 +203,57 @@ final class HomepageViewController: UIViewController,
 
         switch section {
         case .header:
-            let cell = collectionView?.dequeueReusableCell(
-                withReuseIdentifier: HomepageHeaderCell.cellIdentifier,
+            guard let headerCell = collectionView?.dequeueReusableCell(
+                cellType: HomepageHeaderCell.self,
                 for: indexPath
-            )
-            guard let headerCell = cell as? HomepageHeaderCell else {
+            )  else {
                 return UICollectionViewCell()
             }
+
             headerCell.configure(
                 headerState: homepageState.headerState,
                 showiPadSetup: shouldUseiPadSetup()
             ) { [weak self] in
-                guard let self else { return }
-                store.dispatch(
-                    HeaderAction(
-                        windowUUID: self.windowUUID,
-                        actionType: HeaderActionType.toggleHomepageMode
-                    )
-                )
+                self?.toggleHomepageMode()
             }
-            headerCell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+            headerCell.applyTheme(theme: currentTheme)
+
             return headerCell
+        case .customizeHomepage:
+            guard let customizeHomeCell = collectionView?.dequeueReusableCell(
+                cellType: CustomizeHomepageSectionCell.self,
+                for: indexPath
+            ) else {
+                return UICollectionViewCell()
+            }
+
+            customizeHomeCell.configure(onTapAction: { [weak self] _ in
+                self?.navigateToHomepageSettings()
+            }, theme: currentTheme)
+
+            return customizeHomeCell
         default:
             return UICollectionViewCell()
         }
+    }
+
+    // MARK: Dispatch Actions
+    private func toggleHomepageMode() {
+        store.dispatch(
+            HeaderAction(
+                windowUUID: windowUUID,
+                actionType: HeaderActionType.toggleHomepageMode
+            )
+        )
+    }
+
+    private func navigateToHomepageSettings() {
+        store.dispatch(
+            HomepageAction(
+                windowUUID: windowUUID,
+                actionType: HomepageActionType.tappedOnCustomizeHomepage
+            )
+        )
     }
 
     // MARK: UICollectionViewDelegate

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -6,6 +6,8 @@ import Common
 import Redux
 
 final class HomepageAction: Action {
+    var navigationDestination: HomepageState.NavigationDestination?
+
     override init(windowUUID: WindowUUID, actionType: any ActionType) {
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
@@ -13,4 +15,5 @@ final class HomepageAction: Action {
 
 enum HomepageActionType: ActionType {
     case initialize
+    case tappedOnCustomizeHomepage
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -37,8 +37,7 @@ struct HomepageState: ScreenState, Equatable {
         self.init(
             windowUUID: windowUUID,
             loadInitialData: false,
-            headerState: HeaderState(windowUUID: windowUUID),
-            navigateTo: nil
+            headerState: HeaderState(windowUUID: windowUUID)
         )
     }
 
@@ -46,7 +45,7 @@ struct HomepageState: ScreenState, Equatable {
         windowUUID: WindowUUID,
         loadInitialData: Bool,
         headerState: HeaderState,
-        navigateTo: NavigationDestination?
+        navigateTo: NavigationDestination? = nil
     ) {
         self.windowUUID = windowUUID
         self.loadInitialData = loadInitialData
@@ -60,8 +59,7 @@ struct HomepageState: ScreenState, Equatable {
             return HomepageState(
                 windowUUID: state.windowUUID,
                 loadInitialData: false,
-                headerState: HeaderState.reducer(state.headerState, action),
-                navigateTo: nil
+                headerState: HeaderState.reducer(state.headerState, action)
             )
         }
 
@@ -70,8 +68,7 @@ struct HomepageState: ScreenState, Equatable {
             return HomepageState(
                 windowUUID: state.windowUUID,
                 loadInitialData: true,
-                headerState: HeaderState.reducer(state.headerState, action),
-                navigateTo: nil
+                headerState: HeaderState.reducer(state.headerState, action)
             )
         case HomepageActionType.tappedOnCustomizeHomepage:
             return HomepageState(
@@ -84,8 +81,7 @@ struct HomepageState: ScreenState, Equatable {
             return HomepageState(
                 windowUUID: state.windowUUID,
                 loadInitialData: false,
-                headerState: HeaderState.reducer(state.headerState, action),
-                navigateTo: nil
+                headerState: HeaderState.reducer(state.headerState, action)
             )
         }
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -6,9 +6,14 @@ import Common
 import Redux
 
 struct HomepageState: ScreenState, Equatable {
+    enum NavigationDestination {
+        case customizeHomepage
+    }
+
     var windowUUID: WindowUUID
     var loadInitialData: Bool
     var headerState: HeaderState
+    var navigateTo: NavigationDestination?
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let homepageState = store.state.screenState(
@@ -23,7 +28,8 @@ struct HomepageState: ScreenState, Equatable {
         self.init(
             windowUUID: homepageState.windowUUID,
             loadInitialData: homepageState.loadInitialData,
-            headerState: homepageState.headerState
+            headerState: homepageState.headerState,
+            navigateTo: homepageState.navigateTo
         )
     }
 
@@ -31,18 +37,21 @@ struct HomepageState: ScreenState, Equatable {
         self.init(
             windowUUID: windowUUID,
             loadInitialData: false,
-            headerState: HeaderState(windowUUID: windowUUID)
+            headerState: HeaderState(windowUUID: windowUUID),
+            navigateTo: nil
         )
     }
 
     private init(
         windowUUID: WindowUUID,
         loadInitialData: Bool,
-        headerState: HeaderState
+        headerState: HeaderState,
+        navigateTo: NavigationDestination?
     ) {
         self.windowUUID = windowUUID
         self.loadInitialData = loadInitialData
         self.headerState = headerState
+        self.navigateTo = navigateTo
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -51,7 +60,8 @@ struct HomepageState: ScreenState, Equatable {
             return HomepageState(
                 windowUUID: state.windowUUID,
                 loadInitialData: false,
-                headerState: HeaderState.reducer(state.headerState, action)
+                headerState: HeaderState.reducer(state.headerState, action),
+                navigateTo: nil
             )
         }
 
@@ -60,13 +70,22 @@ struct HomepageState: ScreenState, Equatable {
             return HomepageState(
                 windowUUID: state.windowUUID,
                 loadInitialData: true,
-                headerState: HeaderState.reducer(state.headerState, action)
+                headerState: HeaderState.reducer(state.headerState, action),
+                navigateTo: nil
+            )
+        case HomepageActionType.tappedOnCustomizeHomepage:
+            return HomepageState(
+                windowUUID: state.windowUUID,
+                loadInitialData: true,
+                headerState: HeaderState.reducer(state.headerState, action),
+                navigateTo: .customizeHomepage
             )
         default:
             return HomepageState(
                 windowUUID: state.windowUUID,
                 loadInitialData: false,
-                headerState: HeaderState.reducer(state.headerState, action)
+                headerState: HeaderState.reducer(state.headerState, action),
+                navigateTo: nil
             )
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -35,11 +35,12 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.applyInitialSnapshot()
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfSections, 3)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites, .pocket])
+        XCTAssertEqual(snapshot.numberOfSections, 4)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites, .pocket, .customizeHomepage])
 
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .topSites).count, 0)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .pocket).count, 0)
+        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .customizeHomepage).count, 1)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
@@ -33,6 +33,22 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertTrue(newState.headerState.showPrivateModeToggle)
     }
 
+    func test_tappedOnCustomizeHomepage_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = homepageReducer()
+
+        let newState = reducer(
+            initialState,
+            HomepageAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.tappedOnCustomizeHomepage
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.navigateTo, .customizeHomepage)
+    }
+
     // MARK: - Private
     private func createSubject() -> HomepageState {
         return HomepageState(windowUUID: .XCTestDefaultUUID)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10166)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22268)

## :bulb: Description
Add customize homepage section and presenting the view. (actual settings currently not reflected)
- Reuses same simple customize homepage cell
- Add homepage action that navigates to the settings through `BrowserCoordinator`
- Simplify some redundant code related to cell configurations

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Video

https://github.com/user-attachments/assets/d667f4a0-cf88-48ea-86af-845eaf3be6a1

