### PR TITLE
Bugfix FXIOS-10277 [Toolbar redesign] Remove location view a11y label

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -399,7 +399,6 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         lockIconButton.accessibilityLabel = state.lockIconButtonA11yLabel
 
         urlTextField.accessibilityIdentifier = state.urlTextFieldA11yId
-        urlTextField.accessibilityLabel = state.urlTextFieldA11yLabel
     }
 
     func accessibilityCustomActionsForView(_ view: UIView) -> [UIAccessibilityCustomAction]? {

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewState.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewState.swift
@@ -13,7 +13,6 @@ public struct LocationViewState {
 
     public let urlTextFieldPlaceholder: String
     public let urlTextFieldA11yId: String
-    public let urlTextFieldA11yLabel: String
 
     public let searchEngineImage: UIImage?
     public let lockIconImageName: String?
@@ -33,7 +32,6 @@ public struct LocationViewState {
         lockIconButtonA11yLabel: String,
         urlTextFieldPlaceholder: String,
         urlTextFieldA11yId: String,
-        urlTextFieldA11yLabel: String,
         searchEngineImage: UIImage?,
         lockIconImageName: String?,
         url: URL?,
@@ -51,7 +49,6 @@ public struct LocationViewState {
         self.lockIconButtonA11yLabel = lockIconButtonA11yLabel
         self.urlTextFieldPlaceholder = urlTextFieldPlaceholder
         self.urlTextFieldA11yId = urlTextFieldA11yId
-        self.urlTextFieldA11yLabel = urlTextFieldA11yLabel
         self.searchEngineImage = searchEngineImage
         self.lockIconImageName = lockIconImageName
         self.url = url

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -45,7 +45,6 @@ class AddressToolbarContainerModel: Equatable {
             lockIconButtonA11yLabel: .AddressToolbar.PrivacyAndSecuritySettingsA11yLabel,
             urlTextFieldPlaceholder: .AddressToolbar.LocationPlaceholder,
             urlTextFieldA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField,
-            urlTextFieldA11yLabel: .AddressToolbar.LocationA11yLabel,
             searchEngineImage: searchEngineImage,
             lockIconImageName: lockIconImageName,
             url: url,

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -6485,11 +6485,6 @@ extension String {
             tableName: "AddressToolbar",
             value: "Search or enter address",
             comment: "Placeholder for the address field in the address toolbar.")
-        public static let LocationA11yLabel = MZLocalizedString(
-            key: "AddressToolbar.Location.A11y.Label.v128",
-            tableName: "AddressToolbar",
-            value: "Search or enter address",
-            comment: "Accessibility label for the address field in the address toolbar.")
         public static let SearchEngineA11yLabel = MZLocalizedString(
             key: "AddressToolbar.SearchEngine.A11y.Label.v128",
             tableName: "AddressToolbar",
@@ -7398,6 +7393,13 @@ extension String {
                 tableName: "PrivateBrowsing",
                 value: nil,
                 comment: "Accessiblity hint for toggling on/off private mode")
+        }
+        struct v133 {
+            public static let LocationA11yLabel = MZLocalizedString(
+                key: "AddressToolbar.Location.A11y.Label.v128",
+                tableName: "AddressToolbar",
+                value: "Search or enter address",
+                comment: "Accessibility label for the address field in the address toolbar.")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10277)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22507)

## :bulb: Description
Remove the a11y label from the `LocationView` text field

### 📝 Discussion
- The `LocationView` text field had identical placeholder and a11y label text ("Search or enter address"), so when the placeholder text was visible, the same thing would be read twice by voiceover. This change removes the a11y label, so the only thing read is the text inside the text field (placeholder or website name)

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

