### PR TITLE
Bugfix FXIOS-10251 iPad not recognizing Firefox pair website

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		0AFF7F6D2C7C7BBA00265214 /* CertificatesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFF7F6A2C7C7BB900265214 /* CertificatesViewController.swift */; };
 		0B11AF022CB412D100AD51D5 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B11AF002CB412D100AD51D5 /* Metrics.swift */; };
 		0B11AF042CB4130F00AD51D5 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B11AF032CB4130F00AD51D5 /* Metrics.swift */; };
+		0B1C58D12CE5019A00F498F0 /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B1C58D02CE5019A00F498F0 /* UserAgentTests.swift */; };
 		0B305E1B1E3A98A900BE0767 /* BookmarksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B305E1A1E3A98A900BE0767 /* BookmarksTests.swift */; };
 		0B3D670E1E09B90B00C1EFC7 /* AuthenticationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3D670D1E09B90B00C1EFC7 /* AuthenticationTest.swift */; };
 		0B3F8C5E2CA4471C00DB5367 /* EditBookmarkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3F8C5D2CA4471C00DB5367 /* EditBookmarkViewModel.swift */; };
@@ -2307,6 +2308,7 @@
 		0AFF7F6A2C7C7BB900265214 /* CertificatesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CertificatesViewController.swift; sourceTree = "<group>"; };
 		0B11AF002CB412D100AD51D5 /* Metrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
 		0B11AF032CB4130F00AD51D5 /* Metrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
+		0B1C58D02CE5019A00F498F0 /* UserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
 		0B305E1A1E3A98A900BE0767 /* BookmarksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksTests.swift; sourceTree = "<group>"; };
 		0B3D670D1E09B90B00C1EFC7 /* AuthenticationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationTest.swift; sourceTree = "<group>"; };
 		0B3F8C5D2CA4471C00DB5367 /* EditBookmarkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditBookmarkViewModel.swift; sourceTree = "<group>"; };
@@ -13775,6 +13777,7 @@
 				E6F9650E1B2F1CF20034B023 /* Supporting Files */,
 				E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */,
 				28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */,
+				0B1C58D02CE5019A00F498F0 /* UserAgentTests.swift */,
 			);
 			path = SharedTests;
 			sourceTree = "<group>";
@@ -15841,6 +15844,7 @@
 			files = (
 				6F994AFD2AF56234008B8112 /* NetworkUtilsTests.swift in Sources */,
 				28532BEB1C472015000072D9 /* UtilsTests.swift in Sources */,
+				0B1C58D12CE5019A00F498F0 /* UserAgentTests.swift in Sources */,
 				28532BEA1C472008000072D9 /* DeferredTests.swift in Sources */,
 				0ECB6B6D2CCFF718006A7C82 /* DateGroupedTableDataTests.swift in Sources */,
 				5A292129295CA8A900242235 /* ThemableTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		0B8BF3752CA2EFC000E9812D /* EditBookmarkCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8BF3742CA2EFC000E9812D /* EditBookmarkCell.swift */; };
 		0B8E0FF41A932BD500161DC3 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8E0FF31A932BD500161DC3 /* ImageIO.framework */; };
 		0BA02DB22942605600C92603 /* FormAutofillHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA02DB12942605600C92603 /* FormAutofillHelper.swift */; };
+		0BA152502CE78DAD0090B869 /* UserAgentBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA1524F2CE78DAD0090B869 /* UserAgentBuilderTests.swift */; };
 		0BA1E00E1B03FB0B007675AF /* NetError.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BA1E00D1B03FB0B007675AF /* NetError.html */; };
 		0BA1E0301B051A07007675AF /* NetError.css in Resources */ = {isa = PBXBuildFile; fileRef = 0BA1E02F1B051A07007675AF /* NetError.css */; };
 		0BA8964B1A250E6500C1010C /* ProfileTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA896491A250E6500C1010C /* ProfileTest.swift */; };
@@ -2330,6 +2331,7 @@
 		0B9D40781E8D5AC80059E664 /* XCUITests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUITests-Bridging-Header.h"; sourceTree = "<group>"; };
 		0BA02DB12942605600C92603 /* FormAutofillHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormAutofillHelper.swift; sourceTree = "<group>"; };
 		0BA049CE9929DAA536A2CB2F /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/3DTouchActions.strings"; sourceTree = "<group>"; };
+		0BA1524F2CE78DAD0090B869 /* UserAgentBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentBuilderTests.swift; sourceTree = "<group>"; };
 		0BA1E00D1B03FB0B007675AF /* NetError.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = NetError.html; sourceTree = "<group>"; };
 		0BA1E02F1B051A07007675AF /* NetError.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = NetError.css; sourceTree = "<group>"; };
 		0BA896491A250E6500C1010C /* ProfileTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileTest.swift; sourceTree = "<group>"; };
@@ -13778,6 +13780,7 @@
 				E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */,
 				28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */,
 				0B1C58D02CE5019A00F498F0 /* UserAgentTests.swift */,
+				0BA1524F2CE78DAD0090B869 /* UserAgentBuilderTests.swift */,
 			);
 			path = SharedTests;
 			sourceTree = "<group>";
@@ -15856,6 +15859,7 @@
 				28532BE91C471FFB000072D9 /* ResultTests.swift in Sources */,
 				E6F9653C1B2F1D5D0034B023 /* NSURLExtensionsTests.swift in Sources */,
 				5A29212A295CAA1700242235 /* XCTestCaseRootViewController.swift in Sources */,
+				0BA152502CE78DAD0090B869 /* UserAgentBuilderTests.swift in Sources */,
 				3B4AA24B1D8B8C4C00A2E008 /* ArrayExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/firefox-ios/Shared/UserAgent.swift
+++ b/firefox-ios/Shared/UserAgent.swift
@@ -108,7 +108,7 @@ struct CustomUserAgentConstant {
         "yahoo.com": defaultMobileUA,
         "disneyplus.com": customDesktopUA
     ]
-    
+
     static let customDesktopUAForDomain = [
         "firefox.com": defaultMobileUA
     ]

--- a/firefox-ios/Shared/UserAgent.swift
+++ b/firefox-ios/Shared/UserAgent.swift
@@ -71,13 +71,15 @@ open class UserAgent {
     public static func getUserAgent(domain: String, platform: UserAgentPlatform) -> String {
         switch platform {
         case .Desktop:
-            return desktopUserAgent()
+            guard let customUA = CustomUserAgentConstant.customDesktopUAForDomain[domain] else {
+                return desktopUserAgent()
+            }
+            return customUA
         case .Mobile:
-            if let customUA = CustomUserAgentConstant.customUAFor[domain] {
-                return customUA
-            } else {
+            guard let customUA = CustomUserAgentConstant.customMobileUAForDomain[domain] else {
                 return mobileUserAgent()
             }
+            return customUA
         }
     }
 
@@ -97,14 +99,19 @@ public enum UserAgentPlatform {
     case Mobile
 }
 
-public struct CustomUserAgentConstant {
+struct CustomUserAgentConstant {
     private static let defaultMobileUA = UserAgentBuilder.defaultMobileUserAgent().userAgent()
     private static let customDesktopUA = UserAgentBuilder.defaultDesktopUserAgent().clone(extensions: "Version/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
 
-    public static let customUAFor = [
+    static let customMobileUAForDomain = [
         "paypal.com": defaultMobileUA,
         "yahoo.com": defaultMobileUA,
-        "disneyplus.com": customDesktopUA]
+        "disneyplus.com": customDesktopUA
+    ]
+    
+    static let customDesktopUAForDomain = [
+        "firefox.com": defaultMobileUA
+    ]
 }
 
 public struct UserAgentBuilder {

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+@testable import Shared
+
+final class UserAgentBuilderTests: XCTestCase {
+    func testUserAgent_generateCorrectString() {
+        let builder = createSubject(
+            product: "FXIOS",
+            systemInfo: "iPhone",
+            platform: "Apple",
+            platformDetails: "",
+            extensions: "15.09.0"
+        )
+        let agent = builder.userAgent()
+
+        XCTAssertEqual(agent, "FXIOS iPhone Apple 15.09.0")
+    }
+
+    func testClone_generateCorrectString() {
+        let builder = createSubject(
+            product: "FXIOS",
+            systemInfo: "iPhone",
+            platform: "Apple  ",
+            platformDetails: " Details ",
+            extensions: " 15.09.0 "
+        )
+
+        let agent = builder.clone(
+            product: "FXIOS1",
+            systemInfo: "iPhone12",
+            platform: "Apple 5",
+            platformDetails: "New details",
+            extensions: "14.090"
+        )
+        return XCTAssertEqual(agent, "FXIOS1 iPhone12 Apple 5 New details 14.090")
+    }
+
+    func testDefaultMobileUserAgent() {
+        let builder = UserAgentBuilder.defaultMobileUserAgent()
+        let systemInfo = "(\(UIDevice.current.model); CPU iPhone OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)"
+        let extensions = "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)"
+        let testAgent = "\(UserAgent.product) \(systemInfo) \(UserAgent.platform) \(UserAgent.platformDetails) \(extensions)"
+        XCTAssertEqual(builder.userAgent(), testAgent)
+    }
+
+    func testDefaultDesktopUserAgent() {
+        let builder = UserAgentBuilder.defaultDesktopUserAgent()
+        let systemInfo = "(Macintosh; Intel Mac OS X 10.15)"
+        let extensions = "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)"
+        let testAgent = "\(UserAgent.product) \(systemInfo) \(UserAgent.platform) \(UserAgent.platformDetails) \(extensions)"
+        XCTAssertEqual(builder.userAgent(), testAgent)
+    }
+
+    private func createSubject(
+        product: String,
+        systemInfo: String,
+        platform: String,
+        platformDetails: String,
+        extensions: String
+    ) -> UserAgentBuilder {
+        return UserAgentBuilder(
+            product: product,
+            systemInfo: systemInfo,
+            platform: platform,
+            platformDetails: platformDetails,
+            extensions: extensions
+        )
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Shared
+import Common
+
+final class UserAgentTests: XCTestCase {
+    func testGetUserAgentDesktop_withListedDomain_returnProperUserAgent() {
+        let domains = CustomUserAgentConstant.customDesktopUAForDomain
+        domains.forEach { domain, agent in
+            XCTAssertEqual(agent, UserAgent.getUserAgent(domain: domain, platform: .Desktop))
+        }
+    }
+
+    func testGetUserAgentMobile_withListedDomain_returnProperUserAgent() {
+        let domains = CustomUserAgentConstant.customMobileUAForDomain
+        domains.forEach { domain, agent in
+            XCTAssertEqual(agent, UserAgent.getUserAgent(domain: domain, platform: .Mobile))
+        }
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10251)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22435)

## :bulb: Description
Bugfix iPad not recognizing Firefox pair website.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

