### PR TITLE
Bugfix FXIOS-10404 Fix lock icon displaying incorrectly on homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -370,11 +370,10 @@ class TabLocationView: UIView, FeatureFlaggable {
     }
 
     func showTrackingProtectionButton(for url: URL?) {
-        guard let url else { return }
         ensureMainThread {
             let isValidHttpUrlProtocol = self.isValidHttpUrlProtocol(url)
-            let isReaderModeURL = url.isReaderModeURL
-            let isFxHomeUrl = url.isFxHomeUrl
+            let isReaderModeURL = url?.isReaderModeURL ?? false
+            let isFxHomeUrl = url?.isFxHomeUrl ?? false
             if !isFxHomeUrl, !isReaderModeURL, isValidHttpUrlProtocol, self.trackingProtectionButton.isHidden {
                 self.trackingProtectionButton.transform = UX.trackingProtectionxOffset
                 self.trackingProtectionButton.alpha = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10404)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22790)

## :bulb: Description

Summary:
- Changes were recently made to our SSL icon [here](https://github.com/mozilla-mobile/firefox-ios/pull/22474) for a security ticket.
- That update had brought over even earlier commits from a [prior WIP PR](https://github.com/mozilla-mobile/firefox-ios/pull/21573).
- One of the original commits had added a guard to `showTrackingProtectionButton`, bailing early if the url is nil

The problem is that the current code for `showTrackingProtectionButton` is slightly misleading in that it actually is responsible for hiding the lock icon for things like the homepage or some error pages. This is true even though in some cases the URL is `nil` and `isFxHomeUrl` in that func evaluates to false.

## Other Notes

- I regression-tested the original [security ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1843467) and the change here does not appear to have any impact
- This area of the codebase is brittle and needs refactoring. I will check if we have any existing tickets tracking that and if not will add a new one.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

