### PR TITLE
Revert rust-components-swift back to 132.0.0 for v132

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -24444,7 +24444,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 133.0.20241009050322;
+				version = 132.0.0;
 			};
 		};
 		435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */ = {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
       "state" : {
-        "revision" : "e535bbe6d66996f32d0e4f632e9d8588372cd489",
-        "version" : "133.0.20241009050322"
+        "revision" : "2e82cebc4fc89afbb3b2e880eccf5243e401b0e2",
+        "version" : "132.0.0"
       }
     },
     {

--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -7164,7 +7164,7 @@
 			repositoryURL = "https://github.com/mozilla/rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 133.0.20241009050322;
+				version = 132.0.0;
 			};
 		};
 		8A0E7F2C2BA0F0E0006BC6B6 /* XCRemoteSwiftPackageReference "Fuzi" */ = {

--- a/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/focus-ios/Blockzilla.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/mozilla/rust-components-swift",
         "state": {
           "branch": null,
-          "revision": "e535bbe6d66996f32d0e4f632e9d8588372cd489",
-          "version": "133.0.20241009050322"
+          "revision": "2e82cebc4fc89afbb3b2e880eccf5243e401b0e2",
+          "version": "132.0.0"
         }
       },
       {


### PR DESCRIPTION
https://github.com/mozilla-mobile/firefox-ios/commit/20db914c430707f1c8e5bfb1a1e80eb837743786 intended to bump Glean to v61.2.0 in support of backporting the new dau telemetry ping but also brought along with it a bump to an AppServices 133 nightly build which shouldn't have been included. This reverts it back to the 132.0.0 release.

@badboy Adding you as a reviewer just to doubly-confirm that we're safe keeping Glean v61.2.0 with A-S 132.0.0 (which has v61.1.0 by default). From our previous discussions, I believe that answer is yes, but better safe than sorry!