### PR TITLE
Bugfix FXIOS-10200 WKWebView showing gray background while loading content

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -369,10 +369,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable {
             guard nightMode != oldValue else { return }
 
             webView?.evaluateJavascriptInDefaultContentWorld("window.__firefox__.NightMode.setEnabled(\(nightMode))")
-            // For WKWebView background color to take effect, isOpaque must be false,
-            // which is counter-intuitive. Default is true. The color is previously
-            // set to black in the WKWebView init.
-            webView?.isOpaque = !nightMode
 
             UserScriptManager.shared.injectUserScriptsIntoWebView(
                 webView,
@@ -531,9 +527,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable {
             if #available(iOS 16.4, *) {
                 webView.isInspectable = true
             }
-
-            // Night mode enables this by toggling WKWebView.isOpaque, otherwise this has no effect.
-            webView.backgroundColor = .black
 
             // Turning off masking allows the web content to flow outside of the scrollView's frame
             // which allows the content appear beneath the toolbars in the BrowserViewController
@@ -911,6 +904,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable {
     func applyTheme(theme: Theme) {
         UITextField.appearance().keyboardAppearance = theme.type.keyboardAppearence(isPrivate: isPrivate)
         webView?.applyTheme(theme: theme)
+        webView?.underPageBackgroundColor = nightMode ? .black : nil
     }
 
     // MARK: - Static Helpers

--- a/firefox-ios/Client/TabManagement/TabManagerNavDelegate.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerNavDelegate.swift
@@ -15,6 +15,7 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        restoreWebViewBackgroundColorToDefault(webView)
         for delegate in delegates {
             delegate.webView?(webView, didCommit: navigation)
         }
@@ -25,6 +26,7 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
         didFail navigation: WKNavigation!,
         withError error: Error
     ) {
+        restoreWebViewBackgroundColorToDefault(webView)
         for delegate in delegates {
             delegate.webView?(webView, didFail: navigation, withError: error)
         }
@@ -35,6 +37,7 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
         didFailProvisionalNavigation navigation: WKNavigation!,
         withError error: Error
     ) {
+        restoreWebViewBackgroundColorToDefault(webView)
         for delegate in delegates {
             delegate.webView?(webView, didFailProvisionalNavigation: navigation, withError: error)
         }
@@ -47,6 +50,7 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
     }
 
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        restoreWebViewBackgroundColorToDefault(webView)
         for delegate in delegates {
             delegate.webViewWebContentProcessDidTerminate?(webView)
         }
@@ -77,6 +81,7 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        webView.evaluateJavascriptInDefaultContentWorld("document.body.style.backgroundColor = 'transparent';")
         for delegate in delegates {
             delegate.webView?(webView, didStartProvisionalNavigation: navigation)
         }
@@ -111,5 +116,9 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
         }
 
         decisionHandler(res)
+    }
+
+    private func restoreWebViewBackgroundColorToDefault(_ webView: WKWebView) {
+        webView.evaluateJavascriptInDefaultContentWorld("document.body.style.backgroundColor = '';")
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10200)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22322)

## :bulb: Description
Bugfix `WKWebView` showing gray background while loading content. Now the content background while loading has been replaced with transparent background, but can be modified to any color.

Fix pull to refresh showing always in first web view load, i think this comes since adding clear background to web view with this PR.

## Pull bug

https://github.com/user-attachments/assets/cd71deaf-d045-4f24-91b7-e5e372642e1b

## Background fix and pull bug

https://github.com/user-attachments/assets/4fbe354a-2f8c-4950-9a3f-26a35f079009



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

