### PR TITLE
Fix a possible cause of flacky test if the user is already logged

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
@@ -10,7 +10,21 @@ class AuthenticationTest: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2360560
     func testBasicHTTPAuthenticationPromptVisibleAndLogin() {
         navigator.openURL(testBasicHTTPAuthURL)
-        mozWaitForElementToExist(app.staticTexts["Authentication required"], timeout: 100)
+
+        // Predicate to wait for element to exist
+        let existsPredicate = NSPredicate(format: "exists == true")
+
+        // Wait for the element to appear within the timeout
+        let expectation = XCTNSPredicateExpectation(
+            predicate: existsPredicate,
+            object: app.staticTexts["Authentication required"]
+        )
+        let result = XCTWaiter().wait(for: [expectation], timeout: 5)
+
+        if result != .completed {
+            // User already logged, tap on reload button
+            app.buttons["TabLocationView.reloadButton"].tap()
+        }
         mozWaitForElementToExist(app.staticTexts[
             "A username and password are being requested by jigsaw.w3.org. The site says: test"
         ])
@@ -26,6 +40,7 @@ class AuthenticationTest: BaseTestCase {
         )
         app.alerts.textFields["Username"].typeText("guest")
         app.alerts.secureTextFields["Password"].tapAndTypeText("guest")
+        mozWaitElementHittable(element: app.alerts.buttons["Log in"], timeout: TIMEOUT)
         app.alerts.buttons["Log in"].tap()
         /* There is no other way to verify basic auth is successful as the webview is
          inaccessible after sign in to verify the success text. */


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3802)

## :bulb: Description
I realized that if we run the test two times without restarting the simulator the test was failing because the user was already logged. The session was not cleaned. I add a check to see if the user is already logged or not.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

