### PR TITLE
Add FXIOS-9649 - Password Generator: Use strong password keyboard button

### DIFF
--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -7,7 +7,7 @@ import Common
 import Shared
 
 enum AccessoryType {
-    case standard, creditCard, address, login
+    case standard, creditCard, address, login, passwordGenerator
 }
 
 class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
@@ -35,6 +35,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
     var savedCardsClosure: (() -> Void)?
     var savedAddressesClosure: (() -> Void)?
     var savedLoginsClosure: (() -> Void)?
+    var useStrongPasswordClosure: (() -> Void)?
 
     // MARK: - UI Elements
     private let toolbar: UIToolbar = .build {
@@ -127,6 +128,20 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
         return accessoryView
     }()
 
+    private lazy var passwordGeneratorView: AutofillAccessoryViewButtonItem = {
+        let accessoryView = AutofillAccessoryViewButtonItem(
+            image: UIImage(named: StandardImageIdentifiers.Large.login),
+            labelText: .PasswordGenerator.KeyboardAccessoryButtonLabel,
+            tappedAction: { [weak self] in
+                self?.tappedUseStrongPasswordButton()
+            })
+        accessoryView.accessibilityTraits = .button
+        accessoryView.accessibilityLabel = .PasswordAutofill.UseSavedPasswordFromKeyboard
+        accessoryView.accessibilityIdentifier = AccessibilityIdentifiers.Autofill.footerPrimaryAction
+        accessoryView.isAccessibilityElement = true
+        return accessoryView
+    }()
+
     // MARK: - Initialization
     init(themeManager: ThemeManager = AppContainer.shared.resolve(),
          windowUUID: WindowUUID,
@@ -169,6 +184,8 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
             currentAccessoryView = addressAutofillView
         case .login:
             currentAccessoryView = loginAutofillView
+        case .passwordGenerator:
+            currentAccessoryView = passwordGeneratorView
         }
 
         setNeedsLayout()
@@ -224,7 +241,7 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
             $0.customView?.tintColor = theme.colors.iconAccentBlue
         }
 
-        [creditCardAutofillView, addressAutofillView, loginAutofillView].forEach {
+        [creditCardAutofillView, addressAutofillView, loginAutofillView, passwordGeneratorView].forEach {
             $0.accessoryImageViewTintColor = theme.colors.iconPrimary
             $0.backgroundColor = theme.colors.layer5Hover
         }
@@ -260,6 +277,11 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
     @objc
     private func tappedLoginsButton() {
         savedLoginsClosure?()
+    }
+
+    @objc
+    private func tappedUseStrongPasswordButton() {
+        useStrongPasswordClosure?()
     }
 
     // MARK: - Telemetry

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -221,5 +221,5 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
 }
 
 extension PasswordGeneratorViewController: BottomSheetChild {
-    func willDismiss() { }
+    func willDismiss() { currentTab.webView?.accessoryView.reloadViewFor(.standard)}
 }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -42,6 +42,8 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
 
     public var foundFieldValues: ((FocusFieldType, String) -> Void)?
 
+    public var passwordFieldInteraction: (() -> Void)?
+
     // Exposed for mocking purposes
     var logins: RustLogins {
         return profile.logins
@@ -126,10 +128,20 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
 
         if self.featureFlags.isFeatureEnabled(.passwordGenerator, checking: .buildOnly) {
             if type == "generatePassword", let tab = self.tab, !tab.isPrivate {
-                let newAction = GeneralBrowserAction(
-                    windowUUID: tab.windowUUID,
-                    actionType: GeneralBrowserActionType.showPasswordGenerator)
-                store.dispatch(newAction)
+                let userDefaults = UserDefaults.standard
+                let showPassGenClosure = {
+                    let newAction = GeneralBrowserAction(
+                        windowUUID: tab.windowUUID,
+                        actionType: GeneralBrowserActionType.showPasswordGenerator)
+                    store.dispatch(newAction)
+                }
+                if userDefaults.value(forKey: PrefsKeys.PasswordGeneratorShown) == nil {
+                    userDefaults.set(true, forKey: PrefsKeys.PasswordGeneratorShown)
+                    showPassGenClosure()
+                } else {
+                    tab.webView?.accessoryView.useStrongPasswordClosure = showPassGenClosure
+                    tab.webView?.accessoryView.reloadViewFor(.passwordGenerator)
+                }
             }
         }
 

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -129,7 +129,7 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
         if self.featureFlags.isFeatureEnabled(.passwordGenerator, checking: .buildOnly) {
             if type == "generatePassword", let tab = self.tab, !tab.isPrivate {
                 let userDefaults = UserDefaults.standard
-                let showPassGenClosure = {
+                let showPasswordGeneratorClosure = {
                     let newAction = GeneralBrowserAction(
                         windowUUID: tab.windowUUID,
                         actionType: GeneralBrowserActionType.showPasswordGenerator)
@@ -137,9 +137,9 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
                 }
                 if userDefaults.value(forKey: PrefsKeys.PasswordGeneratorShown) == nil {
                     userDefaults.set(true, forKey: PrefsKeys.PasswordGeneratorShown)
-                    showPassGenClosure()
+                    showPasswordGeneratorClosure()
                 } else {
-                    tab.webView?.accessoryView.useStrongPasswordClosure = showPassGenClosure
+                    tab.webView?.accessoryView.useStrongPasswordClosure = showPasswordGeneratorClosure
                     tab.webView?.accessoryView.reloadViewFor(.passwordGenerator)
                 }
             }

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -189,6 +189,8 @@ public struct PrefsKeys {
 
     // Used to show splash screen only during first time on fresh install
     public static let splashScreenShownKey = "splashScreenShownKey"
+
+    public static let PasswordGeneratorShown = "PasswordGeneratorShown"
 }
 
 public protocol Prefs {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9649)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21251)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Adds the Keyboard Accessory button for showing the password generator prompt when accessing the password field of a signup form. 

**Intended Behaviour:**

- When a device first interacts with the password field of a signup form after downloading the app: Show the password generator prompt automatically
- Any other time a user interacts with the password field of a signup form: Show the password generator keyboard accessory button, allowing the user to open the password generator prompt

Known (non-blocking) bug: https://mozilla-hub.atlassian.net/browse/FXIOS-10332

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

