### PR TITLE
Refactor MTE-3689 Dedicate runner resource to one job

### DIFF
--- a/.github/workflows/firefox-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/firefox-ios-ui-tests-previous-os.yml
@@ -58,6 +58,7 @@ jobs:
       needs: compile
       strategy:
         fail-fast: false
+        max-parallel: 1
         matrix:
           include:
             - ios_version: 16.4

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -61,6 +61,7 @@ jobs:
       needs: compile
       strategy:
         fail-fast: false
+        max-parallel: 1
         matrix:
           ios_simulator: ['iPhone 15 Plus', 'iPad Pro 13-inch (M4)']
       steps:

--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -3,7 +3,7 @@ name: "Firefox UI Tests"
 on:
     workflow_dispatch: {}
     schedule:
-      - cron: "0 2 * * *"
+      - cron: "0 11 * * *"
 
 env:
     browser: firefox-ios

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -18,12 +18,12 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          #- ios_version: 16.4
-          #  ios_simulator: iPhone 14
-          #- ios_version: 15.5
-          #  ios_simulator: iPhone' 13
-          - ios_version: 18.1
-            ios_simulator: iPhone 15
+          - ios_version: 16.4
+            ios_simulator: iPhone 14
+          - ios_version: 15.5
+            ios_simulator: iPhone 13
+          # - ios_version: 18.1
+          #   ios_simulator: iPhone 15
 
     steps:
       - name: Check out source code
@@ -49,7 +49,7 @@ jobs:
           ./bootstrap.sh --force
       - name: Create iOS ${{ matrix.ios_version }} simulator
         id: setup-simulator
-        if: ${{ matrix.ios_version != '18.1' }}
+        if: ${{ startsWith(matrix.ios_version,  '18') }}
         run: |
           # "xcodes runtime install" does not support iOS 18 at this point.
           # macos-14 Github Actions runner contains iOS 18 runtime, so we can 

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -49,7 +49,7 @@ jobs:
           ./bootstrap.sh --force
       - name: Create iOS ${{ matrix.ios_version }} simulator
         id: setup-simulator
-        if: ${{ matrix.ios_version != '18.0' }}
+        if: ${{ matrix.ios_version != '18.1' }}
         run: |
           # "xcodes runtime install" does not support iOS 18 at this point.
           # macos-14 Github Actions runner contains iOS 18 runtime, so we can 

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: macos-14
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         include:
           - ios_version: 16.4

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -18,10 +18,10 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - ios_version: 16.4
-            ios_simulator: iPhone 14
-          - ios_version: 15.5
-            ios_simulator: iPhone 13
+          #- ios_version: 16.4
+          #  ios_simulator: iPhone 14
+          #- ios_version: 15.5
+          #  ios_simulator: iPhone 13
           - ios_version: 18.0
             ios_simulator: iPhone 15
 
@@ -49,7 +49,7 @@ jobs:
           ./bootstrap.sh --force
       - name: Create iOS ${{ matrix.ios_version }} simulator
         id: setup-simulator
-        if: ${{ env.ios_version != '18.0' }}
+        if: ${{ matrix.ios_version != '18.0' }}
         run: |
           # "xcodes runtime install" does not support iOS 18 at this point.
           # macos-14 Github Actions runner contains iOS 18 runtime, so we can 

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -21,8 +21,8 @@ jobs:
           #- ios_version: 16.4
           #  ios_simulator: iPhone 14
           #- ios_version: 15.5
-          #  ios_simulator: iPhone 13
-          - ios_version: 18.0
+          #  ios_simulator: iPhone' 13
+          - ios_version: '18.0'
             ios_simulator: iPhone 15
 
     steps:

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -18,12 +18,11 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          # - ios_version: 16.4
-          #  ios_simulator: iPhone 14
-          # - ios_version: 15.5
-          #  ios_simulator: iPhone 13
-          - ios_version: 18.0
-            ios_simulator: iPhone 16
+          - ios_version: 16.4
+            ios_simulator: iPhone 14
+          - ios_version: 15.5
+            ios_simulator: iPhone 13
+
     steps:
       - name: Check out source code
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -22,7 +22,7 @@ jobs:
           #  ios_simulator: iPhone 14
           #- ios_version: 15.5
           #  ios_simulator: iPhone' 13
-          - ios_version: '18.0'
+          - ios_version: 18.1
             ios_simulator: iPhone 15
 
     steps:

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -49,7 +49,7 @@ jobs:
           ./bootstrap.sh --force
       - name: Create iOS ${{ matrix.ios_version }} simulator
         id: setup-simulator
-        if: ${{ startsWith(matrix.ios_version,  '18') }}
+        if: ${{ ! startsWith(matrix.ios_version,  '18') }}
         run: |
           # "xcodes runtime install" does not support iOS 18 at this point.
           # macos-14 Github Actions runner contains iOS 18 runtime, so we can 

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -22,6 +22,8 @@ jobs:
             ios_simulator: iPhone 14
           - ios_version: 15.5
             ios_simulator: iPhone 13
+          - ios_version: 18.0
+            ios_simulator: iPhone 15
 
     steps:
       - name: Check out source code
@@ -47,7 +49,11 @@ jobs:
           ./bootstrap.sh --force
       - name: Create iOS ${{ matrix.ios_version }} simulator
         id: setup-simulator
+        if: ${{ env.ios_version != '18.0' }}
         run: |
+          # "xcodes runtime install" does not support iOS 18 at this point.
+          # macos-14 Github Actions runner contains iOS 18 runtime, so we can 
+          # skip this step.
           sudo xcodes runtimes install "iOS ${{ matrix.ios_version }}"
           xcrun simctl list devices iphone
       - name: Build Focus

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -22,7 +22,6 @@ jobs:
             ios_simulator: iPhone 14
           - ios_version: 15.5
             ios_simulator: iPhone 13
-
     steps:
       - name: Check out source code
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -22,8 +22,6 @@ jobs:
             ios_simulator: iPhone 14
           - ios_version: 15.5
             ios_simulator: iPhone 13
-          # - ios_version: 18.1
-          #   ios_simulator: iPhone 15
 
     steps:
       - name: Check out source code
@@ -49,11 +47,7 @@ jobs:
           ./bootstrap.sh --force
       - name: Create iOS ${{ matrix.ios_version }} simulator
         id: setup-simulator
-        if: ${{ ! startsWith(matrix.ios_version,  '18') }}
         run: |
-          # "xcodes runtime install" does not support iOS 18 at this point.
-          # macos-14 Github Actions runner contains iOS 18 runtime, so we can 
-          # skip this step.
           sudo xcodes runtimes install "iOS ${{ matrix.ios_version }}"
           xcrun simctl list devices iphone
       - name: Build Focus

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -18,10 +18,12 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - ios_version: 16.4
-            ios_simulator: iPhone 14
-          - ios_version: 15.5
-            ios_simulator: iPhone 13
+          # - ios_version: 16.4
+          #  ios_simulator: iPhone 14
+          # - ios_version: 15.5
+          #  ios_simulator: iPhone 13
+          - ios_version: 18.0
+            ios_simulator: iPhone 16
     steps:
       - name: Check out source code
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -55,7 +55,7 @@ jobs:
             fail-fast: false
             max-parallel: 1
             matrix:
-                xcodebuild_test_plan: ['SmokeTest'] # , 'FullFunctionalTests']
+                xcodebuild_test_plan: ['SmokeTest', 'FullFunctionalTests']
                 ios_simulator: [ 'iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
         steps:
             - name: Check out source code

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -55,8 +55,8 @@ jobs:
             fail-fast: false
             max-parallel: 1
             matrix:
-              xcodebuild_test_plan: ['SmokeTest'] # , 'FullFunctionalTests']
-              ios_simulator: [ 'iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
+                xcodebuild_test_plan: ['SmokeTest'] # , 'FullFunctionalTests']
+                ios_simulator: [ 'iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -55,7 +55,7 @@ jobs:
             fail-fast: false
             max-parallel: 1
             matrix:
-                xcodebuild_test_plan: ['SmokeTest', 'FullFunctionalTests']
+                xcodebuild_test_plan: ['SmokeTest'] #, 'FullFunctionalTests']
                 ios_simulator: [ 'iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
         steps:
             - name: Check out source code

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -55,8 +55,8 @@ jobs:
             fail-fast: false
             max-parallel: 1
             matrix:
-                xcodebuild_test_plan: ['SmokeTest'] #, 'FullFunctionalTests']
-                ios_simulator: [ 'iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
+              xcodebuild_test_plan: ['SmokeTest'] # , 'FullFunctionalTests']
+              ios_simulator: [ 'iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -53,6 +53,7 @@ jobs:
         needs: compile
         strategy:
             fail-fast: false
+            max-parallel: 1
             matrix:
                 xcodebuild_test_plan: ['SmokeTest'] # , 'FullFunctionalTests']
                 ios_simulator: [ 'iPhone 15', 'iPad Pro (12.9-inch) (6th generation)']


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3689)

## :bulb: Description
Last ideas before finalizing the findings for Github Actions:
* Only 1 job is run at a given time during a workflow (see `max-parallel: 1`). The job that does not get run first may be throttled. Let's dedicate the resource to 1 job to improve stability.
* Spread out Firefox/Focus jobs so that the runner resource could be dedicated to one job.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

