### PR TITLE
Add FXIOS-10481 [Unified Search] Add SearchEngineSelection middleware tests and a Redux MockStoreForMiddleware

### DIFF
--- a/BrowserKit/Sources/Redux/DispatchStore.swift
+++ b/BrowserKit/Sources/Redux/DispatchStore.swift
@@ -9,8 +9,8 @@ public protocol DispatchStore {
     func dispatch(_ action: Action)
 }
 
-public protocol DefaultDispatchStore: DispatchStore {
-    associatedtype State: StateType
+public protocol DefaultDispatchStore<State>: DispatchStore where State: StateType {
+    associatedtype State
 
     var state: State { get }
 

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1856,6 +1856,7 @@
 		ED45893E2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893D2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift */; };
 		ED4589402CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */; };
 		ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */; };
+		ED70CD812CE3BD2C0018761B /* MockStoreForMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */; };
 		EDC3C2562CCAC9CB005A047F /* SearchEnginesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3C2552CCAC9CB005A047F /* SearchEnginesManager.swift */; };
 		EDC3D34F2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EDC3D34E2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets */; };
 		EDC3D3552CB70A3F00C62DE3 /* OpenSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */; };
@@ -9295,6 +9296,7 @@
 		ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSearchEngineSelectionCoordinator.swift; sourceTree = "<group>"; };
 		ED5144A0BE3A8C7B15047C3F /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinatorTests.swift; sourceTree = "<group>"; };
+		ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreForMiddleware.swift; sourceTree = "<group>"; };
 		ED84423D8666C751BBFC76AC /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Storage.strings; sourceTree = "<group>"; };
 		EDA240A8BBFD0A19FB2C3D7E /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Intro.strings; sourceTree = "<group>"; };
 		EDB94DDC89DE1F2C624C9841 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -10795,6 +10797,7 @@
 				C29B64822AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift */,
 				21FA8FB12AE856EB0013B815 /* MockTabTrayCoordinatorDelegate.swift */,
 				E19443F72AF953B000964EA5 /* MockSidebarEnabledView.swift */,
+				ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -16987,6 +16990,7 @@
 				C8EDDBF029DD83FC003A4C07 /* RouteTests.swift in Sources */,
 				0A7693612C7DD19600103A6D /* CertificatesViewModelTests.swift in Sources */,
 				8A454D372CB86B86009436D9 /* PocketStateTests.swift in Sources */,
+				ED70CD812CE3BD2C0018761B /* MockStoreForMiddleware.swift in Sources */,
 				8AED868328CA3B3400351A50 /* BookmarkPanelViewModelTests.swift in Sources */,
 				434CD57829F6FC4500A0D04B /* MockAppAuthenticator.swift in Sources */,
 				8A94418A2CE3E190007FF4E5 /* MockSearchEngineManager.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -9,10 +9,10 @@ import ToolbarKit
 final class SearchEngineSelectionMiddleware {
     private let profile: Profile
     private let logger: Logger
-    private let searchEnginesManager: SearchEnginesManager
+    private let searchEnginesManager: SearchEnginesManagerProvider
 
     init(profile: Profile = AppContainer.shared.resolve(),
-         searchEnginesManager: SearchEnginesManager? = nil,
+         searchEnginesManager: SearchEnginesManagerProvider? = nil,
          logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.logger = logger

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -9,6 +9,8 @@ import Storage
 
 protocol SearchEnginesManagerProvider {
     var defaultEngine: OpenSearchEngine? { get }
+    var orderedEngines: [OpenSearchEngine]! { get }
+    func getOrderedEngines(completion: @escaping ([OpenSearchEngine]) -> Void)
 }
 
 protocol SearchEngineDelegate: AnyObject {

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -81,11 +81,11 @@ let middlewares = [
 // we change the store to be instantiated as a variable.
 // For non testing builds, we leave the store as a constant.
 #if TESTING
-var store: some DefaultDispatchStore<AppState> = Store(state: AppState(),
-                                                       reducer: AppState.reducer,
-                                                       middlewares: middlewares)
+var store: any DefaultDispatchStore<AppState> = Store(state: AppState(),
+                                                      reducer: AppState.reducer,
+                                                      middlewares: middlewares)
 #else
-let store: some DefaultDispatchStore<AppState> = Store(state: AppState(),
-                                                       reducer: AppState.reducer,
-                                                       middlewares: middlewares)
+let store: any DefaultDispatchStore<AppState> = Store(state: AppState(),
+                                                      reducer: AppState.reducer,
+                                                      middlewares: middlewares)
 #endif

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -81,9 +81,9 @@ let middlewares = [
 // we change the store to be instantiated as a variable.
 // For non testing builds, we leave the store as a constant.
 #if TESTING
-var store = Store(state: AppState(),
-                  reducer: AppState.reducer,
-                  middlewares: middlewares)
+var store: any DefaultDispatchStore = Store(state: AppState(), // TODO make it possible to override this type...
+                                            reducer: AppState.reducer,
+                                            middlewares: middlewares)
 #else
 let store = Store(state: AppState(),
                   reducer: AppState.reducer,

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -81,11 +81,11 @@ let middlewares = [
 // we change the store to be instantiated as a variable.
 // For non testing builds, we leave the store as a constant.
 #if TESTING
-var store: any DefaultDispatchStore = Store(state: AppState(), // TODO make it possible to override this type...
-                                            reducer: AppState.reducer,
-                                            middlewares: middlewares)
+var store: some DefaultDispatchStore<AppState> = Store(state: AppState(),
+                                                       reducer: AppState.reducer,
+                                                       middlewares: middlewares)
 #else
-let store = Store(state: AppState(),
-                  reducer: AppState.reducer,
-                  middlewares: middlewares)
+let store: some DefaultDispatchStore<AppState> = Store(state: AppState(),
+                                                       reducer: AppState.reducer,
+                                                       middlewares: middlewares)
 #endif

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
@@ -14,8 +14,8 @@ import Redux
 class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
     var state: State
 
-    /// Stores the number of times dispatch is called, and the actions with which it is called. Use to ensure that your
-    /// middleware correctly dispatches the right actions in response to a given action.
+    /// Records the number of times dispatch is called, and the actions with which it is called. Check this property to
+    /// ensure that your middleware correctly dispatches the right action(s) in response to a given action.
     var dispatchCalled: (numberOfTimes: Int, withActions: [Redux.Action]) = (0, [])
 
     init(state: State) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+
+@testable import Client
+
+/// A mock Store used to test redux middlewares.
+///
+/// You should subclass and/or make your own mock store implementation if you need to highly customize it to meet the needs
+/// of testing a particular middleware. (e.g. storing a completion handler for asynchronous middleware actions so you can
+/// await expectations in your tests)
+class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
+    var state: State
+
+    /// Stores the number of times dispatch is called, and the actions with which it is called. Use to ensure that your
+    /// middleware correctly dispatches the right actions in response to a given action.
+    var dispatchCalled: (numberOfTimes: Int, withActions: [Redux.Action]) = (0, [])
+
+    init(state: State) {
+        self.state = state
+    }
+
+    func subscribe<S>(_ subscriber: S) where S: Redux.StoreSubscriber, State == S.SubscriberStateType {
+        // TODO if you need it
+    }
+
+    func subscribe<SubState, S>(
+        _ subscriber: S,
+        transform: (
+            (
+                Redux.Subscription<State>
+            ) -> Redux.Subscription<SubState>
+        )?
+    ) where SubState == S.SubscriberStateType, S: Redux.StoreSubscriber {
+        // TODO if you need it
+    }
+
+    func unsubscribe<S>(_ subscriber: S) where S: Redux.StoreSubscriber, State == S.SubscriberStateType {
+        // TODO if you need it
+    }
+
+    func unsubscribe(_ subscriber: any Redux.StoreSubscriber) {
+        // TODO if you need it
+    }
+
+    func dispatch(_ action: Redux.Action) {
+        var dispatchActions = dispatchCalled.withActions
+        dispatchActions.append(action)
+
+        dispatchCalled = (dispatchCalled.numberOfTimes + 1, dispatchActions)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
@@ -8,9 +8,9 @@ import Redux
 
 /// A mock Store used to test redux middlewares.
 ///
-/// You should subclass and/or make your own mock store implementation if you need to highly customize it to meet the needs
-/// of testing a particular middleware. (e.g. storing a completion handler for asynchronous middleware actions so you can
-/// await expectations in your tests)
+/// If you need to highly customize this mock to meet your testing needs, you should subclass it and/or make your own mock
+/// store implementation (e.g. storing a completion handler for asynchronous middleware actions so you can await expectations
+///  in your tests).
 class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
     var state: State
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
@@ -29,10 +29,8 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase {
 
         // We must reset and configure the global mock store prior to each test
         subject = createSubject(mockSearchEnginesManager: mockSearchEnginesManager)
-        let mockStore: some DefaultDispatchStore<AppState> = MockStoreForMiddleware(state: AppState())
-        #if TESTING
+        mockStore = MockStoreForMiddleware(state: AppState())
         store = mockStore
-        #endif
     }
 
     override func tearDown() {
@@ -43,7 +41,7 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase {
     func testViewDidLoad_dispatchesDidLoadSearchEngines() throws {
         let action = getAction(for: .viewDidLoad)
 
-        store.dispatch(action)
+        subject.searchEngineSelectionProvider(AppState(), action)
 
         guard let actionCalled = mockStore.dispatchCalled.withActions.first as? SearchEngineSelectionAction,
               case SearchEngineSelectionActionType.didLoadSearchEngines = actionCalled.actionType else {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
@@ -10,7 +10,7 @@ import XCTest
 final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockStore: MockStoreForMiddleware<AppState>!
     var mockProfile: MockProfile!
-    var mockSearchEnginesManager: SearchEnginesManager!
+    var mockSearchEnginesManager: SearchEnginesManagerProvider!
     let mockSearchEngines: [OpenSearchEngine] = [
         OpenSearchEngineTests.generateOpenSearchEngine(type: .wikipedia, withImage: UIImage()),
         OpenSearchEngineTests.generateOpenSearchEngine(type: .youtube, withImage: UIImage()),
@@ -24,8 +24,7 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
 
         DependencyHelperMock().bootstrapDependencies()
         mockProfile = MockProfile()
-        mockSearchEnginesManager = SearchEnginesManager(prefs: mockProfile.prefs, files: mockProfile.files)
-        mockSearchEnginesManager.orderedEngines = mockSearchEngines
+        mockSearchEnginesManager = MockSearchEnginesManager(searchEngines: mockSearchEngines)
 
         // We must reset the global mock store prior to each test
         setupTestingStore()
@@ -68,7 +67,7 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
 
     // MARK: - Helpers
 
-    private func createSubject(mockSearchEnginesManager: SearchEnginesManager) -> SearchEngineSelectionMiddleware {
+    private func createSubject(mockSearchEnginesManager: SearchEnginesManagerProvider) -> SearchEngineSelectionMiddleware {
         return SearchEngineSelectionMiddleware(profile: mockProfile, searchEnginesManager: mockSearchEnginesManager)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @testable import Client
 
-final class SearchEngineSelectionMiddlewareTests: XCTestCase {
+final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockStore: MockStoreForMiddleware<AppState>!
     var mockProfile: MockProfile!
     var mockSearchEnginesManager: SearchEnginesManager!
@@ -21,18 +21,19 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+
         DependencyHelperMock().bootstrapDependencies()
         mockProfile = MockProfile()
         mockSearchEnginesManager = SearchEnginesManager(prefs: mockProfile.prefs, files: mockProfile.files)
         mockSearchEnginesManager.orderedEngines = mockSearchEngines
 
         // We must reset the global mock store prior to each test
-        mockStore = MockStoreForMiddleware(state: AppState())
-        store = mockStore
+        setupTestingStore()
     }
 
     override func tearDown() {
         DependencyHelperMock().reset()
+        resetTestingStore()
         super.tearDown()
     }
 
@@ -76,5 +77,30 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase {
             windowUUID: .XCTestDefaultUUID,
             actionType: actionType
         )
+    }
+
+    // MARK: StoreTestUtility
+
+    func setupAppState() -> AppState {
+        return AppState(
+            activeScreens: ActiveScreensState(
+                screens: [
+                    .searchEngineSelection(
+                        SearchEngineSelectionState(windowUUID: .XCTestDefaultUUID)
+                    )
+                ]
+            )
+        )
+    }
+
+    func setupTestingStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupTestingStore(with: mockStore)
+    }
+
+    // In order to avoid flaky tests, we should reset the store
+    // similar to production
+    func resetTestingStore() {
+        StoreTestUtilityHelper.resetTestingStore()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
@@ -29,9 +29,9 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase {
 
         // We must reset and configure the global mock store prior to each test
         subject = createSubject(mockSearchEnginesManager: mockSearchEnginesManager)
-        let mockStore = MockStoreForMiddleware(state: AppState())
+        let mockStore: some DefaultDispatchStore<AppState> = MockStoreForMiddleware(state: AppState())
         #if TESTING
-        store = mockStore as? DefaultDispatchStore
+        store = mockStore
         #endif
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockSearchEngineManager.swift
@@ -7,11 +7,21 @@ import Foundation
 @testable import Client
 
 class MockSearchEnginesManager: SearchEnginesManagerProvider {
-    private let searchEngine: OpenSearchEngine?
+    private let searchEngines: [OpenSearchEngine]
+
     var defaultEngine: OpenSearchEngine? {
-        return searchEngine
+        return searchEngines.first
     }
-    init(searchEngine: OpenSearchEngine? = nil) {
-        self.searchEngine = searchEngine
+
+    var orderedEngines: [OpenSearchEngine]! {
+        return searchEngines
+    }
+
+    init(searchEngines: [OpenSearchEngine] = []) {
+        self.searchEngines = searchEngines
+    }
+
+    func getOrderedEngines(completion: @escaping ([OpenSearchEngine]) -> Void) {
+        completion(searchEngines)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
@@ -8,7 +8,6 @@ import XCTest
 @testable import Client
 
 final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
-    let storeUtilityHelper = StoreTestUtilityHelper()
     let pocketManager = MockPocketManager()
     override func setUp() {
         super.setUp()
@@ -68,7 +67,7 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
     }
 
     func setupTestingStore() {
-        storeUtilityHelper.setupTestingStore(
+        StoreTestUtilityHelper.setupTestingStore(
             with: setupAppState(),
             middlewares: [PocketMiddleware().pocketSectionProvider]
         )
@@ -77,6 +76,6 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
     // In order to avoid flaky tests, we should reset the store
     // similar to production
     func resetTestingStore() {
-        storeUtilityHelper.resetTestingStore()
+        StoreTestUtilityHelper.resetTestingStore()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
@@ -241,7 +241,7 @@ final class TopSitesManagerTests: XCTestCase {
             contileProvider: MockContileProvider(
                 result: .success(MockContileProvider.defaultSuccessData)
             ),
-            searchEngineManager: MockSearchEnginesManager(searchEngine: searchEngine)
+            searchEngineManager: MockSearchEnginesManager(searchEngines: [searchEngine])
         )
 
         let topSites = await subject.getTopSites()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
@@ -9,7 +9,6 @@ import XCTest
 @testable import Client
 
 final class MicrosurveyMiddlewareIntegrationTests: XCTestCase, StoreTestUtility {
-    let storeUtilityHelper = StoreTestUtilityHelper()
     override func setUp() {
         super.setUp()
         Glean.shared.resetGlean(clearStores: true)
@@ -118,7 +117,7 @@ final class MicrosurveyMiddlewareIntegrationTests: XCTestCase, StoreTestUtility 
     }
 
     func setupTestingStore() {
-        storeUtilityHelper.setupTestingStore(
+        StoreTestUtilityHelper.setupTestingStore(
             with: setupAppState(),
             middlewares: [MicrosurveyMiddleware().microsurveyProvider]
         )
@@ -127,6 +126,6 @@ final class MicrosurveyMiddlewareIntegrationTests: XCTestCase, StoreTestUtility 
     // In order to avoid flaky tests, we should reset the store
     // similar to production
     func resetTestingStore() {
-        storeUtilityHelper.resetTestingStore()
+        StoreTestUtilityHelper.resetTestingStore()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
@@ -15,20 +15,24 @@ protocol StoreTestUtility {
 /// Utility class used when replacing the global store for testing purposes
 class StoreTestUtilityHelper {
     func setupTestingStore(with appState: AppState, middlewares: [Middleware<AppState>]) {
+        #if TESTING
         store = Store(
             state: appState,
             reducer: AppState.reducer,
             middlewares: middlewares
         )
+        #endif
     }
 
     /// In order to avoid flaky tests, we should reset the store
     /// similar to production
     func resetTestingStore() {
+        #if TESTING
         store = Store(
             state: AppState(),
             reducer: AppState.reducer,
             middlewares: middlewares
         )
+        #endif
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
@@ -14,7 +14,7 @@ protocol StoreTestUtility {
 
 /// Utility class used when replacing the global store for testing purposes
 class StoreTestUtilityHelper {
-    func setupTestingStore(with appState: AppState, middlewares: [Middleware<AppState>]) {
+    static func setupTestingStore(with appState: AppState, middlewares: [Middleware<AppState>]) {
         store = Store(
             state: appState,
             reducer: AppState.reducer,
@@ -22,9 +22,12 @@ class StoreTestUtilityHelper {
         )
     }
 
-    /// In order to avoid flaky tests, we should reset the store
-    /// similar to production
-    func resetTestingStore() {
+    static func setupTestingStore(with mockStore: any DefaultDispatchStore<AppState>) {
+        store = mockStore
+    }
+
+    /// In order to avoid flaky tests, we should reset the store similar to production
+    static func resetTestingStore() {
         store = Store(
             state: AppState(),
             reducer: AppState.reducer,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
@@ -15,34 +15,20 @@ protocol StoreTestUtility {
 /// Utility class used when replacing the global store for testing purposes
 class StoreTestUtilityHelper {
     func setupTestingStore(with appState: AppState, middlewares: [Middleware<AppState>]) {
-        #if TESTING
-        let mockStore: some DefaultDispatchStore<AppState> = MockStoreForMiddleware(state: AppState())
-
-        store = mockStore
-
-        // FIXME
-//        store = Store(
-//            state: AppState(),
-//            reducer: AppState.reducer,
-//            middlewares: middlewares
-//        )
-        #endif
+        store = Store(
+            state: appState,
+            reducer: AppState.reducer,
+            middlewares: middlewares
+        )
     }
 
     /// In order to avoid flaky tests, we should reset the store
     /// similar to production
     func resetTestingStore() {
-        #if TESTING
-        let mockStore: some DefaultDispatchStore<AppState> = MockStoreForMiddleware(state: AppState())
-
-        store = mockStore
-
-        // FIXME
-//        store = Store(
-//            state: AppState(),
-//            reducer: AppState.reducer,
-//            middlewares: middlewares
-//        )
-        #endif
+        store = Store(
+            state: AppState(),
+            reducer: AppState.reducer,
+            middlewares: middlewares
+        )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
@@ -16,11 +16,16 @@ protocol StoreTestUtility {
 class StoreTestUtilityHelper {
     func setupTestingStore(with appState: AppState, middlewares: [Middleware<AppState>]) {
         #if TESTING
-        store = Store(
-            state: appState,
-            reducer: AppState.reducer,
-            middlewares: middlewares
-        )
+        let mockStore: some DefaultDispatchStore<AppState> = MockStoreForMiddleware(state: AppState())
+
+        store = mockStore
+
+        // FIXME
+//        store = Store(
+//            state: AppState(),
+//            reducer: AppState.reducer,
+//            middlewares: middlewares
+//        )
         #endif
     }
 
@@ -28,11 +33,16 @@ class StoreTestUtilityHelper {
     /// similar to production
     func resetTestingStore() {
         #if TESTING
-        store = Store(
-            state: AppState(),
-            reducer: AppState.reducer,
-            middlewares: middlewares
-        )
+        let mockStore: some DefaultDispatchStore<AppState> = MockStoreForMiddleware(state: AppState())
+
+        store = mockStore
+
+        // FIXME
+//        store = Store(
+//            state: AppState(),
+//            reducer: AppState.reducer,
+//            middlewares: middlewares
+//        )
         #endif
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10481)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22951)

## :bulb: Description
This PR implements a way for us to mock our global redux store so we can more effectively test our middlewares.

Using this basic implementation of `MockStoreForMiddleware`, we can now inspect how a middleware interacts with the global store (e.g. firing additional middleware actions with the correct payloads, etc.).

@cyndichin and @Cramsden can extend and/or otherwise repurpose this work for their own needs for [FXIOS-10519](https://mozilla-hub.atlassian.net/browse/FXIOS-10519).

Thanks @Cramsden for pairing on this! 🙏 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)



[FXIOS-10519]: https://mozilla-hub.atlassian.net/browse/FXIOS-10519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ