### PR TITLE
Bugfix FXIOS-9526 - Hide new tab button on homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -663,7 +663,10 @@ struct AddressBarState: StateType, Equatable {
                                                          window: action.windowUUID)
         else { return actions }
 
-        if !(action.isShowingTopTabs ?? toolbarState.isShowingTopTabs) {
+        let isShowingTopTabs = action.isShowingTopTabs ?? toolbarState.isShowingTopTabs
+        let isHomepage = toolbarState.addressToolbar.url == nil
+
+        if !isShowingTopTabs, !isHomepage {
             actions.append(newTabAction)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -663,8 +663,9 @@ struct AddressBarState: StateType, Equatable {
                                                          window: action.windowUUID)
         else { return actions }
 
+        let isURLDidChangeAction = action.actionType as? ToolbarActionType == .urlDidChange
         let isShowingTopTabs = action.isShowingTopTabs ?? toolbarState.isShowingTopTabs
-        let isHomepage = toolbarState.addressToolbar.url == nil
+        let isHomepage = (isURLDidChangeAction ? action.url : toolbarState.addressToolbar.url) == nil
 
         if !isShowingTopTabs, !isHomepage {
             actions.append(newTabAction)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9526)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21083)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### Screenshots
![iPadLandscape](https://github.com/user-attachments/assets/f4839a35-2760-4b7e-bb84-86e90203b10f)
![iPadPortrait](https://github.com/user-attachments/assets/262dccba-1f89-4f14-a223-7cad03c9e147)
![iPhoneLandscapeHomepage](https://github.com/user-attachments/assets/f9dd34d5-19be-432a-b293-b1a06afc8d94)
![iPhoneLandscapeWebpage](https://github.com/user-attachments/assets/7fc54577-7102-4b40-8fbf-979f8334d920)
![iPhonePortraitHomepage](https://github.com/user-attachments/assets/30fabf3a-5d34-4aac-a951-c5a94c3e9c80)
![iPhonePortraitWebpage](https://github.com/user-attachments/assets/6b50b631-e49f-4975-86da-d024dee1ca25)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

