### PR TITLE
Add FXIOS-10463 - Use password rules from remote settings when domain is in the list

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
@@ -9,6 +9,7 @@ import "Assets/CC_Script/Helpers.ios.mjs";
 import { Logic } from "Assets/CC_Script/LoginManager.shared.sys.mjs";
 import { PasswordGenerator } from "resource://gre/modules/PasswordGenerator.sys.mjs";
 import { LoginFormFactory } from "resource://gre/modules/shared/LoginFormFactory.sys.mjs";
+import { PasswordRulesParser } from "Assets/CC_Script/PasswordRulesParser.sys.mjs"
 
 // Ensure this module only gets included once. This is
 // required for user scripts injected into all frames.
@@ -453,9 +454,9 @@ window.__firefox__.includeOnce("LoginsHelper", function() {
     // The rules are provided by swift depending on the domain
     if(rules) {
       const domainRules = PasswordRulesParser.parsePasswordRules(
-        rules
+        rules["password-rules"] ?? ""
       );
-      mapOfRules = transformRulesToMap(domainRules);
+      mapOfRules = Logic.transformRulesToMap(domainRules);
     }
 
     const generatedPassword = PasswordGenerator.generatePassword({


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10463)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22905)

## :bulb: Description
This PR:
- ~Manually pulls [D227966](https://phabricator.services.mozilla.com/D227966) from central.~( Merged now in main via the automated PR )
- Passes password rules from RS to JS only if the frame's origin is in the list ( either subdomain or domain match, not different subdomains though)
- Updates JS code to take the rules and parse them.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

