### PR TITLE
Refactor FXIOS-9485 - Use Diffable Datasource in the Tab Tray

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -9729,8 +9729,8 @@
 				214EF4142AC5D5D0005BCCDA /* TabDisplayView.swift */,
 				1DDE3DB22AC34E1E0039363B /* TabCell.swift */,
 				21E77E4D2AA8BA5200FABA10 /* TabTrayViewController.swift */,
-				219A0FD32ACC84C5009A6D1A /* InactiveTabs */,
 				F605DD572CC73469009A671B /* TabDisplayDiffableDataSource.swift */,
+				219A0FD32ACC84C5009A6D1A /* InactiveTabs */,
 			);
 			path = Views;
 			sourceTree = "<group>";

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1845,6 +1845,7 @@
 		F018F84C2719AE8300B9A52D /* ThemedDefaultNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F018F84B2719AE8300B9A52D /* ThemedDefaultNavigationController.swift */; };
 		F18859502A3E454E0004AA7B /* EnhancedTrackingProtectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F188594F2A3E454E0004AA7B /* EnhancedTrackingProtectionCoordinator.swift */; };
 		F1BC457E2A40F6D2005541D5 /* EnhancedTrackingProtectionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18859512A3E46020004AA7B /* EnhancedTrackingProtectionCoordinatorTests.swift */; };
+		F605DD582CC73469009A671B /* TabDisplayDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F605DD572CC73469009A671B /* TabDisplayDiffableDataSource.swift */; };
 		F80D53CF2A09A3350047ED14 /* RustSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80D53CD2A09A30F0047ED14 /* RustSyncManagerTests.swift */; };
 		F80DF73F27034F6400E4C37D /* LegacyDynamicFontHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65075531E37F6FC006961AC /* LegacyDynamicFontHelper.swift */; };
 		F80DF7412703BC8E00E4C37D /* CredentialPasscodeRequirementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80DF7402703BC8E00E4C37D /* CredentialPasscodeRequirementViewController.swift */; };
@@ -9055,6 +9056,7 @@
 		F5CC4C0ABF114E4553AFA780 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		F5E84699B672AEC4CE4D5871 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		F5F94E989BFE5C0AAD2FFCFD /* bo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bo; path = bo.lproj/LoginManager.strings; sourceTree = "<group>"; };
+		F605DD572CC73469009A671B /* TabDisplayDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayDiffableDataSource.swift; sourceTree = "<group>"; };
 		F63D438AB501007BE110524A /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		F6AA4920A08DE9E2F0BC44C2 /* br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = br; path = br.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		F6EA434FA5D8305063BC630B /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -9728,6 +9730,7 @@
 				1DDE3DB22AC34E1E0039363B /* TabCell.swift */,
 				21E77E4D2AA8BA5200FABA10 /* TabTrayViewController.swift */,
 				219A0FD32ACC84C5009A6D1A /* InactiveTabs */,
+				F605DD572CC73469009A671B /* TabDisplayDiffableDataSource.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -16295,6 +16298,7 @@
 				8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */,
 				211046CD2A7D842A00A7309F /* TPAccessoryInfo.swift in Sources */,
 				8CEDF0802BFE138B00D2617B /* AddressProvider.swift in Sources */,
+				F605DD582CC73469009A671B /* TabDisplayDiffableDataSource.swift in Sources */,
 				8A454D292CB7078D009436D9 /* PocketState.swift in Sources */,
 				21E77E502AA8BAEC00FABA10 /* TabTrayState.swift in Sources */,
 				0EC57D0A2CA6FCC5002E3F04 /* PasswordGeneratorPasswordFieldView.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -225,8 +225,7 @@ class TabManagerMiddleware {
         // Be careful to use active tabs and not inactive tabs
         let tabManagerTabs = isPrivateMode ? tabManager.privateTabs : tabManager.normalActiveTabs
         tabManagerTabs.forEach { tab in
-            let tabModel = TabModel(id: tab.tabUUID,
-                                    tabUUID: tab.tabUUID,
+            let tabModel = TabModel(tabUUID: tab.tabUUID,
                                     isSelected: tab.tabUUID == selectedTab?.tabUUID,
                                     isPrivate: tab.isPrivate,
                                     isFxHomeTab: tab.isFxHomeTab,
@@ -251,8 +250,7 @@ class TabManagerMiddleware {
         let tabManager = tabManager(for: uuid)
         var inactiveTabs = [InactiveTabsModel]()
         for tab in tabManager.getInactiveTabs() {
-            let inactiveTab = InactiveTabsModel(id: tab.tabUUID,
-                                                tabUUID: tab.tabUUID,
+            let inactiveTab = InactiveTabsModel(tabUUID: tab.tabUUID,
                                                 title: tab.displayTitle,
                                                 url: tab.url,
                                                 favIconURL: tab.faviconURL)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -225,7 +225,8 @@ class TabManagerMiddleware {
         // Be careful to use active tabs and not inactive tabs
         let tabManagerTabs = isPrivateMode ? tabManager.privateTabs : tabManager.normalActiveTabs
         tabManagerTabs.forEach { tab in
-            let tabModel = TabModel(tabUUID: tab.tabUUID,
+            let tabModel = TabModel(id: tab.tabUUID,
+                                    tabUUID: tab.tabUUID,
                                     isSelected: tab.tabUUID == selectedTab?.tabUUID,
                                     isPrivate: tab.isPrivate,
                                     isFxHomeTab: tab.isFxHomeTab,
@@ -250,7 +251,9 @@ class TabManagerMiddleware {
         let tabManager = tabManager(for: uuid)
         var inactiveTabs = [InactiveTabsModel]()
         for tab in tabManager.getInactiveTabs() {
-            let inactiveTab = InactiveTabsModel(tabUUID: tab.tabUUID,
+            let inactiveTab = InactiveTabsModel(
+                                                id: tab.tabUUID,
+                                                tabUUID: tab.tabUUID,
                                                 title: tab.displayTitle,
                                                 url: tab.url,
                                                 favIconURL: tab.faviconURL)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -251,8 +251,7 @@ class TabManagerMiddleware {
         let tabManager = tabManager(for: uuid)
         var inactiveTabs = [InactiveTabsModel]()
         for tab in tabManager.getInactiveTabs() {
-            let inactiveTab = InactiveTabsModel(
-                                                id: tab.tabUUID,
+            let inactiveTab = InactiveTabsModel(id: tab.tabUUID,
                                                 tabUUID: tab.tabUUID,
                                                 title: tab.displayTitle,
                                                 url: tab.url,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/InactiveTabsModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/InactiveTabsModel.swift
@@ -5,7 +5,6 @@
 import Foundation
 
 struct InactiveTabsModel: Equatable, Identifiable, Hashable {
-    // why are these var instead of let??
     let id: String
     var tabUUID: TabUUID
     var title: String

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/InactiveTabsModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/InactiveTabsModel.swift
@@ -4,7 +4,9 @@
 
 import Foundation
 
-struct InactiveTabsModel: Equatable {
+struct InactiveTabsModel: Equatable, Identifiable, Hashable {
+    // why are these var instead of let??
+    let id: String
     var tabUUID: TabUUID
     var title: String
     var url: URL?

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/InactiveTabsModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/InactiveTabsModel.swift
@@ -5,10 +5,10 @@
 import Foundation
 
 struct InactiveTabsModel: Equatable, Identifiable, Hashable {
-    let id: String
-    var tabUUID: TabUUID
-    var title: String
-    var url: URL?
+    var id: String { return tabUUID }
+    let tabUUID: TabUUID
+    let title: String
+    let url: URL?
     var favIconURL: String?
 
     var displayURL: String {
@@ -22,7 +22,6 @@ struct InactiveTabsModel: Equatable, Identifiable, Hashable {
         title: String
     ) -> InactiveTabsModel {
         return InactiveTabsModel(
-            id: tabUUID,
             tabUUID: tabUUID,
             title: title,
             url: nil

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/InactiveTabsModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/InactiveTabsModel.swift
@@ -23,6 +23,7 @@ struct InactiveTabsModel: Equatable, Identifiable, Hashable {
         title: String
     ) -> InactiveTabsModel {
         return InactiveTabsModel(
+            id: tabUUID,
             tabUUID: tabUUID,
             title: title,
             url: nil

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
@@ -4,7 +4,8 @@
 
 import Foundation
 
-struct TabModel: Equatable {
+struct TabModel: Equatable, Identifiable, Hashable {
+    let id: String
     let tabUUID: TabUUID
     let isSelected: Bool
     let isPrivate: Bool
@@ -22,6 +23,7 @@ struct TabModel: Equatable {
         isSelected: Bool = false
     ) -> TabModel {
         return TabModel(
+            id: tabUUID, 
             tabUUID: tabUUID,
             isSelected: isSelected,
             isPrivate: isPrivate,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 struct TabModel: Equatable, Identifiable, Hashable {
-    let id: String
+    var id: String { return tabUUID }
     let tabUUID: TabUUID
     let isSelected: Bool
     let isPrivate: Bool
@@ -23,7 +23,6 @@ struct TabModel: Equatable, Identifiable, Hashable {
         isSelected: Bool = false
     ) -> TabModel {
         return TabModel(
-            id: tabUUID,
             tabUUID: tabUUID,
             isSelected: isSelected,
             isPrivate: isPrivate,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
@@ -23,7 +23,7 @@ struct TabModel: Equatable, Identifiable, Hashable {
         isSelected: Bool = false
     ) -> TabModel {
         return TabModel(
-            id: tabUUID, 
+            id: tabUUID,
             tabUUID: tabUUID,
             isSelected: isSelected,
             isPrivate: isPrivate,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -66,7 +66,6 @@ struct TabsPanelState: ScreenState, Equatable {
          toastType: ToastType? = nil,
          scrollState: ScrollState? = nil,
          didTapAddTab: Bool = false,
-         didMoveTab: Bool = false,
          urlRequest: URLRequest? = nil) {
         self.isPrivateMode = isPrivateMode
         self.tabs = tabs

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsPanelState.swift
@@ -66,6 +66,7 @@ struct TabsPanelState: ScreenState, Equatable {
          toastType: ToastType? = nil,
          scrollState: ScrollState? = nil,
          didTapAddTab: Bool = false,
+         didMoveTab: Bool = false,
          urlRequest: URLRequest? = nil) {
         self.isPrivateMode = isPrivateMode
         self.tabs = tabs
@@ -151,17 +152,6 @@ struct TabsPanelState: ScreenState, Equatable {
                                   inactiveTabs: state.inactiveTabs,
                                   isInactiveTabsExpanded: state.isInactiveTabsExpanded,
                                   scrollState: scrollModel)
-
-//        case TabPanelAction.didTapAddTab:
-//        let didTapNewTab = context.didTapAddTab
-//        let urlRequest = context.urlRequest
-//        let isPrivateMode = context.isPrivate
-//        return TabsPanelState(windowUUID: state.windowUUID,
-//        isPrivateMode: isPrivateMode,
-//        tabs: state.tabs,
-//        inactiveTabs: state.inactiveTabs,
-//        isInactiveTabsExpanded: state.isInactiveTabsExpanded,
-//        didTapAddTab: didTapNewTab)
 
         default:
             return defaultState(fromPreviousState: state)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayDiffableDataSource.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+typealias TabDisplayViewSection = TabDisplayDiffableDataSource.TabSection
+typealias TabDisplayItem = TabDisplayDiffableDataSource.TabItem
+
+final class TabDisplayDiffableDataSource: UICollectionViewDiffableDataSource<TabDisplayViewSection, TabDisplayItem> {
+    enum TabSection: Int, CaseIterable {
+        case inactiveTabs
+        case tabs
+    }
+
+    enum TabItem: Hashable {
+        case inactiveTab(InactiveTabsModel)
+        case tab(TabModel)
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayDiffableDataSource.swift
@@ -15,4 +15,23 @@ final class TabDisplayDiffableDataSource: UICollectionViewDiffableDataSource<Tab
         case inactiveTab(InactiveTabsModel)
         case tab(TabModel)
     }
+
+    func updateSnapshot(state: TabsPanelState) {
+        var snapshot = NSDiffableDataSourceSnapshot<TabDisplayViewSection, TabDisplayItem>()
+
+        snapshot.appendSections([.inactiveTabs, .tabs])
+
+        // reloading .inactiveTabs is necessary to animate the caret moving when we show or hide inactive tabs
+        snapshot.reloadSections([.inactiveTabs])
+
+        if state.isInactiveTabsExpanded {
+            let inactiveTabs = state.inactiveTabs.map { TabDisplayItem.inactiveTab($0) }
+            snapshot.appendItems(inactiveTabs, toSection: .inactiveTabs)
+        }
+
+        let tabs = state.tabs.map { TabDisplayItem.tab($0) }
+        snapshot.appendItems(tabs, toSection: .tabs)
+
+        apply(snapshot, animatingDifferences: true)
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayDiffableDataSource.swift
@@ -3,9 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 typealias TabDisplayViewSection = TabDisplayDiffableDataSource.TabSection
-typealias TabDisplayItem = TabDisplayDiffableDataSource.TabItem
+typealias TabDisplayViewItem = TabDisplayDiffableDataSource.TabItem
 
-final class TabDisplayDiffableDataSource: UICollectionViewDiffableDataSource<TabDisplayViewSection, TabDisplayItem> {
+final class TabDisplayDiffableDataSource: UICollectionViewDiffableDataSource<TabDisplayViewSection, TabDisplayViewItem> {
     enum TabSection: Int, CaseIterable {
         case inactiveTabs
         case tabs
@@ -17,7 +17,7 @@ final class TabDisplayDiffableDataSource: UICollectionViewDiffableDataSource<Tab
     }
 
     func updateSnapshot(state: TabsPanelState) {
-        var snapshot = NSDiffableDataSourceSnapshot<TabDisplayViewSection, TabDisplayItem>()
+        var snapshot = NSDiffableDataSourceSnapshot<TabDisplayViewSection, TabDisplayViewItem>()
 
         snapshot.appendSections([.inactiveTabs, .tabs])
 
@@ -25,11 +25,11 @@ final class TabDisplayDiffableDataSource: UICollectionViewDiffableDataSource<Tab
         snapshot.reloadSections([.inactiveTabs])
 
         if state.isInactiveTabsExpanded {
-            let inactiveTabs = state.inactiveTabs.map { TabDisplayItem.inactiveTab($0) }
+            let inactiveTabs = state.inactiveTabs.map { TabDisplayViewItem.inactiveTab($0) }
             snapshot.appendItems(inactiveTabs, toSection: .inactiveTabs)
         }
 
-        let tabs = state.tabs.map { TabDisplayItem.tab($0) }
+        let tabs = state.tabs.map { TabDisplayViewItem.tab($0) }
         snapshot.appendItems(tabs, toSection: .tabs)
 
         apply(snapshot, animatingDifferences: true)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -196,7 +196,7 @@ class TabDisplayView: UIView,
 
         tabsState = state
 
-        updateCollectionView(state: tabsState)
+        dataSource?.updateSnapshot(state: tabsState)
 
         if let scrollState = state.scrollState {
             scrollToTab(scrollState)
@@ -208,24 +208,6 @@ class TabDisplayView: UIView,
                                             actionType: TabPanelViewActionType.addNewTab)
             store.dispatch(action)
         }
-    }
-
-    private func updateCollectionView(state: TabsPanelState) {
-        var snapshot = NSDiffableDataSourceSnapshot<TabDisplayViewSection, TabDisplayItem>()
-
-        snapshot.deleteAllItems()
-        snapshot.appendSections([.inactiveTabs, .tabs])
-        snapshot.reloadSections([.inactiveTabs])
-
-        if state.isInactiveTabsExpanded {
-            let inactiveTabs = state.inactiveTabs.map { TabDisplayItem.inactiveTab($0) }
-            snapshot.appendItems(inactiveTabs, toSection: .inactiveTabs)
-        }
-
-        let tabs = state.tabs.map { TabDisplayItem.tab($0) }
-        snapshot.appendItems(tabs, toSection: .tabs)
-
-        dataSource?.apply(snapshot, animatingDifferences: true)
     }
 
     private func scrollToTab(_ scrollState: TabsPanelState.ScrollState) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -82,8 +82,10 @@ class TabDisplayView: UIView,
     }()
 
     private func configureDataSource() {
-        dataSource = TabDisplayDiffableDataSource(collectionView: collectionView)
-         { [weak self] (collectionView, indexPath, sectionItem) -> UICollectionViewCell in
+        // swiftlint:disable line_length
+        dataSource = TabDisplayDiffableDataSource(collectionView: collectionView) { [weak self] (collectionView, indexPath, sectionItem) ->
+            UICollectionViewCell in
+            // swiftlint:enable line_length
             guard let self else { return UICollectionViewCell() }
 
             switch sectionItem {
@@ -113,11 +115,9 @@ class TabDisplayView: UIView,
             }
         }
 
-        dataSource?.supplementaryViewProvider = { [weak self] (
-            collectionView,
-            kind,
-            indexPath
-        ) -> UICollectionReusableView? in
+        // swiftlint:disable line_length
+        dataSource?.supplementaryViewProvider = { [weak self] (collectionView, kind, indexPath) -> UICollectionReusableView? in
+            // swiftlint:enable line_length
             let reusableView = UICollectionReusableView()
             let section = self?.getTabDisplay(for: indexPath.section)
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -29,13 +29,8 @@ class TabDisplayView: UIView,
     private var dataSource: TabDisplayDiffableDataSource?
 
     private var shouldHideInactiveTabs: Bool {
-        if tabsState.isPrivateMode {
-            return true
-        } else if tabsState.inactiveTabs.isEmpty {
-            return true
-        } else {
-            return false
-        }
+        guard !tabsState.isPrivateMode else { return true }
+        return tabsState.inactiveTabs.isEmpty
     }
 
     // Dragging on the collection view is either an 'active drag' where the item is moved, or

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -250,7 +250,7 @@ class TabDisplayView: UIView,
     }
 
     private func scrollToTab(_ scrollState: TabsPanelState.ScrollState) {
-        let section: Int = scrollState.isInactiveTabSection ? 1 : 0
+        let section: Int = scrollState.isInactiveTabSection ? 0 : 1
         let indexPath = IndexPath(row: scrollState.toIndex, section: section)
 
         // We cannot get the visible cells unless all layout operations have finished finished (e.g. after `reloadData()`)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
@@ -51,8 +51,7 @@ class TabCellTests: XCTestCase {
 
     private func createDefaultState() -> TabModel {
         let tabUUID = "0022-22D3"
-        return TabModel(id: tabUUID,
-                        tabUUID: tabUUID,
+        return TabModel(tabUUID: tabUUID,
                         isSelected: false,
                         isPrivate: false,
                         isFxHomeTab: false,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
@@ -50,7 +50,9 @@ class TabCellTests: XCTestCase {
     }
 
     private func createDefaultState() -> TabModel {
-        return TabModel(tabUUID: "0022-22D3",
+        let tabUUID = "0022-22D3"
+        return TabModel(id: tabUUID,
+                        tabUUID: tabUUID,
                         isSelected: false,
                         isPrivate: false,
                         isFxHomeTab: false,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
@@ -65,7 +65,7 @@ final class TabDisplayPanelTests: XCTestCase {
         if !emptyInactiveTabs {
             let uuid = "UUID"
             for index in 0...2 {
-                let inactiveTabModel = InactiveTabsModel(id: uuid,                                             
+                let inactiveTabModel = InactiveTabsModel(id: uuid,
                                                          tabUUID: uuid,
                                                          title: "InactiveTab\(index)",
                                                          url: nil)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
@@ -63,8 +63,10 @@ final class TabDisplayPanelTests: XCTestCase {
         let tabs = createTabs(emptyTabs)
         var inactiveTabs = [InactiveTabsModel]()
         if !emptyInactiveTabs {
+            let uuid = "UUID"
             for index in 0...2 {
-                let inactiveTabModel = InactiveTabsModel(tabUUID: "UUID",
+                let inactiveTabModel = InactiveTabsModel(id: uuid,                                             
+                                                         tabUUID: uuid,
                                                          title: "InactiveTab\(index)",
                                                          url: nil)
                 inactiveTabs.append(inactiveTabModel)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
@@ -65,8 +65,7 @@ final class TabDisplayPanelTests: XCTestCase {
         if !emptyInactiveTabs {
             let uuid = "UUID"
             for index in 0...2 {
-                let inactiveTabModel = InactiveTabsModel(id: uuid,
-                                                         tabUUID: uuid,
+                let inactiveTabModel = InactiveTabsModel(tabUUID: uuid,
                                                          title: "InactiveTab\(index)",
                                                          url: nil)
                 inactiveTabs.append(inactiveTabModel)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
@@ -121,8 +121,7 @@ final class TabDisplayViewTests: XCTestCase {
         var inactiveTabs = [InactiveTabsModel]()
         let tabUUID = "UUID"
         for index in 0..<numberOfTabs {
-            let inactiveTabModel = InactiveTabsModel(id: tabUUID,
-                                                     tabUUID: tabUUID,
+            let inactiveTabModel = InactiveTabsModel(tabUUID: tabUUID,
                                                      title: "InactiveTab\(index)",
                                                      url: nil)
             inactiveTabs.append(inactiveTabModel)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
@@ -7,74 +7,104 @@ import XCTest
 
 @testable import Client
 final class TabDisplayViewTests: XCTestCase {
-    var profile: MockProfile!
-
-    override func setUp() {
-        super.setUp()
-        DependencyHelperMock().bootstrapDependencies()
-        profile = MockProfile()
-    }
+    var tabDisplayView: TabDisplayView?
+    var diffableDataSource: TabDisplayDiffableDataSource?
 
     override func tearDown() {
+        diffableDataSource = nil
+        tabDisplayView = nil
         super.tearDown()
-        DependencyHelperMock().reset()
-        profile = nil
     }
 
     // TODO: Add Tests Using Diffable Datasource
 
-//    func testNumberOfSections_ForRegularTabsWithInactiveTabs() {
-//        let subject = createSubject(isPrivateMode: false,
-//                                    emptyTabs: false,
-//                                    emptyInactiveTabs: false)
-//
-//        XCTAssertEqual(subject.collectionView.numberOfSections, 2)
-//    }
-//
-//    func testNumberOfSections_ForRegularTabsWithoutInactiveTabs() {
-//        let subject = createSubject(isPrivateMode: false,
-//                                    emptyTabs: false,
-//                                    emptyInactiveTabs: true)
-//
-//        XCTAssertEqual(subject.collectionView.numberOfSections, 1)
-//    }
-//
-//    func testNumberOfSections_PrivateTabsAndInactiveTabs() {
+    func testNumberOfSections_ForRegularTabsWithInactiveTabs() {
+        let subject = createSubject(isPrivateMode: false,
+                                    numberInactiveTabs: 2,
+                                    numberActiveTabs: 5)
+
+        XCTAssertEqual(subject.collectionView.numberOfSections, 2)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 2)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 5)
+    }
+
+    func testNumberOfSections_ForRegularTabsWithoutInactiveTabs() {
+        let subject = createSubject(isPrivateMode: false,
+                                    numberInactiveTabs: 0,
+                                    numberActiveTabs: 2)
+
+        XCTAssertEqual(subject.collectionView.numberOfSections, 2)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 0)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 2)
+    }
+
+    func testNumberOfSections_PrivateTabsAndInactiveTabs() {
+        let subject = createSubject(isPrivateMode: true,
+                                    numberInactiveTabs: 4,
+                                    numberActiveTabs: 2)
+
+        XCTAssertEqual(subject.collectionView.numberOfSections, 2)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 4)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 2)
+
 //        let subject = createSubject(isPrivateMode: true,
 //                                    emptyTabs: false,
 //                                    emptyInactiveTabs: false)
 //
 //        let numberOfSections = subject.collectionView.numberOfSections
-//        XCTAssertEqual(numberOfSections, 1)
-//    }
-//
-//    func testNumberOfSections_PrivateTabsWithoutInactiveTabs() {
+//        XCTAssertEqual(numberOfSections, 2)
+    }
+
+    func testNumberOfSections_PrivateTabsWithoutInactiveTabs() {
+        let subject = createSubject(isPrivateMode: true,
+                                    numberInactiveTabs: 0,
+                                    numberActiveTabs: 9)
+
+        XCTAssertEqual(subject.collectionView.numberOfSections, 2)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 0)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 9)
+
 //        let subject = createSubject(isPrivateMode: true,
 //                                    emptyTabs: false,
 //                                    emptyInactiveTabs: true)
 //
 //        let numberOfSections = subject.collectionView.numberOfSections
-//        XCTAssertEqual(numberOfSections, 1)
-//    }
-//
-//    func testNumberOfSections_PrivateTabsWithEmptyTabs() {
+//        XCTAssertEqual(numberOfSections, 2)
+    }
+
+    func testNumberOfSections_PrivateTabsWithEmptyTabs() {
+        let subject = createSubject(isPrivateMode: true,
+                                    numberInactiveTabs: 0,
+                                    numberActiveTabs: 0)
+
+        XCTAssertEqual(subject.collectionView.numberOfSections, 2)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 0)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 0)
+
 //        let subject = createSubject(isPrivateMode: true,
 //                                    emptyTabs: true,
 //                                    emptyInactiveTabs: true)
 //
 //        let numberOfSections = subject.collectionView.numberOfSections
-//        XCTAssertEqual(numberOfSections, 0)
-//    }
-//
-//    func testAmountOfSections_ForPrivateTabsWithoutInactiveTabs() {
+//        XCTAssertEqual(numberOfSections, 2)
+    }
+
+    func testAmountOfSections_ForPrivateTabsWithoutInactiveTabs() {
+        let subject = createSubject(isPrivateMode: true,
+                                    numberInactiveTabs: 0,
+                                    numberActiveTabs: 4)
+
+        XCTAssertEqual(subject.collectionView.numberOfSections, 2)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 0)
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 4)
+
 //        let subject = createSubject(isPrivateMode: true,
 //                                    emptyTabs: false,
 //                                    emptyInactiveTabs: true)
 //
-//        XCTAssertEqual(subject.collectionView.numberOfSections, 1)
-//    }
-//
-//    // This case is not possible adding the test to check the logic still
+//        XCTAssertEqual(subject.collectionView.numberOfSections, 2)
+    }
+
 //    func testAmountOfSections_ForPrivateTabsWithInactiveTabs() {
 //        let subject = createSubject(isPrivateMode: true,
 //                                    emptyTabs: false,
@@ -82,56 +112,64 @@ final class TabDisplayViewTests: XCTestCase {
 //
 //        XCTAssertEqual(subject.collectionView.numberOfSections, 1)
 //    }
-//
-//    func testNumberOfItemsSection_ForRegularTabsWithInactiveTabs() {
-//        let subject = createSubject(isPrivateMode: false,
-//                                    emptyTabs: false,
-//                                    emptyInactiveTabs: false)
-//
-//        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 2)
-//        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 3)
-//    }
-//
-//    // MARK: - Private
-//    private func createSubject(isPrivateMode: Bool,
-//                               emptyTabs: Bool,
-//                               emptyInactiveTabs: Bool,
-//                               file: StaticString = #file,
-//                               line: UInt = #line) -> TabDisplayView {
-//        let tabs = createTabs(emptyTabs)
-//        var inactiveTabs = [InactiveTabsModel]()
-//        let tabUUID = "UUID"
-//        if !emptyInactiveTabs {
-//            for index in 0..<2 {
-//                let inactiveTabModel = InactiveTabsModel(id: tabUUID,
-//                                                         tabUUID: tabUUID,
-//                                                         title: "InactiveTab\(index)",
-//                                                         url: nil)
-//                inactiveTabs.append(inactiveTabModel)
-//            }
-//        }
-//        let isInactiveTabsExpanded = !isPrivateMode && !inactiveTabs.isEmpty
-//        let tabState = TabsPanelState(windowUUID: .XCTestDefaultUUID,
-//                                      isPrivateMode: isPrivateMode,
-//                                      tabs: tabs,
-//                                      inactiveTabs: inactiveTabs,
-//                                      isInactiveTabsExpanded: isInactiveTabsExpanded)
-//
-//        let subject = TabDisplayView(panelType: isPrivateMode ? .privateTabs : .tabs,
-//                                     state: tabState,
-//                                     windowUUID: .XCTestDefaultUUID)
-//        trackForMemoryLeaks(subject, file: file, line: line)
-//        return subject
-//    }
-//
-//    private func createTabs(_ emptyTabs: Bool) -> [TabModel] {
-//        guard !emptyTabs else { return [TabModel]() }
-//
-//        var tabs = [TabModel]()
-//        for index in 0...2 {
-//            let tabModel = TabModel.emptyState(tabUUID: "", title: "Tab \(index)")
-//            tabs.append(tabModel)
-//        }
-//        return tabs
-//    }
+
+    // MARK: - Private
+    private func createSubject(isPrivateMode: Bool,
+                               numberInactiveTabs: Int,
+                               numberActiveTabs: Int,
+                               file: StaticString = #file,
+                               line: UInt = #line) -> TabDisplayView {
+        let tabs = createTabs(numberOfTabs: numberActiveTabs)
+
+        let inactiveTabs = createInactiveTabs(numberOfTabs: numberInactiveTabs)
+        let isInactiveTabsExpanded = !isPrivateMode && !inactiveTabs.isEmpty
+
+        let tabState = TabsPanelState(windowUUID: .XCTestDefaultUUID,
+                                      isPrivateMode: isPrivateMode,
+                                      tabs: tabs,
+                                      inactiveTabs: inactiveTabs,
+                                      isInactiveTabsExpanded: isInactiveTabsExpanded)
+
+        let subject = TabDisplayView(panelType: isPrivateMode ? .privateTabs : .tabs,
+                                     state: tabState,
+                                     windowUUID: .XCTestDefaultUUID)
+
+        let tabCollectionView = subject.collectionView
+
+        diffableDataSource = TabDisplayDiffableDataSource(
+            collectionView: tabCollectionView
+        ) { (collectionView, indexPath, item) -> UICollectionViewCell? in
+            return UICollectionViewCell()
+        }
+
+        diffableDataSource?.updateSnapshot(state: tabState)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+
+    private func createInactiveTabs(numberOfTabs: Int) -> [InactiveTabsModel] {
+        guard numberOfTabs != 0 else { return [InactiveTabsModel]() }
+
+        var inactiveTabs = [InactiveTabsModel]()
+        let tabUUID = "UUID"
+        for index in 0..<numberOfTabs {
+            let inactiveTabModel = InactiveTabsModel(id: tabUUID,
+                                                     tabUUID: tabUUID,
+                                                     title: "InactiveTab\(index)",
+                                                     url: nil)
+            inactiveTabs.append(inactiveTabModel)
+        }
+        return inactiveTabs
+    }
+
+    private func createTabs(numberOfTabs: Int) -> [TabModel] {
+        guard numberOfTabs != 0 else { return [TabModel]() }
+
+        var tabs = [TabModel]()
+        for index in 0..<numberOfTabs {
+            let tabModel = TabModel.emptyState(tabUUID: "", title: "Tab \(index)")
+            tabs.append(tabModel)
+        }
+        return tabs
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
@@ -98,9 +98,11 @@ final class TabDisplayViewTests: XCTestCase {
                                line: UInt = #line) -> TabDisplayView {
         let tabs = createTabs(emptyTabs)
         var inactiveTabs = [InactiveTabsModel]()
+        let tabUUID = "UUID"
         if !emptyInactiveTabs {
             for index in 0..<2 {
-                let inactiveTabModel = InactiveTabsModel(tabUUID: "UUID",
+                let inactiveTabModel = InactiveTabsModel(id: tabUUID,
+                                                         tabUUID: tabUUID,
                                                          title: "InactiveTab\(index)",
                                                          url: nil)
                 inactiveTabs.append(inactiveTabModel)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
@@ -21,115 +21,117 @@ final class TabDisplayViewTests: XCTestCase {
         profile = nil
     }
 
-    func testNumberOfSections_ForRegularTabsWithInactiveTabs() {
-        let subject = createSubject(isPrivateMode: false,
-                                    emptyTabs: false,
-                                    emptyInactiveTabs: false)
+    // TODO: Add Tests Using Diffable Datasource
 
-        XCTAssertEqual(subject.collectionView.numberOfSections, 2)
-    }
-
-    func testNumberOfSections_ForRegularTabsWithoutInactiveTabs() {
-        let subject = createSubject(isPrivateMode: false,
-                                    emptyTabs: false,
-                                    emptyInactiveTabs: true)
-
-        XCTAssertEqual(subject.collectionView.numberOfSections, 1)
-    }
-
-    func testNumberOfSections_PrivateTabsAndInactiveTabs() {
-        let subject = createSubject(isPrivateMode: true,
-                                    emptyTabs: false,
-                                    emptyInactiveTabs: false)
-
-        let numberOfSections = subject.collectionView.numberOfSections
-        XCTAssertEqual(numberOfSections, 1)
-    }
-
-    func testNumberOfSections_PrivateTabsWithoutInactiveTabs() {
-        let subject = createSubject(isPrivateMode: true,
-                                    emptyTabs: false,
-                                    emptyInactiveTabs: true)
-
-        let numberOfSections = subject.collectionView.numberOfSections
-        XCTAssertEqual(numberOfSections, 1)
-    }
-
-    func testNumberOfSections_PrivateTabsWithEmptyTabs() {
-        let subject = createSubject(isPrivateMode: true,
-                                    emptyTabs: true,
-                                    emptyInactiveTabs: true)
-
-        let numberOfSections = subject.collectionView.numberOfSections
-        XCTAssertEqual(numberOfSections, 0)
-    }
-
-    func testAmountOfSections_ForPrivateTabsWithoutInactiveTabs() {
-        let subject = createSubject(isPrivateMode: true,
-                                    emptyTabs: false,
-                                    emptyInactiveTabs: true)
-
-        XCTAssertEqual(subject.collectionView.numberOfSections, 1)
-    }
-
-    // This case is not possible adding the test to check the logic still
-    func testAmountOfSections_ForPrivateTabsWithInactiveTabs() {
-        let subject = createSubject(isPrivateMode: true,
-                                    emptyTabs: false,
-                                    emptyInactiveTabs: false)
-
-        XCTAssertEqual(subject.collectionView.numberOfSections, 1)
-    }
-
-    func testNumberOfItemsSection_ForRegularTabsWithInactiveTabs() {
-        let subject = createSubject(isPrivateMode: false,
-                                    emptyTabs: false,
-                                    emptyInactiveTabs: false)
-
-        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 2)
-        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 3)
-    }
-
-    // MARK: - Private
-    private func createSubject(isPrivateMode: Bool,
-                               emptyTabs: Bool,
-                               emptyInactiveTabs: Bool,
-                               file: StaticString = #file,
-                               line: UInt = #line) -> TabDisplayView {
-        let tabs = createTabs(emptyTabs)
-        var inactiveTabs = [InactiveTabsModel]()
-        let tabUUID = "UUID"
-        if !emptyInactiveTabs {
-            for index in 0..<2 {
-                let inactiveTabModel = InactiveTabsModel(id: tabUUID,
-                                                         tabUUID: tabUUID,
-                                                         title: "InactiveTab\(index)",
-                                                         url: nil)
-                inactiveTabs.append(inactiveTabModel)
-            }
-        }
-        let isInactiveTabsExpanded = !isPrivateMode && !inactiveTabs.isEmpty
-        let tabState = TabsPanelState(windowUUID: .XCTestDefaultUUID,
-                                      isPrivateMode: isPrivateMode,
-                                      tabs: tabs,
-                                      inactiveTabs: inactiveTabs,
-                                      isInactiveTabsExpanded: isInactiveTabsExpanded)
-
-        let subject = TabDisplayView(panelType: isPrivateMode ? .privateTabs : .tabs,
-                                     state: tabState,
-                                     windowUUID: .XCTestDefaultUUID)
-        trackForMemoryLeaks(subject, file: file, line: line)
-        return subject
-    }
-
-    private func createTabs(_ emptyTabs: Bool) -> [TabModel] {
-        guard !emptyTabs else { return [TabModel]() }
-
-        var tabs = [TabModel]()
-        for index in 0...2 {
-            let tabModel = TabModel.emptyState(tabUUID: "", title: "Tab \(index)")
-            tabs.append(tabModel)
-        }
-        return tabs
-    }
+//    func testNumberOfSections_ForRegularTabsWithInactiveTabs() {
+//        let subject = createSubject(isPrivateMode: false,
+//                                    emptyTabs: false,
+//                                    emptyInactiveTabs: false)
+//
+//        XCTAssertEqual(subject.collectionView.numberOfSections, 2)
+//    }
+//
+//    func testNumberOfSections_ForRegularTabsWithoutInactiveTabs() {
+//        let subject = createSubject(isPrivateMode: false,
+//                                    emptyTabs: false,
+//                                    emptyInactiveTabs: true)
+//
+//        XCTAssertEqual(subject.collectionView.numberOfSections, 1)
+//    }
+//
+//    func testNumberOfSections_PrivateTabsAndInactiveTabs() {
+//        let subject = createSubject(isPrivateMode: true,
+//                                    emptyTabs: false,
+//                                    emptyInactiveTabs: false)
+//
+//        let numberOfSections = subject.collectionView.numberOfSections
+//        XCTAssertEqual(numberOfSections, 1)
+//    }
+//
+//    func testNumberOfSections_PrivateTabsWithoutInactiveTabs() {
+//        let subject = createSubject(isPrivateMode: true,
+//                                    emptyTabs: false,
+//                                    emptyInactiveTabs: true)
+//
+//        let numberOfSections = subject.collectionView.numberOfSections
+//        XCTAssertEqual(numberOfSections, 1)
+//    }
+//
+//    func testNumberOfSections_PrivateTabsWithEmptyTabs() {
+//        let subject = createSubject(isPrivateMode: true,
+//                                    emptyTabs: true,
+//                                    emptyInactiveTabs: true)
+//
+//        let numberOfSections = subject.collectionView.numberOfSections
+//        XCTAssertEqual(numberOfSections, 0)
+//    }
+//
+//    func testAmountOfSections_ForPrivateTabsWithoutInactiveTabs() {
+//        let subject = createSubject(isPrivateMode: true,
+//                                    emptyTabs: false,
+//                                    emptyInactiveTabs: true)
+//
+//        XCTAssertEqual(subject.collectionView.numberOfSections, 1)
+//    }
+//
+//    // This case is not possible adding the test to check the logic still
+//    func testAmountOfSections_ForPrivateTabsWithInactiveTabs() {
+//        let subject = createSubject(isPrivateMode: true,
+//                                    emptyTabs: false,
+//                                    emptyInactiveTabs: false)
+//
+//        XCTAssertEqual(subject.collectionView.numberOfSections, 1)
+//    }
+//
+//    func testNumberOfItemsSection_ForRegularTabsWithInactiveTabs() {
+//        let subject = createSubject(isPrivateMode: false,
+//                                    emptyTabs: false,
+//                                    emptyInactiveTabs: false)
+//
+//        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 2)
+//        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 3)
+//    }
+//
+//    // MARK: - Private
+//    private func createSubject(isPrivateMode: Bool,
+//                               emptyTabs: Bool,
+//                               emptyInactiveTabs: Bool,
+//                               file: StaticString = #file,
+//                               line: UInt = #line) -> TabDisplayView {
+//        let tabs = createTabs(emptyTabs)
+//        var inactiveTabs = [InactiveTabsModel]()
+//        let tabUUID = "UUID"
+//        if !emptyInactiveTabs {
+//            for index in 0..<2 {
+//                let inactiveTabModel = InactiveTabsModel(id: tabUUID,
+//                                                         tabUUID: tabUUID,
+//                                                         title: "InactiveTab\(index)",
+//                                                         url: nil)
+//                inactiveTabs.append(inactiveTabModel)
+//            }
+//        }
+//        let isInactiveTabsExpanded = !isPrivateMode && !inactiveTabs.isEmpty
+//        let tabState = TabsPanelState(windowUUID: .XCTestDefaultUUID,
+//                                      isPrivateMode: isPrivateMode,
+//                                      tabs: tabs,
+//                                      inactiveTabs: inactiveTabs,
+//                                      isInactiveTabsExpanded: isInactiveTabsExpanded)
+//
+//        let subject = TabDisplayView(panelType: isPrivateMode ? .privateTabs : .tabs,
+//                                     state: tabState,
+//                                     windowUUID: .XCTestDefaultUUID)
+//        trackForMemoryLeaks(subject, file: file, line: line)
+//        return subject
+//    }
+//
+//    private func createTabs(_ emptyTabs: Bool) -> [TabModel] {
+//        guard !emptyTabs else { return [TabModel]() }
+//
+//        var tabs = [TabModel]()
+//        for index in 0...2 {
+//            let tabModel = TabModel.emptyState(tabUUID: "", title: "Tab \(index)")
+//            tabs.append(tabModel)
+//        }
+//        return tabs
+//    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewTests.swift
@@ -7,16 +7,18 @@ import XCTest
 
 @testable import Client
 final class TabDisplayViewTests: XCTestCase {
-    var tabDisplayView: TabDisplayView?
     var diffableDataSource: TabDisplayDiffableDataSource?
 
-    override func tearDown() {
-        diffableDataSource = nil
-        tabDisplayView = nil
-        super.tearDown()
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
     }
 
-    // TODO: Add Tests Using Diffable Datasource
+    override func tearDown() {
+        DependencyHelperMock().reset()
+        diffableDataSource = nil
+        super.tearDown()
+    }
 
     func testNumberOfSections_ForRegularTabsWithInactiveTabs() {
         let subject = createSubject(isPrivateMode: false,
@@ -40,19 +42,13 @@ final class TabDisplayViewTests: XCTestCase {
 
     func testNumberOfSections_PrivateTabsAndInactiveTabs() {
         let subject = createSubject(isPrivateMode: true,
-                                    numberInactiveTabs: 4,
+                                    numberInactiveTabs: 2,
                                     numberActiveTabs: 2)
 
         XCTAssertEqual(subject.collectionView.numberOfSections, 2)
-        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 4)
+        // if in private mode we should not have any inactive tabs added to the section
+        XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 0)
         XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 2)
-
-//        let subject = createSubject(isPrivateMode: true,
-//                                    emptyTabs: false,
-//                                    emptyInactiveTabs: false)
-//
-//        let numberOfSections = subject.collectionView.numberOfSections
-//        XCTAssertEqual(numberOfSections, 2)
     }
 
     func testNumberOfSections_PrivateTabsWithoutInactiveTabs() {
@@ -63,13 +59,6 @@ final class TabDisplayViewTests: XCTestCase {
         XCTAssertEqual(subject.collectionView.numberOfSections, 2)
         XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 0)
         XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 9)
-
-//        let subject = createSubject(isPrivateMode: true,
-//                                    emptyTabs: false,
-//                                    emptyInactiveTabs: true)
-//
-//        let numberOfSections = subject.collectionView.numberOfSections
-//        XCTAssertEqual(numberOfSections, 2)
     }
 
     func testNumberOfSections_PrivateTabsWithEmptyTabs() {
@@ -80,13 +69,6 @@ final class TabDisplayViewTests: XCTestCase {
         XCTAssertEqual(subject.collectionView.numberOfSections, 2)
         XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 0)
         XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 0)
-
-//        let subject = createSubject(isPrivateMode: true,
-//                                    emptyTabs: true,
-//                                    emptyInactiveTabs: true)
-//
-//        let numberOfSections = subject.collectionView.numberOfSections
-//        XCTAssertEqual(numberOfSections, 2)
     }
 
     func testAmountOfSections_ForPrivateTabsWithoutInactiveTabs() {
@@ -97,21 +79,7 @@ final class TabDisplayViewTests: XCTestCase {
         XCTAssertEqual(subject.collectionView.numberOfSections, 2)
         XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 0), 0)
         XCTAssertEqual(subject.collectionView.numberOfItems(inSection: 1), 4)
-
-//        let subject = createSubject(isPrivateMode: true,
-//                                    emptyTabs: false,
-//                                    emptyInactiveTabs: true)
-//
-//        XCTAssertEqual(subject.collectionView.numberOfSections, 2)
     }
-
-//    func testAmountOfSections_ForPrivateTabsWithInactiveTabs() {
-//        let subject = createSubject(isPrivateMode: true,
-//                                    emptyTabs: false,
-//                                    emptyInactiveTabs: false)
-//
-//        XCTAssertEqual(subject.collectionView.numberOfSections, 1)
-//    }
 
     // MARK: - Private
     private func createSubject(isPrivateMode: Bool,


### PR DESCRIPTION
## :scroll: Main Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9485)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20988)

## Bugs Fixed By This Change
[Zoomed tab thumbnails no longer animate when opening](https://mozilla-hub.atlassian.net/browse/FXIOS-9707)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21341)

[UI glitch then moving the tab position in tab tray](https://mozilla-hub.atlassian.net/browse/FXIOS-9348)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20702)

[Swiping to close a tab thumbnail in the tab tray sometimes closes the wrong tab](https://mozilla-hub.atlassian.net/browse/FXIOS-9809)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21546)

[Dragging a Tab in the Tab Tray duplicates the next tab's title/screenshot](https://mozilla-hub.atlassian.net/browse/FXIOS-9880)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21672)

[ Unresponsive tabs when trying to rearrange them (intermittent)](https://mozilla-hub.atlassian.net/browse/FXIOS-9466)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20956)

## :bulb: Description
Replaced UICollectionViewDatasource with UICollectionViewDiffableDataSource to only update TabDisplayView collectionView UI when there are pending new state changes

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

