### PR TITLE
Refactor FXIOS-10274 Remote Tab Management: Send close tab command

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -76,10 +76,7 @@ class RemoteTabsPanelMiddleware {
     }
 
     private func getTabsAndDevices(window: WindowUUID, useCache: Bool = false) {
-        let fetchClientsAndTabs: (@escaping ([ClientAndTabs]?) -> Void) -> Void = useCache ?
-            profile.getCachedClientsAndTabs :
-            profile.getClientsAndTabs
-        fetchClientsAndTabs { result in
+        let completion = { (result: [ClientAndTabs]?) -> Void in
             guard let clientAndTabs = result else {
                 let action = RemoteTabsPanelAction(reason: .failedToSync,
                                                    windowUUID: window,
@@ -103,6 +100,12 @@ class RemoteTabsPanelMiddleware {
                                                actionType: RemoteTabsPanelActionType.refreshDidSucceed)
             }
             store.dispatch(action)
+        }
+
+        if useCache {
+            profile.getCachedClientsAndTabs(completion: completion)
+        } else {
+            profile.getClientsAndTabs(completion: completion)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -76,7 +76,7 @@ class RemoteTabsPanelMiddleware {
     }
 
     private func getTabsAndDevices(window: WindowUUID, useCache: Bool = false) {
-        let completion = { (result: [ClientAndTabs]?) -> Void in
+        let completion = { (result: [ClientAndTabs]?) in
             guard let clientAndTabs = result else {
                 let action = RemoteTabsPanelAction(reason: .failedToSync,
                                                    windowUUID: window,

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -608,17 +608,14 @@ open class BrowserProfile: Profile {
                 case .success:
                     // mark all pending tab commands as sent
                     self.tabs.setPendingCommandsSent(deviceId: deviceId)
-                case .failure(let error):
-                    switch error {
-                    case .tabsNotClosed(let urls):
-                        // mark pending tab commands as sent excluding unsentUrls
-                        self.tabs.setPendingCommandsSent(deviceId: deviceId, unsentCommandUrls: urls)
-                    default:
-                        // technically this should not be possible here as a non-tabsNotClosed error would
-                        // result after a sendTab sendEventToDevice call but we are covering this case to
-                        // make the compiler happy
-                        break
-                    }
+                case .failure(.tabsNotClosed(let urls)):
+                    // mark pending tab commands as sent excluding unsentUrls
+                    self.tabs.setPendingCommandsSent(deviceId: deviceId, unsentCommandUrls: urls)
+                default:
+                    // technically this should not be possible here as a non-tabsNotClosed error would
+                    // result after a sendTab sendEventToDevice call but we are covering this case to
+                    // make the compiler happy
+                    break
                 }
             }
         }

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustRemoteTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustRemoteTabsTests.swift
@@ -139,132 +139,61 @@ class RustRemoteTabsTests: XCTestCase {
     }
 
     func testAddRemoteCommand() {
-        mockTabs.tabsCommandQueue?.getUnsentCommands { getResult in
-            switch getResult {
-            case .success(let commands):
-                // checking that the command queue is empty
-                XCTAssert(commands.isEmpty)
+        let commands = mockTabs.tabsCommandQueue!.getUnsentCommands()
+        XCTAssert(commands.isEmpty)
 
-                // adding the record to the command queue
-                let deviceId = "AAAAAA"
-                let url = "https://test.com"
-                self.mockTabs.tabsCommandQueue?.addRemoteCommand(deviceId: deviceId,
-                                                                 command: .closeTab(url: url)) { addResult in
-                    switch addResult {
-                    case .success(let didAddCommand):
-                        XCTAssert(didAddCommand)
+        // adding the record to the command queue
+        let deviceId = "AAAAAA"
+        let url = "https://test.com"
+        self.mockTabs.tabsCommandQueue?.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url))
 
-                        // checking that the command queue has the added record
-                        self.mockTabs.tabsCommandQueue?.getUnsentCommands { getResult2 in
-                            switch getResult2 {
-                            case .success(let commands2):
-                                XCTAssertEqual(commands2.count, 1)
-                                XCTAssertEqual(commands2[0].deviceId, deviceId)
-                            case .failure(let error):
-                                XCTFail("Expected to get unsent commands successfully after add \(error)")
-                            }
-                        }
-                    case .failure(let error):
-                        XCTFail("Expected to add a command successfully \(error)")
-                    }
-                }
-            case .failure(let error):
-                XCTFail("Expected to get unsent commands successfully \(error)")
-            }
-        }
+        // checking that the command queue has the added record
+        let commands2 = self.mockTabs.tabsCommandQueue!.getUnsentCommands()
+        XCTAssertEqual(commands2.count, 1)
+        XCTAssertEqual(commands2[0].deviceId, deviceId)
     }
 
     func testRemoveRemoteCommand() {
         // adding the record to the command queue
         let deviceId = "BBBBBB"
         let url = "https://test.com"
+        self.mockTabs.tabsCommandQueue!.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url))
 
-        self.mockTabs.tabsCommandQueue?.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url)) { addResult in
-            switch addResult {
-            case .success(let didAddCommand):
-                XCTAssertTrue(didAddCommand)
+        // checking that the command queue has the added record
+        let commands = self.mockTabs.tabsCommandQueue!.getUnsentCommands()
 
-                // checking that the command queue has the added record
-                self.mockTabs.tabsCommandQueue?.getUnsentCommands { getResult in
-                    switch getResult {
-                    case .success(let commands):
-                        XCTAssertEqual(commands.count, 1)
-                        XCTAssertEqual(commands[0].deviceId, deviceId)
+        XCTAssertEqual(commands.count, 1)
+        XCTAssertEqual(commands[0].deviceId, deviceId)
 
-                        // removing the record from the command queue
-                        self.mockTabs.tabsCommandQueue?.removeRemoteCommand(deviceId: deviceId,
-                                                                            command: .closeTab(url: url)) { removeResult in
-                            switch removeResult {
-                            case .success(let didRemove):
-                                XCTAssert(didRemove)
+        // removing the record from the command queue
+        self.mockTabs.tabsCommandQueue!.removeRemoteCommand(deviceId: deviceId, command: .closeTab(url: url))
 
-                                // checking that record is removed from command queue
-                                self.mockTabs.tabsCommandQueue?.getUnsentCommands { getResult2 in
-                                    switch getResult2 {
-                                    case .success(let commands2):
-                                        XCTAssert(commands2.isEmpty)
-                                    case .failure(let error):
-                                        XCTFail("Expected to get unsent commands after remove successfully \(error)")
-                                    }
-                                }
-                            case .failure(let error):
-                                XCTFail("Expected to remove command successfully \(error)")
-                            }
-                        }
-                    case .failure(let error):
-                        XCTFail("Expected to get unsent commands successfully \(error)")
-                    }
-                }
-            case .failure(let error):
-                XCTFail("Expected to add a command successfully \(error)")
-            }
-        }
+        // checking that record is removed from command queue
+        let commands2 = self.mockTabs.tabsCommandQueue!.getUnsentCommands()
+        XCTAssert(commands2.isEmpty)
     }
 
     func testSetPendingCommandsSent() {
         // adding the record to the command queue
         let deviceId = "CCCCC"
         let url = "https://test.com"
+        mockTabs.tabsCommandQueue!.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url))
 
-        mockTabs.tabsCommandQueue?.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url)) { addResult in
-            switch addResult {
-            case .success(let didAddCommand):
-                XCTAssertTrue(didAddCommand)
+        // retrieving unsent commands
+        let commands = self.mockTabs.tabsCommandQueue!.getUnsentCommands()
+        XCTAssertEqual(commands.count, 1)
+        XCTAssertEqual(commands[0].deviceId, deviceId)
 
-                // retrieving unsent commands
-                self.mockTabs.tabsCommandQueue?.getUnsentCommands { getResult in
-                    switch getResult {
-                    case .success(let commands):
-                        XCTAssertEqual(commands.count, 1)
-                        XCTAssertEqual(commands[0].deviceId, deviceId)
+        // setting command as sent
+        let command = PendingCommand(deviceId: deviceId,
+                                     command: .closeTab(url: url),
+                                     timeRequested: Date().toMillisecondsSince1970(),
+                                     timeSent: nil)
+        self.mockTabs.tabsCommandQueue!.setPendingCommandsSent(deviceId: deviceId, commands: [command])
 
-                        // setting command as sent
-                        let command = PendingCommand(deviceId: deviceId,
-                                                     command: .closeTab(url: url),
-                                                     timeRequested: Date().toMillisecondsSince1970(),
-                                                     timeSent: nil)
-                        self.mockTabs.tabsCommandQueue?.setPendingCommandsSent(deviceId: deviceId,
-                                                                               commands: [command]) { errors in
-                            XCTAssert(errors.isEmpty)
-
-                            // retrieving unsent commands
-                            self.mockTabs.tabsCommandQueue?.getUnsentCommands { getResult2 in
-                                switch getResult2 {
-                                case .success(let commands):
-                                    XCTAssert(commands.isEmpty)
-                                case .failure(let error):
-                                    XCTFail("Expected to retrieve unsent commands successfully \(error)")
-                                }
-                            }
-                        }
-                    case .failure(let error):
-                        XCTFail("Expected to retrieve added unsent command successfully \(error)")
-                    }
-                }
-            case .failure(let error):
-                XCTFail("Expected to add a command successfully \(error)")
-            }
-        }
+         // retrieving unsent commands
+        let commands2 = self.mockTabs.tabsCommandQueue!.getUnsentCommands()
+        XCTAssert(commands2.isEmpty)
     }
 
     func testGetUnsentCommandUrlsByDeviceId() {
@@ -272,32 +201,16 @@ class RustRemoteTabsTests: XCTestCase {
         let deviceId = "DDDD"
         let url = "https://test.com"
         let url2 = "https://test2.com"
+        mockTabs.tabsCommandQueue!.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url))
 
-        mockTabs.tabsCommandQueue?.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url)) { addResult in
-            switch addResult {
-            case .success(let didAddCommand):
-                XCTAssert(didAddCommand)
+        // adding another record to the command queue
+        self.mockTabs.tabsCommandQueue!.addRemoteCommand(deviceId: deviceId, command: .closeTab(url: url2))
 
-                // adding another record to the command queue
-                self.mockTabs.tabsCommandQueue?.addRemoteCommand(deviceId: deviceId,
-                                                                 command: .closeTab(url: url2)) { addResult2 in
-                    switch addResult2 {
-                    case .success(let didAddCommit2):
-                        XCTAssert(didAddCommit2)
-
-                        // getting unsent command urls
-                        self.mockTabs.getUnsentCommandUrlsByDeviceId(deviceId: deviceId) { urls in
-                            XCTAssertEqual(urls.count, 2)
-                            XCTAssert(urls.contains(url))
-                            XCTAssert(urls.contains(url2))
-                        }
-                    case .failure(let error):
-                        XCTFail("Expected to add second command successfully \(error)")
-                    }
-                }
-            case .failure(let error):
-                XCTFail("Expected to add a command succesfully \(error)")
-            }
+        // getting unsent command urls
+        self.mockTabs.getUnsentCommandUrlsByDeviceId(deviceId: deviceId) { urls in
+            XCTAssertEqual(urls.count, 2)
+            XCTAssert(urls.contains(url))
+            XCTAssert(urls.contains(url2))
         }
     }
 
@@ -315,7 +228,7 @@ class RustRemoteTabsTests: XCTestCase {
                                       timeSent: nil)
         let commands = [command1, command2]
 
-        let sentCommands = mockTabs.getSentCommands(unsentCommandUrls: unsentCommandUrls, commands: commands)
+        let sentCommands = filterSentCommands(unsentCommandUrls: unsentCommandUrls, commands: commands)
 
         XCTAssertEqual(sentCommands.count, 1)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR addresses non-blocking code review feedback in #22156. I've attempted to organize the commits in a way that makes it easier to map my changes to the comments. In summary, this PR does the following:
- Refactors the `RemoteTabsPanelMiddleware.swift.getTabsAndDevices` function to circumvent ambiguous variable naming
- Updates the logic to accurately mark successfully executed close tab commands as sent
- Refactors the `RustRemoteTabs` command queue logic to remove global dispatch queue usage, clean up the command queue initialization logic, and clarify how the `addRemoteCommand` function is handling errors
- Adds a test to cover new logic

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

