### PR TITLE
Refactor MTE-3847 testWebsiteDataOptions fails intermittently

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
@@ -36,8 +36,9 @@ class DataManagementTests: BaseTestCase {
             app.cells.staticTexts.firstMatch.tap()
         }
 
-        app.otherElements.staticTexts["Clear Items: 1"].tap()
-        app.alerts.buttons["OK"].tap()
+        app.otherElements.staticTexts["Clear Items: 1"].waitAndTap()
+        app.alerts.buttons["OK"].waitAndTap()
+        mozWaitForElementToNotExist(app.alerts.buttons["OK"])
         if #available(iOS 17, *) {
             XCTAssertEqual(beforeDelete-1, app.cells.images.count, "The first entry has not been deleted correctly")
         } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browseMTE-3847)

## :bulb: Description
`testWebsiteDataOptions` fails intermittently because the list of websites may not be updated quickly enough. Let's check the number of sites *after* the dialog is closed completely.

Example report: https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests-iPad/result_863/build/reports/index.html

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

