### PR TITLE
Bugfix MTE-3742 PDF Test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -31,6 +31,9 @@ class BrowsingPDFTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2307117
     // Smoketest
     func testOpenLinkFromPDF() {
+        // Sometimes the test fails before opening the URL
+        // Let's make sure the homepage is ready
+        mozWaitForElementToExist(app.collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView])
         navigator.openURL(PDF_website["url"]!)
         waitUntilPageLoad()
 
@@ -42,7 +45,8 @@ class BrowsingPDFTests: BaseTestCase {
             checkboxValidation.tap()
         }
         mozWaitForValueContains(url, value: PDF_website["urlValue"]!)
-        mozWaitForElementToExist(app.staticTexts["Education and schools"])
+        // Let's comment the next line until that fails intermittently due to the page re-direction
+        // mozWaitForElementToExist(app.staticTexts["Education and schools"])
 
         // Go back to pdf view
         app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3742)

The test accessing a link in a PDF is failing intermittently. There are two main reasons:
- Trying to open the site before the homepage is ready
Let's make sure the homepage is ready before trying to type in Urlbar
- When the link is opened, sometimes redirects to a page with a captcha. 
Let's just check that the urlbar contains the expecte site we are visiting.

We have tried to create a pdf to control the page that is open. That looks simple, however, no matter which tool we have used to create that pdf that the link in it is not as such when running the tests. That's  why we keep the same page and add these workarounds for now.

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

