### PR TITLE
Bugfix FXIOS-10434 ⁃ [Menu] [Accessibility] - Account name is incorrectly announced with voice over

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -32,11 +32,10 @@ final class MainMenuMiddleware {
                             icon: image)
                     }
                 } else {
-                    self.dispatchUpdateAccountHeader(
-                        accountData: accountData,
-                        action: action,
-                        icon: nil)
+                    self.dispatchUpdateAccountHeader(accountData: accountData, action: action)
                 }
+            } else {
+                self.dispatchUpdateAccountHeader(action: action)
             }
             store.dispatch(
                 MainMenuAction(
@@ -49,9 +48,9 @@ final class MainMenuMiddleware {
         }
     }
 
-    private func dispatchUpdateAccountHeader(accountData: AccountData?,
+    private func dispatchUpdateAccountHeader(accountData: AccountData? = nil,
                                              action: MainMenuAction,
-                                             icon: UIImage?) {
+                                             icon: UIImage? = nil) {
         store.dispatch(
             MainMenuAction(
                 windowUUID: action.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -119,15 +119,14 @@ struct MainMenuState: ScreenState, Equatable {
                 accountIcon: state.accountIcon
             )
         case MainMenuMiddlewareActionType.updateAccountHeader:
-            guard let action = action as? MainMenuAction,
-                  let accountData = action.accountData
+            guard let action = action as? MainMenuAction
             else { return state }
 
             return MainMenuState(
                 windowUUID: state.windowUUID,
                 menuElements: state.menuElements,
                 currentTabInfo: state.currentTabInfo,
-                accountData: accountData,
+                accountData: action.accountData,
                 accountIcon: action.accountIcon
             )
         case MainMenuActionType.updateCurrentTabInfo:

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -243,6 +243,7 @@ class MainMenuViewController: UIViewController,
 
         if let accountData = menuState.accountData {
             updateHeaderWith(accountData: accountData, icon: menuState.accountIcon)
+            setupAccessibilityIdentifiers(mainButtonA11yLabel: accountData.title)
         }
 
         if menuState.currentSubmenuView != nil {
@@ -306,11 +307,12 @@ class MainMenuViewController: UIViewController,
         return sheetController.selectedDetentIdentifier
     }
 
-    private func setupAccessibilityIdentifiers() {
+    private func setupAccessibilityIdentifiers(
+        mainButtonA11yLabel: String = .MainMenu.Account.AccessibilityLabels.MainButton) {
         menuContent.setupAccessibilityIdentifiers(
             closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButton,
             closeButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.closeButton,
-            mainButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.MainButton,
+            mainButtonA11yLabel: mainButtonA11yLabel,
             mainButtonA11yId: AccessibilityIdentifiers.MainMenu.HeaderView.mainButton,
             menuA11yId: AccessibilityIdentifiers.MainMenu.mainMenu,
             menuA11yLabel: .MainMenu.TabsSection.AccessibilityLabels.MainMenu)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10434)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22840)

## :bulb: Description
Fixed the accessibility for the account header, when user is signed in
Changed the logic for updating the account header labels because sometimes account data is displayed in header even if user is disconnected

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

