### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from MicrosurveyPromptState.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -76,4 +76,13 @@ struct MicrosurveyPromptState: StateType, Equatable {
             model: model
         )
     }
+
+    private static func handleClosePromptAction(state: Self) -> Self {
+        return MicrosurveyPromptState(
+            windowUUID: state.windowUUID,
+            showPrompt: false,
+            showSurvey: false,
+            model: state.model
+        )
+    }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -38,13 +38,7 @@ struct MicrosurveyPromptState: StateType, Equatable {
 
         switch action.actionType {
         case MicrosurveyPromptMiddlewareActionType.initialize:
-            let model = (action as? MicrosurveyPromptMiddlewareAction)?.microsurveyModel
-            return MicrosurveyPromptState(
-                windowUUID: state.windowUUID,
-                showPrompt: true,
-                showSurvey: false,
-                model: model
-            )
+            return handleInitialize(state: state, action: action)
         case MicrosurveyPromptActionType.closePrompt:
             return MicrosurveyPromptState(
                 windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -40,12 +40,7 @@ struct MicrosurveyPromptState: StateType, Equatable {
         case MicrosurveyPromptMiddlewareActionType.initialize:
             return handleInitializeAction(state: state, action: action)
         case MicrosurveyPromptActionType.closePrompt:
-            return MicrosurveyPromptState(
-                windowUUID: state.windowUUID,
-                showPrompt: false,
-                showSurvey: false,
-                model: state.model
-            )
+            return handleClosePromptAction(state: state)
         case MicrosurveyPromptActionType.continueToSurvey:
             return MicrosurveyPromptState(
                 windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -80,4 +80,13 @@ struct MicrosurveyPromptState: StateType, Equatable {
             model: state.model
         )
     }
+
+    private static func handleContinueToSurveyAction(state: Self) -> Self {
+        return MicrosurveyPromptState(
+            windowUUID: state.windowUUID,
+            showPrompt: true,
+            showSurvey: true,
+            model: state.model
+        )
+    }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -72,4 +72,14 @@ struct MicrosurveyPromptState: StateType, Equatable {
             model: state.model
         )
     }
+
+    private static func handleInitialize(state: Self, action: Action) -> Self {
+        let model = (action as? MicrosurveyPromptMiddlewareAction)?.microsurveyModel
+        return MicrosurveyPromptState(
+            windowUUID: state.windowUUID,
+            showPrompt: true,
+            showSurvey: false,
+            model: model
+        )
+    }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -38,7 +38,7 @@ struct MicrosurveyPromptState: StateType, Equatable {
 
         switch action.actionType {
         case MicrosurveyPromptMiddlewareActionType.initialize:
-            return handleInitialize(state: state, action: action)
+            return handleInitializeAction(state: state, action: action)
         case MicrosurveyPromptActionType.closePrompt:
             return MicrosurveyPromptState(
                 windowUUID: state.windowUUID,
@@ -67,7 +67,7 @@ struct MicrosurveyPromptState: StateType, Equatable {
         )
     }
 
-    private static func handleInitialize(state: Self, action: Action) -> Self {
+    private static func handleInitializeAction(state: Self, action: Action) -> Self {
         let model = (action as? MicrosurveyPromptMiddlewareAction)?.microsurveyModel
         return MicrosurveyPromptState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -42,12 +42,7 @@ struct MicrosurveyPromptState: StateType, Equatable {
         case MicrosurveyPromptActionType.closePrompt:
             return handleClosePromptAction(state: state)
         case MicrosurveyPromptActionType.continueToSurvey:
-            return MicrosurveyPromptState(
-                windowUUID: state.windowUUID,
-                showPrompt: true,
-                showSurvey: true,
-                model: state.model
-            )
+            return handleContinueToSurveyAction(state: state)
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
@@ -74,7 +74,7 @@ final class MicrosurveyPromptStateTests: XCTestCase {
         )
         let reducer = microsurveyReducer()
 
-        let action = getInvalidAction()
+        let action = MicrosurveyPromptAction(windowUUID: .XCTestDefaultUUID, actionType: FakeActionType.testAction)
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
@@ -77,10 +77,10 @@ final class MicrosurveyPromptStateTests: XCTestCase {
         let action = getInvalidAction()
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.windowUUID, initialState.windowUUID)
-        XCTAssertEqual(newState.showPrompt, initialState.showPrompt)
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.showPrompt, true)
         XCTAssertEqual(newState.showSurvey, false)
-        XCTAssertEqual(newState.model, initialState.model)
+        XCTAssertEqual(newState.model, MicrosurveyMock.model)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
@@ -96,10 +96,6 @@ final class MicrosurveyPromptStateTests: XCTestCase {
         return  MicrosurveyPromptAction(windowUUID: .XCTestDefaultUUID, actionType: actionType)
     }
 
-    private func getInvalidAction() -> MicrosurveyPromptAction {
-        return MicrosurveyPromptAction(windowUUID: .XCTestDefaultUUID, actionType: FakeActionType.testAction)
-    }
-
     enum FakeActionType: ActionType {
         case testAction
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
@@ -97,10 +97,10 @@ final class MicrosurveyPromptStateTests: XCTestCase {
     }
 
     private func getInvalidAction() -> MicrosurveyPromptAction {
-        return MicrosurveyPromptAction(windowUUID: .XCTestDefaultUUID, actionType: FakeActionType.invalid)
+        return MicrosurveyPromptAction(windowUUID: .XCTestDefaultUUID, actionType: FakeActionType.testAction)
     }
 
     enum FakeActionType: ActionType {
-        case invalid
+        case testAction
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
@@ -97,10 +97,10 @@ final class MicrosurveyPromptStateTests: XCTestCase {
     }
 
     private func getInvalidAction() -> MicrosurveyPromptAction {
-        return MicrosurveyPromptAction(windowUUID: .XCTestDefaultUUID, actionType: InvalidActionType.invalid)
+        return MicrosurveyPromptAction(windowUUID: .XCTestDefaultUUID, actionType: FakeActionType.invalid)
     }
 
-    enum InvalidActionType: ActionType {
+    enum FakeActionType: ActionType {
         case invalid
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyPromptStateTests.swift
@@ -65,6 +65,24 @@ final class MicrosurveyPromptStateTests: XCTestCase {
         XCTAssertEqual(newState.showPrompt, true)
     }
 
+    func testDefaultAction() {
+        let initialState = MicrosurveyPromptState(
+            windowUUID: .XCTestDefaultUUID,
+            showPrompt: true,
+            showSurvey: true,
+            model: MicrosurveyMock.model
+        )
+        let reducer = microsurveyReducer()
+
+        let action = getInvalidAction()
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.windowUUID, initialState.windowUUID)
+        XCTAssertEqual(newState.showPrompt, initialState.showPrompt)
+        XCTAssertEqual(newState.showSurvey, false)
+        XCTAssertEqual(newState.model, initialState.model)
+    }
+
     // MARK: - Private
     private func createSubject() -> MicrosurveyPromptState {
         return MicrosurveyPromptState(windowUUID: .XCTestDefaultUUID)
@@ -76,5 +94,13 @@ final class MicrosurveyPromptStateTests: XCTestCase {
 
     private func getAction(for actionType: MicrosurveyPromptActionType) -> MicrosurveyPromptAction {
         return  MicrosurveyPromptAction(windowUUID: .XCTestDefaultUUID, actionType: actionType)
+    }
+
+    private func getInvalidAction() -> MicrosurveyPromptAction {
+        return MicrosurveyPromptAction(windowUUID: .XCTestDefaultUUID, actionType: InvalidActionType.invalid)
+    }
+
+    enum InvalidActionType: ActionType {
+        case invalid
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `MicrosurveyPromptState.swift` file by extracting some switch case statements to new functions. 

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

