### PR TITLE
Bugfix FXIOS-10376 [Toolbar Redesign] Reader view button isAccessibilityElement false

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -25,7 +25,6 @@ class ToolbarButton: UIButton, ThemeApplicable {
     private var badgeImageView: UIImageView?
     private var maskImageView: UIImageView?
 
-    private var shouldDisplayAsHighlighted = false
     private var onLongPress: ((UIButton) -> Void)?
 
     override init(frame: CGRect) {
@@ -43,7 +42,7 @@ class ToolbarButton: UIButton, ThemeApplicable {
         removeAllGestureRecognizers()
         configureLongPressGestureRecognizerIfNeeded(for: element)
         configureCustomA11yActionIfNeeded(for: element)
-        shouldDisplayAsHighlighted = element.isSelected
+        isSelected = element.isSelected
 
         let image = imageConfiguredForRTL(for: element)
         let action = UIAction(title: element.a11yLabel,
@@ -86,7 +85,7 @@ class ToolbarButton: UIButton, ThemeApplicable {
         case .disabled:
             updatedConfiguration.baseForegroundColor = foregroundColorDisabled
         default:
-            updatedConfiguration.baseForegroundColor = shouldDisplayAsHighlighted ?
+            updatedConfiguration.baseForegroundColor = isSelected ?
                                                        foregroundColorHighlighted :
                                                        foregroundColorNormal
         }

--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -43,7 +43,7 @@ class ToolbarButton: UIButton, ThemeApplicable {
         removeAllGestureRecognizers()
         configureLongPressGestureRecognizerIfNeeded(for: element)
         configureCustomA11yActionIfNeeded(for: element)
-        shouldDisplayAsHighlighted = element.shouldDisplayAsHighlighted
+        shouldDisplayAsHighlighted = element.isSelected
 
         let image = imageConfiguredForRTL(for: element)
         let action = UIAction(title: element.a11yLabel,

--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -53,6 +53,7 @@ class ToolbarButton: UIButton, ThemeApplicable {
 
         config.image = image
         isEnabled = element.isEnabled
+        isAccessibilityElement = true
         accessibilityIdentifier = element.a11yId
         accessibilityLabel = element.a11yLabel
         accessibilityHint = element.a11yHint

--- a/BrowserKit/Sources/ToolbarKit/ToolbarElement.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarElement.swift
@@ -23,8 +23,8 @@ public struct ToolbarElement: Equatable {
     /// Indicates whether the toolbar element's image should be flipped for right-to-left layout direction
     let isFlippedForRTL: Bool
 
-    /// Indicates if the element should be displayed as highlighted
-    let shouldDisplayAsHighlighted: Bool
+    /// Indicates if the element is in the selected state and should be displayed as highlighted.
+    let isSelected: Bool
 
     /// Indicates that there is an associated contextual hint
     let contextualHintType: String?
@@ -62,7 +62,7 @@ public struct ToolbarElement: Equatable {
                 numberOfTabs: Int? = nil,
                 isEnabled: Bool,
                 isFlippedForRTL: Bool = false,
-                shouldDisplayAsHighlighted: Bool = false,
+                isSelected: Bool = false,
                 contextualHintType: String? = nil,
                 a11yLabel: String,
                 a11yHint: String?,
@@ -78,7 +78,7 @@ public struct ToolbarElement: Equatable {
         self.numberOfTabs = numberOfTabs
         self.isEnabled = isEnabled
         self.isFlippedForRTL = isFlippedForRTL
-        self.shouldDisplayAsHighlighted = shouldDisplayAsHighlighted
+        self.isSelected = isSelected
         self.contextualHintType = contextualHintType
         self.onSelected = onSelected
         self.onLongPress = onLongPress
@@ -97,7 +97,7 @@ public struct ToolbarElement: Equatable {
         lhs.numberOfTabs == rhs.numberOfTabs &&
         lhs.isEnabled == rhs.isEnabled &&
         lhs.isFlippedForRTL == rhs.isFlippedForRTL &&
-        lhs.shouldDisplayAsHighlighted == rhs.shouldDisplayAsHighlighted &&
+        lhs.isSelected == rhs.isSelected &&
         lhs.contextualHintType == rhs.contextualHintType &&
         lhs.hasLongPressAction == rhs.hasLongPressAction &&
         lhs.a11yLabel == rhs.a11yLabel &&

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -130,7 +130,7 @@ class AddressToolbarContainerModel: Equatable {
                 numberOfTabs: action.numberOfTabs,
                 isEnabled: action.isEnabled,
                 isFlippedForRTL: action.isFlippedForRTL,
-                shouldDisplayAsHighlighted: action.shouldDisplayAsHighlighted,
+                isSelected: action.isSelected,
                 contextualHintType: action.contextualHintType,
                 a11yLabel: action.a11yLabel,
                 a11yHint: action.a11yHint,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/NavigationToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/NavigationToolbarContainerModel.swift
@@ -26,7 +26,7 @@ struct NavigationToolbarContainerModel: Equatable {
                 numberOfTabs: action.numberOfTabs,
                 isEnabled: action.isEnabled,
                 isFlippedForRTL: action.isFlippedForRTL,
-                shouldDisplayAsHighlighted: action.shouldDisplayAsHighlighted,
+                isSelected: action.isSelected,
                 contextualHintType: action.contextualHintType,
                 a11yLabel: action.a11yLabel,
                 a11yHint: action.a11yHint,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -620,20 +620,20 @@ struct AddressBarState: StateType, Equatable {
 
         switch readerModeState {
         case .active, .available:
-            let shouldDisplayAsHighlighted = readerModeState == .active
-            let iconName = shouldDisplayAsHighlighted ?
+            let isSelected = readerModeState == .active
+            let iconName = isSelected ?
             StandardImageIdentifiers.Large.readerViewFill :
             StandardImageIdentifiers.Large.readerView
 
-            var readerModeAction = ToolbarActionState(
+            let readerModeAction = ToolbarActionState(
                 actionType: .readerMode,
                 iconName: iconName,
                 isEnabled: true,
+                isSelected: isSelected,
                 a11yLabel: .TabLocationReaderModeAccessibilityLabel,
                 a11yHint: .TabLocationReloadAccessibilityHint,
                 a11yId: AccessibilityIdentifiers.Toolbar.readerModeButton,
                 a11yCustomActionName: .TabLocationReaderModeAddToReadingListAccessibilityLabel)
-            readerModeAction.shouldDisplayAsHighlighted = shouldDisplayAsHighlighted
             actions.append(readerModeAction)
         default: break
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarActionState.swift
@@ -31,7 +31,7 @@ struct ToolbarActionState: Equatable, FeatureFlaggable {
     var numberOfTabs: Int?
     var isFlippedForRTL = false
     var isEnabled: Bool
-    var shouldDisplayAsHighlighted = false
+    var isSelected = false
     var contextualHintType: String?
     var a11yLabel: String
     var a11yHint: String?


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10376)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22733)

## :bulb: Description
Enables toolbar buttons as accessibility elements and also set the selected state for buttons.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

