### PR TITLE
Add FXIOS-10360 [Toolbar Refactor] [Unified Search] Add toolbar refactor and unified search to the list of debug flags in FeatureFlagsDebugViewController

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -47,15 +47,17 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case trackingProtectionRefactor
     case zoomFeature
 
+    // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`
     var debugKey: String? {
         switch self {
         case .closeRemoteTabs,
-                .homepageRebuild,
                 .microsurvey,
+                .homepageRebuild,
                 .menuRefactor,
-                .nativeErrorPage,
                 .trackingProtectionRefactor,
-                .toolbarRefactor:
+                .nativeErrorPage,
+                .toolbarRefactor,
+                .unifiedSearch,
             return rawValue + PrefsKeys.FeatureFlags.DebugSuffixKey
         default:
             return nil

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -57,7 +57,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .trackingProtectionRefactor,
                 .nativeErrorPage,
                 .toolbarRefactor,
-                .unifiedSearch,
+                .unifiedSearch:
             return rawValue + PrefsKeys.FeatureFlags.DebugSuffixKey
         default:
             return nil

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -73,7 +73,14 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     statusText: format(string: "Toggle to enable the toolbar redesign")
                 ) { [weak self] _ in
                     self?.reloadView()
-                }
+                },
+                FeatureFlagsBoolSetting(
+                    with: .unifiedSearch,
+                    titleText: format(string: "Enable Unified Search"),
+                    statusText: format(string: "Toggle to use unified search within the new toolbar")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
             ]
         )
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10360)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22701)

## :bulb: Description
This PR simply adds the toolbar refactor and unified search to the `FeatureFlagsDebugViewController` so the debug options can be easily toggled within the app.

### Demo
This screen can be accessed from Settings > Reveal the debug menu > Feature Flags
<img width="300" alt="Screenshot 2024-10-22 at 3 59 03 PM" src="https://github.com/user-attachments/assets/ae7e0dcc-1e7b-40f0-b48f-96d96cba1952">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

