### PR TITLE
Fix MTE-3719 - l10n-screenshots tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
@@ -136,7 +136,7 @@ private func createTestGraph(for test: XCTestCase, with app: XCUIApplication) ->
     map.addScreenState(URLBarOpen) { screenState in
         screenState.gesture(forAction: TestActions.LoadURLByTyping, TestActions.LoadURL) { userState in
             let urlString = userState.url ?? defaultURL
-            urlBarAddress.typeText("\(urlString)\r")
+            app.textFields[AccessibilityIdentifiers.Browser.UrlBar.searchTextField].typeText("\(urlString)\r")
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3719

## :bulb: Description
https://github.com/mozilla-mobile/firefox-ios/pull/22608 caused l10n-screenshots tests to fail.
ScreenGraphTest class is not inheriting BaseTestCase class, so its need its own path to "address" string
<img width="697" alt="Screenshot 2024-10-18 at 11 13 04" src="https://github.com/user-attachments/assets/6714fc5f-89c6-4233-bd96-9506d4144e1d">

