### PR TITLE
Refactor FXIOS-10381 [Unified Search] Rename SearchEngines to SearchEnginesManager

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1444,7 +1444,6 @@
 		D0FCF8081FE4772D004A7995 /* MainFrameAtDocumentStart.js in Resources */ = {isa = PBXBuildFile; fileRef = D0FCF8051FE4772D004A7995 /* MainFrameAtDocumentStart.js */; };
 		D301AAEE1A3A55B70078DD1D /* LegacyGridTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D301AAED1A3A55B70078DD1D /* LegacyGridTabViewController.swift */; };
 		D30684F11C84F12A002D8D82 /* SearchPlugins in Resources */ = {isa = PBXBuildFile; fileRef = D30684F01C84F12A002D8D82 /* SearchPlugins */; };
-		D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
 		D308EE561CBF0BF5006843F2 /* CertError.css in Resources */ = {isa = PBXBuildFile; fileRef = D308EE551CBF0BF5006843F2 /* CertError.css */; };
 		D313BE981B2F5096009EF241 /* DomainAutocompleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D313BE971B2F5096009EF241 /* DomainAutocompleteTests.swift */; };
 		D314E7F71A37B98700426A76 /* TabToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D314E7F51A37B98700426A76 /* TabToolbar.swift */; };
@@ -1466,7 +1465,6 @@
 		D37DE2CB1CA356F900A5EC69 /* testcert2.pem in Resources */ = {isa = PBXBuildFile; fileRef = D37DE2C91CA356F900A5EC69 /* testcert2.pem */; };
 		D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38A1BEC1A9FA2CA00F6A386 /* SiteTableViewController.swift */; };
 		D38A1EE01CB458EC0080C842 /* CertError.html in Resources */ = {isa = PBXBuildFile; fileRef = D38A1EDF1CB458EC0080C842 /* CertError.html */; };
-		D38B2D8A1A8D98D00040E6B5 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
 		D38B2D8C1A8D98D90040E6B5 /* OpenSearchParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearchParser.swift */; };
 		D38F02D11C05127100175932 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38F02D01C05127100175932 /* Authenticator.swift */; };
 		D38F03701C06387900175932 /* AuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38F036F1C06387900175932 /* AuthenticationTests.swift */; };
@@ -1832,11 +1830,14 @@
 		EBE26B57220C959D00D1D99A /* BrowserViewController+TabToolbarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBE26B4E220C959D00D1D99A /* BrowserViewController+TabToolbarDelegate.swift */; };
 		EBF47E701F7979DF00899189 /* TelemetryWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */; };
 		EBFDB790211C83A5005CCA2F /* BrowserViewController+FindInPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFDB787211C83A5005CCA2F /* BrowserViewController+FindInPage.swift */; };
+		ED07C0E62CCACD7E006C0627 /* Locale+possibilitiesForLanguageIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0E52CCACD7E006C0627 /* Locale+possibilitiesForLanguageIdentifier.swift */; };
+		ED07C0E72CCACE18006C0627 /* Locale+possibilitiesForLanguageIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0E52CCACD7E006C0627 /* Locale+possibilitiesForLanguageIdentifier.swift */; };
 		ED28DAC92C45A95F00D2641C /* TabScrollBehaviorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */; };
 		ED371A682CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */; };
 		ED45893E2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893D2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift */; };
 		ED4589402CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */; };
 		ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */; };
+		EDC3C2562CCAC9CB005A047F /* SearchEnginesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3C2552CCAC9CB005A047F /* SearchEnginesManager.swift */; };
 		EDC3D34F2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EDC3D34E2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets */; };
 		EDC3D3552CB70A3F00C62DE3 /* OpenSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */; };
 		EDD21F2E2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD21F2D2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift */; };
@@ -8145,7 +8146,6 @@
 		D301AAED1A3A55B70078DD1D /* LegacyGridTabViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyGridTabViewController.swift; sourceTree = "<group>"; };
 		D3024F988AFC5EF8EC2878D0 /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		D30684F01C84F12A002D8D82 /* SearchPlugins */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SearchPlugins; path = Search/SearchPlugins; sourceTree = "<group>"; };
-		D308E4E31A5306F500842685 /* SearchEngines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEngines.swift; sourceTree = "<group>"; };
 		D308EE551CBF0BF5006843F2 /* CertError.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = CertError.css; sourceTree = "<group>"; };
 		D30B101D1AA7F9C600C01CA3 /* LibraryPanelHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LibraryPanelHelper.swift; sourceTree = "<group>"; };
 		D313BE971B2F5096009EF241 /* DomainAutocompleteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainAutocompleteTests.swift; sourceTree = "<group>"; };
@@ -8983,6 +8983,7 @@
 		EC734AD49E5483F11375E891 /* zh-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/AuthenticationManager.strings"; sourceTree = "<group>"; };
 		EC934F7BB2F8B247BC714BE2 /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		ECDA4593850BA4E08FDAC5AF /* kk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kk; path = kk.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
+		ED07C0E52CCACD7E006C0627 /* Locale+possibilitiesForLanguageIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+possibilitiesForLanguageIdentifier.swift"; sourceTree = "<group>"; };
 		ED264785844AD63AD616A882 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollBehaviorModel.swift; sourceTree = "<group>"; };
 		ED364EECB95B96AB639A82DE /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -8995,6 +8996,7 @@
 		EDA240A8BBFD0A19FB2C3D7E /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Intro.strings; sourceTree = "<group>"; };
 		EDB94DDC89DE1F2C624C9841 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		EDBE49119AB71D7076BC2CA3 /* zh-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/Menu.strings"; sourceTree = "<group>"; };
+		EDC3C2552CCAC9CB005A047F /* SearchEnginesManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginesManager.swift; sourceTree = "<group>"; };
 		EDC3D34E2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = SearchEngineTestAssets.xcassets; sourceTree = "<group>"; };
 		EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearchEngineTests.swift; sourceTree = "<group>"; };
 		EDCA4CBC8077FC37971CC0C7 /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -9929,6 +9931,7 @@
 				E1442FC9294782D8003680B0 /* URL+Mail.swift */,
 				1BE7A48F2C636AC800460798 /* URLSession+sharedMPTCP.swift */,
 				1BE7A4912C636AEA00460798 /* URLSessionConfiguration+defaultMPTCP.swift */,
+				ED07C0E52CCACD7E006C0627 /* Locale+possibilitiesForLanguageIdentifier.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -10851,7 +10854,7 @@
 			isa = PBXGroup;
 			children = (
 				ED371A692CB885B20099F3C8 /* Views */,
-				D308E4E31A5306F500842685 /* SearchEngines.swift */,
+				EDC3C2552CCAC9CB005A047F /* SearchEnginesManager.swift */,
 				8A1E3BE528CBBF44003388C4 /* OpenSearchEngine.swift */,
 				D3FA77831A43B2CE0010CD32 /* OpenSearchParser.swift */,
 				96A5F72F298D8BEE00234E5F /* DefaultSearchEngineProvider.swift */,
@@ -15667,6 +15670,7 @@
 				8AE80BBC2891C20D00BC12EA /* JumpBackInList.swift in Sources */,
 				8A395552299AF83400B2AFBB /* UIControl+Extension.swift in Sources */,
 				C2A72A692A769460002ACCE2 /* ReadingListCoordinator.swift in Sources */,
+				EDC3C2562CCAC9CB005A047F /* SearchEnginesManager.swift in Sources */,
 				F85C7F122721048E004BDBA4 /* Layout.swift in Sources */,
 				DF036E43274FD434002E834E /* HistoryHighlightsCell.swift in Sources */,
 				B2FEA68D2B460D390058E616 /* AddressAutofillSettingsViewController.swift in Sources */,
@@ -15692,7 +15696,6 @@
 				E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */,
 				E177989C2BD7D48500F6F0EB /* ToolbarAction.swift in Sources */,
 				F8A0B08229AD61FA0091C75B /* RustSyncManager.swift in Sources */,
-				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,
 				438FE8642988ABA600155B10 /* CreditCardTableViewController.swift in Sources */,
 				3BCE6D3C1CEB9E4D0080928C /* ThirdPartySearchAlerts.swift in Sources */,
 				8A93F86229D36F0F004159D9 /* NavigationController.swift in Sources */,
@@ -16191,6 +16194,7 @@
 				1DA6F6512B48B42900BB5AD6 /* WindowEventCoordinator.swift in Sources */,
 				0B11AF022CB412D100AD51D5 /* Metrics.swift in Sources */,
 				C4E3984C1D21F2FD004E89BA /* TabTrayButtonExtensions.swift in Sources */,
+				ED07C0E62CCACD7E006C0627 /* Locale+possibilitiesForLanguageIdentifier.swift in Sources */,
 				437A857827E43FE100E42764 /* FxAWebViewTelemetry.swift in Sources */,
 				E13E9AB42AAB0FB5001A0E9D /* FakespotCoordinator.swift in Sources */,
 				E1442FD1294782D9003680B0 /* UIModalPresentationStyle+Photon.swift in Sources */,
@@ -16847,7 +16851,6 @@
 				FA6B2AC41D41F02D00429414 /* String+Punycode.swift in Sources */,
 				E1D6F2D928E32A5300B2C8CC /* ImageIdentifiers.swift in Sources */,
 				F8A0B08429AD64790091C75B /* RustSyncManager.swift in Sources */,
-				D38B2D8A1A8D98D00040E6B5 /* SearchEngines.swift in Sources */,
 				EB6E0C60207E6C3100FBFF7E /* SendToDevice.swift in Sources */,
 				D3C744CF1A687D6C004CE85D /* URIFixup.swift in Sources */,
 				EB94075320850C9F00702E05 /* photon-colors.swift in Sources */,
@@ -16856,6 +16859,7 @@
 				D04CD74D216CF86F004FF5B0 /* DevicePickerViewController.swift in Sources */,
 				6025B10F267B6C7F00F59F6B /* LoginRecordExtension.swift in Sources */,
 				E418D0D91A251B3200CAE47A /* Profile.swift in Sources */,
+				ED07C0E72CCACE18006C0627 /* Locale+possibilitiesForLanguageIdentifier.swift in Sources */,
 				E1CD81C3290C670A00124B27 /* HostingTableViewCell.swift in Sources */,
 				DDA24A451FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */,
 				F8708D321A0970B70051AB07 /* ShareViewController.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -290,7 +290,7 @@
 		2F44FCC51A9E85E900FD20CC /* SettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCC41A9E85E900FD20CC /* SettingsTableViewController.swift */; };
 		2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */; };
 		2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */; };
-		2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */; };
+		2F697F7E1A9FD22D009E03AE /* SearchEnginesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F697F7D1A9FD22D009E03AE /* SearchEnginesManagerTests.swift */; };
 		2FCAE25F1ABB531100877008 /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE2411ABB531100877008 /* Cursor.swift */; };
 		2FCAE2611ABB531100877008 /* FileAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE2431ABB531100877008 /* FileAccessor.swift */; };
 		2FCAE2651ABB531100877008 /* RemoteTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE2471ABB531100877008 /* RemoteTabs.swift */; };
@@ -2772,7 +2772,7 @@
 		2F44FCC41A9E85E900FD20CC /* SettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableViewController.swift; sourceTree = "<group>"; };
 		2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsTableViewController.swift; sourceTree = "<group>"; };
 		2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginePicker.swift; sourceTree = "<group>"; };
-		2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginesTests.swift; sourceTree = "<group>"; };
+		2F697F7D1A9FD22D009E03AE /* SearchEnginesManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginesManagerTests.swift; sourceTree = "<group>"; };
 		2F7A4680A2BCE93CE0BD8392 /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/Menu.strings; sourceTree = "<group>"; };
 		2F884BA290D689F05C289FDE /* pa-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pa-IN"; path = "pa-IN.lproj/Shared.strings"; sourceTree = "<group>"; };
 		2FA435FB1ABB83B4008031D1 /* libAccount.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAccount.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -10867,7 +10867,7 @@
 			isa = PBXGroup;
 			children = (
 				EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */,
-				2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */,
+				2F697F7D1A9FD22D009E03AE /* SearchEnginesManagerTests.swift */,
 				ED45893D2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift */,
 				D3FA777A1A43B2990010CD32 /* SearchTests.swift */,
 				96A5F734298D8EB900234E5F /* MockSearchEngineProvider.swift */,
@@ -16543,7 +16543,7 @@
 				96AF8C1C29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift in Sources */,
 				21FA8FB02AE856590013B815 /* RemoteTabsCoordinatorTests.swift in Sources */,
 				C80C11F428B3CD580062922A /* MockUserDefaultsTests.swift in Sources */,
-				2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */,
+				2F697F7E1A9FD22D009E03AE /* SearchEnginesManagerTests.swift in Sources */,
 				2197DF8A287624BF00215624 /* LibraryViewModelTests.swift in Sources */,
 				5A3A7DDC2889EC5D0065F81A /* BookmarksHandlerMock.swift in Sources */,
 				2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */,

--- a/firefox-ios/Client/Extensions/Locale+possibilitiesForLanguageIdentifier.swift
+++ b/firefox-ios/Client/Extensions/Locale+possibilitiesForLanguageIdentifier.swift
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+extension Locale {
+    func possibilitiesForLanguageIdentifier() -> [String] {
+        var possibilities: [String] = []
+        let components = identifier.components(separatedBy: "-")
+
+        possibilities.append(identifier)
+
+        if components.count == 3,
+           let first = components.first,
+           let last = components.last {
+            possibilities.append("\(first)-\(last)")
+        }
+        if components.count >= 2,
+            let first = components.first {
+            possibilities.append("\(first)")
+        }
+
+        return possibilities
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -206,7 +206,7 @@ extension BrowserViewController: URLBarDelegate {
         if let url = searchURL, InternalURL.isValid(url: url) {
             searchURL = url
         }
-        if let query = profile.searchEngines.queryForSearchURL(searchURL as URL?) {
+        if let query = profile.searchEnginesManager.queryForSearchURL(searchURL as URL?) {
             return (query, true)
         } else {
             return (url?.absoluteString, false)
@@ -255,7 +255,7 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func submitSearchText(_ text: String, forTab tab: Tab) {
-        guard let engine = profile.searchEngines.defaultEngine,
+        guard let engine = profile.searchEnginesManager.defaultEngine,
               let searchURL = engine.searchURLForQuery(text)
         else {
             DefaultLogger.shared.log("Error handling URL entry: \"\(text)\".", level: .warning, category: .tabs)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1572,12 +1572,12 @@ class BrowserViewController: UIViewController,
         let searchViewModel = SearchViewModel(isPrivate: isPrivate,
                                               isBottomSearchBar: isBottomSearchBar,
                                               profile: profile,
-                                              model: profile.searchEngines,
+                                              model: profile.searchEnginesManager,
                                               tabManager: tabManager)
         let searchController = SearchViewController(profile: profile,
                                                     viewModel: searchViewModel,
                                                     tabManager: tabManager)
-        searchViewModel.searchEngines = profile.searchEngines
+        searchViewModel.searchEnginesManager = profile.searchEnginesManager
         searchController.searchDelegate = self
 
         let searchLoader = SearchLoader(
@@ -2581,7 +2581,7 @@ class BrowserViewController: UIViewController,
     func openSearchNewTab(isPrivate: Bool = false, _ text: String) {
         popToBVC()
 
-        guard let engine = profile.searchEngines.defaultEngine,
+        guard let engine = profile.searchEnginesManager.defaultEngine,
               let searchURL = engine.searchURLForQuery(text)
         else {
             DefaultLogger.shared.log("Error handling URL entry: \"\(text)\".", level: .warning, category: .tabs)
@@ -2994,7 +2994,7 @@ class BrowserViewController: UIViewController,
             .searchScreenState
             .showSearchSugestionsView ?? false
 
-        let isSettingEnabled = profile.searchEngines.shouldShowPrivateModeSearchSuggestions
+        let isSettingEnabled = profile.searchEnginesManager.shouldShowPrivateModeSearchSuggestions
 
         return featureFlagEnabled && !alwaysShowSearchSuggestionsView && !isSettingEnabled
     }

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -328,7 +328,7 @@ class SearchViewController: SiteTableViewController,
                 ]
             )
 
-            if engine === self.viewModel.searchEngines?.quickSearchEngines.last {
+            if engine === self.viewModel.searchEnginesManager?.quickSearchEngines.last {
                 engineButton.trailingAnchor.constraint(
                     equalTo: searchEngineScrollViewContent.trailingAnchor
                 ).isActive = true
@@ -436,7 +436,7 @@ class SearchViewController: SiteTableViewController,
         searchTelemetry?.engagementType = .tap
         switch SearchListSection(rawValue: indexPath.section)! {
         case .searchSuggestions:
-            guard let defaultEngine = viewModel.searchEngines?.defaultEngine else { return }
+            guard let defaultEngine = viewModel.searchEnginesManager?.defaultEngine else { return }
 
             searchTelemetry?.selectedResult = .searchSuggest
             // Assume that only the default search engine can provide search suggestions.
@@ -525,7 +525,7 @@ class SearchViewController: SiteTableViewController,
         case SearchListSection.firefoxSuggestions.rawValue:
             title = .Search.SuggestSectionTitle
         case SearchListSection.searchSuggestions.rawValue:
-            title = viewModel.searchEngines?.defaultEngine?.headerSearchTitle ?? ""
+            title = viewModel.searchEnginesManager?.defaultEngine?.headerSearchTitle ?? ""
         default:  title = ""
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
@@ -24,7 +24,7 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
     var filteredOpenedTabs = [Tab]()
     var searchHighlights = [HighlightItem]()
     var firefoxSuggestions = [RustFirefoxSuggestion]()
-    let model: SearchEngines
+    let model: SearchEnginesManager
     var suggestions: [String]? = []
     static var userAgent: String?
     var searchFeature: FeatureHolder<Search>
@@ -52,22 +52,22 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
     }
 
     var quickSearchEngines: [OpenSearchEngine] {
-        guard let defaultEngine = searchEngines?.defaultEngine else { return [] }
+        guard let defaultEngine = searchEnginesManager?.defaultEngine else { return [] }
 
-        var engines = searchEngines?.quickSearchEngines
+        var engines = searchEnginesManager?.quickSearchEngines
 
         // If we're not showing search suggestions, the default search engine won't be visible
         // at the top of the table. Show it with the others in the bottom search bar.
-        if !(searchEngines?.shouldShowSearchSuggestions ?? false) {
+        if !(searchEnginesManager?.shouldShowSearchSuggestions ?? false) {
             engines?.insert(defaultEngine, at: 0)
         }
 
         return engines!
     }
 
-    var searchEngines: SearchEngines? {
+    var searchEnginesManager: SearchEnginesManager? {
         didSet {
-            guard let defaultEngine = searchEngines?.defaultEngine else { return }
+            guard let defaultEngine = searchEnginesManager?.defaultEngine else { return }
 
             suggestClient?.cancelPendingRequest()
 
@@ -95,7 +95,7 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
 
     /// Whether to show suggestions from the search engine.
     var shouldShowSearchEngineSuggestions: Bool {
-        return searchEngines?.shouldShowSearchSuggestions ?? false
+        return searchEnginesManager?.shouldShowSearchSuggestions ?? false
     }
 
     var shouldShowSyncedTabsSuggestions: Bool {
@@ -146,7 +146,7 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
 
     init(isPrivate: Bool, isBottomSearchBar: Bool,
          profile: Profile,
-         model: SearchEngines,
+         model: SearchEnginesManager,
          tabManager: TabManager,
          featureConfig: FeatureHolder<Search> = FxNimbus.shared.features.search,
          highlightManager: HistoryHighlightsManagerProtocol = HistoryHighlightsManager()

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/DefaultSearchEngineProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/DefaultSearchEngineProvider.swift
@@ -35,7 +35,6 @@ class DefaultSearchEngineProvider: SearchEngineProvider {
             // might not work to change the default.
             guard let orderedEngineNames = orderedEngineNames else {
                 // We haven't persisted the engine order, so return whatever order we got from disk.
-
                 DispatchQueue.main.async {
                     completion(unorderedEngines)
                 }
@@ -83,13 +82,11 @@ class DefaultSearchEngineProvider: SearchEngineProvider {
             with: pluginDirectory.appendingPathComponent("list.json")
         ) else {
             logger.log("Failed to parse List.json", level: .fatal, category: .setup)
-            // swiftlint:disable line_length
             fatalError("We are unable to populate search engines for this locale because list.json could not be parsed.")
-            // swiftlint:enable line_length
         }
-        let possibilities = possibleLanguageIdentifier
-        let engineNames = defaultSearchPrefs.visibleDefaultEngines(for: possibilities, and: region)
-        let defaultEngineName = defaultSearchPrefs.searchDefault(for: possibilities, and: region)
+
+        let engineNames = defaultSearchPrefs.visibleDefaultEngines(for: possibleLanguageIdentifier, and: region)
+        let defaultEngineName = defaultSearchPrefs.searchDefault(for: possibleLanguageIdentifier, and: region)
 
         guard !engineNames.isEmpty else {
             logger.log("No search engines.", level: .fatal, category: .setup)

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -11,26 +11,26 @@ protocol SearchEngineDelegate: AnyObject {
     func searchEnginesDidUpdate()
 }
 
-/// Manage a set of Open Search engines.
+/// Manages a set of `OpenSearchEngine`s.
 ///
-/// The search engines are ordered.
+/// The search engines are ordered (order is stored in Prefs, i.e. UserDefaults). Custom search engines entered by the user
+/// are saved to a file. Default search engines are localized and given by the `SearchEngineProvider` (from list.json).
 ///
 /// Individual search engines can be enabled and disabled.
 ///
 /// The first search engine is distinguished and labeled the "default" search engine; it can never be
-/// disabled.  Search suggestions should always be sourced from the default search engine.
-/// 
-/// Two additional bits of information are maintained: whether search suggestions are enabled and whether
-/// search suggestions in private mode is disabled
+/// disabled. FIXME FXIOS-10187 this will change: Search suggestions should always be sourced from the default search engine
 ///
-/// Consumers will almost always use `defaultEngine` if they want a single search engine, and
-/// `quickSearchEngines()` if they want a list of enabled quick search engines (possibly empty,
-/// since the default engine is never included in the list of enabled quick search engines, and
-/// it is possible to disable every non-default quick search engine).
+/// Two additional bits of information are maintained: whether search suggestions are enabled and whether search suggestions
+/// in private mode is disabled.
 ///
-/// The search engines are backed by a write-through cache into a ProfilePrefs instance.  This class
-/// is not thread-safe -- you should only access it on a single thread (usually, the main thread)!
-class SearchEngines {
+/// Consumers will almost always use `defaultEngine` if they want a single search engine, and `quickSearchEngines()` if they
+/// want a list of enabled quick search engines (possibly empty, since the default engine is never included in the list of
+/// enabled quick search engines, and it is possible to disable every non-default quick search engine).
+///
+/// The search engines are backed by a write-through cache into a ProfilePrefs instance.  This class is not thread-safe --
+/// you should only access it on a single thread (usually, the main thread)!
+class SearchEnginesManager {
     private let prefs: Prefs
     private let fileAccessor: FileAccessor
     private let orderedEngineNames = "search.orderedEngineNames"
@@ -300,22 +300,5 @@ class SearchEngines {
                        level: .debug,
                        category: .storage)
         }
-    }
-}
-
-extension Locale {
-    func possibilitiesForLanguageIdentifier() -> [String] {
-        var possibilities: [String] = []
-        let languageIdentifier = self.identifier
-        let components = languageIdentifier.components(separatedBy: "-")
-        possibilities.append(languageIdentifier)
-
-        if components.count == 3, let first = components.first, let last = components.last {
-            possibilities.append("\(first)-\(last)")
-        }
-        if components.count >= 2, let first = components.first {
-            possibilities.append("\(first)")
-        }
-        return possibilities
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -13,23 +13,23 @@ protocol SearchEngineDelegate: AnyObject {
 
 /// Manages a set of `OpenSearchEngine`s.
 ///
-/// The search engines are ordered (order is stored in Prefs, i.e. UserDefaults). Custom search engines entered by the user
-/// are saved to a file. Default search engines are localized and given by the `SearchEngineProvider` (from list.json).
+/// The search engines are ordered and can be enabled and disabled by the user. Order and disabled state are backed by a
+/// write-through cache into a Prefs instance (i.e. UserDefaults).
 ///
-/// Individual search engines can be enabled and disabled.
+/// Default search engines are localized and given by the `SearchEngineProvider` (from list.json). The user may add
+/// additional custom search engines. Custom search engines entered by the user are saved to a file.
 ///
-/// The first search engine is distinguished and labeled the "default" search engine; it can never be
-/// disabled. FIXME FXIOS-10187 this will change: Search suggestions should always be sourced from the default search engine
+/// The first search engine is distinguished and labeled the "default" search engine; it can never be disabled.
+/// [FIXME FXIOS-10187 this will change soon ->] Search suggestions should always be sourced from the default search engine
 ///
 /// Two additional bits of information are maintained: whether search suggestions are enabled and whether search suggestions
-/// in private mode is disabled.
+/// in private mode are disabled.
 ///
 /// Consumers will almost always use `defaultEngine` if they want a single search engine, and `quickSearchEngines()` if they
 /// want a list of enabled quick search engines (possibly empty, since the default engine is never included in the list of
 /// enabled quick search engines, and it is possible to disable every non-default quick search engine).
 ///
-/// The search engines are backed by a write-through cache into a ProfilePrefs instance.  This class is not thread-safe --
-/// you should only access it on a single thread (usually, the main thread)!
+/// This class is not thread-safe -- you should only access it on a single thread (usually, the main thread)!
 class SearchEnginesManager {
     private let prefs: Prefs
     private let fileAccessor: FileAccessor
@@ -116,7 +116,9 @@ class SearchEnginesManager {
         }
     }
 
-    // The subset of search engines that are enabled and not the default search engine.
+    /// The subset of search engines that are enabled and not the default search engine.
+    ///
+    /// The results can be empty if the user disables all search engines besides the default (which can't be disabled).
     var quickSearchEngines: [OpenSearchEngine]! {
         return self.orderedEngines.filter({ (engine) in !self.isEngineDefault(engine) && self.isEngineEnabled(engine) })
     }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -116,6 +116,7 @@ class SearchEnginesManager {
         }
     }
 
+    // The subset of search engines that are enabled and not the default search engine.
     var quickSearchEngines: [OpenSearchEngine]! {
         return self.orderedEngines.filter({ (engine) in !self.isEngineDefault(engine) && self.isEngineEnabled(engine) })
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -14,7 +14,7 @@ class AddressToolbarContainerModel: Equatable {
     let borderPosition: AddressToolbarBorderPosition?
     let searchEngineName: String?
     let searchEngineImage: UIImage?
-    let searchEngines: SearchEngines
+    let searchEnginesManager: SearchEnginesManager
     let lockIconImageName: String?
     let safeListedURLImageName: String?
     let url: URL?
@@ -30,7 +30,7 @@ class AddressToolbarContainerModel: Equatable {
     let windowUUID: UUID
 
     var addressToolbarState: AddressToolbarState {
-        let term = searchTerm ?? searchTermFromURL(url, searchEngines: searchEngines)
+        let term = searchTerm ?? searchTermFromURL(url, searchEnginesManager: searchEnginesManager)
 
         var droppableUrl: URL?
         if let url, !InternalURL.isValid(url: url) {
@@ -92,9 +92,9 @@ class AddressToolbarContainerModel: Equatable {
                                                                       isShowingTopTabs: state.isShowingTopTabs,
                                                                       windowUUID: windowUUID)
         self.windowUUID = windowUUID
-        self.searchEngineName = profile.searchEngines.defaultEngine?.shortName
-        self.searchEngineImage = profile.searchEngines.defaultEngine?.image
-        self.searchEngines = profile.searchEngines
+        self.searchEngineName = profile.searchEnginesManager.defaultEngine?.shortName
+        self.searchEngineImage = profile.searchEnginesManager.defaultEngine?.image
+        self.searchEnginesManager = profile.searchEnginesManager
         self.lockIconImageName = state.addressToolbar.lockIconImageName
         self.safeListedURLImageName = state.addressToolbar.safeListedURLImageName
         self.url = state.addressToolbar.url
@@ -108,14 +108,14 @@ class AddressToolbarContainerModel: Equatable {
         self.canShowNavigationHint = state.canShowNavigationHint
     }
 
-    func searchTermFromURL(_ url: URL?, searchEngines: SearchEngines) -> String? {
+    func searchTermFromURL(_ url: URL?, searchEnginesManager: SearchEnginesManager) -> String? {
         var searchURL: URL? = url
 
         if let url = searchURL, InternalURL.isValid(url: url) {
             searchURL = url
         }
 
-        guard let query = searchEngines.queryForSearchURL(searchURL) else { return nil }
+        guard let query = searchEnginesManager.queryForSearchURL(searchURL) else { return nil }
         return query
     }
 

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -173,7 +173,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
         if sponsoredTileSpaces > 0 {
             sites.addSponsoredTiles(sponsoredTileSpaces: sponsoredTileSpaces,
                                     contiles: contiles,
-                                    defaultSearchEngine: profile.searchEngines.defaultEngine)
+                                    defaultSearchEngine: profile.searchEnginesManager.defaultEngine)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -80,7 +80,7 @@ extension BookmarkItemData: BookmarksFolderCell {
         // (e.g., "http://foo.com/bar/?query=%s"), and this will get them the same behavior as if
         // they'd copied and pasted into the URL bar.
         // See BrowserViewController.urlBar:didSubmitText:.
-        guard let url = URIFixup.getURL(url) ?? profile.searchEngines.defaultEngine?.searchURLForQuery(url) else {
+        guard let url = URIFixup.getURL(url) ?? profile.searchEnginesManager.defaultEngine?.searchURLForQuery(url) else {
             logger.log("Invalid URL, and couldn't generate a search URL for it.",
                        level: .warning,
                        category: .library)

--- a/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -69,7 +69,7 @@ class CustomSearchViewController: SettingsTableViewController {
             do {
                 let engine = try await createEngine(query: trimmedQuery, name: trimmedTitle)
                 self.spinnerView.stopAnimating()
-                self.profile.searchEngines.addSearchEngine(engine)
+                self.profile.searchEnginesManager.addSearchEngine(engine)
 
                 CATransaction.begin() // Use transaction to call callback after animation has been completed
                 CATransaction.setCompletionBlock(self.successCallback)
@@ -124,7 +124,7 @@ class CustomSearchViewController: SettingsTableViewController {
     }
 
     private func engineExists(name: String, template: String) -> Bool {
-        return profile.searchEngines.orderedEngines.contains { (engine) -> Bool in
+        return profile.searchEnginesManager.orderedEngines.contains { (engine) -> Bool in
             return engine.shortName == name || engine.searchTemplate == template
         }
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
@@ -16,7 +16,7 @@ class SearchSetting: Setting {
 
     override var status: NSAttributedString {
         return NSAttributedString(
-            string: profile.searchEngines.defaultEngine?.shortName ?? ""
+            string: profile.searchEnginesManager.defaultEngine?.shortName ?? ""
         )
     }
 

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -40,7 +40,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
     }
 
     private let profile: Profile
-    private let model: SearchEngines
+    private let model: SearchEnginesManager
 
     var shouldHidePrivateModeFirefoxSuggestSetting: Bool {
         return !model.shouldShowBookmarksSuggestions &&
@@ -82,7 +82,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
 
     init(profile: Profile, windowUUID: WindowUUID) {
         self.profile = profile
-        model = profile.searchEngines
+        model = profile.searchEnginesManager
 
         super.init(windowUUID: windowUUID)
     }

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -89,7 +89,7 @@ class URLBarView: UIView,
     }
 
     var parent: UIStackView?
-    var searchEngines: SearchEngines?
+    var searchEnginesManager: SearchEnginesManager?
     weak var delegate: URLBarDelegate?
     weak var tabToolbarDelegate: TabToolbarDelegate?
     var helper: TabToolbarHelper?
@@ -245,7 +245,7 @@ class URLBarView: UIView,
     init(profile: Profile, windowUUID: WindowUUID) {
         self.profile = profile
         self.windowUUID = windowUUID
-        self.searchEngines = SearchEngines(prefs: profile.prefs, files: profile.files)
+        self.searchEnginesManager = SearchEnginesManager(prefs: profile.prefs, files: profile.files)
         super.init(frame: CGRect())
         commonInit()
     }
@@ -255,7 +255,7 @@ class URLBarView: UIView,
     }
 
     func searchEnginesDidUpdate() {
-        let engineID = profile.searchEngines.defaultEngine?.engineID ?? "custom"
+        let engineID = profile.searchEnginesManager.defaultEngine?.engineID ?? "custom"
         TelemetryWrapper.recordEvent(
             category: .information,
             method: .change,
@@ -264,8 +264,8 @@ class URLBarView: UIView,
             extras: [TelemetryWrapper.EventExtraKey.recordSearchEngineID.rawValue: engineID]
         )
 
-        self.searchIconImageView.image = profile.searchEngines.defaultEngine?.image
-        self.searchIconImageView.largeContentTitle = profile.searchEngines.defaultEngine?.shortName
+        self.searchIconImageView.image = profile.searchEnginesManager.defaultEngine?.image
+        self.searchIconImageView.largeContentTitle = profile.searchEnginesManager.defaultEngine?.shortName
         self.searchIconImageView.largeContentImage = nil
     }
 
@@ -291,7 +291,7 @@ class URLBarView: UIView,
             addSubview($0)
         }
 
-        profile.searchEngines.delegate = self
+        profile.searchEnginesManager.delegate = self
 
         privateModeBadge.add(toParent: self)
         warningMenuBadge.add(toParent: self)

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -96,7 +96,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         // If there's no default search engine, (there's not, at this point), we will
         // send "unavailable" in order not to send `null`, but still differentiate
         // the event in the startup sequence.
-        let defaultEngine = profile.searchEngines.defaultEngine
+        let defaultEngine = profile.searchEnginesManager.defaultEngine
         GleanMetrics.Search.defaultEngine.set(defaultEngine?.engineID ?? "unavailable")
 
         // Get the legacy telemetry ID and record it in Glean for the deletion-request ping
@@ -161,7 +161,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         }
 
         // Record default search engine setting
-        let defaultEngine = profile.searchEngines.defaultEngine
+        let defaultEngine = profile.searchEnginesManager.defaultEngine
         GleanMetrics.Search.defaultEngine.set(defaultEngine?.engineID ?? "custom")
 
         // Record the open tab count

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -88,7 +88,7 @@ protocol Profile: AnyObject {
     var prefs: Prefs { get }
     var queue: TabQueue { get }
     #if !MOZ_TARGET_NOTIFICATIONSERVICE && !MOZ_TARGET_SHARETO && !MOZ_TARGET_CREDENTIAL_PROVIDER
-    var searchEngines: SearchEngines { get }
+    var searchEnginesManager: SearchEnginesManager { get }
     #endif
     var files: FileAccessor { get }
     var pinnedSites: PinnedSites { get }
@@ -470,8 +470,8 @@ open class BrowserProfile: Profile {
     lazy var autofill = RustAutofill(databasePath: autofillDbPath)
 
     #if !MOZ_TARGET_NOTIFICATIONSERVICE && !MOZ_TARGET_SHARETO && !MOZ_TARGET_CREDENTIAL_PROVIDER
-    lazy var searchEngines: SearchEngines = {
-        return SearchEngines(prefs: self.prefs, files: self.files)
+    lazy var searchEnginesManager: SearchEnginesManager = {
+        return SearchEnginesManager(prefs: self.prefs, files: self.files)
     }()
     #endif
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchTests.swift
@@ -72,6 +72,8 @@ class SearchTests: XCTestCase {
             withExtendedLifetime(client) {
                 if error != nil {
                     XCTFail("Error: \(error?.description ?? "nil")")
+                    query1.fulfill()
+                    return
                 }
 
                 XCTAssertEqual(response![0], "foo")
@@ -88,6 +90,8 @@ class SearchTests: XCTestCase {
             withExtendedLifetime(client) {
                 if error != nil {
                     XCTFail("Error: \(error?.description ?? "nil")")
+                    query2.fulfill()
+                    return
                 }
 
                 XCTAssertEqual(response![0], "foo bar soap")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -546,7 +546,7 @@ extension TopSitesDataAdaptorTests {
     }
 
     func add(searchEngine: OpenSearchEngine) {
-        profile.searchEngines.defaultEngine = searchEngine
+        profile.searchEnginesManager.defaultEngine = searchEngine
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
@@ -169,8 +169,8 @@ open class MockProfile: Client.Profile {
         return CertStore()
     }()
 
-    public lazy var searchEngines: SearchEngines = {
-        return SearchEngines(prefs: self.prefs, files: self.files)
+    public lazy var searchEnginesManager: SearchEnginesManager = {
+        return SearchEnginesManager(prefs: self.prefs, files: self.files)
     }()
 
     public lazy var prefs: Prefs = {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/SearchViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/SearchViewControllerTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class SearchViewControllerTest: XCTestCase {
     var profile: MockProfile!
-    var engines: SearchEngines!
+    var searchEnginesManager: SearchEnginesManager!
     var searchViewController: SearchViewController!
 
     override func setUp() {
@@ -22,7 +22,7 @@ class SearchViewControllerTest: XCTestCase {
         LegacyFeatureFlagsManager.shared.set(feature: .firefoxSuggestFeature, to: true)
 
         let mockSearchEngineProvider = MockSearchEngineProvider()
-        engines = SearchEngines(
+        searchEnginesManager = SearchEnginesManager(
             prefs: profile.prefs,
             files: profile.files,
             engineProvider: mockSearchEngineProvider
@@ -31,7 +31,7 @@ class SearchViewControllerTest: XCTestCase {
             isPrivate: false,
             isBottomSearchBar: false,
             profile: profile,
-            model: engines,
+            model: searchEnginesManager,
             tabManager: MockTabManager()
         )
 
@@ -48,7 +48,7 @@ class SearchViewControllerTest: XCTestCase {
     }
 
     func testHistoryAndBookmarksAreFilteredWhenShowSponsoredSuggestionsIsTrue() {
-        engines.shouldShowSponsoredSuggestions = true
+        searchEnginesManager.shouldShowSponsoredSuggestions = true
         let data = ArrayCursor<Site>(data: [ Site(url: "https://example.com?mfadid=adm", title: "Test1"),
                                              Site(url: "https://example.com", title: "Test2"),
                                              Site(url: "https://example.com?a=b&c=d", title: "Test3")])
@@ -58,7 +58,7 @@ class SearchViewControllerTest: XCTestCase {
     }
 
     func testHistoryAndBookmarksAreNotFilteredWhenShowSponsoredSuggestionsIsFalse() {
-        engines.shouldShowSponsoredSuggestions = false
+        searchEnginesManager.shouldShowSponsoredSuggestions = false
         let data = ArrayCursor<Site>(data: [ Site(url: "https://example.com?mfadid=adm", title: "Test1"),
                                              Site(url: "https://example.com", title: "Test2"),
                                              Site(url: "https://example.com?a=b&c=d", title: "Test3")])

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/SearchViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Search/SearchViewModelTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class SearchViewModelTests: XCTestCase {
     var profile: MockProfile!
     var mockDelegate: MockSearchDelegate!
-    var engines: SearchEngines!
+    var searchEnginesManager: SearchEnginesManager!
     var remoteClient: RemoteClient!
 
     override func setUp() {
@@ -25,7 +25,7 @@ final class SearchViewModelTests: XCTestCase {
         let mockSearchEngineProvider = MockSearchEngineProvider()
         mockDelegate = MockSearchDelegate()
 
-        engines = SearchEngines(
+        searchEnginesManager = SearchEnginesManager(
             prefs: profile.prefs,
             files: profile.files,
             engineProvider: mockSearchEngineProvider
@@ -54,16 +54,16 @@ final class SearchViewModelTests: XCTestCase {
                                     [.amp: false, .ampMobile: false, .wikipedia: false])
        })
 
-        engines.shouldShowFirefoxSuggestions = false
-        engines.shouldShowSponsoredSuggestions = false
+        searchEnginesManager.shouldShowFirefoxSuggestions = false
+        searchEnginesManager.shouldShowSponsoredSuggestions = false
 
         let subject = createSubject()
         await subject.loadFirefoxSuggestions()?.value
         XCTAssertEqual(subject.firefoxSuggestions.count, 0)
 
         // Providers set to false, so regardless of the prefs, we shouldn't see anything
-        engines.shouldShowFirefoxSuggestions = true
-        engines.shouldShowSponsoredSuggestions = true
+        searchEnginesManager.shouldShowFirefoxSuggestions = true
+        searchEnginesManager.shouldShowSponsoredSuggestions = true
         await subject.loadFirefoxSuggestions()?.value
         XCTAssertEqual(subject.firefoxSuggestions.count, 0)
     }
@@ -74,8 +74,8 @@ final class SearchViewModelTests: XCTestCase {
                                     [.amp: false, .ampMobile: true, .wikipedia: true])
        })
 
-        engines.shouldShowFirefoxSuggestions = false
-        engines.shouldShowSponsoredSuggestions = false
+        searchEnginesManager.shouldShowFirefoxSuggestions = false
+        searchEnginesManager.shouldShowSponsoredSuggestions = false
 
         let subject = createSubject()
 
@@ -90,8 +90,8 @@ final class SearchViewModelTests: XCTestCase {
                                     [.amp: false, .ampMobile: true, .wikipedia: true])
        })
 
-        engines.shouldShowFirefoxSuggestions = true
-        engines.shouldShowSponsoredSuggestions = true
+        searchEnginesManager.shouldShowFirefoxSuggestions = true
+        searchEnginesManager.shouldShowSponsoredSuggestions = true
         let subject = createSubject()
         await subject.loadFirefoxSuggestions()?.value
 
@@ -100,7 +100,7 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     func testSyncedTabsAreFilteredWhenShowSponsoredSuggestionsIsTrue() {
-        engines.shouldShowSponsoredSuggestions = true
+        searchEnginesManager.shouldShowSponsoredSuggestions = true
         let remoteTab1 = RemoteTab(
             clientGUID: "1",
             URL: URL(string: "www.mozilla.org?mfadid=adm")!,
@@ -137,7 +137,7 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     func testSyncedTabsAreNotFilteredWhenShowSponsoredSuggestionsIsFalse() {
-        engines.shouldShowSponsoredSuggestions = false
+        searchEnginesManager.shouldShowSponsoredSuggestions = false
 
         let remoteTab1 = RemoteTab(
             clientGUID: "1",
@@ -176,8 +176,8 @@ final class SearchViewModelTests: XCTestCase {
 
     func testSponsoredSuggestionsAreNotShownInPrivateBrowsingMode() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
-        engines.shouldShowFirefoxSuggestions = true
-        engines.shouldShowSponsoredSuggestions = true
+        searchEnginesManager.shouldShowFirefoxSuggestions = true
+        searchEnginesManager.shouldShowSponsoredSuggestions = true
 
         await subject.loadFirefoxSuggestions()?.value
         XCTAssertTrue(subject.firefoxSuggestions.isEmpty)
@@ -187,8 +187,8 @@ final class SearchViewModelTests: XCTestCase {
     func testNonSponsoredSuggestionsAreNotShownInPrivateBrowsingMode() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
 
-        engines.shouldShowFirefoxSuggestions = true
-        engines.shouldShowSponsoredSuggestions = true
+        searchEnginesManager.shouldShowFirefoxSuggestions = true
+        searchEnginesManager.shouldShowSponsoredSuggestions = true
 
         await subject.loadFirefoxSuggestions()?.value
 
@@ -199,9 +199,9 @@ final class SearchViewModelTests: XCTestCase {
     func testNonSponsoredAndSponsoredSuggestionsInPrivateModeWithPrivateSuggestionsOn() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
 
-        engines.shouldShowFirefoxSuggestions = true
-        engines.shouldShowSponsoredSuggestions = true
-        engines.shouldShowPrivateModeFirefoxSuggestions = true
+        searchEnginesManager.shouldShowFirefoxSuggestions = true
+        searchEnginesManager.shouldShowSponsoredSuggestions = true
+        searchEnginesManager.shouldShowPrivateModeFirefoxSuggestions = true
         await subject.loadFirefoxSuggestions()?.value
 
         XCTAssertTrue(subject.firefoxSuggestions.isEmpty)
@@ -210,9 +210,9 @@ final class SearchViewModelTests: XCTestCase {
 
     func testNonSponsoredInPrivateModeWithPrivateSuggestionsOn() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
-        engines.shouldShowFirefoxSuggestions = true
-        engines.shouldShowSponsoredSuggestions = false
-        engines.shouldShowPrivateModeFirefoxSuggestions = true
+        searchEnginesManager.shouldShowFirefoxSuggestions = true
+        searchEnginesManager.shouldShowSponsoredSuggestions = false
+        searchEnginesManager.shouldShowPrivateModeFirefoxSuggestions = true
         await subject.loadFirefoxSuggestions()?.value
 
         XCTAssertTrue(subject.firefoxSuggestions.isEmpty)
@@ -222,7 +222,7 @@ final class SearchViewModelTests: XCTestCase {
     func testNonSponsoredAndSponsoredSuggestionsAreNotShownInPrivateBrowsingMode() async throws {
         let subject = createSubject(isPrivate: true, isBottomSearchBar: false)
 
-        engines.shouldShowPrivateModeFirefoxSuggestions = false
+        searchEnginesManager.shouldShowPrivateModeFirefoxSuggestions = false
         await subject.loadFirefoxSuggestions()?.value
 
         XCTAssertTrue(subject.firefoxSuggestions.isEmpty)
@@ -235,8 +235,8 @@ final class SearchViewModelTests: XCTestCase {
                                     [.amp: false, .ampMobile: true, .wikipedia: true])
        })
 
-        engines.shouldShowFirefoxSuggestions = true
-        engines.shouldShowSponsoredSuggestions = true
+        searchEnginesManager.shouldShowFirefoxSuggestions = true
+        searchEnginesManager.shouldShowSponsoredSuggestions = true
         let subject = createSubject()
         await subject.loadFirefoxSuggestions()?.value
         await subject.loadFirefoxSuggestions()?.value
@@ -246,7 +246,7 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     func testLoad_forHistoryAndBookmarks_doesNotTriggerReloadForSameSuggestions() async throws {
-        engines.shouldShowSponsoredSuggestions = false
+        searchEnginesManager.shouldShowSponsoredSuggestions = false
         let subject = createSubject()
         XCTAssertEqual(subject.delegate?.searchData.count, 0)
         let data = ArrayCursor<Site>(data: [ Site(url: "https://example.com?mfadid=adm", title: "Test1"),
@@ -258,7 +258,7 @@ final class SearchViewModelTests: XCTestCase {
     }
 
     func testLoad_multipleTimes_doesNotTriggerReloadForSameSuggestions() async throws {
-        engines.shouldShowSponsoredSuggestions = false
+        searchEnginesManager.shouldShowSponsoredSuggestions = false
         let subject = createSubject()
         let data = ArrayCursor<Site>(data: [ Site(url: "https://example.com?mfadid=adm", title: "Test1"),
                                              Site(url: "https://example.com", title: "Test2"),
@@ -275,8 +275,8 @@ final class SearchViewModelTests: XCTestCase {
                                     [.amp: false, .ampMobile: true, .wikipedia: true])
        })
 
-        engines.shouldShowFirefoxSuggestions = false
-        engines.shouldShowSponsoredSuggestions = true
+        searchEnginesManager.shouldShowFirefoxSuggestions = false
+        searchEnginesManager.shouldShowSponsoredSuggestions = true
         let subject = createSubject()
         await subject.loadFirefoxSuggestions()?.value
 
@@ -290,8 +290,8 @@ final class SearchViewModelTests: XCTestCase {
                                     [.amp: false, .ampMobile: true, .wikipedia: true])
        })
 
-        engines.shouldShowFirefoxSuggestions = true
-        engines.shouldShowSponsoredSuggestions = false
+        searchEnginesManager.shouldShowFirefoxSuggestions = true
+        searchEnginesManager.shouldShowSponsoredSuggestions = false
         let subject = createSubject()
         await subject.loadFirefoxSuggestions()?.value
 
@@ -301,26 +301,26 @@ final class SearchViewModelTests: XCTestCase {
 
     func testQuickSearchEnginesWithSearchSuggestionsEnabled() {
         let subject = createSubject()
-        subject.searchEngines = engines
+        subject.searchEnginesManager = searchEnginesManager
         let quickSearchEngines = subject.quickSearchEngines
 
         let expectedEngineNames = ["BTester", "CTester", "DTester", "ETester", "FTester"]
 
-        XCTAssertEqual(subject.searchEngines?.defaultEngine?.shortName, "ATester")
+        XCTAssertEqual(subject.searchEnginesManager?.defaultEngine?.shortName, "ATester")
         XCTAssertEqual(quickSearchEngines.map { $0.shortName }, expectedEngineNames)
         XCTAssertEqual(quickSearchEngines.count, 5)
     }
 
     func testQuickSearchEnginesWithSearchSuggestionsDisabled() {
-        engines.shouldShowSearchSuggestions = false
+        searchEnginesManager.shouldShowSearchSuggestions = false
         let subject = createSubject()
-        subject.searchEngines = engines
+        subject.searchEnginesManager = searchEnginesManager
         let quickSearchEngines = subject.quickSearchEngines
 
         let expectedEngineNames = ["ATester", "BTester", "CTester", "DTester", "ETester", "FTester"]
 
         XCTAssertEqual(quickSearchEngines.first?.shortName, "ATester")
-        XCTAssertEqual(subject.searchEngines?.defaultEngine?.shortName, "ATester")
+        XCTAssertEqual(subject.searchEnginesManager?.defaultEngine?.shortName, "ATester")
         XCTAssertEqual(quickSearchEngines.map { $0.shortName }, expectedEngineNames)
         XCTAssertEqual(quickSearchEngines.count, 6)
     }
@@ -335,7 +335,7 @@ final class SearchViewModelTests: XCTestCase {
             isPrivate: isPrivate,
             isBottomSearchBar: isBottomSearchBar,
             profile: profile,
-            model: engines,
+            model: searchEnginesManager,
             tabManager: MockTabManager()
         )
         subject.delegate = mockDelegate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -9,7 +9,7 @@ import XCTest
 class AddressToolbarContainerModelTests: XCTestCase {
     private var viewModel: AddressToolbarContainerModel!
     private var mockProfile: MockProfile!
-    private var engines: SearchEngines!
+    private var searchEnginesManager: SearchEnginesManager!
     private let windowUUID: WindowUUID = .XCTestDefaultUUID
 
     override func setUp() {
@@ -44,7 +44,7 @@ class AddressToolbarContainerModelTests: XCTestCase {
                                                  windowUUID: windowUUID)
 
         let mockSearchEngineProvider = MockSearchEngineProvider()
-        engines = SearchEngines(
+        searchEnginesManager = SearchEnginesManager(
             prefs: mockProfile.prefs,
             files: mockProfile.files,
             engineProvider: mockSearchEngineProvider
@@ -55,23 +55,23 @@ class AddressToolbarContainerModelTests: XCTestCase {
         super.tearDown()
         viewModel = nil
         mockProfile = nil
-        engines = nil
+        searchEnginesManager = nil
     }
 
     func testSearchWordFromURLWhenUrlIsNilThenSearchWordIsNil() {
-        XCTAssertNil(viewModel.searchTermFromURL(nil, searchEngines: engines))
+        XCTAssertNil(viewModel.searchTermFromURL(nil, searchEnginesManager: searchEnginesManager))
     }
 
     func testSearchWordFromURLWhenUsingGoogleSearchThenSearchWordIsCorrect() {
         let searchTerm = "test"
         let url = URL(string: "http://firefox.com/find?q=\(searchTerm)")
-        let result = viewModel.searchTermFromURL(url, searchEngines: engines)
+        let result = viewModel.searchTermFromURL(url, searchEnginesManager: searchEnginesManager)
         XCTAssertEqual(searchTerm, result)
     }
 
     func testSearchWordFromURLWhenUsingInternalUrlThenSearchWordIsNil() {
         let searchTerm = "test"
         let url = URL(string: "internal://local?q=\(searchTerm)")
-        XCTAssertNil(viewModel.searchTermFromURL(url, searchEngines: engines))
+        XCTAssertNil(viewModel.searchTermFromURL(url, searchEnginesManager: searchEnginesManager))
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10381)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22748)

## :bulb: Description
This PR refactors the naming of the preexisting `SearchEngines` class to be called `SearchEnginesManager`, which more aptly reflects how it is being used throughout the app.

❗  _There should be no functionality changes. This PR simply renames a class, associated variables of that class type, and moves an extension into its own dedicated file._

### Background Information
The `SearchEnginesManager` documentation has also been updated to reflect what it does:
- Archives and writes to file any user-entered custom search engines
- Stores to the UserDefaults (Prefs) the user's saved ordering of search engines and disabled search engines
- Gets and sets user preferences for a number of search-related settings (e.g. shouldShowSearchSuggestions, etc.)
- Provides getters for the disabled search engines, ordered search engines, the default search engine, etc.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

