### PR TITLE
Replace MTE-3715 - address identifiers with a single path

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -9,6 +9,7 @@ import XCTest
 let page1 = "http://localhost:\(serverPort)/test-fixture/find-in-page-test.html"
 let page2 = "http://localhost:\(serverPort)/test-fixture/test-example.html"
 let serverPort = ProcessInfo.processInfo.environment["WEBSERVER_PORT"] ?? "\(Int.random(in: 1025..<65000))"
+let urlBarAddress = XCUIApplication().textFields[AccessibilityIdentifiers.Browser.UrlBar.searchTextField]
 
 func path(forTestPage page: String) -> String {
     return "http://localhost:\(serverPort)/test-fixture/\(page)"

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -129,8 +129,8 @@ class BookmarksTests: BaseTestCase {
         typeOnSearchBar(text: "www.google")
         mozWaitForElementToExist(app.tables["SiteTable"])
         mozWaitForElementToExist(app.tables["SiteTable"].cells.staticTexts["www.google"])
-        app.textFields["address"].typeText(".com")
-        app.textFields["address"].typeText("\r")
+        urlBarAddress.typeText(".com")
+        urlBarAddress.typeText("\r")
         navigator.nowAt(BrowserTab)
 
         // Clear text and enter new url
@@ -142,7 +142,7 @@ class BookmarksTests: BaseTestCase {
         // Site table exists but is empty
         mozWaitForElementToExist(app.tables["SiteTable"])
         XCTAssertEqual(app.tables["SiteTable"].cells.count, 0)
-        app.textFields["address"].typeText("\r")
+        urlBarAddress.typeText("\r")
         navigator.nowAt(BrowserTab)
 
         // Add page to bookmarks
@@ -271,7 +271,7 @@ class BookmarksTests: BaseTestCase {
     private func typeOnSearchBar(text: String) {
         mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
         app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
-        app.textFields["address"].typeText(text)
+        urlBarAddress.typeText(text)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306909

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
@@ -16,10 +16,10 @@ class ClipBoardTests: BaseTestCase {
     // Copy url from the browser
     func copyUrl() {
         navigator.goto(URLBarOpen)
-        mozWaitForElementToExist(app.textFields["address"])
-        app.textFields["address"].tap()
+        mozWaitForElementToExist(urlBarAddress)
+        urlBarAddress.tap()
         if iPad() {
-            app.textFields["address"].press(forDuration: 1)
+            urlBarAddress.press(forDuration: 1)
             app.menuItems["Select All"].tap()
         }
         mozWaitForElementToExist(app.menuItems["Copy"])
@@ -62,9 +62,9 @@ class ClipBoardTests: BaseTestCase {
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         navigator.nowAt(NewTabScreen)
         navigator.goto(URLBarOpen)
-        app.textFields["address"].press(forDuration: 3)
+        urlBarAddress.press(forDuration: 3)
         app.menuItems["Paste"].tap()
-        mozWaitForValueContains(app.textFields["address"], value: "www.example.com")
+        mozWaitForValueContains(urlBarAddress, value: "www.example.com")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307051

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
@@ -56,17 +56,17 @@ class DomainAutocompleteTests: BaseTestCase {
             navigator.performAction(Action.CloseTabFromTabTrayLongPressMenu)
         }
         navigator.goto(URLBarOpen)
-        app.textFields["address"].typeText("moz")
+        urlBarAddress.typeText("moz")
 
-        mozWaitForValueContains(app.textFields["address"], value: website["value"]!)
-        let value = app.textFields["address"].value
+        mozWaitForValueContains(urlBarAddress, value: website["value"]!)
+        let value = urlBarAddress.value
         XCTAssertEqual(value as? String, website["value"]!, "Wrong autocompletion")
 
         // Enter the complete website and check that there is not more text added, just what user typed
         app.buttons["Clear text"].tap()
-        app.textFields["address"].typeText(website["value"]!)
-        mozWaitForValueContains(app.textFields["address"], value: website["value"]!)
-        let value2 = app.textFields["address"].value
+        urlBarAddress.typeText(website["value"]!)
+        mozWaitForValueContains(urlBarAddress, value: website["value"]!)
+        let value2 = urlBarAddress.value
         XCTAssertEqual(value2 as? String, website["value"]!, "Wrong autocompletion")
     }
 
@@ -83,20 +83,20 @@ class DomainAutocompleteTests: BaseTestCase {
         navigator.nowAt(HomePanelsScreen)
 
         navigator.goto(URLBarOpen)
-        mozWaitForElementToExist(app.textFields["address"])
-        app.textFields["address"].typeText("moz")
+        mozWaitForElementToExist(urlBarAddress)
+        urlBarAddress.typeText("moz")
 
         // First delete the autocompleted part
-        app.textFields["address"].typeText("\u{0008}")
+        urlBarAddress.typeText("\u{0008}")
         // Then remove an extra char and check that the autocompletion stops working
-        app.textFields["address"].typeText("\u{0008}")
-        mozWaitForValueContains(app.textFields["address"], value: "mo")
+        urlBarAddress.typeText("\u{0008}")
+        mozWaitForValueContains(urlBarAddress, value: "mo")
         // Then write another letter and the autocompletion works again
-        app.textFields["address"].typeText("z")
-        mozWaitForValueContains(app.textFields["address"], value: "moz")
+        urlBarAddress.typeText("z")
+        mozWaitForValueContains(urlBarAddress, value: "moz")
 
         if #available(iOS 16, *) {
-            let value = app.textFields["address"].value
+            let value = urlBarAddress.value
             XCTAssertEqual(value as? String, website["value"]!, "Wrong autocompletion")
         }
     }
@@ -104,12 +104,12 @@ class DomainAutocompleteTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2334648
     func test6DeleteEntireString() {
         navigator.goto(URLBarOpen)
-        app.textFields["address"].typeText("www.moz")
+        urlBarAddress.typeText("www.moz")
         mozWaitForElementToExist(app.buttons["Clear text"])
         app.buttons["Clear text"].tap()
 
         // Check that the address field is empty and that the home panels are shown
-        let value = app.textFields["address"].value
+        let value = urlBarAddress.value
         XCTAssertEqual(value as? String, "", "The url has not been removed correctly")
 
         mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
@@ -121,10 +121,10 @@ class DomainAutocompleteTests: BaseTestCase {
         navigator.openURL(websiteExample["url"]!)
         waitUntilPageLoad()
         navigator.goto(URLBarOpen)
-        app.textFields["address"].typeText("ex")
+        urlBarAddress.typeText("ex")
         if #available(iOS 16, *) {
             mozWaitForValueContains(app.otherElements.textFields["Address Bar"], value: "www.example.com/")
-            let value = app.textFields["address"].value
+            let value = urlBarAddress.value
             XCTAssertEqual(value as? String, "example.com", "Wrong autocompletion")
         }
     }
@@ -135,44 +135,44 @@ class DomainAutocompleteTests: BaseTestCase {
         navigator.openURL("twitter.com/login")
         waitUntilPageLoad()
         navigator.goto(URLBarOpen)
-        app.textFields["address"].typeText("baz")
-        let value = app.textFields["address"].value
+        urlBarAddress.typeText("baz")
+        let value = urlBarAddress.value
         // Check there is not more text added, just what user typed
         XCTAssertEqual(value as? String, "baz", "Wrong autocompletion")
 
         // Ensure we don't match against TLDs.
         app.buttons["Clear text"].tap()
-        app.textFields["address"].typeText(".com")
-        let value2 = app.textFields["address"].value
+        urlBarAddress.typeText(".com")
+        let value2 = urlBarAddress.value
         // Check there is not more text added, just what user typed
         XCTAssertEqual(value2 as? String, ".com", "Wrong autocompletion")
 
         // Ensure we don't match other characters ie: ., :, /
         app.buttons["Clear text"].tap()
-        app.textFields["address"].typeText(".")
-        let value3 = app.textFields["address"].value
+        urlBarAddress.typeText(".")
+        let value3 = urlBarAddress.value
         XCTAssertEqual(value3 as? String, ".", "Wrong autocompletion")
 
         app.buttons["Clear text"].tap()
-        app.textFields["address"].typeText(":")
-        let value4 = app.textFields["address"].value
+        urlBarAddress.typeText(":")
+        let value4 = urlBarAddress.value
         XCTAssertEqual(value4 as? String, ":", "Wrong autocompletion")
 
         app.buttons["Clear text"].tap()
-        app.textFields["address"].typeText("/")
-        let value5 = app.textFields["address"].value
+        urlBarAddress.typeText("/")
+        let value5 = urlBarAddress.value
         XCTAssertEqual(value5 as? String, "/", "Wrong autocompletion")
 
         // Ensure we don't match strings that don't start a word.
         app.buttons["Clear text"].tap()
-        app.textFields["address"].typeText("tter")
-        let value6 = app.textFields["address"].value
+        urlBarAddress.typeText("tter")
+        let value6 = urlBarAddress.value
         XCTAssertEqual(value6 as? String, "tter", "Wrong autocompletion")
 
         // Ensure we don't match words outside of the domain
         app.buttons["Clear text"].tap()
-        app.textFields["address"].typeText("login")
-        let value7 = app.textFields["address"].value
+        urlBarAddress.typeText("login")
+        let value7 = urlBarAddress.value
         XCTAssertEqual(value7 as? String, "login", "Wrong autocompletion")
     }
 
@@ -180,21 +180,21 @@ class DomainAutocompleteTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2334651
     func test2DefaultDomains() {
         navigator.goto(URLBarOpen)
-        app.textFields["address"].typeText("a")
-        mozWaitForValueContains(app.textFields["address"], value: ".com")
-        let value = app.textFields["address"].value
+        urlBarAddress.typeText("a")
+        mozWaitForValueContains(urlBarAddress, value: ".com")
+        let value = urlBarAddress.value
         XCTAssertEqual(value as? String, "amazon.com", "Wrong autocompletion")
 
         app.buttons["Clear text"].tap()
-        app.textFields["address"].typeText("an")
-        mozWaitForValueContains(app.textFields["address"], value: ".com")
-        let value2 = app.textFields["address"].value
+        urlBarAddress.typeText("an")
+        mozWaitForValueContains(urlBarAddress, value: ".com")
+        let value2 = urlBarAddress.value
         XCTAssertEqual(value2 as? String, "answers.com", "Wrong autocompletion")
 
         app.buttons["Clear text"].tap()
-        app.textFields["address"].typeText("anc")
-        mozWaitForValueContains(app.textFields["address"], value: ".com")
-        let value3 = app.textFields["address"].value
+        urlBarAddress.typeText("anc")
+        mozWaitForValueContains(urlBarAddress, value: ".com")
+        let value3 = urlBarAddress.value
         XCTAssertEqual(value3 as? String, "ancestry.com", "Wrong autocompletion")
     }
 
@@ -202,23 +202,23 @@ class DomainAutocompleteTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2334653
     func testMixedCaseAutocompletion() {
         navigator.goto(URLBarOpen)
-        app.textFields["address"].typeText("MoZ")
-        mozWaitForValueContains(app.textFields["address"], value: ".org")
-        let value = app.textFields["address"].value
+        urlBarAddress.typeText("MoZ")
+        mozWaitForValueContains(urlBarAddress, value: ".org")
+        let value = urlBarAddress.value
         XCTAssertEqual(value as? String, "MoZilla.org", "Wrong autocompletion")
 
         // Test that leading spaces still show suggestions.
         app.buttons["Clear text"].tap()
-        app.textFields["address"].typeText("    moz")
-        mozWaitForValueContains(app.textFields["address"], value: ".org")
-        let value2 = app.textFields["address"].value
+        urlBarAddress.typeText("    moz")
+        mozWaitForValueContains(urlBarAddress, value: ".org")
+        let value2 = urlBarAddress.value
         XCTAssertEqual(value2 as? String, "    mozilla.org", "Wrong autocompletion")
 
         // Test that trailing spaces do *not* show suggestions.
         app.buttons["Clear text"].tap()
-        app.textFields["address"].typeText("    moz ")
-        mozWaitForValueContains(app.textFields["address"], value: "moz")
-        let value3 = app.textFields["address"].value
+        urlBarAddress.typeText("    moz ")
+        mozWaitForValueContains(urlBarAddress, value: "moz")
+        let value3 = urlBarAddress.value
         // No autocompletion, just what user typed
         XCTAssertEqual(value3 as? String, "    moz ", "Wrong autocompletion")
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -175,7 +175,7 @@ class FindInPageTests: BaseTestCase {
 
         // Before reloading, it is necessary to hide the keyboard
         app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
-        app.textFields["address"].typeText("\n")
+        urlBarAddress.typeText("\n")
 
         // Once the page is reloaded the search bar should not appear
         if #available(iOS 16, *) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FirefoxSuggestTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FirefoxSuggestTest.swift
@@ -10,7 +10,7 @@ class FirefoxSuggestTest: BaseTestCase {
         navigator.openURL("www.example.com")
         navigator.createNewTab()
         navigator.goto(URLBarOpen)
-        app.textFields["address"].typeText("ex")
+        urlBarAddress.typeText("ex")
         mozWaitForElementToExist(app.tables["SiteTable"])
         mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["Google Search"])
         mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["Firefox Suggest"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -199,11 +199,11 @@ class NavigationTest: BaseTestCase {
         throw XCTSkip("Test needs to be updated")
         /*
             // This test is for populated clipboard only so we need to make sure there's something in Pasteboard
-            app.textFields["address"].typeText("www.google.com")
+            urlBarAddress.typeText("www.google.com")
             // Tapping two times when the text is not selected will reveal the menu
-            app.textFields["address"].tap()
-            mozWaitForElementToExist(app.textFields["address"])
-            app.textFields["address"].tap()
+            urlBarAddress.tap()
+            mozWaitForElementToExist(urlBarAddress)
+            urlBarAddress.tap()
             mozWaitForElementToExist(app.menuItems["Select All"])
             XCTAssertTrue(app.menuItems["Select All"].exists)
             XCTAssertTrue(app.menuItems["Select"].exists)
@@ -226,7 +226,7 @@ class NavigationTest: BaseTestCase {
                 XCTAssertTrue(app.menuItems["Open Link"].exists)
             }
 
-            app.textFields["address"].typeText("\n")
+            urlBarAddress.typeText("\n")
             waitUntilPageLoad()
             mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
 
@@ -238,7 +238,7 @@ class NavigationTest: BaseTestCase {
             // Since the textField value appears all selected first time is clicked
             // this workaround is necessary
             mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-            app.textFields["address"].tap()
+            urlBarAddress.tap()
             mozWaitForElementToExist(app.menuItems["Copy"])
             if iPad() {
                 XCTAssertTrue(app.menuItems["Cut"].exists)
@@ -431,8 +431,7 @@ class NavigationTest: BaseTestCase {
         mozWaitForElementToExist(urlBar)
         urlBar.tap()
 
-        let addressBar = app.textFields["address"]
-        XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
+        XCTAssertTrue(urlBarAddress.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
 
         // These instances are false positives of the swiftlint configuration
         // swiftlint:disable empty_count

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
@@ -29,8 +29,7 @@ class NewTabSettingsTest: BaseTestCase {
         navigator.performAction(Action.SelectNewTabAsBlankPage)
         navigator.performAction(Action.OpenNewTabFromTabTray)
 
-        let addressBar = app.textFields["address"]
-        XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
+        XCTAssertTrue(urlBarAddress.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
         let keyboardCount = app.keyboards.count
         XCTAssert(keyboardCount > 0, "The keyboard is not shown")
         mozWaitForElementToNotExist(app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
@@ -164,8 +163,7 @@ class NewTabSettingsTest: BaseTestCase {
 
     private func validateKeyboardIsRaisedAndDismissed() {
         // The keyboard is raised up
-        let addressBar = app.textFields["address"]
-        XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
+        XCTAssertTrue(urlBarAddress.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
         XCTAssertTrue(app.keyboards.element.isVisible(), "The keyboard is not shown")
         // Tap the back button
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
@@ -136,7 +136,7 @@ private func createTestGraph(for test: XCTestCase, with app: XCUIApplication) ->
     map.addScreenState(URLBarOpen) { screenState in
         screenState.gesture(forAction: TestActions.LoadURLByTyping, TestActions.LoadURL) { userState in
             let urlString = userState.url ?? defaultURL
-            app.textFields["address"].typeText("\(urlString)\r")
+            urlBarAddress.typeText("\(urlString)\r")
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -107,11 +107,11 @@ class SearchTests: BaseTestCase {
         }
 
         // Typing / should stop showing suggestions
-        app.textFields["address"].typeText("/")
+        urlBarAddress.typeText("/")
         mozWaitForElementToNotExist(app.tables["SiteTable"].cells[SuggestedSite])
 
         // Typing space and char after / should show suggestions again
-        app.textFields["address"].typeText(" b")
+        urlBarAddress.typeText(" b")
         mozWaitForElementToExist(app.tables["SiteTable"])
         if !(app.tables["SiteTable"].cells.staticTexts[SuggestedSite4].exists) {
             if !(app.tables["SiteTable"].cells.staticTexts[SuggestedSite5].exists) {
@@ -127,7 +127,7 @@ class SearchTests: BaseTestCase {
         // Copy, Paste and Go to url
         navigator.goto(URLBarOpen)
         typeOnSearchBar(text: "www.mozilla.org")
-        app.textFields["address"].press(forDuration: 5)
+        urlBarAddress.press(forDuration: 5)
         app.menuItems["Select All"].tap()
         mozWaitForElementToExist(app.menuItems["Copy"])
         app.menuItems["Copy"].tap()
@@ -140,8 +140,8 @@ class SearchTests: BaseTestCase {
         )
         mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url])
         app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
-        mozWaitForElementToExist(app.textFields["address"])
-        app.textFields["address"].tap()
+        mozWaitForElementToExist(urlBarAddress)
+        urlBarAddress.tap()
 
         mozWaitForElementToExist(app.menuItems["Paste"])
         app.menuItems["Paste"].tap()
@@ -161,8 +161,8 @@ class SearchTests: BaseTestCase {
         navigator.nowAt(HomePanelsScreen)
         waitForTabsButton()
         typeOnSearchBar(text: "moz")
-        mozWaitForValueContains(app.textFields["address"], value: "mozilla.org")
-        let value = app.textFields["address"].value
+        mozWaitForValueContains(urlBarAddress, value: "mozilla.org")
+        let value = urlBarAddress.value
         XCTAssertEqual(value as? String, "mozilla.org")
     }
 
@@ -258,13 +258,13 @@ class SearchTests: BaseTestCase {
             mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
             app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].tap()
 
-            let addressBar = app.textFields["address"]
+            let addressBar = urlBarAddress
             mozWaitForElementToExist(addressBar)
             XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
             let keyboardCount = app.keyboards.count
             XCTAssert(keyboardCount > 0, "The keyboard is not shown")
 
-            app.textFields["address"].typeText("www.google.com\n")
+            urlBarAddress.typeText("www.google.com\n")
             waitUntilPageLoad()
 
             // Reload icon is displayed.
@@ -371,7 +371,6 @@ class SearchTests: BaseTestCase {
         app.tables.buttons["appendUpLeftLarge"].firstMatch.tap()
 
         // The search suggestion fills the URL bar but does not conduct the search
-        let urlBarAddress = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.searchTextField]
         waitForValueContains(urlBarAddress, value: "g")
         XCTAssertEqual(app.tables.cells.count, 4, "There should be 4 search suggestions")
 
@@ -440,7 +439,7 @@ class SearchTests: BaseTestCase {
     }
 
     private func validateUrlHasFocusAndKeyboardIsDisplayed() {
-        let addressBar = app.textFields["address"]
+        let addressBar = urlBarAddress
         XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
         let keyboardCount = app.keyboards.count
         XCTAssert(keyboardCount > 0, "The keyboard is not shown")
@@ -465,7 +464,7 @@ class SearchTests: BaseTestCase {
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 //        navigator.goto(URLBarOpen)
-//        app.textFields["address"].typeText("ex")
+//        urlBarAddress.typeText("ex")
 //
 //        let dimmingView = app.otherElements[AccessibilityIdentifiers.PrivateMode.dimmingView]
 //        mozWaitForElementToExist(dimmingView)
@@ -484,7 +483,7 @@ class SearchTests: BaseTestCase {
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 //        navigator.goto(URLBarOpen)
-//        app.textFields["address"].typeText("ex")
+//        urlBarAddress.typeText("ex")
 //
 //        mozWaitForElementToNotExist(dimmingView)
 //        mozWaitForElementToExist(app.tables["SiteTable"])
@@ -509,7 +508,7 @@ class SearchTests: BaseTestCase {
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 //        navigator.goto(URLBarOpen)
-//        app.textFields["address"].typeText("ex")
+//        urlBarAddress.typeText("ex")
 //
 //        let dimmingView = app.otherElements[AccessibilityIdentifiers.PrivateMode.dimmingView]
 //        mozWaitForElementToExist(dimmingView)
@@ -528,7 +527,7 @@ class SearchTests: BaseTestCase {
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
 //        navigator.goto(URLBarOpen)
-//        app.textFields["address"].typeText("ex")
+//        urlBarAddress.typeText("ex")
 //
 //        mozWaitForElementToNotExist(dimmingView)
 //        mozWaitForElementToExist(app.tables["SiteTable"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -86,9 +86,9 @@ class ToolbarTests: BaseTestCase {
 
         // Simulate pressing on backspace key should remove the text
         app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
-        app.textFields["address"].typeText("\u{8}")
+        urlBarAddress.typeText("\u{8}")
 
-        let value = app.textFields["address"].value
+        let value = urlBarAddress.value
         XCTAssertEqual(value as? String, "", "The url has not been removed correctly")
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
@@ -35,12 +35,11 @@ class UrlBarTests: BaseTestCase {
         waitUntilPageLoad()
         app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].tap()
         // The keyboard is brought up.
-        let addressBar = app.textFields["address"]
-        XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
+        XCTAssertTrue(urlBarAddress.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
         // Scroll on the page
         app.swipeUp()
         // The keyboard is dismissed
-        XCTAssertFalse(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? true)
+        XCTAssertFalse(urlBarAddress.value(forKey: "hasKeyboardFocus") as? Bool ?? true)
         // Select the tab tray and add a new tab
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
@@ -77,21 +76,20 @@ class UrlBarTests: BaseTestCase {
         waitForTabsButton()
         app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].tap()
         // The keyboard pops up and the default search icon is correctly displayed in the URL bar
-        let addressBar = app.textFields["address"]
-        XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
+        XCTAssertTrue(urlBarAddress.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
         let keyboardCount = app.keyboards.count
         XCTAssert(keyboardCount > 0, "The keyboard is not shown")
         if iPad() {
             XCTAssertTrue(iPadSearchIcon.exists)
-            XCTAssertTrue(iPadSearchIcon.isLeftOf(rightElement: addressBar))
+            XCTAssertTrue(iPadSearchIcon.isLeftOf(rightElement: urlBarAddress))
         } else {
             XCTAssertTrue(iPhoneSearchIcon.exists)
-            XCTAssertTrue(iPhoneSearchIcon.isLeftOf(rightElement: addressBar))
+            XCTAssertTrue(iPhoneSearchIcon.isLeftOf(rightElement: urlBarAddress))
         }
     }
 
     private func typeSearchTermAndHitGo(searchTerm: String) {
-        app.textFields["address"].typeText(searchTerm)
+        urlBarAddress.typeText(searchTerm)
         waitUntilPageLoad()
         mozWaitForElementToExist(app.buttons["Go"])
         app.buttons["Go"].tap()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3715

## :bulb: Description
Replaced all the app.textFields["address"] with an accessibility identifier.
This will be helpful in the future to replace the string only in one place rather all of them. (ex: toolbar redesign feature)
