### PR TITLE
Bugfix MTE-3647 Inactive Tabs Test Update

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
@@ -110,7 +110,11 @@ final class InactiveTabsTest: BaseTestCase {
         app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView].tap()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerButton])
         mozWaitForElementToExist(app.otherElements["Tabs Tray"].staticTexts["Google"])
-        mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Homepage"])
+        if !iPad() {
+            // The active tabs on iPhone is so far down that "Homepage" is invisible.
+            // iPad is large enough that "Homepage" is still visible"
+            mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Homepage"])
+        }
 
         // Swipe on a tab from the list to delete
         app.otherElements["Tabs Tray"].staticTexts["Google"].swipeLeft()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
@@ -67,7 +67,6 @@ final class InactiveTabsTest: BaseTestCase {
 
         // Return to tabs tray
         navigator.goto(TabTray)
-        mozWaitForElementToExist(app.otherElements["Tabs Tray"])
         app.otherElements["Tabs Tray"].swipeDown()
         app.otherElements["Tabs Tray"].swipeDown()
         app.otherElements["Tabs Tray"].swipeDown()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
@@ -67,6 +67,10 @@ final class InactiveTabsTest: BaseTestCase {
 
         // Return to tabs tray
         navigator.goto(TabTray)
+        mozWaitForElementToExist(app.otherElements["Tabs Tray"])
+        app.otherElements["Tabs Tray"].swipeDown()
+        app.otherElements["Tabs Tray"].swipeDown()
+        app.otherElements["Tabs Tray"].swipeDown()
         mozWaitForElementToExist(app.otherElements["Tabs Tray"].staticTexts["Homepage"])
         mozWaitForElementToExist(app.otherElements["Tabs Tray"].staticTexts["Google"])
         mozWaitForElementToExist(app.otherElements["Tabs Tray"].staticTexts["Facebook - log in or sign up"])
@@ -110,8 +114,8 @@ final class InactiveTabsTest: BaseTestCase {
 
         // Swipe on a tab from the list to delete
         app.otherElements["Tabs Tray"].staticTexts["Google"].swipeLeft()
-        mozWaitForElementToExist(app.buttons["Close"])
-        app.buttons["Close"].tap() // Note: No AccessibilityIdentifier
+        mozWaitForElementToExist(app.otherElements["Tabs Tray"].buttons["Close"])
+        app.otherElements["Tabs Tray"].buttons["Close"].tap() // Note: No AccessibilityIdentifier
         mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Google"])
         mozWaitForElementToExist(app.otherElements["Tabs Tray"].staticTexts["Facebook - log in or sign up"])
         mozWaitForElementToExist(app.otherElements["Tabs Tray"].staticTexts["Amazon.com. Spend less. Smile more."])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3647)

## :bulb: Description

Here are the changes after observing the test failure on a full functional test run:
* The active tab could be appended after the inactive tabs once the inactive tabs are expanded.
* On iPad, all active and inactive tabs could be visible at the same time. (Not the case on iPhone.)

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

