### PR TITLE
Refactor FXIOS-10338 - UI Tests > Updated url validation test to execute in any locale

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
@@ -8,7 +8,7 @@ class URLValidationTests: BaseTestCase {
     let urlTypes = ["www.mozilla.org", "www.mozilla.org/", "https://www.mozilla.org", "www.mozilla.org/en", "www.mozilla.org/en-",
                     "www.mozilla.org/en-US", "https://www.mozilla.org/", "https://www.mozilla.org/en", "https://www.mozilla.org/en-US"]
     let urlHttpTypes = ["http://example.com", "http://example.com/"]
-    let url = XCUIApplication().textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
+    let urlField = XCUIApplication().textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
 
     override func setUp() {
         super.setUp()
@@ -23,20 +23,26 @@ class URLValidationTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2460854
     // Smoketest
     func testDifferentURLTypes() {
-        for i in urlTypes {
-            navigator.openURL(i)
+        for url in urlTypes {
+            navigator.openURL(url)
             waitUntilPageLoad()
             mozWaitForElementToExist(app.otherElements.staticTexts["Mozilla"])
             mozWaitForElementToExist(app.buttons["Menu"])
-            mozWaitForValueContains(url, value: "www.mozilla.org/en-US/")
+            // Getting the current system locale ex:- en-US
+            var locale = Locale.preferredLanguages[0]
+            // Only the below url suffixes should lead to en-US website
+            if url.hasSuffix("en") || url.hasSuffix("en-") || url.hasSuffix("en-US") {
+                locale = "en-US"
+            }
+            mozWaitForValueContains(urlField, value: "www.mozilla.org/\(locale)/")
             clearURL()
         }
 
-        for i in urlHttpTypes {
-            navigator.openURL(i)
+        for url in urlHttpTypes {
+            navigator.openURL(url)
             waitUntilPageLoad()
             mozWaitForElementToExist(app.otherElements.staticTexts["Example Domain"])
-            mozWaitForValueContains(url, value: "example.com/")
+            mozWaitForValueContains(urlField, value: "example.com/")
             clearURL()
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10338)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22657)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
 Currently, the `testDifferentURLTypes()` test is failing when a non `en-US` locale user is running.
So, i have updated the test to get current locale and validate expected values in the nav bar url based on that.

**Before the fix:**

<img width="1208" alt="Screenshot 2024-10-18 at 11 07 51 PM" src="https://github.com/user-attachments/assets/bf071bd0-1454-48bd-bc9e-c4dca9f9762b">

**After the fix:**

<img width="528" alt="Screenshot 2024-10-18 at 10 53 46 PM" src="https://github.com/user-attachments/assets/8c2816af-facb-4916-90a9-06ba08424876">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

