### PR TITLE
Bugfix FXIOS-10500 [Toolbar redesign] Menu not displayed after tapping on button

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -257,9 +257,15 @@ public class BrowserAddressToolbar: UIView,
     }
 
     private func updateActionStack(stackView: UIStackView, toolbarElements: [ToolbarElement]) {
+        let existingButtons = stackView.arrangedSubviews.compactMap { $0 as? ToolbarButton }
         stackView.removeAllArrangedViews()
+
         toolbarElements.forEach { toolbarElement in
-            let button = toolbarElement.numberOfTabs != nil ? TabNumberButton() : ToolbarButton()
+            // find existing button or create new one
+            // we do this to avoid having a new button every time we re-configure the address toolbar
+            // as this can result in button taps not resulting in correct action because the action
+            // as the reference to an old and not displayed button (e.g. the menu that is displayed from the menu button)
+            let button = newOrExistingToolbarButton(for: toolbarElement, existingButtons: existingButtons)
             button.configure(element: toolbarElement)
             stackView.addArrangedSubview(button)
 
@@ -277,6 +283,17 @@ public class BrowserAddressToolbar: UIView,
                 toolbarDelegate?.configureContextualHint(self, for: button, with: contextualHintType)
             }
         }
+    }
+
+    private func newOrExistingToolbarButton(for element: ToolbarElement,
+                                            existingButtons: [ToolbarButton]) -> ToolbarButton {
+        let existingButton = existingButtons.first { $0.isButtonFor(toolbarElement: element) }
+
+        guard let existingButton else {
+            return element.numberOfTabs != nil ? TabNumberButton() : ToolbarButton()
+        }
+
+        return existingButton
     }
 
     private func updateActionSpacing() {

--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -97,7 +97,7 @@ class ToolbarButton: UIButton, ThemeApplicable {
     }
 
     public func isButtonFor(toolbarElement: ToolbarElement) -> Bool {
-        guard var config = configuration else { return false }
+        guard let config = configuration else { return false }
 
         return isSelected == toolbarElement.isSelected &&
             config.image == imageConfiguredForRTL(for: toolbarElement) &&

--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -96,6 +96,17 @@ class ToolbarButton: UIButton, ThemeApplicable {
         configuration = updatedConfiguration
     }
 
+    public func isButtonFor(toolbarElement: ToolbarElement) -> Bool {
+        guard var config = configuration else { return false }
+
+        return isSelected == toolbarElement.isSelected &&
+            config.image == imageConfiguredForRTL(for: toolbarElement) &&
+            isEnabled == toolbarElement.isEnabled &&
+            accessibilityIdentifier == toolbarElement.a11yId &&
+            accessibilityLabel == toolbarElement.a11yLabel &&
+            accessibilityHint == toolbarElement.a11yHint
+    }
+
     private func addBadgeIcon(imageName: String) {
         badgeImageView = UIImageView(image: UIImage(named: imageName))
         guard let badgeImageView, configuration?.image != nil else { return }

--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -70,6 +70,12 @@ class ToolbarButton: UIButton, ThemeApplicable {
             if let maskImageName = element.maskImageName {
                 addMaskIcon(maskImageName: maskImageName)
             }
+        } else {
+            // Remove badge & mask icons
+            imageView?.subviews.forEach { view in
+                guard view as? UIImageView != nil else { return }
+                view.removeFromSuperview()
+            }
         }
         layoutIfNeeded()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10500)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23022)

## :bulb: Description
Uses existing toolbar buttons instead of creating a new ones if possible when updating the address toolbar for a new state.
Video: https://github.com/user-attachments/assets/fc852418-65ae-474b-937b-81e3511794ba

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
