### PR TITLE
Bugfix FXIOS-10418 [Menu] [Accessibility] Update accessibility strings for tools

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4011,14 +4011,14 @@ extension String {
                     value: "Find in page",
                     comment: "On the main menu, the accessibility label for the action that will bring up the Search menu, so the user can search for a word or a pharse on the current page.")
                 public static let Tools = MZLocalizedString(
-                    key: "MainMenu.ToolsSection.AccessibilityLabels.Tools.v132",
+                    key: "MainMenu.ToolsSection.AccessibilityLabels.Tools.v133",
                     tableName: "MainMenu",
-                    value: "Tools",
+                    value: "Tools submenu",
                     comment: "On the main menu, the accessibility label for the action that will take the user to the Tools submenu in the menu.")
                 public static let Save = MZLocalizedString(
-                    key: "MainMenu.ToolsSection.AccessibilityLabels.Save.v132",
+                    key: "MainMenu.ToolsSection.AccessibilityLabels.Save.v133",
                     tableName: "MainMenu",
-                    value: "Save",
+                    value: "Save submenu",
                     comment: "On the main menu, the accessibility label for the action that will take the user to the Save submenu in the menu. In the main menu, there is an option called Save that is taking the user to the Save submenu where user can share, bookmark the page and so on.")
             }
         }
@@ -7465,6 +7465,16 @@ extension String {
                 tableName: "AddressToolbar",
                 value: "Search or enter address",
                 comment: "Accessibility label for the address field in the address toolbar.")
+            public static let Tools = MZLocalizedString(
+                key: "MainMenu.ToolsSection.AccessibilityLabels.Tools.v132",
+                tableName: "MainMenu",
+                value: "Tools",
+                comment: "On the main menu, the accessibility label for the action that will take the user to the Tools submenu in the menu.")
+            public static let Save = MZLocalizedString(
+                key: "MainMenu.ToolsSection.AccessibilityLabels.Save.v132",
+                tableName: "MainMenu",
+                value: "Save",
+                comment: "On the main menu, the accessibility label for the action that will take the user to the Save submenu in the menu. In the main menu, there is an option called Save that is taking the user to the Save submenu where user can share, bookmark the page and so on.")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10418)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22818)

## :bulb: Description
Update string to have submenu for the a11y string

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

