### PR TITLE
Add MTE-3844 Skip widget tests for iOS 18

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -316,7 +316,10 @@ class TodayWidgetTests: BaseTestCase {
 
     // TESTS
     // https://mozilla.testrail.io/index.php?/cases/view/2769289
-    func testNewSearchWidget() {
+    func testNewSearchWidget() throws {
+        if #available(iOS 18, *) {
+            throw XCTSkip("This test is only for iOS versions 17.5 and lower.")
+        }
         XCUIDevice.shared.press(.home)
         // Go to Today Widget Page
         goToTodayWidgetPage()
@@ -375,7 +378,10 @@ class TodayWidgetTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2769297
-    func testNewPrivateSearchWidget() {
+    func testNewPrivateSearchWidget() throws {
+        if #available(iOS 18, *) {
+            throw XCTSkip("This test is only for iOS versions 17.5 and lower.")
+        }
         // Return to the Home screen
         XCUIDevice.shared.press(.home)
         // Navigate to the Today Widget Page
@@ -448,7 +454,10 @@ class TodayWidgetTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2769300
-    func testGoToCopiedLinkWidget() {
+    func testGoToCopiedLinkWidget() throws {
+        if #available(iOS 18, *) {
+            throw XCTSkip("This test is only for iOS versions 17.5 and lower.")
+        }
         let copiedString = "www.mozilla.org"
         // Press Home and navigate to Today Widget Page
         XCUIDevice.shared.press(.home)
@@ -522,7 +531,10 @@ class TodayWidgetTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2783001
-    func testFxShortcutSearchWidget() {
+    func testFxShortcutSearchWidget() throws {
+        if #available(iOS 18, *) {
+            throw XCTSkip("This test is only for iOS versions 17.5 and lower.")
+        }
         XCUIDevice.shared.press(.home)
         goToTodayWidgetPage()
         // Remove Firefox Widget if it already exists
@@ -556,7 +568,10 @@ class TodayWidgetTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2783002
-    func testFxShortcutPrivateSearchWidget() {
+    func testFxShortcutPrivateSearchWidget() throws {
+        if #available(iOS 18, *) {
+            throw XCTSkip("This test is only for iOS versions 17.5 and lower.")
+        }
         XCUIDevice.shared.press(.home)
         app.terminate()
         goToTodayWidgetPage()
@@ -602,7 +617,10 @@ class TodayWidgetTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2783003
-    func testFxShortcutGoToCopiedLinkWidget() {
+    func testFxShortcutGoToCopiedLinkWidget() throws {
+        if #available(iOS 18, *) {
+            throw XCTSkip("This test is only for iOS versions 17.5 and lower.")
+        }
         let copiedString = "www.mozilla.org"
         UIPasteboard.general.string = copiedString
         XCUIDevice.shared.press(.home)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3844)

## :bulb: Description
iOS v 18 changed the way to manage the widgets so we have to skip the tests for this version and keep the compatibility for the older versions only

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

