### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from XCUITests (2/3)

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
@@ -36,7 +36,10 @@ class ClipBoardTests: BaseTestCase {
                     allowBtn.tap()
                 }
 
-                var value = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
+                guard var value = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as? String else {
+                    XCTFail("Failed to retrieve the value from the URL bar text field")
+                    return
+                }
                 if value.hasPrefix("http") == false {
                     value = "http://\(value)"
                 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -155,10 +155,10 @@ class CreditCardsTests: BaseTestCase {
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
         let saveAndFillPaymentMethodsSwitch =
             app.switches[creditCardsStaticTexts.AutoFillCreditCard.saveAutofillCards].switches.firstMatch
-        if saveAndFillPaymentMethodsSwitch.value! as! String == "1" {
+        if saveAndFillPaymentMethodsSwitch.value! as? String == "1" {
             saveAndFillPaymentMethodsSwitch.tap()
         }
-        XCTAssertEqual(saveAndFillPaymentMethodsSwitch.value! as! String, "0")
+        XCTAssertEqual(saveAndFillPaymentMethodsSwitch.value! as? String, "0")
         app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].tap()
         let dateFiveYearsFromNow = Calendar.current.date(byAdding: .year, value: 5, to: Date())
         let formatter = DateFormatter()
@@ -181,7 +181,7 @@ class CreditCardsTests: BaseTestCase {
             mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
             // Enable the "Save and Fill Payment Methods" toggle
             app.switches.element(boundBy: 1).tap()
-            XCTAssertEqual(saveAndFillPaymentMethodsSwitch.value! as! String, "1")
+            XCTAssertEqual(saveAndFillPaymentMethodsSwitch.value! as? String, "1")
             app.buttons["Settings"].tap()
             navigator.nowAt(SettingsScreen)
             waitForExistence(app.buttons["Done"])
@@ -207,11 +207,11 @@ class CreditCardsTests: BaseTestCase {
         // The credit card's number and name are imported correctly on the designated fields
         let contentView = app.webViews["Web content"].textFields
         mozWaitForElementToExist(contentView["Card number"])
-        XCTAssertEqual(contentView["Card number"].value! as! String, "2720 9943 2658 1252")
-        XCTAssertEqual(contentView["Expiration"].value! as! String, "05 / 40")
-        XCTAssertEqual(contentView["Full name on card"].value! as! String, "Test")
-        XCTAssertEqual(contentView["CVC"].value! as! String, "CVC")
-        XCTAssertEqual(contentView["ZIP"].value! as! String, "ZIP")
+        XCTAssertEqual(contentView["Card number"].value! as? String, "2720 9943 2658 1252")
+        XCTAssertEqual(contentView["Expiration"].value! as? String, "05 / 40")
+        XCTAssertEqual(contentView["Full name on card"].value! as? String, "Test")
+        XCTAssertEqual(contentView["CVC"].value! as? String, "CVC")
+        XCTAssertEqual(contentView["ZIP"].value! as? String, "ZIP")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306976
@@ -666,11 +666,11 @@ class CreditCardsTests: BaseTestCase {
 
     private func validateAutofillCardInfo(cardNr: String, expirationNr: String, name: String) {
         let contentView = app.webViews["Web content"].textFields
-        XCTAssertEqual(contentView["Card number"].value! as! String, cardNr)
-        XCTAssertEqual(contentView["Expiration"].value! as! String, expirationNr)
-        XCTAssertEqual(contentView["Full name on card"].value! as! String, name)
-        XCTAssertEqual(contentView["CVC"].value! as! String, "CVC")
-        XCTAssertEqual(contentView["ZIP"].value! as! String, "ZIP")
+        XCTAssertEqual(contentView["Card number"].value! as? String, cardNr)
+        XCTAssertEqual(contentView["Expiration"].value! as? String, expirationNr)
+        XCTAssertEqual(contentView["Full name on card"].value! as? String, name)
+        XCTAssertEqual(contentView["CVC"].value! as? String, "CVC")
+        XCTAssertEqual(contentView["ZIP"].value! as? String, "ZIP")
     }
 
     private func reachAutofillWebsite() {
@@ -698,7 +698,7 @@ class CreditCardsTests: BaseTestCase {
         unlockLoginsView()
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
         let saveAndFillPaymentMethodsSwitch = app.switches[creditCardsStaticTexts.AutoFillCreditCard.saveAutofillCards]
-        if saveAndFillPaymentMethodsSwitch.value! as! String == "0" {
+        if saveAndFillPaymentMethodsSwitch.value! as? String == "0" {
             saveAndFillPaymentMethodsSwitch.tap()
         }
         app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].tap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DisplaySettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DisplaySettingsTests.swift
@@ -16,7 +16,7 @@ class DisplaySettingTests: BaseTestCase {
             ]
         )
         let switchValue = app.switches["SystemThemeSwitchValue"].value!
-        XCTAssertEqual(switchValue as! String, "1")
+        XCTAssertEqual(switchValue as? String, "1")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2337487
@@ -37,7 +37,7 @@ class DisplaySettingTests: BaseTestCase {
         navigator.goto(DisplaySettings)
         mozWaitForElementToExist(app.switches["SystemThemeSwitchValue"])
         let switchValue = app.switches["SystemThemeSwitchValue"].value!
-        XCTAssertEqual(switchValue as! String, "0")
+        XCTAssertEqual(switchValue as? String, "0")
         waitForElementsToExist(
             [
                 app.cells.staticTexts["Light"],
@@ -64,7 +64,7 @@ class DisplaySettingTests: BaseTestCase {
         // Enable back system theme
         navigator.performAction(Action.SystemThemeSwitch)
         let switchValueAfter = app.switches["SystemThemeSwitchValue"].value!
-        XCTAssertEqual(switchValueAfter as! String, "1")
+        XCTAssertEqual(switchValueAfter as? String, "1")
         mozWaitForElementToNotExist(app.tables["DisplayTheme.Setting.Options"].otherElements.staticTexts["SWITCH MODE"])
         mozWaitForElementToNotExist(app.tables["DisplayTheme.Setting.Options"].otherElements.staticTexts["THEME PICKER"])
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -9,9 +9,9 @@ class SettingsTests: BaseTestCase {
         let noImageStatusMode = app.otherElements.tables.cells.switches["NoImageModeStatus"]
         mozWaitForElementToExist(noImageStatusMode)
         if showImages {
-            XCTAssertEqual(noImageStatusMode.value as! String, "0")
+            XCTAssertEqual(noImageStatusMode.value as? String, "0")
         } else {
-            XCTAssertEqual(noImageStatusMode.value as! String, "1")
+            XCTAssertEqual(noImageStatusMode.value as? String, "1")
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
@@ -27,7 +27,10 @@ class ThirdPartySearchTest: BaseTestCase {
         app.scrollViews.otherElements.buttons["Mozilla Engine search"].tap()
         waitUntilPageLoad()
 
-        var url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
+        guard var url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as? String else {
+            XCTFail("Failed to retrieve the URL value from the browser's URL bar")
+            return
+        }
         if url.hasPrefix("https://") == false {
             url = "https://\(url)"
         }
@@ -50,7 +53,10 @@ class ThirdPartySearchTest: BaseTestCase {
         waitUntilPageLoad()
 
         // Ensure that the default search is MDN
-        var url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
+        guard var url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as? String else {
+            XCTFail("Failed to retrieve the URL value from the browser's URL bar")
+            return
+        }
         if url.hasPrefix("https://") == false {
             url = "https://\(url)"
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -43,7 +43,10 @@ class ToolbarTests: BaseTestCase {
         navigator.openURL(website1["url"]!)
         waitUntilPageLoad()
         mozWaitForElementToExist(app.webViews.links["Mozilla"], timeout: 10)
-        let valueMozilla = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
+        guard let valueMozilla = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as? String else {
+            XCTFail("Failed to retrieve the value from the Mozilla URL bar text field")
+            return
+        }
         XCTAssertEqual(valueMozilla, urlValueLong)
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
@@ -81,7 +84,10 @@ class ToolbarTests: BaseTestCase {
         waitUntilPageLoad()
         waitForTabsButton()
         mozWaitForElementToExist(app.webViews.links["Mozilla"], timeout: 10)
-        let valueMozilla = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
+        guard let valueMozilla = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as? String else {
+            XCTFail("Failed to retrieve the value from the Mozilla URL bar text field")
+            return
+        }
         XCTAssertEqual(valueMozilla, urlValueLong)
 
         // Simulate pressing on backspace key should remove the text
@@ -172,7 +178,7 @@ class ToolbarTests: BaseTestCase {
             }
             app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
             mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
-            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value as! String, "2")
+            XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value as? String, "2")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
    - ClipBoardTests 
    - DisplaySettingsTests
    - ToolbarTest
    - SettingsTests
    - CreditCardsTests
    - ThirdPartySearchTest
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)