### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from KeychainWrapperExtensions, KeyboardHelper and Prefs

### DIFF
--- a/firefox-ios/Shared/Extensions/KeychainWrapperExtensions.swift
+++ b/firefox-ios/Shared/Extensions/KeychainWrapperExtensions.swift
@@ -11,7 +11,9 @@ import enum MozillaAppServices.MZKeychainItemAccessibility
 public extension MZKeychainWrapper {
     static var sharedClientAppContainerKeychain: MZKeychainWrapper {
         let baseBundleIdentifier = AppInfo.baseBundleIdentifier
-        let accessGroupPrefix = Bundle.main.object(forInfoDictionaryKey: "MozDevelopmentTeam") as! String
+        guard let accessGroupPrefix = Bundle.main.object(forInfoDictionaryKey: "MozDevelopmentTeam") as? String else {
+            return MZKeychainWrapper(serviceName: baseBundleIdentifier)
+        }
         let accessGroupIdentifier = AppInfo.keychainAccessGroupWithPrefix(accessGroupPrefix)
         return MZKeychainWrapper(serviceName: baseBundleIdentifier, accessGroup: accessGroupIdentifier)
     }

--- a/firefox-ios/Shared/KeyboardHelper.swift
+++ b/firefox-ios/Shared/KeyboardHelper.swift
@@ -14,7 +14,11 @@ public struct KeyboardState {
 
     fileprivate init(_ userInfo: [AnyHashable: Any]) {
         self.userInfo = userInfo
-        animationDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as! Double
+        if let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double {
+            animationDuration = duration
+        } else {
+            animationDuration = 0.0
+        }
         // HACK: UIViewAnimationCurve doesn't expose the keyboard animation used (curveValue = 7),
         // so UIViewAnimationCurve(rawValue: curveValue) returns nil. As a workaround, get a
         // reference to an EaseIn curve, then change the underlying pointer data with that ref.

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -329,7 +329,7 @@ open class MockProfilePrefs: Prefs {
     }
 
     open func clearAll() {
-        let dictionary = things as! [String: Any]
+        guard let dictionary = things as? [String: Any] else { return }
         let keysToDelete: [String] = dictionary.keys.filter { $0.hasPrefix(self.prefix) }
         things.removeObjects(forKeys: keysToDelete)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove force_cast violations from KeychainWrapperExtensions, KeyboardHelper and Prefs
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in https://github.com/mozilla-mobile/firefox-ios/issues/22916

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

