### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from ReaderModeHandlers.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -93,26 +93,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
                                     contentsOfFile: readerViewLoadingPath,
                                     encoding: String.Encoding.utf8.rawValue
                                 )
-                                readerViewLoading.replaceOccurrences(
-                                    of: "%ORIGINAL-URL%",
-                                    with: url.absoluteString,
-                                    options: .literal,
-                                    range: NSRange(location: 0, length: readerViewLoading.length))
-                                readerViewLoading.replaceOccurrences(
-                                    of: "%LOADING-TEXT%",
-                                    with: .ReaderModeHandlerLoadingContent,
-                                    options: .literal,
-                                    range: NSRange(location: 0, length: readerViewLoading.length))
-                                readerViewLoading.replaceOccurrences(
-                                    of: "%LOADING-FAILED-TEXT%",
-                                    with: .ReaderModeHandlerPageCantDisplay,
-                                    options: .literal,
-                                    range: NSRange(location: 0, length: readerViewLoading.length))
-                                readerViewLoading.replaceOccurrences(
-                                    of: "%LOAD-ORIGINAL-TEXT%",
-                                    with: .ReaderModeHandlerLoadOriginalPage,
-                                    options: .literal,
-                                    range: NSRange(location: 0, length: readerViewLoading.length))
+                                replaceOccurrencesOf(readerViewLoading, url: url)
                                 return GCDWebServerDataResponse(html: readerViewLoading as String)
                             } catch _ {
                             }

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -125,4 +125,27 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
             return GCDWebServerDataResponse(html: errorString) // TODO Needs a proper error page
         }
     }
+
+    private static func replaceOccurrencesOf(_ readerViewLoading: NSMutableString, url: URL) {
+        readerViewLoading.replaceOccurrences(
+            of: "%ORIGINAL-URL%",
+            with: url.absoluteString,
+            options: .literal,
+            range: NSRange(location: 0, length: readerViewLoading.length))
+        readerViewLoading.replaceOccurrences(
+            of: "%LOADING-TEXT%",
+            with: .ReaderModeHandlerLoadingContent,
+            options: .literal,
+            range: NSRange(location: 0, length: readerViewLoading.length))
+        readerViewLoading.replaceOccurrences(
+            of: "%LOADING-FAILED-TEXT%",
+            with: .ReaderModeHandlerPageCantDisplay,
+            options: .literal,
+            range: NSRange(location: 0, length: readerViewLoading.length))
+        readerViewLoading.replaceOccurrences(
+            of: "%LOAD-ORIGINAL-TEXT%",
+            with: .ReaderModeHandlerLoadOriginalPage,
+            options: .literal,
+            range: NSRange(location: 0, length: readerViewLoading.length))
+    }
 }

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -107,6 +107,30 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
         }
     }
 
+    private static func generateHtmlFor(readabilityResult: ReadabilityResult, profile: Profile) -> GCDWebServerDataResponse? {
+        var readerModeStyle = ReaderModeStyle.defaultStyle()
+
+        // We have this page in our cache, so we can display it. Just grab the correct style from the
+        // profile and then generate HTML from the Readability results.
+        if let dict = profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle),
+           let style = ReaderModeStyle(windowUUID: nil, dict: dict) {
+            readerModeStyle = style
+        } else {
+            readerModeStyle.theme = ReaderModeTheme.preferredTheme(window: nil)
+        }
+        
+        guard let html = ReaderModeUtils.generateReaderContent(
+            readabilityResult,
+            initialStyle: readerModeStyle
+        ),
+              let response = GCDWebServerDataResponse(html: html) else { return nil }
+        // Apply a Content Security Policy that disallows everything except images from
+        // anywhere and fonts and css from our internal server
+        response.setValue("default-src 'none'; img-src *; style-src http://localhost:* '\(ReaderModeStyleHash)'; font-src http://localhost:*",
+                          forAdditionalHeader: "Content-Security-Policy")
+        return response
+    }
+
     private static func replaceOccurrencesIn(_ readerViewLoading: NSMutableString, url: URL) {
         readerViewLoading.replaceOccurrences(
             of: "%ORIGINAL-URL%",

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -89,7 +89,8 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
         }
     }
 
-    private static func generateHtmlFor(readabilityResult: ReadabilityResult, profile: Profile) -> GCDWebServerDataResponse? {
+    private static func generateHtmlFor(readabilityResult: ReadabilityResult,
+                                        profile: Profile) -> GCDWebServerDataResponse? {
         var readerModeStyle = ReaderModeStyle.defaultStyle()
 
         // We have this page in our cache, so we can display it. Just grab the correct style from the

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -101,7 +101,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
         } else {
             readerModeStyle.theme = ReaderModeTheme.preferredTheme(window: nil)
         }
-        
+
         guard let html = ReaderModeUtils.generateReaderContent(
             readabilityResult,
             initialStyle: readerModeStyle

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -93,7 +93,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
                                     contentsOfFile: readerViewLoadingPath,
                                     encoding: String.Encoding.utf8.rawValue
                                 )
-                                replaceOccurrencesOf(readerViewLoading, url: url)
+                                replaceOccurrencesIn(readerViewLoading, url: url)
                                 return GCDWebServerDataResponse(html: readerViewLoading as String)
                             } catch _ {
                             }
@@ -107,7 +107,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
         }
     }
 
-    private static func replaceOccurrencesOf(_ readerViewLoading: NSMutableString, url: URL) {
+    private static func replaceOccurrencesIn(_ readerViewLoading: NSMutableString, url: URL) {
         readerViewLoading.replaceOccurrences(
             of: "%ORIGINAL-URL%",
             with: url.absoluteString,

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -44,8 +44,6 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
             return GCDWebServerResponse(statusCode: status)
         }
 
-        var readerModeStyle = ReaderModeStyle.defaultStyle()
-
         // Register the handler that accepts /reader-mode/page?url=http://www.example.com requests.
         webServer.registerHandlerForMethod(
             "GET",

--- a/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -77,7 +77,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
                                     contentsOfFile: readerViewLoadingPath,
                                     encoding: String.Encoding.utf8.rawValue
                                 )
-                                replaceOccurrencesIn(readerViewLoading, url: url)
+                                replaceOccurrencesIn(readerViewLoading: readerViewLoading, url: url)
                                 return GCDWebServerDataResponse(html: readerViewLoading as String)
                             } catch _ {
                             }
@@ -115,7 +115,7 @@ struct ReaderModeHandlers: ReaderModeHandlersProtocol {
         return response
     }
 
-    private static func replaceOccurrencesIn(_ readerViewLoading: NSMutableString, url: URL) {
+    private static func replaceOccurrencesIn(readerViewLoading: NSMutableString, url: URL) {
         readerViewLoading.replaceOccurrences(
             of: "%ORIGINAL-URL%",
             with: url.absoluteString,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `ReaderModeHandlers.swift` file by extracting the "generate HTML" logic and the "replace occurrences" logic to new functions.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

