### PR TITLE
Add FXIOS-9650 - Password Generator: Fill Password Field Use Strong Password Button

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -136,6 +136,14 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
             usePasswordButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
     }
+    // MARK: - Interaction Handlers
+    @objc
+    func useButtonOnClick() {
+        store.dispatch(PasswordGeneratorAction(windowUUID: windowUUID,
+                                               actionType: PasswordGeneratorActionType.userTappedUsePassword,
+                                               currentTab: currentTab))
+        dismiss(animated: true)
+    }
 
     // MARK: - Themable
     func applyTheme() {
@@ -152,6 +160,7 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
             title: .PasswordGenerator.UsePasswordButtonLabel,
             a11yIdentifier: AccessibilityIdentifiers.PasswordGenerator.usePasswordButton)
         usePasswordButton.configure(viewModel: usePasswordButtonVM)
+        usePasswordButton.addTarget(self, action: #selector(useButtonOnClick), for: .touchUpInside)
     }
 
     // MARK: - Redux


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9650)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21252)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
After the password generator prompt is shown, give the user the option to “Use strong password“ which fills in the password field of the associated signup form.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

