### PR TITLE
Bugfix FXIOS-10315 Fix WebKit exceptions from JS alert completion handlers

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -40,7 +40,7 @@ protocol JSAlertInfo {
 struct MessageAlert: JSAlertInfo {
     let message: String
     let frame: WKFrameInfo
-    let completionHandler: (() -> Void)?
+    let completionHandler: () -> Void
 
     func alertController() -> JSPromptAlertController {
         let alertController = JSPromptAlertController(
@@ -48,7 +48,7 @@ struct MessageAlert: JSAlertInfo {
             message: message,
             preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
-            completionHandler?()
+            completionHandler()
         })
         alertController.alertInfo = self
         return alertController

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -69,7 +69,6 @@ extension BrowserViewController: WKUIDelegate {
             logger.log("Javascript message alert is queued.", level: .info, category: .webview)
 
             promptingTab.queueJavascriptAlertPrompt(messageAlert)
-            completionHandler()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1298,11 +1298,12 @@ class BrowserViewController: UIViewController,
     }
 
     fileprivate func showQueuedAlertIfAvailable() {
-        if let queuedAlertInfo = tabManager.selectedTab?.dequeueJavascriptAlertPrompt() {
-            let alertController = queuedAlertInfo.alertController()
-            alertController.delegate = self
-            present(alertController, animated: true, completion: nil)
-        }
+        // See also: similar safety checks in `shouldDisplayJSAlertForWebView`
+        guard presentedViewController == nil else { return }
+        guard let queuedAlertInfo = tabManager.selectedTab?.dequeueJavascriptAlertPrompt() else { return }
+        let alertController = queuedAlertInfo.alertController()
+        alertController.delegate = self
+        present(alertController, animated: true, completion: nil)
     }
 
     func resetBrowserChrome() {
@@ -4099,6 +4100,9 @@ extension BrowserViewController: TabTrayDelegate {
 
 extension BrowserViewController: JSPromptAlertControllerDelegate {
     func promptAlertControllerDidDismiss(_ alertController: JSPromptAlertController) {
+        logger.log("JS prompt was dismissed. Will dequeue next alert.",
+                   level: .info,
+                   category: .webview)
         showQueuedAlertIfAvailable()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10315)
[Github Issue](https://github.com/mozilla-mobile/firefox-ios/issues/22591)

## :bulb: Description

This should fix two separate categories of exceptions being thrown from WebKit, both a result of improper handling of the JS alert completion handlers. 

1. In one crash, an enqueued alert was incorrectly calling the completion handler twice (`called more than once` crash)
    - This crash was recently introduced when the completion handlers for `MessageAlert` were (correctly) moved out of the presentation callback and into the actual OK button handler for the alert, however one of the old completionHandlers was never cleaned up.
2. In another crash, an enqueued alert could end up being presented in some user flows which would cause the alert itself to fail (`never called` crash)
    - This crash appears to have been ongoing and can happen in different scenarios. If a JS alert is presented while an existing UIAlertController is on screen, for example, it will be enqueued. Then if something triggers `viewDidLayoutSubviews` (such as a device rotation), the code to dequeue and present the alert would fail to check whether there was already a presented VC. The JS alert would then fail, but this would not actually crash, the crash was because the completionHandler was never called. The solution is that we should not be dequeuing and attempting to present at all when we know there is already a presented VC (this matches the logic used by `shouldDisplayJSAlertForWebView`)

At least based on the investigation and data I have so far, this should hopefully fix all of these types of crashes. However we're going to want to monitor these exceptions to see if there are other similar scenarios (for crash 2) that are still occurring.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

