### PR TITLE
Add FXIOS-10273 [Unified Search] Add SearchEngineSelectionCoordinator and stub SearchEngineSelectionViewController

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1834,6 +1834,7 @@
 		ED28DAC92C45A95F00D2641C /* TabScrollBehaviorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */; };
 		ED371A682CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */; };
 		ED45893E2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893D2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift */; };
+		ED4589402CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */; };
 		ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */; };
 		EDC3D34F2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EDC3D34E2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets */; };
 		EDC3D3552CB70A3F00C62DE3 /* OpenSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */; };
@@ -8983,6 +8984,7 @@
 		ED364EECB95B96AB639A82DE /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/Localizable.strings; sourceTree = "<group>"; };
 		ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinator.swift; sourceTree = "<group>"; };
 		ED45893D2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionViewControllerTests.swift; sourceTree = "<group>"; };
+		ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSearchEngineSelectionCoordinator.swift; sourceTree = "<group>"; };
 		ED5144A0BE3A8C7B15047C3F /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinatorTests.swift; sourceTree = "<group>"; };
 		ED84423D8666C751BBFC76AC /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Storage.strings; sourceTree = "<group>"; };
@@ -12287,6 +12289,7 @@
 				C8C3FEA029F973C40038E3BA /* MockBrowserViewController.swift */,
 				8AF6D4DE2A856A9000B0474B /* MockContileNetworking.swift */,
 				8AABBD042A0041380089941E /* MockCoordinator.swift */,
+				ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */,
 				8AE80BB42891AE6700BC12EA /* MockDispatchGroup.swift */,
 				8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */,
 				8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */,
@@ -16733,6 +16736,7 @@
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
 				C89C91AD2A1FE9E900BE57B1 /* OnboardingTelemetryDelegationTests.swift in Sources */,
 				8A36BE2C29EDE16C00AC1C5C /* ContentContainerTests.swift in Sources */,
+				ED4589402CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift in Sources */,
 				5A9A09D228AFD51900B6F51E /* MockHomepageDataModelDelegate.swift in Sources */,
 				D525DFB325FBE5E000B18763 /* TabTests.swift in Sources */,
 				C8E78BDD27F4A1E700C48BAA /* HistoryDeletionUtilityTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1835,6 +1835,8 @@
 		ED28DAC92C45A95F00D2641C /* TabScrollBehaviorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */; };
 		EDC3D34F2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EDC3D34E2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets */; };
 		EDC3D3552CB70A3F00C62DE3 /* OpenSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */; };
+		ED371A682CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */; };
+		EDD21F2E2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD21F2D2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift */; };
 		EDF567A02C8B51DC00FDB09D /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = EDF5679F2C8B51DC00FDB09D /* SiteImageView */; };
 		EDF567A22C8B51E100FDB09D /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = EDF567A12C8B51E100FDB09D /* Kingfisher */; };
 		F018F84C2719AE8300B9A52D /* ThemedDefaultNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F018F84B2719AE8300B9A52D /* ThemedDefaultNavigationController.swift */; };
@@ -8979,6 +8981,7 @@
 		ED264785844AD63AD616A882 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollBehaviorModel.swift; sourceTree = "<group>"; };
 		ED364EECB95B96AB639A82DE /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/Localizable.strings; sourceTree = "<group>"; };
+		ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinator.swift; sourceTree = "<group>"; };
 		ED5144A0BE3A8C7B15047C3F /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		ED84423D8666C751BBFC76AC /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Storage.strings; sourceTree = "<group>"; };
 		EDA240A8BBFD0A19FB2C3D7E /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Intro.strings; sourceTree = "<group>"; };
@@ -8987,6 +8990,7 @@
 		EDC3D34E2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = SearchEngineTestAssets.xcassets; sourceTree = "<group>"; };
 		EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearchEngineTests.swift; sourceTree = "<group>"; };
 		EDCA4CBC8077FC37971CC0C7 /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EDD21F2D2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionViewController.swift; sourceTree = "<group>"; };
 		EDEE4CC7BD65892525632A4E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Today.strings; sourceTree = "<group>"; };
 		EE294A97B40C4FDBD67AE536 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		EE4D49BBA90C11374B6718A4 /* ur */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ur; path = ur.lproj/LoginManager.strings; sourceTree = "<group>"; };
@@ -10835,10 +10839,12 @@
 		8A1E3BE428CBBF1E003388C4 /* SearchEngines */ = {
 			isa = PBXGroup;
 			children = (
+				ED371A692CB885B20099F3C8 /* Views */,
 				D308E4E31A5306F500842685 /* SearchEngines.swift */,
 				8A1E3BE528CBBF44003388C4 /* OpenSearchEngine.swift */,
 				D3FA77831A43B2CE0010CD32 /* OpenSearchParser.swift */,
 				96A5F72F298D8BEE00234E5F /* DefaultSearchEngineProvider.swift */,
+				ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */,
 			);
 			path = SearchEngines;
 			sourceTree = "<group>";
@@ -13489,6 +13495,14 @@
 			path = InternalSchemeHandler;
 			sourceTree = "<group>";
 		};
+		ED371A692CB885B20099F3C8 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				EDD21F2D2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		F8324A082649A188007E4BFA /* CredentialProvider */ = {
 			isa = PBXGroup;
 			children = (
@@ -16077,6 +16091,7 @@
 				D83822001FC7961D00303C12 /* DispatchQueueHelper.swift in Sources */,
 				EBC486992195F46B00CDA48D /* InternalSchemeHandler.swift in Sources */,
 				E18BAAFD28E4A44500098AE2 /* TopTabFader.swift in Sources */,
+				EDD21F2E2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift in Sources */,
 				C8656D79270F866700E199EA /* CustomizeHomepageSectionCell.swift in Sources */,
 				ABE4393E2AC432040074FFE1 /* PartnerWebsites.swift in Sources */,
 				C84655FB28879FC600861B4A /* WallpaperStorageUtility.swift in Sources */,
@@ -16436,6 +16451,7 @@
 				81A3F6F22C2DB00900BDD86B /* MainMenuViewController.swift in Sources */,
 				E16E1C9828C25F1D00EE2EF5 /* SiteTableViewHeader.swift in Sources */,
 				BD2577992C9D85B5007B344C /* AnyHashable.swift in Sources */,
+				ED371A682CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift in Sources */,
 				E177989E2BD7D75A00F6F0EB /* ToolbarMiddleware.swift in Sources */,
 				AB4FB4DC2C89FB10005EF0CC /* BlockedTrackerCell.swift in Sources */,
 				C8CD80D72A1E2C6E0097C3AE /* NimbusMessagingHelperUtilityProtocol.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -32,7 +32,6 @@
 		0AFF7F6D2C7C7BBA00265214 /* CertificatesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFF7F6A2C7C7BB900265214 /* CertificatesViewController.swift */; };
 		0B11AF022CB412D100AD51D5 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B11AF002CB412D100AD51D5 /* Metrics.swift */; };
 		0B11AF042CB4130F00AD51D5 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B11AF032CB4130F00AD51D5 /* Metrics.swift */; };
-		0AFF7F6E2C7C7BBA00265214 /* CertificatesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFF7F6B2C7C7BB900265214 /* CertificatesModel.swift */; };
 		0B305E1B1E3A98A900BE0767 /* BookmarksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B305E1A1E3A98A900BE0767 /* BookmarksTests.swift */; };
 		0B3D670E1E09B90B00C1EFC7 /* AuthenticationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3D670D1E09B90B00C1EFC7 /* AuthenticationTest.swift */; };
 		0B3F8C5E2CA4471C00DB5367 /* EditBookmarkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3F8C5D2CA4471C00DB5367 /* EditBookmarkViewModel.swift */; };
@@ -1833,9 +1832,10 @@
 		EBF47E701F7979DF00899189 /* TelemetryWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */; };
 		EBFDB790211C83A5005CCA2F /* BrowserViewController+FindInPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFDB787211C83A5005CCA2F /* BrowserViewController+FindInPage.swift */; };
 		ED28DAC92C45A95F00D2641C /* TabScrollBehaviorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */; };
+		ED371A682CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */; };
+		ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */; };
 		EDC3D34F2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EDC3D34E2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets */; };
 		EDC3D3552CB70A3F00C62DE3 /* OpenSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */; };
-		ED371A682CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */; };
 		EDD21F2E2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD21F2D2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift */; };
 		EDF567A02C8B51DC00FDB09D /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = EDF5679F2C8B51DC00FDB09D /* SiteImageView */; };
 		EDF567A22C8B51E100FDB09D /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = EDF567A12C8B51E100FDB09D /* Kingfisher */; };
@@ -2281,7 +2281,6 @@
 		0AFF7F6A2C7C7BB900265214 /* CertificatesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CertificatesViewController.swift; sourceTree = "<group>"; };
 		0B11AF002CB412D100AD51D5 /* Metrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
 		0B11AF032CB4130F00AD51D5 /* Metrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
-		0AFF7F6B2C7C7BB900265214 /* CertificatesModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CertificatesModel.swift; sourceTree = "<group>"; };
 		0B305E1A1E3A98A900BE0767 /* BookmarksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksTests.swift; sourceTree = "<group>"; };
 		0B3D670D1E09B90B00C1EFC7 /* AuthenticationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationTest.swift; sourceTree = "<group>"; };
 		0B3F8C5D2CA4471C00DB5367 /* EditBookmarkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditBookmarkViewModel.swift; sourceTree = "<group>"; };
@@ -8983,6 +8982,7 @@
 		ED364EECB95B96AB639A82DE /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/Localizable.strings; sourceTree = "<group>"; };
 		ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinator.swift; sourceTree = "<group>"; };
 		ED5144A0BE3A8C7B15047C3F /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
+		ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinatorTests.swift; sourceTree = "<group>"; };
 		ED84423D8666C751BBFC76AC /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Storage.strings; sourceTree = "<group>"; };
 		EDA240A8BBFD0A19FB2C3D7E /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Intro.strings; sourceTree = "<group>"; };
 		EDB94DDC89DE1F2C624C9841 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -11187,6 +11187,7 @@
 			children = (
 				8A93F86929D37FC9004159D9 /* BaseCoordinatorTests.swift */,
 				8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */,
+				ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */,
 				C2D80BEA2AAF395200CDF7A9 /* CredentialAutofillCoordinatorTests.swift */,
 				8A93F86429D37331004159D9 /* DefaultRouterTests.swift */,
 				F18859512A3E46020004AA7B /* EnhancedTrackingProtectionCoordinatorTests.swift */,
@@ -16646,6 +16647,7 @@
 				5A3A7DD62889CF3D0065F81A /* BookmarksDataAdaptorTests.swift in Sources */,
 				8AD08D1727E91AC800B8E907 /* TabsTelemetryTests.swift in Sources */,
 				C8C3FE9D29F907B30038E3BA /* MockSearchHandlerRouteCoordinator.swift in Sources */,
+				ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */,
 				C8C3FEA129F973C40038E3BA /* MockBrowserViewController.swift in Sources */,
 				8A93F86B29D39BDA004159D9 /* BaseCoordinatorTests.swift in Sources */,
 				8AF3B15A2AF99B86009BB262 /* HistoryPanelTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1199,7 +1199,7 @@
 		C23889DF2A4EFCE500429673 /* ShareExtensionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889DE2A4EFCE500429673 /* ShareExtensionCoordinator.swift */; };
 		C23889E12A4F3E7200429673 /* ParentCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889E02A4F3E7200429673 /* ParentCoordinatorDelegate.swift */; };
 		C23889E32A50319A00429673 /* ShareExtensionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889E22A50319A00429673 /* ShareExtensionCoordinatorTests.swift */; };
-		C23889E52A50329200429673 /* MockParentCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889E42A50329200429673 /* MockParentCoordinatorDelegate.swift */; };
+		C23889E52A50329200429673 /* MockParentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889E42A50329200429673 /* MockParentCoordinator.swift */; };
 		C2446B312A856D13000C527D /* MockLibraryCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2446B302A856D13000C527D /* MockLibraryCoordinatorDelegate.swift */; };
 		C2506C932A6A863600F2B76E /* HistoryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2506C922A6A863600F2B76E /* HistoryCoordinator.swift */; };
 		C2506C952A6A8D2600F2B76E /* HistoryCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2506C942A6A8D2600F2B76E /* HistoryCoordinatorTests.swift */; };
@@ -1833,6 +1833,7 @@
 		EBFDB790211C83A5005CCA2F /* BrowserViewController+FindInPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFDB787211C83A5005CCA2F /* BrowserViewController+FindInPage.swift */; };
 		ED28DAC92C45A95F00D2641C /* TabScrollBehaviorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */; };
 		ED371A682CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */; };
+		ED45893E2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893D2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift */; };
 		ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */; };
 		EDC3D34F2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EDC3D34E2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets */; };
 		EDC3D3552CB70A3F00C62DE3 /* OpenSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */; };
@@ -7806,7 +7807,7 @@
 		C23889DE2A4EFCE500429673 /* ShareExtensionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionCoordinator.swift; sourceTree = "<group>"; };
 		C23889E02A4F3E7200429673 /* ParentCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		C23889E22A50319A00429673 /* ShareExtensionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionCoordinatorTests.swift; sourceTree = "<group>"; };
-		C23889E42A50329200429673 /* MockParentCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockParentCoordinatorDelegate.swift; sourceTree = "<group>"; };
+		C23889E42A50329200429673 /* MockParentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockParentCoordinator.swift; sourceTree = "<group>"; };
 		C2446B302A856D13000C527D /* MockLibraryCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLibraryCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		C2506C922A6A863600F2B76E /* HistoryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCoordinator.swift; sourceTree = "<group>"; };
 		C2506C942A6A8D2600F2B76E /* HistoryCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -8981,6 +8982,7 @@
 		ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollBehaviorModel.swift; sourceTree = "<group>"; };
 		ED364EECB95B96AB639A82DE /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/Localizable.strings; sourceTree = "<group>"; };
 		ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinator.swift; sourceTree = "<group>"; };
+		ED45893D2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionViewControllerTests.swift; sourceTree = "<group>"; };
 		ED5144A0BE3A8C7B15047C3F /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinatorTests.swift; sourceTree = "<group>"; };
 		ED84423D8666C751BBFC76AC /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Storage.strings; sourceTree = "<group>"; };
@@ -10485,7 +10487,7 @@
 			children = (
 				5AE371812A4DD0D70092A760 /* PasswordManagerCoordinatorDelegateMock.swift */,
 				5AE371832A4DD6F50092A760 /* PasswordManagerListViewControllerSpy.swift */,
-				C23889E42A50329200429673 /* MockParentCoordinatorDelegate.swift */,
+				C23889E42A50329200429673 /* MockParentCoordinator.swift */,
 				C2446B302A856D13000C527D /* MockLibraryCoordinatorDelegate.swift */,
 				8A7AE4452BAC76B00072DAEC /* MockLibraryNavigationHandler.swift */,
 				C2D80BEC2AAF3C6B00CDF7A9 /* MockBrowserCoordinator.swift */,
@@ -10854,6 +10856,7 @@
 			children = (
 				EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */,
 				2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */,
+				ED45893D2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift */,
 				D3FA777A1A43B2990010CD32 /* SearchTests.swift */,
 				96A5F734298D8EB900234E5F /* MockSearchEngineProvider.swift */,
 				EDC3D34E2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets */,
@@ -16699,7 +16702,7 @@
 				D8BA1790206D47830023AC00 /* DeferredTestUtils.swift in Sources */,
 				5AA75A652A46274A00533F8D /* MockThemeManager.swift in Sources */,
 				8A5038142A5DFCE000A1B02A /* MockBrowserProfile.swift in Sources */,
-				C23889E52A50329200429673 /* MockParentCoordinatorDelegate.swift in Sources */,
+				C23889E52A50329200429673 /* MockParentCoordinator.swift in Sources */,
 				21D8843F2A7959D000AF144C /* HomePageSettingViewControllerTests.swift in Sources */,
 				C2D80BED2AAF3C6B00CDF7A9 /* MockBrowserCoordinator.swift in Sources */,
 				45D5EDC0292D619000311934 /* MockablePinnedSites.swift in Sources */,
@@ -16737,6 +16740,7 @@
 				8AB893A72C73AFCC00DAEED7 /* MockLoginViewModelDelegate.swift in Sources */,
 				8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */,
 				5A475E8F29DB89CE009C13FD /* MockTabDataStore.swift in Sources */,
+				ED45893E2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift in Sources */,
 				8A7A93EE2810ADF2005E7E1B /* ContileProviderTests.swift in Sources */,
 				5A3A7DDA2889EC4D0065F81A /* ReadingListMock.swift in Sources */,
 				8A33221F27DFE318008F809E /* TopSitesDataAdaptorTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -548,7 +548,7 @@ class BrowserCoordinator: BaseCoordinator,
             navigationController.sheetPresentationController?.prefersGrabberVisible = true
         }
 
-        let coordinator = SearchEngineSelectionCoordinator(
+        let coordinator = DefaultSearchEngineSelectionCoordinator(
             router: DefaultRouter(navigationController: navigationController),
             windowUUID: tabManager.windowUUID
         )

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -31,6 +31,10 @@ class BrowserCoordinator: BaseCoordinator,
                           MainMenuCoordinatorDelegate,
                           ETPCoordinatorSSLStatusDelegate,
                           SearchEngineSelectionCoordinatorDelegate {
+    private struct UX {
+        static let searchEnginePopoverSize = CGSize(width: 250, height: 536)
+    }
+
     var browserViewController: BrowserViewController
     var webviewController: WebviewViewController?
     var legacyHomepageViewController: LegacyHomepageViewController?
@@ -533,7 +537,7 @@ class BrowserCoordinator: BaseCoordinator,
         let navigationController = DismissableNavigationViewController()
         if navigationController.shouldUseiPadSetup() {
             navigationController.modalPresentationStyle = .popover
-            navigationController.preferredContentSize = CGSize(width: 250, height: 536) // FIXME constants
+            navigationController.preferredContentSize = UX.searchEnginePopoverSize
             navigationController.popoverPresentationController?.sourceView = sourceView
             navigationController.popoverPresentationController?.canOverlapSourceViewRect = false
         } else {
@@ -545,6 +549,7 @@ class BrowserCoordinator: BaseCoordinator,
             router: DefaultRouter(navigationController: navigationController),
             windowUUID: tabManager.windowUUID
         )
+
         coordinator.parentCoordinator = self
         coordinator.navigationHandler = self
         add(child: coordinator)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -534,6 +534,8 @@ class BrowserCoordinator: BaseCoordinator,
     // MARK: - SearchEngineSelectionCoordinatorDelegate
 
     func showSearchEngineSelection(forSourceView sourceView: UIView) {
+        guard !childCoordinators.contains(where: { $0 is SearchEngineSelectionCoordinator }) else { return }
+
         let navigationController = DismissableNavigationViewController()
         if navigationController.shouldUseiPadSetup() {
             navigationController.modalPresentationStyle = .popover
@@ -541,6 +543,7 @@ class BrowserCoordinator: BaseCoordinator,
             navigationController.popoverPresentationController?.sourceView = sourceView
             navigationController.popoverPresentationController?.canOverlapSourceViewRect = false
         } else {
+            navigationController.modalPresentationStyle = .pageSheet
             navigationController.sheetPresentationController?.detents = [.medium(), .large()]
             navigationController.sheetPresentationController?.prefersGrabberVisible = true
         }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -98,7 +98,7 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     func showMainMenu()
 
     /// Shows the toolbar's search engine selection bottom sheet (iPhone) or popup (iPad)
-    func showSearchEngineSelection()
+    func showSearchEngineSelection(forSourceView sourceView: UIView)
 }
 
 extension BrowserNavigationHandler {

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -96,6 +96,9 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 
     /// Shows the app menu
     func showMainMenu()
+
+    /// Shows the toolbar's search engine selection bottom sheet (iPhone) or popup (iPad)
+    func showSearchEngineSelection()
 }
 
 extension BrowserNavigationHandler {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3256,7 +3256,7 @@ class BrowserViewController: UIViewController,
     }
 
     func addressToolbarDidTapSearchEngine(_ searchEngineView: UIView) {
-        // TODO FXIOS-10273 Use coordinator to handle search engine bottom sheet display
+        navigationHandler?.showSearchEngineSelection(forSourceView: searchEngineView)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
@@ -10,7 +10,14 @@ protocol SearchEngineSelectionCoordinatorDelegate: AnyObject {
     func showSettings(at destination: Route.SettingsSection)
 }
 
-class SearchEngineSelectionCoordinator: BaseCoordinator, FeatureFlaggable {
+protocol SearchEngineSelectionCoordinator: AnyObject {
+    func navigateToSearchSettings(animated: Bool)
+    func dismissModal(animated: Bool)
+}
+
+class DefaultSearchEngineSelectionCoordinator: BaseCoordinator,
+                                               FeatureFlaggable,
+                                               SearchEngineSelectionCoordinator {
     weak var parentCoordinator: ParentCoordinatorDelegate?
     weak var navigationHandler: SearchEngineSelectionCoordinatorDelegate?
 

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
@@ -7,7 +7,7 @@ import Foundation
 import Shared
 
 protocol SearchEngineSelectionCoordinatorDelegate: AnyObject {
-    func showSettings(at destination: Route.SettingsSection) // TODO search settings
+    func showSettings(at destination: Route.SettingsSection)
 }
 
 class SearchEngineSelectionCoordinator: BaseCoordinator, FeatureFlaggable {
@@ -24,7 +24,7 @@ class SearchEngineSelectionCoordinator: BaseCoordinator, FeatureFlaggable {
     func start() {
         router.setRootViewController(
             createSearchEngineSelectionViewController(),
-            hideBar: true // TODO ?
+            hideBar: true
         )
     }
 
@@ -38,7 +38,13 @@ class SearchEngineSelectionCoordinator: BaseCoordinator, FeatureFlaggable {
         })
     }
 
+    func dismissModal(animated: Bool) {
+        router.dismiss(animated: animated, completion: nil)
+        parentCoordinator?.didFinish(from: self)
+    }
+
     // MARK: - Private helpers
+
     private func createSearchEngineSelectionViewController() -> SearchEngineSelectionViewController {
         let vc = SearchEngineSelectionViewController(windowUUID: windowUUID)
         vc.coordinator = self

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
@@ -28,10 +28,6 @@ class SearchEngineSelectionCoordinator: BaseCoordinator, FeatureFlaggable {
         )
     }
 
-    func dismissDetailViewController() {
-        router.popViewController(animated: true)
-    }
-
     func navigateToSearchSettings(animated: Bool) {
         router.dismiss(animated: animated, completion: { [weak self] in
             guard let self else { return }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineSelectionCoordinator.swift
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Shared
+
+protocol SearchEngineSelectionCoordinatorDelegate: AnyObject {
+    func showSettings(at destination: Route.SettingsSection) // TODO search settings
+}
+
+class SearchEngineSelectionCoordinator: BaseCoordinator, FeatureFlaggable {
+    weak var parentCoordinator: ParentCoordinatorDelegate?
+    weak var navigationHandler: SearchEngineSelectionCoordinatorDelegate?
+
+    private let windowUUID: WindowUUID
+
+    init(router: Router, windowUUID: WindowUUID) {
+        self.windowUUID = windowUUID
+        super.init(router: router)
+    }
+
+    func start() {
+        router.setRootViewController(
+            createSearchEngineSelectionViewController(),
+            hideBar: true // TODO ?
+        )
+    }
+
+    func dismissDetailViewController() {
+        router.popViewController(animated: true)
+    }
+
+    func navigateToSearchSettings(animated: Bool) {
+        router.dismiss(animated: animated, completion: { [weak self] in
+            guard let self else { return }
+
+            self.navigationHandler?.showSettings(at: .search)
+
+            self.parentCoordinator?.didFinish(from: self)
+        })
+    }
+
+    // MARK: - Private helpers
+    private func createSearchEngineSelectionViewController() -> SearchEngineSelectionViewController {
+        let vc = SearchEngineSelectionViewController(windowUUID: windowUUID)
+        vc.coordinator = self
+        return vc
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -9,7 +9,8 @@ import Shared
 import Redux
 
 class SearchEngineSelectionViewController: UIViewController,
-                                           BottomSheetChild,
+                                           UISheetPresentationControllerDelegate,
+                                           UIPopoverPresentationControllerDelegate,
                                            Themeable {
     // MARK: - Properties
     var notificationCenter: NotificationProtocol
@@ -22,12 +23,13 @@ class SearchEngineSelectionViewController: UIViewController,
     private let logger: Logger
 
     // MARK: - UI/UX elements
-    // FXIOS-10192 This button is a temporary placeholder for setting up the navigation / coordinators
+    // FXIOS-10192 This button is a temporary placeholder used to set up the navigation / coordinators. Will be removed.
     private lazy var placeholderOpenSettingsButton: UIButton = .build { view in
         view.setTitle(.UnifiedSearch.SearchEngineSelection.SearchSettings, for: .normal)
         view.setTitleColor(.blue, for: .normal)
         view.titleLabel?.numberOfLines = 0
         view.titleLabel?.textAlignment = .center
+
         view.addTarget(self, action: #selector(self.didTapOpenSettings), for: .touchUpInside)
     }
 
@@ -56,12 +58,16 @@ class SearchEngineSelectionViewController: UIViewController,
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        sheetPresentationController?.delegate = self // For non-iPad setup
+        popoverPresentationController?.delegate = self // For iPad setup
+
         setupView()
         listenForThemeChange(view)
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
         applyTheme()
     }
 
@@ -81,7 +87,14 @@ class SearchEngineSelectionViewController: UIViewController,
 
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
+
         view.backgroundColor = theme.colors.layer3
+    }
+
+    // MARK: - UISheetPresentationControllerDelegate inheriting UIAdaptivePresentationControllerDelegate
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        coordinator?.dismissModal(animated: true)
     }
 
     // MARK: - Navigation
@@ -89,9 +102,5 @@ class SearchEngineSelectionViewController: UIViewController,
     @objc
     func didTapOpenSettings(sender: UIButton) {
         coordinator?.navigateToSearchSettings(animated: true)
-    }
-
-    func willDismiss() {
-        // TODO
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -8,32 +8,44 @@ import UIKit
 import Shared
 import Redux
 
-class SearchEngineSelectionViewController: UIViewController, BottomSheetChild {
+class SearchEngineSelectionViewController: UIViewController,
+                                           BottomSheetChild,
+                                           Themeable {
     // MARK: - Properties
+    var notificationCenter: NotificationProtocol
     var themeManager: ThemeManager
+    var themeObserver: NSObjectProtocol?
+    var currentWindowUUID: UUID? { return windowUUID }
+
     weak var coordinator: SearchEngineSelectionCoordinator?
     private let windowUUID: WindowUUID
     private let logger: Logger
 
     // MARK: - UI/UX elements
-    private lazy var placeholderView: UILabel = .build { view in
-        view.text = "Some content can go here 😀"
-        view.numberOfLines = 0
-        view.textAlignment = .center
+    // FXIOS-10192 This button is a temporary placeholder for setting up the navigation / coordinators
+    private lazy var placeholderOpenSettingsButton: UIButton = .build { view in
+        view.setTitle(.UnifiedSearch.SearchEngineSelection.SearchSettings, for: .normal)
+        view.setTitleColor(.blue, for: .normal)
+        view.titleLabel?.numberOfLines = 0
+        view.titleLabel?.textAlignment = .center
+        view.addTarget(self, action: #selector(self.didTapOpenSettings), for: .touchUpInside)
     }
 
-    // MARK: - Initializers
+    // MARK: - Initializers and Lifecycle
+
     init(
         windowUUID: WindowUUID,
+        notificationCenter: NotificationProtocol = NotificationCenter.default,
         themeManager: ThemeManager = AppContainer.shared.resolve(),
         logger: Logger = DefaultLogger.shared
     ) {
         self.windowUUID = windowUUID
+        self.notificationCenter = notificationCenter
         self.themeManager = themeManager
         self.logger = logger
         super.init(nibName: nil, bundle: nil)
 
-        // TODO
+        // TODO Additional setup to come
         // ...
     }
 
@@ -44,13 +56,39 @@ class SearchEngineSelectionViewController: UIViewController, BottomSheetChild {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = UIColor.white
+        setupView()
+        listenForThemeChange(view)
+    }
 
-        view.addSubview(placeholderView)
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        applyTheme()
+    }
+
+    // MARK: - UI / UX
+
+    private func setupView() {
+        view.addSubview(placeholderOpenSettingsButton)
+
         NSLayoutConstraint.activate([
-            placeholderView.topAnchor.constraint(equalTo: view.topAnchor, constant: 80),
-            placeholderView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+            placeholderOpenSettingsButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 80),
+            placeholderOpenSettingsButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            placeholderOpenSettingsButton.widthAnchor.constraint(equalToConstant: 200)
         ])
+    }
+
+    // MARK: - Theme
+
+    func applyTheme() {
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        view.backgroundColor = theme.colors.layer3
+    }
+
+    // MARK: - Navigation
+
+    @objc
+    func didTapOpenSettings(sender: UIButton) {
+        coordinator?.navigateToSearchSettings(animated: true)
     }
 
     func willDismiss() {

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import UIKit
+import Shared
+import Redux
+
+class SearchEngineSelectionViewController: UIViewController, BottomSheetChild {
+    // MARK: - Properties
+    var themeManager: ThemeManager
+    weak var coordinator: SearchEngineSelectionCoordinator?
+    private let windowUUID: WindowUUID
+    private let logger: Logger
+
+    // MARK: - UI/UX elements
+    private lazy var placeholderView: UILabel = .build { view in
+        view.text = "Some content can go here 😀"
+        view.numberOfLines = 0
+        view.textAlignment = .center
+    }
+
+    // MARK: - Initializers
+    init(
+        windowUUID: WindowUUID,
+        themeManager: ThemeManager = AppContainer.shared.resolve(),
+        logger: Logger = DefaultLogger.shared
+    ) {
+        self.windowUUID = windowUUID
+        self.themeManager = themeManager
+        self.logger = logger
+        super.init(nibName: nil, bundle: nil)
+
+        // TODO
+        // ...
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = UIColor.white
+
+        view.addSubview(placeholderView)
+        NSLayoutConstraint.activate([
+            placeholderView.topAnchor.constraint(equalTo: view.topAnchor, constant: 80),
+            placeholderView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+    }
+
+    func willDismiss() {
+        // TODO
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1078,6 +1078,20 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(mockRouter.presentedViewController?.children.first is AppSettingsTableViewController)
     }
 
+    // MARK: - Menu
+    func testShowSearchEngineSelection_addsSearchEngineSelectionCoordinator() {
+        let subject = createSubject()
+        XCTAssertTrue(subject.childCoordinators.isEmpty)
+
+        subject.showSearchEngineSelection(forSourceView: UIView())
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertTrue(subject.childCoordinators.first is SearchEngineSelectionCoordinator)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertTrue(mockRouter.presentedViewController is DismissableNavigationViewController)
+        XCTAssertTrue(mockRouter.presentedViewController?.children.first is SearchEngineSelectionViewController)
+    }
+
     // MARK: - Microsurvey
     func testShowMicrosurvey_addsMicrosurveyCoordinator() {
         let subject = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1078,7 +1078,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(mockRouter.presentedViewController?.children.first is AppSettingsTableViewController)
     }
 
-    // MARK: - Menu
+    // MARK: - Search Engine Selection
     func testShowSearchEngineSelection_addsSearchEngineSelectionCoordinator() {
         let subject = createSubject()
         XCTAssertTrue(subject.childCoordinators.isEmpty)
@@ -1090,6 +1090,22 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertTrue(mockRouter.presentedViewController is DismissableNavigationViewController)
         XCTAssertTrue(mockRouter.presentedViewController?.children.first is SearchEngineSelectionViewController)
+    }
+
+    func testSearchEngineSelectionCoordinatorDelegate_navigatesToSettings() {
+        let subject = createSubject()
+        subject.browserHasLoaded()
+
+        subject.showSearchEngineSelection(forSourceView: UIView())
+        guard let searchEngineSelectionCoordinator = subject.childCoordinators[0] as? SearchEngineSelectionCoordinator else {
+            XCTFail("Search engine selection coordinator was expected to be resolved")
+            return
+        }
+
+        searchEngineSelectionCoordinator.navigateToSearchSettings(animated: false)
+
+        XCTAssertTrue(subject.childCoordinators[0] is SettingsCoordinator)
+        XCTAssertTrue(mockRouter.presentedViewController?.children.first is AppSettingsTableViewController)
     }
 
     // MARK: - Microsurvey

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -26,6 +26,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
     var showFakespotFlowAsModalCalled = 0
     var showFakespotFlowAsSidebarCalled = 0
     var showBackForwardListCalled = 0
+    var showSearchEngineSelectionCalled = 0
     var dismissFakespotModalCalled = 0
     var dismissFakespotSidebarCalled = 0
     var updateFakespotSidebarCalled = 0
@@ -110,6 +111,10 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
                                    sidebarContainer: Client.SidebarEnabledViewProtocol,
                                    parentViewController: UIViewController) {
         showFakespotFlowAsSidebarCalled += 1
+    }
+
+    func showSearchEngineSelection(forSourceView sourceView: UIView) {
+        showSearchEngineSelectionCalled += 1
     }
 
     func dismissFakespotModal(animated: Bool) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockParentCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockParentCoordinator.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import Client
 
-class MockParentCoordinatorDelegate: ParentCoordinatorDelegate {
+class MockParentCoordinator: ParentCoordinatorDelegate {
     var didFinishCalled = 0
 
     func didFinish(from childCoordinator: Coordinator) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QRCodeCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QRCodeCoordinatorTests.swift
@@ -7,12 +7,12 @@ import XCTest
 
 final class QRCodeCoordinatorTests: XCTestCase {
     private var router: MockRouter!
-    private var parentCoordinator: MockParentCoordinatorDelegate!
+    private var parentCoordinator: MockParentCoordinator!
 
     override func setUp() {
         super.setUp()
         router = MockRouter(navigationController: UINavigationController())
-        parentCoordinator = MockParentCoordinatorDelegate()
+        parentCoordinator = MockParentCoordinator()
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SearchEngineSelectionCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SearchEngineSelectionCoordinatorTests.swift
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import XCTest
+
+@testable import Client
+
+final class SearchEngineSelectionCoordinatorTests: XCTestCase {
+    private var mockRouter: MockRouter!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        mockRouter = MockRouter(navigationController: MockNavigationController())
+    }
+
+    func testInitialState() {
+        _ = createSubject()
+
+        XCTAssertFalse(mockRouter.rootViewController is MicrosurveyViewController)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
+        XCTAssertEqual(mockRouter.pushCalled, 0)
+        XCTAssertEqual(mockRouter.popViewControllerCalled, 0)
+    }
+
+    func testStart_presentsSearchEngineSelectionViewController() throws {
+        let subject = createSubject()
+
+        subject.start()
+
+        XCTAssertTrue(mockRouter.rootViewController is SearchEngineSelectionViewController)
+        XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
+    }
+
+    func testNavigateToSearchSettings_callsDismiss() throws {
+        let subject = createSubject()
+
+        subject.start()
+        subject.navigateToSearchSettings(animated: false)
+
+        XCTAssertEqual(mockRouter.dismissCalled, 1)
+    }
+
+    private func createSubject(file: StaticString = #file, line: UInt = #line) -> SearchEngineSelectionCoordinator {
+        let subject = SearchEngineSelectionCoordinator(router: mockRouter, windowUUID: .XCTestDefaultUUID)
+
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SearchEngineSelectionCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SearchEngineSelectionCoordinatorTests.swift
@@ -64,8 +64,8 @@ final class SearchEngineSelectionCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockRouter.dismissCalled, 1)
     }
 
-    private func createSubject(file: StaticString = #file, line: UInt = #line) -> SearchEngineSelectionCoordinator {
-        let subject = SearchEngineSelectionCoordinator(router: mockRouter, windowUUID: .XCTestDefaultUUID)
+    private func createSubject(file: StaticString = #file, line: UInt = #line) -> DefaultSearchEngineSelectionCoordinator {
+        let subject = DefaultSearchEngineSelectionCoordinator(router: mockRouter, windowUUID: .XCTestDefaultUUID)
         subject.parentCoordinator = mockParentCoordinator
 
         trackForMemoryLeaks(subject, file: file, line: line)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SearchEngineSelectionCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SearchEngineSelectionCoordinatorTests.swift
@@ -9,11 +9,13 @@ import XCTest
 
 final class SearchEngineSelectionCoordinatorTests: XCTestCase {
     private var mockRouter: MockRouter!
+    private var mockParentCoordinator: MockParentCoordinator!
 
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         mockRouter = MockRouter(navigationController: MockNavigationController())
+        mockParentCoordinator = MockParentCoordinator()
     }
 
     func testInitialState() {
@@ -32,9 +34,28 @@ final class SearchEngineSelectionCoordinatorTests: XCTestCase {
 
         XCTAssertTrue(mockRouter.rootViewController is SearchEngineSelectionViewController)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
+        XCTAssertEqual(mockRouter.isNavigationBarHidden, true)
     }
 
-    func testNavigateToSearchSettings_callsDismiss() throws {
+    func testDismissModal_callsRouterDismiss() throws {
+        let subject = createSubject()
+
+        subject.start()
+        subject.dismissModal(animated: false)
+
+        XCTAssertEqual(mockRouter.dismissCalled, 1)
+    }
+
+    func testDismissModal_callsParentCoordinatorDidFinish() throws {
+        let subject = createSubject()
+
+        subject.start()
+        subject.dismissModal(animated: false)
+
+        XCTAssertEqual(mockParentCoordinator.didFinishCalled, 1)
+    }
+
+    func testNavigateToSearchSettings_callsRouterDismiss() throws {
         let subject = createSubject()
 
         subject.start()
@@ -45,6 +66,7 @@ final class SearchEngineSelectionCoordinatorTests: XCTestCase {
 
     private func createSubject(file: StaticString = #file, line: UInt = #line) -> SearchEngineSelectionCoordinator {
         let subject = SearchEngineSelectionCoordinator(router: mockRouter, windowUUID: .XCTestDefaultUUID)
+        subject.parentCoordinator = mockParentCoordinator
 
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShareExtensionCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShareExtensionCoordinatorTests.swift
@@ -6,14 +6,14 @@ import XCTest
 @testable import Client
 
 final class ShareExtensionCoordinatorTests: XCTestCase {
-    private var parentCoordinator: MockParentCoordinatorDelegate!
+    private var parentCoordinator: MockParentCoordinator!
     private var mockRouter: MockRouter!
 
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
-        parentCoordinator = MockParentCoordinatorDelegate()
+        parentCoordinator = MockParentCoordinator()
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionViewControllerTests.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+
+@testable import Client
+
+final class SearchEngineSelectionViewControllerTests: XCTestCase {
+    let windowUUID: WindowUUID = .XCTestDefaultUUID
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        DependencyHelperMock().reset()
+        super.tearDown()
+    }
+
+    func testSearchEngineSelectionViewController_simpleCreation_hasNoLeaks() {
+        let controller = SearchEngineSelectionViewController(windowUUID: windowUUID)
+        trackForMemoryLeaks(controller)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionViewControllerTests.swift
@@ -8,11 +8,13 @@ import Common
 @testable import Client
 
 final class SearchEngineSelectionViewControllerTests: XCTestCase {
-    let windowUUID: WindowUUID = .XCTestDefaultUUID
+    private let windowUUID: WindowUUID = .XCTestDefaultUUID
+    private var mockCoordinator: MockSearchEngineSelectionCoordinator!
 
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
+        mockCoordinator = MockSearchEngineSelectionCoordinator()
     }
 
     override func tearDown() {
@@ -23,5 +25,23 @@ final class SearchEngineSelectionViewControllerTests: XCTestCase {
     func testSearchEngineSelectionViewController_simpleCreation_hasNoLeaks() {
         let controller = SearchEngineSelectionViewController(windowUUID: windowUUID)
         trackForMemoryLeaks(controller)
+    }
+
+    func testDidTapOpenSettings_callsCoordinatorShowSettings() {
+        let controller = SearchEngineSelectionViewController(windowUUID: windowUUID)
+        controller.coordinator = mockCoordinator
+
+        controller.didTapOpenSettings(sender: UIButton())
+
+        XCTAssertEqual(mockCoordinator.navigateToSearchSettingsCalled, 1)
+    }
+
+    func testPresentationControllerDidDismiss_callsCoordinatorDismissModal() {
+        let controller = SearchEngineSelectionViewController(windowUUID: windowUUID)
+        controller.coordinator = mockCoordinator
+
+        controller.didTapOpenSettings(sender: UIButton())
+
+        XCTAssertEqual(mockCoordinator.navigateToSearchSettingsCalled, 1)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
@@ -17,6 +17,7 @@ class MockRouter: NSObject, Router {
     var popViewControllerCalled = 0
     var setRootViewControllerCalled = 0
     var savedCompletion: (() -> Void)?
+    var isNavigationBarHidden = false
 
     init(navigationController: NavigationController) {
         self.navigationController = navigationController
@@ -49,5 +50,6 @@ class MockRouter: NSObject, Router {
     func setRootViewController(_ viewController: UIViewController, hideBar: Bool, animated: Bool) {
         rootViewController = viewController
         setRootViewControllerCalled += 1
+        isNavigationBarHidden = hideBar
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSearchEngineSelectionCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSearchEngineSelectionCoordinator.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+@testable import Client
+
+class MockSearchEngineSelectionCoordinator: SearchEngineSelectionCoordinator {
+    var navigateToSearchSettingsCalled = 0
+    var dismissModalCalled = 0
+
+    func navigateToSearchSettings(animated: Bool) {
+        navigateToSearchSettingsCalled += 1
+    }
+
+    func dismissModal(animated: Bool) {
+        dismissModalCalled += 1
+    }
+}

--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -34,8 +34,8 @@ features:
           navigation_hint: false
       - channel: developer
         value:
-          enabled: false
-          unified_search: false
+          enabled: true
+          unified_search: true
           one_tap_new_tab: false
           navigation_hint: false
 

--- a/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/toolbarRefactorFeature.yaml
@@ -34,8 +34,8 @@ features:
           navigation_hint: false
       - channel: developer
         value:
-          enabled: true
-          unified_search: true
+          enabled: false
+          unified_search: false
           one_tap_new_tab: false
           navigation_hint: false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10273)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22499)

## :bulb: Description

### Background
This PR is for the [Unified Search project](https://mozilla-hub.atlassian.net/browse/FXIOS-4066), which adds a drop-down search engine icon to the toolbar refactor. When tapped, the search engine icon will eventually allow the user to choose to use an alternative search engine from a bottom sheet / popover.

### This PR

- Adds a `SearchEngineSelectionCoordinator`, which will present a bottom sheet (`SearchEngineSelectionViewController`) when the drop-down search engine icon button is tapped in the new toolbar.
- Stubs in the `SearchEngineSelectionViewController` which will eventually hold a list of alternative search engines for the user to select. The temporary Search Settings button should open the Settings > Search screen when tapped.
- Adds unit tests for the  coordinators and the new view controller.

### Demo

Display on iPad is a popover, and display on iPhone is a bottom sheet:

#### iPad

https://github.com/user-attachments/assets/428da129-216b-4829-ab48-329ae1c5df4f

#### iPhone

https://github.com/user-attachments/assets/a29ecce9-69cb-41bd-9296-879eaf5994ed

### Testing Notes

Enable both the toolbar refactor and the `unified_search `flag in `toolbarRefactorFeature.yaml` to see the new drop-down search engine button in the toolbar.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)