### PR TITLE
Add MTE-3746 Firefox Shortcuts widgets Tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
@@ -108,6 +107,7 @@ private func checkFirefoxShortcutsOptions() {
     )
 }
 
+// swiftlint:disable:next type_body_length
 class TodayWidgetTests: BaseTestCase {
     private func removeFirefoxWidget() {
         let maxSwipes = 3
@@ -129,11 +129,9 @@ class TodayWidgetTests: BaseTestCase {
         }
         // Attempt to press and hold on any of the Firefox widget elements
         var widgetFound = false
-        for label in widgetLabels {
-            if pressAndHoldWidget(matching: label) {
+        for label in widgetLabels where pressAndHoldWidget(matching: label) {
                 widgetFound = true
                 break
-            }
         }
 
         guard widgetFound else {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -139,17 +139,17 @@ class TodayWidgetTests: BaseTestCase {
                 return
         }
         if #unavailable(iOS 16) {
-            mozWaitElementHittable(element: springboard.buttons["Remove Widget"], timeout: 5)
+            mozWaitElementHittable(element: springboard.buttons["Remove Widget"], timeout: TIMEOUT)
             springboard.buttons["Remove Widget"].tap()
         } else {
-            mozWaitElementHittable(element: springboard.buttons[removeWidgetButton], timeout: 5)
+            mozWaitElementHittable(element: springboard.buttons[removeWidgetButton], timeout: TIMEOUT)
             springboard.buttons[removeWidgetButton].tap()
         }
 
         mozWaitForElementToExist(springboard.alerts.buttons["Remove"])
         mozWaitForElementToExist(springboard.alerts.buttons["Cancel"])
 
-        mozWaitElementHittable(element: springboard.alerts.buttons["Remove"], timeout: 5)
+        mozWaitElementHittable(element: springboard.alerts.buttons["Remove"], timeout: TIMEOUT)
         springboard.alerts.buttons["Remove"].tap()
     }
 
@@ -205,13 +205,13 @@ class TodayWidgetTests: BaseTestCase {
             pressAndHoldWidget(matching: "Firefox")
         }
 
-        mozWaitElementHittable(element: springboard.buttons[removeWidgetButton], timeout: 5)
+        mozWaitElementHittable(element: springboard.buttons[removeWidgetButton], timeout: TIMEOUT)
         springboard.buttons[removeWidgetButton].tap()
 
         mozWaitForElementToExist(springboard.alerts.buttons["Remove"])
         mozWaitForElementToExist(springboard.alerts.buttons["Cancel"])
 
-        mozWaitElementHittable(element: springboard.alerts.buttons["Remove"], timeout: 5)
+        mozWaitElementHittable(element: springboard.alerts.buttons["Remove"], timeout: TIMEOUT)
         springboard.alerts.buttons["Remove"].tap()
     }
 
@@ -252,7 +252,7 @@ class TodayWidgetTests: BaseTestCase {
 
     private func tapOnWidget(widgetType: String) {
         let widget = springboard.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", widgetType)).element
-        mozWaitElementHittable(element: widget, timeout: 10)
+        mozWaitElementHittable(element: widget, timeout: TIMEOUT)
         widget.tap()
     }
 
@@ -280,7 +280,7 @@ class TodayWidgetTests: BaseTestCase {
             mozWaitForElementToExist(springboard.buttons["Add Widget"])
             springboard.buttons["Add Widget"].tap()
         }
-        mozWaitElementHittable(element: springboard.searchFields["Search Widgets"], timeout: 5)
+        mozWaitElementHittable(element: springboard.searchFields["Search Widgets"], timeout: TIMEOUT)
         springboard.searchFields["Search Widgets"].tap()
         springboard.searchFields["Search Widgets"].typeText(widgetName)
         let predicate = NSPredicate(format: "label CONTAINS[c] %@", widgetName+" (")
@@ -302,7 +302,7 @@ class TodayWidgetTests: BaseTestCase {
 
     private func addAndSearchForWidget(widgetName: String) {
         addWidget(widgetName: widgetName)
-        mozWaitElementHittable(element: springboard.searchFields["Search Widgets"], timeout: 5)
+        mozWaitElementHittable(element: springboard.searchFields["Search Widgets"], timeout: TIMEOUT)
         springboard.searchFields["Search Widgets"].tap()
         springboard.searchFields["Search Widgets"].typeText(widgetName)
         let predicate = NSPredicate(format: "label CONTAINS[c] %@", widgetName + " (")
@@ -337,7 +337,7 @@ class TodayWidgetTests: BaseTestCase {
         } else {
             springboard.buttons[editWidgetButton].tap()
         }
-        mozWaitElementHittable(element: newSearch, timeout: 5)
+        mozWaitElementHittable(element: newSearch, timeout: TIMEOUT)
         newSearch.tap()
         // Verify widget actions
         if #unavailable(iOS 17) {
@@ -399,7 +399,7 @@ class TodayWidgetTests: BaseTestCase {
         } else {
             springboard.buttons[editWidgetButton].tap()
         }
-        mozWaitElementHittable(element: newSearch, timeout: 5)
+        mozWaitElementHittable(element: newSearch, timeout: TIMEOUT)
         newSearch.tap()
         if #unavailable(iOS 17) {
             if #available(iOS 16, *) {
@@ -410,12 +410,12 @@ class TodayWidgetTests: BaseTestCase {
             }
         }
         // Verify the existence of New Search-related buttons
-        mozWaitForElementToExist(goToCopiedLink, timeout: 5)
+        mozWaitForElementToExist(goToCopiedLink, timeout: TIMEOUT)
         XCTAssertTrue(goToCopiedLink.exists, "Go to Copied Link button not found.")
         XCTAssertTrue(newPrivateSearch.exists, "New Private Search button not found.")
         XCTAssertTrue(clearPrivateTabs.exists, "Clear Private Tabs button not found.")
         // Start a new private search
-        mozWaitElementHittable(element: newPrivateSearch, timeout: 5)
+        mozWaitElementHittable(element: newPrivateSearch, timeout: TIMEOUT)
         newPrivateSearch.tap()
         // Tap outside the alert to dismiss it
         mozWaitForElementToExist(newPrivateSearch)
@@ -426,7 +426,7 @@ class TodayWidgetTests: BaseTestCase {
         tapOnWidget(widgetType: "Private Tab")
         // Handle different UI behavior on iPad and iPhone
         if !iPad() {
-            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: 10)
+            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
             app.buttons["CloseButton"].tap()
         }
         // Verify the presence of Private Mode message
@@ -471,7 +471,7 @@ class TodayWidgetTests: BaseTestCase {
         } else {
             springboard.buttons[editWidgetButton].tap()
         }
-        mozWaitElementHittable(element: newSearch, timeout: 3)
+        mozWaitElementHittable(element: newSearch, timeout: TIMEOUT)
         newSearch.tap()
         if #unavailable(iOS 17) {
             if #available(iOS 16, *) {
@@ -482,12 +482,12 @@ class TodayWidgetTests: BaseTestCase {
             }
         }
         // Ensure the Go To Copied Link option exists
-        mozWaitForElementToExist(goToCopiedLink, timeout: 3)
+        mozWaitForElementToExist(goToCopiedLink, timeout: TIMEOUT)
         XCTAssertTrue(goToCopiedLink.exists, "Go To Copied Link button not found.")
         XCTAssertTrue(newPrivateSearch.exists, "New Private Search button not found.")
         XCTAssertTrue(clearPrivateTabs.exists, "Clear Private Tabs button not found.")
         // Tap Go To Copied Link
-        mozWaitElementHittable(element: goToCopiedLink, timeout: 3)
+        mozWaitElementHittable(element: goToCopiedLink, timeout: TIMEOUT)
         goToCopiedLink.tap()
         // Tap outside the alert to close it
         coordinate.tap()
@@ -498,19 +498,17 @@ class TodayWidgetTests: BaseTestCase {
         tapOnWidget(widgetType: "Copied Link")
         // Handle paste alert
         if #available(iOS 16, *) {
-            mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: 3)
+            mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: TIMEOUT)
             springboard.alerts.buttons["Allow Paste"].tap()
         }
-        // mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: 3)
-        // springboard.alerts.buttons["Allow Paste"].tap()
         // Handle iPad/iPhone UI differences
         if !iPad() {
-            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: 10)
+            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
             app.buttons["CloseButton"].tap()
         }
         // Verify the copied string is in the URL field
-        mozWaitForElementToExist(app.textFields["url"], timeout: 10)
-        mozWaitForValueContains(app.textFields["url"], value: copiedString, timeout: 5)
+        mozWaitForElementToExist(app.textFields["url"], timeout: TIMEOUT)
+        mozWaitForValueContains(app.textFields["url"], value: copiedString, timeout: TIMEOUT)
         guard let urlField = app.textFields["url"].value as? String else {
             XCTFail("Expected value to be a String but found \(type(of: app.textFields["url"].value))")
             return
@@ -577,12 +575,12 @@ class TodayWidgetTests: BaseTestCase {
         checkFirefoxShortcutsOptions()
         mozWaitElementHittable(element: springboard.buttons.matching(
             NSPredicate(format: "label CONTAINS[c] %@", "Private Tab")
-        ).element.firstMatch, timeout: 5)
+        ).element.firstMatch, timeout: TIMEOUT)
         springboard.buttons.matching(NSPredicate(
             format: "label CONTAINS[c] %@", "Private Tab")
         ).element.firstMatch.tap()
         if !iPad() {
-            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: 10)
+            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
             app.buttons["CloseButton"].tap()
         }
         // Verify the presence of Private Mode message
@@ -625,21 +623,21 @@ class TodayWidgetTests: BaseTestCase {
         checkFirefoxShortcutsOptions()
         mozWaitElementHittable(element: springboard.buttons.matching(
             NSPredicate(format: "label CONTAINS[c] %@", "Copied Link")
-        ).element, timeout: 5)
+        ).element, timeout: TIMEOUT)
         springboard.buttons.matching(NSPredicate(
             format: "label CONTAINS[c] %@", "Copied Link")
         ).element.tap()
         if #available(iOS 16, *) {
-            mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: 3)
+            mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: TIMEOUT)
             springboard.alerts.buttons["Allow Paste"].tap()
         }
         // Verify the copied string is in the URL field
         if !iPad() {
-            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: 10)
+            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
             app.buttons["CloseButton"].tap()
         }
-        mozWaitForElementToExist(app.textFields["url"], timeout: 10)
-        mozWaitForValueContains(app.textFields["url"], value: copiedString, timeout: 5)
+        mozWaitForElementToExist(app.textFields["url"], timeout: TIMEOUT)
+        mozWaitForValueContains(app.textFields["url"], value: copiedString, timeout: TIMEOUT)
         guard let urlField = app.textFields["url"].value as? String else {
             XCTFail("Expected value to be a String but found \(type(of: app.textFields["url"].value))")
             return

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable type_body_length
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
@@ -11,10 +12,10 @@ let editHomeScreenButton = "com.apple.springboardhome.application-shortcut-item.
 let removeWidgetButton = "com.apple.springboardhome.application-shortcut-item.remove-widget"
 
 // Widget Buttons Identifier
-let goToCopiedLink = springboard.buttons["Go to Copied Link"]
-let newPrivateSearch = springboard.buttons["New Private Search"]
-let newSearch = springboard.buttons["New Search"]
-let clearPrivateTabs = springboard.buttons["Clear Private Tabs"]
+var goToCopiedLink = springboard.buttons["Go to Copied Link"]
+var newPrivateSearch = springboard.buttons["New Private Search"]
+var newSearch = springboard.buttons["New Search"]
+var clearPrivateTabs = springboard.buttons["Clear Private Tabs"]
 
 // Widget coordinates
 let normalized = springboard.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
@@ -30,54 +31,96 @@ let centerRightY = screenSize.height / 2
 let coordinate = springboard.coordinate(withNormalizedOffset: CGVector(
     dx: centerRightX / screenSize.width, dy: centerRightY / screenSize.height))
 
-class TodayWidgetTests: BaseTestCase {
-    enum SwipeDirection {
-        case swipeUp
-        case swipeRight
-    }
+// Functions
+enum SwipeDirection {
+    case swipeUp
+    case swipeRight
+}
 
-    private func widgetExist() -> Bool {
-        let firefoxWidgetButton = springboard
-            .buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Firefox")).element.exists
-        let firefoxWidgetSecureSearchButton = springboard
-            .buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Private Tab")).element.exists
-        let firefoxCopiedLinkWidget = springboard.buttons
-            .matching(NSPredicate(format: "label CONTAINS[c] %@", "Copied Link")).element.exists
-        return firefoxWidgetButton || firefoxWidgetSecureSearchButton || firefoxCopiedLinkWidget
-    }
+private func widgetExist() -> Bool {
+    let firefoxWidgetButton = springboard
+        .buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Firefox")).element.exists
+    let firefoxWidgetSecureSearchButton = springboard
+        .buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Private Tab")).element.exists
+    let firefoxCopiedLinkWidget = springboard.buttons
+        .matching(NSPredicate(format: "label CONTAINS[c] %@", "Copied Link")).element.exists
+    return firefoxWidgetButton || firefoxWidgetSecureSearchButton || firefoxCopiedLinkWidget
+}
 
-    private func checkPresenceFirefoxWidget() -> Bool {
-        let maxSwipes = 3
-        var firefoxWidgetExists = false
-        var numberOfSwipes = 0
-
-        // Initial check for widget presence
-        if widgetExist() {
-            firefoxWidgetExists = true
-        } else {
-            // Perform swipe up until the widget is found or maxSwipes reached
-            while !springboard.buttons["Edit"].exists && numberOfSwipes < maxSwipes {
-                springboard.swipeUp()
-                if widgetExist() {
-                    firefoxWidgetExists = true
-                    break
-                }
-                numberOfSwipes += 1
-            }
+private func goToTodayWidgetPage() {
+    // Swipe right until the "Screen Time" icon appears
+    if #unavailable(iOS 16) {
+        while !springboard.textFields["SpotlightSearchField"].exists {
+            springboard.swipeRight()
         }
+    } else {
+        while !springboard.icons["Screen Time"].exists {
+            springboard.swipeRight()
+        }
+    }
+}
 
-        return firefoxWidgetExists
+private func checkPresenceFirefoxWidget() -> Bool {
+    let maxSwipes = 3
+    var firefoxWidgetExists = false
+    var numberOfSwipes = 0
+
+    // Initial check for widget presence
+    if widgetExist() {
+        firefoxWidgetExists = true
+    } else {
+        // Perform swipe up until the widget is found or maxSwipes reached
+        while !springboard.buttons["Edit"].exists && numberOfSwipes < maxSwipes {
+            springboard.swipeUp()
+            if widgetExist() {
+                firefoxWidgetExists = true
+                break
+            }
+            numberOfSwipes += 1
+        }
     }
 
+    return firefoxWidgetExists
+}
+
+private func checkFirefoxShortcutsOptions() {
+    let maxSwipes = 3
+    var swipeCount = 0
+    while !springboard.buttons["Edit"].exists && swipeCount < maxSwipes {
+        springboard.swipeUp()
+        swipeCount += 1
+    }
+    XCTAssertTrue(springboard.buttons.matching(
+        NSPredicate(format: "label CONTAINS[c] %@", "Firefox")).element.exists,
+                  "Search in Firefox Option doesn't exist"
+    )
+    XCTAssertTrue(springboard.buttons.matching(
+        NSPredicate(format: "label CONTAINS[c] %@", "Private Tab")).element.exists,
+                  "Search in Private Tab Option doesn't exist"
+    )
+    XCTAssertTrue(springboard.buttons.matching(
+        NSPredicate(format: "label CONTAINS[c] %@", "Private Tabs")).element.exists,
+                  "Close Private Tabs option doesn't exist"
+    )
+    XCTAssertTrue(springboard.buttons.matching(
+        NSPredicate(format: "label CONTAINS[c] %@", "Copied Link")).element.exists,
+                  "Go to copied link option doesn't exist"
+    )
+}
+
+class TodayWidgetTests: BaseTestCase {
     private func removeFirefoxWidget() {
         let maxSwipes = 3
         var numberOfSwipes = 0
+        let widgetLabels = ["Firefox", "Private Tab", "Copied Link"]
         // Function to press and hold on a widget if it exists
-        func pressAndHoldWidget(matching label: String) {
+        func pressAndHoldWidget(matching label: String) -> Bool {
             let widget = springboard.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", label)).element
             if widget.exists {
                 widget.press(forDuration: 1)
+                return true
             }
+            return false
         }
         // Swipe up until the "Edit" button is visible or maxSwipes is reached
         while !springboard.buttons["Edit"].exists && numberOfSwipes < maxSwipes {
@@ -85,12 +128,25 @@ class TodayWidgetTests: BaseTestCase {
             numberOfSwipes += 1
         }
         // Attempt to press and hold on any of the Firefox widget elements
-        pressAndHoldWidget(matching: "Firefox")
-        pressAndHoldWidget(matching: "Private Tab")
-        pressAndHoldWidget(matching: "Copied Link")
+        var widgetFound = false
+        for label in widgetLabels {
+            if pressAndHoldWidget(matching: label) {
+                widgetFound = true
+                break
+            }
+        }
 
-        mozWaitElementHittable(element: springboard.buttons[removeWidgetButton], timeout: 5)
-        springboard.buttons[removeWidgetButton].tap()
+        guard widgetFound else {
+                XCTFail("Firefox widget not found")
+                return
+        }
+        if #unavailable(iOS 16) {
+            mozWaitElementHittable(element: springboard.buttons["Remove Widget"], timeout: 5)
+            springboard.buttons["Remove Widget"].tap()
+        } else {
+            mozWaitElementHittable(element: springboard.buttons[removeWidgetButton], timeout: 5)
+            springboard.buttons[removeWidgetButton].tap()
+        }
 
         mozWaitForElementToExist(springboard.alerts.buttons["Remove"])
         mozWaitForElementToExist(springboard.alerts.buttons["Cancel"])
@@ -122,6 +178,45 @@ class TodayWidgetTests: BaseTestCase {
         XCTAssertTrue(quickActionExists, "Failed to find 'Quick Actions' after swiping back.")
     }
 
+    private func removeFirefoxShortcutWidget() {
+        let maxSwipes = 3
+        var numberOfSwipes = 0
+        // Function to press and hold on a widget if it exists
+        func pressAndHoldWidget(matching label: String) {
+            let widget = springboard.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", label)).element
+            if widget.exists {
+                widget.press(forDuration: 1)
+            }
+        }
+        // Swipe up until the "Edit" button is visible or maxSwipes is reached
+        while !springboard.buttons["Edit"].exists && numberOfSwipes < maxSwipes {
+            springboard.swipeUp()
+            numberOfSwipes += 1
+        }
+
+        let firefoxSearchOption = springboard.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", "Firefox")).element.exists
+        let firefoxPrivateSearchOption = springboard.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", "Private Tab")).element.exists
+        let firefoxClearPrivateTabsOption = springboard.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", "Private Tabs")).element.exists
+        let firefoxCopiedLinkOptions = springboard.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", "Copied Link")).element.exists
+        if firefoxSearchOption && firefoxPrivateSearchOption &&
+            firefoxClearPrivateTabsOption && firefoxCopiedLinkOptions {
+            pressAndHoldWidget(matching: "Firefox")
+        }
+
+        mozWaitElementHittable(element: springboard.buttons[removeWidgetButton], timeout: 5)
+        springboard.buttons[removeWidgetButton].tap()
+
+        mozWaitForElementToExist(springboard.alerts.buttons["Remove"])
+        mozWaitForElementToExist(springboard.alerts.buttons["Cancel"])
+
+        mozWaitElementHittable(element: springboard.alerts.buttons["Remove"], timeout: 5)
+        springboard.alerts.buttons["Remove"].tap()
+    }
+
     private func checkFirefoxWidgetOptions() {
         let maxSwipes = 3
         var swipeCount = 0
@@ -133,15 +228,14 @@ class TodayWidgetTests: BaseTestCase {
         // Long press on the Firefox widget
         longPressOnWidget(widgetType: "Firefox", duration: 1)
         // Assert the presence of widget options
-        XCTAssertTrue(springboard.buttons[removeWidgetButton].exists, "Remove Widget option not found.")
-        XCTAssertTrue(springboard.buttons[editHomeScreenButton].exists, "Edit Home Screen option not found.")
-        XCTAssertTrue(springboard.buttons[editWidgetButton].exists, "Edit Widget option not found.")
-    }
-
-    private func goToTodayWidgetPage() {
-        // Swipe right until the "Screen Time" icon appears
-        while !springboard.icons["Screen Time"].exists {
-            springboard.swipeRight()
+        if #unavailable(iOS 16) {
+            XCTAssertTrue(springboard.buttons["Edit Widget"].exists, "Edit Widget option not found.")
+            XCTAssertTrue(springboard.buttons["Edit Home Screen"].exists, "Edit Home Screen option not found.")
+            XCTAssertTrue(springboard.buttons["Remove Widget"].exists, "Remove Widget option not found.")
+        } else {
+            XCTAssertTrue(springboard.buttons[removeWidgetButton].exists, "Remove Widget option not found.")
+            XCTAssertTrue(springboard.buttons[editHomeScreenButton].exists, "Edit Home Screen option not found.")
+            XCTAssertTrue(springboard.buttons[editWidgetButton].exists, "Edit Widget option not found.")
         }
     }
 
@@ -160,7 +254,7 @@ class TodayWidgetTests: BaseTestCase {
 
     private func tapOnWidget(widgetType: String) {
         let widget = springboard.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", widgetType)).element
-        mozWaitElementHittable(element: widget, timeout: 5)
+        mozWaitElementHittable(element: widget, timeout: 10)
         widget.tap()
     }
 
@@ -202,18 +296,6 @@ class TodayWidgetTests: BaseTestCase {
         widget.tap()
     }
 
-    private func swipeUntilExists(element: XCUIElement, maxSwipes: Int = 3, direction: SwipeDirection = .swipeUp) {
-        var swipes = 0
-        while !element.exists && swipes < maxSwipes {
-            if direction == .swipeUp {
-                springboard.swipeUp()
-            } else {
-                springboard.swipeRight()
-            }
-            swipes += 1
-        }
-    }
-
     private func removeWidgetIfExists(widgetType: String) {
         if checkPresenceFirefoxWidget() {
             removeFirefoxWidget()
@@ -252,16 +334,29 @@ class TodayWidgetTests: BaseTestCase {
         // Check Quick Action widget options
         checkFirefoxWidgetOptions()
         // Edit Widget and check the options
-        springboard.buttons[editWidgetButton].tap()
+        if #unavailable(iOS 16) {
+            springboard.buttons["Edit Widget"].tap()
+        } else {
+            springboard.buttons[editWidgetButton].tap()
+        }
         mozWaitElementHittable(element: newSearch, timeout: 5)
         newSearch.tap()
         // Verify widget actions
+        if #unavailable(iOS 17) {
+            if #available(iOS 16, *) {
+                goToCopiedLink = springboard.staticTexts["Go to Copied Link"]
+                newPrivateSearch = springboard.staticTexts["New Private Search"]
+                newSearch = springboard.staticTexts["New Search"]
+                clearPrivateTabs = springboard.staticTexts["Clear Private Tabs"]
+            }
+        }
         mozWaitForElementToExist(goToCopiedLink)
         XCTAssertTrue(goToCopiedLink.exists)
         XCTAssertTrue(newPrivateSearch.exists)
         XCTAssertTrue(clearPrivateTabs.exists)
         newSearch.tap()
         // Tap outside alert to close it
+        mozWaitForElementToExist(newSearch)
         coordinate.tap()
         // Check New Search action
         tapOnWidget(widgetType: "Firefox")
@@ -301,9 +396,21 @@ class TodayWidgetTests: BaseTestCase {
         // Verify options available in the Quick Action Widget
         checkFirefoxWidgetOptions()
         // Edit widget and interact with options
-        springboard.buttons[editWidgetButton].tap()
+        if #unavailable(iOS 16) {
+            springboard.buttons["Edit Widget"].tap()
+        } else {
+            springboard.buttons[editWidgetButton].tap()
+        }
         mozWaitElementHittable(element: newSearch, timeout: 5)
         newSearch.tap()
+        if #unavailable(iOS 17) {
+            if #available(iOS 16, *) {
+                goToCopiedLink = springboard.staticTexts["Go to Copied Link"]
+                newPrivateSearch = springboard.staticTexts["New Private Search"]
+                newSearch = springboard.staticTexts["New Search"]
+                clearPrivateTabs = springboard.staticTexts["Clear Private Tabs"]
+            }
+        }
         // Verify the existence of New Search-related buttons
         mozWaitForElementToExist(goToCopiedLink, timeout: 5)
         XCTAssertTrue(goToCopiedLink.exists, "Go to Copied Link button not found.")
@@ -313,6 +420,7 @@ class TodayWidgetTests: BaseTestCase {
         mozWaitElementHittable(element: newPrivateSearch, timeout: 5)
         newPrivateSearch.tap()
         // Tap outside the alert to dismiss it
+        mozWaitForElementToExist(newPrivateSearch)
         coordinate.tap()
         // Terminate the app to start a fresh session
         app.terminate()
@@ -360,14 +468,26 @@ class TodayWidgetTests: BaseTestCase {
         // Check available options in Quick Action Widget
         checkFirefoxWidgetOptions()
         // Tap on Edit Widget and check the available options
-        springboard.buttons[editWidgetButton].tap()
+        if #unavailable(iOS 16) {
+            springboard.buttons["Edit Widget"].tap()
+        } else {
+            springboard.buttons[editWidgetButton].tap()
+        }
         mozWaitElementHittable(element: newSearch, timeout: 3)
         newSearch.tap()
+        if #unavailable(iOS 17) {
+            if #available(iOS 16, *) {
+                goToCopiedLink = springboard.staticTexts["Go to Copied Link"]
+                newPrivateSearch = springboard.staticTexts["New Private Search"]
+                newSearch = springboard.staticTexts["New Search"]
+                clearPrivateTabs = springboard.staticTexts["Clear Private Tabs"]
+            }
+        }
         // Ensure the Go To Copied Link option exists
         mozWaitForElementToExist(goToCopiedLink, timeout: 3)
         XCTAssertTrue(goToCopiedLink.exists, "Go To Copied Link button not found.")
         XCTAssertTrue(newPrivateSearch.exists, "New Private Search button not found.")
-        XCTAssertTrue(springboard.buttons["Clear Private Tabs"].exists, "Clear Private Tabs button not found.")
+        XCTAssertTrue(clearPrivateTabs.exists, "Clear Private Tabs button not found.")
         // Tap Go To Copied Link
         mozWaitElementHittable(element: goToCopiedLink, timeout: 3)
         goToCopiedLink.tap()
@@ -379,14 +499,147 @@ class TodayWidgetTests: BaseTestCase {
         // Reopen and interact with the Copied Link widget
         tapOnWidget(widgetType: "Copied Link")
         // Handle paste alert
-        mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: 3)
-        springboard.alerts.buttons["Allow Paste"].tap()
+        if #available(iOS 16, *) {
+            mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: 3)
+            springboard.alerts.buttons["Allow Paste"].tap()
+        }
+        // mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: 3)
+        // springboard.alerts.buttons["Allow Paste"].tap()
         // Handle iPad/iPhone UI differences
         if !iPad() {
             mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: 10)
             app.buttons["CloseButton"].tap()
         }
         // Verify the copied string is in the URL field
+        mozWaitForElementToExist(app.textFields["url"], timeout: 10)
+        mozWaitForValueContains(app.textFields["url"], value: copiedString, timeout: 5)
+        guard let urlField = app.textFields["url"].value as? String else {
+            XCTFail("Expected value to be a String but found \(type(of: app.textFields["url"].value))")
+            return
+        }
+        XCTAssertTrue(urlField.contains(copiedString),
+                      "URL does not contain the copied string.")
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/2783001
+    func testFxShortcutSearchWidget() {
+        XCUIDevice.shared.press(.home)
+        goToTodayWidgetPage()
+        // Remove Firefox Widget if it already exists
+        if checkPresenceFirefoxWidget() {
+            removeFirefoxWidget()
+        }
+        // Add Firefox Widget
+        if iPad() {
+            coordinate.press(forDuration: 3)
+        }
+        addWidget(widgetName: "Fennec")
+        checkFirefoxAvailablesWidgets()
+        // Add Firefox Shortcut Widget
+        springboard.swipeLeft()
+        mozWaitForElementToExist(springboard.staticTexts["Firefox Shortcuts"])
+        springboard.buttons[" Add Widget"].tap()
+        springboard.swipeDown()
+        springboard.buttons["Done"].tap()
+        checkFirefoxShortcutsOptions()
+        springboard.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Firefox")).element.tap()
+        var elementToAssert = AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton
+        if iPad() {
+            elementToAssert = AccessibilityIdentifiers.Browser.TopTabs.privateModeButton
+        }
+        mozWaitForElementToExist(app.buttons[elementToAssert])
+        guard let buttonValue = app.buttons[elementToAssert].value as? String else {
+            XCTFail("Expected value to be a String but found \(type(of: app.buttons[elementToAssert].value))")
+            return
+        }
+        XCTAssertTrue(buttonValue == "Off", "Expected button value to be 'Off', but got \(buttonValue)")
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/2783002
+    func testFxShortcutPrivateSearchWidget() {
+        XCUIDevice.shared.press(.home)
+        app.terminate()
+        goToTodayWidgetPage()
+        // Remove Firefox Widget if it already exists
+        if checkPresenceFirefoxWidget() {
+            removeFirefoxWidget()
+        }
+        // Add Firefox Widget
+        if iPad() {
+            coordinate.press(forDuration: 3)
+        }
+        addWidget(widgetName: "Fennec")
+        checkFirefoxAvailablesWidgets()
+        // Add Firefox Shortcut Widget
+        springboard.swipeLeft()
+        mozWaitForElementToExist(springboard.staticTexts["Firefox Shortcuts"])
+        springboard.buttons[" Add Widget"].tap()
+        springboard.swipeDown()
+        springboard.buttons["Done"].tap()
+        checkFirefoxShortcutsOptions()
+        mozWaitElementHittable(element: springboard.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", "Private Tab")
+        ).element.firstMatch, timeout: 5)
+        springboard.buttons.matching(NSPredicate(
+            format: "label CONTAINS[c] %@", "Private Tab")
+        ).element.firstMatch.tap()
+        if !iPad() {
+            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: 10)
+            app.buttons["CloseButton"].tap()
+        }
+        // Verify the presence of Private Mode message
+        mozWaitForElementToExist(app.staticTexts["Leave no traces on this device"])
+        // Verify private mode toggle is on
+        var elementToAssert = AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton
+        if iPad() {
+            elementToAssert = AccessibilityIdentifiers.Browser.TopTabs.privateModeButton
+        }
+        guard let buttonValue = app.buttons[elementToAssert].value as? String else {
+            XCTFail("Expected value to be a String but found \(type(of: app.buttons[elementToAssert].value))")
+            return
+        }
+        XCTAssertTrue(buttonValue == "On", "Expected button value to be 'On', but got \(buttonValue)")
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/2783003
+    func testFxShortcutGoToCopiedLinkWidget() {
+        let copiedString = "www.mozilla.org"
+        UIPasteboard.general.string = copiedString
+        XCUIDevice.shared.press(.home)
+        app.terminate()
+        goToTodayWidgetPage()
+        // Remove Firefox Widget if it already exists
+        if checkPresenceFirefoxWidget() {
+            removeFirefoxWidget()
+        }
+        // Add Firefox Widget
+        if iPad() {
+            coordinate.press(forDuration: 3)
+        }
+        addWidget(widgetName: "Fennec")
+        checkFirefoxAvailablesWidgets()
+        // Add Firefox Shortcut Widget
+        springboard.swipeLeft()
+        mozWaitForElementToExist(springboard.staticTexts["Firefox Shortcuts"])
+        springboard.buttons[" Add Widget"].tap()
+        springboard.swipeDown()
+        springboard.buttons["Done"].tap()
+        checkFirefoxShortcutsOptions()
+        mozWaitElementHittable(element: springboard.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", "Copied Link")
+        ).element, timeout: 5)
+        springboard.buttons.matching(NSPredicate(
+            format: "label CONTAINS[c] %@", "Copied Link")
+        ).element.tap()
+        if #available(iOS 16, *) {
+            mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: 3)
+            springboard.alerts.buttons["Allow Paste"].tap()
+        }
+        // Verify the copied string is in the URL field
+        if !iPad() {
+            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: 10)
+            app.buttons["CloseButton"].tap()
+        }
         mozWaitForElementToExist(app.textFields["url"], timeout: 10)
         mozWaitForValueContains(app.textFields["url"], value: copiedString, timeout: 5)
         guard let urlField = app.textFields["url"].value as? String else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3746)

## :bulb: Description
Add new test cases for the Firefox Shortcut Widget. This PR also ensure the retro compatibility with the iOS versions 15.5 and 16.4. 

The tests were working only for iOS 17.5.

Test cases implemented in this PR are:
- https://mozilla.testrail.io/index.php?/cases/view/2783001
- https://mozilla.testrail.io/index.php?/cases/view/2783002
- https://mozilla.testrail.io/index.php?/cases/view/2783003

This PR also moved some common functions outside the class in order to reduce the class body length (linter issue)

## :pencil: Checklist
You have to check all boxes before merging
- [X ] Filled in the above information (tickets numbers and description of your work)
- [ X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

