### PR TITLE
Refactor FXIOS-10492 UITests > Fix skipped flakey tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -388,7 +388,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             // Workaround BB iOS13 be sure tap happens on url bar
             app.textFields.firstMatch.tap()
             app.textFields.firstMatch.tap()
-            app.textFields.firstMatch.clearAndTypeText(url)
+            app.textFields.firstMatch.typeText(url)
             app.textFields.firstMatch.typeText("\r")
         }
 
@@ -1310,15 +1310,5 @@ extension XCUIElement {
             bottom.press(forDuration: 0.1, thenDragTo: top)
             screenNum += 1
         }
-    }
-    func clearAndTypeText(_ text: String) {
-        if let existingText = value as? String, !existingText.isEmpty {
-            if existingText != text {
-                doubleTap()
-            } else {
-                return
-            }
-        }
-        typeText(text)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -388,7 +388,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             // Workaround BB iOS13 be sure tap happens on url bar
             app.textFields.firstMatch.tap()
             app.textFields.firstMatch.tap()
-            app.textFields.firstMatch.typeText(url)
+            app.textFields.firstMatch.clearAndTypeText(url)
             app.textFields.firstMatch.typeText("\r")
         }
 
@@ -1310,5 +1310,15 @@ extension XCUIElement {
             bottom.press(forDuration: 0.1, thenDragTo: top)
             screenNum += 1
         }
+    }
+    func clearAndTypeText(_ text: String) {
+        if let existingText = value as? String, !existingText.isEmpty {
+            if existingText != text {
+                doubleTap()
+            } else {
+                return
+            }
+        }
+        typeText(text)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -88,7 +88,7 @@ class JumpBackInTests: BaseTestCase {
         mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
 
         // Visit "mozilla.org" and check the "Jump Back In" section
-        navigator.openURL("https://www.mozilla.org")
+        navigator.openURL("http://localhost:\(serverPort)/test-fixture/test-example.html")
         waitUntilPageLoad()
 
         navigator.goto(TabTray)
@@ -99,7 +99,7 @@ class JumpBackInTests: BaseTestCase {
         // Amazon and Twitter are visible in the "Jump Back In" section
         scrollDown()
         mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
-        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Mozilla"])
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Example Domain"])
         mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Wikipedia"])
         mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
 
@@ -121,7 +121,7 @@ class JumpBackInTests: BaseTestCase {
         mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
 
         // Amazon is visible in "Jump Back In"
-        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Mozilla"])
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Example Domain"])
 
         // Close the amazon tab
         navigator.goto(TabTray)
@@ -130,7 +130,7 @@ class JumpBackInTests: BaseTestCase {
         } else {
             mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
         }
-        app.cells["Internet for people, not profit"].buttons[StandardImageIdentifiers.Large.cross].tap()
+        app.cells["Example Domain"].buttons[StandardImageIdentifiers.Large.cross].tap()
 
         // Revisit the "Jump Back In" section
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
@@ -141,7 +141,7 @@ class JumpBackInTests: BaseTestCase {
         scrollDown()
         mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
         // FXIOS-5448 - Amazon should not be listed because we've closed the Amazon tab
-        // mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
+        // mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["Example Domain"])
         mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Wikipedia"])
         mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -87,8 +87,8 @@ class JumpBackInTests: BaseTestCase {
         mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Wikipedia"])
         mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
 
-        // Visit "amazon.com" and check the "Jump Back In" section
-        navigator.openURL("https://www.amazon.com")
+        // Visit "mozilla.org" and check the "Jump Back In" section
+        navigator.openURL("https://www.mozilla.org")
         waitUntilPageLoad()
 
         navigator.goto(TabTray)
@@ -99,7 +99,7 @@ class JumpBackInTests: BaseTestCase {
         // Amazon and Twitter are visible in the "Jump Back In" section
         scrollDown()
         mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
-        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Mozilla"])
         mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Wikipedia"])
         mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
 
@@ -121,7 +121,7 @@ class JumpBackInTests: BaseTestCase {
         mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
 
         // Amazon is visible in "Jump Back In"
-        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Mozilla"])
 
         // Close the amazon tab
         navigator.goto(TabTray)
@@ -130,7 +130,7 @@ class JumpBackInTests: BaseTestCase {
         } else {
             mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
         }
-        app.cells["Amazon.com. Spend less. Smile more."].buttons[StandardImageIdentifiers.Large.cross].tap()
+        app.cells["Internet for people, not profit"].buttons[StandardImageIdentifiers.Large.cross].tap()
 
         // Revisit the "Jump Back In" section
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -52,99 +52,98 @@ class JumpBackInTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2306920
     // Smoketest
     func testPrivateTab() throws {
-        throw XCTSkip("This test is flaky")
-//        // Visit https://www.twitter.com
-//        navigator.openURL("https://www.twitter.com")
-//        waitUntilPageLoad()
-//
-//        // Open a new tab and check the "Jump Back In" section
-//        navigator.goto(TabTray)
-//        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
-//        navigator.performAction(Action.OpenNewTabFromTabTray)
-//        closeKeyboard()
-//
-//        // Twitter tab is visible in the "Jump Back In" section
-//        scrollDown()
-//        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
-//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Twitter"])
-//
-//        // Open private browsing
-//        navigator.goto(TabTray)
-//        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
-//
-//        // Visit YouTube in private browsing
-//        navigator.performAction(Action.OpenNewTabFromTabTray)
-//        navigator.openURL("https://www.youtube.com")
-//        waitUntilPageLoad()
-//
-//        // Open a new tab in normal browsing and check the "Jump Back In" section
-//        navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
-//        navigator.goto(NewTabScreen)
-//        closeKeyboard()
-//
-//        // Twitter should be in "Jump Back In"
-//        scrollDown()
-//        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
-//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Twitter"])
-//        mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
-//
-//        // Visit "amazon.com" and check the "Jump Back In" section
-//        navigator.openURL("https://www.amazon.com")
-//        waitUntilPageLoad()
-//
-//        navigator.goto(TabTray)
-//        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
-//        navigator.performAction(Action.OpenNewTabFromTabTray)
-//        closeKeyboard()
-//
-//        // Amazon and Twitter are visible in the "Jump Back In" section
-//        scrollDown()
-//        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
-//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
-//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Twitter"])
-//        mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
-//
-//        // Tap on Twitter from "Jump Back In"
-//        app.cells["JumpBackInCell"].staticTexts["Twitter"].tap()
-//
-//        // The view is switched to the twitter tab
-//        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
-//        XCTAssertEqual(url, "twitter.com/i/flow/login")
-//
-//        // Open a new tab in normal browsing
-//        navigator.goto(TabTray)
-//        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
-//        navigator.performAction(Action.OpenNewTabFromTabTray)
-//        closeKeyboard()
-//
-//        // Check the "Jump Back In Section"
-//        scrollDown()
-//        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
-//
-//        // Amazon is visible in "Jump Back In"
-//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
-//
-//        // Close the amazon tab
-//        navigator.goto(TabTray)
-//        if isTablet {
-//            mozWaitForElementToExist(app.navigationBars.segmentedControls["navBarTabTray"])
-//        } else {
-//            mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
-//        }
-//        app.cells["Amazon.com. Spend less. Smile more."].buttons[StandardImageIdentifiers.Large.cross].tap()
-//
-//        // Revisit the "Jump Back In" section
-//        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
-//        navigator.performAction(Action.OpenNewTabFromTabTray)
-//        closeKeyboard()
-//
-//        // The "Jump Back In" section is still here with twitter listed
-//        scrollDown()
-//        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
-//        // FXIOS-5448 - Amazon should not be listed because we've closed the Amazon tab
-//        // mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
-//        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Twitter"])
-//        mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
+        // Visit https://www.wikipedia.org
+        navigator.openURL("https://www.wikipedia.org")
+        waitUntilPageLoad()
+
+        // Open a new tab and check the "Jump Back In" section
+        navigator.goto(TabTray)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        closeKeyboard()
+
+        // Twitter tab is visible in the "Jump Back In" section
+        scrollDown()
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Wikipedia"])
+
+        // Open private browsing
+        navigator.goto(TabTray)
+        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
+
+        // Visit YouTube in private browsing
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.openURL("https://www.youtube.com")
+        waitUntilPageLoad()
+
+        // Open a new tab in normal browsing and check the "Jump Back In" section
+        navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
+        navigator.goto(NewTabScreen)
+        closeKeyboard()
+
+        // Twitter should be in "Jump Back In"
+        scrollDown()
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Wikipedia"])
+        mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
+
+        // Visit "amazon.com" and check the "Jump Back In" section
+        navigator.openURL("https://www.amazon.com")
+        waitUntilPageLoad()
+
+        navigator.goto(TabTray)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        closeKeyboard()
+
+        // Amazon and Twitter are visible in the "Jump Back In" section
+        scrollDown()
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Wikipedia"])
+        mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
+
+        // Tap on Twitter from "Jump Back In"
+        app.cells["JumpBackInCell"].staticTexts["Wikipedia"].firstMatch.tap()
+
+        // The view is switched to the twitter tab
+        let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
+        XCTAssertEqual(url, "www.wikipedia.org/")
+
+        // Open a new tab in normal browsing
+        navigator.goto(TabTray)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        closeKeyboard()
+
+        // Check the "Jump Back In Section"
+        scrollDown()
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
+
+        // Amazon is visible in "Jump Back In"
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
+
+        // Close the amazon tab
+        navigator.goto(TabTray)
+        if isTablet {
+            mozWaitForElementToExist(app.navigationBars.segmentedControls["navBarTabTray"])
+        } else {
+            mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
+        }
+        app.cells["Amazon.com. Spend less. Smile more."].buttons[StandardImageIdentifiers.Large.cross].tap()
+
+        // Revisit the "Jump Back In" section
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        closeKeyboard()
+
+        // The "Jump Back In" section is still here with twitter listed
+        scrollDown()
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].firstMatch)
+        // FXIOS-5448 - Amazon should not be listed because we've closed the Amazon tab
+        // mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["Amazon"])
+        mozWaitForElementToExist(app.cells["JumpBackInCell"].staticTexts["Wikipedia"])
+        mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2445811

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -340,38 +340,37 @@ class NavigationTest: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2441776
     // Smoketest
     func testPopUpBlocker() throws {
-        throw XCTSkip("This test is flakey")
-//        // Check that it is enabled by default
-//        navigator.nowAt(BrowserTab)
-//        mozWaitForElementToExist(app.buttons["TabToolbar.menuButton"], timeout: TIMEOUT)
-//        navigator.goto(SettingsScreen)
-//        mozWaitForElementToExist(app.tables[AccessibilityIdentifiers.Settings.tableViewController])
-//        let switchBlockPopUps = app.tables.cells.switches["blockPopups"]
-//        let switchValue = switchBlockPopUps.value!
-//        XCTAssertEqual(switchValue as? String, "1")
-//
-//        // Check that there are no pop ups
-//        navigator.openURL(popUpTestUrl)
-//        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "blocker.html")
-//        mozWaitForElementToExist(app.webViews.staticTexts["Blocked Element"])
-//
-//        let numTabs = app.buttons["Show Tabs"].value
-//        XCTAssertEqual("1", numTabs as? String, "There should be only on tab")
-//
-//        // Now disable the Block PopUps option
-//        navigator.goto(BrowserTabMenu)
-//        navigator.goto(SettingsScreen)
-//        mozWaitForElementToExist(switchBlockPopUps, timeout: TIMEOUT)
-//        switchBlockPopUps.tap()
-//        let switchValueAfter = switchBlockPopUps.value!
-//        XCTAssertEqual(switchValueAfter as? String, "0")
-//
-//        // Check that now pop ups are shown, two sites loaded
-//        navigator.openURL(popUpTestUrl)
-//        waitUntilPageLoad()
-//        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "example.com")
-//        let numTabsAfter = app.buttons["Show Tabs"].value
-//        XCTAssertNotEqual("1", numTabsAfter as? String, "Several tabs are open")
+        // Check that it is enabled by default
+        navigator.nowAt(BrowserTab)
+        mozWaitForElementToExist(app.buttons["TabToolbar.menuButton"], timeout: TIMEOUT)
+        navigator.goto(SettingsScreen)
+        mozWaitForElementToExist(app.tables[AccessibilityIdentifiers.Settings.tableViewController])
+        let switchBlockPopUps = app.tables.cells.switches["blockPopups"]
+        let switchValue = switchBlockPopUps.value!
+        XCTAssertEqual(switchValue as? String, "1")
+
+        // Check that there are no pop ups
+        navigator.openURL(popUpTestUrl)
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "blocker.html")
+        mozWaitForElementToExist(app.webViews.staticTexts["Blocked Element"])
+
+        let numTabs = app.buttons["Show Tabs"].value
+        XCTAssertEqual("1", numTabs as? String, "There should be only on tab")
+
+        // Now disable the Block PopUps option
+        navigator.goto(BrowserTabMenu)
+        navigator.goto(SettingsScreen)
+        mozWaitForElementToExist(switchBlockPopUps, timeout: TIMEOUT)
+        switchBlockPopUps.tap()
+        let switchValueAfter = switchBlockPopUps.value!
+        XCTAssertEqual(switchValueAfter as? String, "0")
+
+        // Check that now pop ups are shown, two sites loaded
+        navigator.openURL(popUpTestUrl)
+        waitUntilPageLoad()
+        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url], value: "example.com")
+        let numTabsAfter = app.buttons["Show Tabs"].value
+        XCTAssertNotEqual("1", numTabsAfter as? String, "Several tabs are open")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306858


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10492)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22986)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This issue is regarding these two skipped/disabled tests
- [testPrivateTab()](https://github.com/mozilla-mobile/firefox-ios/blob/main/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift#L54)
it's failing because `twitter.com` is now `x.com`
**Resolution:** Updated the website to wikipedia

- [testPopUpBlocker()](https://github.com/mozilla-mobile/firefox-ios/blob/main/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift#L342C10-L342C26)
It is failing because the `openUrl` function is not clearing the existing text in the url bar and appending the new url to existing url.
**Resolution:** Added a `clearAndTypeText` function which will clear any existing text in the url bar and then type the url

Tested both these tests locally on iPhone and iPad simulators ✅ 
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

