### PR TITLE
Fixes MTE-3779 - for drag and drop tests on iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -6,11 +6,13 @@ import XCTest
 
 let firstWebsite = (
     url: path(forTestPage: "test-mozilla-org.html"),
-    tabName: "Internet for people, not profit — Mozilla"
+    tabName: "Internet for people, not profit — Mozilla",
+    browserTabName: "http://localhost:7777/test-fixture/test-mozilla-book.html. Currently selected tab."
 )
 let secondWebsite = (
     url: path(forTestPage: "test-mozilla-book.html"),
-    tabName: "The Book of Mozilla. Currently selected tab."
+    tabName: "The Book of Mozilla. Currently selected tab.",
+    browserTabName: "http://localhost:7777/test-fixture/test-mozilla-book.html. Currently selected tab."
 )
 let secondWebsiteUnselected = (
     url: path(forTestPage: "test-mozilla-book.html"),
@@ -257,13 +259,13 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         if skipPlatform { return }
 
         openTwoWebsites()
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.browserTabName)
         // Drag first tab on the second one
         dragAndDrop(
             dragElement: app.collectionViews.cells[firstWebsite.tabName],
-            dropOnElement: app.collectionViews.cells[secondWebsite.tabName]
+            dropOnElement: app.collectionViews.cells[secondWebsite.browserTabName]
         )
-        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
+        checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.browserTabName, secondTab: firstWebsite.tabName)
         // Check that focus is kept on last website open
         XCTAssert(
             secondWebsite.url.contains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value! as! String),
@@ -275,7 +277,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
     func testRearrangeTabsTabTrayIsKeptinTopTabs() {
         if skipPlatform { return }
         openTwoWebsites()
-        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.tabName)
+        checkTabsOrder(dragAndDropTab: false, firstTab: firstWebsite.tabName, secondTab: secondWebsite.browserTabName)
         navigator.goto(TabTray)
 
         // Drag first tab on the second one

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
@@ -106,12 +106,8 @@ class OnboardingTests: BaseTestCase {
             value: "www.mozilla.org/en-US/firefox/ios/" + releaseVersion + "/releasenotes/"
         )
         mozWaitForElementToExist(app.staticTexts["Release Notes"])
-        if iPad() {
-            mozWaitForElementToExist(
-                app.staticTexts["Firefox for iOS \(releaseVersion), See All New Features, Updates and Fixes"]
-            )
-        }
         mozWaitForElementToExist(app.staticTexts["Firefox for iOS Release"])
+        mozWaitForElementToExist(app.staticTexts["\(releaseVersion)"])
         mozWaitForElementToExist(app.staticTexts["Get the most recent version"])
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3779

## :bulb: Description
Fixed drag and drop tests failures on Ipad.
Included a fix for testWhatsNewPage also, on a staticText change.
