### PR TITLE
Bugfix FXIOS-10283 - Missing autocomplete suggestion for a word with spaces in front

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -97,7 +97,7 @@ final class LocationView: UIView, LocationTextFieldDelegate, ThemeApplicable, Ac
         notifyTextChanged = { [self] in
             guard urlTextField.isEditing else { return }
 
-            urlAbsolutePath = urlTextField.text?.lowercased()
+            urlAbsolutePath = urlTextField.text?.lowercased().trimmingCharacters(in: .whitespaces)
             delegate?.locationViewDidEnterText(urlAbsolutePath ?? "")
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10283)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22530)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### Video

https://github.com/user-attachments/assets/fbbeb0ca-5236-454b-b7a7-57a583ad0092

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

