### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from StorageTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestBrowserDB.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestBrowserDB.swift
@@ -55,10 +55,12 @@ class TestBrowserDB: XCTestCase {
                                   args: nil,
                                   factory: { row in
             guard let bmkUri = row[0] as? String else {
+                XCTFail("Failed to cast value for key 'bmkUri' to String.")
                 return ("", "")
             }
 
             guard let title = row[1] as? String else {
+                XCTFail("Failed to cast value for key 'title' to String.")
                 return (bmkUri, "")
             }
 
@@ -88,10 +90,12 @@ class TestBrowserDB: XCTestCase {
         // Grab a pointer to the -shm so we can compare later.
         let shmAAttributes = try files.attributesForFileAt(relativePath: "foo.db-shm")
         guard let creationA = shmAAttributes[FileAttributeKey.creationDate] as? Date else {
-            return XCTFail("expected object was not a date")
+            XCTFail("Failed to cast value for key 'creationDate' to Date.")
+            return
         }
         guard let inodeA = (shmAAttributes[FileAttributeKey.systemFileNumber] as? NSNumber)?.uintValue else {
-            return XCTFail("expected object was not a number")
+            XCTFail("Failed to cast value for key 'systemFileNumber' to NSNumber.")
+            return
         }
 
         XCTAssertFalse(files.exists("foo.db.bak.1"))

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestBrowserDB.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestBrowserDB.swift
@@ -54,7 +54,15 @@ class TestBrowserDB: XCTestCase {
         let results = db.runQuery("SELECT bmkUri, title FROM bookmarksLocal WHERE type = 1",
                                   args: nil,
                                   factory: { row in
-            (row[0] as! String, row[1] as! String)
+            guard let bmkUri = row[0] as? String else {
+                return ("", "")
+            }
+
+            guard let title = row[1] as? String else {
+                return (bmkUri, "")
+            }
+
+            return (bmkUri, title)
         }).value.successValue!
 
         // The bookmark with the long URL has been deleted.
@@ -79,8 +87,12 @@ class TestBrowserDB: XCTestCase {
 
         // Grab a pointer to the -shm so we can compare later.
         let shmAAttributes = try files.attributesForFileAt(relativePath: "foo.db-shm")
-        let creationA = shmAAttributes[FileAttributeKey.creationDate] as! Date
-        let inodeA = (shmAAttributes[FileAttributeKey.systemFileNumber] as! NSNumber).uintValue
+        guard let creationA = shmAAttributes[FileAttributeKey.creationDate] as? Date else {
+            return XCTFail("expected object was not a date")
+        }
+        guard let inodeA = (shmAAttributes[FileAttributeKey.systemFileNumber] as? NSNumber)?.uintValue else {
+            return XCTFail("expected object was not a number")
+        }
 
         XCTAssertFalse(files.exists("foo.db.bak.1"))
         XCTAssertFalse(files.exists("foo.db.bak.1-shm"))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
    - StorageTestUtils 
    - TestBrowserDB
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)