### PR TITLE
Add FXIOS-10484 [Unified Search] Pass in isUnifiedSearchEnabled feature flag updates to the BrowserKit ToolbarKit target

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -33,7 +33,6 @@ public class BrowserAddressToolbar: UIView,
     public var notificationCenter: any Common.NotificationProtocol = NotificationCenter.default
     private weak var toolbarDelegate: AddressToolbarDelegate?
     private var theme: Theme?
-    private var isUnifiedSearchEnabled = false
     private var droppableUrl: URL?
 
     private lazy var toolbarContainerView: UIView = .build()
@@ -62,6 +61,16 @@ public class BrowserAddressToolbar: UIView,
     private var trailingBrowserActionStackConstraint: NSLayoutConstraint?
     private var locationContainerHeightConstraint: NSLayoutConstraint?
 
+    // FXIOS-10210 Temporary to support updating the Unified Search feature flag during runtime
+    private var previousLocationViewState: LocationViewState?
+    public var isUnifiedSearchEnabled: Bool = false {
+        didSet {
+            guard let previousLocationViewState, oldValue != isUnifiedSearchEnabled else { return }
+
+            locationView.configure(previousLocationViewState, delegate: self, isUnifiedSearchEnabled: isUnifiedSearchEnabled)
+        }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: .zero)
         setupLayout()
@@ -80,6 +89,8 @@ public class BrowserAddressToolbar: UIView,
                           trailingSpace: CGFloat,
                           isUnifiedSearchEnabled: Bool) {
         self.toolbarDelegate = toolbarDelegate
+        self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
+        self.previousLocationViewState = state.locationViewState
         configure(state: state, isUnifiedSearchEnabled: isUnifiedSearchEnabled)
         updateSpacing(leading: leadingSpace, trailing: trailingSpace)
     }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -63,7 +63,7 @@ public class BrowserAddressToolbar: UIView,
 
     // FXIOS-10210 Temporary to support updating the Unified Search feature flag during runtime
     private var previousLocationViewState: LocationViewState?
-    public var isUnifiedSearchEnabled: Bool = false {
+    public var isUnifiedSearchEnabled = false {
         didSet {
             guard let previousLocationViewState, oldValue != isUnifiedSearchEnabled else { return }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -863,6 +863,11 @@ class BrowserViewController: UIViewController,
     private func switchToolbarIfNeeded() {
         var updateNeeded = false
 
+        // FXIOS-10210 Temporary to support updating the Unified Search feature flag during runtime
+        if isToolbarRefactorEnabled {
+            addressToolbarContainer.isUnifiedSearchEnabled = isUnifiedSearchEnabled
+        }
+
         if isToolbarRefactorEnabled, addressToolbarContainer.superview == nil {
             // Show toolbar refactor
             updateNeeded = true

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -38,7 +38,16 @@ final class AddressToolbarContainer: UIView,
     private var profile: Profile?
     private var model: AddressToolbarContainerModel?
     private(set) weak var delegate: AddressToolbarContainerDelegate?
-    private var isUnifiedSearchEnabled = false
+
+    // FXIOS-10210 Temporary to support updating the Unified Search feature flag during runtime
+    public var isUnifiedSearchEnabled = false {
+        didSet {
+            guard oldValue != isUnifiedSearchEnabled else { return }
+
+            compactToolbar.isUnifiedSearchEnabled = isUnifiedSearchEnabled
+            regularToolbar.isUnifiedSearchEnabled = isUnifiedSearchEnabled
+        }
+    }
 
     private var toolbar: BrowserAddressToolbar {
         return shouldDisplayCompact ? compactToolbar : regularToolbar
@@ -164,6 +173,7 @@ final class AddressToolbarContainer: UIView,
         let newModel = AddressToolbarContainerModel(state: toolbarState,
                                                     profile: profile,
                                                     windowUUID: windowUUID)
+
         shouldDisplayCompact = newModel.shouldDisplayCompact
         if self.model != newModel {
             updateProgressBarPosition(toolbarState.toolbarPosition)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10484)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22955)

## :bulb: Description
Currently the Unified Search feature flag set from our secret debug settings > Feature Flags > Unified Search toggle does not update the UI during runtime.

This PR fixes that by propagating the flag changes from the Client down into the BrowserKit ToolbarKit target.

Once Unified Search is approved, this temporary extra code (marked with [FXIOS-10210](https://mozilla-hub.atlassian.net/browse/FXIOS-10210)) can be deleted.

### Demo

https://github.com/user-attachments/assets/ab58fec0-0e60-4eff-ac78-cdddc861a2e6

### Background
This PR is for the [Unified Search project](https://mozilla-hub.atlassian.net/browse/FXIOS-4066), which adds a drop-down search engine icon to the toolbar refactor. When tapped, the search engine icon will eventually allow the user to choose to use an alternative search engine from a bottom sheet / popover.

### Tester Notes

You must enable the toolbar refactor toggle before you can toggle the unified search on and off and observe the changes.

When Unified Search and Toolbar Refactor are both enabled, the search engine icon in the new toolbar will have a little drop-down arrow beside it. When the Toolbar Refactor is enabled but Unified Search disabled, the search engine icon has no arrow.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)



[FXIOS-10210]: https://mozilla-hub.atlassian.net/browse/FXIOS-10210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ