### PR TITLE
Bugfix FXIOS-10482 Improve memory usage during tab tray open/close

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -971,6 +971,8 @@ class BrowserCoordinator: BaseCoordinator,
 
     func didDismissTabTray(from coordinator: TabTrayCoordinator) {
         router.dismiss(animated: true, completion: nil)
+        // [FXIOS-10482] Initial bandaid for memory leaking during tab tray open/close. Needs further investigation.
+        coordinator.dismissChildTabTrayPanels()
         remove(child: coordinator)
     }
 

--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -34,7 +34,7 @@ class TabTrayCoordinator: BaseCoordinator,
     }
 
     func dismissChildTabTrayPanels() {
-        // [FXIOS-10482] Initial fix for memory leak. Needs further investigation.
+        // [FXIOS-10482] Initial bandaid for memory leaking during tab tray open/close. Needs further investigation.
         guard let childVCs = tabTrayViewController.currentPanel?.viewControllers else { return }
         childVCs.forEach { ($0 as? TabDisplayPanel)?.removeTabPanel() }
     }

--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -34,7 +34,7 @@ class TabTrayCoordinator: BaseCoordinator,
     }
 
     func dismissChildTabTrayPanels() {
-        let childVCs: [UIViewController] =  tabTrayViewController.childPanelControllers.flatMap { $0.viewControllers }
+        let childVCs: [UIViewController] = tabTrayViewController.childPanelControllers.flatMap { $0.viewControllers }
         childVCs.forEach { $0.removeFromParent() }
     }
 

--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -34,8 +34,9 @@ class TabTrayCoordinator: BaseCoordinator,
     }
 
     func dismissChildTabTrayPanels() {
-        let childVCs: [UIViewController] = tabTrayViewController.childPanelControllers.flatMap { $0.viewControllers }
-        childVCs.forEach { $0.removeFromParent() }
+        // [FXIOS-10482] Initial fix for memory leak. Needs further investigation.
+        guard let childVCs = tabTrayViewController.currentPanel?.viewControllers else { return }
+        childVCs.forEach { ($0 as? TabDisplayPanel)?.removeTabPanel() }
     }
 
     private func initializeTabTrayViewController(selectedTab: TabTrayPanelType) {

--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -33,6 +33,11 @@ class TabTrayCoordinator: BaseCoordinator,
         initializeTabTrayViewController(selectedTab: tabTraySection)
     }
 
+    func dismissChildTabTrayPanels() {
+        let childVCs: [UIViewController] =  tabTrayViewController.childPanelControllers.flatMap { $0.viewControllers }
+        childVCs.forEach { $0.removeFromParent() }
+    }
+
     private func initializeTabTrayViewController(selectedTab: TabTrayPanelType) {
         tabTrayViewController = TabTrayViewController(selectedTab: selectedTab, windowUUID: tabManager.windowUUID)
         router.setRootViewController(tabTrayViewController)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -49,6 +49,12 @@ class TabDisplayPanel: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func removeFromParent() {
+        view.removeConstraints(view.constraints)
+        view.subviews.forEach { $0.removeFromSuperview() }
+        super.removeFromParent()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.accessibilityLabel = .TabTrayViewAccessibilityLabel

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanel.swift
@@ -49,10 +49,10 @@ class TabDisplayPanel: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func removeFromParent() {
+    func removeTabPanel() {
         view.removeConstraints(view.constraints)
         view.subviews.forEach { $0.removeFromSuperview() }
-        super.removeFromParent()
+        view.removeFromSuperview()
     }
 
     override func viewDidLoad() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10482)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22952)

## :bulb: Description

Bandaid for a memory leak that occurs after opening/closing the tab tray. A general memory comparison graph (before/after) is shown below. 

The underlying bug is still a problem unfortunately, and I believe we are still leaking a few of the container views higher up in the view hierarchy. Additionally, I'm seeing some other related scenarios that need further investigation and also might be leaking other UI.

This PR, however, does free up memory use considerably in this basic scenario, so I'm opening this for review now so we can have this available in the meantime until there is a better longterm solution in place.

**Note**: this appears to be a longstanding issue with the tab tray that predates any of the recent UI updates.

---

### Memory Use Comparison

For this test the app was launched and then the tab tray was opened and closed repeatedly.

Allocations on device (iPhone 12 mini)

**Before**
![Screenshot 2024-11-08 at 1 16 16 PM](https://github.com/user-attachments/assets/efbbfe22-1ecb-41c0-9f35-a5d9e616002b)

**After**
![Screenshot 2024-11-08 at 1 14 44 PM](https://github.com/user-attachments/assets/7fd1f44b-721c-4f94-ade3-33cc6da1355f)

**Before**
![before](https://github.com/user-attachments/assets/03d0893a-e366-4870-baaf-10a87ab6d3e2)

**After**
![after](https://github.com/user-attachments/assets/a2bbdbef-37d6-4a93-a2c1-21a4b970b30c)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

