### PR TITLE
Fix FXIOS-10373 - Set readermode state to unavailable when document type is pdf

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2602,9 +2602,12 @@ class BrowserViewController: UIViewController,
 
         self.screenshotHelper.takeScreenshot(tab)
 
-        // when navigate in tab, if the tab mime type is pdf, we should scroll to top
+        // when navigating in a tab, if the tab's mime type is pdf, we should:
+        // - scroll to top
+        // - set readermode state to unavailable
         if tab.mimeType == MIMEType.PDF {
             tab.shouldScrollToTop = true
+            updateReaderModeState(for: tab, readerModeState: .unavailable)
         }
 
         if let url = webView.url {

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/FocusHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/FocusHelper.js
@@ -38,7 +38,7 @@ window.__firefox__.includeOnce("FocusHelper", function() {
   };
 
   const body = window.document.body;
-  ["focus", "blur"].forEach((eventType) => {
-    body.addEventListener(eventType, handler, options);
-  });
+  // In certain contexts, like PDF documents, the body might not exist, hence the optional chaining.
+  body?.addEventListener("focus", handler, options);
+  body?.addEventListener("blur", handler, options);
 });


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10373)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22730)

## :bulb: Description
This PR:
- Explicitly sets readerModeState to `.unavailbale` when mime type is `application/pdf`
- Fixes error in `FocusHelper.js` thrown by accessing `body` inside pdf documents.

### Before

https://github.com/user-attachments/assets/ad6797ef-9553-464c-b2f9-03ed0692d975



### After

https://github.com/user-attachments/assets/3a16305b-acb0-4fc1-a786-c03992b098f7



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

