### PR TITLE
Bugfix MTE-3647 InactiveTabsTest fails intermittently

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
@@ -132,7 +132,7 @@ final class InactiveTabsTest: BaseTestCase {
         // All inactive tabs are deleted
         navigator.nowAt(TabTray)
         mozWaitForElementToExist(app.otherElements["Tabs Tray"].staticTexts["Homepage"])
-        mozWaitForElementToExist(app.otherElements["Tabs Tray"].staticTexts["Walmart | Save Money. Live better."])
+        XCTAssertEqual(app.otherElements["Tabs Tray"].collectionViews.cells.count, 2)
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView])
         mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Google"])
         mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Facebook - log in or sign up"])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3647)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## 💡 Description

`testInactiveTabs` fails intermittently at the step checking for the presence of "Walmart" from the tab tray. Intermittently, the login page is launched (or redirected?) instead of the home page:
![Simulator Screenshot - iPhone 15 - 2024-10-28 at 14 00 55](https://github.com/user-attachments/assets/f0ae49bc-f4fc-46f5-9bf3-e5e5fcf99af1)
![Simulator Screenshot - iPhone 15 - 2024-10-28 at 14 01 08](https://github.com/user-attachments/assets/a08eee48-32d2-4cbd-9784-1f288e8bed34)

I can't figure out the cause of the page getting redirected. Let me ensure there's two active tabs on the tab tray instead. I have run the test with this change for 50 times.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

