### PR TITLE
Add FXIOS-9885 - Add last hour section to history tab

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		0EC57CE52CA31E59002E3F04 /* PasswordGeneratorStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57CE42CA31E59002E3F04 /* PasswordGeneratorStateTests.swift */; };
 		0EC57D082CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57D072CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift */; };
 		0EC57D0A2CA6FCC5002E3F04 /* PasswordGeneratorPasswordFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC57D092CA6FCC5002E3F04 /* PasswordGeneratorPasswordFieldView.swift */; };
+		0ECB6B6D2CCFF718006A7C82 /* DateGroupedTableDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECB6B672CCFE663006A7C82 /* DateGroupedTableDataTests.swift */; };
 		158241282820698B00956B39 /* RustRemoteTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158241272820698B00956B39 /* RustRemoteTabsTests.swift */; };
 		15DE98FD27FCED4F00F1ECDB /* RustRemoteTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DE98FC27FCED4F00F1ECDB /* RustRemoteTabs.swift */; };
 		1BE7A4902C636AC800460798 /* URLSession+sharedMPTCP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE7A48F2C636AC800460798 /* URLSession+sharedMPTCP.swift */; };
@@ -2370,6 +2371,7 @@
 		0EC57CE42CA31E59002E3F04 /* PasswordGeneratorStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorStateTests.swift; sourceTree = "<group>"; };
 		0EC57D072CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorHeaderView.swift; sourceTree = "<group>"; };
 		0EC57D092CA6FCC5002E3F04 /* PasswordGeneratorPasswordFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorPasswordFieldView.swift; sourceTree = "<group>"; };
+		0ECB6B672CCFE663006A7C82 /* DateGroupedTableDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateGroupedTableDataTests.swift; sourceTree = "<group>"; };
 		0EEE4B2AA4EEEF77B6F992F7 /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		0F894AD0807E49799E2534E6 /* nn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nn; path = nn.lproj/Today.strings; sourceTree = "<group>"; };
 		0FB44A1B9437AF9EABCD398E /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
@@ -13818,6 +13820,7 @@
 				1D74FF4D2B27962200FF01D0 /* WindowManagerTests.swift */,
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
 				8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */,
+				0ECB6B672CCFE663006A7C82 /* DateGroupedTableDataTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -15600,6 +15603,7 @@
 				6F994AFD2AF56234008B8112 /* NetworkUtilsTests.swift in Sources */,
 				28532BEB1C472015000072D9 /* UtilsTests.swift in Sources */,
 				28532BEA1C472008000072D9 /* DeferredTests.swift in Sources */,
+				0ECB6B6D2CCFF718006A7C82 /* DateGroupedTableDataTests.swift in Sources */,
 				5A292129295CA8A900242235 /* ThemableTests.swift in Sources */,
 				39E65D271CA5B92000C63CE3 /* AsyncReducerTests.swift in Sources */,
 				E4E7EB6D1C4AED5E0094275D /* SupportUtilsTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "df5d2fcd22e3f480e3ef85bf23e277a4a0ef524d",
-        "version" : "1.2.0"
+        "revision" : "7faebca1ea4f9aaf0cda1cef7c43aecd2311ddf6",
+        "version" : "1.3.0"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "9f95b4d033a4edd3814b48608db3f2ca90c7218b",
-        "version" : "3.7.0"
+        "revision" : "21f7878f2b39d46fd8ba2b06459ccb431cdf876c",
+        "version" : "3.8.1"
       }
     },
     {

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -267,7 +267,7 @@ class HistoryPanel: UIViewController,
         if let actionableItem = item as? HistoryActionablesModel {
             switch actionableItem.itemIdentity {
             case .clearHistory:
-                isEnabled = !viewModel.groupedSites.isEmpty
+                isEnabled = !viewModel.dateGroupedSites.isEmpty
             case .recentlyClosed:
                 isEnabled = viewModel.hasRecentlyClosed
                 recentlyClosedCell = cell
@@ -498,7 +498,7 @@ class HistoryPanel: UIViewController,
         snapshot.sectionIdentifiers.forEach { section in
             if !viewModel.hiddenSections.contains(where: { $0 == section }) {
                 snapshot.appendItems(
-                    viewModel.groupedSites.itemsForSection(section.rawValue - 1),
+                    viewModel.dateGroupedSites.itemsForSection(section.rawValue - 1),
                     toSection: section
                 )
             }
@@ -514,7 +514,7 @@ class HistoryPanel: UIViewController,
                 let groupTimeInterval = TimeInterval.fromMicrosecondTimestamp(lastVisit.date)
 
                 if let groupPlacedAfterItem = (
-                    viewModel.groupedSites.itemsForSection(groupSection.rawValue - 1)
+                    viewModel.dateGroupedSites.itemsForSection(groupSection.rawValue - 1)
                 ).first(where: { site in
                     guard let lastVisit = site.latestVisit else { return false }
                     return groupTimeInterval > TimeInterval.fromMicrosecondTimestamp(lastVisit.date)
@@ -938,7 +938,7 @@ extension HistoryPanel: UITableViewDataSourcePrefetching {
     func shouldLoadRow(for indexPath: IndexPath) -> Bool {
         guard HistoryPanelSections(rawValue: indexPath.section) != .additionalHistoryActions else { return false }
 
-        return indexPath.row >= viewModel.groupedSites.numberOfItemsForSection(
+        return indexPath.row >= viewModel.dateGroupedSites.numberOfItemsForSection(
             indexPath.section - 1
         ) - historyPanelPrefetchOffset
     }

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1332,6 +1332,11 @@ extension String {
     /// Identifiers of all new strings should begin with `LibraryPanel.{PanelName}.`
     public struct LibraryPanel {
         public struct Sections {
+            public static let LastHour = MZLocalizedString(
+                key: "Last Hour",
+                tableName: nil,
+                value: "Last Hour",
+                comment: "This label is meant to signify the section containing a group of items from the past hour")
             public static let Today = MZLocalizedString(
                 key: "Today",
                 tableName: nil,

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1336,7 +1336,7 @@ extension String {
                 key: "LibraryPanel.Sections.LastHour.v134",
                 tableName: "LibraryPanel",
                 value: "Last Hour",
-                comment: "This label is meant to signify the section containing a group of items from the past hour")
+                comment: "This label is meant to signify the section containing a group of items from the past hour. This is primarily used in the history library panel when grouping sites that have been visited in the last hour.")
             public static let Today = MZLocalizedString(
                 key: "Today",
                 tableName: nil,

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -1333,8 +1333,8 @@ extension String {
     public struct LibraryPanel {
         public struct Sections {
             public static let LastHour = MZLocalizedString(
-                key: "Last Hour",
-                tableName: nil,
+                key: "LibraryPanel.Sections.LastHour.v134",
+                tableName: "LibraryPanel",
                 value: "Last Hour",
                 comment: "This label is meant to signify the section containing a group of items from the past hour")
             public static let Today = MZLocalizedString(

--- a/firefox-ios/Shared/TimeConstants.swift
+++ b/firefox-ios/Shared/TimeConstants.swift
@@ -182,6 +182,9 @@ extension Date {
 extension Date {
     public static var yesterday: Date { return Date().dayBefore }
     public static var tomorrow: Date { return Date().dayAfter }
+    public var lastHour: Date {
+        return Calendar.current.date(byAdding: .hour, value: -1, to: Date()) ?? Date()
+    }
     public var lastTwoWeek: Date {
         return Calendar.current.date(byAdding: .day, value: -14, to: noon) ?? Date()
     }
@@ -218,6 +221,10 @@ extension Date {
 
     public func isWithinLast14Days() -> Bool {
         return (Date().lastTwoWeek ... Date()).contains(self)
+    }
+
+    public func isWithinLastHour() -> Bool {
+        return (Date().lastHour ... Date()).contains(self)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DateGroupedTableDataTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DateGroupedTableDataTests.swift
@@ -1,0 +1,148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Shared
+
+final class DateGroupedTableDataTests: XCTestCase {
+    let lastHour = Date()
+    let today = Calendar.current.date(byAdding: .hour, value: -2, to: Date()) ?? Date()
+    let yesterday = Date().dayBefore
+    let lastWeek = Calendar.current.date(byAdding: .day, value: -4, to: Date()) ?? Date()
+    let lastMonth = Calendar.current.date(byAdding: .day, value: -14, to: Date()) ?? Date()
+    let older = Calendar.current.date(byAdding: .month, value: -2, to: Date()) ?? Date()
+    let customTimeStamps = [Date().lastHour.timeIntervalSince1970, Date().lastMonth.timeIntervalSince1970]
+
+    func testIncludeLastHourAddNow() {
+        var subject = DateGroupedTableData<String>(includeLastHour: true)
+        subject.add("Now", timestamp: Date().timeIntervalSince1970)
+
+        XCTAssertEqual(subject.itemsForSection(0), ["Now"])
+    }
+
+    func testAddNow() {
+        var subject = DateGroupedTableData<String>()
+        subject.add("Now", timestamp: Date().timeIntervalSince1970)
+
+        XCTAssertEqual(subject.itemsForSection(0), ["Now"])
+    }
+
+    func testAddOneHourAgo() {
+        var subject = DateGroupedTableData<String>()
+        subject.add("One Hour Ago", timestamp: lastHour.timeIntervalSince1970)
+
+        XCTAssertEqual(subject.itemsForSection(0), ["One Hour Ago"])
+    }
+
+    func testAddYesterday() {
+        var subject = DateGroupedTableData<String>()
+        subject.add("Yesterday", timestamp: yesterday.timeIntervalSince1970)
+
+        XCTAssertEqual(subject.itemsForSection(1), ["Yesterday"])
+    }
+
+    func testAddOlder() {
+        var subject = DateGroupedTableData<String>()
+        subject.add("Older", timestamp: older.timeIntervalSince1970)
+
+        XCTAssertEqual(subject.itemsForSection(4), ["Older"])
+    }
+
+    func testIncludeLastHourRemove() {
+        var subject = DateGroupedTableData<String>(includeLastHour: true)
+        subject.add("Yesterday1", timestamp: yesterday.timeIntervalSince1970)
+        subject.add("Yesterday2", timestamp: yesterday.timeIntervalSince1970)
+
+        subject.remove("Yesterday1")
+
+        XCTAssertEqual(subject.itemsForSection(2), ["Yesterday2"])
+    }
+
+    func testAllItems() {
+        var subject = DateGroupedTableData<String>(includeLastHour: true)
+        subject.add("Last Hour", timestamp: lastHour.timeIntervalSince1970)
+        subject.add("Today", timestamp: today.timeIntervalSince1970)
+        subject.add("Yesterday", timestamp: yesterday.timeIntervalSince1970)
+        subject.add("Last Week", timestamp: lastWeek.timeIntervalSince1970)
+        subject.add("Last Month", timestamp: lastMonth.timeIntervalSince1970)
+        subject.add("Older", timestamp: older.timeIntervalSince1970)
+
+        XCTAssertEqual(subject.allItems(), ["Last Hour",
+                                            "Today",
+                                            "Yesterday",
+                                            "Last Week",
+                                            "Last Month",
+                                            "Older"])
+    }
+
+    func testIsEmptySucceeds() {
+        let subject = DateGroupedTableData<String>(includeLastHour: true)
+        XCTAssertTrue(subject.isEmpty)
+    }
+
+    func testIsEmptyFails() {
+        var subject = DateGroupedTableData<String>(includeLastHour: true)
+        subject.add("Last Hour", timestamp: lastHour.timeIntervalSince1970)
+        XCTAssertFalse(subject.isEmpty)
+    }
+
+    func testNumberOfItemsForSection() {
+        var subject = DateGroupedTableData<String>(includeLastHour: true)
+        subject.add("Yesterday1", timestamp: yesterday.timeIntervalSince1970)
+        subject.add("Yesterday2", timestamp: yesterday.timeIntervalSince1970)
+
+        XCTAssertEqual(subject.numberOfItemsForSection(2), 2)
+    }
+
+    func testItemsForSection() {
+        var subject = DateGroupedTableData<String>(includeLastHour: true)
+        subject.add("Yesterday1", timestamp: yesterday.timeIntervalSince1970)
+        subject.add("Yesterday2", timestamp: yesterday.timeIntervalSince1970)
+
+        XCTAssertEqual(subject.itemsForSection(2), ["Yesterday1", "Yesterday2"])
+    }
+
+    func testCustomIntervalsCreation() {
+        let subject = DateGroupedTableData<String>(timestamps: customTimeStamps)
+
+        XCTAssertEqual(subject.timestamps.count, 2)
+        XCTAssertEqual(subject.timestampData.count, 3)
+    }
+
+    func testCustomIntervalsItemsForSection () {
+        var subject = DateGroupedTableData<String>(timestamps: customTimeStamps)
+
+        subject.add("Last Hour", timestamp: lastHour.timeIntervalSince1970)
+        subject.add("Last Month", timestamp: lastMonth.timeIntervalSince1970)
+        subject.add("Older", timestamp: older.timeIntervalSince1970)
+
+        XCTAssertEqual(subject.itemsForSection(0), ["Last Hour"])
+        XCTAssertEqual(subject.itemsForSection(1), ["Last Month"])
+        XCTAssertEqual(subject.itemsForSection(2), ["Older"])
+    }
+
+    func testCustomIntervalsAdd() {
+        var subject = DateGroupedTableData<String>(timestamps: customTimeStamps)
+
+        subject.add("Last Hour", timestamp: lastHour.timeIntervalSince1970)
+        subject.add("Last Month", timestamp: lastMonth.timeIntervalSince1970)
+        subject.add("Older", timestamp: older.timeIntervalSince1970)
+
+        XCTAssertEqual(subject.itemsForSection(0), ["Last Hour"])
+        XCTAssertEqual(subject.itemsForSection(1), ["Last Month"])
+        XCTAssertEqual(subject.itemsForSection(2), ["Older"])
+    }
+
+    func testCustomIntervalsRemove() {
+        var subject = DateGroupedTableData<String>(timestamps: customTimeStamps)
+
+        subject.add("Last Hour", timestamp: lastHour.timeIntervalSince1970)
+
+        XCTAssertEqual(subject.itemsForSection(0), ["Last Hour"])
+
+        subject.remove("Last Hour")
+
+        XCTAssertEqual(subject.itemsForSection(0), [])
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
@@ -174,7 +174,7 @@ class HistoryPanelViewModelTests: XCTestCase {
         let searchTermGroup = createSearchTermGroup(timestamp: Date().toMicrosecondsSince1970())
         XCTAssertNil(self.subject.shouldAddGroupToSections(group: searchTermGroup))
     }
-    
+
     func testGroupBelongToSection_ForLastHour() {
         let searchTermGroup = createSearchTermGroup(timestamp: Date().toMicrosecondsSince1970())
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
@@ -37,6 +37,8 @@ class HistoryPanelViewModelTests: XCTestCase {
     func testHistorySectionTitle() {
         HistoryPanelViewModel.Sections.allCases.forEach({ section in
             switch section {
+            case .lastHour:
+                XCTAssertEqual(section.title, .LibraryPanel.Sections.LastHour)
             case .today:
                 XCTAssertEqual(section.title, .LibraryPanel.Sections.Today)
             case .yesterday:
@@ -59,7 +61,7 @@ class HistoryPanelViewModelTests: XCTestCase {
         fetchHistory { success in
             XCTAssertTrue(success)
             XCTAssertNotNil(self.subject.searchTermGroups)
-            XCTAssertFalse(self.subject.groupedSites.isEmpty)
+            XCTAssertFalse(self.subject.dateGroupedSites.isEmpty)
             XCTAssertFalse(self.subject.visibleSections.isEmpty)
         }
     }
@@ -133,7 +135,7 @@ class HistoryPanelViewModelTests: XCTestCase {
             XCTAssertEqual(self.subject.hiddenSections.count, 1)
             // Starts at 0, removing the Additional section
             XCTAssertTrue(self.subject.isSectionCollapsed(sectionIndex: 0))
-            XCTAssertTrue(self.subject.hiddenSections.contains(where: { $0 == .today }))
+            XCTAssertTrue(self.subject.hiddenSections.contains(where: { $0 == .lastHour }))
         }
     }
 
@@ -146,7 +148,7 @@ class HistoryPanelViewModelTests: XCTestCase {
             XCTAssertEqual(self.subject.hiddenSections.count, 1)
             // Starts at 0, removing the Additional section
             XCTAssertTrue(self.subject.isSectionCollapsed(sectionIndex: 0))
-            XCTAssertTrue(self.subject.hiddenSections.contains(where: { $0 == .today }))
+            XCTAssertTrue(self.subject.hiddenSections.contains(where: { $0 == .lastHour }))
 
             self.subject.collapseSection(sectionIndex: 1)
             XCTAssertTrue(self.subject.hiddenSections.isEmpty)
@@ -163,7 +165,7 @@ class HistoryPanelViewModelTests: XCTestCase {
 
             XCTAssertEqual(self.subject.currentFetchOffset, 0)
             XCTAssertTrue(self.subject.searchTermGroups.isEmpty)
-            XCTAssertTrue(self.subject.groupedSites.isEmpty)
+            XCTAssertTrue(self.subject.dateGroupedSites.isEmpty)
             XCTAssertTrue(self.subject.visibleSections.isEmpty)
         }
     }
@@ -172,9 +174,22 @@ class HistoryPanelViewModelTests: XCTestCase {
         let searchTermGroup = createSearchTermGroup(timestamp: Date().toMicrosecondsSince1970())
         XCTAssertNil(self.subject.shouldAddGroupToSections(group: searchTermGroup))
     }
+    
+    func testGroupBelongToSection_ForLastHour() {
+        let searchTermGroup = createSearchTermGroup(timestamp: Date().toMicrosecondsSince1970())
+
+        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup) else {
+            XCTFail("Expected to return today section")
+            return
+        }
+
+        XCTAssertEqual(section, .lastHour)
+    }
 
     func testGroupBelongToSection_ForToday() {
-        let searchTermGroup = createSearchTermGroup(timestamp: Date().toMicrosecondsSince1970())
+        let date = Calendar.current.date(byAdding: .hour, value: -2, to: Date()) ?? Date()
+        let timestamp = date.toMicrosecondsSince1970()
+        let searchTermGroup = createSearchTermGroup(timestamp: timestamp)
 
         guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup) else {
             XCTFail("Expected to return today section")
@@ -221,7 +236,9 @@ class HistoryPanelViewModelTests: XCTestCase {
     }
 
     func testShouldAddGroupToSections_ForToday() {
-        let searchTermGroup = createSearchTermGroup(timestamp: Date().toMicrosecondsSince1970())
+        let date = Calendar.current.date(byAdding: .hour, value: -2, to: Date()) ?? Date()
+        let timestamp = date.toMicrosecondsSince1970()
+        let searchTermGroup = createSearchTermGroup(timestamp: timestamp)
         subject.visibleSections.append(.today)
 
         guard let section = self.subject.shouldAddGroupToSections(group: searchTermGroup) else {
@@ -234,12 +251,12 @@ class HistoryPanelViewModelTests: XCTestCase {
 
     // MARK: - Deletion
 
-    func testDeleteGroup_ForToday() {
+    func testDeleteGroup_ForLastHour() {
         setupSiteVisits()
 
         fetchHistory { _ in
-            XCTAssertEqual(self.subject.visibleSections[0], .today)
-            self.subject.deleteGroupsFor(dateOption: .today)
+            XCTAssertEqual(self.subject.visibleSections[0], .lastHour)
+            self.subject.deleteGroupsFor(dateOption: .lastHour)
             XCTAssertEqual(self.subject.visibleSections.count, 0)
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -439,7 +439,7 @@ class HistoryTests: BaseTestCase {
             mozWaitForElementToExist(app.tables.cells.staticTexts[entry])
         }
         mozWaitForElementToNotExist(app.staticTexts["Today"])
-        mozWaitForElementToExist(app.staticTexts["Older"])
+        mozWaitForElementToExist(app.staticTexts["Last month"])
 
         // Begin Test for Today and Yesterday
         // Visit a page to create a recent history entry.
@@ -452,7 +452,7 @@ class HistoryTests: BaseTestCase {
             XCTAssertTrue(app.tables.cells.staticTexts[entry].exists)
         }
         mozWaitForElementToNotExist(app.staticTexts["Today"])
-        mozWaitForElementToExist(app.staticTexts["Older"])
+        mozWaitForElementToExist(app.staticTexts["Last month"])
 
         // Begin Test for Everything
         // Visit a page to create a recent history entry.
@@ -464,7 +464,7 @@ class HistoryTests: BaseTestCase {
             mozWaitForElementToNotExist(app.tables.cells.staticTexts[entry])
         }
         mozWaitForElementToNotExist(app.staticTexts["Today"])
-        mozWaitForElementToNotExist(app.staticTexts["Older"])
+        mozWaitForElementToNotExist(app.staticTexts["Last month"])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306890


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9885)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21682)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The `DateGroupedTableData` struct was coupled to specific timestamps. I augmented it to be able to operate with any set of timestamps passed to it. I know that there were other places in which the struct was used and so I wasn't confident in augmenting the structure to just include last hour in every case.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

