### PR TITLE
Bugfix FXIOS-10414 - The app crashes while in onboarding tour after multiple scenarios

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -22,7 +22,7 @@ import struct MozillaAppServices.EncryptedLogin
 import enum MozillaAppServices.BookmarkRoots
 import enum MozillaAppServices.VisitType
 
-class BrowserViewController: UIViewController,
+final class BrowserViewController: UIViewController,
                              SearchBarLocationProvider,
                              Themeable,
                              LibraryPanelDelegate,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -22,7 +22,7 @@ import struct MozillaAppServices.EncryptedLogin
 import enum MozillaAppServices.BookmarkRoots
 import enum MozillaAppServices.VisitType
 
-final class BrowserViewController: UIViewController,
+class BrowserViewController: UIViewController,
                              SearchBarLocationProvider,
                              Themeable,
                              LibraryPanelDelegate,

--- a/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
@@ -53,6 +53,12 @@ final class TabErrorTelemetryHelper {
     // MARK: - Internal Utility
 
     private func getTabCount(window: WindowUUID) -> Int {
+        // This check indicates that the app was backgrounded while in the onboarding state,
+        // and the TabManager has not been initialized still.
+        guard let firstWindow = windowManager.windows.first?.value,
+              let tabManager = firstWindow.tabManager else {
+            return 0
+        }
         return windowManager.tabManager(for: window).normalTabs.count
     }
 

--- a/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
@@ -55,10 +55,7 @@ final class TabErrorTelemetryHelper {
     private func getTabCount(window: WindowUUID) -> Int {
         // This check indicates that the app was backgrounded while in the onboarding state,
         // and the TabManager has not been initialized still.
-        guard let firstWindow = windowManager.windows.first?.value,
-              let tabManager = firstWindow.tabManager else {
-            return 0
-        }
+        guard windowManager.windows.first?.value.tabManager != nil else { return 0 }
         return windowManager.tabManager(for: window).normalTabs.count
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10414)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22807)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Technical context for this crash:

* The crash occurs because the `func tabManager(for windowUUID: WindowUUID) -> TabManager` method is called, and it should never return a `nil` `TabManager` instance.
* However, it can return `nil` if the app is in the onboarding state and is put in the background. In this case, the `TabManager` is not yet initialized, and calling `func tabManager(for windowUUID: WindowUUID) -> TabManager` in the `TabErrorTelemetryHelper` class, specifically in the `private func getTabCount(window: WindowUUID) -> Int `method, causes the app to crash due to a `nil` `TabManager`. The `TabManager` is initialized only after the onboarding process is complete.
* This PR fixes the crash by checking if a `TabManager` instance exists when calling `private func getTabCount(window: WindowUUID) -> Int`. If there is no `TabManager`, the method returns 0 tabs, indicating that the app is in the onboarding state and the browser has not been initialized yet.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

