### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from XCUITests (1/3)

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -390,7 +390,7 @@ class HomePageSettingsUITests: BaseTestCase {
 //            "1"
 //        )
         XCTAssertEqual(
-            app.cells.switches["Thought-Provoking Stories, Articles powered by Pocket"].value as! String,
+            app.cells.switches["Thought-Provoking Stories, Articles powered by Pocket"].value as? String,
             "1"
         )
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
@@ -66,10 +66,10 @@ final class InactiveTabsTest: BaseTestCase {
         app.cells[AccessibilityIdentifiers.Settings.Tabs.title].tap()
         mozWaitForElementToExist(app.tables.otherElements[AccessibilityIdentifiers.Settings.Tabs.Customize.title])
         XCTAssertEqual(
-            app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].value as! String, "1")
+            app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].value as? String, "1")
         app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].tap()
         XCTAssertEqual(
-            app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].value as! String, "0")
+            app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].value as? String, "0")
         app.navigationBars.buttons["Settings"].tap() // Note: No AccessibilityIdentifiers
         navigator.nowAt(SettingsScreen)
 
@@ -97,7 +97,7 @@ final class InactiveTabsTest: BaseTestCase {
         mozWaitForElementToExist(app.tables.otherElements[AccessibilityIdentifiers.Settings.Tabs.Customize.title])
         app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].tap()
         XCTAssertEqual(
-            app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].value as! String, "1")
+            app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].value as? String, "1")
         app.navigationBars.buttons["Settings"].tap()
         navigator.nowAt(SettingsScreen)
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -145,7 +145,7 @@ class IntegrationTests: BaseTestCase {
         app.tables.cells.element(boundBy: 1).waitAndTap()
         mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"])
         XCTAssertEqual(
-            app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as! String,
+            app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"].value! as? String,
             "Fennec (administrator) on iOS"
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
@@ -51,7 +51,7 @@ class MultiWindowTests: IpadOnlyTestCase {
         app.tables.otherElements[newTab].tap()
         app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
         let tabButtonSecondWindow = app.buttons.matching(identifier: tabsButtonIdentifier).element(boundBy: 0)
-        XCTAssertEqual(tabButtonSecondWindow.value as! String, "2", "Number of tabs opened should be equal to 2")
+        XCTAssertEqual(tabButtonSecondWindow.value as? String, "2", "Number of tabs opened should be equal to 2")
         // A new tab is opened in the same window
         app.collectionViews.cells.matching(identifier: topSites).element(boundBy: 6).waitAndTap()
         mozWaitForElementToExist(app.buttons[homeButtom])
@@ -59,7 +59,7 @@ class MultiWindowTests: IpadOnlyTestCase {
         app.tables.otherElements[newTab].tap()
         app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
         let tabButtonFirstWindow = app.buttons.matching(identifier: tabsButtonIdentifier).element(boundBy: 1)
-        XCTAssertEqual(tabButtonFirstWindow.value as! String, "2", "Number of tabs opened should be equal to 2")
+        XCTAssertEqual(tabButtonFirstWindow.value as? String, "2", "Number of tabs opened should be equal to 2")
     }
 
     func testOpenWindowFromTabSwitcher() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
@@ -42,6 +42,6 @@ class PocketTests: BaseTestCase {
         waitUntilPageLoad()
         // The url textField is not empty
         let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
-        XCTAssertNotEqual(url.value as! String, "", "The url textField is empty")
+        XCTAssertNotEqual(url.value as? String, "", "The url textField is empty")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
@@ -45,7 +45,7 @@ class UrlBarTests: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         // The URL bar is empty on the new tab
         let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
-        XCTAssertEqual(url.value as! String, "Search or enter address")
+        XCTAssertEqual(url.value as? String, "Search or enter address")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306887


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
    - UrlBarTests 
    - IntegrationTests
    - HomePageSettingsUITest
    - InactiveTabsTest
    - PocketTests
    - MultiWindowTests
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

