### PR TITLE
Bugfix MTE-3713 Pin Python version for gsutil

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1469,6 +1469,12 @@ workflows:
               bash install.sh --disable-prompts
               source $HOME/google-cloud-sdk/path.bash.inc
             fi
+    - script@1:
+        title: Pin Python version
+        content: |-
+            brew unlink python@3.12
+            brew unlink python@3.11
+            brew link --force python@3.11
     - cache-push@2.7.1:
         inputs:
         - cache_paths: "$HOME/google-cloud-sdk"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3713)

## :bulb: Description
`Firebase_Performance_Test` Bitrise workflow stopped working during this week because Google Cloud CLI has an update. The current version of `gsutil` command relies on Python 3.5-3.11, but the default Python version on the Bitrise stack is 3.12.

A solution would be ensure Python 3.11 is the default version being used in the workflow. Since this version has been installed in the stack (see https://stacks.bitrise.io/stack_reports/osx-xcode-15.4.x/) via `brew`🍺 , let's use the `brew` way to ensure that 3.11 is the default Python version.

Bitrise workflow on this branch:
https://app.bitrise.io/build/ead2cb3c-c745-49c1-886d-f4856dbdf80b?tab=log

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

