### PR TITLE
Bugfix FXIOS-10303 Remove location text field trailing margin

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -172,7 +172,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
 
             urlTextField.topAnchor.constraint(equalTo: topAnchor),
             urlTextField.bottomAnchor.constraint(equalTo: bottomAnchor),
-            urlTextField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.horizontalSpace),
+            urlTextField.trailingAnchor.constraint(equalTo: trailingAnchor),
 
             iconContainerBackgroundView.topAnchor.constraint(equalTo: urlTextField.topAnchor),
             iconContainerBackgroundView.bottomAnchor.constraint(equalTo: urlTextField.bottomAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10303)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22563)

## :bulb: Description
- Remove the trailing margin of the `LocationTextField` inside `LocationView` so the clear text "X" button's clickable area extends to the edge of the `LocationView`

### 📷 Screenshots
| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 - 2024-10-15 at 16 01 18](https://github.com/user-attachments/assets/981474dc-52d3-4e53-8c4f-79a478809912) | ![Simulator Screenshot - iPhone 15 - 2024-10-15 at 15 54 24](https://github.com/user-attachments/assets/06dd89d2-e5c2-4a83-8a8a-f8eeb654fc0a) |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

