### PR TITLE
Bugfix MTE-3739 Remove reference to fire button 🔥

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -155,11 +155,7 @@ class ToolbarTests: BaseTestCase {
         // Swipe up to close the app does not work on iOS 15.
         if #available(iOS 16, *) {
             closeFromAppSwitcherAndRelaunch()
-            if isPrivate {
-                mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.fireButton])
-            } else {
-                mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
-            }
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
             let addNewTabButton = app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton]
             mozWaitForElementToExist(addNewTabButton)
             addNewTabButton.tapOnApp()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -147,18 +147,10 @@ class ToolbarTests: BaseTestCase {
     }
 
     private func validateAddNewTabButtonOnToolbar(isPrivate: Bool) {
-        if isPrivate {
-            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.fireButton])
-        } else {
-            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
-        }
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
         restartInBackground()
-        if isPrivate {
-            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.fireButton])
-        } else {
-            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
-        }
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton])
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
         // Swipe up to close the app does not work on iOS 15.
         if #available(iOS 16, *) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
The Fire Button 🔥 from the private tabs tray has been replaced by the magnifying glass 🔍  button. See https://github.com/mozilla-mobile/firefox-ios/issues/22384#issuecomment-2427164083.

This PR is to remove the references about the button.

All `ToolbarTests` has been run against iOS 15, 16, 17 and 18 simulators.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

