### PR TITLE
Bugfix MTE-3733 TrackingProtectionTests for iOS 15

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -369,7 +369,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                 // There is no Cancel option in iPad.
                 app.otherElements["PopoverDismissRegion"].tap()
             } else {
-                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].tapOnApp()
+                app.buttons[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.closeButton].tap()
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -50,7 +50,12 @@ class TrackingProtectionTests: BaseTestCase {
             )
         }
         app.otherElements.element(matching: .any, identifier: reloadWithWithoutProtectionButton).tap()
+        waitUntilPageLoad()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
+        if #unavailable(iOS 16) {
+            XCTAssert(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].isHittable)
+            sleep(2)
+        }
     }
 
     private func enableStrictMode() {
@@ -247,40 +252,40 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.openURL(trackingProtectionTestUrl)
         waitUntilPageLoad()
 
-        if #available(iOS 17, *) {
-            if checkTrackingProtectionOn() {
-                XCTAssertEqual(
-                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                    secureTrackingProtectionOnLabel
-                )
-                navigator.nowAt(BrowserTab)
-                reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
-                XCTAssertEqual(
-                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                    secureTrackingProtectionOffLabel
-                )
-                reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
-                XCTAssertEqual(
-                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                    secureTrackingProtectionOnLabel
-                )
-            } else {
-                XCTAssertEqual(
-                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                    secureTrackingProtectionOffLabel
-                )
-                navigator.nowAt(BrowserTab)
-                reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
-                XCTAssertEqual(
-                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                    secureTrackingProtectionOnLabel
-                )
-                reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
-                XCTAssertEqual(
-                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                    secureTrackingProtectionOffLabel
-                )
-            }
+        if checkTrackingProtectionOn() {
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOnLabel
+            )
+            navigator.nowAt(BrowserTab)
+            reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOffLabel
+            )
+            reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOnLabel
+            )
+        } else {
+            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOffLabel
+            )
+            navigator.nowAt(BrowserTab)
+            reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOnLabel
+            )
+            reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
+            XCTAssertEqual(
+                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                secureTrackingProtectionOffLabel
+            )
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -200,7 +200,7 @@ class TrackingProtectionTests: BaseTestCase {
             "Secure connection"
         )
         // Dismiss the view and visit "badssl.com". Tap on "expired"
-        app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].tap(force: true)
+        navigator.performAction(Action.CloseTPContextMenu)
         navigator.nowAt(BrowserTab)
         navigator.openNewURL(urlString: "https://www.badssl.com")
         waitUntilPageLoad()
@@ -231,9 +231,11 @@ class TrackingProtectionTests: BaseTestCase {
         // Tap "Secure connection"
         navigator.nowAt(BrowserTab)
         navigator.goto(TrackingProtectionContextMenuDetails)
-        mozWaitForElementToExist(app.staticTexts["Secure connection"])
+        mozWaitForElementToExist(
+            app.staticTexts[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusLabel])
         navigator.performAction(Action.CloseTPContextMenu)
-        mozWaitForElementToNotExist(app.staticTexts["Secure connection"])
+        mozWaitForElementToNotExist(
+            app.staticTexts[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusLabel])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307063
@@ -245,38 +247,40 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.openURL(trackingProtectionTestUrl)
         waitUntilPageLoad()
 
-        if checkTrackingProtectionOn() {
-            XCTAssertEqual(
-                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                secureTrackingProtectionOnLabel
-            )
-            navigator.nowAt(BrowserTab)
-            reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
-            XCTAssertEqual(
-                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                secureTrackingProtectionOffLabel
-            )
-            reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
-            XCTAssertEqual(
-                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                secureTrackingProtectionOnLabel
-            )
-        } else {
-            XCTAssertEqual(
-                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                secureTrackingProtectionOffLabel
-            )
-            navigator.nowAt(BrowserTab)
-            reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
-            XCTAssertEqual(
-                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                secureTrackingProtectionOnLabel
-            )
-            reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
-            XCTAssertEqual(
-                app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
-                secureTrackingProtectionOffLabel
-            )
+        if #available(iOS 17, *) {
+            if checkTrackingProtectionOn() {
+                XCTAssertEqual(
+                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                    secureTrackingProtectionOnLabel
+                )
+                navigator.nowAt(BrowserTab)
+                reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
+                XCTAssertEqual(
+                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                    secureTrackingProtectionOffLabel
+                )
+                reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
+                XCTAssertEqual(
+                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                    secureTrackingProtectionOnLabel
+                )
+            } else {
+                XCTAssertEqual(
+                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                    secureTrackingProtectionOffLabel
+                )
+                navigator.nowAt(BrowserTab)
+                reloadWithWithoutTrackingProtection(label: "With Tracking Protection")
+                XCTAssertEqual(
+                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                    secureTrackingProtectionOnLabel
+                )
+                reloadWithWithoutTrackingProtection(label: "Without Tracking Protection")
+                XCTAssertEqual(
+                    app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection].label,
+                    secureTrackingProtectionOffLabel
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

The following `TrackingProtectionTests` fail on iOS 15:

* `testLockIconSecureConnection`
* `testLockIconCloseMenu`
* `testStrictTrackingProtection`

This PR addresses the following:
* Closing the Tracking Protection menu should involve tapping the "x" button instead of tapping outside of the menu. On iOS 15, the whole menu covers the screen and the URL bar is not visible and tappable. (For `testLockIconSecureConnection` and `testLockIconCloseMenu`)
* `testStrictTrackingProtection` needs extra time to update the lock icon after reloading especially for iOS 15

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

