### PR TITLE
Add FXIOS-9640-[Native Error Page] Added UI for iPad

### DIFF
--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -150,6 +150,12 @@ final class NativeErrorPageViewController: UIViewController,
         showViewForCurrentOrientation()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        adjustConstraints()
+        showViewForCurrentOrientation()
+    }
+
     // TODO: FXIOS-9639 #21237 [a11y] Verify accessibility for Voice Over, Dynamic text
     private func configureUI() {
         let viewModel = PrimaryRoundedButtonViewModel(
@@ -235,7 +241,7 @@ final class NativeErrorPageViewController: UIViewController,
 
         NSLayoutConstraint.activate(commonContraintsList)
 
-        if UIDevice().userInterfaceIdiom == .pad {
+        if shouldUseiPadSetup() {
             NSLayoutConstraint.activate(iPadContraintsList)
         } else {
             NSLayoutConstraint.activate(iPhoneContraintsList)
@@ -248,12 +254,10 @@ final class NativeErrorPageViewController: UIViewController,
 
     private func showViewForCurrentOrientation() {
         commonContainer.distribution = .equalCentering
-        if UIDevice().userInterfaceIdiom == .pad {
-            scrollContainer.axis = .horizontal
-        } else if isLandscape {
-            scrollContainer.axis = .horizontal
+        if shouldUseiPadSetup() {
+            scrollContainer.axis = .horizontal // Use horizontal layout for iPad setup
         } else {
-            scrollContainer.axis = .vertical
+            scrollContainer.axis = self.isLandscape ? .horizontal : .vertical // For non-iPad or compact size classes
         }
     }
 

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -28,19 +28,26 @@ final class NativeErrorPageViewController: UIViewController,
     // MARK: UI Elements
     private struct UX {
         static let logoSizeWidth: CGFloat = 221
+        static let logoSizeWidthiPad: CGFloat = 240
         static let mainStackSpacing: CGFloat = 24
         static let textStackSpacing: CGFloat = 16
         static let portraitPadding = NSDirectionalEdgeInsets(
             top: 76,
-            leading: 16,
+            leading: 32,
             bottom: -16,
-            trailing: -16
+            trailing: -32
         )
         static let landscapePadding = NSDirectionalEdgeInsets(
             top: 60,
             leading: 64,
             bottom: -16,
             trailing: -64
+        )
+        static let iPadPadding = NSDirectionalEdgeInsets(
+            top: 100,
+            leading: 165.5,
+            bottom: -16,
+            trailing: -145.5
         )
     }
 
@@ -73,6 +80,7 @@ final class NativeErrorPageViewController: UIViewController,
         label.font = FXFontStyles.Bold.title2.scaledFont()
         label.numberOfLines = 0
         label.text = .NativeErrorPage.NoInternetConnection.TitleLabel
+        label.textAlignment = .left
     }
 
     private lazy var errorDescriptionLabel: UILabel = .build { label in
@@ -80,6 +88,7 @@ final class NativeErrorPageViewController: UIViewController,
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.text = .NativeErrorPage.NoInternetConnection.Description
+        label.textAlignment = .left
     }
 
     private lazy var reloadButton: PrimaryRoundedButton = .build { button in
@@ -87,7 +96,9 @@ final class NativeErrorPageViewController: UIViewController,
         button.isEnabled = true
     }
 
-    private var contraintsList = [NSLayoutConstraint]()
+    private var commonContraintsList = [NSLayoutConstraint]()
+    private var iPhoneContraintsList = [NSLayoutConstraint]()
+    private var iPadContraintsList = [NSLayoutConstraint]()
 
     required init?(
         coder aDecoder: NSCoder
@@ -161,8 +172,8 @@ final class NativeErrorPageViewController: UIViewController,
     }
 
     func adjustConstraints() {
-        NSLayoutConstraint.deactivate(contraintsList)
-        contraintsList = [
+        NSLayoutConstraint.deactivate(iPhoneContraintsList + iPadContraintsList + commonContraintsList)
+        commonContraintsList = [
             scrollView.topAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.topAnchor
             ),
@@ -174,7 +185,10 @@ final class NativeErrorPageViewController: UIViewController,
             ),
             scrollView.bottomAnchor.constraint(
                 equalTo: view.bottomAnchor
-            ),
+            )
+        ]
+
+        iPhoneContraintsList = [
             scrollContainer.topAnchor.constraint(
                 equalTo: scrollView.topAnchor,
                 constant: self.isLandscape ? UX.landscapePadding.top : UX.portraitPadding.top
@@ -193,7 +207,35 @@ final class NativeErrorPageViewController: UIViewController,
             ),
             logoImage.widthAnchor.constraint(equalToConstant: UX.logoSizeWidth)
         ]
-        NSLayoutConstraint.activate(contraintsList)
+
+        iPadContraintsList = [
+            scrollContainer.topAnchor.constraint(
+                equalTo: scrollView.topAnchor,
+                constant: UX.iPadPadding.top
+            ),
+            scrollContainer.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+                constant: UX.iPadPadding.leading
+            ),
+            scrollContainer.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                constant: UX.iPadPadding.trailing
+            ),
+            scrollContainer.bottomAnchor.constraint(
+                equalTo: scrollView.bottomAnchor,
+                constant: UX.iPadPadding.bottom
+            ),
+            logoImage.widthAnchor.constraint(equalToConstant: UX.logoSizeWidthiPad),
+            reloadButton.widthAnchor.constraint(equalTo: commonContainer.widthAnchor, multiplier: 0.7145)
+        ]
+
+        NSLayoutConstraint.activate(commonContraintsList)
+
+        if UIDevice().userInterfaceIdiom == .pad {
+            NSLayoutConstraint.activate(iPadContraintsList)
+        } else {
+            NSLayoutConstraint.activate(iPhoneContraintsList)
+        }
     }
 
     private var isLandscape: Bool {
@@ -201,14 +243,13 @@ final class NativeErrorPageViewController: UIViewController,
     }
 
     private func showViewForCurrentOrientation() {
-        if isLandscape {
+        commonContainer.distribution = .equalCentering
+        if UIDevice().userInterfaceIdiom == .pad {
             scrollContainer.axis = .horizontal
-            titleLabel.textAlignment = .left
-            errorDescriptionLabel.textAlignment = .left
+        } else if isLandscape {
+            scrollContainer.axis = .horizontal
         } else {
             scrollContainer.axis = .vertical
-            titleLabel.textAlignment = .center
-            errorDescriptionLabel.textAlignment = .center
         }
     }
 

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -31,8 +31,9 @@ final class NativeErrorPageViewController: UIViewController,
         static let logoSizeWidthiPad: CGFloat = 240
         static let mainStackSpacing: CGFloat = 24
         static let textStackSpacing: CGFloat = 16
+        static let reloadButtonIpadMultiplier = 0.7146
         static let portraitPadding = NSDirectionalEdgeInsets(
-            top: 76,
+            top: 120,
             leading: 32,
             bottom: -16,
             trailing: -32
@@ -45,9 +46,9 @@ final class NativeErrorPageViewController: UIViewController,
         )
         static let iPadPadding = NSDirectionalEdgeInsets(
             top: 100,
-            leading: 165.5,
+            leading: 166,
             bottom: -16,
-            trailing: -145.5
+            trailing: -144
         )
     }
 
@@ -226,7 +227,10 @@ final class NativeErrorPageViewController: UIViewController,
                 constant: UX.iPadPadding.bottom
             ),
             logoImage.widthAnchor.constraint(equalToConstant: UX.logoSizeWidthiPad),
-            reloadButton.widthAnchor.constraint(equalTo: commonContainer.widthAnchor, multiplier: 0.7145)
+            reloadButton.widthAnchor.constraint(
+                equalTo: commonContainer.widthAnchor,
+                multiplier: UX.reloadButtonIpadMultiplier
+            )
         ]
 
         NSLayoutConstraint.activate(commonContraintsList)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9640)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21238)

## :bulb: Description
Added UI for iPad and updated UI for iPhone.
For reference: [iOS Design](https://www.figma.com/design/yawrXicozZQ2zvLYsjdQBb/Error-Pages?node-id=4232-32963&node-type=canvas&t=sxsarQm8xLxlbEbS-0)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots 
| iPhone SE 3rd Gen  | iPad Air 11 inch M2 |
| --- | --- |
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-11-04 at 11 26 28](https://github.com/user-attachments/assets/5bed14c6-c3ac-4bde-b73f-473dd90e1f93) | ![IMG_0031](https://github.com/user-attachments/assets/bc9a0acb-4dbf-4761-bda1-a69d0fdc126f) |