### PR TITLE
Refactor MTE-3807 Send notification to mobile-alerts-ios

### DIFF
--- a/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
+++ b/.github/workflows/firefox-ios-autofill-playwrite-tests.yml
@@ -60,5 +60,5 @@ jobs:
           env:
             JOB_STATUS: ${{ job.status == 'success' && ':white_check_mark:' || job.status == 'failure' && ':x:' }}
             JOB_STATUS_COLOR: ${{ job.status == 'success' && '#36a64f' || job.status == 'failure' && '#FF0000' }}
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            SLACK_WEBHOOK_URL: ${{ secrets.WEBHOOK_SLACK_TOKEN }}
             SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/firefox-ios-update_credential_provider_script.yml
+++ b/.github/workflows/firefox-ios-update_credential_provider_script.yml
@@ -64,4 +64,4 @@ jobs:
   call-firefox-ios-autofill-playwrite-tests:
     uses: ./.github/workflows/firefox-ios-autofill-playwrite-tests.yml
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.WEBHOOK_SLACK_TOKEN }}

--- a/.github/workflows/firefox-ios-update_remote_settings_data_script.yml
+++ b/.github/workflows/firefox-ios-update_remote_settings_data_script.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           JOB_STATUS: ${{ job.status == 'success' && ':white_check_mark:' || job.status == 'failure' && ':x:' }}
           JOB_STATUS_COLOR: ${{ job.status == 'success' && '#36a64f' || job.status == 'failure' && '#FF0000' }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.WEBHOOK_SLACK_TOKEN }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         with:
           payload-file-path: "./test-fixtures/ci/slack-notification-payload-remote-settings-fetch.json"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3807)

Currently the slack notifications are sent to mobile-alerts-sandbox, a channel the MTE team has to experiment and polish the notifications. Once they are good to go, they should be in the iOS specific channel for more visibility.


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

