### PR TITLE
Bugfix FXIOS-10302 - Password Generator: copy password on longpress

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
@@ -52,11 +52,6 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
         self.layer.borderWidth = UX.passwordFieldBorderWidth
         self.layer.cornerRadius = UX.passwordFieldCornerRadius
         self.accessibilityIdentifier = AccessibilityIdentifiers.PasswordGenerator.passwordField
-        self.isUserInteractionEnabled = true
-       let longPressGesture = UILongPressGestureRecognizer(
-           target: self,
-           action: #selector(self.handleLongPress(_:)))
-        self.addGestureRecognizer(longPressGesture)
         setupNotifications(forObserver: self,
                            observing: [.DynamicFontChanged])
         setupLayout()
@@ -94,6 +89,12 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
     func configure(password: String) {
         passwordLabel.text = password
         passwordLabel.accessibilityAttributedLabel = generateAccessibilityAttributedLabel(password: password)
+        self.becomeFirstResponder()
+        let longPressGesture = UILongPressGestureRecognizer(
+            target: self,
+            action: #selector(self.handleLongPress))
+        longPressGesture.cancelsTouchesInView = true
+        self.addGestureRecognizer(longPressGesture)
     }
 
     private func generateAccessibilityAttributedLabel(password: String) -> NSMutableAttributedString {
@@ -106,10 +107,14 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
 
     @objc
     private func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+        let copyItem = UIMenuItem(title: .PasswordGenerator.CopyPasswordButtonLabel, action: #selector(self.copyText))
         let menuController = UIMenuController.shared
-        let copyItem = UIMenuItem(title: .PasswordGenerator.CopyPasswordButtonLabel, action: #selector(copyText(_:)))
         menuController.menuItems = [copyItem]
         menuController.showMenu(from: passwordLabel, rect: passwordLabel.bounds)
+    }
+
+    override var canBecomeFirstResponder: Bool {
+        return true
     }
 
     @objc


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10302)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22562)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
After removing the password generator from debug settings, upon longpress, the copy password button is no longer shown.
This pr restores the desired behaviour when longpressing the generated password

Epic: https://mozilla-hub.atlassian.net/browse/FXIOS-8348
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

