### PR TITLE
Bugfix FXIOS-10438 - Incorrect display of pocket articles in tab tray after a specific scenario

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -32,13 +32,13 @@ class ScreenshotHelper {
             return
         }
         /// Handle home page snapshots, can not use Apple API snapshot function for this
-        guard let browserVC = controller else {
-            return
-        }
+        guard controller != nil else { return }
 
-        /// For homepage and native error page, instead of checking url,
-        /// we check the ContentContainer. Only in webview case we don't need to check.
-        if !browserVC.contentContainer.hasWebView {
+        /// If the tab is the homepage, take a screenshot of the homepage view.
+        /// This is done by accessing the content view from the content container.
+        /// The screenshot is then set for the tab, and a TabEvent is posted to indicate
+        /// that a screenshot has been set for the homepage.
+        if tab.isFxHomeTab {
             if let homeview = controller?.contentContainer.contentView {
                 let screenshot = homeview.screenshot(quality: UIConstants.ActiveScreenshotQuality)
                 tab.hasHomeScreenshot = true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10438)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22850)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Instead of checking for `contentContainer.hasWebview`, this PR modifies the logic to check if the tab `isFxHomeTab` to capture the snapshot. By making this change, we accurately determine the tab state. This prevents the scenario where using the `Open in New Tab` feature for a website results in capturing a misleading homepage snapshot.
### Video

https://github.com/user-attachments/assets/53b56696-4998-46c6-aa28-f49e8ed0090b

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

