### PR TITLE
Add FXIOS-10189 Generic UITableView to ComponentLibrary Proposal

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/GeneralTableView/ConfigurableTableViewCell.swift
+++ b/BrowserKit/Sources/ComponentLibrary/GeneralTableView/ConfigurableTableViewCell.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+
+public protocol ConfigurableTableViewCell: UITableViewCell {
+    associatedtype E: ElementData
+
+    func configureCellWith(model: E)
+    func applyTheme(theme: Theme)
+}

--- a/BrowserKit/Sources/ComponentLibrary/GeneralTableView/GeneralImageTableViewCell.swift
+++ b/BrowserKit/Sources/ComponentLibrary/GeneralTableView/GeneralImageTableViewCell.swift
@@ -6,33 +6,34 @@ import Foundation
 import Common
 import UIKit
 
-public protocol ImageLabelTableViewCellModel: ElementData {
+/// Model used to configure the appearance and behaviour of `GeneralImageTableViewCell` cells.
+public protocol GeneralImageTableViewCellModel: ElementData {
     var title: String { get }
     var description: String? { get }
     var image: UIImage { get }
+    var isEnabled: Bool { get }
+    var isActive: Bool { get }
+    var hasDisclosure: Bool { get }
 
     // Accessibility
     var a11yLabel: String { get }
     var a11yHint: String? { get }
     var a11yId: String { get }
 
-    // Extra props for unique type?
-    var isEnabled: Bool { get }
-    var isActive: Bool { get }
-    var hasDisclosure: Bool { get }
-
     var action: (() -> Void)? { get }
 }
 
-open class ImageLabelTableViewCell<
-    Model: ImageLabelTableViewCellModel
+/// Renders a simple `UITableViewCell` with a leading image and some text. Optionally supports an information disclosure
+/// arrow as well as cell `isActive` and `isEnabled` visual states.
+open class GeneralImageTableViewCell<
+    Model: GeneralImageTableViewCellModel
 >: UITableViewCell,
    ConfigurableTableViewCell,
    ReusableCell,
    ThemeApplicable {
-    public typealias E = Model
+    public typealias E = Model // For ConfigurableTableViewCell conformance
 
-    // Static stored properties not supported in generic types :(
+    // FIXME Static stored properties not supported in generic types :(
     private struct UXType {
         let contentMargin: CGFloat = 10
         let iconSize: CGFloat = 24
@@ -68,6 +69,7 @@ open class ImageLabelTableViewCell<
     public var model: Model?
 
     // MARK: - Initializers
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
@@ -79,13 +81,15 @@ open class ImageLabelTableViewCell<
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - View Setup
+
     open func configureCellWith(model: Model) {
         self.model = model
         self.titleLabel.text = model.title
         self.descriptionLabel.text = model.description
         self.icon.image = model.image.withRenderingMode(.alwaysTemplate)
-        self.accessoryArrowView.image =
-        UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
+        self.accessoryArrowView.image = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?
+                                        .withRenderingMode(.alwaysTemplate)
         self.isAccessibilityElement = true
         self.accessibilityIdentifier = model.a11yId
         self.accessibilityLabel = model.a11yLabel
@@ -100,6 +104,7 @@ open class ImageLabelTableViewCell<
         self.addSubview(accessoryArrowView)
         contentStackView.addArrangedSubview(titleLabel)
         contentStackView.addArrangedSubview(descriptionLabel)
+
         NSLayoutConstraint.activate([
             icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.contentMargin),
             icon.centerYAnchor.constraint(equalTo: centerYAnchor),
@@ -115,6 +120,7 @@ open class ImageLabelTableViewCell<
             accessoryArrowView.widthAnchor.constraint(equalToConstant: UX.iconSize),
             accessoryArrowView.heightAnchor.constraint(equalToConstant: UX.iconSize)
         ])
+
         adjustLayout(isAccessibilityCategory: UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory)
     }
 
@@ -130,6 +136,7 @@ open class ImageLabelTableViewCell<
     }
 
     // MARK: - Theme Applicable
+
     open func applyTheme(theme: Theme) {
         guard let model else { return }
         backgroundColor = theme.colors.layer2

--- a/BrowserKit/Sources/ComponentLibrary/GeneralTableView/GeneralTableView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/GeneralTableView/GeneralTableView.swift
@@ -6,10 +6,12 @@ import Foundation
 import UIKit
 import Common
 
+// FIXME Improve naming, separate file
 public protocol ElementData {
     var action: (() -> Void)? { get }
 }
 
+// FIXME Improve naming, separate file
 public protocol SectionData {
     associatedtype E: ElementData
 

--- a/BrowserKit/Sources/ComponentLibrary/GeneralTableView/GeneralTableView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/GeneralTableView/GeneralTableView.swift
@@ -1,0 +1,150 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import UIKit
+import Common
+
+public protocol ElementData {
+}
+
+public protocol SectionData {
+    associatedtype E: ElementData
+
+    var elementData: [E] { get set }
+}
+
+public protocol GeneralTableViewDataDelegate: AnyObject {
+    associatedtype S: SectionData
+
+    func didSelectRowAt(indexPath: IndexPath, withModel: S.E)
+    func scrollViewDidScroll(_ scrollView: UIScrollView, inScrollViewWithTopPadding topPadding: CGFloat)
+}
+
+public protocol ConfigurableTableViewCell: UITableViewCell {
+    associatedtype E: ElementData
+
+    func configureCellWith(model: E)
+    func applyTheme(theme: Theme)
+}
+
+public class GeneralTableView<
+    S: SectionData,
+    Cell: ConfigurableTableViewCell,
+    D: GeneralTableViewDataDelegate
+>: UIView,
+   UITableViewDelegate,
+   UITableViewDataSource,
+   ThemeApplicable
+where S.E == Cell.E, D.S == S {
+    // Static stored properties not supported in generic types :(
+    private struct UXType {
+        let topPadding: CGFloat = 10
+    }
+    private let UX = UXType()
+
+    // MARK: - Properties
+    public weak var delegate: D?
+    private var sectionData: [S]
+    private var configureCellWith: ((Cell, S.E) -> Void)?
+
+    private var tableView: UITableView
+    private let cellReuseIdentifier = String(describing: Cell.self)
+
+    private var theme: Theme?
+
+    // MARK: - Inits and UI Setup
+
+    override init(frame: CGRect) {
+        tableView = UITableView(frame: .zero, style: .insetGrouped)
+        sectionData = []
+        super.init(frame: .zero)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        setupTableView()
+        setupUI()
+    }
+
+    private func setupUI() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: self.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+        ])
+    }
+
+    private func setupTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(
+            Cell.self,
+            forCellReuseIdentifier: cellReuseIdentifier
+        )
+    }
+
+    public func reloadTableView(with data: [S]) {
+        sectionData = data
+        tableView.reloadData()
+    }
+
+    // MARK: - UITableViewDataSource
+
+    public func numberOfSections(in tableView: UITableView) -> Int {
+        return sectionData.count
+    }
+
+    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return section == 0 ? UX.topPadding : UITableView.automaticDimension
+    }
+
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sectionData[section].elementData.count
+    }
+
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier, for: indexPath) as! Cell
+
+        cell.configureCellWith(model: sectionData[indexPath.section].elementData[indexPath.row])
+        if let theme { cell.applyTheme(theme: theme) }
+
+        return cell
+    }
+
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: false)
+        delegate?.didSelectRowAt(indexPath: indexPath, withModel: sectionData[indexPath.section].elementData[indexPath.row])
+    }
+
+    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        if section == 0 {
+            let headerView = UIView()
+            headerView.backgroundColor = .clear
+            return headerView
+        }
+        return nil
+    }
+
+    // MARK: - UITableViewDelegate
+
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        delegate?.scrollViewDidScroll(scrollView, inScrollViewWithTopPadding: UX.topPadding)
+    }
+
+    // MARK: - Theme Applicable
+    public func applyTheme(theme: Theme) {
+        self.theme = theme
+        backgroundColor = .clear
+        tableView.backgroundColor = .clear
+    }
+}

--- a/BrowserKit/Sources/ComponentLibrary/GeneralTableView/GeneralTableView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/GeneralTableView/GeneralTableView.swift
@@ -15,7 +15,7 @@ public protocol SectionData {
     var elementData: [E] { get set }
 }
 
-public protocol GeneralTableViewDataDelegate: AnyObject {
+public protocol GeneralTableViewDelegate: AnyObject {
     associatedtype S: SectionData
 
     func didSelectRowAt(indexPath: IndexPath, withModel: S.E)
@@ -32,7 +32,7 @@ public protocol ConfigurableTableViewCell: UITableViewCell {
 public class GeneralTableView<
     S: SectionData,
     Cell: ConfigurableTableViewCell,
-    D: GeneralTableViewDataDelegate
+    D: GeneralTableViewDelegate
 >: UIView,
    UITableViewDelegate,
    UITableViewDataSource,

--- a/BrowserKit/Sources/ComponentLibrary/GeneralTableView/ImageLabelTableViewCell.swift
+++ b/BrowserKit/Sources/ComponentLibrary/GeneralTableView/ImageLabelTableViewCell.swift
@@ -6,26 +6,25 @@ import Foundation
 import Common
 import UIKit
 
-// Image comes from bundle vs. uiimage from cache/internet?
 public protocol ImageLabelTableViewCellModel: ElementData {
     var title: String { get }
     var description: String? { get }
-    var iconName: String { get } // UIImage?
+    var image: UIImage { get }
 
     // Accessibility
     var a11yLabel: String { get }
     var a11yHint: String? { get }
     var a11yId: String { get }
 
-//    // Extra props for unique type?
-//    var isEnabled: Bool { get }
-//    var isActive: Bool { get }
-//    var hasSubmenu: Bool { get }
+    // Extra props for unique type?
+    var isEnabled: Bool { get }
+    var isActive: Bool { get }
+    var hasDisclosure: Bool { get }
 
     var action: (() -> Void)? { get }
 }
 
-public class ImageLabelTableViewCell<
+open class ImageLabelTableViewCell<
     Model: ImageLabelTableViewCellModel
 >: UITableViewCell,
    ConfigurableTableViewCell,
@@ -61,7 +60,6 @@ public class ImageLabelTableViewCell<
     private var contentStackView: UIStackView = .build { stackView in
         stackView.axis = .vertical
         stackView.distribution = .fillProportionally
-        stackView.spacing = 20 // FIXME UX.contentSpacing
     }
 
     private var accessoryArrowView: UIImageView = .build()
@@ -72,17 +70,20 @@ public class ImageLabelTableViewCell<
     // MARK: - Initializers
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        // FIXME can't use UX in build atm because self isn't available :/
+        contentStackView.spacing = UX.contentSpacing
     }
 
-    required init?(coder: NSCoder) {
+    public required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public func configureCellWith(model: Model) {
+    open func configureCellWith(model: Model) {
         self.model = model
         self.titleLabel.text = model.title
         self.descriptionLabel.text = model.description
-        self.icon.image = UIImage(named: model.iconName)?.withRenderingMode(.alwaysTemplate)
+        self.icon.image = model.image.withRenderingMode(.alwaysTemplate)
         self.accessoryArrowView.image =
         UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
         self.isAccessibilityElement = true
@@ -129,26 +130,25 @@ public class ImageLabelTableViewCell<
     }
 
     // MARK: - Theme Applicable
-    public func applyTheme(theme: Theme) {
+    open func applyTheme(theme: Theme) {
         guard let model else { return }
         backgroundColor = theme.colors.layer2
 
-        print("** TODO model \(model)")
-//        accessoryArrowView.isHidden = !model.hasSubmenu || model.isActive ? true : false
-//        if model.isActive {
-//            titleLabel.textColor = theme.colors.textAccent
-//            descriptionLabel.textColor = theme.colors.textSecondary
-//            icon.tintColor = theme.colors.iconAccentBlue
-//        } else if !model.isEnabled {
-//            titleLabel.textColor = theme.colors.textDisabled
-//            descriptionLabel.textColor = theme.colors.textDisabled
-//            icon.tintColor = theme.colors.iconDisabled
-//            accessoryArrowView.tintColor = theme.colors.iconDisabled
-//        } else {
-//            titleLabel.textColor = theme.colors.textPrimary
-//            descriptionLabel.textColor = theme.colors.textSecondary
-//            icon.tintColor = theme.colors.iconSecondary
-//            accessoryArrowView.tintColor = theme.colors.iconSecondary
-//        }
+        accessoryArrowView.isHidden = !model.hasDisclosure || model.isActive ? true : false
+        if model.isActive {
+            titleLabel.textColor = theme.colors.textAccent
+            descriptionLabel.textColor = theme.colors.textSecondary
+            icon.tintColor = theme.colors.iconAccentBlue
+        } else if !model.isEnabled {
+            titleLabel.textColor = theme.colors.textDisabled
+            descriptionLabel.textColor = theme.colors.textDisabled
+            icon.tintColor = theme.colors.iconDisabled
+            accessoryArrowView.tintColor = theme.colors.iconDisabled
+        } else {
+            titleLabel.textColor = theme.colors.textPrimary
+            descriptionLabel.textColor = theme.colors.textSecondary
+            icon.tintColor = theme.colors.iconSecondary
+            accessoryArrowView.tintColor = theme.colors.iconSecondary
+        }
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/GeneralTableView/ImageLabelTableViewCell.swift
+++ b/BrowserKit/Sources/ComponentLibrary/GeneralTableView/ImageLabelTableViewCell.swift
@@ -1,0 +1,154 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+import UIKit
+
+// Image comes from bundle vs. uiimage from cache/internet?
+public protocol ImageLabelTableViewCellModel: ElementData {
+    var title: String { get }
+    var description: String? { get }
+    var iconName: String { get } // UIImage?
+
+    // Accessibility
+    var a11yLabel: String { get }
+    var a11yHint: String? { get }
+    var a11yId: String { get }
+
+//    // Extra props for unique type?
+//    var isEnabled: Bool { get }
+//    var isActive: Bool { get }
+//    var hasSubmenu: Bool { get }
+
+    var action: (() -> Void)? { get }
+}
+
+public class ImageLabelTableViewCell<
+    Model: ImageLabelTableViewCellModel
+>: UITableViewCell,
+   ConfigurableTableViewCell,
+   ReusableCell,
+   ThemeApplicable {
+    public typealias E = Model
+
+    // Static stored properties not supported in generic types :(
+    private struct UXType {
+        let contentMargin: CGFloat = 10
+        let iconSize: CGFloat = 24
+        let largeIconSize: CGFloat = 48
+        let contentSpacing: CGFloat = 2
+    }
+    private let UX = UXType()
+
+    private var separatorInsetSize: CGFloat {
+        return UX.contentMargin * 2 + UX.iconSize
+    }
+
+    // MARK: - UI Elements
+    private var titleLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.numberOfLines = 2
+    }
+
+    private var descriptionLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.caption1.scaledFont()
+    }
+
+    private var icon: UIImageView = .build()
+
+    private var contentStackView: UIStackView = .build { stackView in
+        stackView.axis = .vertical
+        stackView.distribution = .fillProportionally
+        stackView.spacing = 20 // FIXME UX.contentSpacing
+    }
+
+    private var accessoryArrowView: UIImageView = .build()
+
+    // MARK: - Properties
+    public var model: Model?
+
+    // MARK: - Initializers
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public func configureCellWith(model: Model) {
+        self.model = model
+        self.titleLabel.text = model.title
+        self.descriptionLabel.text = model.description
+        self.icon.image = UIImage(named: model.iconName)?.withRenderingMode(.alwaysTemplate)
+        self.accessoryArrowView.image =
+        UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
+        self.isAccessibilityElement = true
+        self.accessibilityIdentifier = model.a11yId
+        self.accessibilityLabel = model.a11yLabel
+        self.accessibilityHint = model.a11yHint
+        self.separatorInset = UIEdgeInsets(top: 0, left: separatorInsetSize, bottom: 0, right: 0)
+        setupView()
+    }
+
+    private func setupView() {
+        self.addSubview(icon)
+        self.addSubview(contentStackView)
+        self.addSubview(accessoryArrowView)
+        contentStackView.addArrangedSubview(titleLabel)
+        contentStackView.addArrangedSubview(descriptionLabel)
+        NSLayoutConstraint.activate([
+            icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.contentMargin),
+            icon.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            contentStackView.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: UX.contentMargin),
+            contentStackView.topAnchor.constraint(equalTo: topAnchor, constant: UX.contentMargin),
+            contentStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.contentMargin),
+
+            accessoryArrowView.leadingAnchor.constraint(equalTo: contentStackView.trailingAnchor,
+                                                        constant: UX.contentMargin),
+            accessoryArrowView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.contentMargin),
+            accessoryArrowView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            accessoryArrowView.widthAnchor.constraint(equalToConstant: UX.iconSize),
+            accessoryArrowView.heightAnchor.constraint(equalToConstant: UX.iconSize)
+        ])
+        adjustLayout(isAccessibilityCategory: UIApplication.shared.preferredContentSizeCategory.isAccessibilityCategory)
+    }
+
+    private func adjustLayout(isAccessibilityCategory: Bool) {
+        let iconSize = isAccessibilityCategory ? UX.largeIconSize : UX.iconSize
+        icon.widthAnchor.constraint(equalToConstant: iconSize).isActive = true
+        icon.heightAnchor.constraint(equalToConstant: iconSize).isActive = true
+    }
+
+    func performAction() {
+        guard let action = model?.action else { return }
+        action()
+    }
+
+    // MARK: - Theme Applicable
+    public func applyTheme(theme: Theme) {
+        guard let model else { return }
+        backgroundColor = theme.colors.layer2
+
+        print("** TODO model \(model)")
+//        accessoryArrowView.isHidden = !model.hasSubmenu || model.isActive ? true : false
+//        if model.isActive {
+//            titleLabel.textColor = theme.colors.textAccent
+//            descriptionLabel.textColor = theme.colors.textSecondary
+//            icon.tintColor = theme.colors.iconAccentBlue
+//        } else if !model.isEnabled {
+//            titleLabel.textColor = theme.colors.textDisabled
+//            descriptionLabel.textColor = theme.colors.textDisabled
+//            icon.tintColor = theme.colors.iconDisabled
+//            accessoryArrowView.tintColor = theme.colors.iconDisabled
+//        } else {
+//            titleLabel.textColor = theme.colors.textPrimary
+//            descriptionLabel.textColor = theme.colors.textSecondary
+//            icon.tintColor = theme.colors.iconSecondary
+//            accessoryArrowView.tintColor = theme.colors.iconSecondary
+//        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -8,36 +8,65 @@ import UIKit
 import Shared
 import Redux
 
-struct ImageLabelRowData: ElementData {
-    // FIXME Pass image later
-    var testPlaceholderImage: UIImage = UIImage(named: "globeLarge")!.withRenderingMode(.alwaysTemplate)
-    var titleLabel: String
-}
+// struct ImageLabelRowData: ElementData {
+//    // FIXME Pass image later
+//    var testPlaceholderImage: UIImage = UIImage(named: "globeLarge")!.withRenderingMode(.alwaysTemplate)
+//    var titleLabel: String
+// }
 
 struct SearchEngineSection: SectionData {
-    typealias E = ImageLabelRowData
+    typealias E = SearchEngineSelectionCellModel
 
-    var elementData: [ImageLabelRowData]
+    var elementData: [SearchEngineSelectionCellModel]
 }
 
-class SearchEngineSelectionCell: UITableViewCell, ConfigurableTableViewCell {
-    // MARK: - Initializers
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+struct SearchEngineSelectionCellModel: ImageLabelTableViewCellModel {
+    let title: String
+    let description: String?
+    let image: UIImage
 
-        self.backgroundColor = .green
+    // Accessibility
+    let a11yLabel: String
+    let a11yHint: String?
+    let a11yId: String
+
+    var isEnabled = true
+    var isActive = false // FIXME isHighlighted?
+    var hasDisclosure = false
+
+    var action: (() -> Void)?
+
+    init(title: String) {
+        // TODO
+        self.title = title
+        self.description = nil
+        self.image = UIImage(named: "globeLarge")! // For testing
+        self.a11yLabel = ""
+        self.a11yHint = ""
+        self.a11yId = ""
+        self.action =  nil
     }
+}
+
+class SearchEngineSelectionCell: ImageLabelTableViewCell<SearchEngineSelectionCellModel> {
+    // MARK: - Initializers
+//    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+//        super.init(style: style, reuseIdentifier: reuseIdentifier)
+//
+//        self.backgroundColor = .green
+//    }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func applyTheme(theme: any Common.Theme) {
-        // TODO apply theme
-    }
+//    func applyTheme(theme: any Common.Theme) {
+//        // TODO apply theme
+//    }
 
-    func configureCellWith(model: ImageLabelRowData) {
-        // TODO set label and image
+    override func configureCellWith(model: SearchEngineSelectionCellModel) {
+        super.configureCellWith(model: model)
+        // TODO additional customization
     }
 }
 
@@ -45,7 +74,7 @@ class SearchEngineSelectionViewController: UIViewController,
                                            UISheetPresentationControllerDelegate,
                                            UIPopoverPresentationControllerDelegate,
                                            Themeable,
-                                           GeneralTableViewDataDelegate {
+                                           GeneralTableViewDelegate {
     typealias S = SearchEngineSection // For GeneralTableViewDataDelegate conformance
 
     // MARK: - Properties
@@ -61,8 +90,8 @@ class SearchEngineSelectionViewController: UIViewController,
     // MARK: - UI/UX elements
     private var tableView: GeneralTableView<
         SearchEngineSection,
-            SearchEngineSelectionCell,
-            SearchEngineSelectionViewController
+        SearchEngineSelectionCell,
+        SearchEngineSelectionViewController
     > = .build()
 
     // MARK: - Initializers and Lifecycle
@@ -101,12 +130,12 @@ class SearchEngineSelectionViewController: UIViewController,
         // FIXME Mock data for testing. Hookups to search engines to come later.
         let fakeData: [SearchEngineSection] = [
             SearchEngineSection(elementData: [
-                ImageLabelRowData(titleLabel: "Search engine 1"),
-                ImageLabelRowData(titleLabel: "Search engine 2"),
-                ImageLabelRowData(titleLabel: "Search engine 3")
+                SearchEngineSelectionCellModel(title: "Search engine 1"),
+                SearchEngineSelectionCellModel(title: "Search engine 2"),
+                SearchEngineSelectionCellModel(title: "Search engine 3")
             ]),
             SearchEngineSection(elementData: [
-                ImageLabelRowData(titleLabel: "Search Settings")
+                SearchEngineSelectionCellModel(title: "Search Settings"), // TODO include disclosure?
             ])
         ]
         tableView.reloadTableView(with: fakeData)
@@ -124,7 +153,7 @@ class SearchEngineSelectionViewController: UIViewController,
         view.addSubviews(tableView)
 
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: 12), // TODO Temporary constant
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
@@ -137,6 +166,7 @@ class SearchEngineSelectionViewController: UIViewController,
         let theme = themeManager.getCurrentTheme(for: windowUUID)
 
         view.backgroundColor = theme.colors.layer3
+        tableView.applyTheme(theme: theme)
     }
 
     // MARK: - UISheetPresentationControllerDelegate inheriting UIAdaptivePresentationControllerDelegate
@@ -154,7 +184,7 @@ class SearchEngineSelectionViewController: UIViewController,
 
     // MARK: - GeneralTableViewDataDelegate
 
-    func didSelectRowAt(indexPath: IndexPath, withModel: ImageLabelRowData) {
+    func didSelectRowAt(indexPath: IndexPath, withModel: SearchEngineSelectionCellModel) {
         // TODO
         print("** didSelectRowAt \(indexPath)")
     }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -21,8 +21,6 @@ struct SearchEngineSection: SectionData {
 }
 
 class SearchEngineSelectionCell: UITableViewCell, ConfigurableTableViewCell {
-//    typealias E = SearchEngineData
-
     // MARK: - Initializers
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -100,6 +98,7 @@ class SearchEngineSelectionViewController: UIViewController,
         setupView()
         listenForThemeChange(view)
 
+        // FIXME Mock data for testing. Hookups to search engines to come later.
         let fakeData: [SearchEngineSection] = [
             SearchEngineSection(elementData: [
                 ImageLabelRowData(titleLabel: "Search engine 1"),
@@ -130,14 +129,6 @@ class SearchEngineSelectionViewController: UIViewController,
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
-
-//        view.addSubview(placeholderOpenSettingsButton)
-//
-//        NSLayoutConstraint.activate([
-//            placeholderOpenSettingsButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 80),
-//            placeholderOpenSettingsButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-//            placeholderOpenSettingsButton.widthAnchor.constraint(equalToConstant: 200)
-//        ])
     }
 
     // MARK: - Theme

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -8,10 +8,48 @@ import UIKit
 import Shared
 import Redux
 
+struct ImageLabelRowData: ElementData {
+    // FIXME Pass image later
+    var testPlaceholderImage: UIImage = UIImage(named: "globeLarge")!.withRenderingMode(.alwaysTemplate)
+    var titleLabel: String
+}
+
+struct SearchEngineSection: SectionData {
+    typealias E = ImageLabelRowData
+
+    var elementData: [ImageLabelRowData]
+}
+
+class SearchEngineSelectionCell: UITableViewCell, ConfigurableTableViewCell {
+//    typealias E = SearchEngineData
+
+    // MARK: - Initializers
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        self.backgroundColor = .green
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func applyTheme(theme: any Common.Theme) {
+        // TODO apply theme
+    }
+
+    func configureCellWith(model: ImageLabelRowData) {
+        // TODO set label and image
+    }
+}
+
 class SearchEngineSelectionViewController: UIViewController,
                                            UISheetPresentationControllerDelegate,
                                            UIPopoverPresentationControllerDelegate,
-                                           Themeable {
+                                           Themeable,
+                                           GeneralTableViewDataDelegate {
+    typealias S = SearchEngineSection // For GeneralTableViewDataDelegate conformance
+
     // MARK: - Properties
     var notificationCenter: NotificationProtocol
     var themeManager: ThemeManager
@@ -23,15 +61,11 @@ class SearchEngineSelectionViewController: UIViewController,
     private let logger: Logger
 
     // MARK: - UI/UX elements
-    // FXIOS-10192 This button is a temporary placeholder used to set up the navigation / coordinators. Will be removed.
-    private lazy var placeholderOpenSettingsButton: UIButton = .build { view in
-        view.setTitle(.UnifiedSearch.SearchEngineSelection.SearchSettings, for: .normal)
-        view.setTitleColor(.blue, for: .normal)
-        view.titleLabel?.numberOfLines = 0
-        view.titleLabel?.textAlignment = .center
-
-        view.addTarget(self, action: #selector(self.didTapOpenSettings), for: .touchUpInside)
-    }
+    private var tableView: GeneralTableView<
+        SearchEngineSection,
+            SearchEngineSelectionCell,
+            SearchEngineSelectionViewController
+    > = .build()
 
     // MARK: - Initializers and Lifecycle
 
@@ -46,6 +80,8 @@ class SearchEngineSelectionViewController: UIViewController,
         self.themeManager = themeManager
         self.logger = logger
         super.init(nibName: nil, bundle: nil)
+
+        tableView.delegate = self
 
         // TODO Additional setup to come
         // ...
@@ -63,6 +99,18 @@ class SearchEngineSelectionViewController: UIViewController,
 
         setupView()
         listenForThemeChange(view)
+
+        let fakeData: [SearchEngineSection] = [
+            SearchEngineSection(elementData: [
+                ImageLabelRowData(titleLabel: "Search engine 1"),
+                ImageLabelRowData(titleLabel: "Search engine 2"),
+                ImageLabelRowData(titleLabel: "Search engine 3")
+            ]),
+            SearchEngineSection(elementData: [
+                ImageLabelRowData(titleLabel: "Search Settings")
+            ])
+        ]
+        tableView.reloadTableView(with: fakeData)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -74,13 +122,22 @@ class SearchEngineSelectionViewController: UIViewController,
     // MARK: - UI / UX
 
     private func setupView() {
-        view.addSubview(placeholderOpenSettingsButton)
+        view.addSubviews(tableView)
 
         NSLayoutConstraint.activate([
-            placeholderOpenSettingsButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 80),
-            placeholderOpenSettingsButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            placeholderOpenSettingsButton.widthAnchor.constraint(equalToConstant: 200)
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+
+//        view.addSubview(placeholderOpenSettingsButton)
+//
+//        NSLayoutConstraint.activate([
+//            placeholderOpenSettingsButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 80),
+//            placeholderOpenSettingsButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+//            placeholderOpenSettingsButton.widthAnchor.constraint(equalToConstant: 200)
+//        ])
     }
 
     // MARK: - Theme
@@ -102,5 +159,17 @@ class SearchEngineSelectionViewController: UIViewController,
     @objc
     func didTapOpenSettings(sender: UIButton) {
         coordinator?.navigateToSearchSettings(animated: true)
+    }
+
+    // MARK: - GeneralTableViewDataDelegate
+
+    func didSelectRowAt(indexPath: IndexPath, withModel: ImageLabelRowData) {
+        // TODO
+        print("** didSelectRowAt \(indexPath)")
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView, inScrollViewWithTopPadding topPadding: CGFloat) {
+        // TODO
+        print("** scrollViewDidScroll \(scrollView.contentOffset.y)")
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -8,39 +8,32 @@ import UIKit
 import Shared
 import Redux
 
-// struct ImageLabelRowData: ElementData {
-//    // FIXME Pass image later
-//    var testPlaceholderImage: UIImage = UIImage(named: "globeLarge")!.withRenderingMode(.alwaysTemplate)
-//    var titleLabel: String
-// }
-
 struct SearchEngineSection: SectionData {
     typealias E = SearchEngineSelectionCellModel
 
     var elementData: [SearchEngineSelectionCellModel]
 }
 
-struct SearchEngineSelectionCellModel: ImageLabelTableViewCellModel {
+struct SearchEngineSelectionCellModel: GeneralImageTableViewCellModel {
     let title: String
     let description: String?
     let image: UIImage
+    var isEnabled = true
+    var isActive = false
+    var hasDisclosure = false
 
     // Accessibility
     let a11yLabel: String
     let a11yHint: String?
     let a11yId: String
 
-    var isEnabled = true
-    var isActive = false // FIXME isHighlighted?
-    var hasDisclosure = false
-
     var action: (() -> Void)?
 
     init(title: String) {
-        // TODO
+        // FIXME Temporary placeholder initialization
         self.title = title
         self.description = nil
-        self.image = UIImage(named: "globeLarge")! // For testing
+        self.image = UIImage(named: "globeLarge")!
         self.a11yLabel = ""
         self.a11yHint = ""
         self.a11yId = ""
@@ -48,21 +41,10 @@ struct SearchEngineSelectionCellModel: ImageLabelTableViewCellModel {
     }
 }
 
-class SearchEngineSelectionCell: ImageLabelTableViewCell<SearchEngineSelectionCellModel> {
-    // MARK: - Initializers
-//    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-//        super.init(style: style, reuseIdentifier: reuseIdentifier)
-//
-//        self.backgroundColor = .green
-//    }
-
+class SearchEngineSelectionCell: GeneralImageTableViewCell<SearchEngineSelectionCellModel> {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-//    func applyTheme(theme: any Common.Theme) {
-//        // TODO apply theme
-//    }
 
     override func configureCellWith(model: SearchEngineSelectionCellModel) {
         super.configureCellWith(model: model)
@@ -184,13 +166,7 @@ class SearchEngineSelectionViewController: UIViewController,
 
     // MARK: - GeneralTableViewDataDelegate
 
-    func didSelectRowAt(indexPath: IndexPath, withModel: SearchEngineSelectionCellModel) {
-        // TODO
-        print("** didSelectRowAt \(indexPath)")
-    }
-
     func scrollViewDidScroll(_ scrollView: UIScrollView, inScrollViewWithTopPadding topPadding: CGFloat) {
-        // TODO
-        print("** scrollViewDidScroll \(scrollView.contentOffset.y)")
+        // TODO scrollViewDidScroll
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -8,12 +8,14 @@ import UIKit
 import Shared
 import Redux
 
+// FIXME Equatable, separate file, fix naming
 struct SearchEngineSection: SectionData {
     typealias E = SearchEngineSelectionCellModel
 
     var elementData: [SearchEngineSelectionCellModel]
 }
 
+// FIXME Separate file, audit naming
 struct SearchEngineSelectionCellModel: GeneralImageTableViewCellModel {
     let title: String
     let description: String?
@@ -41,6 +43,7 @@ struct SearchEngineSelectionCellModel: GeneralImageTableViewCellModel {
     }
 }
 
+// FIXME Separate file, audit naming
 class SearchEngineSelectionCell: GeneralImageTableViewCell<SearchEngineSelectionCellModel> {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10189)

## :bulb: Description

This is a draft PR with a rough proposal for making the UITableView and its cells generic for reuse across other areas of the app.

The idea will be that we can leverage these generic component types anywhere we need to show an insetGrouped tableview as in Unified Search, Main Menu, Settings Redesign, etc.

@adudenamedruby -- I just grabbed your preexisting MenuTableView, MenuCell, etc. and took a stab at making it generic. It needs some cleanup and some polish but I wanted to get your opinion on this before I push onward.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

