### PR TITLE
Bugfix FXIOS-10319 Fix lock icon visibility when visiting invalid cert website

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2643,9 +2643,6 @@ class BrowserViewController: UIViewController,
             if isSelectedTab && !isToolbarRefactorEnabled {
                 // Refresh secure content state after completed navigation
                 urlBar.locationView.hasSecureContent = webView.hasOnlySecureContent
-                if let url = webView.url {
-                    urlBar.locationView.showTrackingProtectionButton(for: url)
-                }
             }
 
             if !isSelectedTab, let webView = tab.webView, tab.screenshot == nil {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -214,9 +214,7 @@ class TrackingProtectionTests: BaseTestCase {
         )
         mozWaitForElementToExist(app.staticTexts.elementContainingText("Firefox has not connected to this website."))
 
-        // The lock icon is no longer here.
-        // https://github.com/mozilla-mobile/firefox-ios/issues/22600
-        // XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, "Connection not secure")
+        XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label, "Connection not secure")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2693741


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10319)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22600)

## :bulb: Description

Fixes a regression with the lock icon. The line removed here was originally added in https://github.com/mozilla-mobile/firefox-ios/pull/22474, which in turn had brought it over from commits in an earlier PR from a different author. Removing that line fixes this bug (FXIOS-10319), and I also regression-tested the original Bugzilla that https://github.com/mozilla-mobile/firefox-ios/pull/22474 was created to fix (1843467) and removal of this line does not appear to have any impact for that issue. As best as I can see, this safety check isn't actually necessary and in fact is problematic because it has the potential to hide the lock icon in incorrect scenarios.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

