### PR TITLE
Bugfix MTE-3814 Perf tests perfherder object is not created

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -15,6 +15,7 @@
     {
       "skippedTests" : [
         "ActivityStreamTest",
+        "AddressesTests",
         "AddressesTests\/testAddNewAddressAllFieldsFilled()",
         "AddressesTests\/testAddNewAddressCityFilled()",
         "AddressesTests\/testAddNewAddressEmailFilled()",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-MTE3814)


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

