### PR TITLE
Add FXIOS-10477 [Homepage] initial top sites calculation

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
@@ -8,7 +8,7 @@ import Shared
 import Storage
 
 // TODO: FXIOS-10165 - Add full logic + tests for retrieving top sites
-/// Manager to fetch the top sites data, The data gets updated from notifications on specific user actions
+/// Manager to fetch the top sites data, the data gets updated from notifications on specific user actions
 class TopSitesManager {
     private var logger: Logger
     private let prefs: Prefs
@@ -16,34 +16,56 @@ class TopSitesManager {
     private let googleTopSiteManager: GoogleTopSiteManagerProvider
     private let topSiteHistoryManager: TopSiteHistoryManagerProvider
 
+    // TODO: FXIOS-10477 - Add number of rows calculation and device size updates
+    private let maxTopSites: Int
+    private let maxNumberOfSponsoredTile: Int = 2
+
     init(
         prefs: Prefs,
         contileProvider: ContileProviderInterface = ContileProvider(),
         googleTopSiteManager: GoogleTopSiteManagerProvider,
         topSiteHistoryManager: TopSiteHistoryManagerProvider,
-        logger: Logger = DefaultLogger.shared
+        logger: Logger = DefaultLogger.shared,
+        maxTopSites: Int = 4 * 14 // Max rows * max tiles on the largest screen plus some padding
     ) {
         self.prefs = prefs
         self.contileProvider = contileProvider
         self.googleTopSiteManager = googleTopSiteManager
         self.topSiteHistoryManager = topSiteHistoryManager
         self.logger = logger
+        self.maxTopSites = maxTopSites
     }
 
     func getTopSites() async -> [TopSiteState] {
-        var topSites: [TopSiteState] = []
-
-        let googleTopSite = addGoogleTopSite()
-        let sponsoredTopSites = await getSponsoredSites()
-        let historyBasedTopSites = await getHistoryBasedSites()
-
-        topSites = googleTopSite + sponsoredTopSites + historyBasedTopSites
-
-        return topSites
+        return await calculateTopSites()
     }
 
-    private func addGoogleTopSite() -> [TopSiteState] {
-        guard let googleSite = googleTopSiteManager.suggestedSiteData else {
+    /// Top sites are composed of pinned sites, history, sponsored tiles and google top site.
+    /// In terms of space, pinned tiles has precedence over the Google tile, 
+    /// which has precedence over sponsored and frecency tiles.
+    ///
+    /// From a user perspective, Google top site is always first (from left to right),
+    /// then comes the sponsored tiles, pinned sites and then frecency top sites.
+    /// We only add Google or sponsored tiles if number of pinned tiles doesn't exceeds the available number shown of tiles.
+    private func calculateTopSites() async -> [TopSiteState] {
+        // TODO: FXIOS-10477 - Look into creating task groups to run asynchronous methods concurrently
+        let otherSites = await getOtherSites()
+
+        let availableSpaceCount = getAvailableSpaceCount(with: otherSites)
+        let googleTopSite = addGoogleTopSite(with: availableSpaceCount)
+
+        let updatedSpaceCount = getUpdatedSpaceCount(with: googleTopSite, and: availableSpaceCount)
+        let sponsoredSites = await getSponsoredSites(with: updatedSpaceCount)
+
+        let totalTopSites = googleTopSite + sponsoredSites + otherSites
+        return Array(totalTopSites.prefix(maxTopSites))
+    }
+
+    // MARK: Google tile
+    private func addGoogleTopSite(with availableSpaceCount: Int) -> [TopSiteState] {
+        guard googleTopSiteManager.shouldAddGoogleTopSite(hasSpace: availableSpaceCount > 0),
+                let googleSite = googleTopSiteManager.suggestedSiteData
+        else {
             return []
         }
         return [TopSiteState(site: googleSite)]
@@ -54,9 +76,19 @@ class TopSitesManager {
         return prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.SponsoredShortcuts) ?? true
     }
 
-    private func getSponsoredSites() async -> [TopSiteState] {
-        guard shouldLoadSponsoredTiles else { return [] }
+    private func getSponsoredSites(with availableSpaceCount: Int) async -> [TopSiteState] {
+        guard availableSpaceCount > 0, shouldLoadSponsoredTiles else { return [] }
 
+        let contiles = await fetchSponsoredSites()
+
+        let filteredContiles = contiles
+            .filter { shouldShowSponsoredSite(with: $0) }
+            .compactMap { TopSiteState(site: $0) }
+
+        return filteredContiles
+    }
+
+    private func fetchSponsoredSites() async -> [SponsoredTile] {
         let contiles = await withCheckedContinuation { continuation in
             contileProvider.fetchContiles { [weak self] result in
                 if case .success(let contiles) = result {
@@ -72,19 +104,42 @@ class TopSitesManager {
             }
         }
 
-        return contiles.compactMap {
-            TopSiteState(site: SponsoredTile(contile: $0))
-        }
+        return contiles
+            .prefix(maxNumberOfSponsoredTile)
+            .compactMap { SponsoredTile(contile: $0) }
     }
 
-    // MARK: History-based (Frencency) + Pinned + Default suggested tiles
-    private func getHistoryBasedSites() async -> [TopSiteState] {
-        let frecencySites = await withCheckedContinuation { continuation in
+    /// Show the next sponsored site if site is already present in the pinned sites
+    /// or if it's the default search engine
+    private func shouldShowSponsoredSite(with site: Site) -> Bool {
+        // TODO: FXIOS-10477 - To replace with proper logic in when to show sponsored sites 
+        // such as if there's duplicates or if default engine is showed
+        return true
+    }
+
+    // MARK: Other Sites = History-based (Frencency) + Pinned + Default suggested tiles
+    private func getOtherSites() async -> [TopSiteState] {
+        let otherSites = await withCheckedContinuation { continuation in
             topSiteHistoryManager.getTopSites { sites in
                 continuation.resume(returning: sites)
             }
         }
 
-        return frecencySites?.compactMap { TopSiteState(site: $0) } ?? []
+        return otherSites?.compactMap { TopSiteState(site: $0) } ?? []
+    }
+
+    // MARK: - Tiles space calculation
+
+    /// Get available space count for the sponsored tiles and Google tiles, pinned tiles are prioritized first
+    /// - Parameter otherSites: Comes from fetching the other top sites that are not sponsored or google tile
+    /// - Returns: The available space count for the rest of the calculation
+    private func getAvailableSpaceCount(with otherSites: [TopSiteState]) -> Int {
+        let pinnedSiteCount = otherSites.filter { $0.site is PinnedSite }.count
+        return maxTopSites - pinnedSiteCount
+    }
+
+    private func getUpdatedSpaceCount(with googleTopSite: [TopSiteState], and availableSpaceCount: Int) -> Int {
+        guard !googleTopSite.isEmpty else { return availableSpaceCount }
+        return availableSpaceCount - GoogleTopSiteManager.Constants.reservedSpaceCount
     }
 }

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
@@ -9,6 +9,7 @@ import SiteImageView
 
 public protocol GoogleTopSiteManagerProvider {
     var suggestedSiteData: PinnedSite? { get }
+    func shouldAddGoogleTopSite(hasSpace: Bool) -> Bool
 }
 // Manage the specific Google top site case
 class GoogleTopSiteManager: GoogleTopSiteManagerProvider {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockContileProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockContileProvider.swift
@@ -19,7 +19,7 @@ class MockContileProvider: ContileProviderInterface {
     static var defaultSuccessData: [Contile] {
         return [
             Contile(id: 1,
-                    name: "Firefox",
+                    name: "Firefox Sponsored Tile",
                     url: "https://firefox.com",
                     clickUrl: "https://firefox.com/click",
                     imageUrl: "https://test.com/image1.jpg",
@@ -27,7 +27,7 @@ class MockContileProvider: ContileProviderInterface {
                     impressionUrl: "https://test.com",
                     position: 1),
             Contile(id: 2,
-                    name: "Mozilla",
+                    name: "Mozilla Sponsored Tile",
                     url: "https://mozilla.com",
                     clickUrl: "https://mozilla.com/click",
                     imageUrl: "https://test.com/image2.jpg",
@@ -35,7 +35,7 @@ class MockContileProvider: ContileProviderInterface {
                     impressionUrl: "https://example.com",
                     position: 2),
             Contile(id: 3,
-                    name: "Focus",
+                    name: "Focus Sponsored Tile",
                     url: "https://support.mozilla.org/en-US/kb/firefox-focus-ios",
                     clickUrl: "https://support.mozilla.org/en-US/kb/firefox-focus-ios/click",
                     imageUrl: "https://test.com/image3.jpg",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockGoogleTopSiteManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockGoogleTopSiteManager.swift
@@ -19,4 +19,8 @@ class MockGoogleTopSiteManager: GoogleTopSiteManagerProvider {
     var suggestedSiteData: PinnedSite? {
         return mockSiteData
     }
+
+    func shouldAddGoogleTopSite(hasSpace: Bool) -> Bool {
+        return hasSpace
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
@@ -8,15 +8,33 @@ import Storage
 @testable import Client
 
 class MockTopSiteHistoryManager: TopSiteHistoryManagerProvider {
-    private let historyBasedSites: [Site]?
+    private let sites: [Site]?
+    static var defaultSuccessData: [Site] {
+        return [
+            PinnedSite(
+                site: Site(url: "www.mozilla.com", title: "Pinned Site Test"),
+                faviconResource: nil
+            ),
+            PinnedSite(
+                site: Site(url: "www.firefox.com", title: "Pinned Site 2 Test"),
+                faviconResource: nil
+            ),
+            Site(url: "www.example.com", title: "History-Based Tile Test")
+        ]
+    }
 
-    init(historyBasedSites: [Site]? = [
-        Site(url: "www.example.com", title: "History-Based Tile Test")
-    ]) {
-        self.historyBasedSites = historyBasedSites
+    static var noPinnedData: [Site] {
+        return [
+            Site(url: "www.mozilla.com", title: "History-Based Tile Test"),
+            Site(url: "www.firefox.com", title: "History-Based Tile 2 Test")
+        ]
+    }
+
+    init(sites: [Site]? = []) {
+        self.sites = sites
     }
 
     func getTopSites(completion: @escaping ([Site]?) -> Void) {
-        completion(historyBasedSites)
+        completion(sites)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
@@ -39,7 +39,8 @@ final class TopSitesManagerTests: XCTestCase {
     }
 
     // MARK: Sponsored Top Site
-    func test_getTopSites_shouldShowSponsoredTiles_returnExpectedTopSites() async throws {
+    func test_getTopSites_shouldShowSponsoredTiles_returnOnlyMaxSponsoredSites() async throws {
+        // Max contiles is currently at 2, so it should add 2 contiles only.
         let subject = try createSubject(
             contileProvider: MockContileProvider(
                 result: .success(MockContileProvider.defaultSuccessData)
@@ -47,9 +48,9 @@ final class TopSitesManagerTests: XCTestCase {
         )
 
         let topSites = await subject.getTopSites()
-        XCTAssertEqual(topSites.count, 3)
-        XCTAssertEqual(topSites.compactMap { $0.isSponsoredTile }, [true, true, true])
-        XCTAssertEqual(topSites.compactMap { $0.title }, ["Firefox", "Mozilla", "Focus"])
+        XCTAssertEqual(topSites.count, 2)
+        XCTAssertEqual(topSites.compactMap { $0.isSponsoredTile }, [true, true])
+        XCTAssertEqual(topSites.compactMap { $0.title }, ["Firefox Sponsored Tile", "Mozilla Sponsored Tile"])
     }
 
     func test_getTopSites_shouldNotShowSponsoredTiles_returnNoSponsoredSites() async throws {
@@ -78,12 +79,15 @@ final class TopSitesManagerTests: XCTestCase {
 
     // MARK: History-based Top Site
     func test_getTopSites_withHistoryBasedTiles_returnExpectedTopSites() async throws {
-        let subject = try createSubject(topSiteHistoryManager: MockTopSiteHistoryManager())
+        let subject = try createSubject(
+            topSiteHistoryManager: MockTopSiteHistoryManager(sites: MockTopSiteHistoryManager.defaultSuccessData)
+        )
 
         let topSites = await subject.getTopSites()
-        XCTAssertEqual(topSites.count, 1)
-        XCTAssertEqual(topSites.compactMap { $0.title }, ["History-Based Tile Test"])
-        XCTAssertEqual(topSites.compactMap { $0.site.url }, ["www.example.com"])
+        XCTAssertEqual(topSites.count, 3)
+        let expectedTitles = ["Pinned Site Test", "Pinned Site 2 Test", "History-Based Tile Test"]
+        XCTAssertEqual(topSites.compactMap { $0.title }, expectedTitles)
+        XCTAssertEqual(topSites.compactMap { $0.site.url }, ["www.mozilla.com", "www.firefox.com", "www.example.com"])
     }
 
     func test_getTopSites_withEmptyHistoryBasedTiles_returnNoTopSites() async throws {
@@ -95,11 +99,75 @@ final class TopSitesManagerTests: XCTestCase {
 
     func test_getTopSites_withNilHistoryBasedTiles_returnNoTopSites() async throws {
         let subject = try createSubject(
-            topSiteHistoryManager: MockTopSiteHistoryManager(historyBasedSites: nil)
+            topSiteHistoryManager: MockTopSiteHistoryManager(sites: nil)
         )
 
         let topSites = await subject.getTopSites()
         XCTAssertEqual(topSites.count, 0)
+    }
+
+    // MARK: Tiles space calculation
+    func test_getTopSites_noAvailableSpace_returnOnlyPinnedSites() async throws {
+        let subject = try createSubject(
+            googleTopSiteManager: MockGoogleTopSiteManager(),
+            contileProvider: MockContileProvider(
+                result: .success(MockContileProvider.defaultSuccessData)
+            ),
+            topSiteHistoryManager: MockTopSiteHistoryManager(sites: MockTopSiteHistoryManager.defaultSuccessData),
+            maxCount: 2
+        )
+
+        let topSites = await subject.getTopSites()
+        XCTAssertEqual(topSites.count, 2)
+        XCTAssertEqual(topSites.compactMap { $0.title }, ["Pinned Site Test", "Pinned Site 2 Test"])
+        XCTAssertEqual(topSites.compactMap { $0.site.url }, ["www.mozilla.com", "www.firefox.com"])
+    }
+
+    func test_getTopSites_andNoPinnedSites_returnGoogleAndSponsoredSites() async throws {
+        let subject = try createSubject(
+            googleTopSiteManager: MockGoogleTopSiteManager(),
+            contileProvider: MockContileProvider(
+                result: .success(MockContileProvider.defaultSuccessData)
+            ),
+            topSiteHistoryManager: MockTopSiteHistoryManager(sites: MockTopSiteHistoryManager.noPinnedData),
+            maxCount: 2
+        )
+
+        let topSites = await subject.getTopSites()
+        XCTAssertEqual(topSites.count, 2)
+        XCTAssertEqual(topSites.compactMap { $0.title }, ["Google Test", "Firefox Sponsored Tile"])
+        XCTAssertEqual(topSites.compactMap { $0.site.url }, ["https://www.google.com/webhp?client=firefox-b-1-m&channel=ts", "https://firefox.com"])
+    }
+
+    func test_getTopSites_availableSpace_returnSitesInOrder() async throws {
+        let subject = try createSubject(
+            googleTopSiteManager: MockGoogleTopSiteManager(),
+            contileProvider: MockContileProvider(
+                result: .success(MockContileProvider.defaultSuccessData)
+            ),
+            topSiteHistoryManager: MockTopSiteHistoryManager(sites: MockTopSiteHistoryManager.defaultSuccessData)
+        )
+
+        let topSites = await subject.getTopSites()
+        XCTAssertEqual(topSites.count, 6)
+        let expectedTitles = [
+            "Google Test",
+            "Firefox Sponsored Tile",
+            "Mozilla Sponsored Tile",
+            "Pinned Site Test",
+            "Pinned Site 2 Test",
+            "History-Based Tile Test"
+        ]
+        XCTAssertEqual(topSites.compactMap { $0.title }, expectedTitles)
+        let expectedURLs = [
+            "https://www.google.com/webhp?client=firefox-b-1-m&channel=ts",
+            "https://firefox.com",
+            "https://mozilla.com",
+            "www.mozilla.com",
+            "www.firefox.com",
+            "www.example.com"
+        ]
+        XCTAssertEqual(topSites.compactMap { $0.site.url }, expectedURLs)
     }
 
     private func createSubject(
@@ -107,7 +175,8 @@ final class TopSitesManagerTests: XCTestCase {
         contileProvider: ContileProviderInterface = MockContileProvider(
             result: .success(MockContileProvider.emptySuccessData)
         ),
-        topSiteHistoryManager: TopSiteHistoryManagerProvider = MockTopSiteHistoryManager(historyBasedSites: []),
+        topSiteHistoryManager: TopSiteHistoryManagerProvider = MockTopSiteHistoryManager(sites: []),
+        maxCount: Int = 10,
         file: StaticString = #file,
         line: UInt = #line
     ) throws -> TopSitesManager {
@@ -116,7 +185,8 @@ final class TopSitesManagerTests: XCTestCase {
             prefs: mockProfile.prefs,
             contileProvider: contileProvider,
             googleTopSiteManager: googleTopSiteManager,
-            topSiteHistoryManager: topSiteHistoryManager
+            topSiteHistoryManager: topSiteHistoryManager,
+            maxTopSites: maxCount
         )
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10477)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22941)

## :bulb: Description
Add initial calculation logic for top sites, following the existing configuration as well as the wiki [doc](https://github.com/mozilla-mobile/firefox-ios/wiki/How-do-Top-Sites-(Shortcuts)-work%3F).

This PR includes adding the logic in calculating available space for showing top sites. I copied over the hardcoded values for the `maxTopSites`, which is the max number of sites we will show.

Based on that max count, we want to calculate how many pinned tiles we have fetched from the `TopSiteHistoryManager`. Pinned tiles are prioritize over any other tiles. If there is available space, then we prioritize the google top site and then sponsored top site to follow, then the rest are the other top sites. The logic to show sponsored tile will be added in the next PR. The max number of sponsored top site that we show is 2.

Note: Once the google tile is added, it will continue to be shown until the user decides to remove it.

This is part one of the logic, added other TODOs to wrap up the other logic.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
| Example w/ maxTopSites = 4 |
| --- |
| <img src="https://github.com/user-attachments/assets/0f1030d3-48d1-4a92-a2f6-e4d706e68f42" width="250"> |