### PR TITLE
Add FXIOS-10477 [Homepage] top sites logic for sponsored tiles + dups

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -886,6 +886,7 @@
 		8A93F87029D3A597004159D9 /* SceneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F86F29D3A597004159D9 /* SceneCoordinator.swift */; };
 		8A93F87229D3A5AD004159D9 /* BrowserCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */; };
 		8A93F87429D3A5C1004159D9 /* LaunchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93F87329D3A5C1004159D9 /* LaunchCoordinator.swift */; };
+		8A94418A2CE3E190007FF4E5 /* MockSearchEngineManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9441892CE3E190007FF4E5 /* MockSearchEngineManager.swift */; };
 		8A95FF642B1E969E00AC303D /* TelemetryContextualIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A95FF632B1E969E00AC303D /* TelemetryContextualIdentifier.swift */; };
 		8A95FF672B1E97A800AC303D /* TelemetryContextualIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A95FF652B1E977E00AC303D /* TelemetryContextualIdentifierTests.swift */; };
 		8A96C4BB28F9E7B300B75884 /* XCTestCaseRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */; };
@@ -7368,6 +7369,7 @@
 		8A93F86F29D3A597004159D9 /* SceneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinator.swift; sourceTree = "<group>"; };
 		8A93F87129D3A5AD004159D9 /* BrowserCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserCoordinator.swift; sourceTree = "<group>"; };
 		8A93F87329D3A5C1004159D9 /* LaunchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchCoordinator.swift; sourceTree = "<group>"; };
+		8A9441892CE3E190007FF4E5 /* MockSearchEngineManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSearchEngineManager.swift; sourceTree = "<group>"; };
 		8A95FF632B1E969E00AC303D /* TelemetryContextualIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryContextualIdentifier.swift; sourceTree = "<group>"; };
 		8A95FF652B1E977E00AC303D /* TelemetryContextualIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryContextualIdentifierTests.swift; sourceTree = "<group>"; };
 		8A96C4B828F9DD8700B75884 /* ThemableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemableTests.swift; sourceTree = "<group>"; };
@@ -11491,6 +11493,7 @@
 				8A6B799C2CDBDAE4003C3077 /* MockContileProvider.swift */,
 				8A6B799F2CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift */,
 				8A1A66062CDD168A00DD883C /* MockTopSiteHistoryManager.swift */,
+				8A9441892CE3E190007FF4E5 /* MockSearchEngineManager.swift */,
 			);
 			path = Mock;
 			sourceTree = "<group>";
@@ -16978,6 +16981,7 @@
 				8A454D372CB86B86009436D9 /* PocketStateTests.swift in Sources */,
 				8AED868328CA3B3400351A50 /* BookmarkPanelViewModelTests.swift in Sources */,
 				434CD57829F6FC4500A0D04B /* MockAppAuthenticator.swift in Sources */,
+				8A94418A2CE3E190007FF4E5 /* MockSearchEngineManager.swift in Sources */,
 				DACDE996225E537900C8F37F /* VersionSettingTests.swift in Sources */,
 				8A83B74C2A265061002FF9AC /* LibraryCoordinatorTests.swift in Sources */,
 				8CEDF07E2BFE04B100D2617B /* AddressListViewModelTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -7,6 +7,10 @@ import Common
 import Shared
 import Storage
 
+protocol SearchEnginesManagerProvider {
+    var defaultEngine: OpenSearchEngine? { get }
+}
+
 protocol SearchEngineDelegate: AnyObject {
     func searchEnginesDidUpdate()
 }
@@ -30,7 +34,7 @@ protocol SearchEngineDelegate: AnyObject {
 /// enabled quick search engines, and it is possible to disable every non-default quick search engine).
 ///
 /// This class is not thread-safe -- you should only access it on a single thread (usually, the main thread)!
-class SearchEnginesManager {
+class SearchEnginesManager: SearchEnginesManagerProvider {
     private let prefs: Prefs
     private let fileAccessor: FileAccessor
     private let orderedEngineNames = "search.orderedEngineNames"

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -15,7 +15,8 @@ final class TopSitesMiddleware {
             googleTopSiteManager: GoogleTopSiteManager(
                 prefs: profile.prefs
             ),
-            topSiteHistoryManager: TopSiteHistoryManager(profile: profile)
+            topSiteHistoryManager: TopSiteHistoryManager(profile: profile),
+            searchEnginesManager: profile.searchEnginesManager
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@testable import Client
+
+class MockSearchEnginesManager: SearchEnginesManagerProvider {
+    private let searchEngine: OpenSearchEngine?
+    var defaultEngine: OpenSearchEngine? {
+        return searchEngine
+    }
+    init(searchEngine: OpenSearchEngine? = nil) {
+        self.searchEngine = searchEngine
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
@@ -23,10 +23,20 @@ class MockTopSiteHistoryManager: TopSiteHistoryManagerProvider {
         ]
     }
 
+    // Demonstrates a tile that exists under sponsored tile list
+    static var duplicateTile: [Site] {
+        return [
+            PinnedSite(
+                site: Site(url: "https://firefox.com", title: "Firefox Sponsored Tile"),
+                faviconResource: nil
+            )
+        ]
+    }
+
     static var noPinnedData: [Site] {
         return [
-            Site(url: "www.mozilla.com", title: "History-Based Tile Test"),
-            Site(url: "www.firefox.com", title: "History-Based Tile 2 Test")
+            Site(url: "https://firefox.com", title: "History-Based Tile Test"),
+            Site(url: "www.example.com", title: "History-Based Tile 2 Test")
         ]
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10477)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22941)

## :bulb: Description
Add more calculation logic for top sites, following the existing configuration as well as the wiki [doc](https://github.com/mozilla-mobile/firefox-ios/wiki/How-do-Top-Sites-(Shortcuts)-work%3F).

This PR includes adding the logic in calculating when to show a sponsored site. We want to show the sponsored site only if site is not already present in the pinned sites and it's not the default search engine.

We also remove any duplicates when comparing the other history based sites to the other sites (i.e. sponsored sites or pinned sites). This is the second part of the logic, will work on the other TODOs to wrap up the other logic.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
| Example |
| --- |
| <img src="https://github.com/user-attachments/assets/250bd1ea-409c-4a70-a079-df576b82b7be" width="250"> |

