### PR TITLE
Add FXIOS-10003 More inactive tab debug timeout options [Inactive Tabs]

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FasterInactiveTabs.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FasterInactiveTabs.swift
@@ -5,6 +5,39 @@
 import Foundation
 import Shared
 
+enum FasterInactiveTabsOption: Int {
+    case normal
+    case tenSeconds
+    case oneMinute
+    case twoMinutes
+
+    var nextOption: FasterInactiveTabsOption {
+        switch self {
+        case .normal:
+            return .tenSeconds
+        case .tenSeconds:
+            return .oneMinute
+        case .oneMinute:
+            return .twoMinutes
+        case .twoMinutes:
+            return .normal
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .normal:
+            return "default"
+        case .tenSeconds:
+            return "ten seconds"
+        case .oneMinute:
+            return "one minute"
+        case .twoMinutes:
+            return "two minutes"
+        }
+    }
+}
+
 class FasterInactiveTabs: HiddenSetting {
     private weak var settingsDelegate: DebugSettingsDelegate?
 
@@ -15,8 +48,10 @@ class FasterInactiveTabs: HiddenSetting {
     }
 
     override var title: NSAttributedString? {
-        let isFasterEnabled = UserDefaults.standard.bool(forKey: PrefsKeys.FasterInactiveTabsOverride)
-        let buttonTitle = isFasterEnabled ? "Set Inactive Tab Timeout to Default" : "Set Inactive Tab Timeout to 10s"
+        let rawValue = UserDefaults.standard.integer(forKey: PrefsKeys.FasterInactiveTabsOverride)
+        let fasterInactiveTabOption = FasterInactiveTabsOption(rawValue: rawValue) ?? .normal
+
+        let buttonTitle = "Set Inactive Tab Timeout (\(fasterInactiveTabOption.title))"
         return NSAttributedString(
             string: buttonTitle,
             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]
@@ -24,8 +59,10 @@ class FasterInactiveTabs: HiddenSetting {
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        let isFasterEnabled = UserDefaults.standard.bool(forKey: PrefsKeys.FasterInactiveTabsOverride)
-        UserDefaults.standard.set(!isFasterEnabled, forKey: PrefsKeys.FasterInactiveTabsOverride)
+        let rawValue = UserDefaults.standard.integer(forKey: PrefsKeys.FasterInactiveTabsOverride)
+        let fasterInactiveTabOption = FasterInactiveTabsOption(rawValue: rawValue) ?? .normal
+
+        UserDefaults.standard.set(fasterInactiveTabOption.nextOption.rawValue, forKey: PrefsKeys.FasterInactiveTabsOverride)
         settingsDelegate?.askedToReload()
     }
 }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -431,7 +431,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable {
         let currentDate = Date()
         let inactiveDate: Date
 
-        // Debug for inactive tabs to easily test in code
+        // Check if we're debugging for inactive tabs to easily test in code
         let rawValue = UserDefaults.standard.integer(forKey: PrefsKeys.FasterInactiveTabsOverride)
         let option = FasterInactiveTabsOption(rawValue: rawValue) ?? .normal
         switch option {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -432,11 +432,18 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable {
         let inactiveDate: Date
 
         // Debug for inactive tabs to easily test in code
-        if UserDefaults.standard.bool(forKey: PrefsKeys.FasterInactiveTabsOverride) {
-            inactiveDate = Calendar.current.date(byAdding: .second, value: -10, to: currentDate) ?? Date()
-        } else {
-            // FIXME Is there a reason we use noon of the current day instead of the exact time, when calculating -14 days?
+        let rawValue = UserDefaults.standard.integer(forKey: PrefsKeys.FasterInactiveTabsOverride)
+        let option = FasterInactiveTabsOption(rawValue: rawValue) ?? .normal
+        switch option {
+        case .normal:
+            // Normal operation when no debug setting overrides the inactive tabs timeout
             inactiveDate = Calendar.current.date(byAdding: .day, value: -14, to: currentDate.noon) ?? Date()
+        case .tenSeconds:
+            inactiveDate = Calendar.current.date(byAdding: .second, value: -10, to: currentDate) ?? Date()
+        case .oneMinute:
+            inactiveDate = Calendar.current.date(byAdding: .minute, value: -1, to: currentDate) ?? Date()
+        case .twoMinutes:
+            inactiveDate = Calendar.current.date(byAdding: .minute, value: -2, to: currentDate) ?? Date()
         }
 
         // If the tabDate is older than our inactive date cutoff, return true

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerTests.swift
@@ -27,7 +27,7 @@ class TabManagerTests: XCTestCase {
         super.setUp()
 
         // Disable debug flag for faster inactive tabs and perform tests based on the real 14 day time to inactive
-        UserDefaults.standard.set(false, forKey: PrefsKeys.FasterInactiveTabsOverride)
+        UserDefaults.standard.set(nil, forKey: PrefsKeys.FasterInactiveTabsOverride)
 
         DependencyHelperMock().bootstrapDependencies()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -19,7 +19,7 @@ class TabTests: XCTestCase {
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
 
         // Disable debug flag for faster inactive tabs and perform tests based on the real 14 day time to inactive
-        UserDefaults.standard.set(false, forKey: PrefsKeys.FasterInactiveTabsOverride)
+        UserDefaults.standard.set(nil, forKey: PrefsKeys.FasterInactiveTabsOverride)
     }
 
     override func tearDown() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10003)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21963)

## :bulb: Description
This PR makes the debug setting for inactive tab toggle between a few different timeout options for QA.

Options include:
- default
- 10 seconds
- 1 minute
- 2 minutes

You need to open the secret debug settings in Settings to see these options.

### Demo
https://github.com/user-attachments/assets/89a64d0e-4c6d-4a4a-a3a5-4f127ef03466

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

