### PR TITLE
Bugfix FXIOS-9859 Don’t call apply theme for every tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3050,14 +3050,7 @@ class BrowserViewController: UIViewController,
         webViewContainerBackdrop.backgroundColor = currentTheme.colors.layer3
         setNeedsStatusBarAppearanceUpdate()
 
-        // Update the `background-color` of any blank webviews.
-        let webViews = tabManager.tabs.compactMap({ $0.webView })
-        webViews.forEach({ $0.applyTheme(theme: currentTheme) })
-
-        let tabs = tabManager.tabs
-        tabs.forEach {
-            $0.applyTheme(theme: currentTheme)
-        }
+        tabManager.selectedTab?.applyTheme(theme: currentTheme)
 
         if !isToolbarRefactorEnabled {
             let isPrivate = tabManager.selectedTab?.isPrivate ?? false

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -910,6 +910,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable {
 
     func applyTheme(theme: Theme) {
         UITextField.appearance().keyboardAppearance = theme.type.keyboardAppearence(isPrivate: isPrivate)
+        webView?.applyTheme(theme: theme)
     }
 
     // MARK: - Static Helpers


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9859)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21644)

## :bulb: Description
There was an increase in hang rate some time around release v129. Since the problem area in calling apply theme my top suspect is this PR https://github.com/mozilla-mobile/firefox-ios/pull/20667. 
The hang rate report from apple pre-dates 129 but it gets much worse in 129. Many of the logs accompanying the metric kit event for our beta builds in Sentry indicate the users experiencing this issue have a large number of tabs (> 100).
I think it's likely something in the refactor above is causing the apply theme to fire more often and since apply theme is triggered on every tab this has the potential to bog things down. 

This PR triggers apply theme on just the selected PR as that is the only place it's really needed. The background of blank tabs get updated when they are selected. 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

