### PR TITLE
Refactor FXIOS-7301 - Remove 1 closure_body_length violation from FxAPushMessageHandler.swift

### DIFF
--- a/firefox-ios/Account/FxAPushMessageHandler.swift
+++ b/firefox-ios/Account/FxAPushMessageHandler.swift
@@ -87,6 +87,19 @@ extension FxAPushMessageHandler {
             return PushMessageError.messageIncomplete("empty message")
         }
     }
+
+    private func getPushMessageBy(deviceCommand: IncomingDeviceCommand) -> PushMessage {
+        switch deviceCommand {
+        case .tabReceived(_, let tabData):
+            let title = tabData.entries.last?.title ?? ""
+            let url = tabData.entries.last?.url ?? ""
+            let command = CommandReceived.tabReceived(tab: ["title": title, "url": url])
+            return PushMessage.commandReceived(command: command)
+        case .tabsClosed(_, let payload):
+            let command = CommandReceived.tabsClosed(urls: payload.urls)
+            return PushMessage.commandReceived(command: command)
+        }
+    }
 }
 
 enum PushMessageType: String {

--- a/firefox-ios/Account/FxAPushMessageHandler.swift
+++ b/firefox-ios/Account/FxAPushMessageHandler.swift
@@ -42,7 +42,7 @@ extension FxAPushMessageHandler {
 
                     switch event {
                     case .commandReceived(let deviceCommand):
-                        let pushMessage = self.getPushMessageBy(deviceCommand: deviceCommand)
+                        let pushMessage = self.makePushMessageFrom(deviceCommand: deviceCommand)
                         completion(.success(pushMessage))
                     case .deviceConnected(let deviceName):
                         completion(.success(PushMessage.deviceConnected(deviceName)))
@@ -80,7 +80,7 @@ extension FxAPushMessageHandler {
         }
     }
 
-    private func getPushMessageBy(deviceCommand: IncomingDeviceCommand) -> PushMessage {
+    private func makePushMessageFrom(deviceCommand: IncomingDeviceCommand) -> PushMessage {
         switch deviceCommand {
         case .tabReceived(_, let tabData):
             let title = tabData.entries.last?.title ?? ""

--- a/firefox-ios/Account/FxAPushMessageHandler.swift
+++ b/firefox-ios/Account/FxAPushMessageHandler.swift
@@ -6,6 +6,7 @@ import Shared
 import Account
 import Common
 import enum MozillaAppServices.IncomingDeviceCommand
+import enum MozillaAppServices.AccountEvent
 
 let PendingAccountDisconnectedKey = "PendingAccountDisconnect"
 
@@ -81,6 +82,22 @@ extension FxAPushMessageHandler {
                     }
                 }
             }
+        }
+    }
+
+    private func getPushMessageError(result: Result<AccountEvent, Error>) -> PushMessageError {
+        if case .failure(let error) = result {
+            self.logger.log("Failed to get any events from FxA",
+                            level: .warning,
+                            category: .sync,
+                            description: error.localizedDescription)
+            return PushMessageError.messageIncomplete(error.localizedDescription)
+        } else {
+            self.logger.log("Got zero events from FxA",
+                            level: .warning,
+                            category: .sync,
+                            description: "No events retrieved from fxa")
+            return PushMessageError.messageIncomplete("empty message")
         }
     }
 }

--- a/firefox-ios/Account/FxAPushMessageHandler.swift
+++ b/firefox-ios/Account/FxAPushMessageHandler.swift
@@ -35,20 +35,7 @@ extension FxAPushMessageHandler {
             RustFirefoxAccounts.reconfig(prefs: self.profile.prefs) { accountManager in
                 accountManager.deviceConstellation()?.handlePushMessage(pushPayload: message) { result in
                     guard case .success(let event) = result else {
-                        let err: PushMessageError
-                        if case .failure(let error) = result {
-                            self.logger.log("Failed to get any events from FxA",
-                                            level: .warning,
-                                            category: .sync,
-                                            description: error.localizedDescription)
-                            err = PushMessageError.messageIncomplete(error.localizedDescription)
-                        } else {
-                            self.logger.log("Got zero events from FxA",
-                                            level: .warning,
-                                            category: .sync,
-                                            description: "No events retrieved from fxa")
-                            err = PushMessageError.messageIncomplete("empty message")
-                        }
+                        let err = self.getPushMessageError(result: result)
                         completion(.failure(err))
                         return
                     }

--- a/firefox-ios/Account/FxAPushMessageHandler.swift
+++ b/firefox-ios/Account/FxAPushMessageHandler.swift
@@ -35,7 +35,7 @@ extension FxAPushMessageHandler {
             RustFirefoxAccounts.reconfig(prefs: self.profile.prefs) { accountManager in
                 accountManager.deviceConstellation()?.handlePushMessage(pushPayload: message) { result in
                     guard case .success(let event) = result else {
-                        let err = self.getPushMessageErrorBy(result: result)
+                        let err = self.makePushErrorMessageFrom(result: result)
                         completion(.failure(err))
                         return
                     }
@@ -64,7 +64,7 @@ extension FxAPushMessageHandler {
         }
     }
 
-    private func getPushMessageErrorBy(result: Result<AccountEvent, Error>) -> PushMessageError {
+    private func makePushErrorMessageFrom(result: Result<AccountEvent, Error>) -> PushMessageError {
         if case .failure(let error) = result {
             self.logger.log("Failed to get any events from FxA",
                             level: .warning,

--- a/firefox-ios/Account/FxAPushMessageHandler.swift
+++ b/firefox-ios/Account/FxAPushMessageHandler.swift
@@ -35,7 +35,7 @@ extension FxAPushMessageHandler {
             RustFirefoxAccounts.reconfig(prefs: self.profile.prefs) { accountManager in
                 accountManager.deviceConstellation()?.handlePushMessage(pushPayload: message) { result in
                     guard case .success(let event) = result else {
-                        let err = self.getPushMessageError(result: result)
+                        let err = self.getPushMessageErrorBy(result: result)
                         completion(.failure(err))
                         return
                     }
@@ -72,7 +72,7 @@ extension FxAPushMessageHandler {
         }
     }
 
-    private func getPushMessageError(result: Result<AccountEvent, Error>) -> PushMessageError {
+    private func getPushMessageErrorBy(result: Result<AccountEvent, Error>) -> PushMessageError {
         if case .failure(let error) = result {
             self.logger.log("Failed to get any events from FxA",
                             level: .warning,

--- a/firefox-ios/Account/FxAPushMessageHandler.swift
+++ b/firefox-ios/Account/FxAPushMessageHandler.swift
@@ -42,16 +42,8 @@ extension FxAPushMessageHandler {
 
                     switch event {
                     case .commandReceived(let deviceCommand):
-                        switch deviceCommand {
-                        case .tabReceived(_, let tabData):
-                            let title = tabData.entries.last?.title ?? ""
-                            let url = tabData.entries.last?.url ?? ""
-                            let command = CommandReceived.tabReceived(tab: ["title": title, "url": url])
-                            completion(.success(PushMessage.commandReceived(command: command)))
-                        case .tabsClosed(_, let payload):
-                            let command = CommandReceived.tabsClosed(urls: payload.urls)
-                            completion(.success(PushMessage.commandReceived(command: command)))
-                        }
+                        let pushMessage = self.getPushMessageBy(deviceCommand: deviceCommand)
+                        completion(.success(pushMessage))
                     case .deviceConnected(let deviceName):
                         completion(.success(PushMessage.deviceConnected(deviceName)))
                     case let .deviceDisconnected(_, isLocalDevice):


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `FxAPushMessageHandler.swift` file by extracting object creation into separate functions. Specifically, it refactors the creation of the push message error and the creation of the push message by device command.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

