### PR TITLE
Add FXIOS-9646 - Password Generator Telemetry

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -68,11 +68,13 @@
 		0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF0DB931A8545800039F300 /* URLBarView.swift */; };
 		0BF1B7E31AC60DEA00A7B407 /* InsetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */; };
 		0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */; };
+		0E12A3152CC2D8410037F8EE /* PasswordGeneratorTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E12A3142CC2D8410037F8EE /* PasswordGeneratorTelemetry.swift */; };
 		0E456F152C541CB300EE93BF /* PasswordGeneratorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E456F142C541CB300EE93BF /* PasswordGeneratorViewController.swift */; };
 		0E6C1E212C909AD7001A43BB /* PasswordGeneratorAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6C1E202C909AD7001A43BB /* PasswordGeneratorAction.swift */; };
 		0E6C1E232C909E04001A43BB /* PasswordGeneratorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6C1E222C909E04001A43BB /* PasswordGeneratorState.swift */; };
 		0E6C1E252C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6C1E242C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift */; };
 		0E77DF0F2CB8220000B80BA1 /* GeneratedPasswordStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E77DF0E2CB8220000B80BA1 /* GeneratedPasswordStorage.swift */; };
+		0E9702742CC2F2FB00C357B7 /* PasswordGeneratorTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E12A3162CC2EE8C0037F8EE /* PasswordGeneratorTelemetryTests.swift */; };
 		0EC57CE32CA31C5B002E3F04 /* PasswordGeneratorViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57CE22CA31C5B002E3F04 /* PasswordGeneratorViewControllerTests.swift */; };
 		0EC57CE52CA31E59002E3F04 /* PasswordGeneratorStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57CE42CA31E59002E3F04 /* PasswordGeneratorStateTests.swift */; };
 		0EC57D082CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57D072CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift */; };
@@ -2350,6 +2352,8 @@
 		0DB0424587EE7A01E376643F /* pa-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pa-IN"; path = "pa-IN.lproj/ClearHistoryConfirm.strings"; sourceTree = "<group>"; };
 		0DB446798061E493F304EDC4 /* az */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = az; path = az.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		0DC14F8BB480069DC6D962D0 /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/LoginManager.strings; sourceTree = "<group>"; };
+		0E12A3142CC2D8410037F8EE /* PasswordGeneratorTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorTelemetry.swift; sourceTree = "<group>"; };
+		0E12A3162CC2EE8C0037F8EE /* PasswordGeneratorTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorTelemetryTests.swift; sourceTree = "<group>"; };
 		0E134A0087CE6D183E5DA1D4 /* jv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = jv; path = jv.lproj/Search.strings; sourceTree = "<group>"; };
 		0E2440E3AD220D7C5EB7BB50 /* ia */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ia; path = ia.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		0E2D4E0FA5490EF048AEE106 /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
@@ -9583,6 +9587,7 @@
 				0E6C1E222C909E04001A43BB /* PasswordGeneratorState.swift */,
 				0E6C1E242C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift */,
 				0E77DF0E2CB8220000B80BA1 /* GeneratedPasswordStorage.swift */,
+				0E12A3142CC2D8410037F8EE /* PasswordGeneratorTelemetry.swift */,
 			);
 			path = PasswordGenerator;
 			sourceTree = "<group>";
@@ -9592,6 +9597,7 @@
 			children = (
 				0EC57CE22CA31C5B002E3F04 /* PasswordGeneratorViewControllerTests.swift */,
 				0EC57CE42CA31E59002E3F04 /* PasswordGeneratorStateTests.swift */,
+				0E12A3162CC2EE8C0037F8EE /* PasswordGeneratorTelemetryTests.swift */,
 			);
 			path = PasswordGenerator;
 			sourceTree = "<group>";
@@ -15696,6 +15702,7 @@
 				81F617C92C8755AB003799BF /* MainMenuAction.swift in Sources */,
 				E13E9AB52AAB0FB5001A0E9D /* FakespotViewModel.swift in Sources */,
 				8A5D1CBD2A30DC4E005AD35C /* AccountStatusSetting.swift in Sources */,
+				0E12A3152CC2D8410037F8EE /* PasswordGeneratorTelemetry.swift in Sources */,
 				E1CD81BC290C5C3F00124B27 /* DevicePickerTableViewCell.swift in Sources */,
 				1DDE3DB72AC3820A0039363B /* TabModel.swift in Sources */,
 				8A19ACB02A329078001C2147 /* AutofillCreditCardSettings.swift in Sources */,
@@ -16876,6 +16883,7 @@
 				21B337BB29B67E4100E4F806 /* BrowserViewControllerWebViewDelegateTests.swift in Sources */,
 				6ADB651B285C03B100947EA4 /* DownloadHelperTests.swift in Sources */,
 				8A6B77CC2811C468001110D2 /* URLProtocolStub.swift in Sources */,
+				0E9702742CC2F2FB00C357B7 /* PasswordGeneratorTelemetryTests.swift in Sources */,
 				CA7BD568248189E800A0A61B /* BreachAlertsTests.swift in Sources */,
 				253648E12B2111C100D5C2C5 /* SearchViewControllerTests.swift in Sources */,
 				4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */,

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
@@ -11,6 +11,7 @@ import WebKit
 final class PasswordGeneratorMiddleware {
     private let logger: Logger
     private let generatedPasswordStorage: GeneratedPasswordStorageProtocol
+    private let passwordGeneratorTelemetry = PasswordGeneratorTelemetry()
 
     init(logger: Logger = DefaultLogger.shared,
          generatedPasswordStorage: GeneratedPasswordStorageProtocol = GeneratedPasswordStorage()) {
@@ -48,6 +49,7 @@ final class PasswordGeneratorMiddleware {
 
     private func showPasswordGenerator(frame: WKFrameInfo, windowUUID: WindowUUID) {
         guard let origin = frame.webView?.url?.origin else {return}
+        passwordGeneratorTelemetry.passwordGeneratorDialogShown()
         if let password = generatedPasswordStorage.getPasswordForOrigin(origin: origin) {
             let newAction = PasswordGeneratorAction(
                 windowUUID: windowUUID,
@@ -83,6 +85,7 @@ final class PasswordGeneratorMiddleware {
     }
 
     private func userTappedUsePassword(frame: WKFrameInfo, password: String) {
+        passwordGeneratorTelemetry.usePasswordButtonPressed()
         let jsFunctionCall = "window.__firefox__.logins.fillGeneratedPassword(\"\(password)\")"
         frame.webView?.evaluateJavascriptInDefaultContentWorld(jsFunctionCall, frame) { (result, error) in
             if error != nil {

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorTelemetry.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorTelemetry.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+public struct PasswordGeneratorTelemetry {
+    func passwordGeneratorDialogShown() {
+        GleanMetrics.PasswordGenerator.shown.add()
+    }
+
+    func usePasswordButtonPressed() {
+        GleanMetrics.PasswordGenerator.filled.add()
+    }
+}

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -656,6 +656,31 @@ downloads:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-01-01"
 
+# Password Generator
+password_generator:
+  shown:
+    type: counter
+    description: |
+        The password generator bottom sheet was shown and is visible
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-01-01"
+  filled:
+    type: counter
+    description: |
+        The "use password button" of the password generator bottom sheet was clicked.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/21248
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-01-01"
+    
 # Microsurvey
 microsurvey:
   shown:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordGenerator/PasswordGeneratorTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordGenerator/PasswordGeneratorTelemetryTests.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+import Redux
+import XCTest
+
+@testable import Client
+
+final class PasswordGeneratorTelemetryTests: XCTestCase {
+    let telemetry = PasswordGeneratorTelemetry()
+    override func setUp() {
+        super.setUp()
+        Glean.shared.resetGlean(clearStores: true)
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        DependencyHelperMock().reset()
+        super.tearDown()
+    }
+
+    func testShowPasswordGeneratorDialog() {
+        telemetry.passwordGeneratorDialogShown()
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.PasswordGenerator.shown)
+    }
+
+    func testUsePasswordButtonPressed() {
+        telemetry.usePasswordButtonPressed()
+        testCounterMetricRecordingSuccess(metric: GleanMetrics.PasswordGenerator.filled)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9646)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21248)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add 2 metrics to telemetry:
- Password Generator Prompt Shown: Counter
- Password field filled with generated password: Counter

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

