### PR TITLE
Refactor FXIOS-7301 - Reduce from 390 to 42 lines a property of AddressBarState.swift - help in closure_body_length

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -623,6 +623,32 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarClearSearch(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: pageActions(action: toolbarAction,
+                                     addressBarState: state,
+                                     isEditing: state.isEditing,
+                                     showQRPageAction: true),
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: nil,
+            searchTerm: nil,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: true
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -133,26 +133,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarReaderModeStateChanged(state: state, action: action)
 
         case ToolbarActionType.websiteLoadingStateDidChange:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: pageActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
-                browserActions: state.browserActions,
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: state.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: toolbarAction.isLoading ?? state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: state.showQRPageAction
-            )
+            return handleToolbarWebsiteLoadingStateDidChange(state: state, action: action)
 
         case ToolbarActionType.urlDidChange:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -155,7 +155,7 @@ struct AddressBarState: StateType, Equatable {
             return handleDidPasteSearchTermAction(state: state, action: action)
 
         case ToolbarActionType.didStartEditingUrl:
-            return handleToolbarDidStartEditingUrl(state: state, action: action)
+            return handleDidStartEditingUrlAction(state: state, action: action)
 
         case ToolbarActionType.cancelEdit:
             return handleToolbarCancelEdit(state: state, action: action)
@@ -417,7 +417,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarDidStartEditingUrl(state: Self, action: Action) -> Self {
+    private static func handleDidStartEditingUrlAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         let searchTerm = toolbarAction.searchTerm ?? state.searchTerm

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -611,6 +611,35 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarCancelEdit(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        let url = toolbarAction.url ?? state.url
+        let showQRPageAction = url == nil
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: navigationActions(action: toolbarAction, addressBarState: state),
+            pageActions: pageActions(action: toolbarAction,
+                                     addressBarState: state,
+                                     isEditing: false,
+                                     showQRPageAction: showQRPageAction),
+            browserActions: browserActions(action: toolbarAction, addressBarState: state),
+            borderPosition: state.borderPosition,
+            url: url,
+            searchTerm: nil,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: false,
+            isScrollingDuringEdit: false,
+            shouldSelectSearchTerm: true,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: false,
+            showQRPageAction: showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -161,30 +161,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarCancelEdit(state: state, action: action)
 
         case ToolbarActionType.didSetTextInLocationView:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: pageActions(action: toolbarAction,
-                                         addressBarState: state,
-                                         isEditing: true,
-                                         showQRPageAction: isEmptySearch),
-                browserActions: state.browserActions,
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: toolbarAction.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: true,
-                shouldSelectSearchTerm: false,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: false,
-                showQRPageAction: isEmptySearch
-            )
+            return handleToolbarDidSetTextInLocationView(state: state, action: action)
 
         case ToolbarActionType.didScrollDuringEdit:
             return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -124,7 +124,7 @@ struct AddressBarState: StateType, Equatable {
 
         switch action.actionType {
         case ToolbarActionType.didLoadToolbars:
-            return handleToolbarDidLoadToolbars(state: state, action: action)
+            return handleDidLoadToolbarsAction(state: state, action: action)
 
         case ToolbarActionType.numberOfTabsChanged:
             return handleToolbarNumberOfTabsChanged(state: state, action: action)
@@ -183,7 +183,7 @@ struct AddressBarState: StateType, Equatable {
         }
     }
 
-    private static func handleToolbarDidLoadToolbars(state: Self, action: Action) -> Self {
+    private static func handleDidLoadToolbarsAction(state: Self, action: Action) -> Self {
         guard let borderPosition = (action as? ToolbarAction)?.addressBorderPosition else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -618,6 +618,28 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleDidStartTyping(state: Self, action: Action) -> Self {
+        guard action is ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: state.pageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: true,
+            showQRPageAction: state.showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -127,26 +127,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarDidLoadToolbars(state: state, action: action)
 
         case ToolbarActionType.numberOfTabsChanged:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: state.pageActions,
-                browserActions: browserActions(action: toolbarAction, addressBarState: state),
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: state.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: toolbarAction.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: state.showQRPageAction
-            )
+            return handleToolbarNumberOfTabsChanged(state: state, action: action)
 
         case ToolbarActionType.readerModeStateChanged:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -149,7 +149,7 @@ struct AddressBarState: StateType, Equatable {
 
         case ToolbarActionType.borderPositionChanged,
             ToolbarActionType.toolbarPositionChanged:
-            return handleToolbarPositionChanged(state: state, action: action)
+            return handlePositionChangedAction(state: state, action: action)
 
         case ToolbarActionType.didPasteSearchTerm:
             return handleToolbarDidPasteSearchTerm(state: state, action: action)
@@ -366,7 +366,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarPositionChanged(state: Self, action: Action) -> Self {
+    private static func handlePositionChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -136,28 +136,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarWebsiteLoadingStateDidChange(state: state, action: action)
 
         case ToolbarActionType.urlDidChange:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: navigationActions(action: toolbarAction,
-                                                     addressBarState: state,
-                                                     isEditing: state.isEditing),
-                pageActions: pageActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
-                browserActions: browserActions(action: toolbarAction, addressBarState: state),
-                borderPosition: state.borderPosition,
-                url: toolbarAction.url,
-                searchTerm: nil,
-                lockIconImageName: toolbarAction.lockIconImageName ?? state.lockIconImageName,
-                safeListedURLImageName: toolbarAction.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: toolbarAction.url == nil
-            )
+            return handleToolbarUrlDidChange(state: state, action: action)
 
         case ToolbarActionType.backForwardButtonStateChanged:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -167,29 +167,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarDidScrollDuringEdit(state: state)
 
         case ToolbarActionType.clearSearch:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: pageActions(action: toolbarAction,
-                                         addressBarState: state,
-                                         isEditing: state.isEditing,
-                                         showQRPageAction: true),
-                browserActions: state.browserActions,
-                borderPosition: state.borderPosition,
-                url: nil,
-                searchTerm: nil,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: true
-            )
+            return handleToolbarClearSearch(state: state, action: action)
 
         case ToolbarActionType.didDeleteSearchTerm:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -164,24 +164,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarDidSetTextInLocationView(state: state, action: action)
 
         case ToolbarActionType.didScrollDuringEdit:
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: state.pageActions,
-                browserActions: state.browserActions,
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: state.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: true,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: state.showQRPageAction
-            )
+            return handleToolbarDidScrollDuringEdit(state: state)
 
         case ToolbarActionType.clearSearch:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -139,28 +139,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarUrlDidChange(state: state, action: action)
 
         case ToolbarActionType.backForwardButtonStateChanged:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: navigationActions(action: toolbarAction,
-                                                     addressBarState: state,
-                                                     isEditing: state.isEditing),
-                pageActions: pageActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
-                browserActions: state.browserActions,
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: nil,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: state.showQRPageAction
-            )
+            return handleToolbarBackForwardButtonStateChanged(state: state, action: action)
 
         case ToolbarActionType.traitCollectionDidChange:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -142,28 +142,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarBackForwardButtonStateChanged(state: state, action: action)
 
         case ToolbarActionType.traitCollectionDidChange:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: navigationActions(action: toolbarAction,
-                                                     addressBarState: state,
-                                                     isEditing: state.isEditing),
-                pageActions: pageActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
-                browserActions: browserActions(action: toolbarAction, addressBarState: state),
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: nil,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: state.showQRPageAction
-            )
+            return handleToolbarTraitCollectionDidChange(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -145,26 +145,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarTraitCollectionDidChange(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: state.pageActions,
-                browserActions: browserActions(action: toolbarAction, addressBarState: state),
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: state.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: state.showQRPageAction
-            )
+            return handleToolbarShowMenuWarningBadge(state: state, action: action)
 
         case ToolbarActionType.borderPositionChanged,
             ToolbarActionType.toolbarPositionChanged:

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -176,7 +176,7 @@ struct AddressBarState: StateType, Equatable {
             return handleDidEnterSearchTermAction(state: state, action: action)
 
         case ToolbarActionType.didStartTyping:
-            return handleDidStartTyping(state: state, action: action)
+            return handleDidStartTypingAction(state: state, action: action)
 
         default:
             return state
@@ -600,7 +600,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleDidStartTyping(state: Self, action: Action) -> Self {
+    private static func handleDidStartTypingAction(state: Self, action: Action) -> Self {
         guard action is ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -173,7 +173,7 @@ struct AddressBarState: StateType, Equatable {
             return handleDidDeleteSearchTermAction(state: state, action: action)
 
         case ToolbarActionType.didEnterSearchTerm:
-            return handleDidEnterSearchTerm(state: state, action: action)
+            return handleDidEnterSearchTermAction(state: state, action: action)
 
         case ToolbarActionType.didStartTyping:
             return handleDidStartTyping(state: state, action: action)
@@ -575,7 +575,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleDidEnterSearchTerm(state: Self, action: Action) -> Self {
+    private static func handleDidEnterSearchTermAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -142,7 +142,7 @@ struct AddressBarState: StateType, Equatable {
             return handleBackForwardButtonStateChangedAction(state: state, action: action)
 
         case ToolbarActionType.traitCollectionDidChange:
-            return handleToolbarTraitCollectionDidChange(state: state, action: action)
+            return handleTraitCollectionDidChangeAction(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:
             return handleToolbarShowMenuWarningBadge(state: state, action: action)
@@ -318,7 +318,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarTraitCollectionDidChange(state: Self, action: Action) -> Self {
+    private static func handleTraitCollectionDidChangeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -615,6 +615,33 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarDidSetTextInLocationView(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: pageActions(action: toolbarAction,
+                                     addressBarState: state,
+                                     isEditing: true,
+                                     showQRPageAction: isEmptySearch),
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: toolbarAction.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: true,
+            shouldSelectSearchTerm: false,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: false,
+            showQRPageAction: isEmptySearch
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -239,24 +239,7 @@ struct AddressBarState: StateType, Equatable {
             )
 
         default:
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: state.pageActions,
-                browserActions: state.browserActions,
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: state.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: state.showQRPageAction
-            )
+            return state
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -170,7 +170,7 @@ struct AddressBarState: StateType, Equatable {
             return handleClearSearchAction(state: state, action: action)
 
         case ToolbarActionType.didDeleteSearchTerm:
-            return handleDidDeleteSearchTerm(state: state, action: action)
+            return handleDidDeleteSearchTermAction(state: state, action: action)
 
         case ToolbarActionType.didEnterSearchTerm:
             return handleDidEnterSearchTerm(state: state, action: action)
@@ -550,7 +550,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleDidDeleteSearchTerm(state: Self, action: Action) -> Self {
+    private static func handleDidDeleteSearchTermAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -567,6 +567,19 @@ struct AddressBarState: StateType, Equatable {
         }
     }
 
+    private static func handleToolbarDidLoadToolbars(state: Self, action: Action) -> Self {
+        guard let borderPosition = (action as? ToolbarAction)?.addressBorderPosition else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: [ToolbarActionState](),
+            pageActions: [qrCodeScanAction],
+            browserActions: [tabsAction(), menuAction()],
+            borderPosition: borderPosition,
+            url: nil
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -587,6 +587,31 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarBackForwardButtonStateChanged(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: navigationActions(action: toolbarAction,
+                                                 addressBarState: state,
+                                                 isEditing: state.isEditing),
+            pageActions: pageActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: nil,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: state.showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -130,29 +130,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarNumberOfTabsChanged(state: state, action: action)
 
         case ToolbarActionType.readerModeStateChanged:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: pageActions(action: toolbarAction,
-                                         addressBarState: state,
-                                         isEditing: state.isEditing,
-                                         showQRPageAction: state.showQRPageAction),
-                browserActions: state.browserActions,
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: state.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: toolbarAction.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: state.showQRPageAction
-            )
+            return handleToolbarReaderModeStateChanged(state: state, action: action)
 
         case ToolbarActionType.websiteLoadingStateDidChange:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -164,7 +164,7 @@ struct AddressBarState: StateType, Equatable {
             return handleDidSetTextInLocationViewAction(state: state, action: action)
 
         case ToolbarActionType.didScrollDuringEdit:
-            return handleToolbarDidScrollDuringEdit(state: state)
+            return handleDidScrollDuringEditAction(state: state)
 
         case ToolbarActionType.clearSearch:
             return handleToolbarClearSearch(state: state, action: action)
@@ -503,7 +503,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarDidScrollDuringEdit(state: Self) -> Self {
+    private static func handleDidScrollDuringEditAction(state: Self) -> Self {
         return AddressBarState(
             windowUUID: state.windowUUID,
             navigationActions: state.navigationActions,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -607,6 +607,36 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarDidStartEditingUrl(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        let searchTerm = toolbarAction.searchTerm ?? state.searchTerm
+        let locationText = searchTerm ?? state.url?.absoluteString
+        let showQRPageAction = locationText == nil || locationText?.isEmpty == true
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: navigationActions(action: toolbarAction, addressBarState: state, isEditing: true),
+            pageActions: pageActions(action: toolbarAction,
+                                     addressBarState: state,
+                                     isEditing: true,
+                                     showQRPageAction: showQRPageAction),
+            browserActions: browserActions(action: toolbarAction, addressBarState: state),
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: true,
+            isScrollingDuringEdit: false,
+            shouldSelectSearchTerm: true,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: false,
+            showQRPageAction: showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -127,7 +127,7 @@ struct AddressBarState: StateType, Equatable {
             return handleDidLoadToolbarsAction(state: state, action: action)
 
         case ToolbarActionType.numberOfTabsChanged:
-            return handleToolbarNumberOfTabsChanged(state: state, action: action)
+            return handleNumberOfTabsChangedAction(state: state, action: action)
 
         case ToolbarActionType.readerModeStateChanged:
             return handleToolbarReaderModeStateChanged(state: state, action: action)
@@ -196,7 +196,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarNumberOfTabsChanged(state: Self, action: Action) -> Self {
+    private static func handleNumberOfTabsChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -167,7 +167,7 @@ struct AddressBarState: StateType, Equatable {
             return handleDidScrollDuringEditAction(state: state)
 
         case ToolbarActionType.clearSearch:
-            return handleToolbarClearSearch(state: state, action: action)
+            return handleClearSearchAction(state: state, action: action)
 
         case ToolbarActionType.didDeleteSearchTerm:
             return handleDidDeleteSearchTerm(state: state, action: action)
@@ -524,7 +524,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarClearSearch(state: Self, action: Action) -> Self {
+    private static func handleClearSearchAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -149,26 +149,7 @@ struct AddressBarState: StateType, Equatable {
 
         case ToolbarActionType.borderPositionChanged,
             ToolbarActionType.toolbarPositionChanged:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: state.pageActions,
-                browserActions: state.browserActions,
-                borderPosition: toolbarAction.addressBorderPosition,
-                url: state.url,
-                searchTerm: state.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: state.showQRPageAction
-            )
+            return handleToolbarPositionChanged(state: state, action: action)
 
         case ToolbarActionType.didPasteSearchTerm:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -152,31 +152,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarPositionChanged(state: state, action: action)
 
         case ToolbarActionType.didPasteSearchTerm:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: navigationActions(action: toolbarAction, addressBarState: state, isEditing: true),
-                pageActions: pageActions(action: toolbarAction,
-                                         addressBarState: state,
-                                         isEditing: true,
-                                         showQRPageAction: isEmptySearch),
-                browserActions: browserActions(action: toolbarAction, addressBarState: state),
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: toolbarAction.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: true,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: false,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: false,
-                showQRPageAction: isEmptySearch
-            )
+            return handleToolbarDidPasteSearchTerm(state: state, action: action)
 
         case ToolbarActionType.didStartEditingUrl:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -591,6 +591,31 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarTraitCollectionDidChange(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: navigationActions(action: toolbarAction,
+                                                 addressBarState: state,
+                                                 isEditing: state.isEditing),
+            pageActions: pageActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
+            browserActions: browserActions(action: toolbarAction, addressBarState: state),
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: nil,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: state.showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -571,6 +571,29 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarNumberOfTabsChanged(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: state.pageActions,
+            browserActions: browserActions(action: toolbarAction, addressBarState: state),
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: toolbarAction.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: state.showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -133,7 +133,7 @@ struct AddressBarState: StateType, Equatable {
             return handleReaderModeStateChangedAction(state: state, action: action)
 
         case ToolbarActionType.websiteLoadingStateDidChange:
-            return handleToolbarWebsiteLoadingStateDidChange(state: state, action: action)
+            return handleWebsiteLoadingStateDidChangeAction(state: state, action: action)
 
         case ToolbarActionType.urlDidChange:
             return handleToolbarUrlDidChange(state: state, action: action)
@@ -245,7 +245,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarWebsiteLoadingStateDidChange(state: Self, action: Action) -> Self {
+    private static func handleWebsiteLoadingStateDidChangeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -152,7 +152,7 @@ struct AddressBarState: StateType, Equatable {
             return handlePositionChangedAction(state: state, action: action)
 
         case ToolbarActionType.didPasteSearchTerm:
-            return handleToolbarDidPasteSearchTerm(state: state, action: action)
+            return handleDidPasteSearchTermAction(state: state, action: action)
 
         case ToolbarActionType.didStartEditingUrl:
             return handleToolbarDidStartEditingUrl(state: state, action: action)
@@ -389,7 +389,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarDidPasteSearchTerm(state: Self, action: Action) -> Self {
+    private static func handleDidPasteSearchTermAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -591,6 +591,7 @@ struct AddressBarState: StateType, Equatable {
             url: state.url,
             searchTerm: state.searchTerm,
             lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
             isEditing: state.isEditing,
             isScrollingDuringEdit: state.isScrollingDuringEdit,
             shouldSelectSearchTerm: state.shouldSelectSearchTerm,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -179,24 +179,7 @@ struct AddressBarState: StateType, Equatable {
             return handleDidStartTypingAction(state: state, action: action)
 
         default:
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: state.pageActions,
-                browserActions: state.browserActions,
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: state.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: state.didStartTyping,
-                showQRPageAction: state.showQRPageAction
-            )
+            return handleDefaultAction(state: state)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -170,28 +170,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarClearSearch(state: state, action: action)
 
         case ToolbarActionType.didDeleteSearchTerm:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: pageActions(action: toolbarAction,
-                                         addressBarState: state,
-                                         isEditing: state.isEditing,
-                                         showQRPageAction: true),
-                browserActions: state.browserActions,
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: state.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: true,
-                showQRPageAction: true
-            )
+            return handleDidDeleteSearchTerm(state: state, action: action)
 
         case ToolbarActionType.didEnterSearchTerm:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -610,6 +610,31 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleDidDeleteSearchTerm(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: pageActions(action: toolbarAction,
+                                     addressBarState: state,
+                                     isEditing: state.isEditing,
+                                     showQRPageAction: true),
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: true,
+            showQRPageAction: true
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -124,16 +124,7 @@ struct AddressBarState: StateType, Equatable {
 
         switch action.actionType {
         case ToolbarActionType.didLoadToolbars:
-            guard let borderPosition = (action as? ToolbarAction)?.addressBorderPosition else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: [ToolbarActionState](),
-                pageActions: [qrCodeScanAction],
-                browserActions: [tabsAction(), menuAction()],
-                borderPosition: borderPosition,
-                url: nil
-            )
+            return handleToolbarDidLoadToolbars(state: state, action: action)
 
         case ToolbarActionType.numberOfTabsChanged:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -642,6 +642,27 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleDefaultAction(state: Self) -> Self {
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: state.pageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: state.showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -603,6 +603,34 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarDidPasteSearchTerm(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: navigationActions(action: toolbarAction, addressBarState: state, isEditing: true),
+            pageActions: pageActions(action: toolbarAction,
+                                     addressBarState: state,
+                                     isEditing: true,
+                                     showQRPageAction: isEmptySearch),
+            browserActions: browserActions(action: toolbarAction, addressBarState: state),
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: toolbarAction.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: true,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: false,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: false,
+            showQRPageAction: isEmptySearch
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -599,6 +599,29 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarPositionChanged(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: state.pageActions,
+            browserActions: state.browserActions,
+            borderPosition: toolbarAction.addressBorderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: state.showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -583,6 +583,31 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarUrlDidChange(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: navigationActions(action: toolbarAction,
+                                                 addressBarState: state,
+                                                 isEditing: state.isEditing),
+            pageActions: pageActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
+            browserActions: browserActions(action: toolbarAction, addressBarState: state),
+            borderPosition: state.borderPosition,
+            url: toolbarAction.url,
+            searchTerm: nil,
+            lockIconImageName: toolbarAction.lockIconImageName ?? state.lockIconImageName,
+            safeListedURLImageName: toolbarAction.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: toolbarAction.url == nil
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -579,6 +579,29 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarWebsiteLoadingStateDidChange(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: pageActions(action: toolbarAction, addressBarState: state, isEditing: state.isEditing),
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: toolbarAction.isLoading ?? state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: state.showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -136,7 +136,7 @@ struct AddressBarState: StateType, Equatable {
             return handleWebsiteLoadingStateDidChangeAction(state: state, action: action)
 
         case ToolbarActionType.urlDidChange:
-            return handleToolbarUrlDidChange(state: state, action: action)
+            return handleUrlDidChangeAction(state: state, action: action)
 
         case ToolbarActionType.backForwardButtonStateChanged:
             return handleToolbarBackForwardButtonStateChanged(state: state, action: action)
@@ -268,7 +268,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarUrlDidChange(state: Self, action: Action) -> Self {
+    private static func handleUrlDidChangeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -595,6 +595,29 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarShowMenuWarningBadge(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: state.pageActions,
+            browserActions: browserActions(action: toolbarAction, addressBarState: state),
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: state.showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -173,28 +173,7 @@ struct AddressBarState: StateType, Equatable {
             return handleDidDeleteSearchTerm(state: state, action: action)
 
         case ToolbarActionType.didEnterSearchTerm:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: pageActions(action: toolbarAction,
-                                         addressBarState: state,
-                                         isEditing: state.isEditing,
-                                         showQRPageAction: false),
-                browserActions: state.browserActions,
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: state.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: true,
-                showQRPageAction: false
-            )
+            return handleDidEnterSearchTerm(state: state, action: action)
 
         case ToolbarActionType.didStartTyping:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -158,32 +158,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarDidStartEditingUrl(state: state, action: action)
 
         case ToolbarActionType.cancelEdit:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            let url = toolbarAction.url ?? state.url
-            let showQRPageAction = url == nil
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: navigationActions(action: toolbarAction, addressBarState: state),
-                pageActions: pageActions(action: toolbarAction,
-                                         addressBarState: state,
-                                         isEditing: false,
-                                         showQRPageAction: showQRPageAction),
-                browserActions: browserActions(action: toolbarAction, addressBarState: state),
-                borderPosition: state.borderPosition,
-                url: url,
-                searchTerm: nil,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: false,
-                isScrollingDuringEdit: false,
-                shouldSelectSearchTerm: true,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: false,
-                showQRPageAction: showQRPageAction
-            )
+            return handleToolbarCancelEdit(state: state, action: action)
 
         case ToolbarActionType.didSetTextInLocationView:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -619,6 +619,27 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarDidScrollDuringEdit(state: Self) -> Self {
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: state.pageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: true,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: state.showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -565,6 +565,7 @@ struct AddressBarState: StateType, Equatable {
             url: state.url,
             searchTerm: state.searchTerm,
             lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
             isEditing: state.isEditing,
             isScrollingDuringEdit: state.isScrollingDuringEdit,
             shouldSelectSearchTerm: state.shouldSelectSearchTerm,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -575,6 +575,32 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleToolbarReaderModeStateChanged(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: pageActions(action: toolbarAction,
+                                     addressBarState: state,
+                                     isEditing: state.isEditing,
+                                     showQRPageAction: state.showQRPageAction),
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: toolbarAction.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: state.showQRPageAction
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -145,7 +145,7 @@ struct AddressBarState: StateType, Equatable {
             return handleTraitCollectionDidChangeAction(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:
-            return handleToolbarShowMenuWarningBadge(state: state, action: action)
+            return handleShowMenuWarningBadgeAction(state: state, action: action)
 
         case ToolbarActionType.borderPositionChanged,
             ToolbarActionType.toolbarPositionChanged:
@@ -343,7 +343,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarShowMenuWarningBadge(state: Self, action: Action) -> Self {
+    private static func handleShowMenuWarningBadgeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -155,33 +155,7 @@ struct AddressBarState: StateType, Equatable {
             return handleToolbarDidPasteSearchTerm(state: state, action: action)
 
         case ToolbarActionType.didStartEditingUrl:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            let searchTerm = toolbarAction.searchTerm ?? state.searchTerm
-            let locationText = searchTerm ?? state.url?.absoluteString
-            let showQRPageAction = locationText == nil || locationText?.isEmpty == true
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: navigationActions(action: toolbarAction, addressBarState: state, isEditing: true),
-                pageActions: pageActions(action: toolbarAction,
-                                         addressBarState: state,
-                                         isEditing: true,
-                                         showQRPageAction: showQRPageAction),
-                browserActions: browserActions(action: toolbarAction, addressBarState: state),
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                safeListedURLImageName: state.safeListedURLImageName,
-                isEditing: true,
-                isScrollingDuringEdit: false,
-                shouldSelectSearchTerm: true,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: false,
-                showQRPageAction: showQRPageAction
-            )
+            return handleToolbarDidStartEditingUrl(state: state, action: action)
 
         case ToolbarActionType.cancelEdit:
             guard let toolbarAction = action as? ToolbarAction else { return state }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -176,25 +176,7 @@ struct AddressBarState: StateType, Equatable {
             return handleDidEnterSearchTerm(state: state, action: action)
 
         case ToolbarActionType.didStartTyping:
-            guard let toolbarAction = action as? ToolbarAction else { return state }
-
-            return AddressBarState(
-                windowUUID: state.windowUUID,
-                navigationActions: state.navigationActions,
-                pageActions: state.pageActions,
-                browserActions: state.browserActions,
-                borderPosition: state.borderPosition,
-                url: state.url,
-                searchTerm: state.searchTerm,
-                lockIconImageName: state.lockIconImageName,
-                isEditing: state.isEditing,
-                isScrollingDuringEdit: state.isScrollingDuringEdit,
-                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
-                isLoading: state.isLoading,
-                readerModeState: state.readerModeState,
-                didStartTyping: true,
-                showQRPageAction: state.showQRPageAction
-            )
+            return handleDidStartTyping(state: state, action: action)
 
         default:
             return state

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -179,7 +179,24 @@ struct AddressBarState: StateType, Equatable {
             return handleDidStartTypingAction(state: state, action: action)
 
         default:
-            return state
+            return AddressBarState(
+                windowUUID: state.windowUUID,
+                navigationActions: state.navigationActions,
+                pageActions: state.pageActions,
+                browserActions: state.browserActions,
+                borderPosition: state.borderPosition,
+                url: state.url,
+                searchTerm: state.searchTerm,
+                lockIconImageName: state.lockIconImageName,
+                safeListedURLImageName: state.safeListedURLImageName,
+                isEditing: state.isEditing,
+                isScrollingDuringEdit: state.isScrollingDuringEdit,
+                shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+                isLoading: state.isLoading,
+                readerModeState: state.readerModeState,
+                didStartTyping: state.didStartTyping,
+                showQRPageAction: state.showQRPageAction
+            )
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -130,7 +130,7 @@ struct AddressBarState: StateType, Equatable {
             return handleNumberOfTabsChangedAction(state: state, action: action)
 
         case ToolbarActionType.readerModeStateChanged:
-            return handleToolbarReaderModeStateChanged(state: state, action: action)
+            return handleReaderModeStateChangedAction(state: state, action: action)
 
         case ToolbarActionType.websiteLoadingStateDidChange:
             return handleToolbarWebsiteLoadingStateDidChange(state: state, action: action)
@@ -219,7 +219,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarReaderModeStateChanged(state: Self, action: Action) -> Self {
+    private static func handleReaderModeStateChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -614,6 +614,7 @@ struct AddressBarState: StateType, Equatable {
             url: state.url,
             searchTerm: state.searchTerm,
             lockIconImageName: state.lockIconImageName,
+            safeListedURLImageName: state.safeListedURLImageName,
             isEditing: state.isEditing,
             isScrollingDuringEdit: state.isScrollingDuringEdit,
             shouldSelectSearchTerm: state.shouldSelectSearchTerm,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -158,7 +158,7 @@ struct AddressBarState: StateType, Equatable {
             return handleDidStartEditingUrlAction(state: state, action: action)
 
         case ToolbarActionType.cancelEdit:
-            return handleToolbarCancelEdit(state: state, action: action)
+            return handleCancelEditAction(state: state, action: action)
 
         case ToolbarActionType.didSetTextInLocationView:
             return handleToolbarDidSetTextInLocationView(state: state, action: action)
@@ -447,7 +447,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarCancelEdit(state: Self, action: Action) -> Self {
+    private static func handleCancelEditAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         let url = toolbarAction.url ?? state.url

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -139,7 +139,7 @@ struct AddressBarState: StateType, Equatable {
             return handleUrlDidChangeAction(state: state, action: action)
 
         case ToolbarActionType.backForwardButtonStateChanged:
-            return handleToolbarBackForwardButtonStateChanged(state: state, action: action)
+            return handleBackForwardButtonStateChangedAction(state: state, action: action)
 
         case ToolbarActionType.traitCollectionDidChange:
             return handleToolbarTraitCollectionDidChange(state: state, action: action)
@@ -293,7 +293,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarBackForwardButtonStateChanged(state: Self, action: Action) -> Self {
+    private static func handleBackForwardButtonStateChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         return AddressBarState(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -614,6 +614,31 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
+    private static func handleDidEnterSearchTerm(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: pageActions(action: toolbarAction,
+                                     addressBarState: state,
+                                     isEditing: state.isEditing,
+                                     showQRPageAction: false),
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: true,
+            showQRPageAction: false
+        )
+    }
+
     // MARK: - Address Toolbar Actions
     private static func navigationActions(
         action: ToolbarAction,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -161,7 +161,7 @@ struct AddressBarState: StateType, Equatable {
             return handleCancelEditAction(state: state, action: action)
 
         case ToolbarActionType.didSetTextInLocationView:
-            return handleToolbarDidSetTextInLocationView(state: state, action: action)
+            return handleDidSetTextInLocationViewAction(state: state, action: action)
 
         case ToolbarActionType.didScrollDuringEdit:
             return handleToolbarDidScrollDuringEdit(state: state)
@@ -476,7 +476,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleToolbarDidSetTextInLocationView(state: Self, action: Action) -> Self {
+    private static func handleDidSetTextInLocationViewAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return state }
 
         let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR reduces from 390 to 42 lines of the `reducer` property from the `AddressBarState.swift` file by extracting the switch case statements to new functions.

The current threshold is 30, and I wasn't able to meet that in this PR. We might need to consider adjusting the threshold or allowing exceptions when we enable this rule. I'm open to any suggestions.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

