### PR TITLE
Add FXIOS-10164 [Homepage] More Pocket Section Tests

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -855,6 +855,9 @@
 		8A8629E2288096C40096DDB1 /* BookmarksFolderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */; };
 		8A8629E72880B7330096DDB1 /* LegacyBookmarksPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E52880B69C0096DDB1 /* LegacyBookmarksPanelTests.swift */; };
 		8A86DAD8277298DE00D7BFFF /* ClosedTabsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */; };
+		8A87B4322CC1A3C0003A9239 /* PocketManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A87B4302CC1A3BA003A9239 /* PocketManagerTests.swift */; };
+		8A87B4342CC1A731003A9239 /* PocketMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A87B42E2CC1A3AA003A9239 /* PocketMiddlewareTests.swift */; };
+		8A87B4382CC1A92D003A9239 /* MockPocketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A87B4362CC1A910003A9239 /* MockPocketManager.swift */; };
 		8A88815A2B20FFE0009635AE /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A8881592B20FFE0009635AE /* GCDWebServers */; };
 		8A88815C2B2103AD009635AE /* WebEngine in Frameworks */ = {isa = PBXBuildFile; productRef = 8A88815B2B2103AD009635AE /* WebEngine */; };
 		8A88815E2B21071E009635AE /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A88815D2B21071E009635AE /* GCDWebServers */; };
@@ -7050,6 +7053,9 @@
 		8A8629E52880B69C0096DDB1 /* LegacyBookmarksPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyBookmarksPanelTests.swift; sourceTree = "<group>"; };
 		8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabsStoreTests.swift; sourceTree = "<group>"; };
 		8A87AEE02C1B4D17007428B2 /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
+		8A87B42E2CC1A3AA003A9239 /* PocketMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketMiddlewareTests.swift; sourceTree = "<group>"; };
+		8A87B4302CC1A3BA003A9239 /* PocketManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PocketManagerTests.swift; path = "firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/PocketManagerTests.swift"; sourceTree = SOURCE_ROOT; };
+		8A87B4362CC1A910003A9239 /* MockPocketManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPocketManager.swift; sourceTree = "<group>"; };
 		8A880C432C63CFE200B77F23 /* MockLoginViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoginViewModelDelegate.swift; sourceTree = "<group>"; };
 		8A8917682B57283B008B01EA /* LegacyHomepageHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHomepageHeaderCell.swift; sourceTree = "<group>"; };
 		8A8BAE152B2119E600D774EB /* InternalURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalURL.swift; sourceTree = "<group>"; };
@@ -10733,6 +10739,8 @@
 		8A00BD852CAB3FC200680AF9 /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
+				8A87B4352CC1A8FD003A9239 /* Mock */,
+				8A87B4302CC1A3BA003A9239 /* PocketManagerTests.swift */,
 				8A552AC22CB43A7000564C98 /* Redux */,
 				8A00BD862CAB3FE500680AF9 /* HomepageViewControllerTests.swift */,
 				8AA0A6662CAC745300AC7EB3 /* HomepageDiffableDataSourceTests.swift */,
@@ -10985,6 +10993,7 @@
 				8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */,
 				8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */,
 				8A454D332CB85C7D009436D9 /* PocketStateTests.swift */,
+				8A87B42E2CC1A3AA003A9239 /* PocketMiddlewareTests.swift */,
 			);
 			path = Redux;
 			sourceTree = "<group>";
@@ -11144,6 +11153,14 @@
 				8A827E342C20CB44008D5E3C /* MicrosurveyPromptMiddlewareTests.swift */,
 			);
 			path = Microsurvey;
+			sourceTree = "<group>";
+		};
+		8A87B4352CC1A8FD003A9239 /* Mock */ = {
+			isa = PBXGroup;
+			children = (
+				8A87B4362CC1A910003A9239 /* MockPocketManager.swift */,
+			);
+			path = Mock;
 			sourceTree = "<group>";
 		};
 		8A93F85C29D36D9F004159D9 /* Coordinators */ = {
@@ -16682,6 +16699,7 @@
 				8A6E8DEB2B275BA9000C4301 /* PrivateHomepageViewControllerTests.swift in Sources */,
 				8A93F86529D37331004159D9 /* DefaultRouterTests.swift in Sources */,
 				8AF10D8A29D713F50086351D /* LaunchScreenViewModelTests.swift in Sources */,
+				8A87B4322CC1A3C0003A9239 /* PocketManagerTests.swift in Sources */,
 				2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */,
 				CA24B52224ABD7D40093848C /* PasswordManagerViewModelTests.swift in Sources */,
 				E169C6E82979CA0E0017B8D7 /* URLMailTests.swift in Sources */,
@@ -16727,6 +16745,7 @@
 				2173326829CCDA8E007F20C7 /* TabScrollControllerTests.swift in Sources */,
 				BA1C68BA2B7E9EA0000D9397 /* WKFrameInfoExtensionsTest.swift in Sources */,
 				9614BF4228A53FDF00D3F7EA /* ContextualHintEligibilityUtilityTests.swift in Sources */,
+				8A87B4342CC1A731003A9239 /* PocketMiddlewareTests.swift in Sources */,
 				21B548972B1E6AC300DC1DF8 /* MockInactiveTabsManager.swift in Sources */,
 				21B337BB29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift in Sources */,
 				6ADB651B285C03B100947EA4 /* DownloadHelperTests.swift in Sources */,
@@ -16768,6 +16787,7 @@
 				E1390FB828B42EF200C9EF3E /* WallpaperManagerMock.swift in Sources */,
 				ABB507CF2A136FB2009CAA67 /* UserConversionMetricsTests.swift in Sources */,
 				21FA8FB22AE856EB0013B815 /* MockTabTrayCoordinatorDelegate.swift in Sources */,
+				8A87B4382CC1A92D003A9239 /* MockPocketManager.swift in Sources */,
 				C8699152289177F5007ACC5C /* WallpaperNetworkingTests.swift in Sources */,
 				C818AD452A2100BA007F30BC /* OnboardingNotificationCardHelperTests.swift in Sources */,
 				E1AEC178286E0CF500062E29 /* LegacyHomepageViewControllerTests.swift in Sources */,

--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -41,6 +41,11 @@ class DependencyHelper {
         let microsurveyManager: MicrosurveyManager = MicrosurveySurfaceManager()
         AppContainer.shared.register(service: microsurveyManager)
 
+        let pocketManager: PocketManagerProvider = PocketManager(
+            pocketAPI: PocketProvider(prefs: profile.prefs)
+        )
+        AppContainer.shared.register(service: pocketManager)
+
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketManager.swift
@@ -4,12 +4,14 @@
 
 import Foundation
 
-class PocketManager {
-    private let pocketAPI: PocketStoriesProviding
+protocol PocketManagerProvider {
+    func getPocketItems() async -> [PocketStoryState]
+}
+
+final class PocketManager: PocketManagerProvider {
     private let storyProvider: StoryProvider
 
     init(pocketAPI: PocketStoriesProviding) {
-        self.pocketAPI = pocketAPI
         self.storyProvider = StoryProvider(pocketAPI: pocketAPI)
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketMiddleware.swift
@@ -6,12 +6,9 @@ import Common
 import Redux
 
 final class PocketMiddleware {
-    private let logger: Logger
-    private let pocketManager: PocketManager
-
-    init(profile: Profile = AppContainer.shared.resolve(), logger: Logger = DefaultLogger.shared) {
-        self.logger = logger
-        self.pocketManager = PocketManager(pocketAPI: PocketProvider(prefs: profile.prefs))
+    private let pocketManager: PocketManagerProvider
+    init(pocketManager: PocketManagerProvider = AppContainer.shared.resolve()) {
+        self.pocketManager = pocketManager
     }
 
     lazy var pocketSectionProvider: Middleware<AppState> = { state, action in

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -11,7 +11,8 @@ import TabDataStore
 class DependencyHelperMock {
     func bootstrapDependencies(
         injectedTabManager: TabManager? = nil,
-        injectedMicrosurveyManager: MicrosurveyManager? = nil
+        injectedMicrosurveyManager: MicrosurveyManager? = nil,
+        injectedPocketManager: PocketManagerProvider? = nil
     ) {
         AppContainer.shared.reset()
 
@@ -50,6 +51,9 @@ class DependencyHelperMock {
 
         let microsurveyManager: MicrosurveyManager = injectedMicrosurveyManager ?? MockMicrosurveySurfaceManager()
         AppContainer.shared.register(service: microsurveyManager)
+
+        let pocketManager: PocketManagerProvider = injectedPocketManager ?? MockPocketManager()
+        AppContainer.shared.register(service: pocketManager)
 
         // Tell the container we are done registering
         AppContainer.shared.bootstrap()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockPocketManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockPocketManager.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@testable import Client
+
+final class MockPocketManager: PocketManagerProvider {
+    var getPocketItemsCalled = 0
+    func getPocketItems() async -> [PocketStoryState] {
+        getPocketItemsCalled += 1
+        let stories: [PocketFeedStory] = [
+            .make(title: "feed1"),
+            .make(title: "feed2"),
+            .make(title: "feed3"),
+        ]
+
+        return stories.compactMap { PocketStoryState(story: PocketStory(pocketFeedStory: $0)) }
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/PocketManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/PocketManagerTests.swift
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+final class PocketManagerTests: XCTestCase {
+    func test_getPocketItems_withSuccess_returnExpectedStories() async {
+        let subject = createSubject(
+            with: MockPocketAPI(result: .success(getMockStoriesData()))
+        )
+        let stories = await subject.getPocketItems()
+        XCTAssertEqual(stories.count, 3)
+    }
+
+    func test_getPocketItems_withSucess_returnEmptyStories() async {
+        let subject = createSubject(
+            with: MockPocketAPI(result: .success([]))
+        )
+        let stories = await subject.getPocketItems()
+        XCTAssertEqual(stories.count, 0)
+    }
+
+    func test_getPocketItems_withFailure_returnEmptyStories() async {
+        let subject = createSubject(
+            with: MockPocketAPI(result: .failure(TestError.example))
+        )
+        let stories = await subject.getPocketItems()
+        XCTAssertEqual(stories.count, 0)
+    }
+
+    private func createSubject(
+        with pocketAPI: MockPocketAPI,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> PocketManager {
+        let subject = PocketManager(pocketAPI: pocketAPI)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+
+    private func getMockStoriesData() -> [PocketFeedStory] {
+        return [
+            .make(title: "feed1"),
+            .make(title: "feed2"),
+            .make(title: "feed3"),
+        ]
+    }
+
+    enum TestError: Error {
+        case example
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
+    let storeUtilityHelper = StoreTestUtilityHelper()
+    let pocketManager = MockPocketManager()
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies(injectedPocketManager: pocketManager)
+        setupTestingStore()
+    }
+
+    override func tearDown() {
+        DependencyHelperMock().reset()
+        resetTestingStore()
+        super.tearDown()
+    }
+
+    func test_initializeAction_getPocketData() async throws {
+        let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
+        store.dispatch(action)
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        let homepageState = store.state.screenState(
+            HomepageState.self,
+            for: .homepage,
+            window: .XCTestDefaultUUID
+        )
+        XCTAssertNotNil(homepageState)
+        XCTAssertEqual(homepageState?.pocketState.pocketData.count, 3)
+        XCTAssertEqual(pocketManager.getPocketItemsCalled, 1)
+    }
+
+    func test_enterForegroundAction_getPocketData() async throws {
+        let action = PocketAction(windowUUID: .XCTestDefaultUUID, actionType: PocketActionType.enteredForeground)
+        store.dispatch(action)
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        let homepageState = store.state.screenState(
+            HomepageState.self,
+            for: .homepage,
+            window: .XCTestDefaultUUID
+        )
+        XCTAssertNotNil(homepageState)
+        XCTAssertEqual(homepageState?.pocketState.pocketData.count, 3)
+        XCTAssertEqual(pocketManager.getPocketItemsCalled, 1)
+    }
+
+    // MARK: StoreTestUtility
+    func setupAppState() -> AppState {
+        return AppState(
+            activeScreens: ActiveScreensState(
+                screens: [
+                    .homepage(
+                        HomepageState(
+                            windowUUID: .XCTestDefaultUUID
+                        )
+                    ),
+                ]
+            )
+        )
+    }
+
+    func setupTestingStore() {
+        storeUtilityHelper.setupTestingStore(
+            with: setupAppState(),
+            middlewares: [PocketMiddleware().pocketSectionProvider]
+        )
+    }
+
+    // In order to avoid flaky tests, we should reset the store
+    // similar to production
+    func resetTestingStore() {
+        storeUtilityHelper.resetTestingStore()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyPromptMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyPromptMiddlewareTests.swift
@@ -29,8 +29,8 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
         DependencyHelperMock().reset()
+        super.tearDown()
     }
 
     func testShowPromptAction_withInvalidModel() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10164)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22266)

## :bulb: Description
Added some more tests for the homepage rebuild - pocket section. These tests are currently passing, but looking for some feedback if this should be the standard of how we do tests.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)