### PR TITLE
Bugfix FXIOS-10372 - Password Generator: Generated Password Clearning not functioning when logins are disabled

### DIFF
--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -263,7 +263,11 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
     private func promptSave(_ login: LoginEntry) {
         guard login.isValid.isSuccess else { return }
 
-        clearStoredPasswordAfterGeneration(origin: login.hostname)
+        if self.featureFlags.isFeatureEnabled(.passwordGenerator, checking: .buildOnly) &&
+            profile.prefs.boolForKey("saveLogins") ?? true &&
+            tab?.isPrivate == false {
+            clearStoredPasswordAfterGeneration(origin: login.hostname)
+        }
 
         let promptMessage: String
         let https = "^https:\\/\\/"

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -127,7 +127,10 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
         else { return }
 
         if self.featureFlags.isFeatureEnabled(.passwordGenerator, checking: .buildOnly) {
-            if type == "generatePassword", let tab = self.tab, !tab.isPrivate {
+            if type == "generatePassword",
+                let tab = self.tab,
+                !tab.isPrivate,
+                profile.prefs.boolForKey("saveLogins") ?? true {
                 let userDefaults = UserDefaults.standard
                 let showPasswordGeneratorClosure = {
                     let newAction = GeneralBrowserAction(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10372)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22726)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Synced with @issammani: Behaviour on desktop is to disable the password generator when saving logins is disabled

https://github.com/mozilla-mobile/firefox-ios/pull/22677#pullrequestreview-2389745220

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

