### PR TITLE
Fix FXIOS-10252 issues with close tab string notifications

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3728,14 +3728,14 @@ extension String {
 
 // MARK: - Close tab notifications
     public static let CloseTab_ArrivingNotification_title = MZLocalizedString(
-        key: "CloseTab_ArrivingNotification_title",
+        key: "CloseTab.ArrivingNotification.title.v133",
         tableName: "FxANotification",
-        value: "Firefox tabs closed: %1$@",
+        value: "%1$@ tabs closed: %2$@",
         comment: "Title of notification shown when a remote device has requested to close a number of tabs defined by ($1)")
 
     // Notification Actions
     public static let CloseTabViewActionTitle = MZLocalizedString(
-        key: "CloseTab.ViewAction.title",
+        key: "CloseTab.ViewAction.title.v133",
         tableName: "FxANotification",
         value: "View recently closed tabs",
         comment: "Label for an action used to view recently closed tabs.")

--- a/firefox-ios/Extensions/NotificationService/NotificationService.swift
+++ b/firefox-ios/Extensions/NotificationService/NotificationService.swift
@@ -226,7 +226,7 @@ class SyncDataDisplay {
         notificationContent.categoryIdentifier = NotificationCloseTabs.notificationCategoryId
 
         presentNotification(
-            title: String(format: .CloseTab_ArrivingNotification_title, "\(urls.count)"),
+            title: String(format: .CloseTab_ArrivingNotification_title, AppInfo.displayName, "\(urls.count)"),
             body: .CloseTabViewActionTitle
         )
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10252)

## :bulb: Description
There were issues in the string extraction PR https://github.com/mozilla-l10n/firefoxios-l10n/pull/247 specifically around some strings I added with close tab notifications. This PR hopefully fixes those issues.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

