### PR TITLE
Bugfix FXIOS-10340 Home page bookmarks cell clear background

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Blurrable.swift
+++ b/firefox-ios/Client/Frontend/Home/Blurrable.swift
@@ -15,9 +15,8 @@ protocol Blurrable: UICollectionViewCell {
 
 extension Blurrable {
     var shouldApplyWallpaperBlur: Bool {
-        return true
-        // guard !UIAccessibility.isReduceTransparencyEnabled else { return false }
+        guard !UIAccessibility.isReduceTransparencyEnabled else { return false }
 
-        // return WallpaperManager().currentWallpaper.type != .defaultWallpaper
+        return WallpaperManager().currentWallpaper.type != .defaultWallpaper
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Blurrable.swift
+++ b/firefox-ios/Client/Frontend/Home/Blurrable.swift
@@ -15,8 +15,9 @@ protocol Blurrable: UICollectionViewCell {
 
 extension Blurrable {
     var shouldApplyWallpaperBlur: Bool {
-        guard !UIAccessibility.isReduceTransparencyEnabled else { return false }
+        return true
+        // guard !UIAccessibility.isReduceTransparencyEnabled else { return false }
 
-        return WallpaperManager().currentWallpaper.type != .defaultWallpaper
+        // return WallpaperManager().currentWallpaper.type != .defaultWallpaper
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Bookmarks/BookmarksCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Bookmarks/BookmarksCell.swift
@@ -124,6 +124,7 @@ extension BookmarksCell: Blurrable {
     func adjustBlur(theme: Theme) {
         // If blur is disabled set background color
         if shouldApplyWallpaperBlur {
+            rootContainer.layoutIfNeeded()
             rootContainer.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
         } else {
             rootContainer.removeVisualEffectView()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10340)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22663)

## :bulb: Description
Bugfix Bookmarks home page cells not rendering background blur due to empty rootContainer view's bonds.

Bug:

https://github.com/user-attachments/assets/29ad40cd-f5a7-41b5-9648-d91e434ed840

Actual:

https://github.com/user-attachments/assets/e170dcca-bbd7-4a78-b6d5-999a000b974a

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

