### PR TITLE
Bugfix FXIOS-10224 Fix inconsistent tab count dimming

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
@@ -9,6 +9,7 @@ final class TabNumberButton: ToolbarButton {
     // MARK: - UX Constants
     struct UX {
         static let cornerRadius: CGFloat = 2
+        static let dimmedOpacity: CGFloat = 0.2
         static let titleFont = FXFontStyles.Bold.caption2.systemFont()
 
         // Tab count related constants
@@ -42,11 +43,12 @@ final class TabNumberButton: ToolbarButton {
         updateTabCount(numberOfTabs)
     }
 
-    override public func updateConfiguration() {
-        super.updateConfiguration()
+    override func tintColorDidChange() {
+        super.tintColorDidChange()
 
-        // Use image view tint color for tab number label as it gets dimmed when a modal gets displayed
-        countLabel.textColor = imageView?.tintColor ?? configuration?.baseForegroundColor
+        if tintAdjustmentMode == .dimmed {
+            UIView.performWithoutAnimation { countLabel.alpha = UX.dimmedOpacity }
+        } else { countLabel.alpha = 1.0 }
     }
 
     private func updateTabCount(_ count: Int) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10223)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22371)

## :bulb: Description
Set the tab count label in the tab tray button to dim and brighten on the same timeline as all of the other toolbar buttons

### 📝 Discussion
- Prior to this change, when closing the app menu, the tab count label in the tab tray button would not transition it's opacity, but instead would immediately change without an animation, causing it to restore color faster than all of the other toolbar buttons, which was visually jarring
- When the app menu opens, we instantaneously (without animation) set the tab count label's opacity to match the button, and when the app menu closes, we animate the tab count label's opacity back to `1.0` to match the button
  - For some reason, the toolbar buttons do not transition to dim when the app menu opens, but instead do so instantaneously, though there is a transition to un-dimmed when the app menu closes - and the tab count label follows the same approach for consistency
- This will not be a problem on iPhone once the [menu redesign](https://mozilla-hub.atlassian.net/browse/FXIOS-8338) is introduced as the new menu will cover the tab tray button, but it would then become a problem on iPad as the menu will no longer cover the tab tray button

### 📹 Videos
#### iPhone:
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/f62e6207-9bb9-424a-8f46-25315fe05176

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/6886da5c-2182-40e2-994b-b80c4fb11458

</details>

#### iPad:
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/99cde344-f70f-493e-8ab6-7c621a13f5d3

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/a7adae93-ade5-4d3a-a57c-e8e03009bc0d

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

