### PR TITLE
Refactor FXIOS-7301 - Remove 2 closure_body_length violations from AddressListView.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -117,7 +117,7 @@ struct AddressListView: View {
                         }
                     }
                 }
-                
+
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(viewModel.primaryButtonLabel) {
                         if viewModel.isEditMode {

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -71,7 +71,7 @@ struct AddressListView: View {
             NavigationView {
                 switch destination {
                 case .add:
-                    handleAddAddress
+                    showAddAddressViewController
 
                 case .edit:
                     handleEditAddress()
@@ -91,7 +91,7 @@ struct AddressListView: View {
         }
     }
 
-    private var handleAddAddress: some View {
+    private var showAddAddressViewController: some View {
         return EditAddressViewControllerRepresentable(model: viewModel)
             .navigationBarTitle(String.Addresses.Settings.Edit.AutofillAddAddressTitle, displayMode: .inline)
             .navigationBarItems(

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -74,30 +74,7 @@ struct AddressListView: View {
                     handleAddAddress()
 
                 case .edit:
-                    EditAddressViewControllerRepresentable(model: viewModel)
-                        .navigationBarTitle(viewModel.editNavigationbarTitle, displayMode: .inline)
-                        .toolbar {
-                            ToolbarItemGroup(placement: .cancellationAction) {
-                                Button(viewModel.cancelButtonLabel) {
-                                    if viewModel.isEditMode {
-                                        viewModel.cancelEditButtonTap()
-                                    } else {
-                                        viewModel.closeEditButtonTap()
-                                    }
-                                }
-                            }
-
-                            ToolbarItemGroup(placement: .primaryAction) {
-                                Button(viewModel.primaryButtonLabel) {
-                                    if viewModel.isEditMode {
-                                        viewModel.saveEditButtonTap()
-                                    } else {
-                                        viewModel.editButtonTap()
-                                    }
-                                }
-                            }
-                        }
-                    .ignoresSafeArea(.keyboard)
+                    handleEditAddress()
                 }
             }
         }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -74,7 +74,7 @@ struct AddressListView: View {
                     addAddressView
 
                 case .edit:
-                    showEditAddressViewController
+                    editAddressView
                 }
             }
         }
@@ -104,7 +104,7 @@ struct AddressListView: View {
             )
     }
 
-    private var showEditAddressViewController: some View {
+    private var editAddressView: some View {
         return EditAddressViewControllerRepresentable(model: viewModel)
             .navigationBarTitle(viewModel.editNavigationbarTitle, displayMode: .inline)
             .toolbar {

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -127,6 +127,33 @@ struct AddressListView: View {
             )
     }
 
+    private func handleEditAddress() -> some View {
+        return EditAddressViewControllerRepresentable(model: viewModel)
+            .navigationBarTitle(viewModel.editNavigationbarTitle, displayMode: .inline)
+            .toolbar {
+                ToolbarItemGroup(placement: .cancellationAction) {
+                    Button(viewModel.cancelButtonLabel) {
+                        if viewModel.isEditMode {
+                            viewModel.cancelEditButtonTap()
+                        } else {
+                            viewModel.closeEditButtonTap()
+                        }
+                    }
+                }
+                
+                ToolbarItemGroup(placement: .primaryAction) {
+                    Button(viewModel.primaryButtonLabel) {
+                        if viewModel.isEditMode {
+                            viewModel.saveEditButtonTap()
+                        } else {
+                            viewModel.editButtonTap()
+                        }
+                    }
+                }
+            }
+            .ignoresSafeArea(.keyboard)
+    }
+
     // MARK: - Theme Application
 
     /// Applies the theme to the view.

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -71,7 +71,7 @@ struct AddressListView: View {
             NavigationView {
                 switch destination {
                 case .add:
-                    handleAddAddress()
+                    handleAddAddress
 
                 case .edit:
                     handleEditAddress()
@@ -91,7 +91,7 @@ struct AddressListView: View {
         }
     }
 
-    private func handleAddAddress() -> some View {
+    private var handleAddAddress: some View {
         return EditAddressViewControllerRepresentable(model: viewModel)
             .navigationBarTitle(String.Addresses.Settings.Edit.AutofillAddAddressTitle, displayMode: .inline)
             .navigationBarItems(

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -74,7 +74,7 @@ struct AddressListView: View {
                     showAddAddressViewController
 
                 case .edit:
-                    handleEditAddress
+                    showEditAddressViewController
                 }
             }
         }
@@ -104,7 +104,7 @@ struct AddressListView: View {
             )
     }
 
-    private var handleEditAddress: some View {
+    private var showEditAddressViewController: some View {
         return EditAddressViewControllerRepresentable(model: viewModel)
             .navigationBarTitle(viewModel.editNavigationbarTitle, displayMode: .inline)
             .toolbar {

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -74,7 +74,7 @@ struct AddressListView: View {
                     showAddAddressViewController
 
                 case .edit:
-                    handleEditAddress()
+                    handleEditAddress
                 }
             }
         }
@@ -104,7 +104,7 @@ struct AddressListView: View {
             )
     }
 
-    private func handleEditAddress() -> some View {
+    private var handleEditAddress: some View {
         return EditAddressViewControllerRepresentable(model: viewModel)
             .navigationBarTitle(viewModel.editNavigationbarTitle, displayMode: .inline)
             .toolbar {

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -71,7 +71,7 @@ struct AddressListView: View {
             NavigationView {
                 switch destination {
                 case .add:
-                    showAddAddressViewController
+                    addAddressView
 
                 case .edit:
                     showEditAddressViewController
@@ -91,7 +91,7 @@ struct AddressListView: View {
         }
     }
 
-    private var showAddAddressViewController: some View {
+    private var addAddressView: some View {
         return EditAddressViewControllerRepresentable(model: viewModel)
             .navigationBarTitle(String.Addresses.Settings.Edit.AutofillAddAddressTitle, displayMode: .inline)
             .navigationBarItems(

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -123,6 +123,19 @@ struct AddressListView: View {
         }
     }
 
+    private func handleAddAddress() -> some View {
+        return EditAddressViewControllerRepresentable(model: viewModel)
+            .navigationBarTitle(String.Addresses.Settings.Edit.AutofillAddAddressTitle, displayMode: .inline)
+            .navigationBarItems(
+                leading: Button(String.Addresses.Settings.Edit.CloseNavBarButtonLabel) {
+                    viewModel.cancelAddButtonTap()
+                },
+                trailing: Button(String.Addresses.Settings.Edit.AutofillSaveButton) {
+                    viewModel.saveAddressButtonTap()
+                }
+            )
+    }
+
     // MARK: - Theme Application
 
     /// Applies the theme to the view.

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -71,16 +71,7 @@ struct AddressListView: View {
             NavigationView {
                 switch destination {
                 case .add:
-                    EditAddressViewControllerRepresentable(model: viewModel)
-                        .navigationBarTitle(String.Addresses.Settings.Edit.AutofillAddAddressTitle, displayMode: .inline)
-                        .navigationBarItems(
-                            leading: Button(String.Addresses.Settings.Edit.CloseNavBarButtonLabel) {
-                                viewModel.cancelAddButtonTap()
-                            },
-                            trailing: Button(String.Addresses.Settings.Edit.AutofillSaveButton) {
-                                viewModel.saveAddressButtonTap()
-                            }
-                        )
+                    handleAddAddress()
 
                 case .edit:
                     EditAddressViewControllerRepresentable(model: viewModel)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 2 `closure_body_length` violations from the `AddressListView.swift` file by extracting two switch case statement to new functions. 

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

