### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from RustSyncManager.swift

### DIFF
--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -537,11 +537,9 @@ public class RustSyncManager: NSObject, SyncManager {
                             engines: SyncEngineSelection.some(engines: rustEngines),
                             enabledChanges: self.getEngineEnablementChangesForAccount(),
                             localEncryptionKeys: localEncryptionKeys,
-                            authInfo: SyncAuthInfo(
-                                kid: key.kid,
-                                fxaAccessToken: accessTokenInfo.token,
-                                syncKey: key.k,
-                                tokenserverUrl: tokenServerEndpointURL.absoluteString),
+                            authInfo: self.createSyncAuthInfo(key: key,
+                                                              accessTokenInfo: accessTokenInfo,
+                                                              tokenServerEndpointURL: tokenServerEndpointURL),
                             persistedState:
                                 self.prefs
                                     .stringForKey(PrefsKeys.RustSyncManagerPersistedState),

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -18,6 +18,8 @@ import struct MozillaAppServices.DeviceSettings
 import struct MozillaAppServices.SyncAuthInfo
 import struct MozillaAppServices.SyncParams
 import struct MozillaAppServices.SyncResult
+import struct MozillaAppServices.ScopedKey
+import struct MozillaAppServices.AccessTokenInfo
 
 // Extends NSObject so we can use timers.
 public class RustSyncManager: NSObject, SyncManager {
@@ -553,6 +555,14 @@ public class RustSyncManager: NSObject, SyncManager {
             }
         }
         return deferred
+    }
+
+    private func createSyncAuthInfo(key: ScopedKey, accessTokenInfo: AccessTokenInfo, tokenServerEndpointURL: URL) -> SyncAuthInfo {
+        return SyncAuthInfo(
+            kid: key.kid,
+            fxaAccessToken: accessTokenInfo.token,
+            syncKey: key.k,
+            tokenserverUrl: tokenServerEndpointURL.absoluteString)
     }
 
     private func createDeviceSettings(device: Device) -> DeviceSettings {

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -13,11 +13,11 @@ import class MozillaAppServices.MZKeychainWrapper
 import enum MozillaAppServices.OAuthScope
 import enum MozillaAppServices.SyncEngineSelection
 import enum MozillaAppServices.SyncReason
-import struct MozillaAppServices.Device
 import struct MozillaAppServices.DeviceSettings
 import struct MozillaAppServices.SyncAuthInfo
 import struct MozillaAppServices.SyncParams
 import struct MozillaAppServices.SyncResult
+import struct MozillaAppServices.Device
 import struct MozillaAppServices.ScopedKey
 import struct MozillaAppServices.AccessTokenInfo
 

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -543,10 +543,7 @@ public class RustSyncManager: NSObject, SyncManager {
                             persistedState:
                                 self.prefs
                                     .stringForKey(PrefsKeys.RustSyncManagerPersistedState),
-                            deviceSettings: DeviceSettings(
-                                fxaDeviceId: device.id,
-                                name: device.displayName,
-                                kind: device.deviceType))
+                            deviceSettings: self.createDeviceSettings(device: device))
 
                         self.doSync(params: params) { syncResult in
                             deferred.fill(Maybe(success: syncResult))

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -13,6 +13,7 @@ import class MozillaAppServices.MZKeychainWrapper
 import enum MozillaAppServices.OAuthScope
 import enum MozillaAppServices.SyncEngineSelection
 import enum MozillaAppServices.SyncReason
+import struct MozillaAppServices.Device
 import struct MozillaAppServices.DeviceSettings
 import struct MozillaAppServices.SyncAuthInfo
 import struct MozillaAppServices.SyncParams
@@ -555,6 +556,13 @@ public class RustSyncManager: NSObject, SyncManager {
             }
         }
         return deferred
+    }
+
+    private func createDeviceSettings(device: Device) -> DeviceSettings {
+        return DeviceSettings(
+            fxaDeviceId: device.id,
+            name: device.displayName,
+            kind: device.deviceType)
     }
 
     @discardableResult

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -557,7 +557,9 @@ public class RustSyncManager: NSObject, SyncManager {
         return deferred
     }
 
-    private func createSyncAuthInfo(key: ScopedKey, accessTokenInfo: AccessTokenInfo, tokenServerEndpointURL: URL) -> SyncAuthInfo {
+    private func createSyncAuthInfo(key: ScopedKey,
+                                    accessTokenInfo: AccessTokenInfo,
+                                    tokenServerEndpointURL: URL) -> SyncAuthInfo {
         return SyncAuthInfo(
             kid: key.kid,
             fxaAccessToken: accessTokenInfo.token,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `RustSyncManager.swift` file by extracting the creation of `DeviceSettings` and `SyncAuthInfo` objects to new functions. 

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

