### PR TITLE
Add workflow to update current tech stack in README

### DIFF
--- a/.github/workflows/update_readme_current_tech_stack.yml
+++ b/.github/workflows/update_readme_current_tech_stack.yml
@@ -1,0 +1,42 @@
+name: Update README with current tech stack
+
+on: 
+    workflow_dispatch:
+    schedule:
+      - cron: '0 12 * * SUN'
+
+jobs:
+    update_readme_with_current_stack:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3    
+    
+            - name: Update README
+              run: |
+               sh update_readme_project_stack.sh
+            
+            - name: Check changes
+              run: |
+                if [[ $(git status --porcelain) ]]; then
+                    echo "changes_detected=true" >> $GITHUB_ENV 
+                fi
+
+            - name: Commit if needed 
+              if: ${{ env.changes_detected }}
+              run: |
+                git config --global user.name "github-actions[bot]"
+                git config --global user.email "github-actions[bot]@users.noreply.github.com"
+                git add README.md
+                git commit -m "Update README with latest tech stack"
+
+            - name: Create Pull Request
+              if: ${{ env.changes_detected }}
+              uses: peter-evans/create-pull-request@v6
+              with:
+                  author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+                  committer: GitHub <noreply@github.com>
+                  title: Update Firefox icons from Acorn repo
+                  branch: update-firefox-project-with-acorn-icons
+                  token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_readme_current_tech_stack.yml
+++ b/.github/workflows/update_readme_current_tech_stack.yml
@@ -37,6 +37,6 @@ jobs:
               with:
                   author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
                   committer: GitHub <noreply@github.com>
-                  title: Update Firefox icons from Acorn repo
-                  branch: update-firefox-project-with-acorn-icons
+                  title: Update README with recent tech stack
+                  branch: update-readme-with-tech-stack
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Download [Firefox iOS](https://apps.apple.com/app/firefox-web-browser/id989804926) and [Focus iOS](https://itunes.apple.com/app/id1055677337) on the App Store.
 
+|          |                |               | |
+|----------|----------------|---------------|--|
+| **Firefox-iOS**| ![Xcode 15.4](https://img.shields.io/badge/Xcode-15.4-blue?logo=Xcode&logoColor=white) | ![Swift 5.6](https://img.shields.io/badge/Swift-5.6-red?logo=Swift&logoColor=white) | ![iOS 15.0+](https://img.shields.io/badge/iOS-15.0+-green?logo=apple&logoColor=white) |
+| **Focus-iOS**| ![Xcode 15.4](https://img.shields.io/badge/Xcode-15.4-blue?logo=Xcode&logoColor=white) | ![Swift 5.6](https://img.shields.io/badge/Swift-5.6-red?logo=Swift&logoColor=white) | ![iOS 15.0+](https://img.shields.io/badge/iOS-15.0+-green?logo=apple&logoColor=white)
+---
+
 ## Building the code
 This is a mono repository containing both Firefox and Focus iOS projects. For their related build instructions, please follow the project readme.
 - [Firefox for iOS](https://github.com/mozilla-mobile/firefox-ios/blob/main/firefox-ios/README.md)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,31 @@
-# Firefox for iOS [![codebeat badge](https://codebeat.co/badges/67e58b6d-bc89-4f22-ba8f-7668a9c15c5a)](https://codebeat.co/projects/github-com-mozilla-firefox-ios) [![codecov](https://codecov.io/gh/mozilla-mobile/firefox-ios/branch/main/graph/badge.svg)](https://codecov.io/gh/mozilla-mobile/firefox-ios/branch/main) and Focus iOS
+# Firefox for iOS and Focus iOS
 
 Download [Firefox iOS](https://apps.apple.com/app/firefox-web-browser/id989804926) and [Focus iOS](https://itunes.apple.com/app/id1055677337) on the App Store.
 
-|          |                |               | |
-|----------|----------------|---------------|--|
-| **Firefox-iOS**| ![Xcode 15.4](https://img.shields.io/badge/Xcode-15.4-blue?logo=Xcode&logoColor=white) | ![Swift 5.6](https://img.shields.io/badge/Swift-5.6-red?logo=Swift&logoColor=white) | ![iOS 15.0+](https://img.shields.io/badge/iOS-15.0+-green?logo=apple&logoColor=white) |
-| **Focus-iOS**| ![Xcode 15.4](https://img.shields.io/badge/Xcode-15.4-blue?logo=Xcode&logoColor=white) | ![Swift 5.6](https://img.shields.io/badge/Swift-5.6-red?logo=Swift&logoColor=white) | ![iOS 15.0+](https://img.shields.io/badge/iOS-15.0+-green?logo=apple&logoColor=white)
----
+<table>
+  <tr>
+    <th style="border: none;"><strong>Firefox iOS</strong></th>
+    <td style="border: none;"><img src="https://img.shields.io/badge/Xcode-15.4-blue?logo=Xcode&logoColor=white" alt="Firefox-iOS"></td>
+    <td style="border: none;"><img src="https://img.shields.io/badge/Swift-5.6-red?logo=Swift&logoColor=white" alt="Firefox-iOS"></td>
+    <td style="border: none;"><img src="https://img.shields.io/badge/iOS-15.0+-green?logo=apple&logoColor=white" alt="Firefox-iOS"></td>
+    <th rowspan="2" style="border: none;">
+        <a href="https://codebeat.co/projects/github-com-mozilla-firefox-ios">
+            <img src="https://codebeat.co/badges/67e58b6d-bc89-4f22-ba8f-7668a9c15c5a" alt="">
+        </a>
+    </th>
+    <th rowspan="2" style="border: none;">
+        <a href="https://codecov.io/gh/mozilla-mobile/firefox-ios/branch/main">
+            <img src="https://codecov.io/gh/mozilla-mobile/firefox-ios/branch/main/graph/badge.svg" alt="">
+        </a>
+    </th>
+  </tr>
+  <tr>
+    <th style="border: none;"><strong>Focus iOS</strong></th>
+    <td style="border: none;"><img src="https://img.shields.io/badge/Xcode-15.4-blue?logo=Xcode&logoColor=white" alt="Focus-iOS"></td>
+    <td style="border: none;"><img src="https://img.shields.io/badge/Swift-5.6-red?logo=Swift&logoColor=white" alt="Focus-iOS"></td>
+    <td style="border: none;"><img src="https://img.shields.io/badge/iOS-15.0+-green?logo=apple&logoColor=white" alt="Focus-iOS"></td>
+  </tr>
+</table>
 
 ## Building the code
 This is a mono repository containing both Firefox and Focus iOS projects. For their related build instructions, please follow the project readme.

--- a/update_readme_project_stack.sh
+++ b/update_readme_project_stack.sh
@@ -1,0 +1,54 @@
+# This script updates the README file with updated Xcode, Swift, and
+# iOS deployment target badges. It extracts relevant project
+# information from Xcode project files, Bitrise configurations, and
+# Swift package manager files.
+# The script is designed to be run within a Github action.
+
+function deployment_target() {
+    PROJECT_FILE=$1
+    echo $(grep -o 'IPHONEOS_DEPLOYMENT_TARGET = [0-9]*.[0-9]*;' "$PROJECT_FILE" | head -1 | cut -d'=' -f2 | tr -d ' ;')
+}
+
+function build_sed_string() {
+    ICON=$1
+    VERSION=$2
+    BADGE=$3
+    echo "!\[$ICON $VERSION\]($BADGE)"
+}
+
+function badge() {
+    APP=$1
+    VERSION=$2
+    COLOR=$3
+    LOGO=$4
+    echo "https:\/\/img.shields.io\/badge\/$APP-$VERSION-$COLOR\?logo=$LOGO\&logoColor=white"
+}
+
+function sed_into_readme() {
+    APP=$1
+    DEPLOYMENT_TARGET=$2
+    VERSION_GREP="[0-9.].*"
+    XCODE_GREP=$(build_sed_string Xcode $VERSION_GREP $(badge Xcode $VERSION_GREP "blue" "Xcode"))
+    SWIFT_GREP=$(build_sed_string Swift $VERSION_GREP $(badge Swift $VERSION_GREP "red" "Swift"))
+    TARGET_GREP=$(build_sed_string iOS "$VERSION_GREP+" $(badge iOS "$VERSION_GREP+" "green" "apple"))
+
+    XCODE=$(build_sed_string Xcode $XCODE_VERSION $(badge Xcode $XCODE_VERSION "blue" "Xcode"))
+    SWIFT=$(build_sed_string Swift $SWIFT_VERSION $(badge Swift $SWIFT_VERSION "red" "Swift"))
+    TARGET=$(build_sed_string iOS "$DEPLOYMENT_TARGET+" $(badge iOS "$DEPLOYMENT_TARGET+" "green" "apple"))
+
+    echo "s/$APP\*\*\| $XCODE_GREP \| $SWIFT_GREP \| $TARGET_GREP/$APP\*\*\| $XCODE \| $SWIFT \| $TARGET/"
+    sed -i "" "s/$APP\*\*\| $XCODE_GREP \| $SWIFT_GREP \| $TARGET_GREP/$APP\*\*\| $XCODE \| $SWIFT \| $TARGET/" $README_FILE
+}
+
+PROJECT_FIREFOX_FILE="firefox-ios/Client.xcodeproj/project.pbxproj"
+PROJECT_FOCUS_FILE="focus-ios/Blockzilla.xcodeproj/project.pbxproj"
+BIT_RISE_FILE="bitrise.yml"
+XCODE_VERSION=$(grep "stack:" $BIT_RISE_FILE | head -n 1 | grep -o '\d\d.\d')
+DEPLOYMENT_TARGET_FIREFOX=$(deployment_target $PROJECT_FIREFOX_FILE)
+DEPLOYMENT_TARGET_FOCUS=$(deployment_target $PROJECT_FOCUS_FILE)
+README_FILE="README.md"
+BROWSER_KIT_SWIFT_PACKAGE_FILE="BrowserKit/Package.swift"
+SWIFT_VERSION=$(head -n 1 $BROWSER_KIT_SWIFT_PACKAGE_FILE | grep -o '\d.\d')
+
+sed_into_readme "Firefox-iOS" $DEPLOYMENT_TARGET_FIREFOX
+sed_into_readme "Focus-iOS" $DEPLOYMENT_TARGET_FOCUS

--- a/update_readme_project_stack.sh
+++ b/update_readme_project_stack.sh
@@ -12,32 +12,26 @@ function deployment_target() {
 function build_sed_string() {
     ICON=$1
     VERSION=$2
-    BADGE=$3
-    echo "!\[$ICON $VERSION\]($BADGE)"
-}
-
-function badge() {
-    APP=$1
-    VERSION=$2
     COLOR=$3
     LOGO=$4
-    echo "https:\/\/img.shields.io\/badge\/$APP-$VERSION-$COLOR\?logo=$LOGO\&logoColor=white"
+    APP=$5
+    echo "<img src=\"https:\/\/img.shields.io\/badge\/$ICON-$VERSION-$COLOR\?logo=$LOGO\&logoColor=white\" alt=\"$APP\"><\/td>"
 }
 
 function sed_into_readme() {
     APP=$1
     DEPLOYMENT_TARGET=$2
     VERSION_GREP="[0-9.].*"
-    XCODE_GREP=$(build_sed_string Xcode $VERSION_GREP $(badge Xcode $VERSION_GREP "blue" "Xcode"))
-    SWIFT_GREP=$(build_sed_string Swift $VERSION_GREP $(badge Swift $VERSION_GREP "red" "Swift"))
-    TARGET_GREP=$(build_sed_string iOS "$VERSION_GREP+" $(badge iOS "$VERSION_GREP+" "green" "apple"))
+    XCODE_GREP=$(build_sed_string "Xcode" $VERSION_GREP "blue" "Xcode" $APP)
+    XCODE=$(build_sed_string "Xcode" $XCODE_VERSION "blue" "Xcode" $APP)
+    SWIFT_GREP=$(build_sed_string "Swift" $VERSION_GREP "red" "Swift" $APP)
+    SWIFT=$(build_sed_string "Swift" $SWIFT_VERSION "red" "Swift" $APP)
+    IOS_GREP=$(build_sed_string "iOS" "$VERSION_GREP+" "green" "apple" $APP)
+    IOS=$(build_sed_string "iOS" "$DEPLOYMENT_TARGET+" "green" "apple" $APP)
 
-    XCODE=$(build_sed_string Xcode $XCODE_VERSION $(badge Xcode $XCODE_VERSION "blue" "Xcode"))
-    SWIFT=$(build_sed_string Swift $SWIFT_VERSION $(badge Swift $SWIFT_VERSION "red" "Swift"))
-    TARGET=$(build_sed_string iOS "$DEPLOYMENT_TARGET+" $(badge iOS "$DEPLOYMENT_TARGET+" "green" "apple"))
-
-    echo "s/$APP\*\*\| $XCODE_GREP \| $SWIFT_GREP \| $TARGET_GREP/$APP\*\*\| $XCODE \| $SWIFT \| $TARGET/"
-    sed -i "" "s/$APP\*\*\| $XCODE_GREP \| $SWIFT_GREP \| $TARGET_GREP/$APP\*\*\| $XCODE \| $SWIFT \| $TARGET/" $README_FILE
+    sed -i "" "s/$XCODE_GREP/$XCODE/" $README_FILE
+    sed -i "" "s/$SWIFT_GREP/$SWIFT/" $README_FILE
+    sed -i "" "s/$IOS_GREP/$IOS/" $README_FILE
 }
 
 PROJECT_FIREFOX_FILE="firefox-ios/Client.xcodeproj/project.pbxproj"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Modify `README.md` with badges with currently support tech stacks. Added a Github action to sync periodically the README with the project.

This is how it will look the README file with the badges.

![Screenshot 2024-10-22 at 17 19 01](https://github.com/user-attachments/assets/b221a1f7-d03b-4adf-875d-854012da2a31)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

