### PR TITLE
Add FXIOS-10477 [Homepage] Fetching other top sites

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -691,6 +691,7 @@
 		8A19ACB42A3290D9001C2147 /* ContentBlockerSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A19ACB32A3290D9001C2147 /* ContentBlockerSetting.swift */; };
 		8A19ACB62A3290F9001C2147 /* NotificationsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A19ACB52A3290F9001C2147 /* NotificationsSetting.swift */; };
 		8A19ACB82A329128001C2147 /* PrivacyPolicySetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A19ACB72A329128001C2147 /* PrivacyPolicySetting.swift */; };
+		8A1A66072CDD168A00DD883C /* MockTopSiteHistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1A66062CDD168A00DD883C /* MockTopSiteHistoryManager.swift */; };
 		8A1A93582B757C7C0069C190 /* gradient.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A1A93522B757C7B0069C190 /* gradient.json */; };
 		8A1A93592B757C7C0069C190 /* landscape.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A1A93532B757C7B0069C190 /* landscape.json */; };
 		8A1A935A2B757C7C0069C190 /* portrait.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A1A93542B757C7B0069C190 /* portrait.json */; };
@@ -6975,6 +6976,7 @@
 		8A19ACB32A3290D9001C2147 /* ContentBlockerSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockerSetting.swift; sourceTree = "<group>"; };
 		8A19ACB52A3290F9001C2147 /* NotificationsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSetting.swift; sourceTree = "<group>"; };
 		8A19ACB72A329128001C2147 /* PrivacyPolicySetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicySetting.swift; sourceTree = "<group>"; };
+		8A1A66062CDD168A00DD883C /* MockTopSiteHistoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTopSiteHistoryManager.swift; sourceTree = "<group>"; };
 		8A1A93522B757C7B0069C190 /* gradient.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = gradient.json; sourceTree = "<group>"; };
 		8A1A93532B757C7B0069C190 /* landscape.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = landscape.json; sourceTree = "<group>"; };
 		8A1A93542B757C7B0069C190 /* portrait.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = portrait.json; sourceTree = "<group>"; };
@@ -11289,6 +11291,7 @@
 				8A87B4362CC1A910003A9239 /* MockPocketManager.swift */,
 				8A6B799C2CDBDAE4003C3077 /* MockContileProvider.swift */,
 				8A6B799F2CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift */,
+				8A1A66062CDD168A00DD883C /* MockTopSiteHistoryManager.swift */,
 			);
 			path = Mock;
 			sourceTree = "<group>";
@@ -16795,6 +16798,7 @@
 				0EC57CE52CA31E59002E3F04 /* PasswordGeneratorStateTests.swift in Sources */,
 				212985E72A72B39D00546684 /* ThemeSettingsControllerTests.swift in Sources */,
 				8A9E46BD2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift in Sources */,
+				8A1A66072CDD168A00DD883C /* MockTopSiteHistoryManager.swift in Sources */,
 				8A5189C92C1B614E00CDB668 /* SearchViewModelTests.swift in Sources */,
 				E1463D0629830E4F0074E16E /* MockUserNotificationCenter.swift in Sources */,
 				439B78182A09721600CAAE37 /* FormAutofillHelperTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -14,7 +14,8 @@ final class TopSitesMiddleware {
             prefs: profile.prefs,
             googleTopSiteManager: GoogleTopSiteManager(
                 prefs: profile.prefs
-            )
+            ),
+            topSiteHistoryManager: TopSiteHistoryManager(profile: profile)
         )
     }
 

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
@@ -6,8 +6,12 @@ import Foundation
 import Shared
 import Storage
 
+protocol TopSiteHistoryManagerProvider {
+    func getTopSites(completion: @escaping ([Site]?) -> Void)
+}
+
 // Manages the top site
-class TopSiteHistoryManager: DataObserver {
+class TopSiteHistoryManager: DataObserver, TopSiteHistoryManagerProvider {
     private let profile: Profile
 
     weak var delegate: DataObserverDelegate?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Storage
+
+@testable import Client
+
+class MockTopSiteHistoryManager: TopSiteHistoryManagerProvider {
+    private let historyBasedSites: [Site]?
+
+    init(historyBasedSites: [Site]? = [
+        Site(url: "www.example.com", title: "History-Based Tile Test")
+    ]) {
+        self.historyBasedSites = historyBasedSites
+    }
+
+    func getTopSites(completion: @escaping ([Site]?) -> Void) {
+        completion(historyBasedSites)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
@@ -4,7 +4,6 @@
 
 import XCTest
 import Shared
-import Storage
 
 @testable import Client
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
@@ -94,6 +94,15 @@ final class TopSitesManagerTests: XCTestCase {
         XCTAssertEqual(topSites.count, 0)
     }
 
+    func test_getTopSites_withNilHistoryBasedTiles_returnNoTopSites() async throws {
+        let subject = try createSubject(
+            topSiteHistoryManager: MockTopSiteHistoryManager(historyBasedSites: nil)
+        )
+
+        let topSites = await subject.getTopSites()
+        XCTAssertEqual(topSites.count, 0)
+    }
+
     private func createSubject(
         googleTopSiteManager: GoogleTopSiteManagerProvider = MockGoogleTopSiteManager(mockSiteData: nil),
         contileProvider: ContileProviderInterface = MockContileProvider(
@@ -112,19 +121,5 @@ final class TopSitesManagerTests: XCTestCase {
         )
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
-    }
-}
-
-class MockTopSiteHistoryManager: TopSiteHistoryManagerProvider {
-    private let historyBasedSites: [Site]
-
-    init(historyBasedSites: [Site] = [
-        Site(url: "www.example.com", title: "History-Based Tile Test")
-    ]) {
-        self.historyBasedSites = historyBasedSites
-    }
-
-    func getTopSites(completion: @escaping ([Site]?) -> Void) {
-        completion(historyBasedSites)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10477)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22941)

## :bulb: Description
Add fetching the rest of the top sites tiles using modern concurrency and added appropriate mocks / tests. This includes fetching history-based (frecency), pinned and default suggested sites which are handled by the top site history manager.

**Next PRs**
The full logic for the top sites are going to be broken into several PRs to keep them small. Need to add the logic in calculating what to show + when. See details on that calculation here:
https://github.com/mozilla-mobile/firefox-ios/wiki/How-do-Top-Sites-(Shortcuts)-work%3F

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
| Phone |
| --- |
| <img src="https://github.com/user-attachments/assets/012afe3f-2302-45ae-8e19-498491cad936" width="250"> |