### PR TITLE
Add FXIOS-10333 [Unified Search] Strings and accessibility labels/hints for Unified Search

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4387,72 +4387,44 @@ extension String {
     }
 
     // MARK: - Unified Search
-    extension String {
-        public struct UnifiedSearch {
-            public struct SearchEngineSelection {
-                public static let TopTitle = MZLocalizedString(
-                    key: "UnifiedSearch.SearchEngineSelection.TopTitle.Title.v134",
+    public struct UnifiedSearch {
+        public struct SearchEngineSelection {
+            public static let TopTitle = MZLocalizedString(
+                key: "UnifiedSearch.SearchEngineSelection.TopTitle.Title.v133",
+                tableName: "SearchEngineSelection",
+                value: "This time search in:",
+                comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the title for the popup.")
+
+            public static let SearchSettings = MZLocalizedString(
+                key: "UnifiedSearch.SearchEngineSelection.SearchSettings.Title.v133",
+                tableName: "SearchEngineSelection",
+                value: "Search Settings",
+                comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This string is the label for the button at the bottom of the list. When this row is tapped, the app's search settings screen appears.")
+
+            public struct AccessibilityLabels {
+                public static let TopTitleLabel = MZLocalizedString(
+                    key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.TopTitle.Label.v133",
                     tableName: "SearchEngineSelection",
                     value: "This time search in:",
-                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the title for the popup.")
+                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the title of that popup.")
 
-                public static let SearchSettings = MZLocalizedString(
-                    key: "UnifiedSearch.SearchEngineSelection.SearchSettings.Title.v134",
+                public static let SearchSettingsLabel = MZLocalizedString(
+                    key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchSettings.Label.v133",
                     tableName: "SearchEngineSelection",
-                    value: "Search Settings",
-                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This string is the label for the button at the bottom of the list. When this row is tapped, the app's search settings screen appears.")
+                    value: "Search settings",
+                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This string is the label for the row at the bottom of the list. When this row is tapped, the app's search settings screen appears.")
 
-                public struct AccessibilityLabels {
-                    public static let TopTitleLabel = MZLocalizedString(
-                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.TopTitle.Label.v134"
-                        tableName: "SearchEngineSelection",
-                        value: "This time search in", // TODO Need official accessibility strings
-                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the title of that popup.")
+                public static let SearchSettingsHint = MZLocalizedString(
+                    key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchSettings.Hint.v133",
+                    tableName: "SearchEngineSelection",
+                    value: "Opens search settings",
+                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility hint for tapping the search settings row at the bottom of the list, which opens the app's search settings screen.")
 
-                    public static let SearchSettingsLabel = MZLocalizedString(
-                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchSettings.Label.v134",
-                        tableName: "SearchEngineSelection",
-                        value: "Search Settings", // TODO Need official accessibility strings
-                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This string is the label for the row at the bottom of the list. When this row is tapped, the app's search settings screen appears.")
-
-                    public static let SearchSettingsHint = MZLocalizedString(
-                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchSettings.Hint.v134",
-                        tableName: "SearchEngineSelection",
-                        value: "Opens the search engine settings screen", // TODO Need official accessibility strings
-                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This string is the label for the row at the bottom of the list. When tapped, this button opens the app's search settings screen.")
-
-                    public static let CloseButtonLabel = MZLocalizedString(
-                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.CloseButton.Label.v134",
-                        tableName: "SearchEngineSelection",
-                        value: "Close", // TODO Need official accessibility strings
-                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the popup's close button.")
-
-                    public static let SearchEngineDropDownButtonLabel = MZLocalizedString(
-                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchEngineDropDownButton.Label.v134",
-                        tableName: "SearchEngineSelection",
-                        value: "Close", // TODO Need official accessibility strings
-                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the popup's close button.")
-
-                    public static let SearchEngineDropDownButtonHint = MZLocalizedString(
-                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchEngineDropDownButton.Hint.v134",
-                        tableName: "SearchEngineSelection",
-                        value: "Close", // TODO Need official accessibility strings
-                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the popup's close button.")
-
-                    public static let CloseButtonHint = MZLocalizedString(
-                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.CloseButton.Hint.v134",
-                        tableName: "SearchEngineSelection",
-                        value: "Closes the search engine selection", // TODO Need official accessibility strings
-                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility hint for what happens when the popup's close button is tapped. Tapping the button closes the popup.")
-
-                    // TODO Do we need a search engine row label if all the values are search engine names, not text strings?
-
-                    public static let AlternativeSearchEngineHint = MZLocalizedString(
-                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.AlternativeSearchEngineLabel.Label.v134",
-                        tableName: "SearchEngineSelection",
-                        value: "Shows alternative search engine selection",  // TODO Need official accessibility strings
-                        comment: "This is the accessibility hint for what happens when the user taps the search engine icon in the toolbar. Tapping the icon will popup the list of alternative search engines.")
-                }
+                public static let CloseButtonLabel = MZLocalizedString(
+                    key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.CloseButton.Label.v133",
+                    tableName: "SearchEngineSelection",
+                    value: "Close",
+                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the popup's close button.")
             }
         }
     }
@@ -6556,11 +6528,19 @@ extension String {
             tableName: "AddressToolbar",
             value: "Search or enter address",
             comment: "Placeholder for the address field in the address toolbar.")
+
         public static let SearchEngineA11yLabel = MZLocalizedString(
             key: "AddressToolbar.SearchEngine.A11y.Label.v128",
             tableName: "AddressToolbar",
             value: "Search Engine: %@",
             comment: "Accessibility label for the search engine icon in the address field of the address toolbar. The placeholder is getting replaced with the name of the search engine (e.g. Google).")
+
+        public static let SearchEngineA11yHint = MZLocalizedString(
+            key: "AddressToolbar.SearchEngine.A11y.Hint.v133",
+            tableName: "AddressToolbar",
+            value: "Opens search engine selection",
+            comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility hint describing what tapping the search engine icon does.")
+
         public static let PrivacyAndSecuritySettingsA11yLabel = MZLocalizedString(
             key: "AddressToolbar.PrivacyAndSecuriySettings.A11y.Label.v128",
             tableName: "AddressToolbar",

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4393,38 +4393,38 @@ extension String {
                 key: "UnifiedSearch.SearchEngineSelection.TopTitle.Title.v133",
                 tableName: "SearchEngineSelection",
                 value: "This time search in:",
-                comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the title for the popup.")
+                comment: "When the user taps the search engine icon in the toolbar, a sheet with a list of alternative search engines appears. This is the title for the sheet.")
 
             public static let SearchSettings = MZLocalizedString(
                 key: "UnifiedSearch.SearchEngineSelection.SearchSettings.Title.v133",
                 tableName: "SearchEngineSelection",
                 value: "Search Settings",
-                comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This string is the label for the button at the bottom of the list. When this row is tapped, the app's search settings screen appears.")
+                comment: "When the user taps the search engine icon in the toolbar, a sheet with a list of alternative search engines appears. This string is the label for the button at the bottom of the list. When this row is tapped, the app's search settings screen appears.")
 
             public struct AccessibilityLabels {
                 public static let TopTitleLabel = MZLocalizedString(
                     key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.TopTitle.Label.v133",
                     tableName: "SearchEngineSelection",
                     value: "This time search in:",
-                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the title of that popup.")
+                    comment: "When the user taps the search engine icon in the toolbar, a sheet with a list of alternative search engines appears. This is the accessibility label for the title of that sheet.")
 
                 public static let SearchSettingsLabel = MZLocalizedString(
                     key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchSettings.Label.v133",
                     tableName: "SearchEngineSelection",
                     value: "Search settings",
-                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This string is the label for the row at the bottom of the list. When this row is tapped, the app's search settings screen appears.")
+                    comment: "When the user taps the search engine icon in the toolbar, a sheet with a list of alternative search engines appears. This string is the label for the row at the bottom of the list. When this row is tapped, the app's search settings screen appears.")
 
                 public static let SearchSettingsHint = MZLocalizedString(
                     key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchSettings.Hint.v133",
                     tableName: "SearchEngineSelection",
                     value: "Opens search settings",
-                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility hint for tapping the search settings row at the bottom of the list, which opens the app's search settings screen.")
+                    comment: "When the user taps the search engine icon in the toolbar, a sheet with a list of alternative search engines appears. This is the accessibility hint for tapping the search settings row at the bottom of the list, which opens the app's search settings screen.")
 
                 public static let CloseButtonLabel = MZLocalizedString(
                     key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.CloseButton.Label.v133",
                     tableName: "SearchEngineSelection",
                     value: "Close",
-                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the popup's close button.")
+                    comment: "When the user taps the search engine icon in the toolbar, a sheet with a list of alternative search engines appears. This is the accessibility label for the sheet's close button.")
             }
         }
     }
@@ -6539,7 +6539,7 @@ extension String {
             key: "AddressToolbar.SearchEngine.A11y.Hint.v133",
             tableName: "AddressToolbar",
             value: "Opens search engine selection",
-            comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility hint describing what tapping the search engine icon does.")
+            comment: "When the user taps the search engine icon in the toolbar, a sheet with a list of alternative search engines appears. This is the accessibility hint describing what tapping the search engine icon does.")
 
         public static let PrivacyAndSecuritySettingsA11yLabel = MZLocalizedString(
             key: "AddressToolbar.PrivacyAndSecuriySettings.A11y.Label.v128",

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4393,7 +4393,7 @@ extension String {
                 public static let TopTitle = MZLocalizedString(
                     key: "UnifiedSearch.SearchEngineSelection.TopTitle.Title.v134",
                     tableName: "SearchEngineSelection",
-                    value: "This time search in:", // TODO Waiting on designer to confirm this string
+                    value: "This time search in:",
                     comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the title for the popup.")
 
                 public static let SearchSettings = MZLocalizedString(

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4386,6 +4386,77 @@ extension String {
         }
     }
 
+    // MARK: - Unified Search
+    extension String {
+        public struct UnifiedSearch {
+            public struct SearchEngineSelection {
+                public static let TopTitle = MZLocalizedString(
+                    key: "UnifiedSearch.SearchEngineSelection.TopTitle.Title.v134",
+                    tableName: "SearchEngineSelection",
+                    value: "This time search in:", // TODO Waiting on designer to confirm this string
+                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the title for the popup.")
+
+                public static let SearchSettings = MZLocalizedString(
+                    key: "UnifiedSearch.SearchEngineSelection.SearchSettings.Title.v134",
+                    tableName: "SearchEngineSelection",
+                    value: "Search Settings",
+                    comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This string is the label for the button at the bottom of the list. When this row is tapped, the app's search settings screen appears.")
+
+                public struct AccessibilityLabels {
+                    public static let TopTitleLabel = MZLocalizedString(
+                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.TopTitle.Label.v134"
+                        tableName: "SearchEngineSelection",
+                        value: "This time search in", // TODO Need official accessibility strings
+                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the title of that popup.")
+
+                    public static let SearchSettingsLabel = MZLocalizedString(
+                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchSettings.Label.v134",
+                        tableName: "SearchEngineSelection",
+                        value: "Search Settings", // TODO Need official accessibility strings
+                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This string is the label for the row at the bottom of the list. When this row is tapped, the app's search settings screen appears.")
+
+                    public static let SearchSettingsHint = MZLocalizedString(
+                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchSettings.Hint.v134",
+                        tableName: "SearchEngineSelection",
+                        value: "Opens the search engine settings screen", // TODO Need official accessibility strings
+                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This string is the label for the row at the bottom of the list. When tapped, this button opens the app's search settings screen.")
+
+                    public static let CloseButtonLabel = MZLocalizedString(
+                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.CloseButton.Label.v134",
+                        tableName: "SearchEngineSelection",
+                        value: "Close", // TODO Need official accessibility strings
+                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the popup's close button.")
+
+                    public static let SearchEngineDropDownButtonLabel = MZLocalizedString(
+                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchEngineDropDownButton.Label.v134",
+                        tableName: "SearchEngineSelection",
+                        value: "Close", // TODO Need official accessibility strings
+                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the popup's close button.")
+
+                    public static let SearchEngineDropDownButtonHint = MZLocalizedString(
+                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.SearchEngineDropDownButton.Hint.v134",
+                        tableName: "SearchEngineSelection",
+                        value: "Close", // TODO Need official accessibility strings
+                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility label for the popup's close button.")
+
+                    public static let CloseButtonHint = MZLocalizedString(
+                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.CloseButton.Hint.v134",
+                        tableName: "SearchEngineSelection",
+                        value: "Closes the search engine selection", // TODO Need official accessibility strings
+                        comment: "When the user taps the search engine icon in the toolbar, a popup with a list of alternative search engines appears. This is the accessibility hint for what happens when the popup's close button is tapped. Tapping the button closes the popup.")
+
+                    // TODO Do we need a search engine row label if all the values are search engine names, not text strings?
+
+                    public static let AlternativeSearchEngineHint = MZLocalizedString(
+                        key: "UnifiedSearch.SearchEngineSelection.AccessibilityLabels.AlternativeSearchEngineLabel.Label.v134",
+                        tableName: "SearchEngineSelection",
+                        value: "Shows alternative search engine selection",  // TODO Need official accessibility strings
+                        comment: "This is the accessibility hint for what happens when the user taps the search engine icon in the toolbar. Tapping the icon will popup the list of alternative search engines.")
+                }
+            }
+        }
+    }
+
     // MARK: - LegacyAppMenu
     // These strings may still be in use, thus have not been moved to the `OldStrings` struct
     public struct LegacyAppMenu {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10333)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22648)

## :bulb: Description
This PR adds strings, accessibility labels, and accessibility hints as required by the Unified Search project.

There are two parts:

### 1) The new drop down search engine button in the toolbar
- Added a new accessibility hint since this is now a tappable element

<img width="374" alt="Screenshot 2024-10-18 at 4 48 37 PM" src="https://github.com/user-attachments/assets/6206ae32-d87f-4365-8047-372d02604a8a">


### 2) The new bottom sheet / iPad popup which shows alternative search engines and can redirect the user to Settings > Search options
- Added label, accessibility label for the popup title
- Added accessibility label for the close button
- Added label, accessibility label, and accessibility hint for the Search Settings row
- No Strings.swift accessibility labels or hints for search engine rows (accessibility label to simply be the search engine's name)

<img width="361" alt="Screenshot 2024-10-18 at 4 48 14 PM" src="https://github.com/user-attachments/assets/ba948bd7-2718-4f75-b200-43ac104865e6">


### Testing Notes

Enable both the toolbar refactor and the `unified_search `flag to see the new drop-down search engine button in the toolbar.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

