### PR TITLE
Add FXIOS-10361 Strings for close remote tab effort

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -6667,6 +6667,19 @@ extension String {
         tableName: nil,
         value: nil,
         comment: "See http://mzl.la/1Qtkf0j")
+
+    public struct RemoteTabPanel {
+        public static let CloseTab_SendingNotification_title = MZLocalizedString(
+            key: "CloseTab.SendingNotification.title.v133",
+            tableName: "RemoteTabPanel",
+            value: "Tab closed",
+            comment: "Text in notification after sending close remote tab command.")
+        public static let CloseTab_UndoButton_title = MZLocalizedString(
+            key: "CloseTab.UndoButton.title.v133",
+            tableName: "RemoteTabPanel",
+            value: "Undo",
+            comment: "Label for undo button in notification after sending close remote tab command.")
+    }
 }
 
 // MARK: - Login list


### PR DESCRIPTION
Adding the strings needed for #22156 (adding ability to close remote tabs) so they'll be available in v133 [as requested](https://github.com/mozilla-mobile/firefox-ios/pull/22156/files#r1810955017).

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10361)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22704)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

