### PR TITLE
Add FXIOS-10385, FXIOS-10384 [Unified Search] Update the search engine icon in the toolbar when an alternative engine has been selected

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuTableView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuTableView.swift
@@ -12,7 +12,8 @@ public protocol MenuTableViewDataDelegate: AnyObject {
 
 class MenuTableView: UIView,
                      UITableViewDelegate,
-                     UITableViewDataSource, ThemeApplicable {
+                     UITableViewDataSource,
+                     ThemeApplicable {
     private struct UX {
         static let topPadding: CGFloat = 10
     }

--- a/BrowserKit/Sources/UnifiedSearchKit/SearchEngineTableView.swift
+++ b/BrowserKit/Sources/UnifiedSearchKit/SearchEngineTableView.swift
@@ -11,7 +11,8 @@ import MenuKit
 // MenuKit's work. Eventually both this target and the MenuKit target will leverage a common reusable tableView component.
 public final class SearchEngineTableView: UIView,
                              UITableViewDelegate,
-                             UITableViewDataSource, ThemeApplicable {
+                             UITableViewDataSource,
+                             ThemeApplicable {
     private struct UX {
         static let topPadding: CGFloat = 10
     }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1856,6 +1856,8 @@
 		EDD21F2E2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD21F2D2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift */; };
 		EDD2A7F82CDACE7C00ED464C /* UnifiedSearchKit in Frameworks */ = {isa = PBXBuildFile; productRef = EDD2A7F72CDACE7C00ED464C /* UnifiedSearchKit */; };
 		EDD2A7FA2CDBD1D100ED464C /* SearchEngineElement+initFromSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD2A7F92CDBD1D000ED464C /* SearchEngineElement+initFromSearchEngine.swift */; };
+		EDDF340A2CDD159F008BB6A4 /* SearchEngineModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */; };
+		EDDF340B2CDD1B7C008BB6A4 /* SearchEngineModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */; };
 		EDF567A02C8B51DC00FDB09D /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = EDF5679F2C8B51DC00FDB09D /* SiteImageView */; };
 		EDF567A22C8B51E100FDB09D /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = EDF567A12C8B51E100FDB09D /* Kingfisher */; };
 		F018F84C2719AE8300B9A52D /* ThemedDefaultNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F018F84B2719AE8300B9A52D /* ThemedDefaultNavigationController.swift */; };
@@ -9100,6 +9102,7 @@
 		EDCA4CBC8077FC37971CC0C7 /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		EDD21F2D2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionViewController.swift; sourceTree = "<group>"; };
 		EDD2A7F92CDBD1D000ED464C /* SearchEngineElement+initFromSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchEngineElement+initFromSearchEngine.swift"; sourceTree = "<group>"; };
+		EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineModel.swift; sourceTree = "<group>"; };
 		EDEE4CC7BD65892525632A4E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Today.strings; sourceTree = "<group>"; };
 		EE294A97B40C4FDBD67AE536 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		EE4D49BBA90C11374B6718A4 /* ur */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ur; path = ur.lproj/LoginManager.strings; sourceTree = "<group>"; };
@@ -13638,6 +13641,7 @@
 			isa = PBXGroup;
 			children = (
 				ED07C0E92CCADCD5006C0627 /* SearchEngineSelectionState.swift */,
+				EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */,
 				ED07C0EC2CCAE745006C0627 /* SearchEngineSelectionAction.swift */,
 				ED07C0EE2CCAE856006C0627 /* SearchEngineSelectionMiddleware.swift */,
 			);
@@ -16030,6 +16034,7 @@
 				96EB6C3827D821B800A9D159 /* HistoryPanelViewModel.swift in Sources */,
 				8A4490922BF3BC2700E7E682 /* MicrosurveyPromptView.swift in Sources */,
 				AB52ED3B2A0E8873001067F5 /* UserConversionMetrics.swift in Sources */,
+				EDDF340A2CDD159F008BB6A4 /* SearchEngineModel.swift in Sources */,
 				219935EC2B07110900E5966F /* TabTrayModel.swift in Sources */,
 				8A3EF7F72A2FCF6D00796E3A /* ExportLogDataSetting.swift in Sources */,
 				43E69EC3254D081D00B591C2 /* SimpleTab.swift in Sources */,
@@ -16994,6 +16999,7 @@
 				E1D6F2D828E325D100B2C8CC /* InstructionsView.swift in Sources */,
 				BD2577982C9D85B5007B344C /* AnyHashable.swift in Sources */,
 				FA6B2AC41D41F02D00429414 /* String+Punycode.swift in Sources */,
+				EDDF340B2CDD1B7C008BB6A4 /* SearchEngineModel.swift in Sources */,
 				E1D6F2D928E32A5300B2C8CC /* ImageIdentifiers.swift in Sources */,
 				F8A0B08429AD64790091C75B /* RustSyncManager.swift in Sources */,
 				EB6E0C60207E6C3100FBFF7E /* SendToDevice.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -178,3 +178,9 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
         return nil
     }
 }
+
+extension OpenSearchEngine {
+    func generateModel() -> SearchEngineModel {
+        return SearchEngineModel(name: self.shortName, image: self.image)
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -177,9 +177,8 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
 
         return nil
     }
-}
 
-extension OpenSearchEngine {
+    /// Helper method for Redux state.
     func generateModel() -> SearchEngineModel {
         return SearchEngineModel(name: self.shortName, image: self.image)
     }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineModel.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+struct SearchEngineModel: Equatable {
+    let name: String
+    let image: UIImage
+}

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionAction.swift
@@ -9,9 +9,16 @@ import Redux
 
 final class SearchEngineSelectionAction: Action {
     let searchEngines: [OpenSearchEngine]?
+    let selectedSearchEngine: OpenSearchEngine?
 
-    init(windowUUID: WindowUUID, actionType: ActionType, searchEngines: [OpenSearchEngine]? = nil) {
+    init(
+        windowUUID: WindowUUID,
+        actionType: ActionType,
+        searchEngines: [OpenSearchEngine]? = nil,
+        selectedSearchEngine: OpenSearchEngine? = nil
+    ) {
         self.searchEngines = searchEngines
+        self.selectedSearchEngine = selectedSearchEngine
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
@@ -19,6 +26,7 @@ final class SearchEngineSelectionAction: Action {
 enum SearchEngineSelectionActionType: ActionType {
     case viewDidLoad
     case didLoadSearchEngines
+    case didTapSearchEngine
 }
 
 enum SearchEngineSelectionMiddlewareActionType: ActionType {}

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionAction.swift
@@ -8,14 +8,14 @@ import MenuKit
 import Redux
 
 final class SearchEngineSelectionAction: Action {
-    let searchEngines: [OpenSearchEngine]?
-    let selectedSearchEngine: OpenSearchEngine?
+    let searchEngines: [SearchEngineModel]?
+    let selectedSearchEngine: SearchEngineModel?
 
     init(
         windowUUID: WindowUUID,
         actionType: ActionType,
-        searchEngines: [OpenSearchEngine]? = nil,
-        selectedSearchEngine: OpenSearchEngine? = nil
+        searchEngines: [SearchEngineModel]? = nil,
+        selectedSearchEngine: SearchEngineModel? = nil
     ) {
         self.searchEngines = searchEngines
         self.selectedSearchEngine = selectedSearchEngine

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -43,7 +43,7 @@ final class SearchEngineSelectionMiddleware {
         let action = SearchEngineSelectionAction(
             windowUUID: windowUUID,
             actionType: SearchEngineSelectionActionType.didLoadSearchEngines,
-            searchEngines: searchEngines
+            searchEngines: searchEngines.map({ $0.generateModel() })
         )
         store.dispatch(action)
     }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
@@ -10,9 +10,9 @@ struct SearchEngineSelectionState: ScreenState, Equatable {
     var windowUUID: WindowUUID
     var shouldDismiss: Bool
     // Default search engine should appear in position 0
-    var searchEngines: [OpenSearchEngine]
+    var searchEngines: [SearchEngineModel]
     // The currently selected search engine, if different from the default. Nil means the user hasn't changed the default.
-    var selectedSearchEngine: OpenSearchEngine?
+    var selectedSearchEngine: SearchEngineModel?
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let state = store.state.screenState(
@@ -38,8 +38,8 @@ struct SearchEngineSelectionState: ScreenState, Equatable {
 
     private init(
         windowUUID: WindowUUID,
-        searchEngines: [OpenSearchEngine],
-        selectedSearchEngine: OpenSearchEngine?,
+        searchEngines: [SearchEngineModel],
+        selectedSearchEngine: SearchEngineModel?,
         shouldDismiss: Bool = false
     ) {
         self.windowUUID = windowUUID

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
@@ -98,7 +98,8 @@ struct SearchEngineSelectionState: ScreenState, Equatable {
     static func defaultState(from state: SearchEngineSelectionState) -> SearchEngineSelectionState {
         return SearchEngineSelectionState(
             windowUUID: state.windowUUID,
-            searchEngines: state.searchEngines
+            searchEngines: state.searchEngines,
+            selectedSearchEngine: state.selectedSearchEngine
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
@@ -74,8 +74,9 @@ struct SearchEngineSelectionState: ScreenState, Equatable {
 
             return SearchEngineSelectionState(
                 windowUUID: state.windowUUID,
-                searchEngines: searchEngines, 
-                selectedSearchEngine: state.selectedSearchEngine // TODO Should this be nil?
+                searchEngines: searchEngines,
+                // With the current usage, we don't want to reset the selectedSearchEngine to nil for didLoadSearchEngines
+                selectedSearchEngine: state.selectedSearchEngine
             )
 
         case SearchEngineSelectionActionType.didTapSearchEngine:

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionState.swift
@@ -48,15 +48,6 @@ struct SearchEngineSelectionState: ScreenState, Equatable {
         self.shouldDismiss = shouldDismiss
     }
 
-    /// Returns a new `SearchEngineSelectionState` which clears any transient data.
-    static func defaultState(fromPreviousState state: SearchEngineSelectionState) -> SearchEngineSelectionState {
-        return SearchEngineSelectionState(
-            windowUUID: state.windowUUID,
-            searchEngines: state.searchEngines,
-            selectedSearchEngine: state.selectedSearchEngine
-        )
-    }
-
     static let reducer: Reducer<Self> = { state, action in
         // Only process actions for the current window
         guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
@@ -82,7 +73,7 @@ struct SearchEngineSelectionState: ScreenState, Equatable {
         case SearchEngineSelectionActionType.didTapSearchEngine:
             guard let action = action as? SearchEngineSelectionAction,
                   let selectedSearchEngine = action.selectedSearchEngine
-            else { return defaultState(fromPreviousState: state) }
+            else { return defaultState(from: state) }
 
             return SearchEngineSelectionState(
                 windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineElement+initFromSearchEngine.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEngineElement+initFromSearchEngine.swift
@@ -5,11 +5,11 @@
 import UnifiedSearchKit
 
 extension SearchEngineElement {
-    init(fromSearchEngine searchEngine: OpenSearchEngine, withAction action: @escaping () -> Void) {
+    init(fromSearchEngine searchEngineModel: SearchEngineModel, withAction action: @escaping () -> Void) {
         self.init(
-            title: searchEngine.shortName,
-            image: searchEngine.image,
-            a11yLabel: searchEngine.shortName,
+            title: searchEngineModel.name,
+            image: searchEngineModel.image,
+            a11yLabel: searchEngineModel.name,
             a11yHint: nil,
             a11yId: AccessibilityIdentifiers.UnifiedSearch.BottomSheetRow.engine,
             action: action

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -45,9 +45,6 @@ class SearchEngineSelectionViewController: UIViewController,
         super.init(nibName: nil, bundle: nil)
 
         subscribeToRedux()
-
-        // TODO Additional setup to come
-        // ...
     }
 
     required init?(coder: NSCoder) {
@@ -176,8 +173,12 @@ class SearchEngineSelectionViewController: UIViewController,
     }
 
     func didTap(searchEngine: OpenSearchEngine) {
-        // TODO FXIOS-10384 Push action to the toolbar to update the search engine selection for the next search and
-        // to focus the toolbar (if it isn't already focused).
-        print("Tapped \(searchEngine.shortName)")
+        store.dispatch(
+            SearchEngineSelectionAction(
+                windowUUID: self.windowUUID,
+                actionType: SearchEngineSelectionActionType.didLoadSearchEngines,
+                selectedSearchEngine: searchEngine
+            )
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -9,20 +9,6 @@ import Shared
 import Redux
 import UnifiedSearchKit
 
-// FXIOS-10189 FIXME This will be refactored later.
-extension SearchEngineElement {
-    init(fromSearchEngine searchEngine: OpenSearchEngine, withAction action: @escaping () -> Void) {
-        self.init(
-            title: searchEngine.shortName,
-            image: searchEngine.image,
-            a11yLabel: searchEngine.shortName,
-            a11yHint: nil,
-            a11yId: AccessibilityIdentifiers.UnifiedSearch.BottomSheetRow.engine,
-            action: action
-        )
-    }
-}
-
 class SearchEngineSelectionViewController: UIViewController,
                                            UISheetPresentationControllerDelegate,
                                            UIPopoverPresentationControllerDelegate,

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -180,5 +180,8 @@ class SearchEngineSelectionViewController: UIViewController,
                 selectedSearchEngine: searchEngine
             )
         )
+
+        // Close the view after a selection has been made
+        coordinator?.dismissModal(animated: true)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -128,10 +128,10 @@ class SearchEngineSelectionViewController: UIViewController,
         )
     }
 
-    func createSearchEngineTableData(withSearchEngines: [OpenSearchEngine]) -> [SearchEngineSection] {
+    func createSearchEngineTableData(withSearchEngines: [SearchEngineModel]) -> [SearchEngineSection] {
         let searchEngineElements = withSearchEngines.map { engine in
             SearchEngineElement(fromSearchEngine: engine, withAction: { [weak self] in
-                self?.didTap(searchEngine: engine)
+                self?.didTap(searchEngineModel: engine)
             })
         }
 
@@ -172,12 +172,12 @@ class SearchEngineSelectionViewController: UIViewController,
         coordinator?.navigateToSearchSettings(animated: true)
     }
 
-    func didTap(searchEngine: OpenSearchEngine) {
+    func didTap(searchEngineModel: SearchEngineModel) {
         store.dispatch(
             SearchEngineSelectionAction(
                 windowUUID: self.windowUUID,
                 actionType: SearchEngineSelectionActionType.didTapSearchEngine,
-                selectedSearchEngine: searchEngine
+                selectedSearchEngine: searchEngineModel
             )
         )
 

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -176,7 +176,7 @@ class SearchEngineSelectionViewController: UIViewController,
         store.dispatch(
             SearchEngineSelectionAction(
                 windowUUID: self.windowUUID,
-                actionType: SearchEngineSelectionActionType.didLoadSearchEngines,
+                actionType: SearchEngineSelectionActionType.didTapSearchEngine,
                 selectedSearchEngine: searchEngine
             )
         )

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -9,6 +9,20 @@ import Shared
 import Redux
 import UnifiedSearchKit
 
+// FXIOS-10189 FIXME This will be refactored later.
+extension SearchEngineElement {
+    init(fromSearchEngine searchEngine: OpenSearchEngine, withAction action: @escaping () -> Void) {
+        self.init(
+            title: searchEngine.shortName,
+            image: searchEngine.image,
+            a11yLabel: searchEngine.shortName,
+            a11yHint: nil,
+            a11yId: AccessibilityIdentifiers.UnifiedSearch.BottomSheetRow.engine,
+            action: action
+        )
+    }
+}
+
 class SearchEngineSelectionViewController: UIViewController,
                                            UISheetPresentationControllerDelegate,
                                            UIPopoverPresentationControllerDelegate,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -95,11 +95,12 @@ class AddressToolbarContainerModel: Equatable {
                                                                       windowUUID: windowUUID)
 
         // If the user has selected an alternative search engine, use that. Otherwise, use the default engine.
-        let searchEngine = state.addressToolbar.alternativeSearchEngine ?? profile.searchEnginesManager.defaultEngine
+        let searchEngineModel = state.addressToolbar.alternativeSearchEngine
+                                ?? profile.searchEnginesManager.defaultEngine?.generateModel()
 
         self.windowUUID = windowUUID
-        self.searchEngineName = searchEngine?.shortName ?? ""
-        self.searchEngineImage = searchEngine?.image ?? UIImage()
+        self.searchEngineName = searchEngineModel?.name ?? ""
+        self.searchEngineImage = searchEngineModel?.image ?? UIImage()
         self.searchEnginesManager = profile.searchEnginesManager
         self.lockIconImageName = state.addressToolbar.lockIconImageName
         self.lockIconNeedsTheming = state.addressToolbar.lockIconNeedsTheming

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -93,9 +93,13 @@ class AddressToolbarContainerModel: Equatable {
         self.browserActions = AddressToolbarContainerModel.mapActions(state.addressToolbar.browserActions,
                                                                       isShowingTopTabs: state.isShowingTopTabs,
                                                                       windowUUID: windowUUID)
+
+        // If the user has selected an alternative search engine, use that. Otherwise, use the default engine.
+        let searchEngine = state.alternativeSearchEngine ?? profile.searchEnginesManager.defaultEngine
+
         self.windowUUID = windowUUID
-        self.searchEngineName = profile.searchEnginesManager.defaultEngine?.shortName
-        self.searchEngineImage = profile.searchEnginesManager.defaultEngine?.image
+        self.searchEngineName = searchEngine?.shortName ?? ""
+        self.searchEngineImage = searchEngine?.image ?? UIImage()
         self.searchEnginesManager = profile.searchEnginesManager
         self.lockIconImageName = state.addressToolbar.lockIconImageName
         self.lockIconNeedsTheming = state.addressToolbar.lockIconNeedsTheming

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -95,7 +95,7 @@ class AddressToolbarContainerModel: Equatable {
                                                                       windowUUID: windowUUID)
 
         // If the user has selected an alternative search engine, use that. Otherwise, use the default engine.
-        let searchEngine = state.alternativeSearchEngine ?? profile.searchEnginesManager.defaultEngine
+        let searchEngine = state.addressToolbar.alternativeSearchEngine ?? profile.searchEnginesManager.defaultEngine
 
         self.windowUUID = windowUUID
         self.searchEngineName = searchEngine?.shortName ?? ""

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -12,8 +12,8 @@ class AddressToolbarContainerModel: Equatable {
     let browserActions: [ToolbarElement]
 
     let borderPosition: AddressToolbarBorderPosition?
-    let searchEngineName: String?
-    let searchEngineImage: UIImage?
+    let searchEngineName: String
+    let searchEngineImage: UIImage
     let searchEnginesManager: SearchEnginesManager
     let lockIconImageName: String?
     let lockIconNeedsTheming: Bool
@@ -42,7 +42,7 @@ class AddressToolbarContainerModel: Equatable {
             searchEngineImageViewA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.searchEngine,
             searchEngineImageViewA11yLabel: String(
                 format: .AddressToolbar.SearchEngineA11yLabel,
-                searchEngineName ?? ""
+                searchEngineName
             ),
             lockIconButtonA11yId: AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon,
             lockIconButtonA11yLabel: .AddressToolbar.PrivacyAndSecuritySettingsA11yLabel,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -211,7 +211,9 @@ struct AddressBarState: StateType, Equatable {
     }
 
     private static func handleDidLoadToolbarsAction(state: Self, action: Action) -> Self {
-        guard let borderPosition = (action as? ToolbarAction)?.addressBorderPosition else { return state }
+        guard let borderPosition = (action as? ToolbarAction)?.addressBorderPosition else {
+            return defaultState(from: state)
+        }
 
         return AddressBarState(
             windowUUID: state.windowUUID,
@@ -702,7 +704,7 @@ struct AddressBarState: StateType, Equatable {
     private static func handleDidTapSearchEngine(state: Self, action: Action) -> AddressBarState {
         guard let searchEngineSelectionAction = action as? SearchEngineSelectionAction,
               let selectedSearchEngine = searchEngineSelectionAction.selectedSearchEngine
-        else { return state }
+        else { return defaultState(from: state) }
 
         return AddressBarState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -24,6 +24,8 @@ struct AddressBarState: StateType, Equatable {
     let readerModeState: ReaderModeState?
     let didStartTyping: Bool
     let showQRPageAction: Bool
+    /// Stores the alternative search engine that the user has temporarily selected (otherwise use the default)
+    let alternativeSearchEngine: OpenSearchEngine?
 
     private static let qrCodeScanAction = ToolbarActionState(
         actionType: .qrCode,
@@ -133,6 +135,7 @@ struct AddressBarState: StateType, Equatable {
         self.readerModeState = readerModeState
         self.didStartTyping = didStartTyping
         self.showQRPageAction = showQRPageAction
+        self.alternativeSearchEngine = alternativeSearchEngine
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -196,6 +199,9 @@ struct AddressBarState: StateType, Equatable {
 
         case ToolbarActionType.didStartTyping:
             return handleDidStartTypingAction(state: state, action: action)
+
+        case SearchEngineSelectionActionType.didTapSearchEngine:
+            return handleDidTapSearchEngine(state: state, action: action)
 
         default:
             return defaultState(from: state)
@@ -673,7 +679,34 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    static func defaultState(from state: AddressBarState) -> AddressBarState {
+    private static func handleDidTapSearchEngine(state: Self, action: Action) -> AddressBarState {
+        guard let searchEngineSelectionAction = action as? SearchEngineSelectionAction,
+              let selectedSearchEngine = searchEngineSelectionAction.selectedSearchEngine
+        else { return state }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: state.pageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            isScrollingDuringEdit: state.isScrollingDuringEdit,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: state.didStartTyping,
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: selectedSearchEngine
+        )
+    }
+
+    private static func handleDefaultAction(state: Self) -> Self {
         return AddressBarState(
             windowUUID: state.windowUUID,
             navigationActions: state.navigationActions,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -25,7 +25,7 @@ struct AddressBarState: StateType, Equatable {
     let didStartTyping: Bool
     let showQRPageAction: Bool
     /// Stores the alternative search engine that the user has temporarily selected (otherwise use the default)
-    let alternativeSearchEngine: OpenSearchEngine?
+    let alternativeSearchEngine: SearchEngineModel?
 
     private static let qrCodeScanAction = ToolbarActionState(
         actionType: .qrCode,
@@ -117,7 +117,8 @@ struct AddressBarState: StateType, Equatable {
          isLoading: Bool,
          readerModeState: ReaderModeState?,
          didStartTyping: Bool,
-         showQRPageAction: Bool) {
+         showQRPageAction: Bool,
+         alternativeSearchEngine: SearchEngineModel? = nil) {
         self.windowUUID = windowUUID
         self.navigationActions = navigationActions
         self.pageActions = pageActions

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -97,7 +97,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: false,
             readerModeState: nil,
             didStartTyping: false,
-            showQRPageAction: true
+            showQRPageAction: true,
+            alternativeSearchEngine: nil
         )
     }
 
@@ -118,7 +119,7 @@ struct AddressBarState: StateType, Equatable {
          readerModeState: ReaderModeState?,
          didStartTyping: Bool,
          showQRPageAction: Bool,
-         alternativeSearchEngine: SearchEngineModel? = nil) {
+         alternativeSearchEngine: SearchEngineModel?) {
         self.windowUUID = windowUUID
         self.navigationActions = navigationActions
         self.pageActions = pageActions
@@ -229,7 +230,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: false,
             readerModeState: nil,
             didStartTyping: false,
-            showQRPageAction: true
+            showQRPageAction: true,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -253,7 +255,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: toolbarAction.readerModeState,
             didStartTyping: state.didStartTyping,
-            showQRPageAction: state.showQRPageAction
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -280,7 +283,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: toolbarAction.readerModeState,
             didStartTyping: state.didStartTyping,
-            showQRPageAction: state.showQRPageAction
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -304,7 +308,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: toolbarAction.isLoading ?? state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: state.didStartTyping,
-            showQRPageAction: state.showQRPageAction
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -330,7 +335,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: state.didStartTyping,
-            showQRPageAction: toolbarAction.url == nil
+            showQRPageAction: toolbarAction.url == nil,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -356,7 +362,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: state.didStartTyping,
-            showQRPageAction: state.showQRPageAction
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -382,7 +389,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: state.didStartTyping,
-            showQRPageAction: state.showQRPageAction
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -406,7 +414,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: state.didStartTyping,
-            showQRPageAction: state.showQRPageAction
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -430,7 +439,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: state.didStartTyping,
-            showQRPageAction: state.showQRPageAction
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -459,7 +469,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: false,
-            showQRPageAction: isEmptySearch
+            showQRPageAction: isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -490,7 +501,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: false,
-            showQRPageAction: showQRPageAction
+            showQRPageAction: showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -520,7 +532,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: false,
-            showQRPageAction: showQRPageAction
+            showQRPageAction: showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -549,7 +562,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: false,
-            showQRPageAction: isEmptySearch
+            showQRPageAction: isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -571,7 +585,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: state.didStartTyping,
-            showQRPageAction: state.showQRPageAction
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -598,7 +613,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: state.didStartTyping,
-            showQRPageAction: true
+            showQRPageAction: true,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -625,7 +641,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: true,
-            showQRPageAction: true
+            showQRPageAction: true,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -652,7 +669,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: true,
-            showQRPageAction: false
+            showQRPageAction: false,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -676,7 +694,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: true,
-            showQRPageAction: state.showQRPageAction
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 
@@ -707,7 +726,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleDefaultAction(state: Self) -> Self {
+    static func defaultState(from state: AddressBarState) -> AddressBarState {
         return AddressBarState(
             windowUUID: state.windowUUID,
             navigationActions: state.navigationActions,
@@ -725,7 +744,8 @@ struct AddressBarState: StateType, Equatable {
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: state.didStartTyping,
-            showQRPageAction: state.showQRPageAction
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -21,8 +21,6 @@ struct ToolbarState: ScreenState, Equatable {
     var isNewTabFeatureEnabled: Bool
     var canShowDataClearanceAction: Bool
     var canShowNavigationHint: Bool
-    /// Stores the alternative search engine that the user has temporarily selected (otherwise use the default)
-    let alternativeSearchEngine: OpenSearchEngine?
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let toolbarState = store.state.screenState(
@@ -47,8 +45,7 @@ struct ToolbarState: ScreenState, Equatable {
                   showMenuWarningBadge: toolbarState.showMenuWarningBadge,
                   isNewTabFeatureEnabled: toolbarState.isNewTabFeatureEnabled,
                   canShowDataClearanceAction: toolbarState.canShowDataClearanceAction,
-                  canShowNavigationHint: toolbarState.canShowNavigationHint,
-                  alternativeSearchEngine: toolbarState.alternativeSearchEngine
+                  canShowNavigationHint: toolbarState.canShowNavigationHint
         )
     }
 
@@ -67,8 +64,7 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: false,
             isNewTabFeatureEnabled: false,
             canShowDataClearanceAction: false,
-            canShowNavigationHint: false,
-            alternativeSearchEngine: nil
+            canShowNavigationHint: false
         )
     }
 
@@ -86,8 +82,7 @@ struct ToolbarState: ScreenState, Equatable {
         showMenuWarningBadge: Bool,
         isNewTabFeatureEnabled: Bool,
         canShowDataClearanceAction: Bool,
-        canShowNavigationHint: Bool,
-        alternativeSearchEngine: OpenSearchEngine?
+        canShowNavigationHint: Bool
     ) {
         self.windowUUID = windowUUID
         self.toolbarPosition = toolbarPosition
@@ -103,7 +98,6 @@ struct ToolbarState: ScreenState, Equatable {
         self.isNewTabFeatureEnabled = isNewTabFeatureEnabled
         self.canShowDataClearanceAction = canShowDataClearanceAction
         self.canShowNavigationHint = canShowNavigationHint
-        self.alternativeSearchEngine = alternativeSearchEngine
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -151,35 +145,11 @@ struct ToolbarState: ScreenState, Equatable {
             return handleNavigationHintFinishedPresenting(state: state, action: action)
 
         case SearchEngineSelectionActionType.didTapSearchEngine:
-            return handleDidTapSearchEngine(state: state, action: action)
+            return handleSearchEngineSelectionAction(state: state, action: action)
 
         default:
             return defaultState(from: state)
         }
-    }
-
-    private static func handleDidTapSearchEngine(state: Self, action: Action) -> ToolbarState {
-        guard let searchEngineSelectionAction = action as? SearchEngineSelectionAction,
-              let selectedSearchEngine = searchEngineSelectionAction.selectedSearchEngine
-        else { return state }
-
-        return ToolbarState(
-            windowUUID: state.windowUUID,
-            toolbarPosition: state.toolbarPosition,
-            isPrivateMode: state.isPrivateMode,
-            addressToolbar: AddressBarState.reducer(state.addressToolbar, searchEngineSelectionAction),
-            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, searchEngineSelectionAction),
-            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
-            isShowingTopTabs: state.isShowingTopTabs,
-            canGoBack: state.canGoBack,
-            canGoForward: state.canGoForward,
-            numberOfTabs: state.numberOfTabs,
-            showMenuWarningBadge: state.showMenuWarningBadge,
-            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
-            canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint,
-            alternativeSearchEngine: selectedSearchEngine
-        )
     }
 
     private static func handleDidLoadToolbars(state: Self, action: Action) -> ToolbarState {
@@ -202,8 +172,7 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: toolbarAction.isNewTabFeatureEnabled ?? state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: toolbarAction.canShowDataClearanceAction ?? state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint,
-            alternativeSearchEngine: state.alternativeSearchEngine
+            canShowNavigationHint: state.canShowNavigationHint
         )
     }
 
@@ -223,8 +192,7 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint,
-            alternativeSearchEngine: state.alternativeSearchEngine
+            canShowNavigationHint: state.canShowNavigationHint
         )
     }
 
@@ -244,8 +212,7 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: toolbarAction.showMenuWarningBadge ?? state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint,
-            alternativeSearchEngine: state.alternativeSearchEngine
+            canShowNavigationHint: state.canShowNavigationHint
         )
     }
 
@@ -265,8 +232,7 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint,
-            alternativeSearchEngine: state.alternativeSearchEngine
+            canShowNavigationHint: state.canShowNavigationHint
         )
     }
 
@@ -291,8 +257,7 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint,
-            alternativeSearchEngine: state.alternativeSearchEngine
+            canShowNavigationHint: state.canShowNavigationHint
         )
     }
 
@@ -312,8 +277,7 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint,
-            alternativeSearchEngine: state.alternativeSearchEngine
+            canShowNavigationHint: state.canShowNavigationHint
         )
     }
 
@@ -333,8 +297,7 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint,
-            alternativeSearchEngine: state.alternativeSearchEngine
+            canShowNavigationHint: state.canShowNavigationHint
         )
     }
 
@@ -354,8 +317,7 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint,
-            alternativeSearchEngine: state.alternativeSearchEngine
+            canShowNavigationHint: state.canShowNavigationHint
         )
     }
 
@@ -375,8 +337,7 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: true,
-            alternativeSearchEngine: state.alternativeSearchEngine
+            canShowNavigationHint: true
         )
     }
 
@@ -396,8 +357,28 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: false,
-            alternativeSearchEngine: state.alternativeSearchEngine
+            canShowNavigationHint: false
+        )
+    }
+
+    private static func handleSearchEngineSelectionAction(state: Self, action: Action) -> ToolbarState {
+        guard let searchEngineSelectionAction = action as? SearchEngineSelectionAction else { return state }
+
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: state.toolbarPosition,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, searchEngineSelectionAction),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, searchEngineSelectionAction),
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: state.isShowingTopTabs,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: state.canShowNavigationHint
         )
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -21,6 +21,8 @@ struct ToolbarState: ScreenState, Equatable {
     var isNewTabFeatureEnabled: Bool
     var canShowDataClearanceAction: Bool
     var canShowNavigationHint: Bool
+    /// Stores the alternative search engine that the user has temporarily selected (otherwise use the default)
+    let alternativeSearchEngine: OpenSearchEngine?
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let toolbarState = store.state.screenState(
@@ -45,7 +47,9 @@ struct ToolbarState: ScreenState, Equatable {
                   showMenuWarningBadge: toolbarState.showMenuWarningBadge,
                   isNewTabFeatureEnabled: toolbarState.isNewTabFeatureEnabled,
                   canShowDataClearanceAction: toolbarState.canShowDataClearanceAction,
-                  canShowNavigationHint: toolbarState.canShowNavigationHint)
+                  canShowNavigationHint: toolbarState.canShowNavigationHint,
+                  alternativeSearchEngine: toolbarState.alternativeSearchEngine
+        )
     }
 
     init(windowUUID: WindowUUID) {
@@ -63,7 +67,8 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: false,
             isNewTabFeatureEnabled: false,
             canShowDataClearanceAction: false,
-            canShowNavigationHint: false
+            canShowNavigationHint: false,
+            alternativeSearchEngine: nil
         )
     }
 
@@ -81,7 +86,8 @@ struct ToolbarState: ScreenState, Equatable {
         showMenuWarningBadge: Bool,
         isNewTabFeatureEnabled: Bool,
         canShowDataClearanceAction: Bool,
-        canShowNavigationHint: Bool
+        canShowNavigationHint: Bool,
+        alternativeSearchEngine: OpenSearchEngine?
     ) {
         self.windowUUID = windowUUID
         self.toolbarPosition = toolbarPosition
@@ -97,6 +103,7 @@ struct ToolbarState: ScreenState, Equatable {
         self.isNewTabFeatureEnabled = isNewTabFeatureEnabled
         self.canShowDataClearanceAction = canShowDataClearanceAction
         self.canShowNavigationHint = canShowNavigationHint
+        self.alternativeSearchEngine = alternativeSearchEngine
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -143,9 +150,36 @@ struct ToolbarState: ScreenState, Equatable {
         case ToolbarActionType.navigationHintFinishedPresenting:
             return handleNavigationHintFinishedPresenting(state: state, action: action)
 
+        case SearchEngineSelectionActionType.didTapSearchEngine:
+            return handleDidTapSearchEngine(state: state, action: action)
+
         default:
             return defaultState(from: state)
         }
+    }
+
+    private static func handleDidTapSearchEngine(state: Self, action: Action) -> ToolbarState {
+        guard let searchEngineSelectionAction = action as? SearchEngineSelectionAction,
+              let selectedSearchEngine = searchEngineSelectionAction.selectedSearchEngine
+        else { return state }
+
+        return ToolbarState(
+            windowUUID: state.windowUUID,
+            toolbarPosition: state.toolbarPosition,
+            isPrivateMode: state.isPrivateMode,
+            addressToolbar: AddressBarState.reducer(state.addressToolbar, searchEngineSelectionAction),
+            navigationToolbar: NavigationBarState.reducer(state.navigationToolbar, searchEngineSelectionAction),
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            isShowingTopTabs: state.isShowingTopTabs,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+            numberOfTabs: state.numberOfTabs,
+            showMenuWarningBadge: state.showMenuWarningBadge,
+            isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
+            canShowDataClearanceAction: state.canShowDataClearanceAction,
+            canShowNavigationHint: state.canShowNavigationHint,
+            alternativeSearchEngine: selectedSearchEngine
+        )
     }
 
     private static func handleDidLoadToolbars(state: Self, action: Action) -> ToolbarState {
@@ -168,7 +202,9 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: toolbarAction.isNewTabFeatureEnabled ?? state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: toolbarAction.canShowDataClearanceAction ?? state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint)
+            canShowNavigationHint: state.canShowNavigationHint,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
     }
 
     private static func handleToolbarUpdates(state: Self, action: Action) -> ToolbarState {
@@ -187,7 +223,9 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint)
+            canShowNavigationHint: state.canShowNavigationHint,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
     }
 
     private static func handleShowMenuWarningBadge(state: Self, action: Action) -> ToolbarState {
@@ -206,7 +244,9 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: toolbarAction.showMenuWarningBadge ?? state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint)
+            canShowNavigationHint: state.canShowNavigationHint,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
     }
 
     private static func handleNumberOfTabsChanged(state: Self, action: Action) -> ToolbarState {
@@ -225,7 +265,9 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint)
+            canShowNavigationHint: state.canShowNavigationHint,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
     }
 
     private static func handleToolbarPositionChanged(state: Self, action: Action) -> ToolbarState {
@@ -249,7 +291,9 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint)
+            canShowNavigationHint: state.canShowNavigationHint,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
     }
 
     private static func handleReaderModeStateChanged(state: Self, action: Action) -> ToolbarState {
@@ -268,7 +312,9 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint)
+            canShowNavigationHint: state.canShowNavigationHint,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
     }
 
     private static func handleBackForwardButtonStateChanged(state: Self, action: Action) -> ToolbarState {
@@ -287,7 +333,9 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint)
+            canShowNavigationHint: state.canShowNavigationHint,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
     }
 
     private static func handleTraitCollectionDidChange(state: Self, action: Action) -> ToolbarState {
@@ -306,7 +354,9 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: state.canShowNavigationHint)
+            canShowNavigationHint: state.canShowNavigationHint,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
     }
 
     private static func handleNavigationButtonDoubleTapped(state: Self, action: Action) -> ToolbarState {
@@ -325,7 +375,9 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: true)
+            canShowNavigationHint: true,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
     }
 
     private static func handleNavigationHintFinishedPresenting(state: Self, action: Action) -> ToolbarState {
@@ -344,7 +396,9 @@ struct ToolbarState: ScreenState, Equatable {
             showMenuWarningBadge: state.showMenuWarningBadge,
             isNewTabFeatureEnabled: state.isNewTabFeatureEnabled,
             canShowDataClearanceAction: state.canShowDataClearanceAction,
-            canShowNavigationHint: false)
+            canShowNavigationHint: false,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
     }
 
     private static func addressToolbarPositionFromSearchBarPosition(_ position: SearchBarPosition)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
@@ -41,11 +41,7 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase {
 
         testStore.dispatch(action)
 
-        // Currently we have a testability problem with our redux archicture:
-        // 1) Every middleware calls the global `store`
-        // 2) We have one global store so every test (including tests running in parallel) accesses the same store
-        //
-        // Ideally we would be able to check that the middleware fired an action of a specific type with a specific payload.
+        // TODO FXIOS-10481 Flesh out middleware tests once we have decided on best practices
         throw XCTSkip("Need Store architecture changes if we want to implement tests")
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionStateTests.swift
@@ -29,10 +29,10 @@ final class SearchEngineSelectionStateTests: XCTestCase {
         let initialState = createSubject()
         let reducer = searchEngineSelectionReducer()
 
-        let expectedResult: [OpenSearchEngine] = [
+        let expectedResult = [
             OpenSearchEngineTests.generateOpenSearchEngine(type: .wikipedia, withImage: UIImage()),
             OpenSearchEngineTests.generateOpenSearchEngine(type: .youtube, withImage: UIImage())
-        ]
+        ].map({ $0.generateModel() })
 
         XCTAssertEqual(initialState.searchEngines, [])
 
@@ -54,6 +54,7 @@ final class SearchEngineSelectionStateTests: XCTestCase {
         let reducer = searchEngineSelectionReducer()
 
         let selectedSearchEngine = OpenSearchEngineTests.generateOpenSearchEngine(type: .wikipedia, withImage: UIImage())
+                                   .generateModel()
 
         XCTAssertEqual(initialState.searchEngines, [])
         XCTAssertNil(initialState.selectedSearchEngine)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionStateTests.swift
@@ -48,6 +48,28 @@ final class SearchEngineSelectionStateTests: XCTestCase {
         XCTAssertEqual(newState.searchEngines, expectedResult)
     }
 
+    func testDidTapSearchEngine() {
+        let initialState = createSubject()
+        let reducer = searchEngineSelectionReducer()
+
+        let selectedSearchEngine = OpenSearchEngineTests.generateOpenSearchEngine(type: .wikipedia, withImage: UIImage())
+
+        XCTAssertEqual(initialState.searchEngines, [])
+        XCTAssertNil(initialState.selectedSearchEngine)
+
+        let newState = reducer(
+            initialState,
+            SearchEngineSelectionAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: SearchEngineSelectionActionType.didLoadSearchEngines,
+                selectedSearchEngine: selectedSearchEngine
+            )
+        )
+
+        XCTAssertTrue(newState.searchEngines.isEmpty)
+        XCTAssertEqual(newState.selectedSearchEngine, selectedSearchEngine)
+    }
+
     // MARK: - Private
     private func createSubject() -> SearchEngineSelectionState {
         return SearchEngineSelectionState(windowUUID: .XCTestDefaultUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionStateTests.swift
@@ -46,6 +46,7 @@ final class SearchEngineSelectionStateTests: XCTestCase {
         )
 
         XCTAssertEqual(newState.searchEngines, expectedResult)
+        XCTAssertNil(newState.selectedSearchEngine)
     }
 
     func testDidTapSearchEngine() {
@@ -61,7 +62,7 @@ final class SearchEngineSelectionStateTests: XCTestCase {
             initialState,
             SearchEngineSelectionAction(
                 windowUUID: .XCTestDefaultUUID,
-                actionType: SearchEngineSelectionActionType.didLoadSearchEngines,
+                actionType: SearchEngineSelectionActionType.didTapSearchEngine,
                 selectedSearchEngine: selectedSearchEngine
             )
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
@@ -170,7 +170,7 @@ open class MockProfile: Client.Profile {
     }()
 
     public lazy var searchEnginesManager: SearchEnginesManager = {
-        return SearchEnginesManager(prefs: self.prefs, files: self.files)
+        return SearchEnginesManager(prefs: self.prefs, files: self.files, engineProvider: MockSearchEngineProvider())
     }()
 
     public lazy var prefs: Prefs = {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -7,7 +7,6 @@ import Common
 import XCTest
 
 class AddressToolbarContainerModelTests: XCTestCase {
-    private var viewModel: AddressToolbarContainerModel!
     private var mockProfile: MockProfile!
     private var searchEnginesManager: SearchEnginesManager!
     private let windowUUID: WindowUUID = .XCTestDefaultUUID
@@ -15,64 +14,26 @@ class AddressToolbarContainerModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
+
         mockProfile = MockProfile()
 
-        let addressState = AddressBarState(windowUUID: windowUUID,
-                                           navigationActions: [],
-                                           pageActions: [],
-                                           browserActions: [],
-                                           borderPosition: nil,
-                                           url: nil,
-                                           searchTerm: nil,
-                                           lockIconImageName: nil,
-                                           lockIconNeedsTheming: true,
-                                           safeListedURLImageName: nil,
-                                           isEditing: false,
-                                           isScrollingDuringEdit: false,
-                                           shouldSelectSearchTerm: true,
-                                           isLoading: false,
-                                           readerModeState: nil,
-                                           didStartTyping: false,
-                                           showQRPageAction: true)
-        let navigationState = NavigationBarState(windowUUID: windowUUID, actions: [], displayBorder: false)
-        let state = ToolbarState(windowUUID: windowUUID,
-                                 toolbarPosition: .top,
-                                 isPrivateMode: false,
-                                 addressToolbar: addressState,
-                                 navigationToolbar: navigationState,
-                                 isShowingNavigationToolbar: true,
-                                 isShowingTopTabs: true,
-                                 canGoBack: true,
-                                 canGoForward: true,
-                                 numberOfTabs: 1,
-                                 showMenuWarningBadge: false,
-                                 isNewTabFeatureEnabled: false,
-                                 canShowDataClearanceAction: false,
-                                 canShowNavigationHint: false)
-        viewModel = AddressToolbarContainerModel(state: state,
-                                                 profile: mockProfile,
-                                                 windowUUID: windowUUID)
-
-        let mockSearchEngineProvider = MockSearchEngineProvider()
-        searchEnginesManager = SearchEnginesManager(
-            prefs: mockProfile.prefs,
-            files: mockProfile.files,
-            engineProvider: mockSearchEngineProvider
-        )
+        // The MockProfile creates a SearchEnginesManager with a `MockSearchEngineProvider`
+        searchEnginesManager = mockProfile.searchEnginesManager
     }
 
     override func tearDown() {
         super.tearDown()
-        viewModel = nil
         mockProfile = nil
         searchEnginesManager = nil
     }
 
     func testSearchWordFromURLWhenUrlIsNilThenSearchWordIsNil() {
+        let viewModel = createSubject(withState: createBasicToolbarState())
         XCTAssertNil(viewModel.searchTermFromURL(nil, searchEnginesManager: searchEnginesManager))
     }
 
     func testSearchWordFromURLWhenUsingGoogleSearchThenSearchWordIsCorrect() {
+        let viewModel = createSubject(withState: createBasicToolbarState())
         let searchTerm = "test"
         let url = URL(string: "http://firefox.com/find?q=\(searchTerm)")
         let result = viewModel.searchTermFromURL(url, searchEnginesManager: searchEnginesManager)
@@ -80,8 +41,93 @@ class AddressToolbarContainerModelTests: XCTestCase {
     }
 
     func testSearchWordFromURLWhenUsingInternalUrlThenSearchWordIsNil() {
+        let viewModel = createSubject(withState: createBasicToolbarState())
         let searchTerm = "test"
         let url = URL(string: "internal://local?q=\(searchTerm)")
         XCTAssertNil(viewModel.searchTermFromURL(url, searchEnginesManager: searchEnginesManager))
+    }
+
+    func testUsesDefaultSearchEngine_WhenNoSearchEngineSelected() {
+        let viewModel = createSubject(withState: createBasicToolbarState())
+
+        guard let defaultEngine = searchEnginesManager.defaultEngine else {
+            XCTFail("No default search engine")
+            return
+        }
+
+        XCTAssertEqual(viewModel.searchEngineName, defaultEngine.shortName)
+        XCTAssertEqual(viewModel.searchEngineImage, defaultEngine.image)
+    }
+
+    func testUsesAlternativeSearchEngine_WhenSearchEngineSelected() {
+        let searchEngineImage = UIImage()
+        let selectedSearchEngine = OpenSearchEngineTests.generateOpenSearchEngine(
+            type: .wikipedia,
+            withImage: searchEngineImage
+        )
+        let viewModel = createSubject(
+            withState: createToolbarStateWithAlternativeSearchEngine(searchEngine: selectedSearchEngine)
+        )
+
+        XCTAssertEqual(viewModel.searchEngineName, selectedSearchEngine.shortName)
+        XCTAssertEqual(viewModel.searchEngineImage, selectedSearchEngine.image)
+    }
+
+    // MARK: - Private helpers
+
+    private func createSubject(withState state: ToolbarState) -> AddressToolbarContainerModel {
+        return AddressToolbarContainerModel(state: state,
+                                            profile: mockProfile,
+                                            windowUUID: windowUUID)
+    }
+
+    private func createBasicAddressBarState() -> AddressBarState {
+        return AddressBarState(windowUUID: windowUUID,
+                               navigationActions: [],
+                               pageActions: [],
+                               browserActions: [],
+                               borderPosition: nil,
+                               url: nil,
+                               lockIconImageName: "")
+    }
+
+    private func createBasicNavigationBarState() -> NavigationBarState {
+        return NavigationBarState(windowUUID: windowUUID, actions: [], displayBorder: false)
+    }
+
+    private func createBasicToolbarState() -> ToolbarState {
+        return ToolbarState(windowUUID: windowUUID,
+                            toolbarPosition: .top,
+                            isPrivateMode: false,
+                            addressToolbar: createBasicAddressBarState(),
+                            navigationToolbar: createBasicNavigationBarState(),
+                            isShowingNavigationToolbar: true,
+                            isShowingTopTabs: true,
+                            canGoBack: true,
+                            canGoForward: true,
+                            numberOfTabs: 1,
+                            showMenuWarningBadge: false,
+                            isNewTabFeatureEnabled: false,
+                            canShowDataClearanceAction: false,
+                            canShowNavigationHint: false,
+                            alternativeSearchEngine: nil)
+    }
+
+    private func createToolbarStateWithAlternativeSearchEngine(searchEngine: OpenSearchEngine) -> ToolbarState {
+        return ToolbarState(windowUUID: windowUUID,
+                            toolbarPosition: .top,
+                            isPrivateMode: false,
+                            addressToolbar: createBasicAddressBarState(),
+                            navigationToolbar: createBasicNavigationBarState(),
+                            isShowingNavigationToolbar: true,
+                            isShowingTopTabs: true,
+                            canGoBack: true,
+                            canGoForward: true,
+                            numberOfTabs: 1,
+                            showMenuWarningBadge: false,
+                            isNewTabFeatureEnabled: false,
+                            canShowDataClearanceAction: false,
+                            canShowNavigationHint: false,
+                            alternativeSearchEngine: searchEngine)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -66,7 +66,7 @@ class AddressToolbarContainerModelTests: XCTestCase {
             withImage: searchEngineImage
         )
         let viewModel = createSubject(
-            withState: createToolbarStateWithAlternativeSearchEngine(searchEngine: selectedSearchEngine)
+            withState: createToolbarStateWithAlternativeSearchEngine(searchEngine: selectedSearchEngine.generateModel())
         )
 
         XCTAssertEqual(viewModel.searchEngineName, selectedSearchEngine.shortName)
@@ -89,7 +89,20 @@ class AddressToolbarContainerModelTests: XCTestCase {
                                borderPosition: nil,
                                url: nil,
                                lockIconImageName: "",
-                               lockIconNeedsTheming: false)
+                               lockIconNeedsTheming: false,
+                               alternativeSearchEngine: nil)
+    }
+
+    private func createAddressBarStateWithAlternativeSearchEngine(searchEngine: SearchEngineModel) -> AddressBarState {
+        return AddressBarState(windowUUID: windowUUID,
+                               navigationActions: [],
+                               pageActions: [],
+                               browserActions: [],
+                               borderPosition: nil,
+                               url: nil,
+                               lockIconImageName: "",
+                               lockIconNeedsTheming: false,
+                               alternativeSearchEngine: searchEngine)
     }
 
     private func createBasicNavigationBarState() -> NavigationBarState {
@@ -110,15 +123,14 @@ class AddressToolbarContainerModelTests: XCTestCase {
                             showMenuWarningBadge: false,
                             isNewTabFeatureEnabled: false,
                             canShowDataClearanceAction: false,
-                            canShowNavigationHint: false,
-                            alternativeSearchEngine: nil)
+                            canShowNavigationHint: false)
     }
 
-    private func createToolbarStateWithAlternativeSearchEngine(searchEngine: OpenSearchEngine) -> ToolbarState {
+    private func createToolbarStateWithAlternativeSearchEngine(searchEngine: SearchEngineModel) -> ToolbarState {
         return ToolbarState(windowUUID: windowUUID,
                             toolbarPosition: .top,
                             isPrivateMode: false,
-                            addressToolbar: createBasicAddressBarState(),
+                            addressToolbar: createAddressBarStateWithAlternativeSearchEngine(searchEngine: searchEngine),
                             navigationToolbar: createBasicNavigationBarState(),
                             isShowingNavigationToolbar: true,
                             isShowingTopTabs: true,
@@ -128,7 +140,6 @@ class AddressToolbarContainerModelTests: XCTestCase {
                             showMenuWarningBadge: false,
                             isNewTabFeatureEnabled: false,
                             canShowDataClearanceAction: false,
-                            canShowNavigationHint: false,
-                            alternativeSearchEngine: searchEngine)
+                            canShowNavigationHint: false)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -81,28 +81,25 @@ class AddressToolbarContainerModelTests: XCTestCase {
                                             windowUUID: windowUUID)
     }
 
-    private func createBasicAddressBarState() -> AddressBarState {
+    private func createAddressBarState(withSearchEngine: SearchEngineModel?) -> AddressBarState {
         return AddressBarState(windowUUID: windowUUID,
                                navigationActions: [],
                                pageActions: [],
                                browserActions: [],
                                borderPosition: nil,
                                url: nil,
-                               lockIconImageName: "",
-                               lockIconNeedsTheming: false,
-                               alternativeSearchEngine: nil)
-    }
-
-    private func createAddressBarStateWithAlternativeSearchEngine(searchEngine: SearchEngineModel) -> AddressBarState {
-        return AddressBarState(windowUUID: windowUUID,
-                               navigationActions: [],
-                               pageActions: [],
-                               browserActions: [],
-                               borderPosition: nil,
-                               url: nil,
-                               lockIconImageName: "",
-                               lockIconNeedsTheming: false,
-                               alternativeSearchEngine: searchEngine)
+                               searchTerm: nil,
+                               lockIconImageName: nil,
+                               lockIconNeedsTheming: true,
+                               safeListedURLImageName: nil,
+                               isEditing: false,
+                               isScrollingDuringEdit: false,
+                               shouldSelectSearchTerm: true,
+                               isLoading: false,
+                               readerModeState: nil,
+                               didStartTyping: false,
+                               showQRPageAction: true,
+                               alternativeSearchEngine: withSearchEngine)
     }
 
     private func createBasicNavigationBarState() -> NavigationBarState {
@@ -113,7 +110,7 @@ class AddressToolbarContainerModelTests: XCTestCase {
         return ToolbarState(windowUUID: windowUUID,
                             toolbarPosition: .top,
                             isPrivateMode: false,
-                            addressToolbar: createBasicAddressBarState(),
+                            addressToolbar: createAddressBarState(withSearchEngine: nil),
                             navigationToolbar: createBasicNavigationBarState(),
                             isShowingNavigationToolbar: true,
                             isShowingTopTabs: true,
@@ -130,7 +127,7 @@ class AddressToolbarContainerModelTests: XCTestCase {
         return ToolbarState(windowUUID: windowUUID,
                             toolbarPosition: .top,
                             isPrivateMode: false,
-                            addressToolbar: createAddressBarStateWithAlternativeSearchEngine(searchEngine: searchEngine),
+                            addressToolbar: createAddressBarState(withSearchEngine: searchEngine),
                             navigationToolbar: createBasicNavigationBarState(),
                             isShowingNavigationToolbar: true,
                             isShowingTopTabs: true,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -88,7 +88,8 @@ class AddressToolbarContainerModelTests: XCTestCase {
                                browserActions: [],
                                borderPosition: nil,
                                url: nil,
-                               lockIconImageName: "")
+                               lockIconImageName: "",
+                               lockIconNeedsTheming: false)
     }
 
     private func createBasicNavigationBarState() -> NavigationBarState {


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-10384](https://mozilla-hub.atlassian.net/browse/FXIOS-10384) Add the currently selected search engine image and name to the ToolbarState
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22754)

[FXIOS-10385](https://mozilla-hub.atlassian.net/browse/FXIOS-10385) Changing the search engine should update the toolbar image
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22755)

## :bulb: Description
### Background
This PR is for the [Unified Search project](https://mozilla-hub.atlassian.net/browse/FXIOS-4066), which adds a drop-down search engine icon to the toolbar refactor. When tapped, the search engine icon will eventually allow the user to choose to use an alternative search engine from a bottom sheet / popover.

### This PR
This PR simply adds the redux state and actions necessary for updating the search engine icon which appears in the toolbar.

When a different search engine is selected, the bottom sheet (iPhone) or popover (iPad) should dismiss.

(Actually _searching_ using the new engine is not currently implemented... coming soon!)

### Demo

https://github.com/user-attachments/assets/c782d2a5-1abd-4377-afb0-9646d9425500

### Tester Notes

Enable both the toolbar refactor and the `unified_search `flag in `toolbarRefactorFeature.yaml` to see the new drop-down search engine button in the toolbar. Alternatively, toggle them both on in the Debug Settings for feature flags.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)



[FXIOS-10384]: https://mozilla-hub.atlassian.net/browse/FXIOS-10384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-10385]: https://mozilla-hub.atlassian.net/browse/FXIOS-10385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ