### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from NavigationBarState.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -71,13 +71,7 @@ struct NavigationBarState: StateType, Equatable {
             )
 
         case ToolbarActionType.numberOfTabsChanged:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return NavigationBarState(
-                windowUUID: state.windowUUID,
-                actions: navigationActions(action: toolbarAction, navigationBarState: state),
-                displayBorder: state.displayBorder
-            )
+            return handleToolbarNumberOfTabsChanged(state: state, action: action)
 
         case ToolbarActionType.backForwardButtonStateChanged:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -62,7 +62,7 @@ struct NavigationBarState: StateType, Equatable {
             return handleDidLoadToolbarsAction(state: state, action: action)
 
         case ToolbarActionType.urlDidChange:
-            return handleToolbarUrlDidChange(state: state, action: action)
+            return handleUrlDidChangeAction(state: state, action: action)
 
         case ToolbarActionType.numberOfTabsChanged:
             return handleToolbarNumberOfTabsChanged(state: state, action: action)
@@ -103,7 +103,7 @@ struct NavigationBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarUrlDidChange(state: Self, action: Action) -> Self {
+    private static func handleUrlDidChangeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return NavigationBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -65,7 +65,7 @@ struct NavigationBarState: StateType, Equatable {
             return handleUrlDidChangeAction(state: state, action: action)
 
         case ToolbarActionType.numberOfTabsChanged:
-            return handleToolbarNumberOfTabsChanged(state: state, action: action)
+            return handleNumberOfTabsChangedAction(state: state, action: action)
 
         case ToolbarActionType.backForwardButtonStateChanged:
             return handleToolbarBackForwardButtonStateChanged(state: state, action: action)
@@ -113,7 +113,7 @@ struct NavigationBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarNumberOfTabsChanged(state: Self, action: Action) -> Self {
+    private static func handleNumberOfTabsChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return NavigationBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -74,13 +74,7 @@ struct NavigationBarState: StateType, Equatable {
             return handleToolbarNumberOfTabsChanged(state: state, action: action)
 
         case ToolbarActionType.backForwardButtonStateChanged:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return NavigationBarState(
-                windowUUID: state.windowUUID,
-                actions: navigationActions(action: toolbarAction, navigationBarState: state),
-                displayBorder: state.displayBorder
-            )
+            return handleToolbarBackForwardButtonStateChanged(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -75,7 +75,7 @@ struct NavigationBarState: StateType, Equatable {
 
         case ToolbarActionType.borderPositionChanged,
             ToolbarActionType.toolbarPositionChanged:
-            return handleToolbarPositionChanged(state: state, action: action)
+            return handlePositionChangedAction(state: state, action: action)
 
         default:
             return NavigationBarState(
@@ -143,7 +143,7 @@ struct NavigationBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarPositionChanged(state: Self, action: Action) -> Self {
+    private static func handlePositionChangedAction(state: Self, action: Action) -> Self {
         guard let displayBorder = (action as? ToolbarAction)?.displayNavBorder else { return state }
 
         return NavigationBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -149,6 +149,16 @@ struct NavigationBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarPositionChanged(state: Self, action: Action) -> Self {
+        guard let displayBorder = (action as? ToolbarAction)?.displayNavBorder else { return state }
+
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: state.actions,
+            displayBorder: displayBorder
+        )
+    }
+
     // MARK: - Navigation Toolbar Actions
 
     private static func navigationActions(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -137,6 +137,16 @@ struct NavigationBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarBackForwardButtonStateChanged(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: navigationActions(action: toolbarAction, navigationBarState: state),
+            displayBorder: state.displayBorder
+        )
+    }
+
     // MARK: - Navigation Toolbar Actions
 
     private static func navigationActions(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -121,6 +121,16 @@ struct NavigationBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarUrlDidChange(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: navigationActions(action: toolbarAction, navigationBarState: state),
+            displayBorder: state.displayBorder
+        )
+    }
+
     private static func handleToolbarNumberOfTabsChanged(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -71,7 +71,7 @@ struct NavigationBarState: StateType, Equatable {
             return handleBackForwardButtonStateChangedAction(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:
-            return handleToolbarShowMenuWarningBadge(state: state, action: action)
+            return handleShowMenuWarningBadgeAction(state: state, action: action)
 
         case ToolbarActionType.borderPositionChanged,
             ToolbarActionType.toolbarPositionChanged:
@@ -133,7 +133,7 @@ struct NavigationBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarShowMenuWarningBadge(state: Self, action: Action) -> Self {
+    private static func handleShowMenuWarningBadgeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return NavigationBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -75,13 +75,7 @@ struct NavigationBarState: StateType, Equatable {
 
         case ToolbarActionType.borderPositionChanged,
             ToolbarActionType.toolbarPositionChanged:
-            guard let displayBorder = (action as? ToolbarAction)?.displayNavBorder else { return state }
-
-            return NavigationBarState(
-                windowUUID: state.windowUUID,
-                actions: state.actions,
-                displayBorder: displayBorder
-            )
+            return handleToolbarPositionChanged(state: state, action: action)
 
         default:
             return NavigationBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -59,7 +59,7 @@ struct NavigationBarState: StateType, Equatable {
 
         switch action.actionType {
         case ToolbarActionType.didLoadToolbars:
-            return handleToolbarDidLoadToolbars(state: state, action: action)
+            return handleDidLoadToolbarsAction(state: state, action: action)
 
         case ToolbarActionType.urlDidChange:
             return handleToolbarUrlDidChange(state: state, action: action)
@@ -86,7 +86,7 @@ struct NavigationBarState: StateType, Equatable {
         }
     }
 
-    private static func handleToolbarDidLoadToolbars(state: Self, action: Action) -> Self {
+    private static func handleDidLoadToolbarsAction(state: Self, action: Action) -> Self {
         guard let displayBorder = (action as? ToolbarAction)?.displayNavBorder else { return state }
 
         let actions = [

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -78,7 +78,11 @@ struct NavigationBarState: StateType, Equatable {
             return handlePositionChangedAction(state: state, action: action)
 
         default:
-            return state
+            return NavigationBarState(
+                windowUUID: state.windowUUID,
+                actions: state.actions,
+                displayBorder: state.displayBorder
+            )
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -129,6 +129,23 @@ struct NavigationBarState: StateType, Equatable {
         }
     }
 
+    private static func handleToolbarDidLoadToolbars(state: Self, action: Action) -> Self {
+        guard let displayBorder = (action as? ToolbarAction)?.displayNavBorder else { return state }
+
+        let actions = [
+            backAction(enabled: false),
+            forwardAction(enabled: false),
+            searchAction,
+            tabsAction(),
+            menuAction()
+        ]
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: actions,
+            displayBorder: displayBorder
+        )
+    }
+
     // MARK: - Navigation Toolbar Actions
 
     private static func navigationActions(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -71,13 +71,7 @@ struct NavigationBarState: StateType, Equatable {
             return handleToolbarBackForwardButtonStateChanged(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return NavigationBarState(
-                windowUUID: state.windowUUID,
-                actions: navigationActions(action: toolbarAction, navigationBarState: state),
-                displayBorder: state.displayBorder
-            )
+            return handleToolbarShowMenuWarningBadge(state: state, action: action)
 
         case ToolbarActionType.borderPositionChanged,
             ToolbarActionType.toolbarPositionChanged:

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -62,13 +62,7 @@ struct NavigationBarState: StateType, Equatable {
             return handleToolbarDidLoadToolbars(state: state, action: action)
 
         case ToolbarActionType.urlDidChange:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return NavigationBarState(
-                windowUUID: state.windowUUID,
-                actions: navigationActions(action: toolbarAction, navigationBarState: state),
-                displayBorder: state.displayBorder
-            )
+            return handleToolbarUrlDidChange(state: state, action: action)
 
         case ToolbarActionType.numberOfTabsChanged:
             return handleToolbarNumberOfTabsChanged(state: state, action: action)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -78,11 +78,7 @@ struct NavigationBarState: StateType, Equatable {
             return handlePositionChangedAction(state: state, action: action)
 
         default:
-            return NavigationBarState(
-                windowUUID: state.windowUUID,
-                actions: state.actions,
-                displayBorder: state.displayBorder
-            )
+            return handleDefaultAction(state: state)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -59,20 +59,7 @@ struct NavigationBarState: StateType, Equatable {
 
         switch action.actionType {
         case ToolbarActionType.didLoadToolbars:
-            guard let displayBorder = (action as? ToolbarAction)?.displayNavBorder else { return state }
-
-            let actions = [
-                backAction(enabled: false),
-                forwardAction(enabled: false),
-                searchAction,
-                tabsAction(),
-                menuAction()
-            ]
-            return NavigationBarState(
-                windowUUID: state.windowUUID,
-                actions: actions,
-                displayBorder: displayBorder
-            )
+            return handleToolbarDidLoadToolbars(state: state, action: action)
 
         case ToolbarActionType.urlDidChange:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -145,6 +145,16 @@ struct NavigationBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarShowMenuWarningBadge(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: navigationActions(action: toolbarAction, navigationBarState: state),
+            displayBorder: state.displayBorder
+        )
+    }
+
     // MARK: - Navigation Toolbar Actions
 
     private static func navigationActions(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -68,7 +68,7 @@ struct NavigationBarState: StateType, Equatable {
             return handleNumberOfTabsChangedAction(state: state, action: action)
 
         case ToolbarActionType.backForwardButtonStateChanged:
-            return handleToolbarBackForwardButtonStateChanged(state: state, action: action)
+            return handleBackForwardButtonStateChangedAction(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:
             return handleToolbarShowMenuWarningBadge(state: state, action: action)
@@ -123,7 +123,7 @@ struct NavigationBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarBackForwardButtonStateChanged(state: Self, action: Action) -> Self {
+    private static func handleBackForwardButtonStateChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return NavigationBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -153,6 +153,14 @@ struct NavigationBarState: StateType, Equatable {
         )
     }
 
+    private static func handleDefaultAction(state: Self) -> Self {
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: state.actions,
+            displayBorder: state.displayBorder
+        )
+    }
+
     // MARK: - Navigation Toolbar Actions
 
     private static func navigationActions(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -133,6 +133,16 @@ struct NavigationBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarNumberOfTabsChanged(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return NavigationBarState(
+            windowUUID: state.windowUUID,
+            actions: navigationActions(action: toolbarAction, navigationBarState: state),
+            displayBorder: state.displayBorder
+        )
+    }
+
     // MARK: - Navigation Toolbar Actions
 
     private static func navigationActions(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -78,11 +78,7 @@ struct NavigationBarState: StateType, Equatable {
             return handlePositionChangedAction(state: state, action: action)
 
         default:
-            return NavigationBarState(
-                windowUUID: state.windowUUID,
-                actions: state.actions,
-                displayBorder: state.displayBorder
-            )
+            return state
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `NavigationBarState.swift` file by extracting the switch case statements to new methods.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

