### PR TITLE
Add FXIOS-10271 - Password Generator: Clear generated password upon form submission

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
@@ -23,13 +23,19 @@ final class PasswordGeneratorMiddleware {
         switch action.actionType {
         case PasswordGeneratorActionType.showPasswordGenerator:
             self.showPasswordGenerator(tab: currentTab, windowUUID: windowUUID)
+
         case PasswordGeneratorActionType.userTappedUsePassword:
             guard let password = state.screenState(PasswordGeneratorState.self,
                                                    for: .passwordGenerator,
                                                    window: action.windowUUID)?.password else {return}
             self.userTappedUsePassword(with: currentTab, password: password)
+
         case PasswordGeneratorActionType.userTappedRefreshPassword:
             self.userTappedRefreshPassword(with: currentTab, windowUUID: windowUUID)
+
+        case PasswordGeneratorActionType.clearGeneratedPasswordForSite:
+            self.clearGeneratedPasswordForSite(with: currentTab, windowUUID: windowUUID)
+
         default:
             break
         }
@@ -95,5 +101,10 @@ final class PasswordGeneratorMiddleware {
             )
             store.dispatch(newAction)
         })
+    }
+
+    private func clearGeneratedPasswordForSite(with tab: Tab, windowUUID: WindowUUID) {
+        guard let origin = tab.url?.origin else {return}
+        generatedPasswordStorage.deletePasswordForOrigin(origin: origin)
     }
 }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -125,8 +125,7 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
         else { return }
 
         if self.featureFlags.isFeatureEnabled(.passwordGenerator, checking: .buildOnly) {
-            if type == "generatePassword" {
-                guard let tab = self.tab, !tab.isPrivate else {return}
+            if type == "generatePassword", let tab = self.tab, !tab.isPrivate {
                 let newAction = GeneralBrowserAction(
                     windowUUID: tab.windowUUID,
                     actionType: GeneralBrowserActionType.showPasswordGenerator)
@@ -268,6 +267,11 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
         ) { bar in
             self.tab?.removeSnackbar(bar)
             self.snackBar = nil
+            guard let windowUUID = self.tab?.windowUUID else {return}
+            let action = PasswordGeneratorAction(windowUUID: windowUUID,
+                                                 actionType: PasswordGeneratorActionType.clearGeneratedPasswordForSite,
+                                                 currentTab: self.tab)
+            store.dispatch(action)
             return
         }
         let save = SnackButton(
@@ -279,6 +283,11 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
             self.snackBar = nil
             self.sendLoginsSavedTelemetry()
             self.profile.logins.addLogin(login: login, completionHandler: { _ in })
+            guard let windowUUID = self.tab?.windowUUID else {return}
+            let action = PasswordGeneratorAction(windowUUID: windowUUID,
+                                                 actionType: PasswordGeneratorActionType.clearGeneratedPasswordForSite,
+                                                 currentTab: self.tab)
+            store.dispatch(action)
         }
 
         applyTheme(for: dontSave, save)

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -245,7 +245,7 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
     private func promptSave(_ login: LoginEntry) {
         guard login.isValid.isSuccess else { return }
 
-        clearStoredPassword()
+        clearStoredPasswordPassGen()
 
         let promptMessage: String
         let https = "^https:\\/\\/"
@@ -341,7 +341,7 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
         currentRequestId = requestId
     }
 
-    private func clearStoredPassword() {
+    private func clearStoredPasswordPassGen() {
         if let windowUUID = self.tab?.windowUUID {
             let action = PasswordGeneratorAction(windowUUID: windowUUID,
                                                  actionType: PasswordGeneratorActionType.clearGeneratedPasswordForSite,

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -245,7 +245,7 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
     private func promptSave(_ login: LoginEntry) {
         guard login.isValid.isSuccess else { return }
 
-        clearStoredPasswordPassGen()
+        clearStoredPasswordAfterGeneration()
 
         let promptMessage: String
         let https = "^https:\\/\\/"
@@ -341,7 +341,7 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
         currentRequestId = requestId
     }
 
-    private func clearStoredPasswordPassGen() {
+    private func clearStoredPasswordAfterGeneration() {
         if let windowUUID = self.tab?.windowUUID {
             let action = PasswordGeneratorAction(windowUUID: windowUUID,
                                                  actionType: PasswordGeneratorActionType.clearGeneratedPasswordForSite,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10271)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22486)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
After using the password generator to populate the password field of a signup form on an origin (recommended testing origin is twitch.tv)...
After submitting a password form, we want to remove the generated password from local storage. This is done so that next time a signup form is accessed at this origin, a new password is generated.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

