### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from Frontend Features & Content View

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Pocket/PocketViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/Pocket/PocketViewModel.swift
@@ -208,15 +208,19 @@ extension PocketViewModel: HomepageSectionHandler {
         recordSectionHasShown()
 
         if isStoryCell(index: indexPath.row) {
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LegacyPocketStandardCell.cellIdentifier,
-                                                          for: indexPath) as! LegacyPocketStandardCell
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LegacyPocketStandardCell.cellIdentifier,
+                                                                for: indexPath) as? LegacyPocketStandardCell else {
+                fatalError("Failed to dequeue cell with identifier \(LegacyPocketStandardCell.cellIdentifier)")
+            }
             let viewModel = pocketStoriesViewModels[indexPath.row]
             viewModel.tag = indexPath.row
             cell.configure(viewModel: viewModel, theme: theme)
             return cell
         } else {
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PocketDiscoverCell.cellIdentifier,
-                                                          for: indexPath) as! PocketDiscoverCell
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PocketDiscoverCell.cellIdentifier,
+                                                                for: indexPath) as? PocketDiscoverCell else {
+                fatalError("Failed to dequeue cell with identifier \(PocketDiscoverCell.cellIdentifier)")
+            }
             cell.configure(text: .FirefoxHomepage.Pocket.DiscoverMore, theme: theme)
             return cell
         }

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -283,8 +283,10 @@ class DownloadsPanel: UIViewController,
 
     // MARK: - TableView Delegate / DataSource
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: TwoLineImageOverlayCell.cellIdentifier,
-                                                 for: indexPath) as! TwoLineImageOverlayCell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: TwoLineImageOverlayCell.cellIdentifier,
+                                                       for: indexPath) as? TwoLineImageOverlayCell else {
+            fatalError("Failed to dequeue cell with identifier \(TwoLineImageOverlayCell.cellIdentifier)")
+        }
 
         return configureDownloadedFile(cell, for: indexPath)
     }

--- a/firefox-ios/Client/Frontend/Library/Reader/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Reader/ReaderPanel.swift
@@ -346,10 +346,12 @@ class ReadingListPanel: UITableViewController,
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(
+        guard let cell = tableView.dequeueReusableCell(
             withIdentifier: "ReadingListTableViewCell",
             for: indexPath
-        ) as! ReadingListTableViewCell
+        ) as? ReadingListTableViewCell else {
+            fatalError("Failed to dequeue cell with identifier 'ReadingListTableViewCell'")
+        }
         if let record = records?[indexPath.row] {
             cell.title = record.title
             cell.url = URL(string: record.url, invalidCharacters: false)!

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
@@ -31,7 +31,9 @@ class FindInPageHelper: TabContentScript {
         _ userContentController: WKUserContentController,
         didReceiveScriptMessage message: WKScriptMessage
     ) {
-        let data = message.body as! [String: Int]
+        guard let data = message.body as? [String: Int] else {
+            fatalError("Invalid data message body: \(message.body)")
+        }
 
         if let currentResult = data["currentResult"] {
             delegate?.findInPageHelper(self, didUpdateCurrentResult: currentResult)

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LocalRequestHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LocalRequestHelper.swift
@@ -19,7 +19,9 @@ class LocalRequestHelper: TabContentScript {
               let internalUrl = InternalURL(requestUrl)
         else { return }
 
-        let params = message.body as! [String: String]
+        guard let params = message.body as? [String: String] else {
+            fatalError("Invalid params message body: \(message.body)")
+        }
 
         guard let token = params["appIdToken"],
               token == UserScriptManager.appIdToken

--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
@@ -171,8 +171,10 @@ class CertificatesViewController: UIViewController,
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let headerView = tableView.dequeueReusableHeaderFooterView(
-            withIdentifier: CertificatesHeaderView.cellIdentifier) as! CertificatesHeaderView
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(
+            withIdentifier: CertificatesHeaderView.cellIdentifier) as? CertificatesHeaderView else {
+            fatalError("Failed to dequeue cell with identifier \(CertificatesHeaderView.cellIdentifier)")
+        }
         var items: [CertificatesHeaderItem] = []
         for (index, certificate) in model.certificates.enumerated() {
             let certificateValues = certificate.subject.description.getDictionary()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
   - PocketViewModel
   - FindInPageHelper
   - LocalRequestHelper
   - ReaderPanel
   - DownloadsPanel
   - CertificatesViewController
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)