### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from ThemeSettingsState.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -126,6 +126,16 @@ struct ThemeSettingsState: ScreenState, Equatable {
                                   systemBrightness: state.systemBrightness)
     }
 
+    private static func handleAutomaticBrightnessChanged(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
+        let enabled = action.themeSettingsState?.isAutomaticBrightnessEnabled ?? state.isAutomaticBrightnessEnabled
+        return ThemeSettingsState(windowUUID: state.windowUUID,
+                                  useSystemAppearance: state.useSystemAppearance,
+                                  isAutomaticBrightnessEnable: enabled,
+                                  manualThemeSelected: state.manualThemeSelected,
+                                  userBrightnessThreshold: state.userBrightnessThreshold,
+                                  systemBrightness: state.systemBrightness)
+    }
+
     static func == (lhs: ThemeSettingsState, rhs: ThemeSettingsState) -> Bool {
         return lhs.useSystemAppearance == rhs.useSystemAppearance
         && lhs.isAutomaticBrightnessEnabled == rhs.isAutomaticBrightnessEnabled

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -64,13 +64,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
             return action.themeSettingsState ?? defaultState(from: state)
 
         case ThemeSettingsMiddlewareActionType.systemThemeChanged:
-            let useSystemAppearance = action.themeSettingsState?.useSystemAppearance ?? state.useSystemAppearance
-            return ThemeSettingsState(windowUUID: state.windowUUID,
-                                      useSystemAppearance: useSystemAppearance,
-                                      isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
-                                      manualThemeSelected: state.manualThemeSelected,
-                                      userBrightnessThreshold: state.userBrightnessThreshold,
-                                      systemBrightness: state.systemBrightness)
+            return handleSystemThemeChanged(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.automaticBrightnessChanged:
             let enabled = action.themeSettingsState?.isAutomaticBrightnessEnabled ??

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -76,7 +76,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
             return handleUserBrightnessChangedAction(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.systemBrightnessChanged:
-            return handleSystemBrightnessChanged(state: state, action: action)
+            return handleSystemBrightnessChangedAction(state: state, action: action)
         default:
             return defaultState(from: state)
         }
@@ -131,7 +131,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
                                   systemBrightness: state.systemBrightness)
     }
 
-    private static func handleSystemBrightnessChanged(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
+    private static func handleSystemBrightnessChangedAction(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
         let brightnessValue = action.themeSettingsState?.systemBrightness ?? state.systemBrightness
         return ThemeSettingsState(windowUUID: state.windowUUID,
                                   useSystemAppearance: state.useSystemAppearance,

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -64,7 +64,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
             return action.themeSettingsState ?? defaultState(from: state)
 
         case ThemeSettingsMiddlewareActionType.systemThemeChanged:
-            return handleSystemThemeChanged(state: state, action: action)
+            return handleSystemThemeChangedAction(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.automaticBrightnessChanged:
             return handleAutomaticBrightnessChanged(state: state, action: action)
@@ -91,7 +91,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
                                   systemBrightness: state.systemBrightness)
     }
 
-    private static func handleSystemThemeChanged(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
+    private static func handleSystemThemeChangedAction(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
         let useSystemAppearance = action.themeSettingsState?.useSystemAppearance ?? state.useSystemAppearance
         return ThemeSettingsState(windowUUID: state.windowUUID,
                                   useSystemAppearance: useSystemAppearance,

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -133,6 +133,16 @@ struct ThemeSettingsState: ScreenState, Equatable {
                                   systemBrightness: state.systemBrightness)
     }
 
+    private static func handleUserBrightnessChanged(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
+        let brightnessValue = action.themeSettingsState?.userBrightnessThreshold ?? state.userBrightnessThreshold
+        return ThemeSettingsState(windowUUID: state.windowUUID,
+                                  useSystemAppearance: state.useSystemAppearance,
+                                  isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
+                                  manualThemeSelected: state.manualThemeSelected,
+                                  userBrightnessThreshold: brightnessValue,
+                                  systemBrightness: state.systemBrightness)
+    }
+
     static func == (lhs: ThemeSettingsState, rhs: ThemeSettingsState) -> Bool {
         return lhs.useSystemAppearance == rhs.useSystemAppearance
         && lhs.isAutomaticBrightnessEnabled == rhs.isAutomaticBrightnessEnabled

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -137,6 +137,16 @@ struct ThemeSettingsState: ScreenState, Equatable {
                                   systemBrightness: state.systemBrightness)
     }
 
+    private static func handleSystemBrightnessChanged(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
+        let brightnessValue = action.themeSettingsState?.systemBrightness ?? state.systemBrightness
+        return ThemeSettingsState(windowUUID: state.windowUUID,
+                                  useSystemAppearance: state.useSystemAppearance,
+                                  isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
+                                  manualThemeSelected: state.manualThemeSelected,
+                                  userBrightnessThreshold: state.userBrightnessThreshold,
+                                  systemBrightness: brightnessValue)
+    }
+
     static func == (lhs: ThemeSettingsState, rhs: ThemeSettingsState) -> Bool {
         return lhs.useSystemAppearance == rhs.useSystemAppearance
         && lhs.isAutomaticBrightnessEnabled == rhs.isAutomaticBrightnessEnabled

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -70,7 +70,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
             return handleAutomaticBrightnessChangedAction(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.manualThemeChanged:
-            return handleManualThemeChanged(state: state, action: action)
+            return handleManualThemeChangedAction(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.userBrightnessChanged:
             return handleUserBrightnessChanged(state: state, action: action)
@@ -111,7 +111,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
                                   systemBrightness: state.systemBrightness)
     }
 
-    private static func handleManualThemeChanged(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
+    private static func handleManualThemeChangedAction(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
         let theme = action.themeSettingsState?.manualThemeSelected ?? state.manualThemeSelected
         return ThemeSettingsState(windowUUID: state.windowUUID,
                                   useSystemAppearance: state.useSystemAppearance,

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -73,13 +73,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
             return handleManualThemeChanged(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.userBrightnessChanged:
-            let brightnessValue = action.themeSettingsState?.userBrightnessThreshold ?? state.userBrightnessThreshold
-            return ThemeSettingsState(windowUUID: state.windowUUID,
-                                      useSystemAppearance: state.useSystemAppearance,
-                                      isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
-                                      manualThemeSelected: state.manualThemeSelected,
-                                      userBrightnessThreshold: brightnessValue,
-                                      systemBrightness: state.systemBrightness)
+            return handleUserBrightnessChanged(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.systemBrightnessChanged:
             let brightnessValue = action.themeSettingsState?.systemBrightness ?? state.systemBrightness

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -70,13 +70,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
             return handleAutomaticBrightnessChanged(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.manualThemeChanged:
-            let theme = action.themeSettingsState?.manualThemeSelected ?? state.manualThemeSelected
-            return ThemeSettingsState(windowUUID: state.windowUUID,
-                                      useSystemAppearance: state.useSystemAppearance,
-                                      isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
-                                      manualThemeSelected: theme,
-                                      userBrightnessThreshold: state.userBrightnessThreshold,
-                                      systemBrightness: state.systemBrightness)
+            return handleManualThemeChanged(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.userBrightnessChanged:
             let brightnessValue = action.themeSettingsState?.userBrightnessThreshold ?? state.userBrightnessThreshold

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -67,7 +67,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
             return handleSystemThemeChangedAction(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.automaticBrightnessChanged:
-            return handleAutomaticBrightnessChanged(state: state, action: action)
+            return handleAutomaticBrightnessChangedAction(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.manualThemeChanged:
             return handleManualThemeChanged(state: state, action: action)
@@ -101,7 +101,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
                                   systemBrightness: state.systemBrightness)
     }
 
-    private static func handleAutomaticBrightnessChanged(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
+    private static func handleAutomaticBrightnessChangedAction(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
         let enabled = action.themeSettingsState?.isAutomaticBrightnessEnabled ?? state.isAutomaticBrightnessEnabled
         return ThemeSettingsState(windowUUID: state.windowUUID,
                                   useSystemAppearance: state.useSystemAppearance,

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -67,14 +67,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
             return handleSystemThemeChanged(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.automaticBrightnessChanged:
-            let enabled = action.themeSettingsState?.isAutomaticBrightnessEnabled ??
-                            state.isAutomaticBrightnessEnabled
-            return ThemeSettingsState(windowUUID: state.windowUUID,
-                                      useSystemAppearance: state.useSystemAppearance,
-                                      isAutomaticBrightnessEnable: enabled,
-                                      manualThemeSelected: state.manualThemeSelected,
-                                      userBrightnessThreshold: state.userBrightnessThreshold,
-                                      systemBrightness: state.systemBrightness)
+            return handleAutomaticBrightnessChanged(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.manualThemeChanged:
             let theme = action.themeSettingsState?.manualThemeSelected ?? state.manualThemeSelected

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -122,6 +122,16 @@ struct ThemeSettingsState: ScreenState, Equatable {
                                   systemBrightness: state.systemBrightness)
     }
 
+    private static func handleSystemThemeChanged(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
+        let useSystemAppearance = action.themeSettingsState?.useSystemAppearance ?? state.useSystemAppearance
+        return ThemeSettingsState(windowUUID: state.windowUUID,
+                                  useSystemAppearance: useSystemAppearance,
+                                  isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
+                                  manualThemeSelected: state.manualThemeSelected,
+                                  userBrightnessThreshold: state.userBrightnessThreshold,
+                                  systemBrightness: state.systemBrightness)
+    }
+
     static func == (lhs: ThemeSettingsState, rhs: ThemeSettingsState) -> Bool {
         return lhs.useSystemAppearance == rhs.useSystemAppearance
         && lhs.isAutomaticBrightnessEnabled == rhs.isAutomaticBrightnessEnabled

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -76,13 +76,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
             return handleUserBrightnessChanged(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.systemBrightnessChanged:
-            let brightnessValue = action.themeSettingsState?.systemBrightness ?? state.systemBrightness
-            return ThemeSettingsState(windowUUID: state.windowUUID,
-                                      useSystemAppearance: state.useSystemAppearance,
-                                      isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
-                                      manualThemeSelected: state.manualThemeSelected,
-                                      userBrightnessThreshold: state.userBrightnessThreshold,
-                                      systemBrightness: brightnessValue)
+            return handleSystemBrightnessChanged(state: state, action: action)
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -73,7 +73,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
             return handleManualThemeChangedAction(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.userBrightnessChanged:
-            return handleUserBrightnessChanged(state: state, action: action)
+            return handleUserBrightnessChangedAction(state: state, action: action)
 
         case ThemeSettingsMiddlewareActionType.systemBrightnessChanged:
             return handleSystemBrightnessChanged(state: state, action: action)
@@ -121,7 +121,7 @@ struct ThemeSettingsState: ScreenState, Equatable {
                                   systemBrightness: state.systemBrightness)
     }
 
-    private static func handleUserBrightnessChanged(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
+    private static func handleUserBrightnessChangedAction(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
         let brightnessValue = action.themeSettingsState?.userBrightnessThreshold ?? state.userBrightnessThreshold
         return ThemeSettingsState(windowUUID: state.windowUUID,
                                   useSystemAppearance: state.useSystemAppearance,

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeSettingsState.swift
@@ -129,6 +129,16 @@ struct ThemeSettingsState: ScreenState, Equatable {
                                   systemBrightness: state.systemBrightness)
     }
 
+    private static func handleManualThemeChanged(state: Self, action: ThemeSettingsMiddlewareAction) -> Self {
+        let theme = action.themeSettingsState?.manualThemeSelected ?? state.manualThemeSelected
+        return ThemeSettingsState(windowUUID: state.windowUUID,
+                                  useSystemAppearance: state.useSystemAppearance,
+                                  isAutomaticBrightnessEnable: state.isAutomaticBrightnessEnabled,
+                                  manualThemeSelected: theme,
+                                  userBrightnessThreshold: state.userBrightnessThreshold,
+                                  systemBrightness: state.systemBrightness)
+    }
+
     static func == (lhs: ThemeSettingsState, rhs: ThemeSettingsState) -> Bool {
         return lhs.useSystemAppearance == rhs.useSystemAppearance
         && lhs.isAutomaticBrightnessEnabled == rhs.isAutomaticBrightnessEnabled


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `ThemeSettingsState.swift` file by extracting switch case statements to new functions. 

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

