### PR TITLE
BugFix FXIOS-10378 TopSiteItem cell showing clear background when wallpaper is enabled

### DIFF
--- a/firefox-ios/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/Cell/TopSiteItemCell.swift
@@ -268,6 +268,7 @@ extension TopSiteItemCell: ThemeApplicable {
 extension TopSiteItemCell: Blurrable {
     func adjustBlur(theme: Theme) {
         if shouldApplyWallpaperBlur {
+            rootContainer.layoutIfNeeded()
             rootContainer.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
         } else {
             // If blur is disabled set background color


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10378)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22738)

## :bulb: Description
BugFix `TopSiteItemCell` showing clear background when wallpaper is enabled

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

