### PR TITLE
Bugfix FXIOS-10512 #23050 ⁃ [Menu] [Accessibility] - "Tools" and "Save" headers are not announced

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
@@ -98,11 +98,16 @@ public final class NavigationHeaderView: UIView {
 
     public func setupAccessibility(closeButtonA11yLabel: String,
                                    closeButtonA11yId: String,
+                                   titleA11yId: String? = nil,
                                    backButtonA11yLabel: String,
                                    backButtonA11yId: String) {
         let closeButtonViewModel = CloseButtonViewModel(a11yLabel: closeButtonA11yLabel,
                                                         a11yIdentifier: closeButtonA11yId)
         closeButton.configure(viewModel: closeButtonViewModel)
+        if let titleA11yId {
+            titleLabel.isAccessibilityElement = true
+            titleLabel.accessibilityIdentifier = titleA11yId
+        }
         backButton.accessibilityIdentifier = backButtonA11yId
         backButton.accessibilityLabel = backButtonA11yLabel
     }

--- a/BrowserKit/Sources/MenuKit/MenuDetailView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuDetailView.swift
@@ -49,10 +49,12 @@ public final class MenuDetailView: UIView,
 
     public func setupAccessibilityIdentifiers(closeButtonA11yLabel: String,
                                               closeButtonA11yId: String,
+                                              titleA11yId: String? = nil,
                                               backButtonA11yLabel: String,
                                               backButtonA11yId: String) {
         detailHeaderView.setupAccessibility(closeButtonA11yLabel: closeButtonA11yLabel,
                                             closeButtonA11yId: closeButtonA11yId,
+                                            titleA11yId: titleA11yId,
                                             backButtonA11yLabel: backButtonA11yLabel,
                                             backButtonA11yId: backButtonA11yId)
     }

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -80,6 +80,7 @@ public struct AccessibilityIdentifiers {
 
         struct NavigationHeaderView {
             static let backButton = "MainMenu.BackButton"
+            static let title = "MainMenu.Title"
             static let closeButton = "MainMenu.CloseMenuButton"
         }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuDetailsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuDetailsViewController.swift
@@ -102,6 +102,7 @@ class MainMenuDetailsViewController: UIViewController,
         submenuContent.setupAccessibilityIdentifiers(
             closeButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.CloseButton,
             closeButtonA11yId: AccessibilityIdentifiers.MainMenu.NavigationHeaderView.closeButton,
+            titleA11yId: AccessibilityIdentifiers.MainMenu.NavigationHeaderView.title,
             backButtonA11yLabel: .MainMenu.Account.AccessibilityLabels.BackButton,
             backButtonA11yId: AccessibilityIdentifiers.MainMenu.NavigationHeaderView.backButton)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10512)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23050)

## :bulb: Description
Fixed the accessibility label for navigation header title label, for Menu

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

