### PR TITLE
Add FXIOS-9657 - Password Generator: refresh button

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "e535bbe6d66996f32d0e4f632e9d8588372cd489",
-        "version" : "133.0.20241009050322"
+        "revision" : "3901044888019e0db324ebb14ec78ca49c859eee",
+        "version" : "133.0.20241012050320"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "7fc7ca43967e2980d8691a8e017c118a84133aac",
-        "version" : "8.26.0"
+        "revision" : "38f4f70d07117b9f958a76b1bff278c2f29ffe0e",
+        "version" : "8.21.0"
       }
     },
     {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "3901044888019e0db324ebb14ec78ca49c859eee",
-        "version" : "133.0.20241012050320"
+        "revision" : "e535bbe6d66996f32d0e4f632e9d8588372cd489",
+        "version" : "133.0.20241009050322"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "38f4f70d07117b9f958a76b1bff278c2f29ffe0e",
-        "version" : "8.21.0"
+        "revision" : "7fc7ca43967e2980d8691a8e017c118a84133aac",
+        "version" : "8.26.0"
       }
     },
     {

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
@@ -28,6 +28,8 @@ final class PasswordGeneratorMiddleware {
                                                    for: .passwordGenerator,
                                                    window: action.windowUUID)?.password else {return}
             self.userTappedUsePassword(with: currentTab, password: password)
+        case PasswordGeneratorActionType.userTappedRefreshPassword:
+            self.userTappedRefreshPassword(with: currentTab, windowUUID: windowUUID)
         default:
             break
         }
@@ -80,5 +82,18 @@ final class PasswordGeneratorMiddleware {
                                 category: .webview)
             }
         }
+    }
+
+    private func userTappedRefreshPassword(with tab: Tab, windowUUID: WindowUUID) {
+        guard let origin = tab.url?.origin else {return}
+        generateNewPassword(with: tab, completion: { generatedPassword in
+            self.generatedPasswordStorage.setPasswordForOrigin(origin: origin, password: generatedPassword)
+            let newAction = PasswordGeneratorAction(
+                windowUUID: windowUUID,
+                actionType: PasswordGeneratorActionType.updateGeneratedPassword,
+                password: generatedPassword
+            )
+            store.dispatch(newAction)
+        })
     }
 }

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -43,7 +43,9 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
 
     private lazy var header: PasswordGeneratorHeaderView = .build()
 
-    private lazy var passwordField: PasswordGeneratorPasswordFieldView = .build()
+    private lazy var passwordField: PasswordGeneratorPasswordFieldView = .build { view in
+        view.refreshPasswordButtonOnClick = self.refreshPasswordButtonOnClick
+    }
 
     private lazy var usePasswordButton: PrimaryRoundedButton = .build()
 
@@ -161,6 +163,14 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
             a11yIdentifier: AccessibilityIdentifiers.PasswordGenerator.usePasswordButton)
         usePasswordButton.configure(viewModel: usePasswordButtonVM)
         usePasswordButton.addTarget(self, action: #selector(useButtonOnClick), for: .touchUpInside)
+    }
+
+    func refreshPasswordButtonOnClick() {
+        store.dispatch(PasswordGeneratorAction(
+            windowUUID: windowUUID,
+            actionType: PasswordGeneratorActionType.userTappedRefreshPassword,
+            currentTab: currentTab)
+        )
     }
 
     // MARK: - Redux

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -43,8 +43,15 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
 
     private lazy var header: PasswordGeneratorHeaderView = .build()
 
-    private lazy var passwordField: PasswordGeneratorPasswordFieldView = .build { view in
-        view.refreshPasswordButtonOnClick = self.refreshPasswordButtonOnClick
+    private lazy var passwordField: PasswordGeneratorPasswordFieldView = .build { [weak self] view in
+        view.refreshPasswordButtonOnClick = {
+            guard let self else {return}
+            store.dispatch(PasswordGeneratorAction(
+                windowUUID: self.windowUUID,
+                actionType: PasswordGeneratorActionType.userTappedRefreshPassword,
+                currentTab: self.currentTab)
+            )
+        }
     }
 
     private lazy var usePasswordButton: PrimaryRoundedButton = .build()
@@ -163,14 +170,6 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
             a11yIdentifier: AccessibilityIdentifiers.PasswordGenerator.usePasswordButton)
         usePasswordButton.configure(viewModel: usePasswordButtonVM)
         usePasswordButton.addTarget(self, action: #selector(useButtonOnClick), for: .touchUpInside)
-    }
-
-    func refreshPasswordButtonOnClick() {
-        store.dispatch(PasswordGeneratorAction(
-            windowUUID: windowUUID,
-            actionType: PasswordGeneratorActionType.userTappedRefreshPassword,
-            currentTab: currentTab)
-        )
     }
 
     // MARK: - Redux

--- a/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Common
-import Redux
 
 final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifiable {
     private enum UX {

--- a/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/View/PasswordGeneratorPasswordFieldView.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Common
+import Redux
 
 final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifiable {
     private enum UX {
@@ -38,7 +39,10 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
         button.contentVerticalAlignment = .fill
         button.accessibilityLabel = .PasswordGenerator.RefreshPasswordButtonA11yLabel
         button.accessibilityIdentifier = AccessibilityIdentifiers.PasswordGenerator.passwordRefreshButton
+        button.addTarget(self, action: #selector(self.refreshOnClick), for: .touchUpInside)
     }
+
+    var refreshPasswordButtonOnClick: (() -> Void)?
 
     convenience init(frame: CGRect, notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.init(frame: frame)
@@ -120,6 +124,11 @@ final class PasswordGeneratorPasswordFieldView: UIView, ThemeApplicable, Notifia
     @objc
     private func copyText(_ sender: Any?) {
         UIPasteboard.general.string = passwordLabel.text
+    }
+
+    @objc
+    private func refreshOnClick() {
+        self.refreshPasswordButtonOnClick?()
     }
 
     func applyTheme(theme: any Common.Theme) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9657)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21260)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add a password refresh button which generates a new password for a given origin when clicked as a part of the password generator prompt

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

