### PR TITLE
Bugfix FXIOS-10354 Tab peek action copy URL copying only selected tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -613,7 +613,7 @@ class TabManagerMiddleware {
 
     private func copyURL(tabID: TabUUID, uuid: WindowUUID) {
         let tabManager = tabManager(for: uuid)
-        UIPasteboard.general.url = tabManager.selectedTab?.canonicalURL
+        UIPasteboard.general.url = tabManager.getTabForUUID(uuid: tabID)?.canonicalURL
         let toastAction = TabPanelMiddlewareAction(toastType: .copyURL,
                                                    windowUUID: uuid,
                                                    actionType: TabPanelMiddlewareActionType.showToast)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10354)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22685)

## :bulb: Description
Bugfix Tab peek action copy URL copying only selected tab. Previously to the paste board was passed the selected tab manager tab and not the currently select tab from the tab peek.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

