### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from SQLiteQueue, SQLiteReadingList and SQLiteHistoryFactories 

### DIFF
--- a/firefox-ios/Storage/SQL/SQLiteHistoryFactories.swift
+++ b/firefox-ios/Storage/SQL/SQLiteHistoryFactories.swift
@@ -11,8 +11,9 @@ import Shared
 extension BrowserDBSQLite {
     class func basicHistoryColumnFactory(_ row: SDRow) -> Site {
         let id = row["historyID"] as? Int
-        let url = row["url"] as! String
-        let title = row["title"] as! String
+        guard let url = row["url"] as? String, let title = row["title"] as? String else {
+            return Site(url: "", title: "")
+        }
         let guid = row["guid"] as? String
 
         // Extract a boolean from the row if it's present.

--- a/firefox-ios/Storage/SQL/SQLiteQueue.swift
+++ b/firefox-ios/Storage/SQL/SQLiteQueue.swift
@@ -18,7 +18,10 @@ open class SQLiteQueue: TabQueue {
     }
 
     fileprivate func factory(_ row: SDRow) -> ShareItem {
-        return ShareItem(url: row["url"] as! String, title: row["title"] as? String)
+        guard let url = row["url"] as? String, let title = row["title"] as? String else {
+            return ShareItem(url: "", title: "")
+        }
+        return ShareItem(url: url, title: title)
     }
 
     open func getQueuedTabs(completion: @escaping ([ShareItem]) -> Void) {

--- a/firefox-ios/Storage/SQL/SQLiteReadingList.swift
+++ b/firefox-ios/Storage/SQL/SQLiteReadingList.swift
@@ -146,11 +146,22 @@ extension SQLiteReadingList: ReadingList {
     }
 
     fileprivate class func ReadingListItemFactory(_ row: SDRow) -> ReadingListItem {
-        let id = row["client_id"] as! Int
+        guard let id = row["client_id"] as? Int,
+              let url = row["url"] as? String,
+              let title = row["title"] as? String,
+              let addedBy = row["added_by"] as? String else {
+            return ReadingListItem(
+                id: 0,
+                lastModified: 0,
+                url: "",
+                title: "",
+                addedBy: "",
+                unread: false,
+                archived: false,
+                favorite: false
+            )
+        }
         let lastModified = row.getTimestamp("client_last_modified")!
-        let url = row["url"] as! String
-        let title = row["title"] as! String
-        let addedBy = row["added_by"] as! String
         let archived = row.getBoolean("archived")
         let unread = row.getBoolean("unread")
         let favorite = row.getBoolean("favorite")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove force_cast violations from SQLiteQueue, SQLiteReadingList and SQLiteHistoryFactories 
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in https://github.com/mozilla-mobile/firefox-ios/issues/22916

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

