### PR TITLE
Fix MTE-3800 - testBasicHTTPAuthenticationPromptVisibleAndLogin test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
@@ -21,16 +21,16 @@ class AuthenticationTest: BaseTestCase {
         waitForElementsToExist(
             [
                 app.alerts.buttons["Cancel"],
-                app.alerts.buttons["Sign in"]
+                app.alerts.buttons["Log in"]
             ]
         )
         app.alerts.textFields["Username"].typeText("guest")
         app.alerts.secureTextFields["Password"].tapAndTypeText("guest")
-        app.alerts.buttons["Sign in"].tap()
+        app.alerts.buttons["Log in"].tap()
         /* There is no other way to verify basic auth is successful as the webview is
          inaccessible after sign in to verify the success text. */
         waitForNoExistence(app.alerts.buttons["Cancel"], timeoutValue: 5)
-        waitForNoExistence(app.alerts.buttons["Sign in"], timeoutValue: 5)
+        waitForNoExistence(app.alerts.buttons["Log in"], timeoutValue: 5)
         // Added this check to ensure the BasicAuth login is persisting after app restart as well.
         app.terminate()
         app.launch()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -284,7 +284,8 @@ class CreditCardsTests: BaseTestCase {
             app.scrollViews.otherElements.tables.cells.firstMatch.tap()
             validateAutofillCardInfo(cardNr: "2720 9943 2658 1252", expirationNr: "05 / 40", name: "Test")
             dismissSavedCardsPrompt()
-            app.swipeUp()
+            swipeUp(nrOfSwipes: 2)
+            swipeDown(nrOfSwipes: 1)
             app.webViews["Web content"].textFields["Full name on card"].tapOnApp()
             if !app.buttons[useSavedCard].exists {
                 app.webViews["Web content"].textFields["Card number"].tapOnApp()
@@ -294,8 +295,7 @@ class CreditCardsTests: BaseTestCase {
             mozWaitForElementToExist(app.staticTexts["Use saved card"])
             app.scrollViews.otherElements.tables.cells["creditCardCell_1"].tap()
             validateAutofillCardInfo(cardNr: "4111 1111 1111 1111", expirationNr: "06 / 40", name: "Test2")
-            dismissSavedCardsPrompt()
-            app.swipeUp()
+            app.webViews["Web content"].textFields["Email"].tapOnApp()
             app.webViews["Web content"].textFields["Card number"].tapOnApp()
             if !app.buttons[useSavedCard].exists {
                 app.webViews["Web content"].textFields["Full name on card"].tapOnApp()
@@ -493,7 +493,8 @@ class CreditCardsTests: BaseTestCase {
         navigator.goto(NewTabScreen)
         navigator.openURL("https://checkout.stripe.dev/preview")
         waitUntilPageLoad()
-        app.swipeUp()
+        swipeUp(nrOfSwipes: 2)
+        swipeDown(nrOfSwipes: 1)
         let cardNumber = app.webViews["Web content"].textFields["Card number"]
         mozWaitForElementToExist(cardNumber)
         cardNumber.tapOnApp()
@@ -565,6 +566,10 @@ class CreditCardsTests: BaseTestCase {
         let cvc = app.webViews["Web content"].textFields["CVC"]
         let zip = app.webViews["Web content"].textFields["ZIP"]
         mozWaitForElementToExist(email)
+        if !email.isHittable {
+            swipeUp(nrOfSwipes: 2)
+            swipeDown(nrOfSwipes: 1)
+        }
         email.tapOnApp()
         var nrOfRetries = 3
         if iPad() {
@@ -576,6 +581,7 @@ class CreditCardsTests: BaseTestCase {
         }
         email.typeText("foo@mozilla.org")
         mozWaitForElementToExist(cardNumber)
+        dismissSavedCardsPrompt()
         if skipFillInfo == false {
             cardNumber.tapOnApp()
             cardNumber.typeText(cardNr)
@@ -584,8 +590,6 @@ class CreditCardsTests: BaseTestCase {
             expiration.tapOnApp()
             expiration.typeText(expirationDate)
         }
-        swipeDown(nrOfSwipes: 1)
-        swipeUp(nrOfSwipes: 1)
         cvc.tapOnApp()
         cvc.typeText("123")
         zip.tapOnApp()
@@ -681,6 +685,8 @@ class CreditCardsTests: BaseTestCase {
         app.swipeUp()
         let cardNumber = app.webViews["Web content"].textFields["Card number"]
         mozWaitForElementToExist(cardNumber)
+        swipeUp(nrOfSwipes: 2)
+        swipeDown(nrOfSwipes: 1)
         cardNumber.tapOnApp()
         if !app.buttons[useSavedCard].exists {
             cardNumber.tapOnApp()
@@ -706,7 +712,8 @@ class CreditCardsTests: BaseTestCase {
         navigator.goto(NewTabScreen)
         navigator.openURL("https://checkout.stripe.dev/preview")
         waitUntilPageLoad()
-        app.swipeUp()
+        swipeUp(nrOfSwipes: 2)
+        swipeDown(nrOfSwipes: 1)
         let cardNumber = app.webViews["Web content"].textFields["Card number"]
         mozWaitForElementToExist(cardNumber)
         cardNumber.tapOnApp()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3800

## :bulb: Description
On AuthenticationTest the sign in button changed to log in button
I attempted some fixes on the credit card tests, but at some point maybe these tests will require to use the new credit card screen.
