### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from XCUITests (3/3)

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -110,11 +110,15 @@ class DragAndDropTests: BaseTestCase {
             checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
             if !iPad() {
                 let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
-                XCTAssert(
-                    secondWebsite.url.contains(url.value! as! String), "The tab has not been dropped correctly"
-                ) } else {
-                    XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+
+                if let urlString = url.value as? String {
+                    XCTAssert(secondWebsite.url.contains(urlString), "The tab has not been dropped correctly")
+                } else {
+                    XCTFail("Failed to retrieve a valid URL from the UrlBar")
                 }
+            } else {
+                XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+            }
         }
     }
 
@@ -138,11 +142,15 @@ class DragAndDropTests: BaseTestCase {
             // Check that focus is kept on last website open
             if !iPad() {
                 let url = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url]
-                XCTAssert(
-                    secondWebsite.url.contains(url.value! as! String), "The tab has not been dropped correctly"
-                ) } else {
-                    XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+
+                if let urlString = url.value as? String {
+                    XCTAssert(secondWebsite.url.contains(urlString), "The tab has not been dropped correctly")
+                } else {
+                    XCTFail("Failed to retrieve a valid URL from the browser's URL bar")
                 }
+            } else {
+                XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
+            }
         }
     }
 
@@ -275,10 +283,12 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         )
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.browserTabName, secondTab: firstWebsite.tabName)
         // Check that focus is kept on last website open
-        XCTAssert(
-            secondWebsite.url.contains(app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value! as! String),
-            "The tab has not been dropped correctly"
-        )
+        // Check that focus is kept on last website open
+        if let urlString = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as? String {
+            XCTAssert(secondWebsite.url.contains(urlString), "The tab has not been dropped correctly")
+        } else {
+            XCTFail("Failed to retrieve a valid URL from the browser's URL bar")
+        }
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2361413

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -114,7 +114,7 @@ class DragAndDropTests: BaseTestCase {
                 if let urlString = url.value as? String {
                     XCTAssert(secondWebsite.url.contains(urlString), "The tab has not been dropped correctly")
                 } else {
-                    XCTFail("Failed to retrieve a valid URL from the UrlBar")
+                    XCTFail("Failed to retrieve a valid URL string from the browser's URL bar")
                 }
             } else {
                 XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
@@ -146,7 +146,7 @@ class DragAndDropTests: BaseTestCase {
                 if let urlString = url.value as? String {
                     XCTAssert(secondWebsite.url.contains(urlString), "The tab has not been dropped correctly")
                 } else {
-                    XCTFail("Failed to retrieve a valid URL from the browser's URL bar")
+                    XCTFail("Failed to retrieve a valid URL string from the browser's URL bar")
                 }
             } else {
                 XCTAssertEqual(app.otherElements["Tabs Tray"].cells.element(boundBy: 0).label, secondWebsite.tabName)
@@ -283,11 +283,10 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         )
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.browserTabName, secondTab: firstWebsite.tabName)
         // Check that focus is kept on last website open
-        // Check that focus is kept on last website open
         if let urlString = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as? String {
             XCTAssert(secondWebsite.url.contains(urlString), "The tab has not been dropped correctly")
         } else {
-            XCTFail("Failed to retrieve a valid URL from the browser's URL bar")
+            XCTFail("Failed to retrieve a valid URL string from the browser's URL bar")
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -27,7 +27,7 @@ class JumpBackInTests: BaseTestCase {
         // "Jump Back In" is enabled by default. See Settings -> Homepage
         navigator.goto(HomeSettings)
         mozWaitForElementToExist(app.switches["Jump Back In"])
-        XCTAssertEqual(app.switches["Jump Back In"].value as! String, "1")
+        XCTAssertEqual(app.switches["Jump Back In"].value as? String, "1")
 
         navigator.goto(NewTabScreen)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
@@ -74,7 +74,10 @@ class NewTabSettingsTest: BaseTestCase {
         navigator.performAction(Action.SelectNewTabAsCustomURL)
         // Check the value typed
         app.textFields["NewTabAsCustomURLTextField"].typeText("mozilla.org")
-        let valueTyped = app.textFields["NewTabAsCustomURLTextField"].value as! String
+        guard let valueTyped = app.textFields["NewTabAsCustomURLTextField"].value as? String else {
+            XCTFail("Failed to retreive the value from 'NewTabAsCustomURLTextField' text field")
+            return
+        }
         mozWaitForValueContains(app.textFields["NewTabAsCustomURLTextField"], value: "mozilla")
         XCTAssertEqual(valueTyped, "mozilla.org")
         // Open new page and check that the custom url is used

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NoImageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NoImageTests.swift
@@ -9,9 +9,9 @@ class NoImageTests: BaseTestCase {
         let noImageStatusMode = app.otherElements.tables.cells.switches["NoImageModeStatus"]
         mozWaitForElementToExist(noImageStatusMode)
         if showImages {
-            XCTAssertEqual(noImageStatusMode.value as! String, "0")
+            XCTAssertEqual(noImageStatusMode.value as? String, "0")
         } else {
-            XCTAssertEqual(noImageStatusMode.value as! String, "1")
+            XCTAssertEqual(noImageStatusMode.value as? String, "1")
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -74,7 +74,10 @@ class TopTabsTest: BaseTestCase {
         navigator.goto(TabTray)
 
         app.cells.staticTexts[urlLabel].firstMatch.waitAndTap()
-        let valueMozilla = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
+        guard let valueMozilla = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as? String else {
+            XCTFail("Failed to retrieve the URL value from the Mozilla browser's URL bar")
+            return
+        }
         XCTAssertEqual(valueMozilla, urlValueLong)
 
         navigator.nowAt(BrowserTab)
@@ -82,7 +85,10 @@ class TopTabsTest: BaseTestCase {
         navigator.goto(TabTray)
 
         app.cells.staticTexts[urlLabelExample].firstMatch.waitAndTap()
-        let value = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as! String
+        guard let value = app.textFields[AccessibilityIdentifiers.Browser.UrlBar.url].value as? String else {
+            XCTFail("Failed to retrieve the URL value from the Mozilla browser's URL bar")
+            return
+        }
         XCTAssertEqual(value, urlValueLongExample)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -142,21 +142,21 @@ class TrackingProtectionTests: BaseTestCase {
         mozWaitForElementToExist(app.staticTexts["Connection not secure"], timeout: 5)
         var switchValue = app.switches.firstMatch.value!
         // Need to make sure first the setting was not turned off previously
-        if switchValue as! String == "0" {
+        if switchValue as? String == "0" {
             app.switches.firstMatch.tap()
         }
         switchValue = app.switches.firstMatch.value!
-        XCTAssertEqual(switchValue as! String, "1")
+        XCTAssertEqual(switchValue as? String, "1")
 
         app.switches.firstMatch.tap()
         let switchValueOFF = app.switches.firstMatch.value!
-        XCTAssertEqual(switchValueOFF as! String, "0")
+        XCTAssertEqual(switchValueOFF as? String, "0")
 
         // Open TP Settings menu
         app.buttons["Privacy settings"].tap()
         mozWaitForElementToExist(app.navigationBars["Tracking Protection"], timeout: 5)
         let switchSettingsValue = app.switches["prefkey.trackingprotection.normalbrowsing"].value!
-        XCTAssertEqual(switchSettingsValue as! String, "1")
+        XCTAssertEqual(switchSettingsValue as? String, "1")
         app.switches["prefkey.trackingprotection.normalbrowsing"].tap()
         // Disable ETP from setting and check that it applies to the site
         app.buttons["Settings"].tap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
    - NewTabSettings 
    - NoImageTests
    - JumpBackInTests
    - TrackingProtectionTests
    - DragAndDropTests
    - TopTabsTest
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)