### PR TITLE
Add FXIOS-10164 [Homepage] Supplementary views for Pocket section

### DIFF
--- a/BrowserKit/Sources/Common/Protocols/ReusableCell.swift
+++ b/BrowserKit/Sources/Common/Protocols/ReusableCell.swift
@@ -40,6 +40,20 @@ public extension UICollectionView {
         return cell
     }
 
+    func dequeueSupplementary<T: ReusableCell>(of kind: String, cellType: T.Type, for indexPath: IndexPath) -> T? {
+        guard let cell = dequeueReusableSupplementaryView(
+            ofKind: kind,
+            withReuseIdentifier: T.cellIdentifier,
+            for: indexPath) as? T
+        else { return nil }
+
+        return cell
+    }
+
+    func registerSupplementary<T: ReusableCell>(of kind: String, cellType: T.Type) {
+        register(T.self, forSupplementaryViewOfKind: kind, withReuseIdentifier: T.cellIdentifier)
+    }
+
     func register<T: ReusableCell>(cellType: T.Type) {
         register(T.self, forCellWithReuseIdentifier: T.cellIdentifier)
     }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -424,7 +424,7 @@
 		43A878FD27AB4A110071C372 /* RustMozillaAppServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43BE578A278BA4D900491291 /* RustMozillaAppServices.framework */; };
 		43A878FE27AC39D30071C372 /* RustMozillaAppServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43BE578A278BA4D900491291 /* RustMozillaAppServices.framework */; };
 		43AB6FA225DC53D30016B015 /* GoogleTopSiteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AB6F9C25DC53D20016B015 /* GoogleTopSiteManager.swift */; };
-		43AB6FA425DC53D30016B015 /* LabelButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AB6F9E25DC53D20016B015 /* LabelButtonHeaderView.swift */; };
+		43AB6FA425DC53D30016B015 /* LegacyLabelButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AB6F9E25DC53D20016B015 /* LegacyLabelButtonHeaderView.swift */; };
 		43B137F223A181A200CB7FA0 /* NSUserDefaultsPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B137F123A181A200CB7FA0 /* NSUserDefaultsPrefs.swift */; };
 		43B296312B305F1E00A5AA9B /* ContextualHints.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43B2962F2B305F1E00A5AA9B /* ContextualHints.strings */; };
 		43B296342B305F1E00A5AA9B /* CredentialProvider.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43B296322B305F1E00A5AA9B /* CredentialProvider.strings */; };
@@ -714,6 +714,7 @@
 		8A2B1A5E28216C4D0061216B /* Common.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8A2B1A5B28216C4C0061216B /* Common.xcconfig */; };
 		8A2B1A5F28216C4D0061216B /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8A2B1A5C28216C4D0061216B /* Release.xcconfig */; };
 		8A2D593E27DC0AA100713EC9 /* TopSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2D593D27DC0AA100713EC9 /* TopSite.swift */; };
+		8A2DAD4B2CC02AA00067ECD0 /* LabelButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2DAD4A2CC02AA00067ECD0 /* LabelButtonHeaderView.swift */; };
 		8A3233FC286270CF003E1C33 /* FxBookmarkNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3233FB286270CF003E1C33 /* FxBookmarkNode.swift */; };
 		8A3233FE28627446003E1C33 /* LocalDesktopFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3233FD28627446003E1C33 /* LocalDesktopFolder.swift */; };
 		8A32DD5028B419B300D57C60 /* HomepageMessageCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A32DD4F28B419B300D57C60 /* HomepageMessageCardViewModelTests.swift */; };
@@ -760,7 +761,7 @@
 		8A454D2E2CB81668009436D9 /* PocketAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A454D2D2CB81668009436D9 /* PocketAction.swift */; };
 		8A454D302CB81697009436D9 /* PocketMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A454D2F2CB81697009436D9 /* PocketMiddleware.swift */; };
 		8A454D322CB8170D009436D9 /* PocketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A454D312CB8170D009436D9 /* PocketManager.swift */; };
-		8A454D362CB86993009436D9 /* PocketItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A454D352CB86993009436D9 /* PocketItem.swift */; };
+		8A454D362CB86993009436D9 /* PocketStoryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A454D352CB86993009436D9 /* PocketStoryState.swift */; };
 		8A454D372CB86B86009436D9 /* PocketStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A454D332CB85C7D009436D9 /* PocketStateTests.swift */; };
 		8A4593C72BF7BECA002758DE /* MicrosurveyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4593C32BF7BEC9002758DE /* MicrosurveyTableViewCell.swift */; };
 		8A4593C82BF7BECA002758DE /* MicrosurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4593C42BF7BECA002758DE /* MicrosurveyViewController.swift */; };
@@ -5083,7 +5084,7 @@
 		43AB384A2C57B33900F19287 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Toolbar.strings; sourceTree = "<group>"; };
 		43AB48762CB3FD4100ABE599 /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/PasswordGenerator.strings; sourceTree = "<group>"; };
 		43AB6F9C25DC53D20016B015 /* GoogleTopSiteManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoogleTopSiteManager.swift; sourceTree = "<group>"; };
-		43AB6F9E25DC53D20016B015 /* LabelButtonHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabelButtonHeaderView.swift; sourceTree = "<group>"; };
+		43AB6F9E25DC53D20016B015 /* LegacyLabelButtonHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyLabelButtonHeaderView.swift; sourceTree = "<group>"; };
 		43AB6FA125DC53D30016B015 /* TopSiteHistoryManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopSiteHistoryManager.swift; sourceTree = "<group>"; };
 		43AB70DD2AC1A42500BB31DA /* sat-Olck */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sat-Olck"; path = "sat-Olck.lproj/TabLocation.strings"; sourceTree = "<group>"; };
 		43ABB40A29BA6A0400E2AC50 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Onboarding.strings; sourceTree = "<group>"; };
@@ -6898,6 +6899,7 @@
 		8A2B1A5B28216C4C0061216B /* Common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Common.xcconfig; path = Configuration/Common.xcconfig; sourceTree = "<group>"; };
 		8A2B1A5C28216C4D0061216B /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Configuration/Release.xcconfig; sourceTree = "<group>"; };
 		8A2D593D27DC0AA100713EC9 /* TopSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSite.swift; sourceTree = "<group>"; };
+		8A2DAD4A2CC02AA00067ECD0 /* LabelButtonHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelButtonHeaderView.swift; sourceTree = "<group>"; };
 		8A3233FB286270CF003E1C33 /* FxBookmarkNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxBookmarkNode.swift; sourceTree = "<group>"; };
 		8A3233FD28627446003E1C33 /* LocalDesktopFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDesktopFolder.swift; sourceTree = "<group>"; };
 		8A32DD4F28B419B300D57C60 /* HomepageMessageCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageMessageCardViewModelTests.swift; sourceTree = "<group>"; };
@@ -6945,7 +6947,7 @@
 		8A454D2F2CB81697009436D9 /* PocketMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketMiddleware.swift; sourceTree = "<group>"; };
 		8A454D312CB8170D009436D9 /* PocketManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketManager.swift; sourceTree = "<group>"; };
 		8A454D332CB85C7D009436D9 /* PocketStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketStateTests.swift; sourceTree = "<group>"; };
-		8A454D352CB86993009436D9 /* PocketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketItem.swift; sourceTree = "<group>"; };
+		8A454D352CB86993009436D9 /* PocketStoryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketStoryState.swift; sourceTree = "<group>"; };
 		8A4593C32BF7BEC9002758DE /* MicrosurveyTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicrosurveyTableViewCell.swift; sourceTree = "<group>"; };
 		8A4593C42BF7BECA002758DE /* MicrosurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicrosurveyViewController.swift; sourceTree = "<group>"; };
 		8A4593C52BF7BECA002758DE /* MicrosurveyTableHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicrosurveyTableHeaderView.swift; sourceTree = "<group>"; };
@@ -11106,6 +11108,7 @@
 				8AA0A6622CAC40AA00AC7EB3 /* HomepageDiffableDataSource.swift */,
 				8AA0A6642CAC6B7100AC7EB3 /* HomepageSectionLayoutProvider.swift */,
 				8AF347DC2CADD0E100624036 /* Redux */,
+				8A2DAD4A2CC02AA00067ECD0 /* LabelButtonHeaderView.swift */,
 			);
 			path = "Homepage Rebuild";
 			sourceTree = "<group>";
@@ -11339,7 +11342,7 @@
 				8A454D312CB8170D009436D9 /* PocketManager.swift */,
 				8A454D2D2CB81668009436D9 /* PocketAction.swift */,
 				8A454D2B2CB81153009436D9 /* PocketStandardCell.swift */,
-				8A454D352CB86993009436D9 /* PocketItem.swift */,
+				8A454D352CB86993009436D9 /* PocketStoryState.swift */,
 			);
 			path = Pocket;
 			sourceTree = "<group>";
@@ -11532,7 +11535,7 @@
 			children = (
 				E17496362991A2480096900A /* SwiftUI */,
 				8AED23C427AC1F9500DE7E97 /* BaseContentStackView.swift */,
-				43AB6F9E25DC53D20016B015 /* LabelButtonHeaderView.swift */,
+				43AB6F9E25DC53D20016B015 /* LegacyLabelButtonHeaderView.swift */,
 				8A36BE2829EDBC6900AC1C5C /* ContentContainer.swift */,
 				8ACE9BFA2A54A010001E7A73 /* ExpandButtonState.swift */,
 				8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */,
@@ -15584,6 +15587,7 @@
 				EB9A179D20E69A7F00B12184 /* LegacyTheme.swift in Sources */,
 				2128E2802934FBB400FB91BE /* CopyLinkActivity.swift in Sources */,
 				E17BE4C42A94BA6900C5124E /* FakespotHighlightGroupView.swift in Sources */,
+				8A2DAD4B2CC02AA00067ECD0 /* LabelButtonHeaderView.swift in Sources */,
 				C825E9832832A425006CB811 /* NimbusSearchBarLayer.swift in Sources */,
 				E1FC23F12A8629380089E14D /* FakespotReliabilityCardView.swift in Sources */,
 				8AF347DE2CADD1B200624036 /* HomepageState.swift in Sources */,
@@ -15932,7 +15936,7 @@
 				CA7FC7D324A6A9B70012F347 /* PasswordManagerDataSourceHelper.swift in Sources */,
 				0E6C1E252C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift in Sources */,
 				8A5BC1EB2C4AA13F009A40A4 /* FeatureFlagsBoolSetting.swift in Sources */,
-				43AB6FA425DC53D30016B015 /* LabelButtonHeaderView.swift in Sources */,
+				43AB6FA425DC53D30016B015 /* LegacyLabelButtonHeaderView.swift in Sources */,
 				43D16B7C29831CD0009F8279 /* CreditCardItemRow.swift in Sources */,
 				39673BC12B6D82F400653F4A /* FxNimbusMessaging.swift in Sources */,
 				965C3C942933A860006499ED /* LaunchSessionProvider.swift in Sources */,
@@ -16137,7 +16141,7 @@
 				274A36CE239EB9EC00A21587 /* LibraryViewController+LibraryPanelDelegate.swift in Sources */,
 				C869912D28917688007ACC5C /* WallpaperImageLoader.swift in Sources */,
 				96A5F73829928B3700234E5F /* GeneralizedImageFetcher.swift in Sources */,
-				8A454D362CB86993009436D9 /* PocketItem.swift in Sources */,
+				8A454D362CB86993009436D9 /* PocketStoryState.swift in Sources */,
 				1D7B78992ADF328E0011E9F2 /* AppEvent.swift in Sources */,
 				43F7952525795F69005AEE40 /* SearchTelemetry.swift in Sources */,
 				E65075541E37F6FC006961AC /* LegacyDynamicFontHelper.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Legacy/LegacyGridTabViewController.swift
@@ -122,7 +122,7 @@ class LegacyGridTabViewController: UIViewController,
         collectionView.register(cellType: LegacyTabCell.self)
         collectionView.register(cellType: LegacyInactiveTabCell.self)
         collectionView.register(
-            LabelButtonHeaderView.self,
+            LegacyLabelButtonHeaderView.self,
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
             withReuseIdentifier: LegacyGridTabViewController.independentTabsHeaderIdentifier)
         tabDisplayManager = LegacyTabDisplayManager(collectionView: collectionView,

--- a/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
@@ -23,7 +23,7 @@ struct LabelButtonHeaderViewModel {
 }
 
 // Firefox home view controller header view
-class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
+class LegacyLabelButtonHeaderView: UICollectionReusableView, ReusableCell {
     struct UX {
         static let inBetweenSpace: CGFloat = 12
         static let bottomSpace: CGFloat = 10
@@ -159,7 +159,7 @@ class LabelButtonHeaderView: UICollectionReusableView, ReusableCell {
 }
 
 // MARK: - Theme
-extension LabelButtonHeaderView: ThemeApplicable {
+extension LegacyLabelButtonHeaderView: ThemeApplicable {
     func applyTheme(theme: Theme) {
         let titleColor = viewModel?.textColor ?? theme.colors.textPrimary
         let moreButtonColor = viewModel?.textColor ?? theme.colors.textAccent
@@ -170,7 +170,7 @@ extension LabelButtonHeaderView: ThemeApplicable {
 }
 
 // MARK: - Notifiable
-extension LabelButtonHeaderView: Notifiable {
+extension LegacyLabelButtonHeaderView: Notifiable {
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
         case .DynamicFontChanged:

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -20,7 +20,7 @@ final class HomepageDiffableDataSource:
 
     enum HomeItem: Hashable {
         case header
-        case pocket(PocketItem)
+        case pocket(PocketStoryState)
         case pocketDiscover(String)
         case customizeHomepage
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -134,6 +134,16 @@ final class HomepageSectionLayoutProvider {
 
         let section = NSCollectionLayoutSection(group: group)
 
+        let headerFooterSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                                      heightDimension: .estimated(UX.PocketConstants.headerFooterHeight))
+        let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerFooterSize,
+                                                                 elementKind: UICollectionView.elementKindSectionHeader,
+                                                                 alignment: .top)
+        let footer = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerFooterSize,
+                                                                 elementKind: UICollectionView.elementKindSectionFooter,
+                                                                 alignment: .bottom)
+        section.boundarySupplementaryItems = [header, footer]
+
         let leadingInset = UX.leadingInset(traitCollection: traitCollection)
         section.contentInsets = NSDirectionalEdgeInsets(top: 0,
                                                         leading: leadingInset,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/LabelButtonHeaderView.swift
@@ -1,0 +1,169 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import Foundation
+
+/// Firefox homepage section header view
+class LabelButtonHeaderView: UICollectionReusableView,
+                             ReusableCell,
+                             ThemeApplicable,
+                             Notifiable {
+    struct UX {
+        static let inBetweenSpace: CGFloat = 12
+        static let bottomSpace: CGFloat = 10
+        static let bottomButtonSpace: CGFloat = 6
+        static let leadingInset: CGFloat = 0
+        static let trailingInset: CGFloat = 16
+    }
+
+    // MARK: - UIElements
+    private lazy var stackView: UIStackView = .build { stackView in
+        stackView.backgroundColor = .clear
+        stackView.spacing = UX.inBetweenSpace
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+    }
+
+    lazy var titleLabel: UILabel = .build { label in
+        label.text = self.title
+        label.font = FXFontStyles.Bold.title3.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+    }
+
+    private lazy var moreButton: ActionButton = .build { button in
+        button.isHidden = true
+    }
+
+    // MARK: - Variables
+    var title: String? {
+        willSet(newTitle) {
+            titleLabel.text = newTitle
+        }
+    }
+
+    var notificationCenter: NotificationProtocol = NotificationCenter.default
+
+    private var stackViewLeadingConstraint: NSLayoutConstraint?
+
+    // MARK: - Initializers
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(moreButton)
+        addSubview(stackView)
+
+        setupLayout()
+        setupNotifications(forObserver: self,
+                           observing: [.DynamicFontChanged])
+    }
+
+    private func setupLayout() {
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(moreButton)
+        addSubview(stackView)
+
+        stackViewLeadingConstraint = stackView.leadingAnchor.constraint(equalTo: leadingAnchor,
+                                                                        constant: UX.leadingInset)
+        stackViewLeadingConstraint?.isActive = true
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor,
+                                                constant: -UX.trailingInset),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.bottomSpace),
+        ])
+
+        // Setting custom values to resolve horizontal ambiguity
+        titleLabel.setContentCompressionResistancePriority(UILayoutPriority(751), for: .horizontal)
+        titleLabel.setContentHuggingPriority(UILayoutPriority(251), for: .horizontal)
+
+        adjustLayout()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
+    // MARK: - Helper functions
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        moreButton.isHidden = true
+        moreButton.setTitle(nil, for: .normal)
+        moreButton.accessibilityIdentifier = nil
+        titleLabel.text = nil
+        moreButton.removeTarget(nil, action: nil, for: .allEvents)
+    }
+
+    func configure(
+        state: SectionHeaderState,
+        theme: Theme
+    ) {
+        self.title = state.sectionHeaderTitle
+        titleLabel.accessibilityIdentifier = state.sectionTitleA11yIdentifier
+
+        moreButton.isHidden = state.isSectionHeaderButtonHidden
+        if !state.isSectionHeaderButtonHidden {
+            let moreButtonViewModel = ActionButtonViewModel(
+                title: .BookmarksSavedShowAllText,
+                a11yIdentifier: state.sectionButtonA11yIdentifier,
+                touchUpAction: nil
+            )
+            moreButton.configure(
+                viewModel: moreButtonViewModel
+            )
+        }
+
+        applyTheme(theme: theme)
+    }
+
+    // MARK: - Dynamic Type Support
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if previousTraitCollection?.preferredContentSizeCategory != self.traitCollection.preferredContentSizeCategory {
+            adjustLayout()
+        }
+    }
+
+    private func adjustLayout() {
+        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+
+        if contentSizeCategory.isAccessibilityCategory {
+            stackView.axis = .vertical
+            moreButton.contentHorizontalAlignment = .leading
+        } else {
+            stackView.axis = .horizontal
+            moreButton.contentHorizontalAlignment = .trailing
+        }
+
+        setNeedsLayout()
+        layoutIfNeeded()
+    }
+
+    // MARK: - ThemeApplicable
+    func applyTheme(theme: Theme) {
+        // enter textColor
+        let titleColor = theme.colors.textPrimary
+        let moreButtonColor = theme.colors.textAccent
+
+        titleLabel.textColor = titleColor
+        moreButton.foregroundColorNormal = moreButtonColor
+    }
+
+    // MARK: - Notifiable
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case .DynamicFontChanged:
+            adjustLayout()
+        default: break
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketAction.swift
@@ -7,10 +7,10 @@ import Foundation
 import Redux
 
 final class PocketAction: Action {
-    var pocketStories: [PocketItem]?
+    var pocketStories: [PocketStoryState]?
 
     init(
-        pocketStories: [PocketItem]? = nil,
+        pocketStories: [PocketStoryState]? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketManager.swift
@@ -13,8 +13,8 @@ class PocketManager {
         self.storyProvider = StoryProvider(pocketAPI: pocketAPI)
     }
 
-    func getPocketItems() async -> [PocketItem] {
+    func getPocketItems() async -> [PocketStoryState] {
         let stories = await storyProvider.fetchPocketStories()
-        return stories.compactMap { PocketItem(story: $0) }
+        return stories.compactMap { PocketStoryState(story: $0) }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketStandardCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketStandardCell.swift
@@ -85,16 +85,16 @@ class PocketStandardCell: UICollectionViewCell, ReusableCell, ThemeApplicable, B
 
     // MARK: - Helpers
 
-    func configure(item: PocketItem, theme: Theme) {
-        titleLabel.text = item.title
-        descriptionLabel.text = item.description
-        accessibilityLabel = item.accessibilityLabel
+    func configure(story: PocketStoryState, theme: Theme) {
+        titleLabel.text = story.title
+        descriptionLabel.text = story.description
+        accessibilityLabel = story.accessibilityLabel
 
-        let heroImageViewModel = HomepageHeroImageViewModel(urlStringRequest: item.imageURL.absoluteString,
+        let heroImageViewModel = HomepageHeroImageViewModel(urlStringRequest: story.imageURL.absoluteString,
                                                             heroImageSize: UX.heroImageSize)
         heroImageView.setHeroImage(heroImageViewModel)
-        sponsoredStack.isHidden = item.shouldHideSponsor
-        descriptionLabel.font = item.shouldHideSponsor
+        sponsoredStack.isHidden = story.shouldHideSponsor
+        descriptionLabel.font = story.shouldHideSponsor
         ? FXFontStyles.Regular.caption1.scaledFont()
         : FXFontStyles.Bold.caption1.scaledFont()
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketState.swift
@@ -6,11 +6,25 @@ import Common
 import Foundation
 import Redux
 
+struct SectionHeaderState: Equatable {
+    var sectionHeaderTitle: String
+    var sectionTitleA11yIdentifier: String
+    var isSectionHeaderButtonHidden: Bool
+    var sectionHeaderColor: UIColor
+    var sectionButtonA11yIdentifier: String?
+}
+
 /// State for the pocket section that is used in the homepage
 struct PocketState: StateType, Equatable {
     var windowUUID: WindowUUID
-    var pocketData: [PocketItem]
+    var pocketData: [PocketStoryState]
     var pocketDiscoverTitle: String
+    // TODO: FXIOS-10312 Update color for section header when wallpaper is configured with redux
+    var sectionHeaderState = SectionHeaderState(
+        sectionHeaderTitle: .FirefoxHomepage.Pocket.SectionTitle,
+        sectionTitleA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket,
+        isSectionHeaderButtonHidden: true,
+        sectionHeaderColor: .systemRed)
 
     init(windowUUID: WindowUUID) {
         self.init(
@@ -22,7 +36,7 @@ struct PocketState: StateType, Equatable {
 
     private init(
         windowUUID: WindowUUID,
-        pocketData: [PocketItem],
+        pocketData: [PocketStoryState],
         pocketDiscoverTitle: String
     ) {
         self.windowUUID = windowUUID

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketStoryState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketStoryState.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// Converts the pocket story model to be presentable for the `PocketStandardCell` view
-class PocketItem: Equatable, Hashable {
+class PocketStoryState: Equatable, Hashable {
     private let story: PocketStory
 
     init(story: PocketStory) {
@@ -34,7 +34,7 @@ class PocketItem: Equatable, Hashable {
     }
 
     // MARK: - Equatable
-    static func == (lhs: PocketItem, rhs: PocketItem) -> Bool {
+    static func == (lhs: PocketStoryState, rhs: PocketStoryState) -> Bool {
         lhs.story == rhs.story
     }
 

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -244,9 +244,9 @@ class LegacyHomepageViewController:
         HomepageSectionType.cellTypes.forEach {
             collectionView.register($0, forCellWithReuseIdentifier: $0.cellIdentifier)
         }
-        collectionView.register(LabelButtonHeaderView.self,
+        collectionView.register(LegacyLabelButtonHeaderView.self,
                                 forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
-                                withReuseIdentifier: LabelButtonHeaderView.cellIdentifier)
+                                withReuseIdentifier: LegacyLabelButtonHeaderView.cellIdentifier)
         collectionView.register(PocketFooterView.self,
                                 forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter,
                                 withReuseIdentifier: PocketFooterView.cellIdentifier)
@@ -503,7 +503,7 @@ class LegacyHomepageViewController:
 
     // MARK: - Contextual hint
 
-    private func prepareJumpBackInContextualHint(onView headerView: LabelButtonHeaderView) {
+    private func prepareJumpBackInContextualHint(onView headerView: LegacyLabelButtonHeaderView) {
         guard jumpBackInContextualHintViewController.shouldPresentHint(),
               !viewModel.shouldDisplayHomeTabBanner,
               !headerView.frame.isEmpty
@@ -567,8 +567,8 @@ extension LegacyHomepageViewController: UICollectionViewDelegate, UICollectionVi
         if kind == UICollectionView.elementKindSectionHeader {
             guard let headerView = collectionView.dequeueReusableSupplementaryView(
                 ofKind: kind,
-                withReuseIdentifier: LabelButtonHeaderView.cellIdentifier,
-                for: indexPath) as? LabelButtonHeaderView else { return reusableView }
+                withReuseIdentifier: LegacyLabelButtonHeaderView.cellIdentifier,
+                for: indexPath) as? LegacyLabelButtonHeaderView else { return reusableView }
             guard let sectionViewModel = viewModel.getSectionViewModel(shownSection: indexPath.section)
             else { return reusableView }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketStateTests.swift
@@ -27,7 +27,7 @@ final class PocketStateTests: XCTestCase {
         ]
 
         let stories = feedStories.compactMap {
-            PocketItem(story: PocketStory(pocketFeedStory: $0))
+            PocketStoryState(story: PocketStory(pocketFeedStory: $0))
         }
 
         let newState = reducer(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10164)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22266)

## :bulb: Description
Add header and footer UI view
Updated `PocketItem` to be `PocketStoryState`

**Next Steps**
- Pocket navigation
- Pocket tests
 
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

