### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from AppInfo.swift

### DIFF
--- a/BrowserKit/Sources/Common/Utilities/AppInfo.swift
+++ b/BrowserKit/Sources/Common/Utilities/AppInfo.swift
@@ -21,21 +21,21 @@ open class AppInfo {
 
     public static var bundleIdentifier: String {
         guard let bundleIdentifier = applicationBundle.object(forInfoDictionaryKey: "CFBundleIdentifier") as? String else {
-            return ""
+            fatalError("CFBundleIdentifier not found in info.plist")
         }
         return bundleIdentifier
     }
 
     public static var appVersion: String {
         guard let appVersion = applicationBundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
-            return ""
+            fatalError("CFBundleShortVersionString not found in info.plist")
         }
         return appVersion
     }
 
     public static var buildNumber: String {
         guard let buildNumber = applicationBundle.object(forInfoDictionaryKey: String(kCFBundleVersionKey)) as? String else {
-            return ""
+            fatalError("kCFBundleVersionKey not found in info.plist")
         }
         return buildNumber
     }
@@ -47,7 +47,9 @@ open class AppInfo {
     /// of the *base* bundle identifier.
     public static var baseBundleIdentifier: String {
         let bundle = Bundle.main
-        guard let packageType = bundle.object(forInfoDictionaryKey: "CFBundlePackageType") as? String else { return "" }
+        guard let packageType = bundle.object(forInfoDictionaryKey: "CFBundlePackageType") as? String else {
+            fatalError("CFBundlePackageType not found in info.plist")
+        }
         let baseBundleIdentifier = bundle.bundleIdentifier!
         if packageType == "XPC!" {
             let components = baseBundleIdentifier.components(separatedBy: ".")

--- a/BrowserKit/Sources/Common/Utilities/AppInfo.swift
+++ b/BrowserKit/Sources/Common/Utilities/AppInfo.swift
@@ -20,15 +20,24 @@ open class AppInfo {
     }
 
     public static var bundleIdentifier: String {
-        return applicationBundle.object(forInfoDictionaryKey: "CFBundleIdentifier") as! String
+        guard let bundleIdentifier = applicationBundle.object(forInfoDictionaryKey: "CFBundleIdentifier") as? String else {
+            return ""
+        }
+        return bundleIdentifier
     }
 
     public static var appVersion: String {
-        return applicationBundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+        guard let appVersion = applicationBundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
+            return ""
+        }
+        return appVersion
     }
 
     public static var buildNumber: String {
-        return applicationBundle.object(forInfoDictionaryKey: String(kCFBundleVersionKey)) as! String
+        guard let buildNumber = applicationBundle.object(forInfoDictionaryKey: String(kCFBundleVersionKey)) as? String else {
+            return ""
+        }
+        return buildNumber
     }
 
     /// Return the base bundle identifier.
@@ -38,7 +47,7 @@ open class AppInfo {
     /// of the *base* bundle identifier.
     public static var baseBundleIdentifier: String {
         let bundle = Bundle.main
-        let packageType = bundle.object(forInfoDictionaryKey: "CFBundlePackageType") as! String
+        guard let packageType = bundle.object(forInfoDictionaryKey: "CFBundlePackageType") as? String else { return "" }
         let baseBundleIdentifier = bundle.bundleIdentifier!
         if packageType == "XPC!" {
             let components = baseBundleIdentifier.components(separatedBy: ".")

--- a/firefox-ios/Shared/AppInfo.swift
+++ b/firefox-ios/Shared/AppInfo.swift
@@ -7,7 +7,10 @@ import Foundation
 
 extension AppInfo {
     public static var displayName: String {
-        return applicationBundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
+        guard let displayNmae = applicationBundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String else {
+            return ""
+        }
+        return displayNmae
     }
 
     public static var majorAppVersion: String {

--- a/firefox-ios/Shared/AppInfo.swift
+++ b/firefox-ios/Shared/AppInfo.swift
@@ -8,7 +8,7 @@ import Foundation
 extension AppInfo {
     public static var displayName: String {
         guard let displayName = applicationBundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String else {
-            return ""
+            fatalError("CFBundleDisplayName not found in info.plist")
         }
         return displayName
     }

--- a/firefox-ios/Shared/AppInfo.swift
+++ b/firefox-ios/Shared/AppInfo.swift
@@ -7,10 +7,10 @@ import Foundation
 
 extension AppInfo {
     public static var displayName: String {
-        guard let displayNmae = applicationBundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String else {
+        guard let displayName = applicationBundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String else {
             return ""
         }
-        return displayNmae
+        return displayName
     }
 
     public static var majorAppVersion: String {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from `AppInfo.swift` file
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)