### PR TITLE
Refactor FXIOS-10351 - UITests maintenance

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -26,10 +26,12 @@ class PhotonActionSheetTests: BaseTestCase {
         // Remove pin
         cell.press(forDuration: 2)
         app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash].tap()
-
         // Check that it has been unpinned
-        // Adding sleep as an workaround until https://github.com/mozilla-mobile/firefox-ios/issues/22323 is fixed
-        sleep(5)
+        /* FIXME: Adding a workaround until https://github.com/mozilla-mobile/firefox-ios/issues/22323 is fixed
+         * We will wait for the pinned icon on the example.com tile to disappear (max 8 seconds polling)
+         */
+        waitForNoExistence(app.cells["Example Domain"].images[StandardImageIdentifiers.Small.pinBadgeFill], timeoutValue: 8)
+
         cell.press(forDuration: 2)
         mozWaitForElementToExist(app.tables.cells.otherElements[StandardImageIdentifiers.Large.pin])
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -244,11 +244,7 @@ class TopTabsTest: BaseTestCase {
     func testOpenNewTabLandscape() {
         XCUIDevice.shared.orientation = .landscapeLeft
         // Verify the '+' icon is shown and open a tab with it
-        if iPad() {
-            app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
-        } else {
-            app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
-        }
+        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
         app.typeText("google.com\n")
         waitUntilPageLoad()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10351)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22681)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Updated the below tests

- `testContextMenuInLandscape()` : This test is passing in iPhone and iPad simulator. 
    So, it doesn't need the ` if iPad()` check ?

- `testOpenNewTabLandscape()` : This test has unnecessary `if iPad()` check

- `testPinToShortcuts()`: This test needs a `polling` check instead of hard `sleep` until https://github.com/mozilla-mobile/firefox-ios/issues/22323 is fixed. In the below test run screenshot, we can see that the test is waiting for the unwanted pin icon on `example.com` tile to disappear.

<img width="886" alt="Screenshot 2024-10-21 at 10 49 01 PM" src="https://github.com/user-attachments/assets/31960e2a-9648-42cc-beed-fc83f15de441">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

