### PR TITLE
Bugfix FXIOS-10275 ⁃ The app crashes when attempting to scan an invalid URL on specific devices

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/QRCodeViewController.swift
@@ -384,7 +384,7 @@ extension QRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
                let text = metaData.stringValue {
                 captureSession.stopRunning()
                 // Open QR codes only when they are recognized as webpages, otherwise open as text
-                if let url = URIFixup.getURL(text), url.isWebPage() {
+                if let url = URIFixup.getURL(text), url.isWebPage(), url.baseDomain != nil {
                     let shouldPrompt = qrCodeDelegate.qrCodeScanningPermissionLevel != .allowURLsWithoutPrompt
 
                     if shouldPrompt {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10275)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22505)

## :bulb: Description
Add one more check for verifying base domain of the URL

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

