### PR TITLE
Add FXIOS-9744 Hide desktop bookmarks folder

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
@@ -116,18 +116,19 @@ class BookmarksPanelViewModel: BookmarksRefactorFeatureFlagProvider {
 
                 // Create a local "Desktop bookmarks" folder only if there exists a bookmark in one of it's nested
                 // subfolders
-                self.bookmarksHandler.countBookmarksInTrees(
-                    folderGuids: [
-                        BookmarkRoots.UnfiledFolderGUID,
-                        BookmarkRoots.MenuFolderGUID,
-                        BookmarkRoots.ToolbarFolderGUID
-                    ]
-                ).uponQueue(.main) { result in
-                    if let bookmarkCount = result.successValue, bookmarkCount > 0 || !self.isBookmarkRefactorEnabled {
-                        let desktopFolder = LocalDesktopFolder()
-                        self.bookmarkNodes.insert(desktopFolder, at: 0)
+                self.bookmarksHandler.countBookmarksInTrees(folderGuids: BookmarkRoots.DesktopRoots.map { $0 }) { result in
+                    DispatchQueue.main.async {
+                        switch result {
+                        case .success(let bookmarkCount):
+                            if bookmarkCount > 0 || !self.isBookmarkRefactorEnabled {
+                                let desktopFolder = LocalDesktopFolder()
+                                self.bookmarkNodes.insert(desktopFolder, at: 0)
+                            }
+                        case .failure(let error):
+                            self.logger.log("Error counting bookmarks: \(error)", level: .debug, category: .library)
+                        }
+                        completion()
                     }
-                    completion()
                 }
             }
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
@@ -259,7 +259,8 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
         if profile.isShutdown { return }
         profile.places.getBookmarksTree(rootGUID: BookmarkRoots.RootGUID, recursive: true)
             .uponQueue(.main) { bookmarksTreeResult in
-            self.profile.places.countBookmarksInTrees(folderGuids: BookmarkRoots.DesktopRoots.map { $0 }) { bookmarksCountResult in
+                self.profile.places.countBookmarksInTrees(
+                    folderGuids: BookmarkRoots.DesktopRoots.map { $0 }) { bookmarksCountResult in
                 DispatchQueue.main.async {
                     guard let rootFolder = bookmarksTreeResult.successValue as? BookmarkFolderData else {
                         // TODO: Handle error case?
@@ -317,8 +318,8 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
                     self.bookmarkFolders = bookmarkFolders
                     self.tableView.reloadData()
                 }
+                }
             }
-        }
     }
 
     func updateSaveButton() {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
@@ -253,7 +253,8 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
     override func reloadData() {
         // Can be called while app backgrounded and the db closed, don't try to reload the data source in this case
         if profile.isShutdown { return }
-        profile.places.getBookmarksTree(rootGUID: BookmarkRoots.RootGUID, recursive: true).uponQueue(.main) { bookmarksTreeResult in
+        profile.places.getBookmarksTree(rootGUID: BookmarkRoots.RootGUID, recursive: true)
+            .uponQueue(.main) { bookmarksTreeResult in
             self.profile.places.countBookmarksInTrees(folderGuids: BookmarkRoots.DesktopRoots.map { $0 })
                 .uponQueue(.main) { bookmarksCountResult in
                     guard let rootFolder = bookmarksTreeResult.successValue as? BookmarkFolderData else {
@@ -309,8 +310,8 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
                     addFolderAndDescendants(rootFolder)
                     self.bookmarkFolders = bookmarkFolders
                     self.tableView.reloadData()
+                }
             }
-        }
     }
 
     func updateSaveButton() {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
@@ -299,8 +299,7 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
                                 addFolder(childFolder: childFolder)
                             } else {
                                 if let bookmarkCount = bookmarksCountResult.successValue,
-                                   bookmarkCount > 0,
-                                   BookmarkRoots.DesktopRoots.contains(childFolder.guid)
+                                   (bookmarkCount > 0 && BookmarkRoots.DesktopRoots.contains(childFolder.guid))
                                     || !self.isBookmarkRefactorEnabled {
                                     addFolder(childFolder: childFolder)
                                 }

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -33,6 +33,7 @@ import struct MozillaAppServices.VisitTransitionSet
 public protocol BookmarksHandler {
     func getRecentBookmarks(limit: UInt, completion: @escaping ([BookmarkItemData]) -> Void)
     func getBookmarksTree(rootGUID: GUID, recursive: Bool) -> Deferred<Maybe<BookmarkNodeData?>>
+    func countBookmarksInTrees(folderGuids: [GUID]) -> Deferred<Maybe<Int>>
     func updateBookmarkNode(
         guid: GUID,
         parentGUID: GUID?,
@@ -197,6 +198,12 @@ public class RustPlaces: BookmarksHandler, HistoryMetadataObserver {
 
         deferredResponse.upon { result in
             completion(result.successValue ?? [])
+        }
+    }
+
+    public func countBookmarksInTrees(folderGuids: [GUID]) -> Deferred<Maybe<Int>> {
+        return withReader { connection in
+            return try connection.countBookmarksInTrees(folderGuids: folderGuids)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Bookmarks/BookmarksHandlerMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Bookmarks/BookmarksHandlerMock.swift
@@ -45,4 +45,10 @@ class BookmarksHandlerMock: BookmarksHandler {
                             url: String?) -> Success {
         succeed()
     }
+
+    func countBookmarksInTrees(folderGuids: [GUID]) -> Deferred<Maybe<Int>> {
+        let deferred = Deferred<Maybe<Int>>()
+        deferred.fill(Maybe(success: 0))
+        return deferred
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Bookmarks/BookmarksHandlerMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Bookmarks/BookmarksHandlerMock.swift
@@ -46,9 +46,7 @@ class BookmarksHandlerMock: BookmarksHandler {
         succeed()
     }
 
-    func countBookmarksInTrees(folderGuids: [GUID]) -> Deferred<Maybe<Int>> {
-        let deferred = Deferred<Maybe<Int>>()
-        deferred.fill(Maybe(success: 0))
-        return deferred
+    func countBookmarksInTrees(folderGuids: [GUID], completion: @escaping (Result<Int, Error>) -> Void) {
+        completion(.success(0))
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
@@ -95,15 +95,23 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
             parentGUID: BookmarkRoots.MenuFolderGUID,
             url: "https://www.firefox.com",
             title: "Firefox",
-            position: 0).uponQueue(.main) { result in
-            self.profile.places.countBookmarksInTrees(folderGuids: [BookmarkRoots.MenuFolderGUID]).uponQueue(.main) { res in
-                guard let bookmarkCount = res.successValue else { return }
-                XCTAssertEqual(bookmarkCount, 1, "Menu folder contains one bookmark")
+            position: 0
+        ).uponQueue(.main) { _ in
+            self.profile.places.countBookmarksInTrees(folderGuids: [BookmarkRoots.MenuFolderGUID]) { result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success(let bookmarkCount):
+                        XCTAssertEqual(bookmarkCount, 1, "Menu folder contains one bookmark")
 
-                subject.reloadData {
-                    XCTAssertNotNil(subject.bookmarkFolder)
-                    XCTAssertEqual(subject.bookmarkNodes.count, 1, "Mobile folder contains the local desktop folder")
-                    expectation.fulfill()
+                        subject.reloadData {
+                            XCTAssertNotNil(subject.bookmarkFolder)
+                            XCTAssertEqual(subject.bookmarkNodes.count, 1, "Mobile folder contains the local desktop folder")
+                            expectation.fulfill()
+                        }
+                    case .failure(let error):
+                        XCTFail("Failed to count bookmarks: \(error)")
+                        expectation.fulfill()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9744)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21408)

## :bulb: Description
- Hide the `Desktop Bookmarks` root folder (and nested `Toolbar`, `Menu`, and `Unfiled`) if it does not contain recursively any bookmarks (even when signed into a Mozilla Account)

### 📝 Discussion
- The nested `Toolbar`, `Menu`, and `Unfiled` are now conditionally hidden from `BookmarksViewController`, `LegacyBookmarkDetailPanel` and `EditBookmarkViewController`

### 📦 Dependencies 
- Depends on the following to A~S PR's
  - [Add countBookmarksInTrees swift wrapper](https://github.com/mozilla/application-services/pull/6463) ✅
  - [Add DesktopRoots convenience property](https://github.com/mozilla/application-services/pull/6470) ✅

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

