### PR TITLE
Bugfix FXIOS-10428 - The reader view button is read twice when selected/tapped

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -49,6 +49,7 @@ class ToolbarButton: UIButton, ThemeApplicable {
                               image: image,
                               handler: { _ in
             element.onSelected?(self)
+            UIAccessibility.post(notification: .announcement, argument: element.a11yLabel)
         })
 
         config.image = image


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10428)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22831)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Add a11y notification when a Toolbar Button is tapped.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

