### PR TITLE
Bugfix FXIOS-10451 - Video from Private Browsing Shows as Preview in App Switcher

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1206,6 +1206,7 @@
 		BD57D9A729D4C42B00039394 /* ZoomLevelStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD57D9A629D4C42B00039394 /* ZoomLevelStoreTests.swift */; };
 		BD6B361E2B3C2511005E5345 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6B361D2B3C2511005E5345 /* CircularProgressView.swift */; };
 		BD6CC84229CDDA3400546A5D /* ZoomLevelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6CC84129CDDA3400546A5D /* ZoomLevelStore.swift */; };
+		BDD262562CE3AC8200DF2C62 /* PrivacyWindowHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD262552CE3AC8200DF2C62 /* PrivacyWindowHelper.swift */; };
 		C2200A6A2B7D148C00DC062A /* ContentBlockerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2200A692B7D148C00DC062A /* ContentBlockerTests.swift */; };
 		C22753402A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C227533F2A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift */; };
 		C2296FCC2A601C190046ECA6 /* IntensityVisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2296FCB2A601C190046ECA6 /* IntensityVisualEffectView.swift */; };
@@ -7965,6 +7966,7 @@
 		BD7B4C6BBA14B1437A321E78 /* hi-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hi-IN"; path = "hi-IN.lproj/3DTouchActions.strings"; sourceTree = "<group>"; };
 		BDB24F4C850C4A269C205FDF /* br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = br; path = br.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		BDB444F281416E39E6A11588 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/Menu.strings; sourceTree = "<group>"; };
+		BDD262552CE3AC8200DF2C62 /* PrivacyWindowHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyWindowHelper.swift; sourceTree = "<group>"; };
 		BDF24048A0CB24CA7CBDB0AF /* hsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hsb; path = hsb.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		BE3B484FBA5F1ECC0994D694 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		BE7C456B81F81CACE2AC654A /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
@@ -10299,6 +10301,7 @@
 				962F39492672D57A006BDA2A /* BookmarkItemsHelper.swift */,
 				39A359E31BFCCE94006B9E87 /* UserActivityHandler.swift */,
 				E18259DE29B25E4F00E6BE76 /* UserNotificationCenterProtocol.swift */,
+				BDD262552CE3AC8200DF2C62 /* PrivacyWindowHelper.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -16632,6 +16635,7 @@
 				EB98550124226EF70040F24B /* AppDelegate+SyncSentTabs.swift in Sources */,
 				744ED5611DBFEB8D00A2B5BE /* MailtoLinkHandler.swift in Sources */,
 				8A720C622A4CBB370003018A /* SupportSettingsDelegate.swift in Sources */,
+				BDD262562CE3AC8200DF2C62 /* PrivacyWindowHelper.swift in Sources */,
 				DF1E6AAB2A976FE7000D4854 /* FakespotNoAnalysisCardView.swift in Sources */,
 				DA4F826729AD221600189590 /* ZoomPageBar.swift in Sources */,
 				59A68E0B4ABBF55E14819668 /* LegacyBookmarksPanel.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -183,9 +183,7 @@ class BrowserViewController: UIViewController,
         return topTabsViewController != nil
     }
     // Backdrop used for displaying greyed background for private tabs
-    private lazy var webViewContainerBackdrop: UIView = .build { containerBackdrop in
-        containerBackdrop.alpha = 0
-    }
+    private var privacyWindow: UIWindow?
     var keyboardBackdrop: UIView?
 
     lazy var scrollController = TabScrollingController(windowUUID: windowUUID)
@@ -510,9 +508,8 @@ class BrowserViewController: UIViewController,
               canShowPrivacyView
         else { return }
 
-        view.bringSubviewToFront(webViewContainerBackdrop)
-        webViewContainerBackdrop.alpha = 1
         contentStackView.alpha = 0
+        showPrivacyWindow()
 
         if isToolbarRefactorEnabled {
             addressToolbarContainer.alpha = 0
@@ -547,8 +544,7 @@ class BrowserViewController: UIViewController,
                 self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
                 self.presentedViewController?.view.alpha = 1
             }, completion: { _ in
-                self.webViewContainerBackdrop.alpha = 0
-                self.view.sendSubviewToBack(self.webViewContainerBackdrop)
+                self.removePrivacyWindow()
             })
 
         if let tab = tabManager.selectedTab, !tab.isFindInPageMode {
@@ -597,6 +593,24 @@ class BrowserViewController: UIViewController,
 
         guard presentedViewController != nil else { return }
         dismissVC()
+    }
+
+    // MARK: - Privacy Window Protection
+    private func showPrivacyWindow() {
+        guard let windowScene = UIWindow.attachedKeyWindow?.windowScene else { return }
+        let backgroundColor = currentTheme().colors.layer3
+
+        privacyWindow = UIWindow(windowScene: windowScene)
+        privacyWindow?.rootViewController = UIViewController()
+        privacyWindow?.rootViewController?.view.backgroundColor = backgroundColor
+        // Set the privacy window level to be above alert windows (highest in importance).
+        privacyWindow?.windowLevel = .alert + 1
+        privacyWindow?.makeKeyAndVisible()
+    }
+
+    private func removePrivacyWindow() {
+        privacyWindow?.isHidden = true
+        privacyWindow = nil
     }
 
     // MARK: - Redux
@@ -927,7 +941,7 @@ class BrowserViewController: UIViewController,
     }
 
     func addSubviews() {
-        view.addSubviews(webViewContainerBackdrop, contentStackView)
+        view.addSubviews(contentStackView)
 
         contentStackView.addArrangedSubview(contentContainer)
 
@@ -1169,13 +1183,6 @@ class BrowserViewController: UIViewController,
                 urlBarHeightConstraint = make.height.equalTo(UIConstants.TopToolbarHeightMax).constraint
             }
         }
-
-        NSLayoutConstraint.activate([
-            webViewContainerBackdrop.topAnchor.constraint(equalTo: view.topAnchor),
-            webViewContainerBackdrop.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            webViewContainerBackdrop.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            webViewContainerBackdrop.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
 
         NSLayoutConstraint.activate([
             contentStackView.topAnchor.constraint(equalTo: header.bottomAnchor),
@@ -3064,7 +3071,6 @@ class BrowserViewController: UIViewController,
         statusBarOverlay.hasTopTabs = ToolbarHelper().shouldShowTopTabs(for: traitCollection)
         statusBarOverlay.applyTheme(theme: currentTheme)
         keyboardBackdrop?.backgroundColor = currentTheme.colors.layer1
-        webViewContainerBackdrop.backgroundColor = currentTheme.colors.layer3
         setNeedsStatusBarAppearanceUpdate()
 
         tabManager.selectedTab?.applyTheme(theme: currentTheme)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -182,8 +182,8 @@ class BrowserViewController: UIViewController,
     var topTabsVisible: Bool {
         return topTabsViewController != nil
     }
-    // Window used for displaying an opaque background for private tabs.
-    private var privacyWindow: UIWindow?
+    // Window helper used for displaying an opaque background for private tabs.
+    private lazy var privacyWindowHelper = PrivacyWindowHelper()
     var keyboardBackdrop: UIView?
 
     lazy var scrollController = TabScrollingController(windowUUID: windowUUID)
@@ -509,7 +509,7 @@ class BrowserViewController: UIViewController,
         else { return }
 
         contentStackView.alpha = 0
-        showPrivacyWindow()
+        privacyWindowHelper.showWindow(withThemedColor: currentTheme().colors.layer3)
 
         if isToolbarRefactorEnabled {
             addressToolbarContainer.alpha = 0
@@ -544,7 +544,7 @@ class BrowserViewController: UIViewController,
                 self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
                 self.presentedViewController?.view.alpha = 1
             }, completion: { _ in
-                self.removePrivacyWindow()
+                self.privacyWindowHelper.removeWindow()
             })
 
         if let tab = tabManager.selectedTab, !tab.isFindInPageMode {
@@ -593,24 +593,6 @@ class BrowserViewController: UIViewController,
 
         guard presentedViewController != nil else { return }
         dismissVC()
-    }
-
-    // MARK: - Privacy Window Protection
-    private func showPrivacyWindow() {
-        guard let windowScene = UIWindow.attachedKeyWindow?.windowScene else { return }
-        let backgroundColor = currentTheme().colors.layer3
-
-        privacyWindow = UIWindow(windowScene: windowScene)
-        privacyWindow?.rootViewController = UIViewController()
-        privacyWindow?.rootViewController?.view.backgroundColor = backgroundColor
-        // Set the privacy window level to be above alert windows (highest in importance).
-        privacyWindow?.windowLevel = .alert + 1
-        privacyWindow?.makeKeyAndVisible()
-    }
-
-    private func removePrivacyWindow() {
-        privacyWindow?.isHidden = true
-        privacyWindow = nil
     }
 
     // MARK: - Redux

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -182,7 +182,7 @@ class BrowserViewController: UIViewController,
     var topTabsVisible: Bool {
         return topTabsViewController != nil
     }
-    // Backdrop used for displaying greyed background for private tabs
+    // Window used for displaying an opaque background for private tabs.
     private var privacyWindow: UIWindow?
     var keyboardBackdrop: UIView?
 

--- a/firefox-ios/Client/PrivacyWindowHelper.swift
+++ b/firefox-ios/Client/PrivacyWindowHelper.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+final class PrivacyWindowHelper {
+    private var privacyWindow: UIWindow?
+
+    func showWindow(withThemedColor color: UIColor) {
+        guard let windowScene = UIWindow.attachedKeyWindow?.windowScene else { return }
+
+        privacyWindow = UIWindow(windowScene: windowScene)
+        privacyWindow?.rootViewController = UIViewController()
+        privacyWindow?.rootViewController?.view.backgroundColor = color
+        // Set the privacy window level to be above alert windows (highest in importance).
+        privacyWindow?.windowLevel = .alert + 1
+        privacyWindow?.makeKeyAndVisible()
+    }
+
+    func removeWindow() {
+        privacyWindow?.isHidden = true
+        privacyWindow = nil
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10451)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22864)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Adds a  privacy window to cover everything that is on the screen when the app is going in background when in private mode.

### Video
#### Before
https://github.com/user-attachments/assets/1a2effed-05c3-45fe-960f-28dbaf570582

#### Now
https://github.com/user-attachments/assets/55c8b620-a625-4cbe-a340-49fb28d1d8fd

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

