### PR TITLE
Bugfix FXIOS-10508 ⁃ [Menu] [Telemetry] - Missing sub-menu events

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -279,7 +279,9 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
                     MainMenuAction(
                         windowUUID: uuid,
                         actionType: MainMenuActionType.tapToggleUserAgent,
-                        telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)
+                        telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage,
+                                                     isDefaultUserAgentDesktop: tabInfo.isDefaultUserAgentDesktop,
+                                                     hasChangedUserAgent: tabInfo.hasChangedUserAgent)
                     )
                 )
             }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuTelemetry.swift
@@ -6,9 +6,19 @@ import Foundation
 import Glean
 
 struct MainMenuTelemetry {
-    func optionTapped(with isHomepage: Bool, and option: String) {
+    func mainMenuOptionTapped(with isHomepage: Bool, and option: String) {
         let extra = GleanMetrics.AppMenu.MainMenuOptionSelectedExtra(isHomepage: isHomepage, option: option)
         GleanMetrics.AppMenu.mainMenuOptionSelected.record(extra)
+    }
+
+    func saveSubmenuOptionTapped(with isHomepage: Bool, and option: String) {
+        let extra = GleanMetrics.AppMenu.SaveMenuOptionSelectedExtra(isHomepage: isHomepage, option: option)
+        GleanMetrics.AppMenu.saveMenuOptionSelected.record(extra)
+    }
+
+    func toolsSubmenuOptionTapped(with isHomepage: Bool, and option: String) {
+        let extra = GleanMetrics.AppMenu.ToolsMenuOptionSelectedExtra(isHomepage: isHomepage, option: option)
+        GleanMetrics.AppMenu.toolsMenuOptionSelected.record(extra)
     }
 
     func closeButtonTapped(isHomepage: Bool) {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -61,9 +61,9 @@ final class MainMenuMiddleware {
                                     and: action.navigationDestination?.url)
         case MainMenuActionType.tapShowDetailsView:
             if action.detailsViewToShow == .tools {
-                self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.tools)
+                self.telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.tools)
             } else if action.detailsViewToShow == .save {
-                self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.save)
+                self.telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.save)
             }
         case MainMenuActionType.tapToggleUserAgent:
             guard let defaultIsDesktop = action.currentTabInfo?.isDefaultUserAgentDesktop,
@@ -71,17 +71,17 @@ final class MainMenuMiddleware {
             else { return }
             if defaultIsDesktop {
                 let option = hasChangedUserAgent ? TelemetryAction.switchToDesktopSite : TelemetryAction.switchToMobileSite
-                self.telemetry.optionTapped(with: isHomepage, and: option)
+                self.telemetry.mainMenuOptionTapped(with: isHomepage, and: option)
             } else {
                 let option = hasChangedUserAgent ? TelemetryAction.switchToMobileSite : TelemetryAction.switchToDesktopSite
-                self.telemetry.optionTapped(with: isHomepage, and: option)
+                self.telemetry.mainMenuOptionTapped(with: isHomepage, and: option)
             }
         case MainMenuActionType.tapCloseMenu:
             self.telemetry.closeButtonTapped(isHomepage: isHomepage)
         case GeneralBrowserActionType.showReaderMode:
             guard let isActionOn = action.telemetryInfo?.isActionOn else { return }
             let option = isActionOn ? TelemetryAction.readerViewTurnOn : TelemetryAction.readerViewTurnOff
-            self.telemetry.optionTapped(with: false, and: option)
+            self.telemetry.toolsSubmenuOptionTapped(with: false, and: option)
         case MainMenuActionType.viewDidLoad:
             if let accountData = self.getAccountData() {
                 if let iconURL = accountData.iconURL {
@@ -107,27 +107,32 @@ final class MainMenuMiddleware {
         case MainMenuActionType.menuDismissed:
             self.telemetry.menuDismissed(isHomepage: isHomepage)
         case MainMenuDetailsActionType.tapZoom:
-            self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.zoom)
+            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
         case MainMenuDetailsActionType.tapReportBrokenSite:
-            self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
+            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
         case MainMenuDetailsActionType.tapAddToBookmarks:
-            self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarkThisPage)
         case MainMenuDetailsActionType.tapEditBookmark:
-            self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
         case MainMenuDetailsActionType.tapAddToShortcuts:
-            self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.addToShortcuts)
         case MainMenuDetailsActionType.tapRemoveFromShortcuts:
-            self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromShortcuts)
         case MainMenuDetailsActionType.tapAddToReadingList:
-            self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.saveToReadingList)
         case MainMenuDetailsActionType.tapRemoveFromReadingList:
-            self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
         case MainMenuDetailsActionType.tapToggleNightMode:
             guard let isActionOn = action.telemetryInfo?.isActionOn else { return }
             let option = isActionOn ? TelemetryAction.nightModeTurnOn : TelemetryAction.nightModeTurnOff
-            self.telemetry.optionTapped(with: isHomepage, and: option)
+            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: option)
         case MainMenuDetailsActionType.tapBackToMainMenu:
-            self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.back)
+            guard let submenuType = action.telemetryInfo?.submenuType else { return }
+            if submenuType == .save {
+                self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.back)
+            } else {
+                self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.back)
+            }
         case MainMenuDetailsActionType.tapDismissView:
             self.telemetry.closeButtonTapped(isHomepage: isHomepage)
         default: break
@@ -179,37 +184,37 @@ final class MainMenuMiddleware {
         let isHomepage = currentTabInfo?.isHomepage ?? false
         switch navigationDestination {
         case .newTab:
-            telemetry.optionTapped(with: isHomepage, and: TelemetryAction.newTab)
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.newTab)
         case .newPrivateTab:
-            telemetry.optionTapped(with: isHomepage, and: TelemetryAction.newPrivateTab)
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.newPrivateTab)
         case .findInPage:
-            telemetry.optionTapped(with: isHomepage, and: TelemetryAction.findInPage)
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.findInPage)
         case .bookmarks:
-            telemetry.optionTapped(with: isHomepage, and: TelemetryAction.bookmarks)
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.bookmarks)
         case .history:
-            telemetry.optionTapped(with: isHomepage, and: TelemetryAction.history)
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.history)
         case .downloads:
-            telemetry.optionTapped(with: isHomepage, and: TelemetryAction.downloads)
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.downloads)
         case .passwords:
-            telemetry.optionTapped(with: isHomepage, and: TelemetryAction.passwords)
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.passwords)
         case .settings:
-            telemetry.optionTapped(with: isHomepage, and: TelemetryAction.settings)
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.settings)
         case .customizeHomepage:
-            telemetry.optionTapped(with: isHomepage, and: TelemetryAction.customizeHomepage)
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.customizeHomepage)
         case .goToURL:
             if urlToVisit == SupportUtils.URLForGetHelp {
-                telemetry.optionTapped(with: isHomepage, and: TelemetryAction.getHelp)
+                telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.getHelp)
             } else if urlToVisit == SupportUtils.URLForWhatsNew {
-                telemetry.optionTapped(with: isHomepage, and: TelemetryAction.newInFirefox)
+                telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.newInFirefox)
             }
         case .shareSheet:
-            telemetry.optionTapped(with: isHomepage, and: TelemetryAction.share)
+            telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.share)
         case .syncSignIn:
-            telemetry.optionTapped(with: isHomepage, and: TelemetryAction.signInAccount)
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.signInAccount)
         case .editBookmark:
-            self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
+            self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.editBookmark)
         case .zoom:
-            self.telemetry.optionTapped(with: isHomepage, and: TelemetryAction.zoom)
+            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.zoom)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -57,7 +57,7 @@ final class MainMenuMiddleware {
         case MainMenuActionType.tapNavigateToDestination:
             guard let destination = action.navigationDestination?.destination else { return }
             self.handleTelemetryFor(for: destination,
-                                    currentTabInfo: action.currentTabInfo,
+                                    isHomepage: isHomepage,
                                     and: action.navigationDestination?.url)
         case MainMenuActionType.tapShowDetailsView:
             if action.detailsViewToShow == .tools {
@@ -66,8 +66,8 @@ final class MainMenuMiddleware {
                 self.telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.save)
             }
         case MainMenuActionType.tapToggleUserAgent:
-            guard let defaultIsDesktop = action.currentTabInfo?.isDefaultUserAgentDesktop,
-                  let hasChangedUserAgent = action.currentTabInfo?.hasChangedUserAgent
+            guard let defaultIsDesktop = action.telemetryInfo?.isDefaultUserAgentDesktop,
+                  let hasChangedUserAgent = action.telemetryInfo?.hasChangedUserAgent
             else { return }
             if defaultIsDesktop {
                 let option = hasChangedUserAgent ? TelemetryAction.switchToDesktopSite : TelemetryAction.switchToMobileSite
@@ -179,9 +179,8 @@ final class MainMenuMiddleware {
     }
 
     private func handleTelemetryFor(for navigationDestination: MainMenuNavigationDestination,
-                                    currentTabInfo: MainMenuTabInfo?,
+                                    isHomepage: Bool,
                                     and urlToVisit: URL?) {
-        let isHomepage = currentTabInfo?.isHomepage ?? false
         switch navigationDestination {
         case .newTab:
             telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.newTab)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -17,10 +17,12 @@ struct AccountData: Equatable {
 struct TelemetryInfo: Equatable {
     let isHomepage: Bool
     let isActionOn: Bool?
+    let submenuType: MainMenuDetailsViewType?
 
-    init(isHomepage: Bool, isActionOn: Bool? = nil) {
+    init(isHomepage: Bool, isActionOn: Bool? = nil, submenuType: MainMenuDetailsViewType? = nil) {
         self.isHomepage = isHomepage
         self.isActionOn = isActionOn
+        self.submenuType = submenuType
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -18,11 +18,19 @@ struct TelemetryInfo: Equatable {
     let isHomepage: Bool
     let isActionOn: Bool?
     let submenuType: MainMenuDetailsViewType?
+    let isDefaultUserAgentDesktop: Bool?
+    let hasChangedUserAgent: Bool?
 
-    init(isHomepage: Bool, isActionOn: Bool? = nil, submenuType: MainMenuDetailsViewType? = nil) {
+    init(isHomepage: Bool,
+         isActionOn: Bool? = nil,
+         submenuType: MainMenuDetailsViewType? = nil,
+         isDefaultUserAgentDesktop: Bool? = nil,
+         hasChangedUserAgent: Bool? = nil) {
         self.isHomepage = isHomepage
         self.isActionOn = isActionOn
         self.submenuType = submenuType
+        self.isDefaultUserAgentDesktop = isDefaultUserAgentDesktop
+        self.hasChangedUserAgent = hasChangedUserAgent
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuDetailsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuDetailsViewController.swift
@@ -117,7 +117,8 @@ class MainMenuDetailsViewController: UIViewController,
                 MainMenuAction(
                     windowUUID: self.windowUUID,
                     actionType: MainMenuDetailsActionType.tapBackToMainMenu,
-                    telemetryInfo: TelemetryInfo(isHomepage: submenuState.isHomepage ?? false)
+                    telemetryInfo: TelemetryInfo(isHomepage: submenuState.isHomepage ?? false,
+                                                 submenuType: submenuState.submenuType)
                 )
             )
         }

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -181,6 +181,46 @@ app_menu:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-01"
+  save_menu_option_selected:
+    type: event
+    description: |
+      Record event when user has tapped on a save sub menu option.
+    extra_keys:
+      option:
+        type: string
+        description: |
+          The option type selected on the save sub menu.
+      is_homepage:
+        type: boolean
+        description: |
+          Indicate if is homepage when select an option.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/23040
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/22788
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-06-01"
+  tools_menu_option_selected:
+    type: event
+    description: |
+      Record event when user has tapped on a tools sub menu option.
+    extra_keys:
+      option:
+        type: string
+        description: |
+          The option type selected on the tools sub menu.
+      is_homepage:
+        type: boolean
+        description: |
+          Indicate if is homepage when select an option.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/23040
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/22788
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-06-01"
   close_button:
     type: event
     description: |

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -197,7 +197,7 @@ app_menu:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/23040
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/22788
+      - https://github.com/mozilla-mobile/firefox-ios/pull/23046
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-01"
@@ -217,7 +217,7 @@ app_menu:
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/23040
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/22788
+      - https://github.com/mozilla-mobile/firefox-ios/pull/23046
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-06-01"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/MainMenuTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/MainMenuTelemetryTests.swift
@@ -18,11 +18,29 @@ final class MainMenuTelemetryTests: XCTestCase {
         subject = MainMenuTelemetry()
     }
 
-    func testRecordMainMenuWhenOptionTappedThenGleanIsCalled() throws {
-        subject?.optionTapped(with: true, and: "test_option")
+    func testRecordMainMenuWhenMainMenuOptionTappedThenGleanIsCalled() throws {
+        subject?.mainMenuOptionTapped(with: true, and: "test_option")
         testEventMetricRecordingSuccess(metric: GleanMetrics.AppMenu.mainMenuOptionSelected)
 
         let resultValue = try XCTUnwrap(GleanMetrics.AppMenu.mainMenuOptionSelected.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?[optionKey], "test_option")
+        XCTAssertEqual(resultValue[0].extra?[isHomepageKey], "true")
+    }
+
+    func testRecordMainMenuWhenSaveSubmenuOptionTappedThenGleanIsCalled() throws {
+        subject?.saveSubmenuOptionTapped(with: true, and: "test_option")
+        testEventMetricRecordingSuccess(metric: GleanMetrics.AppMenu.saveMenuOptionSelected)
+
+        let resultValue = try XCTUnwrap(GleanMetrics.AppMenu.saveMenuOptionSelected.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?[optionKey], "test_option")
+        XCTAssertEqual(resultValue[0].extra?[isHomepageKey], "true")
+    }
+
+    func testRecordMainMenuWhenToolsSubmenuOptionTappedThenGleanIsCalled() throws {
+        subject?.toolsSubmenuOptionTapped(with: true, and: "test_option")
+        testEventMetricRecordingSuccess(metric: GleanMetrics.AppMenu.toolsMenuOptionSelected)
+
+        let resultValue = try XCTUnwrap(GleanMetrics.AppMenu.toolsMenuOptionSelected.testGetValue())
         XCTAssertEqual(resultValue[0].extra?[optionKey], "test_option")
         XCTAssertEqual(resultValue[0].extra?[isHomepageKey], "true")
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10508)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23040)

## :bulb: Description
Added two more events for save submenu and tools submenu

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

