### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from ClientTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -697,7 +697,9 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         subject.browserHasLoaded()
 
         let result = testCanHandleAndHandle(subject, route: .settings(section: .general))
-        let settingsCoordinator = subject.childCoordinators[0] as! SettingsCoordinator
+        guard let settingsCoordinator = subject.childCoordinators[0] as? SettingsCoordinator else {
+            return XCTFail("settingsCoordinator was not found")
+        }
         subject.didFinishSettings(from: settingsCoordinator)
 
         XCTAssertTrue(result)
@@ -720,7 +722,9 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         subject.browserHasLoaded()
 
         subject.showEnhancedTrackingProtection(sourceView: UIView())
-        let etpCoordinator = subject.childCoordinators[0] as! EnhancedTrackingProtectionCoordinator
+        guard let etpCoordinator = subject.childCoordinators[0] as? EnhancedTrackingProtectionCoordinator else {
+            return XCTFail("etpCoordinator was not found")
+        }
         subject.didFinishEnhancedTrackingProtection(from: etpCoordinator)
 
         XCTAssertEqual(mockRouter.dismissCalled, 1)
@@ -778,7 +782,9 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
         // Then
         XCTAssertTrue(result)
-        let windowManager = (AppContainer.shared.resolve() as WindowManager) as! MockWindowManager
+        guard let windowManager = (AppContainer.shared.resolve() as WindowManager) as? MockWindowManager else {
+            return XCTFail("windowManager was not found")
+        }
         XCTAssertEqual(windowManager.closePrivateTabsMultiActionCalled, 1)
     }
 
@@ -937,7 +943,9 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         subject.browserHasLoaded()
 
         subject.showFakespotFlowAsModal(productURL: URL(string: "www.example.com")!)
-        let fakespotCoordinator = subject.childCoordinators[0] as! FakespotCoordinator
+        guard let fakespotCoordinator = subject.childCoordinators[0] as? FakespotCoordinator else {
+            return XCTFail("fakespotCoordinator was not found")
+        }
         fakespotCoordinator.dismissModal(animated: false)
 
         XCTAssertEqual(mockRouter.dismissCalled, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTests/MockUserDefaultsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTests/MockUserDefaultsTests.swift
@@ -34,7 +34,7 @@ class MockUserDefaultsTests: XCTestCase {
         sut.set(date, forKey: key)
 
         XCTAssertEqual(sut.savedData.count, expectedCount)
-        XCTAssertEqual(sut.savedData[key] as! Date, date)
+        XCTAssertEqual(sut.savedData[key] as? Date, date)
     }
 
     func testMUD_retrievingItem_itemIsDate() {
@@ -42,7 +42,9 @@ class MockUserDefaultsTests: XCTestCase {
         let date = Date()
         sut.set(date, forKey: key)
 
-        let actualObject = sut.object(forKey: key) as! Date
+        guard let actualObject = sut.object(forKey: key) as? Date else {
+            return XCTFail("expected object is not a date")
+        }
 
         XCTAssertEqual(actualObject, date)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PrefsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PrefsTests.swift
@@ -81,7 +81,7 @@ class PrefsTests: XCTestCase {
 
     func testMockProfilePrefsKeys() {
         guard let prefs = MockProfilePrefs().branch("baz") as? MockProfilePrefs else {
-            return XCTFail("Expected MockProfilePrefs instance from branch 'bar'")
+            return XCTFail("Expected MockProfilePrefs instance from branch 'baz'")
         }
         let val: Timestamp = Date.now()
         prefs.setLong(val, forKey: "foobar")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PrefsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PrefsTests.swift
@@ -80,15 +80,25 @@ class PrefsTests: XCTestCase {
     }
 
     func testMockProfilePrefsKeys() {
-        let prefs = MockProfilePrefs().branch("baz") as! MockProfilePrefs
+        guard let prefs = MockProfilePrefs().branch("baz") as? MockProfilePrefs else {
+            return XCTFail("Expected MockProfilePrefs instance from branch 'bar'")
+        }
         let val: Timestamp = Date.now()
         prefs.setLong(val, forKey: "foobar")
-        XCTAssertEqual(val, (prefs.things["baz.foobar"] as! NSNumber).uint64Value)
+        guard let numberValue = prefs.things["baz.foobar"] as? NSNumber else {
+            return XCTFail("Expected NSNumber for key 'baz.foobar'")
+        }
+        XCTAssertEqual(val, numberValue.uint64Value)
     }
 
     func testMockProfilePrefsClearAll() {
-        let prefs1 = MockProfilePrefs().branch("bar") as! MockProfilePrefs
-        let prefs2 = MockProfilePrefs().branch("baz") as! MockProfilePrefs
+        guard let prefs1 = MockProfilePrefs().branch("bar") as? MockProfilePrefs else {
+            return XCTFail("Failed to cast branch 'bar' to MockProfilePrefs")
+        }
+
+        guard let prefs2 = MockProfilePrefs().branch("baz") as? MockProfilePrefs else {
+            return XCTFail("Failed to cast branch 'baz' to MockProfilePrefs")
+        }
 
         // Ensure clearing prefs is branch-specific.
         prefs1.setInt(123, forKey: "foo")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperNetworkingModuleTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperNetworkingModuleTests.swift
@@ -30,7 +30,7 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
             _ = try await subject.data(from: url)
             XCTFail("This test should throw an error, but it did not.")
         } catch {
-            XCTAssertEqual(error as! URLError,
+            XCTAssertEqual(error as? URLError,
                            URLError(.cannotConnectToHost))
         }
     }
@@ -46,7 +46,7 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
             _ = try await subject.data(from: url)
             XCTFail("This test should throw an error, but it did not.")
         } catch {
-            XCTAssertEqual(error as! URLError,
+            XCTAssertEqual(error as? URLError,
                            URLError(.badServerResponse))
         }
     }
@@ -62,7 +62,7 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
             _ = try await subject.data(from: url)
             XCTFail("This test should throw an error, but it did not.")
         } catch {
-            XCTAssertEqual(error as! URLError,
+            XCTAssertEqual(error as? URLError,
                            URLError(.badServerResponse))
         }
     }
@@ -94,7 +94,7 @@ class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
             _ = try await subject.data(from: url)
             XCTFail("This test should throw an error, but it did not.")
         } catch {
-            XCTAssertEqual(error as! WallpaperServiceError,
+            XCTAssertEqual(error as? WallpaperServiceError,
                            WallpaperServiceError.dataUnavailable)
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
    - MockUserDefaultsTests 
    - BrowserCoordinatorTests
    - WallpaperNetworkingModuleTests
    -  PrefsTests
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)