### PR TITLE
Add FXIOS-10349 Add Toggle for Bookmarks Redesign in debug menu

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -49,7 +49,8 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`
     var debugKey: String? {
         switch self {
-        case .closeRemoteTabs,
+        case    .bookmarksRefactor,
+                .closeRemoteTabs,
                 .microsurvey,
                 .homepageRebuild,
                 .menuRefactor,

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksRefactorFeatureFlagProvider.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksRefactorFeatureFlagProvider.swift
@@ -7,7 +7,11 @@ import Foundation
 protocol BookmarksRefactorFeatureFlagProvider {}
 
 extension BookmarksRefactorFeatureFlagProvider {
+    var featureFlags: LegacyFeatureFlagsManager {
+        return LegacyFeatureFlagsManager.shared
+    }
+
     var isBookmarkRefactorEnabled: Bool {
-        NimbusManager.shared.featureFlagLayer.checkNimbusConfigFor(.bookmarksRefactor)
+        return featureFlags.isFeatureEnabled(.bookmarksRefactor, checking: .buildOnly)
     }
 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksRefactorFeatureFlagProvider.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksRefactorFeatureFlagProvider.swift
@@ -7,7 +7,7 @@ import Foundation
 protocol BookmarksRefactorFeatureFlagProvider {}
 
 extension BookmarksRefactorFeatureFlagProvider {
-    var featureFlags: LegacyFeatureFlagsManager {
+    private var featureFlags: LegacyFeatureFlagsManager {
         return LegacyFeatureFlagsManager.shared
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -25,6 +25,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
             title: nil,
             children: [
                 FeatureFlagsBoolSetting(
+                    with: .bookmarksRefactor,
+                    titleText: format(string: "Enable Bookmarks Redesign"),
+                    statusText: format(string: "Toggle to use the new bookmarks design")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .closeRemoteTabs,
                     titleText: format(string: "Enable Close Remote Tabs"),
                     statusText: format(string: "Toggle to enable closing tabs remotely feature")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10349)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22674)

## :bulb: Description
Add flag so that design/QA can toggle the bookmarks feature while we work to verify changes.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

