### PR TITLE
Fix FXIOS-10307 - Explicitely set readmode state to unavailable on internal pages

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3866,7 +3866,10 @@ extension BrowserViewController: TabManagerDelegate {
             }
         }
 
-        if let readerMode = selectedTab.getContentScript(name: ReaderMode.name()) as? ReaderMode {
+        // When the newly selected tab is the homepage or another internal tab,
+        // we need to explicitely set the reader mode state to be unavailable.
+        if let url = selectedTab.webView?.url, InternalURL.scheme != url.scheme,
+           let readerMode = selectedTab.getContentScript(name: ReaderMode.name()) as? ReaderMode {
             updateReaderModeState(for: selectedTab, readerModeState: readerMode.state)
             if readerMode.state == .active {
                 showReaderModeBar(animated: false)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10307)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22580)

## :bulb: Description
This PR:
- Adds a check for internal pages that set readmode state to `unavailable` when selecting a tab

⚠️ This bug could happen everytime we call `selectTab`. Instead of fixing it just for wallpapers, this is a more generic fix.

### Behaviour before
Notice that the reader mode icon shows up after changing the wallpaper

https://github.com/user-attachments/assets/f629bc00-553c-4656-b381-98ec7dce72f9

### Behaviour after 
Notice the reader mode icon doesn't show up after changing the wallpaper

https://github.com/user-attachments/assets/c3c16f54-bd49-466b-a3bb-080645c36d97



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] ~Wrote unit tests and/or ensured the tests suite is passing~
- [ ] ~When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)~
- [ ] ~If needed, I updated documentation / comments for complex code and public methods~
- [ ] ~If needed, added a backport comment (example `@Mergifyio backport release/v120`)~

