### PR TITLE
Refactor FXIOS-10387 UITests > Optimize testAutofillCreditCardsToggleOnOff() smoke test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -134,27 +134,19 @@ class CreditCardsTests: BaseTestCase {
         }
         XCTAssertEqual(saveAndFillPaymentMethodsSwitch.value! as! String, "0")
         app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].tap()
-        addCreditCard(name: "Test", cardNumber: cards[0], expirationDate: "0540")
+        let dateFiveYearsFromNow = Calendar.current.date(byAdding: .year, value: 5, to: Date())
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMyy"
+        let futureExpiryMonthYear = formatter.string(from: dateFiveYearsFromNow!)
+        addCreditCard(name: "Test", cardNumber: cards[0], expirationDate: futureExpiryMonthYear)
         if #available(iOS 16, *) {
             navigator.goto(NewTabScreen) // Not working on iOS 15
-            navigator.openURL("https://checkout.stripe.dev/preview")
+            navigator.openURL("https://mozilla.github.io/form-fill-examples/basic_cc.html")
             waitUntilPageLoad()
             // The autofill option (Use saved card prompt) is not displayed
-            let cardNumber = app.webViews["Web content"].textFields["Card number"]
-            app.swipeUp()
-            app.swipeUp()
-            mozWaitForElementToExist(cardNumber)
-            if !cardNumber.isHittable {
-                swipeUp(nrOfSwipes: 2)
-            }
-            cardNumber.tapOnApp()
-            let menuButton = AccessibilityIdentifiers.Toolbar.settingsMenuButton
-            if !app.buttons[menuButton].isHittable {
-                cardNumber.tapOnApp()
-            }
+            let cardNumber = app.webViews["Web content"].textFields["Card Number:"]
+            cardNumber.waitAndTap()
             mozWaitForElementToNotExist(app.buttons[useSavedCard])
-            dismissSavedCardsPrompt()
-            swipeDown(nrOfSwipes: 3)
             navigator.goto(CreditCardsSettings)
             unlockLoginsView()
             mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
@@ -165,13 +157,10 @@ class CreditCardsTests: BaseTestCase {
             navigator.nowAt(SettingsScreen)
             waitForExistence(app.buttons["Done"])
             app.buttons["Done"].tap()
-            app.swipeUp()
-            mozWaitForElementToExist(app.webViews["Web content"].staticTexts["Explore Checkout"], timeout: TIMEOUT)
-            mozWaitForElementToExist(cardNumber)
-            cardNumber.tapOnApp()
+            cardNumber.waitAndTap()
             // The autofill option (Use saved card prompt) is displayed
             if !app.buttons[useSavedCard].exists {
-                app.webViews["Web content"].textFields["Full name on card"].tapOnApp()
+                app.webViews["Web content"].staticTexts["Card Number:"].tap()
             }
             mozWaitForElementToExist(app.buttons[useSavedCard])
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -147,6 +147,9 @@ class CreditCardsTests: BaseTestCase {
             let cardNumber = app.webViews["Web content"].textFields["Card Number:"]
             cardNumber.waitAndTap()
             mozWaitForElementToNotExist(app.buttons[useSavedCard])
+            // If Keyboard is open, hit return button
+            let keyboardReturn = app.keyboards.buttons["return"]
+            if keyboardReturn.waitForExistence(timeout: 5) { keyboardReturn.tap() }
             navigator.goto(CreditCardsSettings)
             unlockLoginsView()
             mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
@@ -159,7 +162,7 @@ class CreditCardsTests: BaseTestCase {
             app.buttons["Done"].tap()
             cardNumber.waitAndTap()
             // The autofill option (Use saved card prompt) is displayed
-            if !app.buttons[useSavedCard].exists {
+            if !app.buttons[useSavedCard].waitForExistence(timeout: 3) {
                 app.webViews["Web content"].staticTexts["Card Number:"].tap()
             }
             mozWaitForElementToExist(app.buttons[useSavedCard])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10387)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22757)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Currently, [testAutofillCreditCardsToggleOnOff()](https://github.com/mozilla-mobile/firefox-ios/blob/main/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift#L124) uses https://checkout.stripe.dev/preview to verify the `Use saved card` functionality. As the card number is hidden down the page, there are swipe up and downs added in the test scripts to bring card number into the visible area.

I have updated the test to use mozilla's https://mozilla.github.io/form-fill-examples/basic_cc.html as i believe our main intention is to just test an input field which has `autocomplete` as `cc-number`
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#cc-number
There is no need to swipeup/down in theis website to test the card number field.

Also, i have updated the card expiry month and year to be dynamic, it will add an expiry month/year which is 5 years from now always.

Updated test passed in both iPhone 15 pro, plus and iPad simulators and it's quicker now.

Happy to update the test if there is any other context i am missing.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

