### PR TITLE
Fix FXIOS-10286 - Adjust textarea row height based on font size

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.mjs
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.mjs
@@ -58,7 +58,8 @@ const init = (record, l10nStrings, isDarkTheme = false) => {
   );
 
   document.querySelectorAll("textarea").forEach((textarea) => {
-    autoResizeTextarea(textarea);
+    const rowHeight = document.querySelector("input").clientHeight;
+    autoResizeTextarea(textarea, rowHeight);
     textarea.addEventListener("input", () => autoResizeTextarea(textarea));
   });
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10286)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22535)

## :bulb: Description
This PR:
- Accounts for larger font sizes when rendering text areas instead of always defaulting to `22`.

### 📷 Screenshots
| Before | After |
| ------------- | ------------- |
| <img width="425" alt="Screenshot 2024-10-17 at 22 56 41" src="https://github.com/user-attachments/assets/e9eef8ef-7fec-4bb0-ad86-49c8ae7e6f7c"> | <img width="425" alt="Screenshot 2024-10-17 at 22 54 58" src="https://github.com/user-attachments/assets/7db6bd14-3b41-46c2-bbbd-82541d7e0f5e"> |



## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

