### PR TITLE
Bugfix MTE-3781 Use of https in history and bookmarks

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_bookmark.js
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_bookmark.js
@@ -14,7 +14,7 @@ var phases = { "phase1": "profile1" };
 // expected bookmark state
 var bookmarksExpected = {
 "mobile": [{
-  uri: "http://www.example.com/",
+  uri: "https://www.example.com/",
   title: "Example Domain"}]
 };
 

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_bookmark_desktop.js
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_bookmark_desktop.js
@@ -14,7 +14,7 @@ var phases = { "phase1": "profile1" };
 // expected bookmark state
 var bookmarksCreated = {
 "mobile": [{
-  uri: "http://www.example.com/",
+  uri: "https://www.example.com/",
   title: "Example Domain"}]
 };
 

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_bookmark_login.js
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_bookmark_login.js
@@ -14,7 +14,7 @@ var phases = { "phase1": "profile1" };
 // expected bookmark state
 var bookmarksCreated = {
 "mobile": [{
-  uri: "http://www.example.com/",
+  uri: "https://www.example.com/",
   title: "Example Domain"}]
 };
 

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_history.js
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_history.js
@@ -13,7 +13,7 @@ var phases = { "phase1": "profile1" };
 
 // expected history state
 var historyExpected = [
-    { uri: "http://www.example.com/",
+    { uri: "https://www.example.com/",
       visits: [
         { type: 1 }
       ]

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_history.js
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_history.js
@@ -13,7 +13,7 @@ var phases = { "phase1": "profile1" };
 
 // expected history state
 var historyExpected = [
-    { uri: "https://www.example.com/",
+    { uri: "http://www.example.com/",
       visits: [
         { type: 1 }
       ]

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_history_desktop.js
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_history_desktop.js
@@ -13,7 +13,7 @@ var phases = { "phase1": "profile1" };
 
 // expected history state
 var historyCreated = [
-    { uri: "http://www.example.com/",
+    { uri: "https://www.example.com/",
       visits: [
         { type: 1 ,
           date: 0 

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_tabs.js
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_tabs.js
@@ -13,8 +13,8 @@ var phases = { "phase1": "profile1" };
 
 // expected tabs state
 var tabs1 = [
-    { uri: "http://example.com/",
-      profile: "Fennec (administrator) on iOS"
+    { uri: "https://example.com/",
+      profile: "Fennec (cso) on iOS"
     }
 ];
 

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_tabs.js
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_tabs.js
@@ -14,7 +14,7 @@ var phases = { "phase1": "profile1" };
 // expected tabs state
 var tabs1 = [
     { uri: "https://example.com/",
-      profile: "Fennec (cso) on iOS"
+      profile: "Fennec (administrator) on iOS"
     }
 ];
 

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_tabs_desktop.js
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_tabs_desktop.js
@@ -12,7 +12,7 @@ var phases = { "phase1": "profile1", "phase2": "profile1" };
 
 
 var tabs1 = [
-    { uri: "http://example.com/",
+    { uri: "https://example.com/",
       profile: "Fennec on iOS"
     }
 ];

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -111,7 +111,7 @@ class IntegrationTests: BaseTestCase {
     func testFxASyncBookmark () {
         // Bookmark is added by the DB
         // Sign into Mozilla Account
-        navigator.openURL("example.com")
+        navigator.openURL(testingURL)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
         navigator.goto(BrowserTabMenu)
         app.tables.otherElements[StandardImageIdentifiers.Large.bookmark].waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -8,9 +8,9 @@ import XCTest
 private let testingURL = "example.com"
 private let userName = "iosmztest"
 private let userPassword = "test15mz"
-private let historyItemSavedOnDesktop = "http://www.example.com/"
+private let historyItemSavedOnDesktop = "https://www.example.com/"
 private let loginEntry = "https://accounts.google.com"
-private let tabOpenInDesktop = "http://example.com/"
+private let tabOpenInDesktop = "https://example.com/"
 
 class IntegrationTests: BaseTestCase {
     let testWithDB = ["testFxASyncHistory"]
@@ -146,7 +146,7 @@ class IntegrationTests: BaseTestCase {
         mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"])
         XCTAssertEqual(
             app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String,
-            "Fennec (administrator) on iOS"
+            "Fennec (cso) on iOS"
         )
 
         // Sync again just to make sure to sync after new name is shown

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -5,7 +5,7 @@
 import Common
 import XCTest
 
-private let testingURL = "example.com"
+private let testingURL = "https://example.com"
 private let userName = "iosmztest"
 private let userPassword = "test15mz"
 private let historyItemSavedOnDesktop = "https://www.example.com/"

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -146,7 +146,7 @@ class IntegrationTests: BaseTestCase {
         mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"])
         XCTAssertEqual(
             app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String,
-            "Fennec (cso) on iOS"
+            "Fennec (administrator) on iOS"
         )
 
         // Sync again just to make sure to sync after new name is shown


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3781)

## :bulb: Description
`test_integration.py::test_sync_tabs_from_desktop` fails because an http URL opened on desktop may be redirected to https. The tabs state in the js file specifies the URL in http.

Let me use https URL throughout the sync integration tests so that we don't need to take care of the http to https redirection.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

