### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from Browser & Settings UI Components

### DIFF
--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenView.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenView.swift
@@ -8,9 +8,14 @@ import UIKit
 class LaunchScreenView: UIView {
     private static let viewName = "LaunchScreen"
 
-    class func fromNib() -> UIView {
-        return Bundle.main.loadNibNamed(LaunchScreenView.viewName,
-                                        owner: nil,
-                                        options: nil)![0] as! UIView
+    class func fromNib() -> UIView? {
+        guard let view = Bundle.main.loadNibNamed(
+            LaunchScreenView.viewName,
+            owner: nil,
+            options: nil
+        )?[0] as? UIView else {
+            return nil
+        }
+        return view
     }
 }

--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
@@ -63,6 +63,10 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
     // MARK: - Setup
 
     private func setupLayout() {
+        guard let launchScreen = launchScreen else {
+            fatalError("LaunchScreen view is nil during layout setup")
+        }
+
         launchScreen.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(launchScreen)
 
@@ -101,7 +105,11 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
         setupLayout()
         guard shouldTriggerSplashScreenExperiment else { return }
         if !UIAccessibility.isReduceMotionEnabled {
-            splashScreenAnimation.configureAnimation(with: launchScreen)
+            if let launchScreen = launchScreen {
+                splashScreenAnimation.configureAnimation(with: launchScreen)
+            } else {
+                fatalError("LaunchScreen view is nil during splash screen animation setup")
+            }
         }
     }
 }

--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
@@ -105,11 +105,7 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
         setupLayout()
         guard shouldTriggerSplashScreenExperiment else { return }
         if !UIAccessibility.isReduceMotionEnabled {
-            if let launchScreen = launchScreen {
-                splashScreenAnimation.configureAnimation(with: launchScreen)
-            } else {
-                fatalError("LaunchScreen view is nil during splash screen animation setup")
-            }
+            splashScreenAnimation.configureAnimation(with: launchScreen!)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -228,11 +228,13 @@ class BrowserViewController: UIViewController,
 
     @available(iOS 13.4, *)
     func keyboardPressesHandler() -> KeyboardPressesHandler {
-        guard let keyboardPressesHandlerValue = keyboardPressesHandlerValue as? KeyboardPressesHandler else {
-            keyboardPressesHandlerValue = KeyboardPressesHandler()
-            return keyboardPressesHandlerValue as! KeyboardPressesHandler
+        if let existingHandler = keyboardPressesHandlerValue as? KeyboardPressesHandler {
+            return existingHandler
+        } else {
+            let newHandler = KeyboardPressesHandler()
+            keyboardPressesHandlerValue = newHandler
+            return newHandler
         }
-        return keyboardPressesHandlerValue
     }
 
     init(

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -53,6 +53,7 @@ class SearchViewController: SiteTableViewController,
     var searchDelegate: SearchViewControllerDelegate?
     let viewModel: SearchViewModel
     private var tabManager: TabManager
+    private let logger: Logger
 
     var searchTelemetry: SearchTelemetry?
 
@@ -85,10 +86,12 @@ class SearchViewController: SiteTableViewController,
     init(profile: Profile,
          viewModel: SearchViewModel,
          tabManager: TabManager,
-         highlightManager: HistoryHighlightsManagerProtocol = HistoryHighlightsManager()) {
+         highlightManager: HistoryHighlightsManagerProtocol = HistoryHighlightsManager(),
+         logger: Logger = DefaultLogger.shared) {
         self.viewModel = viewModel
         self.tabManager = tabManager
         self.searchTelemetry = SearchTelemetry(tabManager: tabManager)
+        self.logger = logger
         super.init(profile: profile, windowUUID: tabManager.windowUUID)
         viewModel.delegate = self
 
@@ -542,13 +545,19 @@ class SearchViewController: SiteTableViewController,
             withIdentifier: TwoLineImageOverlayCell.cellIdentifier,
             for: indexPath
         ) as? TwoLineImageOverlayCell else {
-            fatalError("Failed to dequeue cell with identifier \(TwoLineImageOverlayCell.cellIdentifier)")
+            logger.log("Failed to dequeue TwoLineImageOverlayCell at indexPath: \(indexPath)",
+                       level: .fatal,
+                       category: .lifecycle)
+            return UITableViewCell()
         }
         guard let oneLineTableViewCell = tableView.dequeueReusableCell(
             withIdentifier: OneLineTableViewCell.cellIdentifier,
             for: indexPath
         ) as? OneLineTableViewCell else {
-            fatalError("Failed to dequeue cell with identifier \(OneLineTableViewCell.cellIdentifier)")
+            logger.log("Failed to dequeue OneLineTableViewCell at indexPath: \(indexPath)",
+                       level: .fatal,
+                       category: .lifecycle)
+            return UITableViewCell()
         }
         return getCellForSection(twoLineImageOverlayCell,
                                  oneLineCell: oneLineTableViewCell,

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -542,13 +542,13 @@ class SearchViewController: SiteTableViewController,
             withIdentifier: TwoLineImageOverlayCell.cellIdentifier,
             for: indexPath
         ) as? TwoLineImageOverlayCell else {
-            fatalError("Failed to dequeue TwoLineImageOverlayCell")
+            fatalError("Failed to dequeue cell with identifier \(TwoLineImageOverlayCell.cellIdentifier)")
         }
         guard let oneLineTableViewCell = tableView.dequeueReusableCell(
             withIdentifier: OneLineTableViewCell.cellIdentifier,
             for: indexPath
         ) as? OneLineTableViewCell else {
-            fatalError("Failed to dequeue OneLineTableViewCell")
+            fatalError("Failed to dequeue cell with identifier \(OneLineTableViewCell.cellIdentifier)")
         }
         return getCellForSection(twoLineImageOverlayCell,
                                  oneLineCell: oneLineTableViewCell,

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -538,14 +538,18 @@ class SearchViewController: SiteTableViewController,
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let twoLineImageOverlayCell = tableView.dequeueReusableCell(
+        guard let twoLineImageOverlayCell = tableView.dequeueReusableCell(
             withIdentifier: TwoLineImageOverlayCell.cellIdentifier,
             for: indexPath
-        ) as! TwoLineImageOverlayCell
-        let oneLineTableViewCell = tableView.dequeueReusableCell(
+        ) as? TwoLineImageOverlayCell else {
+            fatalError("Failed to dequeue TwoLineImageOverlayCell")
+        }
+        guard let oneLineTableViewCell = tableView.dequeueReusableCell(
             withIdentifier: OneLineTableViewCell.cellIdentifier,
             for: indexPath
-        ) as! OneLineTableViewCell
+        ) as? OneLineTableViewCell else {
+            fatalError("Failed to dequeue OneLineTableViewCell")
+        }
         return getCellForSection(twoLineImageOverlayCell,
                                  oneLineCell: oneLineTableViewCell,
                                  for: SearchListSection(rawValue: indexPath.section)!,

--- a/firefox-ios/Client/Frontend/Browser/SwipeAnimator.swift
+++ b/firefox-ios/Client/Frontend/Browser/SwipeAnimator.swift
@@ -160,7 +160,9 @@ extension SwipeAnimator: UIGestureRecognizerDelegate {
     @objc
     func gestureRecognizerShouldBegin(_ recognizer: UIGestureRecognizer) -> Bool {
         let cellView = recognizer.view
-        let panGesture = recognizer as! UIPanGestureRecognizer
+        guard let panGesture = recognizer as? UIPanGestureRecognizer else {
+            return false
+        }
         let translation = panGesture.translation(in: cellView?.superview)
         return abs(translation.x) > abs(translation.y)
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -48,6 +48,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
     private var debugSettingsClickCount: Int = 0
     private var appAuthenticator: AppAuthenticationProtocol
     private var applicationHelper: ApplicationHelper
+    private let logger: Logger
 
     weak var parentCoordinator: SettingsFlowDelegate?
 
@@ -60,9 +61,11 @@ class AppSettingsTableViewController: SettingsTableViewController,
          and tabManager: TabManager,
          delegate: SettingsDelegate? = nil,
          appAuthenticator: AppAuthenticationProtocol = AppAuthenticator(),
-         applicationHelper: ApplicationHelper = DefaultApplicationHelper()) {
+         applicationHelper: ApplicationHelper = DefaultApplicationHelper(),
+         logger: Logger = DefaultLogger.shared) {
         self.appAuthenticator = appAuthenticator
         self.applicationHelper = applicationHelper
+        self.logger = logger
 
         super.init(windowUUID: tabManager.windowUUID)
         self.profile = profile
@@ -460,7 +463,10 @@ class AppSettingsTableViewController: SettingsTableViewController,
             tableView,
             viewForHeaderInSection: section
         ) as? ThemedTableSectionHeaderFooterView else {
-            fatalError("Failed to dequeue ThemedTableSectionHeaderFooterView for section \(section)")
+            logger.log("Failed to cast or retrieve ThemedTableSectionHeaderFooterView for section: \(section)",
+                       level: .fatal,
+                       category: .lifecycle)
+            return UIView()
         }
         return headerView
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -460,7 +460,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
             tableView,
             viewForHeaderInSection: section
         ) as? ThemedTableSectionHeaderFooterView else {
-            fatalError("Failed to dequeue ThemedTableSectionHeaderFooterView")
+            fatalError("Failed to dequeue ThemedTableSectionHeaderFooterView for section \(section)")
         }
         return headerView
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -456,10 +456,12 @@ class AppSettingsTableViewController: SettingsTableViewController,
     // MARK: - UITableViewDelegate
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let headerView = super.tableView(
+        guard let headerView = super.tableView(
             tableView,
             viewForHeaderInSection: section
-        ) as! ThemedTableSectionHeaderFooterView
+        ) as? ThemedTableSectionHeaderFooterView else {
+            fatalError("Failed to dequeue ThemedTableSectionHeaderFooterView")
+        }
         return headerView
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -144,7 +144,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
             withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier,
             for: indexPath
         ) as? ThemedSubtitleTableViewCell else {
-            fatalError("Failed to dequeue ThemedSubtitleTableViewCell")
+            fatalError("Failed to dequeue cell with identifier \(ThemedSubtitleTableViewCell.cellIdentifier)")
         }
 
         var engine: OpenSearchEngine!

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -41,6 +41,7 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
 
     private let profile: Profile
     private let model: SearchEnginesManager
+    private let logger: Logger
 
     var shouldHidePrivateModeFirefoxSuggestSetting: Bool {
         return !model.shouldShowBookmarksSuggestions &&
@@ -80,8 +81,11 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
         return defaultEngine.isCustomEngine ? customEngineCount > 1 : customEngineCount > 0
     }
 
-    init(profile: Profile, windowUUID: WindowUUID) {
+    init(profile: Profile,
+         windowUUID: WindowUUID,
+         logger: Logger = DefaultLogger.shared) {
         self.profile = profile
+        self.logger = logger
         model = profile.searchEnginesManager
 
         super.init(windowUUID: windowUUID)
@@ -144,7 +148,10 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
             withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier,
             for: indexPath
         ) as? ThemedSubtitleTableViewCell else {
-            fatalError("Failed to dequeue cell with identifier \(ThemedSubtitleTableViewCell.cellIdentifier)")
+            logger.log("Failed to dequeue ThemedSubtitleTableViewCell at indexPath: \(indexPath)",
+                       level: .fatal,
+                       category: .lifecycle)
+            return UITableViewCell()
         }
 
         var engine: OpenSearchEngine!

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -140,10 +140,12 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
 
     // MARK: - UITableViewDataSource
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(
+        guard let cell = tableView.dequeueReusableCell(
             withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier,
             for: indexPath
-        ) as! ThemedSubtitleTableViewCell
+        ) as? ThemedSubtitleTableViewCell else {
+            fatalError("Failed to dequeue ThemedSubtitleTableViewCell")
+        }
 
         var engine: OpenSearchEngine!
         let section = Section(rawValue: sectionsToDisplay[indexPath.section].rawValue) ?? .defaultEngine


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
   - LaunchScreenView
   - LaunchScreenViewController
   - BrowserViewController
   - SearchViewController
   - SwipeAnimator
   - AppSettingsTableViewController
   - SearchSettingsTableViewController
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)