### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from RustAutofillTests.swift

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -13,6 +13,18 @@ class RustAutofillTests: XCTestCase {
     var autofill: RustAutofill!
     var encryptionKey: String!
 
+    let mockAddress = UpdatableAddressFields(
+        name: "Jane Doe",
+        organization: "",
+        streetAddress: "123 Second Avenue",
+        addressLevel3: "",
+        addressLevel2: "Chicago, IL",
+        addressLevel1: "",
+        postalCode: "",
+        country: "United States",
+        tel: "",
+        email: "")
+
     override func setUp() {
         super.setUp()
         files = MockFiles()

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -178,26 +178,6 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
-    func testAddCreditCard() {
-        let expectationAddCard = expectation(description: "completed add card")
-        let expectationGetCard = expectation(description: "completed getting card")
-
-        addCreditCard { creditCard, err in
-            XCTAssertNotNil(creditCard)
-            XCTAssertNil(err)
-            expectationAddCard.fulfill()
-
-            self.autofill.getCreditCard(id: creditCard!.guid) { card, error in
-                XCTAssertNotNil(card)
-                XCTAssertNil(err)
-                XCTAssertEqual(creditCard!.guid, card!.guid)
-                expectationGetCard.fulfill()
-            }
-        }
-
-        waitForExpectations(timeout: 3, handler: nil)
-    }
-
     func testAddCreditCard() async throws {
         let creditCard = try await addCreditCard()
         let retrievedCreditCard = try await getCreditCard(id: creditCard.guid)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -279,4 +279,20 @@ class RustAutofillTests: XCTestCase {
 
         waitForExpectations(timeout: 3, handler: nil)
     }
+
+    func testDeleteCreditCard() async throws {
+        let creditCard = try await addCreditCard()
+        let retrievedCreditCard = try await getCreditCard(id: creditCard.guid)
+        let deleteCreditCardResult = try await deleteCreditCard(id: retrievedCreditCard.guid)
+
+        do {
+            _ = try await getCreditCard(id: creditCard.guid)
+        } catch {
+            let expectedError = "NoSuchRecord(guid: \"\(creditCard.guid)\")"
+            XCTAssertEqual(expectedError, "\(error)")
+        }
+
+        XCTAssertEqual(creditCard.guid, retrievedCreditCard.guid)
+        XCTAssertTrue(deleteCreditCardResult)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -130,7 +130,7 @@ class RustAutofillTests: XCTestCase {
                 country: "United States",
                 tel: "",
                 email: "")
-            autofill.addAddress(address: address) { result in
+            autofill.addAddress(address: mockAddress) { result in
                 switch result {
                 case .success(let addedAddress):
                     continuation.resume(returning: addedAddress)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -171,10 +171,10 @@ class RustAutofillTests: XCTestCase {
         let addresses = try await listAllAddresses()
 
         for address in addresses {
-            XCTAssertEqual(address.name, "Jane Doe")
-            XCTAssertEqual(address.streetAddress, "123 Second Avenue")
-            XCTAssertEqual(address.addressLevel2, "Chicago, IL")
-            XCTAssertEqual(address.country, "United States")
+            XCTAssertEqual(address.name, mockAddress.name)
+            XCTAssertEqual(address.streetAddress, mockAddress.streetAddress)
+            XCTAssertEqual(address.addressLevel2, mockAddress.addressLevel2)
+            XCTAssertEqual(address.country, mockAddress.country)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -209,8 +209,8 @@ class RustAutofillTests: XCTestCase {
                             expectationUpdateCard.fulfill()
 
                             self.makeAssertionsToCheckUpdatedCard(id: creditCard.guid,
-                                                               updatedCreditCard: updatedCreditCard,
-                                                               expectationCheckUpdateCard: expectationCheckUpdateCard)
+                                                                  updatedCreditCard: updatedCreditCard,
+                                                                  expectationCheckUpdateCard: expectationCheckUpdateCard)
                         }
                     } catch {
                         XCTFail("The card variable should not be nil.")
@@ -241,7 +241,7 @@ class RustAutofillTests: XCTestCase {
         self.autofill.getCreditCard(id: id) { updatedCardVal, err in
             do {
                 let updatedCardVal = try XCTUnwrap(updatedCardVal)
-                
+
                 XCTAssertNil(err)
                 XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
                 expectationCheckUpdateCard.fulfill()

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -220,15 +220,10 @@ class RustAutofillTests: XCTestCase {
         let creditCard = try await addCreditCard()
         let retrievedCreditCard = try await getCreditCard(id: creditCard.guid)
         let deleteCreditCardResult = try await deleteCreditCard(id: retrievedCreditCard.guid)
-
-        do {
-            _ = try await getCreditCard(id: creditCard.guid)
-        } catch {
-            let expectedError = "NoSuchRecord(guid: \"\(creditCard.guid)\")"
-            XCTAssertEqual(expectedError, "\(error)")
-        }
+        let result = try? await getCreditCard(id: creditCard.guid)
 
         XCTAssertEqual(creditCard.guid, retrievedCreditCard.guid)
         XCTAssertTrue(deleteCreditCardResult)
+        XCTAssertNil(result)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -144,38 +144,6 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
-    func testAddAndGetAddress() {
-        let expectationAddAddress = expectation(description: "Completes the add address operation")
-        let expectationGetAddress = expectation(description: "Completes the get address operation")
-
-        addAddress { result in
-            switch result {
-            case .success(let address):
-                XCTAssertEqual(address.name, "Jane Doe")
-                XCTAssertEqual(address.streetAddress, "123 Second Avenue")
-                XCTAssertEqual(address.addressLevel2, "Chicago, IL")
-                XCTAssertEqual(address.country, "United States")
-                expectationAddAddress.fulfill()
-                self.autofill.getAddress(id: address.guid) { retrievedAddress, getAddressError in
-                    guard let retrievedAddress = retrievedAddress, getAddressError == nil else {
-                        XCTFail("Failed to get address. Retrieved Address: \(String(describing: retrievedAddress)), Error: \(String(describing: getAddressError))")
-                        expectationGetAddress.fulfill()
-                        return
-                    }
-                    XCTAssertEqual(address.guid, retrievedAddress.guid)
-                    expectationGetAddress.fulfill()
-                }
-
-            case .failure(let error):
-                XCTFail("Failed to add address, Error: \(String(describing: error))")
-                expectationAddAddress.fulfill()
-                return
-            }
-        }
-
-        waitForExpectations(timeout: 3, handler: nil)
-    }
-
     func testAddAndGetAddress() async throws {
         let address = try await addAddress()
         let retrievedAddress = try await getAddress(id: address.guid)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -216,15 +216,15 @@ class RustAutofillTests: XCTestCase {
                                                         ccExpYear: Int64(2028),
                                                         ccType: creditCard.ccType)
         let result = try await updateCreditCard(id: creditCard.guid, creditCard: creditCardVal)
-        let updatedCardVal = try await getCreditCard(id: creditCard.guid)
+        let updatedCreditCardVal = try await getCreditCard(id: creditCard.guid)
 
         XCTAssertEqual(creditCard.guid, card.guid)
         XCTAssertTrue(result)
-        XCTAssertEqual(updatedCardVal.ccName, creditCardVal.ccName)
-        XCTAssertEqual(updatedCardVal.ccNumberLast4, creditCardVal.ccNumberLast4)
-        XCTAssertEqual(updatedCardVal.ccExpMonth, creditCardVal.ccExpMonth)
-        XCTAssertEqual(updatedCardVal.ccExpYear, creditCardVal.ccExpYear)
-        XCTAssertEqual(updatedCardVal.ccType, creditCardVal.ccType)
+        XCTAssertEqual(updatedCreditCardVal.ccName, creditCardVal.ccName)
+        XCTAssertEqual(updatedCreditCardVal.ccNumberLast4, creditCardVal.ccNumberLast4)
+        XCTAssertEqual(updatedCreditCardVal.ccExpMonth, creditCardVal.ccExpMonth)
+        XCTAssertEqual(updatedCreditCardVal.ccExpYear, creditCardVal.ccExpYear)
+        XCTAssertEqual(updatedCreditCardVal.ccType, creditCardVal.ccType)
     }
 
     func testDeleteCreditCard() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -196,34 +196,7 @@ class RustAutofillTests: XCTestCase {
 
         XCTAssertEqual(creditCard.guid, retrievedCreditCard.guid)
     }
-
-    func testListCreditCards() {
-        let expectationCardList = expectation(description: "getting empty card list")
-        let expectationAddCard = expectation(description: "add card")
-        let expectationGetCards = expectation(description: "getting card list")
-        autofill.listCreditCards { cards, err in
-            XCTAssertNotNil(cards)
-            XCTAssertNil(err)
-            XCTAssertEqual(cards!.count, 0)
-            expectationCardList.fulfill()
-
-            self.addCreditCard { creditCard, err in
-                XCTAssertNotNil(creditCard)
-                XCTAssertNil(err)
-                expectationAddCard.fulfill()
-
-                self.autofill.listCreditCards { cards, err in
-                    XCTAssertNotNil(cards)
-                    XCTAssertNil(err)
-                    XCTAssertEqual(cards!.count, 1)
-                    expectationGetCards.fulfill()
-                }
-            }
-        }
-
-        waitForExpectations(timeout: 3, handler: nil)
-    }
-
+    
     func testListCreditCards() async throws {
         let cards = try await listCreditCards()
         let addedCreditCard = try await addCreditCard()

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -132,6 +132,18 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
+    func getAddress(id: String) async throws -> Address {
+        return try await withCheckedThrowingContinuation { continuation in
+            autofill.getAddress(id: id) { retrievedAddress, getAddressError in
+                guard let retrievedAddress else {
+                    continuation.resume(throwing: getAddressError ?? NSError(domain: "Couldn't get address", code: 0))
+                    return
+                }
+                continuation.resume(returning: retrievedAddress)
+            }
+        }
+    }
+
     func testAddAndGetAddress() {
         let expectationAddAddress = expectation(description: "Completes the add address operation")
         let expectationGetAddress = expectation(description: "Completes the get address operation")

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -222,6 +222,12 @@ class RustAutofillTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testListAllAddressesEmpty() async throws {
+        let addresses = try await listAllAddresses()
+
+        XCTAssertEqual(addresses.count, 0, "Addresses count should be 0 for an empty list")
+    }
+
     func testUpdateCreditCard() async throws {
         let creditCard = try await addCreditCard()
         let card = try await getCreditCard(id: creditCard.guid)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -120,8 +120,8 @@ class RustAutofillTests: XCTestCase {
                 email: "")
             autofill.addAddress(address: address) { result in
                 switch result {
-                case .success(let addressAdded):
-                    continuation.resume(returning: addressAdded)
+                case .success(let addedAddress):
+                    continuation.resume(returning: addedAddress)
                     return
                 case .failure(let error):
                     continuation.resume(throwing: error)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -208,18 +208,9 @@ class RustAutofillTests: XCTestCase {
                             XCTAssertNil(err)
                             expectationUpdateCard.fulfill()
 
-                            self.autofill.getCreditCard(id: creditCard.guid) { updatedCardVal, err in
-                                do {
-                                    let updatedCardVal = try XCTUnwrap(updatedCardVal)
-
-                                    XCTAssertNil(err)
-                                    XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
-                                    expectationCheckUpdateCard.fulfill()
-                                } catch {
-                                    XCTFail("The updatedCardVal variable should not be nil.")
-                                    expectationCheckUpdateCard.fulfill()
-                                }
-                            }
+                            self.makeUpdateCreditCardAssertion(id: creditCard.guid,
+                                                               updatedCreditCard: updatedCreditCard,
+                                                               expectationCheckUpdateCard: expectationCheckUpdateCard)
                         }
                     } catch {
                         XCTFail("The card variable should not be nil.")

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -267,6 +267,15 @@ class RustAutofillTests: XCTestCase {
     }
 
     func testUpdateCreditCard() async throws {
+        let creditCard = try await addCreditCard()
+        let card = try await getCreditCard(id: creditCard.guid)
+        let updatedCreditCard = createUnencryptedCreditCardFields(creditCard: creditCard)
+        let result = try await updateCreditCard(id: creditCard.guid, creditCard: updatedCreditCard)
+        let updatedCardVal = try await getCreditCard(id: creditCard.guid)
+
+        XCTAssertEqual(creditCard.guid, card.guid)
+        XCTAssert(result)
+        XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
     }
 
     private func createUnencryptedCreditCardFields(creditCard: CreditCard) -> UnencryptedCreditCardFields {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -221,7 +221,6 @@ class RustAutofillTests: XCTestCase {
         XCTAssertEqual(creditCard.guid, card.guid)
         XCTAssertTrue(result)
         XCTAssertEqual(updatedCardVal.ccName, updatedCreditCard.ccName)
-        XCTAssertEqual(updatedCardVal.ccNumberEnc, updatedCreditCard.ccNumber)
         XCTAssertEqual(updatedCardVal.ccNumberLast4, updatedCreditCard.ccNumberLast4)
         XCTAssertEqual(updatedCardVal.ccExpMonth, updatedCreditCard.ccExpMonth)
         XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -248,15 +248,6 @@ class RustAutofillTests: XCTestCase {
                                            ccType: creditCard.ccType)
     }
 
-    private func makeAssertionsForUpdateCard(success: Bool?, err: Error?, expectation: XCTestExpectation) {
-        XCTAssertNotNil(success)
-        if let updated = success {
-            XCTAssert(updated)
-        }
-        XCTAssertNil(err)
-        expectation.fulfill()
-    }
-
     private func getCreditCardAndMakeAssertionsForCheckUpdateCard(id: String,
                                                                   updatedCreditCard: UnencryptedCreditCardFields,
                                                                   expectation: XCTestExpectation) {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -235,6 +235,15 @@ class RustAutofillTests: XCTestCase {
                                            ccType: creditCard.ccType)
     }
 
+    private func makeAssertionsForUpdateCard(success: Bool?, err: Error?, expectation: XCTestExpectation) {
+        XCTAssertNotNil(success)
+        if let updated = success {
+            XCTAssert(updated)
+        }
+        XCTAssertNil(err)
+        expectation.fulfill()
+    }
+
     private func getCreditCardAndMakeAssertionsToCheckUpdatedCard(id: String,
                                                                   updatedCreditCard: UnencryptedCreditCardFields,
                                                                   expectation: XCTestExpectation) {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -208,7 +208,7 @@ class RustAutofillTests: XCTestCase {
                             XCTAssertNil(err)
                             expectationUpdateCard.fulfill()
 
-                            self.makeUpdateCreditCardAssertion(id: creditCard.guid,
+                            self.makeAssertionsToCheckUpdatedCard(id: creditCard.guid,
                                                                updatedCreditCard: updatedCreditCard,
                                                                expectationCheckUpdateCard: expectationCheckUpdateCard)
                         }
@@ -235,7 +235,7 @@ class RustAutofillTests: XCTestCase {
                                            ccType: creditCard.ccType)
     }
 
-    private func makeUpdateCreditCardAssertion(id: String,
+    private func makeAssertionsToCheckUpdatedCard(id: String,
                                                updatedCreditCard: UnencryptedCreditCardFields,
                                                expectationCheckUpdateCard: XCTestExpectation) {
         self.autofill.getCreditCard(id: id) { updatedCardVal, err in

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -91,6 +91,18 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
+    func listCreditCards() async throws -> [CreditCard] {
+        return try await withCheckedThrowingContinuation { continuation in
+            autofill.listCreditCards { cards, error in
+                guard let cards else {
+                    continuation.resume(throwing: error ?? NSError(domain: "Couldn't list credit cards", code: 0))
+                    return
+                }
+                continuation.resume(returning: cards)
+            }
+        }
+    }
+
     func addAddress(completion: @escaping (Result<Address, Error>) -> Void) {
         let address = UpdatableAddressFields(
             name: "Jane Doe",

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -221,6 +221,9 @@ class RustAutofillTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testUpdateCreditCard() async throws {
+    }
+
     private func createUnencryptedCreditCardFields(creditCard: CreditCard) -> UnencryptedCreditCardFields {
         return UnencryptedCreditCardFields(ccName: creditCard.ccName,
                                            ccNumber: creditCard.ccNumberEnc,

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -206,22 +206,6 @@ class RustAutofillTests: XCTestCase {
         XCTAssertEqual(updatedCards.count, 1)
     }
 
-    func testListAllAddressesEmpty() {
-        let expectationListAddresses = expectation(
-            description: "Completes the list all addresses operation for an empty list"
-        )
-
-        autofill.listAllAddresses { addresses, error in
-            XCTAssertNil(error, "Error should be nil")
-            XCTAssertNotNil(addresses, "Addresses should not be nil")
-            XCTAssertEqual(addresses?.count, 0, "Addresses count should be 0 for an empty list")
-
-            expectationListAddresses.fulfill()
-        }
-
-        waitForExpectations(timeout: 3, handler: nil)
-    }
-
     func testListAllAddressesEmpty() async throws {
         let addresses = try await listAllAddresses()
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -209,12 +209,12 @@ class RustAutofillTests: XCTestCase {
     func testUpdateCreditCard() async throws {
         let creditCard = try await addCreditCard()
         let card = try await getCreditCard(id: creditCard.guid)
-        let creditCardVal = UnencryptedCreditCardFields(ccName: creditCard.ccName,
-                                                        ccNumber: creditCard.ccNumberEnc,
-                                                        ccNumberLast4: creditCard.ccNumberLast4,
-                                                        ccExpMonth: creditCard.ccExpMonth,
-                                                        ccExpYear: Int64(2028),
-                                                        ccType: creditCard.ccType)
+        let creditCardVal = UnencryptedCreditCardFields(ccName: "Jane Smith",
+                                                        ccNumber: "0123456789987654",
+                                                        ccNumberLast4: "7654",
+                                                        ccExpMonth: 01,
+                                                        ccExpYear: 2028,
+                                                        ccType: "Master")
         let result = try await updateCreditCard(id: creditCard.guid, creditCard: creditCardVal)
         let updatedCreditCardVal = try await getCreditCard(id: creditCard.guid)
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -224,6 +224,16 @@ class RustAutofillTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testListCreditCards() async throws {
+        let cards = try await listCreditCards()
+        let addedCreditCard = try await addCreditCard()
+        let updatedCards = try await listCreditCards()
+
+        XCTAssertEqual(cards.count, 0)
+        XCTAssertNotNil(addedCreditCard)
+        XCTAssertEqual(updatedCards.count, 1)
+    }
+
     func testListAllAddressesEmpty() {
         let expectationListAddresses = expectation(
             description: "Completes the list all addresses operation for an empty list"

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -65,7 +65,7 @@ class RustAutofillTests: XCTestCase {
             ccType: "Visa")
 
         return try await withCheckedThrowingContinuation { continuation in
-            autofill.addCreditCard(creditCard: creditCard) { card, error in
+            autofill.addCreditCard(creditCard: mockCreditCard) { card, error in
                 guard let card else {
                     continuation.resume(throwing: error ?? NSError(domain: "Couldn't add credit card", code: 0))
                     return

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -189,7 +189,14 @@ class RustAutofillTests: XCTestCase {
     }
 
     func testListAllAddressesSuccess() async throws {
-        
+        let addresses = try await getListAllAddresses()
+
+        for address in addresses {
+            XCTAssertEqual(address.name, "Jane Doe")
+            XCTAssertEqual(address.streetAddress, "123 Second Avenue")
+            XCTAssertEqual(address.addressLevel2, "Chicago, IL")
+            XCTAssertEqual(address.country, "United States")
+        }
     }
 
     func testAddCreditCard() {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -119,17 +119,6 @@ class RustAutofillTests: XCTestCase {
 
     func addAddress() async throws -> Address {
         return try await withCheckedThrowingContinuation { continuation in
-            let address = UpdatableAddressFields(
-                name: "Jane Doe",
-                organization: "",
-                streetAddress: "123 Second Avenue",
-                addressLevel3: "",
-                addressLevel2: "Chicago, IL",
-                addressLevel1: "",
-                postalCode: "",
-                country: "United States",
-                tel: "",
-                email: "")
             autofill.addAddress(address: mockAddress) { result in
                 switch result {
                 case .success(let addedAddress):

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -198,6 +198,13 @@ class RustAutofillTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testAddCreditCard() async throws {
+        let creditCard = try await addCreditCard()
+        let retrievedCreditCard = try await getCreditCard(id: creditCard.guid)
+
+        XCTAssertEqual(creditCard.guid, retrievedCreditCard.guid)
+    }
+
     func testListCreditCards() {
         let expectationCardList = expectation(description: "getting empty card list")
         let expectationAddCard = expectation(description: "add card")

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -208,9 +208,9 @@ class RustAutofillTests: XCTestCase {
                             XCTAssertNil(err)
                             expectationUpdateCard.fulfill()
 
-                            self.makeAssertionsToCheckUpdatedCard(id: creditCard.guid,
-                                                                  updatedCreditCard: updatedCreditCard,
-                                                                  expectationCheckUpdateCard: expectationCheckUpdateCard)
+                            self.getCreditCardAndMakeAssertionsToCheckUpdatedCard(id: creditCard.guid,
+                                                                                  updatedCreditCard: updatedCreditCard,
+                                                                                  expectationCheckUpdateCard: expectationCheckUpdateCard)
                         }
                     } catch {
                         XCTFail("The card variable should not be nil.")
@@ -235,9 +235,9 @@ class RustAutofillTests: XCTestCase {
                                            ccType: creditCard.ccType)
     }
 
-    private func makeAssertionsToCheckUpdatedCard(id: String,
-                                                  updatedCreditCard: UnencryptedCreditCardFields,
-                                                  expectationCheckUpdateCard: XCTestExpectation) {
+    private func getCreditCardAndMakeAssertionsToCheckUpdatedCard(id: String,
+                                                                  updatedCreditCard: UnencryptedCreditCardFields,
+                                                                  expectationCheckUpdateCard: XCTestExpectation) {
         self.autofill.getCreditCard(id: id) { updatedCardVal, err in
             do {
                 let updatedCardVal = try XCTUnwrap(updatedCardVal)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -35,17 +35,6 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
-    func addCreditCard(completion: @escaping (CreditCard?, Error?) -> Void) {
-        let creditCard = UnencryptedCreditCardFields(
-            ccName: "Jane Doe",
-            ccNumber: "1234567890123456",
-            ccNumberLast4: "3456",
-            ccExpMonth: 03,
-            ccExpYear: 2027,
-            ccType: "Visa")
-        return autofill.addCreditCard(creditCard: creditCard, completion: completion)
-    }
-
     func addCreditCard() async throws -> CreditCard {
         let creditCard = UnencryptedCreditCardFields(
             ccName: "Jane Doe",

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -46,6 +46,26 @@ class RustAutofillTests: XCTestCase {
         return autofill.addCreditCard(creditCard: creditCard, completion: completion)
     }
 
+    func addCreditCard() async throws -> CreditCard {
+        let creditCard = UnencryptedCreditCardFields(
+            ccName: "Jane Doe",
+            ccNumber: "1234567890123456",
+            ccNumberLast4: "3456",
+            ccExpMonth: 03,
+            ccExpYear: 2027,
+            ccType: "Visa")
+
+        return try await withCheckedThrowingContinuation { continuation in
+            autofill.addCreditCard(creditCard: creditCard) { card, error in
+                guard let card else {
+                    continuation.resume(throwing: error ?? NSError(domain: "Couldn't add credit card", code: 0))
+                    return
+                }
+                continuation.resume(returning: card)
+            }
+        }
+    }
+
     func addAddress(completion: @escaping (Result<Address, Error>) -> Void) {
         let address = UpdatableAddressFields(
             name: "Jane Doe",

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -269,7 +269,12 @@ class RustAutofillTests: XCTestCase {
     func testUpdateCreditCard() async throws {
         let creditCard = try await addCreditCard()
         let card = try await getCreditCard(id: creditCard.guid)
-        let updatedCreditCard = createUnencryptedCreditCardFields(creditCard: creditCard)
+        let updatedCreditCard = UnencryptedCreditCardFields(ccName: creditCard.ccName,
+                                                            ccNumber: creditCard.ccNumberEnc,
+                                                            ccNumberLast4: creditCard.ccNumberLast4,
+                                                            ccExpMonth: creditCard.ccExpMonth,
+                                                            ccExpYear: Int64(2028),
+                                                            ccType: creditCard.ccType)
         let result = try await updateCreditCard(id: creditCard.guid, creditCard: updatedCreditCard)
         let updatedCardVal = try await getCreditCard(id: creditCard.guid)
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -103,6 +103,19 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
+    func deleteCreditCard(id: String) async throws -> Bool {
+        return try await withCheckedThrowingContinuation { continuation in
+            autofill.deleteCreditCard(id: id) { success, error in
+                guard let error else {
+                    continuation.resume(returning: success)
+                    return
+                }
+
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
     func addAddress(completion: @escaping (Result<Address, Error>) -> Void) {
         let address = UpdatableAddressFields(
             name: "Jane Doe",

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -209,22 +209,22 @@ class RustAutofillTests: XCTestCase {
     func testUpdateCreditCard() async throws {
         let creditCard = try await addCreditCard()
         let card = try await getCreditCard(id: creditCard.guid)
-        let updatedCreditCard = UnencryptedCreditCardFields(ccName: creditCard.ccName,
-                                                            ccNumber: creditCard.ccNumberEnc,
-                                                            ccNumberLast4: creditCard.ccNumberLast4,
-                                                            ccExpMonth: creditCard.ccExpMonth,
-                                                            ccExpYear: Int64(2028),
-                                                            ccType: creditCard.ccType)
-        let result = try await updateCreditCard(id: creditCard.guid, creditCard: updatedCreditCard)
+        let creditCardVal = UnencryptedCreditCardFields(ccName: creditCard.ccName,
+                                                        ccNumber: creditCard.ccNumberEnc,
+                                                        ccNumberLast4: creditCard.ccNumberLast4,
+                                                        ccExpMonth: creditCard.ccExpMonth,
+                                                        ccExpYear: Int64(2028),
+                                                        ccType: creditCard.ccType)
+        let result = try await updateCreditCard(id: creditCard.guid, creditCard: creditCardVal)
         let updatedCardVal = try await getCreditCard(id: creditCard.guid)
 
         XCTAssertEqual(creditCard.guid, card.guid)
         XCTAssertTrue(result)
-        XCTAssertEqual(updatedCardVal.ccName, updatedCreditCard.ccName)
-        XCTAssertEqual(updatedCardVal.ccNumberLast4, updatedCreditCard.ccNumberLast4)
-        XCTAssertEqual(updatedCardVal.ccExpMonth, updatedCreditCard.ccExpMonth)
-        XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
-        XCTAssertEqual(updatedCardVal.ccType, updatedCreditCard.ccType)
+        XCTAssertEqual(updatedCardVal.ccName, creditCardVal.ccName)
+        XCTAssertEqual(updatedCardVal.ccNumberLast4, creditCardVal.ccNumberLast4)
+        XCTAssertEqual(updatedCardVal.ccExpMonth, creditCardVal.ccExpMonth)
+        XCTAssertEqual(updatedCardVal.ccExpYear, creditCardVal.ccExpYear)
+        XCTAssertEqual(updatedCardVal.ccType, creditCardVal.ccType)
     }
 
     func testDeleteCreditCard() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -242,44 +242,6 @@ class RustAutofillTests: XCTestCase {
         XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
     }
 
-    func testDeleteCreditCard() {
-        let expectationAddCard = expectation(description: "completed add card")
-        let expectationGetCard = expectation(description: "completed getting card")
-        let expectationDeleteCard = expectation(description: "delete card")
-        let expectationCheckDeleteCard = expectation(description: "check that no card exist")
-
-        addCreditCard { creditCard, err in
-            XCTAssertNotNil(creditCard)
-            XCTAssertNil(err)
-            expectationAddCard.fulfill()
-
-            self.autofill.getCreditCard(id: creditCard!.guid) { card, error in
-                XCTAssertNotNil(card)
-                XCTAssertNil(err)
-                XCTAssertEqual(creditCard!.guid, card!.guid)
-                expectationGetCard.fulfill()
-
-                self.autofill.deleteCreditCard(id: card!.guid) { success, err in
-                    XCTAssert(success)
-                    XCTAssertNil(err)
-                    expectationDeleteCard.fulfill()
-
-                    self.autofill.getCreditCard(id: creditCard!.guid) { deletedCreditCard, error in
-                        XCTAssertNil(deletedCreditCard)
-                        XCTAssertNotNil(error)
-
-                        let expectedError =
-                        "NoSuchRecord(guid: \"\(creditCard!.guid)\")"
-                        XCTAssertEqual(expectedError, "\(error!)")
-                        expectationCheckDeleteCard.fulfill()
-                    }
-                }
-            }
-        }
-
-        waitForExpectations(timeout: 3, handler: nil)
-    }
-
     func testDeleteCreditCard() async throws {
         let creditCard = try await addCreditCard()
         let retrievedCreditCard = try await getCreditCard(id: creditCard.guid)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -160,10 +160,10 @@ class RustAutofillTests: XCTestCase {
         let address = try await addAddress()
         let retrievedAddress = try await getAddress(id: address.guid)
 
-        XCTAssertEqual(address.name, "Jane Doe")
-        XCTAssertEqual(address.streetAddress, "123 Second Avenue")
-        XCTAssertEqual(address.addressLevel2, "Chicago, IL")
-        XCTAssertEqual(address.country, "United States")
+        XCTAssertEqual(address.name, retrievedAddress.name)
+        XCTAssertEqual(address.streetAddress, retrievedAddress.streetAddress)
+        XCTAssertEqual(address.addressLevel2, retrievedAddress.addressLevel2)
+        XCTAssertEqual(address.country, retrievedAddress.country)
         XCTAssertEqual(address.guid, retrievedAddress.guid)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -222,50 +222,6 @@ class RustAutofillTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
-    func testUpdateCreditCard() {
-        let expectationAddCard = expectation(description: "completed add card")
-        let expectationGetCard = expectation(description: "completed getting card")
-        let expectationUpdateCard = expectation(description: "update card")
-        let expectationCheckUpdateCard = expectation(description: "checking updated card")
-
-        addCreditCard { creditCard, err in
-            do {
-                let creditCard = try XCTUnwrap(creditCard)
-
-                XCTAssertNil(err)
-                expectationAddCard.fulfill()
-
-                self.autofill.getCreditCard(id: creditCard.guid) { card, err in
-                    do {
-                        let card = try XCTUnwrap(card)
-
-                        XCTAssertNil(err)
-                        XCTAssertEqual(creditCard.guid, card.guid)
-                        expectationGetCard.fulfill()
-
-                        let updatedCreditCard = self.createUnencryptedCreditCardFields(creditCard: creditCard)
-                        self.autofill.updateCreditCard(id: creditCard.guid,
-                                                       creditCard: updatedCreditCard) { success, err in
-                            self.makeAssertionsForUpdateCard(success: success, err: err, expectation: expectationUpdateCard)
-
-                            self.getCreditCardAndMakeAssertionsForCheckUpdateCard(id: creditCard.guid,
-                                                                                  updatedCreditCard: updatedCreditCard,
-                                                                                  expectation: expectationCheckUpdateCard)
-                        }
-                    } catch {
-                        XCTFail("The card variable should not be nil.")
-                        expectationGetCard.fulfill()
-                    }
-                }
-            } catch {
-                XCTFail("The creditCard variable should not be nil.")
-                expectationAddCard.fulfill()
-            }
-        }
-
-        waitForExpectations(timeout: 3, handler: nil)
-    }
-
     func testUpdateCreditCard() async throws {
         let creditCard = try await addCreditCard()
         let card = try await getCreditCard(id: creditCard.guid)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -244,6 +244,23 @@ class RustAutofillTests: XCTestCase {
                                            ccType: creditCard.ccType)
     }
 
+    private func makeUpdateCreditCardAssertion(id: String,
+                                               updatedCreditCard: UnencryptedCreditCardFields,
+                                               expectationCheckUpdateCard: XCTestExpectation) {
+        self.autofill.getCreditCard(id: id) { updatedCardVal, err in
+            do {
+                let updatedCardVal = try XCTUnwrap(updatedCardVal)
+
+                XCTAssertNil(err)
+                XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
+                expectationCheckUpdateCard.fulfill()
+            } catch {
+                XCTFail("The updatedCardVal variable should not be nil.")
+                expectationCheckUpdateCard.fulfill()
+            }
+        }
+    }
+
     func testDeleteCreditCard() {
         let expectationAddCard = expectation(description: "completed add card")
         let expectationGetCard = expectation(description: "completed getting card")

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -106,6 +106,32 @@ class RustAutofillTests: XCTestCase {
         return autofill.addAddress(address: address, completion: completion)
     }
 
+    func addAddress() async throws -> Address {
+        return try await withCheckedThrowingContinuation { continuation in
+            let address = UpdatableAddressFields(
+                name: "Jane Doe",
+                organization: "",
+                streetAddress: "123 Second Avenue",
+                addressLevel3: "",
+                addressLevel2: "Chicago, IL",
+                addressLevel1: "",
+                postalCode: "",
+                country: "United States",
+                tel: "",
+                email: "")
+            autofill.addAddress(address: address) { result in
+                switch result {
+                case .success(let addressAdded):
+                    continuation.resume(returning: addressAdded)
+                    return
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                    return
+                }
+            }
+        }
+    }
+
     func testAddAndGetAddress() {
         let expectationAddAddress = expectation(description: "Completes the add address operation")
         let expectationGetAddress = expectation(description: "Completes the get address operation")

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -203,7 +203,6 @@ class RustAutofillTests: XCTestCase {
         let updatedCards = try await listCreditCards()
 
         XCTAssertEqual(cards.count, 0)
-        XCTAssertNotNil(addedCreditCard)
         XCTAssertEqual(updatedCards.count, 1)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -144,6 +144,18 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
+    func getListAllAddresses() async throws -> [Address] {
+        return try await withCheckedThrowingContinuation { continuation in
+            autofill.listAllAddresses { addresses, error in
+                guard let addresses else {
+                    continuation.resume(throwing: error ?? NSError(domain: "Couldn't get addresses", code: 0))
+                    return
+                }
+                continuation.resume(returning: addresses)
+            }
+        }
+    }
+
     func testAddAndGetAddress() async throws {
         let address = try await addAddress()
         let retrievedAddress = try await getAddress(id: address.guid)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -177,7 +177,14 @@ class RustAutofillTests: XCTestCase {
     }
 
     func testAddAndGetAddress() async throws {
-        
+        let address = try await addAddress()
+        let retrievedAddress = try await getAddress(id: address.guid)
+
+        XCTAssertEqual(address.name, "Jane Doe")
+        XCTAssertEqual(address.streetAddress, "123 Second Avenue")
+        XCTAssertEqual(address.addressLevel2, "Chicago, IL")
+        XCTAssertEqual(address.country, "United States")
+        XCTAssertEqual(address.guid, retrievedAddress.guid)
     }
 
     func testListAllAddressesSuccess() {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -138,6 +138,10 @@ class RustAutofillTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testAddAndGetAddress() async throws {
+        
+    }
+
     func testListAllAddressesSuccess() {
         let expectationListAddresses = expectation(description: "Completes the list all addresses operation")
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -203,7 +203,7 @@ class RustAutofillTests: XCTestCase {
                                                        creditCard: updatedCreditCard) { success, err in
                             self.makeAssertionsForUpdateCard(success: success, err: err, expectation: expectationUpdateCard)
 
-                            self.getCreditCardAndMakeAssertionsToCheckUpdatedCard(id: creditCard.guid,
+                            self.getCreditCardAndMakeAssertionsForCheckUpdateCard(id: creditCard.guid,
                                                                                   updatedCreditCard: updatedCreditCard,
                                                                                   expectation: expectationCheckUpdateCard)
                         }
@@ -239,7 +239,7 @@ class RustAutofillTests: XCTestCase {
         expectation.fulfill()
     }
 
-    private func getCreditCardAndMakeAssertionsToCheckUpdatedCard(id: String,
+    private func getCreditCardAndMakeAssertionsForCheckUpdateCard(id: String,
                                                                   updatedCreditCard: UnencryptedCreditCardFields,
                                                                   expectation: XCTestExpectation) {
         self.autofill.getCreditCard(id: id) { updatedCardVal, err in

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -213,7 +213,12 @@ class RustAutofillTests: XCTestCase {
 
         XCTAssertEqual(creditCard.guid, card.guid)
         XCTAssertTrue(result)
+        XCTAssertEqual(updatedCardVal.ccName, updatedCreditCard.ccName)
+        XCTAssertEqual(updatedCardVal.ccNumberEnc, updatedCreditCard.ccNumber)
+        XCTAssertEqual(updatedCardVal.ccNumberLast4, updatedCreditCard.ccNumberLast4)
+        XCTAssertEqual(updatedCardVal.ccExpMonth, updatedCreditCard.ccExpMonth)
         XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
+        XCTAssertEqual(updatedCardVal.ccType, updatedCreditCard.ccType)
     }
 
     func testDeleteCreditCard() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -144,7 +144,7 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
-    func getListAllAddresses() async throws -> [Address] {
+    func listAllAddresses() async throws -> [Address] {
         return try await withCheckedThrowingContinuation { continuation in
             autofill.listAllAddresses { addresses, error in
                 guard let addresses else {
@@ -189,7 +189,7 @@ class RustAutofillTests: XCTestCase {
     }
 
     func testListAllAddressesSuccess() async throws {
-        let addresses = try await getListAllAddresses()
+        let addresses = try await listAllAddresses()
 
         for address in addresses {
             XCTAssertEqual(address.name, "Jane Doe")

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -236,12 +236,12 @@ class RustAutofillTests: XCTestCase {
     }
 
     private func makeAssertionsToCheckUpdatedCard(id: String,
-                                               updatedCreditCard: UnencryptedCreditCardFields,
-                                               expectationCheckUpdateCard: XCTestExpectation) {
+                                                  updatedCreditCard: UnencryptedCreditCardFields,
+                                                  expectationCheckUpdateCard: XCTestExpectation) {
         self.autofill.getCreditCard(id: id) { updatedCardVal, err in
             do {
                 let updatedCardVal = try XCTUnwrap(updatedCardVal)
-
+                
                 XCTAssertNil(err)
                 XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
                 expectationCheckUpdateCard.fulfill()

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -196,7 +196,7 @@ class RustAutofillTests: XCTestCase {
 
         XCTAssertEqual(creditCard.guid, retrievedCreditCard.guid)
     }
-    
+
     func testListCreditCards() async throws {
         let cards = try await listCreditCards()
         _ = try await addCreditCard()

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -78,6 +78,19 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
+    func updateCreditCard(id: String,
+                          creditCard: UnencryptedCreditCardFields) async throws -> Bool {
+        return try await withCheckedThrowingContinuation { continuation in
+            autofill.updateCreditCard(id: id, creditCard: creditCard) { success, error in
+                guard let success else {
+                    continuation.resume(throwing: error ?? NSError(domain: "Couldn't update credit card", code: 0))
+                    return
+                }
+                continuation.resume(returning: success)
+            }
+        }
+    }
+
     func addAddress(completion: @escaping (Result<Address, Error>) -> Void) {
         let address = UpdatableAddressFields(
             name: "Jane Doe",

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -199,7 +199,7 @@ class RustAutofillTests: XCTestCase {
     
     func testListCreditCards() async throws {
         let cards = try await listCreditCards()
-        let addedCreditCard = try await addCreditCard()
+        _ = try await addCreditCard()
         let updatedCards = try await listCreditCards()
 
         XCTAssertEqual(cards.count, 0)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -279,7 +279,7 @@ class RustAutofillTests: XCTestCase {
         let updatedCardVal = try await getCreditCard(id: creditCard.guid)
 
         XCTAssertEqual(creditCard.guid, card.guid)
-        XCTAssert(result)
+        XCTAssertTrue(result)
         XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -56,14 +56,6 @@ class RustAutofillTests: XCTestCase {
     }
 
     func addCreditCard() async throws -> CreditCard {
-        let creditCard = UnencryptedCreditCardFields(
-            ccName: "Jane Doe",
-            ccNumber: "1234567890123456",
-            ccNumberLast4: "3456",
-            ccExpMonth: 03,
-            ccExpYear: 2027,
-            ccType: "Visa")
-
         return try await withCheckedThrowingContinuation { continuation in
             autofill.addCreditCard(creditCard: mockCreditCard) { card, error in
                 guard let card else {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -167,27 +167,6 @@ class RustAutofillTests: XCTestCase {
         XCTAssertEqual(address.guid, retrievedAddress.guid)
     }
 
-    func testListAllAddressesSuccess() {
-        let expectationListAddresses = expectation(description: "Completes the list all addresses operation")
-
-        autofill.listAllAddresses { addresses, error in
-            XCTAssertNil(error, "Error should be nil")
-            XCTAssertNotNil(addresses, "Addresses should not be nil")
-
-            // Assert on individual addresses in the list
-            for address in addresses ?? [] {
-                XCTAssertEqual(address.name, "Jane Doe")
-                XCTAssertEqual(address.streetAddress, "123 Second Avenue")
-                XCTAssertEqual(address.addressLevel2, "Chicago, IL")
-                XCTAssertEqual(address.country, "United States")
-            }
-
-            expectationListAddresses.fulfill()
-        }
-
-        waitForExpectations(timeout: 3, handler: nil)
-    }
-
     func testListAllAddressesSuccess() async throws {
         let addresses = try await listAllAddresses()
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -239,23 +239,6 @@ class RustAutofillTests: XCTestCase {
         XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
     }
 
-    private func getCreditCardAndMakeAssertionsForCheckUpdateCard(id: String,
-                                                                  updatedCreditCard: UnencryptedCreditCardFields,
-                                                                  expectation: XCTestExpectation) {
-        self.autofill.getCreditCard(id: id) { updatedCardVal, err in
-            do {
-                let updatedCardVal = try XCTUnwrap(updatedCardVal)
-
-                XCTAssertNil(err)
-                XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
-                expectation.fulfill()
-            } catch {
-                XCTFail("The updatedCardVal variable should not be nil.")
-                expectation.fulfill()
-            }
-        }
-    }
-
     func testDeleteCreditCard() {
         let expectationAddCard = expectation(description: "completed add card")
         let expectationGetCard = expectation(description: "completed getting card")

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -146,9 +146,9 @@ class RustAutofillTests: XCTestCase {
 
     func getAddress(id: String) async throws -> Address {
         return try await withCheckedThrowingContinuation { continuation in
-            autofill.getAddress(id: id) { address, getAddressError in
+            autofill.getAddress(id: id) { address, error in
                 guard let address else {
-                    continuation.resume(throwing: getAddressError ?? NSError(domain: "Couldn't get address", code: 0))
+                    continuation.resume(throwing: error ?? NSError(domain: "Couldn't get address", code: 0))
                     return
                 }
                 continuation.resume(returning: address)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -66,6 +66,18 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
+    func getCreditCard(id: String) async throws -> CreditCard {
+        return try await withCheckedThrowingContinuation { continuation in
+            autofill.getCreditCard(id: id) { card, error in
+                guard let card else {
+                    continuation.resume(throwing: error ?? NSError(domain: "Couldn't get credit card", code: 0))
+                    return
+                }
+                continuation.resume(returning: card)
+            }
+        }
+    }
+
     func addAddress(completion: @escaping (Result<Address, Error>) -> Void) {
         let address = UpdatableAddressFields(
             name: "Jane Doe",

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -25,6 +25,14 @@ class RustAutofillTests: XCTestCase {
         tel: "",
         email: "")
 
+    let mockCreditCard = UnencryptedCreditCardFields(
+        ccName: "Jane Doe",
+        ccNumber: "1234567890123456",
+        ccNumberLast4: "3456",
+        ccExpMonth: 03,
+        ccExpYear: 2027,
+        ccType: "Visa")
+
     override func setUp() {
         super.setUp()
         files = MockFiles()

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -201,12 +201,7 @@ class RustAutofillTests: XCTestCase {
                         let updatedCreditCard = self.createUnencryptedCreditCardFields(creditCard: creditCard)
                         self.autofill.updateCreditCard(id: creditCard.guid,
                                                        creditCard: updatedCreditCard) { success, err in
-                            XCTAssertNotNil(success)
-                            if let updated = success {
-                                XCTAssert(updated)
-                            }
-                            XCTAssertNil(err)
-                            expectationUpdateCard.fulfill()
+                            self.makeAssertionsForUpdateCard(success: success, err: err, expectation: expectationUpdateCard)
 
                             self.getCreditCardAndMakeAssertionsToCheckUpdatedCard(id: creditCard.guid,
                                                                                   updatedCreditCard: updatedCreditCard,

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -188,6 +188,10 @@ class RustAutofillTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testListAllAddressesSuccess() async throws {
+        
+    }
+
     func testAddCreditCard() {
         let expectationAddCard = expectation(description: "completed add card")
         let expectationGetCard = expectation(description: "completed getting card")

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -183,6 +183,12 @@ class RustAutofillTests: XCTestCase {
         let retrievedCreditCard = try await getCreditCard(id: creditCard.guid)
 
         XCTAssertEqual(creditCard.guid, retrievedCreditCard.guid)
+        XCTAssertEqual(creditCard.ccName, retrievedCreditCard.ccName)
+        XCTAssertEqual(creditCard.ccNumberEnc, retrievedCreditCard.ccNumberEnc)
+        XCTAssertEqual(creditCard.ccNumberLast4, retrievedCreditCard.ccNumberLast4)
+        XCTAssertEqual(creditCard.ccExpMonth, retrievedCreditCard.ccExpMonth)
+        XCTAssertEqual(creditCard.ccExpYear, retrievedCreditCard.ccExpYear)
+        XCTAssertEqual(creditCard.ccType, retrievedCreditCard.ccType)
     }
 
     func testListCreditCards() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -239,15 +239,6 @@ class RustAutofillTests: XCTestCase {
         XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
     }
 
-    private func createUnencryptedCreditCardFields(creditCard: CreditCard) -> UnencryptedCreditCardFields {
-        return UnencryptedCreditCardFields(ccName: creditCard.ccName,
-                                           ccNumber: creditCard.ccNumberEnc,
-                                           ccNumberLast4: creditCard.ccNumberLast4,
-                                           ccExpMonth: creditCard.ccExpMonth,
-                                           ccExpYear: Int64(2028),
-                                           ccType: creditCard.ccType)
-    }
-
     private func getCreditCardAndMakeAssertionsForCheckUpdateCard(id: String,
                                                                   updatedCreditCard: UnencryptedCreditCardFields,
                                                                   expectation: XCTestExpectation) {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -217,6 +217,7 @@ class RustAutofillTests: XCTestCase {
                                     expectationCheckUpdateCard.fulfill()
                                 } catch {
                                     XCTFail("The updatedCardVal variable should not be nil.")
+                                    expectationCheckUpdateCard.fulfill()
                                 }
                             }
                         }

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -146,12 +146,12 @@ class RustAutofillTests: XCTestCase {
 
     func getAddress(id: String) async throws -> Address {
         return try await withCheckedThrowingContinuation { continuation in
-            autofill.getAddress(id: id) { retrievedAddress, getAddressError in
-                guard let retrievedAddress else {
+            autofill.getAddress(id: id) { address, getAddressError in
+                guard let address else {
                     continuation.resume(throwing: getAddressError ?? NSError(domain: "Couldn't get address", code: 0))
                     return
                 }
-                continuation.resume(returning: retrievedAddress)
+                continuation.resume(returning: address)
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -210,7 +210,7 @@ class RustAutofillTests: XCTestCase {
 
                             self.getCreditCardAndMakeAssertionsToCheckUpdatedCard(id: creditCard.guid,
                                                                                   updatedCreditCard: updatedCreditCard,
-                                                                                  expectationCheckUpdateCard: expectationCheckUpdateCard)
+                                                                                  expectation: expectationCheckUpdateCard)
                         }
                     } catch {
                         XCTFail("The card variable should not be nil.")
@@ -237,17 +237,17 @@ class RustAutofillTests: XCTestCase {
 
     private func getCreditCardAndMakeAssertionsToCheckUpdatedCard(id: String,
                                                                   updatedCreditCard: UnencryptedCreditCardFields,
-                                                                  expectationCheckUpdateCard: XCTestExpectation) {
+                                                                  expectation: XCTestExpectation) {
         self.autofill.getCreditCard(id: id) { updatedCardVal, err in
             do {
                 let updatedCardVal = try XCTUnwrap(updatedCardVal)
 
                 XCTAssertNil(err)
                 XCTAssertEqual(updatedCardVal.ccExpYear, updatedCreditCard.ccExpYear)
-                expectationCheckUpdateCard.fulfill()
+                expectation.fulfill()
             } catch {
                 XCTFail("The updatedCardVal variable should not be nil.")
-                expectationCheckUpdateCard.fulfill()
+                expectation.fulfill()
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -105,21 +105,6 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
-    func addAddress(completion: @escaping (Result<Address, Error>) -> Void) {
-        let address = UpdatableAddressFields(
-            name: "Jane Doe",
-            organization: "",
-            streetAddress: "123 Second Avenue",
-            addressLevel3: "",
-            addressLevel2: "Chicago, IL",
-            addressLevel1: "",
-            postalCode: "",
-            country: "United States",
-            tel: "",
-            email: "")
-        return autofill.addAddress(address: address, completion: completion)
-    }
-
     func addAddress() async throws -> Address {
         return try await withCheckedThrowingContinuation { continuation in
             let address = UpdatableAddressFields(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `RustAutofillTests.swift` file by extracting the creation of the `UnencryptedCreditCardFields` object to a new function. 

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

