### PR TITLE
Bugfix FXIOS-10336 [Toolbar redesign] Address toolbar not respecting safe area

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbar.swift
@@ -8,8 +8,8 @@ import Foundation
 public protocol AddressToolbar {
     func configure(state: AddressToolbarState,
                    toolbarDelegate: AddressToolbarDelegate,
-                   leadingSpace: CGFloat?,
-                   trailingSpace: CGFloat?,
+                   leadingSpace: CGFloat,
+                   trailingSpace: CGFloat,
                    isUnifiedSearchEnabled: Bool)
 
     func setAutocompleteSuggestion(_ suggestion: String?)

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -76,8 +76,8 @@ public class BrowserAddressToolbar: UIView,
 
     public func configure(state: AddressToolbarState,
                           toolbarDelegate: any AddressToolbarDelegate,
-                          leadingSpace: CGFloat? = nil,
-                          trailingSpace: CGFloat? = nil,
+                          leadingSpace: CGFloat,
+                          trailingSpace: CGFloat,
                           isUnifiedSearchEnabled: Bool) {
         self.toolbarDelegate = toolbarDelegate
         configure(state: state, isUnifiedSearchEnabled: isUnifiedSearchEnabled)
@@ -142,25 +142,23 @@ public class BrowserAddressToolbar: UIView,
         toolbarBottomBorderHeightConstraint?.isActive = true
 
         leadingNavigationActionStackConstraint = navigationActionStack.leadingAnchor.constraint(
-            equalTo: toolbarContainerView.leadingAnchor,
-            constant: UX.horizontalEdgeSpace)
+            equalTo: toolbarContainerView.leadingAnchor)
         leadingNavigationActionStackConstraint?.isActive = true
 
         trailingBrowserActionStackConstraint = browserActionStack.trailingAnchor.constraint(
-            equalTo: toolbarContainerView.trailingAnchor,
-            constant: -UX.horizontalEdgeSpace)
+            equalTo: toolbarContainerView.trailingAnchor)
         trailingBrowserActionStackConstraint?.isActive = true
 
         locationContainerHeightConstraint = locationContainer.heightAnchor.constraint(equalToConstant: UX.locationHeight)
         locationContainerHeightConstraint?.isActive = true
 
         NSLayoutConstraint.activate([
-            toolbarContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            toolbarContainerView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
             toolbarContainerView.topAnchor.constraint(equalTo: toolbarTopBorderView.topAnchor,
                                                       constant: UX.verticalEdgeSpace),
             toolbarContainerView.bottomAnchor.constraint(equalTo: toolbarBottomBorderView.bottomAnchor,
                                                          constant: -UX.verticalEdgeSpace),
-            toolbarContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            toolbarContainerView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
 
             toolbarTopBorderView.leadingAnchor.constraint(equalTo: leadingAnchor),
             toolbarTopBorderView.topAnchor.constraint(equalTo: topAnchor),
@@ -236,9 +234,9 @@ public class BrowserAddressToolbar: UIView,
         updateActionSpacing()
     }
 
-    private func updateSpacing(leading: CGFloat?, trailing: CGFloat?) {
-        leadingNavigationActionStackConstraint?.constant = leading ?? UX.horizontalEdgeSpace
-        trailingBrowserActionStackConstraint?.constant = trailing ?? -UX.horizontalEdgeSpace
+    private func updateSpacing(leading: CGFloat, trailing: CGFloat) {
+        leadingNavigationActionStackConstraint?.constant = leading
+        trailingBrowserActionStackConstraint?.constant = -trailing
     }
 
     private func setZeroWidthConstraint(_ stackView: UIStackView) {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -30,8 +30,7 @@ final class AddressToolbarContainer: UIView,
                                      Autocompletable,
                                      URLBarViewProtocol {
     private enum UX {
-        static let compactLeadingEdgeEditing: CGFloat = 8
-        static let compactHorizontalEdge: CGFloat = 16
+        static let toolbarHorizontalPadding: CGFloat = 16
     }
 
     typealias SubscriberStateType = ToolbarState
@@ -67,20 +66,9 @@ final class AddressToolbarContainer: UIView,
     private var progressBarTopConstraint: NSLayoutConstraint?
     private var progressBarBottomConstraint: NSLayoutConstraint?
 
-    private func calculateToolbarSpace(isLeading: Bool) -> CGFloat? {
-        guard let toolbarState = store.state.screenState(ToolbarState.self,
-                                                         for: .toolbar,
-                                                         window: windowUUID)
-        else { return nil }
-
-        let isCompact = shouldDisplayCompact
-        let isEditing = toolbarState.addressToolbar.isEditing
-
-        if isCompact && isEditing {
-            return isLeading ? UX.compactLeadingEdgeEditing : -UX.compactHorizontalEdge
-        }
-
-        return nil
+    private func calculateToolbarSpace() -> CGFloat {
+        // Provide 0 padding in iPhone landscape due to safe area insets
+        return shouldDisplayCompact || UIDevice.current.userInterfaceIdiom == .pad ? UX.toolbarHorizontalPadding : 0
     }
 
     /// Overlay mode is the state where the lock/reader icons are hidden, the home panels are shown,
@@ -182,13 +170,13 @@ final class AddressToolbarContainer: UIView,
             updateProgressBarPosition(toolbarState.toolbarPosition)
             compactToolbar.configure(state: newModel.addressToolbarState,
                                      toolbarDelegate: self,
-                                     leadingSpace: calculateToolbarSpace(isLeading: true),
-                                     trailingSpace: calculateToolbarSpace(isLeading: false),
+                                     leadingSpace: calculateToolbarSpace(),
+                                     trailingSpace: calculateToolbarSpace(),
                                      isUnifiedSearchEnabled: isUnifiedSearchEnabled)
             regularToolbar.configure(state: newModel.addressToolbarState,
                                      toolbarDelegate: self,
-                                     leadingSpace: calculateToolbarSpace(isLeading: true),
-                                     trailingSpace: calculateToolbarSpace(isLeading: false),
+                                     leadingSpace: calculateToolbarSpace(),
+                                     trailingSpace: calculateToolbarSpace(),
                                      isUnifiedSearchEnabled: isUnifiedSearchEnabled)
 
             // the layout (compact/regular) that should be displayed is driven by the state


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10336)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22653)

## :bulb: Description
- Prevent navigation and browser actions from displaying behind the notch/dynamic island by making the address toolbar respect the safe area

| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 - 2024-10-24 at 15 52 03](https://github.com/user-attachments/assets/2baeb541-2824-41cc-8ea7-1bdbc91dd139) | ![Simulator Screenshot - iPhone 15 - 2024-10-24 at 15 52 51](https://github.com/user-attachments/assets/4b6a4415-2614-4862-b1f6-63f3eb8cdcd4) |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

