### PR TITLE
Add FXIOS-9627-[Native Error Page] Initial changes for manager support

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -577,7 +577,11 @@
 		60D71AEC26AAF45E00355588 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D71AEB26AAF45E00355588 /* UIColorExtension.swift */; };
 		630FE1342C7FB42500D9D6B2 /* NativeErrorPageMockModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1302C7FB42500D9D6B2 /* NativeErrorPageMockModel.swift */; };
 		630FE1352C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1322C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift */; };
+		631A369F2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */; };
+		631A36A32CC0B2470044DFEB /* NativeErrorPageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A36A22CC0B2470044DFEB /* NativeErrorPageHelper.swift */; };
 		63306D3921103EAE00F25400 /* LegacySavedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63306D3821103EAE00F25400 /* LegacySavedTab.swift */; };
+		63B213282CCA796D00A466DB /* NativeErrorPageAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B213272CCA796D00A466DB /* NativeErrorPageAction.swift */; };
+		63B2132A2CCA797400A466DB /* NativeErrorPageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B213292CCA797400A466DB /* NativeErrorPageState.swift */; };
 		63F7A9AA2C7529ED005846F5 /* NativeErrorPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F7A9A92C7529ED005846F5 /* NativeErrorPageModel.swift */; };
 		63F7A9AC2C752BB0005846F5 /* NativeErrorPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F7A9AB2C752BB0005846F5 /* NativeErrorPageViewController.swift */; };
 		6669B5E2211418A200CA117B /* WebsiteDataSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6669B5E1211418A200CA117B /* WebsiteDataSearchResultsViewController.swift */; };
@@ -6580,9 +6584,13 @@
 		63094229AA6EC744599B77A4 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		630FE1302C7FB42500D9D6B2 /* NativeErrorPageMockModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeErrorPageMockModel.swift; sourceTree = "<group>"; };
 		630FE1322C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeErrorPageViewControllerTests.swift; sourceTree = "<group>"; };
+		631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeErrorPageMiddleware.swift; sourceTree = "<group>"; };
+		631A36A22CC0B2470044DFEB /* NativeErrorPageHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeErrorPageHelper.swift; sourceTree = "<group>"; };
 		63306D3821103EAE00F25400 /* LegacySavedTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacySavedTab.swift; sourceTree = "<group>"; };
 		634148899F41CAA3BCF71E8B /* or */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = or; path = or.lproj/Localizable.strings; sourceTree = "<group>"; };
 		63B04BE882C41584580E0E59 /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = "fa.lproj/Default Browser.strings"; sourceTree = "<group>"; };
+		63B213272CCA796D00A466DB /* NativeErrorPageAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeErrorPageAction.swift; sourceTree = "<group>"; };
+		63B213292CCA797400A466DB /* NativeErrorPageState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeErrorPageState.swift; sourceTree = "<group>"; };
 		63F7A9A92C7529ED005846F5 /* NativeErrorPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeErrorPageModel.swift; sourceTree = "<group>"; };
 		63F7A9AB2C752BB0005846F5 /* NativeErrorPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeErrorPageViewController.swift; sourceTree = "<group>"; };
 		63FE433D87018CDDFCF592E3 /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/ErrorPages.strings; sourceTree = "<group>"; };
@@ -10609,6 +10617,10 @@
 			isa = PBXGroup;
 			children = (
 				63F7A9A92C7529ED005846F5 /* NativeErrorPageModel.swift */,
+				63B213292CCA797400A466DB /* NativeErrorPageState.swift */,
+				63B213272CCA796D00A466DB /* NativeErrorPageAction.swift */,
+				631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */,
+				631A36A22CC0B2470044DFEB /* NativeErrorPageHelper.swift */,
 				63F7A9AB2C752BB0005846F5 /* NativeErrorPageViewController.swift */,
 			);
 			path = NativeErrorPage;
@@ -15859,6 +15871,7 @@
 				8A454D432CB9B8F5009436D9 /* TopSitesManager.swift in Sources */,
 				7482205C1DBAB56300EEEA72 /* MailProviders.swift in Sources */,
 				8A93F87029D3A597004159D9 /* SceneCoordinator.swift in Sources */,
+				631A36A32CC0B2470044DFEB /* NativeErrorPageHelper.swift in Sources */,
 				C88E7A602A05551B0072E638 /* NimbusOnboardingFeatureLayerProtocol.swift in Sources */,
 				8CFD56882AAF057D003157A6 /* SwitchFakespotProduction.swift in Sources */,
 				C40046FA1CF8E0B200B08303 /* BackForwardListAnimator.swift in Sources */,
@@ -15907,6 +15920,7 @@
 				2386E4E624F8358E0072EF17 /* HomepageMessageCard.swift in Sources */,
 				21618A8C2A438A0900A5189E /* ActiveScreenAction.swift in Sources */,
 				E15DE7C2293A7AED00B32667 /* PhotonActionSheetLineSeparator.swift in Sources */,
+				631A369F2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift in Sources */,
 				8CE1E43A2B8C76C80026530B /* LoginListView.swift in Sources */,
 				8A832A9429DC99BA0025D5DD /* LaunchScreenViewController.swift in Sources */,
 				21E77E4E2AA8BA5200FABA10 /* TabTrayViewController.swift in Sources */,
@@ -15985,6 +15999,7 @@
 				0E77DF0F2CB8220000B80BA1 /* GeneratedPasswordStorage.swift in Sources */,
 				219A0FDB2ACCCFFC009A6D1A /* InactiveTabsSectionManager.swift in Sources */,
 				B2981F8A2B71AD7A00132C1B /* AutofillAccessoryViewButtonItem.swift in Sources */,
+				63B213282CCA796D00A466DB /* NativeErrorPageAction.swift in Sources */,
 				211F00AC27F4D918001D9189 /* HistoryPanel+Search.swift in Sources */,
 				8AF347E02CADD1C300624036 /* HomepageAction.swift in Sources */,
 				96EB6C3827D821B800A9D159 /* HistoryPanelViewModel.swift in Sources */,
@@ -16337,6 +16352,7 @@
 				3BF56D271CDBBE1F00AC4D75 /* SimpleToast.swift in Sources */,
 				8C4B0F5D2C076B12008B3E74 /* UpdatableAddressFields+Decodable.swift in Sources */,
 				C8B0F5F6283B7CCE007AE65D /* PocketStory.swift in Sources */,
+				63B2132A2CCA797400A466DB /* NativeErrorPageState.swift in Sources */,
 				8ADAE4222A33A113007BF926 /* SendAnonymousUsageDataSetting.swift in Sources */,
 				E170CA542B72C07A0082EFC5 /* FakespotActionFooterView.swift in Sources */,
 				C8EDDBF229DF1159003A4C07 /* URLScanner.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -872,9 +872,7 @@ class BrowserCoordinator: BaseCoordinator,
 
     func showNativeErrorPage(overlayManager: OverlayModeManager) {
         // TODO: FXIOS-9641 #21239 Integration with Redux - presenting view
-        let errorPageModel = ErrorPageModel(errorTitle: "", errorDecription: "", errorCode: "")
-        let errorpageController = NativeErrorPageViewController(model: errorPageModel,
-                                                                windowUUID: windowUUID,
+        let errorpageController = NativeErrorPageViewController(windowUUID: windowUUID,
                                                                 overlayManager: overlayManager)
         guard browserViewController.embedContent(errorpageController) else {
             logger.log("Unable to embed private homepage", level: .debug, category: .coordinator)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -187,6 +187,7 @@ class BrowserCoordinator: BaseCoordinator,
         }
 
         screenshotService.screenshotableView = webviewController
+        self.errorViewController = nil
     }
 
     func browserHasLoaded() {
@@ -872,10 +873,12 @@ class BrowserCoordinator: BaseCoordinator,
 
     func showNativeErrorPage(overlayManager: OverlayModeManager) {
         // TODO: FXIOS-9641 #21239 Integration with Redux - presenting view
-        let errorpageController = NativeErrorPageViewController(windowUUID: windowUUID,
-                                                                overlayManager: overlayManager)
+        let errorpageController = self.errorViewController ?? NativeErrorPageViewController(
+            windowUUID: windowUUID,
+            overlayManager: overlayManager
+        )
         guard browserViewController.embedContent(errorpageController) else {
-            logger.log("Unable to embed private homepage", level: .debug, category: .coordinator)
+            logger.log("Unable to embed error page", level: .debug, category: .coordinator)
             return
         }
         self.errorViewController = errorpageController

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -771,22 +771,21 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
-        if isNativeErrorPageEnabled {
-            guard var errorURLpath = URLComponents(string: "\(InternalURL.baseUrl)/\(ErrorPageHandler.path)" ) else { return }
-            errorURLpath.queryItems = [URLQueryItem(
-                name: InternalURL.Param.url.rawValue,
-                value: webView.url?.absoluteString
-            )]
-            guard let errorPageURL = errorURLpath.url else { return }
-            let action = NativeErrorPageAction(networkError: error,
-                                               windowUUID: windowUUID,
-                                               actionType: NativeErrorPageActionType.receivedError
-            )
-            store.dispatch(action)
-
-            webView.load(PrivilegedRequest(url: errorPageURL) as URLRequest)
-        } else {
-            if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
+        if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
+            if isNativeErrorPageEnabled {
+                guard var errorURLpath = URLComponents(string: "\(InternalURL.baseUrl)/\(ErrorPageHandler.path)" ) else { return }
+                errorURLpath.queryItems = [URLQueryItem(
+                    name: InternalURL.Param.url.rawValue,
+                    value: url.absoluteString
+                )]
+                guard let errorPageURL = errorURLpath.url else { return }
+                let action = NativeErrorPageAction(networkError: error,
+                                                   windowUUID: windowUUID,
+                                                   actionType: NativeErrorPageActionType.receivedError
+                )
+                store.dispatch(action)
+                webView.load(PrivilegedRequest(url: errorPageURL) as URLRequest)
+            } else {
                 ErrorPageHelper(certStore: profile.certStore).loadPage(error, forUrl: url, inWebView: webView)
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -134,6 +134,11 @@ class BrowserViewController: UIViewController,
     var isToolbarNavigationHintEnabled: Bool {
         return featureFlags.isFeatureEnabled(.toolbarNavigationHint, checking: .buildOnly)
     }
+
+    var isNativeErrorPageEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.nativeErrorPage, checking: .buildOnly)
+    }
+
     private var browserViewControllerState: BrowserViewControllerState?
 
     // Header stack view can contain the top url bar, top reader mode, top ZoomPageBar
@@ -1491,10 +1496,6 @@ class BrowserViewController: UIViewController,
 
     // MARK: - Native Error Page
 
-    private func isNativeErrorPage() -> Bool {
-        featureFlags.isFeatureEnabled(.nativeErrorPage, checking: .buildOnly)
-    }
-
     func showEmbeddedNativeErrorPage() {
     // TODO: FXIOS-9641 #21239 Implement Redux for Native Error Pages
         browserDelegate?.showNativeErrorPage(overlayManager: overlayManager)
@@ -1542,7 +1543,7 @@ class BrowserViewController: UIViewController,
 
         if isAboutHomeURL {
             showEmbeddedHomepage(inline: true, isPrivate: tabManager.selectedTab?.isPrivate ?? false)
-        } else if isErrorURL && isNativeErrorPage() {
+        } else if isErrorURL && isNativeErrorPageEnabled {
             showEmbeddedNativeErrorPage()
         } else {
             showEmbeddedWebview()

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageAction.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageAction.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import Common
+
+final class NativeErrorPageAction: Action {
+    let networkError: NSError?
+    let nativePageErrorModel: ErrorPageModel?
+    init(
+        networkError: NSError? = nil,
+        nativePageErrorModel: ErrorPageModel? = nil,
+        windowUUID: WindowUUID,
+        actionType: any ActionType
+    ) {
+        self.networkError = networkError
+        self.nativePageErrorModel = nativePageErrorModel
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
+
+enum NativeErrorPageActionType: ActionType {
+    case receivedError
+}
+
+enum NativeErrorPageMiddlewareActionType: ActionType {
+    case initialize
+}

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageAction.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageAction.swift
@@ -23,6 +23,7 @@ final class NativeErrorPageAction: Action {
 
 enum NativeErrorPageActionType: ActionType {
     case receivedError
+    case errorPageLoaded
 }
 
 enum NativeErrorPageMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageAction.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageAction.swift
@@ -8,6 +8,7 @@ import Common
 final class NativeErrorPageAction: Action {
     let networkError: NSError?
     let nativePageErrorModel: ErrorPageModel?
+
     init(
         networkError: NSError? = nil,
         nativePageErrorModel: ErrorPageModel? = nil,

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -27,6 +27,7 @@ class NativeErrorPageHelper {
     func parseErrorDetails() -> ErrorPageModel {
         var title = ""
         var description = ""
+
         switch error.code {
         case Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue):
             title = .NativeErrorPage.NoInternetConnection.TitleLabel

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import WebKit
+import GCDWebServers
+import Shared
+import Storage
+
+class NativeErrorPageHelper {
+    enum NetworkErrorType {
+        case noInternetConnection
+    }
+
+    var error: NSError
+
+    var errorDescriptionItem: String {
+        return error.localizedDescription
+    }
+
+    init(error: NSError) {
+        self.error = error
+    }
+
+    func parseErrorDetails() -> ErrorPageModel {
+        var title = ""
+        var description = ""
+        switch error.code {
+        case Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue):
+            title = .NativeErrorPage.NoInternetConnection.TitleLabel
+            description = .NativeErrorPage.NoInternetConnection.Description
+        default:
+            break
+        }
+
+        let model = ErrorPageModel(errorTitle: title, errorDescription: description)
+        return model
+    }
+}

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageMiddleware.swift
@@ -10,23 +10,23 @@ import Common
 final class NativeErrorPageMiddleware {
     lazy var nativeErrorPageProvider: Middleware<AppState> = { state, action in
         let windowUUID = action.windowUUID
-        print(action.actionType)
+
         switch action.actionType {
         case NativeErrorPageActionType.receivedError:
             guard let action = action as? NativeErrorPageAction, let error = action.networkError else {return}
             self.initializeNativeErrorPage(windowUUID: windowUUID, error: error)
             break
         default:
-           break
+            break
         }
     }
 
     private func initializeNativeErrorPage(windowUUID: WindowUUID, error: NSError) {
         let model = NativeErrorPageHelper(error: error).parseErrorDetails()
-        let newAction = NativeErrorPageAction(nativePageErrorModel: model,
-                                              windowUUID: windowUUID,
-                                              actionType: NativeErrorPageMiddlewareActionType.initialize
+
+        store.dispatch(NativeErrorPageAction(nativePageErrorModel: model,
+                                             windowUUID: windowUUID,
+                                             actionType: NativeErrorPageMiddlewareActionType.initialize)
         )
-        store.dispatch(newAction)
     }
 }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageMiddleware.swift
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Redux
+import Shared
+import Common
+
+final class NativeErrorPageMiddleware {
+    lazy var nativeErrorPageProvider: Middleware<AppState> = { state, action in
+        let windowUUID = action.windowUUID
+        print(action.actionType)
+        switch action.actionType {
+        case NativeErrorPageActionType.receivedError:
+            guard let action = action as? NativeErrorPageAction, let error = action.networkError else {return}
+            self.initializeNativeErrorPage(windowUUID: windowUUID, error: error)
+            break
+        default:
+           break
+        }
+    }
+
+    private func initializeNativeErrorPage(windowUUID: WindowUUID, error: NSError) {
+        let model = NativeErrorPageHelper(error: error).parseErrorDetails()
+        let newAction = NativeErrorPageAction(nativePageErrorModel: model,
+                                              windowUUID: windowUUID,
+                                              actionType: NativeErrorPageMiddlewareActionType.initialize
+        )
+        store.dispatch(newAction)
+    }
+}

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
@@ -4,8 +4,7 @@
 
 import Foundation
 
-struct ErrorPageModel {
+struct ErrorPageModel: Equatable {
     let errorTitle: String
-    let errorDecription: String
-    let errorCode: String
+    let errorDescription: String
 }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
@@ -39,12 +39,13 @@ struct NativeErrorPageState: ScreenState, Equatable {
     }
 
     static let reducer: Reducer<Self> = { state, action in
-        print(action.actionType)
-        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return NativeErrorPageState(
-            windowUUID: state.windowUUID,
-            title: state.title,
-            description: state.description
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else {
+            return NativeErrorPageState(
+                windowUUID: state.windowUUID,
+                title: state.title,
+                description: state.description
         )}
+
         switch action.actionType {
         case NativeErrorPageMiddlewareActionType.initialize:
             guard let action = action as? NativeErrorPageAction, let model = action.nativePageErrorModel else {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import Shared
+import Common
+
+struct NativeErrorPageState: ScreenState, Equatable {
+    var windowUUID: WindowUUID
+    var title: String?
+    var description: String?
+
+    init(appState: AppState, uuid: WindowUUID) {
+        guard let nativeErrorPageState = store.state.screenState(
+            NativeErrorPageState.self,
+            for: .nativeErrorPage,
+            window: uuid
+        ) else {
+            self.init(windowUUID: uuid)
+            return
+        }
+
+        self.init(
+            windowUUID: nativeErrorPageState.windowUUID,
+            title: nativeErrorPageState.title,
+            description: nativeErrorPageState.description
+        )
+    }
+
+    init(
+        windowUUID: WindowUUID,
+        title: String? = nil,
+        description: String? = nil
+    ) {
+        self.windowUUID = windowUUID
+        self.title = title
+        self.description = description
+    }
+
+    static let reducer: Reducer<Self> = { state, action in
+        print(action.actionType)
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else { return NativeErrorPageState(
+            windowUUID: state.windowUUID,
+            title: state.title,
+            description: state.description
+        )}
+        switch action.actionType {
+        case NativeErrorPageMiddlewareActionType.initialize:
+            guard let action = action as? NativeErrorPageAction, let model = action.nativePageErrorModel else {
+                return NativeErrorPageState(
+                    windowUUID: state.windowUUID,
+                    title: state.title,
+                    description: state.description
+                )
+            }
+            return NativeErrorPageState(
+                windowUUID: state.windowUUID,
+                title: model.errorTitle,
+                description: model.errorDescription
+            )
+        default:
+            return NativeErrorPageState(
+                windowUUID: state.windowUUID,
+                title: state.title,
+                description: state.description
+            )
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -127,11 +127,9 @@ final class NativeErrorPageViewController: UIViewController,
 
     // MARK: Redux
     func newState(state: NativeErrorPageState) {
-//        if state.title != nil {
-            nativeErrorPageState = state
-            titleLabel.text = state.title
-            errorDescriptionLabel.text = state.description
-//        }
+        nativeErrorPageState = state
+        titleLabel.text = state.title
+        errorDescriptionLabel.text = state.description
     }
 
     func subscribeToRedux() {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -10,8 +10,9 @@ import Shared
 
 final class NativeErrorPageViewController: UIViewController,
                                            Themeable,
-                                           ContentContainable {
-    private let model: ErrorPageModel
+                                           ContentContainable,
+                                           StoreSubscriber {
+    typealias SubscriberStateType = NativeErrorPageState
     private let windowUUID: WindowUUID
 
     // MARK: Themable Variables
@@ -24,6 +25,7 @@ final class NativeErrorPageViewController: UIViewController,
 
     private var overlayManager: OverlayModeManager
     var contentType: ContentType = .nativeErrorPage
+    private var nativeErrorPageState: NativeErrorPageState
 
     // MARK: UI Elements
     private struct UX {
@@ -80,7 +82,6 @@ final class NativeErrorPageViewController: UIViewController,
         label.adjustsFontForContentSizeCategory = true
         label.font = FXFontStyles.Bold.title2.scaledFont()
         label.numberOfLines = 0
-        label.text = .NativeErrorPage.NoInternetConnection.TitleLabel
         label.textAlignment = .left
     }
 
@@ -88,7 +89,6 @@ final class NativeErrorPageViewController: UIViewController,
         label.adjustsFontForContentSizeCategory = true
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
-        label.text = .NativeErrorPage.NoInternetConnection.Description
         label.textAlignment = .left
     }
 
@@ -101,35 +101,65 @@ final class NativeErrorPageViewController: UIViewController,
     private var iPhoneContraintsList = [NSLayoutConstraint]()
     private var iPadContraintsList = [NSLayoutConstraint]()
 
-    required init?(
-        coder aDecoder: NSCoder
-    ) {
-        fatalError(
-            "init(coder:) has not been implemented"
-        )
-    }
-
     init(
-        model: ErrorPageModel,
         windowUUID: WindowUUID,
         themeManager: ThemeManager = AppContainer.shared.resolve(),
         overlayManager: OverlayModeManager,
         notificationCenter: NotificationProtocol = NotificationCenter.default
     ) {
-        self.model = model
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.overlayManager = overlayManager
         self.notificationCenter = notificationCenter
+        nativeErrorPageState = NativeErrorPageState(windowUUID: windowUUID)
+
         super.init(
             nibName: nil,
             bundle: nil
         )
 
+        subscribeToRedux()
         configureUI()
         setupLayout()
         adjustConstraints()
         showViewForCurrentOrientation()
+    }
+
+    // MARK: Redux
+    func newState(state: NativeErrorPageState) {
+//        if state.title != nil {
+            nativeErrorPageState = state
+            titleLabel.text = state.title
+            errorDescriptionLabel.text = state.description
+//        }
+    }
+
+    func subscribeToRedux() {
+        let action = ScreenAction(windowUUID: windowUUID,
+                                  actionType: ScreenActionType.showScreen,
+                                  screen: .nativeErrorPage)
+        store.dispatch(action)
+        let uuid = windowUUID
+        store.subscribe(self, transform: {
+            return $0.select({ appState in
+                return NativeErrorPageState(appState: appState, uuid: uuid)
+            })
+        })
+    }
+
+    func unsubscribeFromRedux() {
+        let action = ScreenAction(windowUUID: windowUUID,
+                                  actionType: ScreenActionType.closeScreen,
+                                  screen: .nativeErrorPage)
+        store.dispatch(action)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        unsubscribeFromRedux()
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -164,6 +164,10 @@ final class NativeErrorPageViewController: UIViewController,
         super.viewDidLoad()
         listenForThemeChange(view)
         applyTheme()
+        store.dispatch(NativeErrorPageAction( windowUUID: windowUUID,
+                                              actionType: NativeErrorPageActionType.errorPageLoaded
+                                            )
+        )
     }
 
     override func viewWillTransition(

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenAction.swift
@@ -34,6 +34,7 @@ enum AppScreen {
     case toolbar
     case searchEngineSelection
     case passwordGenerator
+    case nativeErrorPage
 }
 
 enum ScreenActionType: ActionType {

--- a/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/ActiveScreenState.swift
@@ -23,6 +23,7 @@ enum AppScreenState: Equatable {
     case toolbar(ToolbarState)
     case searchEngineSelection(SearchEngineSelectionState)
     case passwordGenerator(PasswordGeneratorState)
+    case nativeErrorPage(NativeErrorPageState)
 
     static let reducer: Reducer<Self> = { state, action in
         switch state {
@@ -56,6 +57,8 @@ enum AppScreenState: Equatable {
             return .searchEngineSelection(SearchEngineSelectionState.reducer(state, action))
         case .passwordGenerator(let state):
             return .passwordGenerator(PasswordGeneratorState.reducer(state, action))
+        case .nativeErrorPage(let state):
+            return .nativeErrorPage(NativeErrorPageState.reducer(state, action))
         }
     }
 
@@ -77,6 +80,7 @@ enum AppScreenState: Equatable {
         case .toolbar: return .toolbar
         case .searchEngineSelection: return .searchEngineSelection
         case .passwordGenerator: return .passwordGenerator
+        case .nativeErrorPage: return .nativeErrorPage
         }
     }
 
@@ -97,6 +101,7 @@ enum AppScreenState: Equatable {
         case .toolbar(let state): return state.windowUUID
         case .searchEngineSelection(let state): return state.windowUUID
         case .passwordGenerator(let state): return state.windowUUID
+        case .nativeErrorPage(let state): return state.windowUUID
         }
     }
 }
@@ -165,6 +170,8 @@ struct ActiveScreensState: Equatable {
                 screens.append(.searchEngineSelection(SearchEngineSelectionState(windowUUID: uuid)))
             case .passwordGenerator:
                 screens.append(.passwordGenerator(PasswordGeneratorState(windowUUID: uuid)))
+            case .nativeErrorPage:
+                screens.append(.nativeErrorPage(NativeErrorPageState(windowUUID: uuid)))
             }
         default:
             return screens

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -33,6 +33,7 @@ struct AppState: StateType {
                 case (.searchEngineSelection(let state), .searchEngineSelection): return state as? S
                 case (.trackingProtection(let state), .trackingProtection): return state as? S
                 case (.passwordGenerator(let state), .passwordGenerator): return state as? S
+                case (.nativeErrorPage(let state), .nativeErrorPage): return state as? S
                 default: return nil
                 }
             }.first(where: {
@@ -68,7 +69,8 @@ let middlewares = [
     TopSitesMiddleware().topSitesProvider,
     TrackingProtectionMiddleware().trackingProtectionProvider,
     PasswordGeneratorMiddleware().passwordGeneratorProvider,
-    PocketMiddleware().pocketSectionProvider
+    PocketMiddleware().pocketSectionProvider,
+    NativeErrorPageMiddleware().nativeErrorPageProvider
 ]
 
 // In order for us to mock and test the middlewares easier,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/Mock/NativeErrorPageMockModel.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/Mock/NativeErrorPageMockModel.swift
@@ -9,8 +9,7 @@ final class NativeErrorPageMock {
     static var model: ErrorPageModel {
         return ErrorPageModel(
             errorTitle: "NoInternetConnection",
-            errorDecription: "There’s a problem with your internet connection.",
-            errorCode: "-1009"
+            errorDescription: "There’s a problem with your internet connection."
         )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageViewControllerTests.swift
@@ -23,7 +23,6 @@ final class NativeErrorPageViewControllerTests: XCTestCase {
     func testNativeErrorPageViewController_simpleCreation_hasNoLeaks() {
         let overlayManager = MockOverlayModeManager()
         let nativeErrroPageViewController = NativeErrorPageViewController(
-            model: NativeErrorPageMock.model,
             windowUUID: windowUUID,
             overlayManager: overlayManager
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9627)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21220)

## :bulb: Description
Added Native error page action, middleware, state and helper for NIC error.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

