### PR TITLE
Add FXIOS-10363 Toolbar redesign feature flag toggle

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -54,7 +54,8 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .microsurvey,
                 .menuRefactor,
                 .nativeErrorPage,
-                .trackingProtectionRefactor:
+                .trackingProtectionRefactor,
+                .toolbarRefactor:
             return rawValue + PrefsKeys.FeatureFlags.DebugSuffixKey
         default:
             return nil

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -66,6 +66,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     statusText: format(string: "Toggle to display natively created error pages")
                 ) { [weak self] _ in
                     self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
+                    with: .toolbarRefactor,
+                    titleText: format(string: "Toolbar Redesign"),
+                    statusText: format(string: "Toggle to enable the toolbar redesign")
+                ) { [weak self] _ in
+                    self?.reloadView()
                 }
             ]
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10363)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22708)

## :bulb: Description
- Add a "Toolbar redesign" toggle to the feature flag debug menu to easily enable and disable the toolbar redesign without needing to enroll in the experiment on developer and debug builds

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

