### PR TITLE
Bugfix FXIOS-10509 ⁃ [Experiment] The Menu Redesign CFR should be displayed for new users that have seen the old menu

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2332,7 +2332,8 @@ class BrowserViewController: UIViewController,
         menuHelper.navigationHandler = navigationHandler
 
         updateZoomPageBarVisibility(visible: false)
-        menuHelper.getToolbarActions(navigationController: navigationController) { actions in
+        menuHelper.getToolbarActions(navigationController: navigationController) { [weak self] actions in
+            guard let self else { return }
             let shouldInverse = PhotonActionSheetViewModel.hasInvertedMainMenu(
                 trait: self.traitCollection,
                 isBottomSearchBar: self.isBottomSearchBar
@@ -2343,6 +2344,9 @@ class BrowserViewController: UIViewController,
                 isMainMenu: true,
                 isMainMenuInverted: shouldInverse
             )
+            if self.profile.prefs.boolForKey(PrefsKeys.PhotonMainMenuShown) == nil {
+                self.profile.prefs.setBool(true, forKey: PrefsKeys.PhotonMainMenuShown)
+            }
             self.presentSheetWith(viewModel: viewModel, on: self, from: button)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -380,12 +380,12 @@ class MainMenuViewController: UIViewController,
         if InstallType.get() == .fresh {
             if let photonMainMenuShown = profile.prefs.boolForKey(PrefsKeys.PhotonMainMenuShown),
                photonMainMenuShown {
-                return viewProvider.shouldPresentContextualHint() ? true : false
+                return viewProvider.shouldPresentContextualHint()
             }
             viewProvider.markContextualHintPresented()
             return false
         }
-        return viewProvider.shouldPresentContextualHint() ? true : false
+        return viewProvider.shouldPresentContextualHint()
     }
 
     // MARK: - UIAdaptivePresentationControllerDelegate

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -376,8 +376,12 @@ class MainMenuViewController: UIViewController,
             return false
         }
 
-        // Don't display CFR for fresh installs
+        // Don't display CFR for fresh installs for users that never saw before the photon main menu
         if InstallType.get() == .fresh {
+            if let photonMainMenuShown = profile.prefs.boolForKey(PrefsKeys.PhotonMainMenuShown),
+               photonMainMenuShown {
+                return viewProvider.shouldPresentContextualHint() ? true : false
+            }
             viewProvider.markContextualHintPresented()
             return false
         }

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -191,6 +191,9 @@ public struct PrefsKeys {
     public static let splashScreenShownKey = "splashScreenShownKey"
 
     public static let PasswordGeneratorShown = "PasswordGeneratorShown"
+
+    // Represents whether or not the user has seen the photon main menu once, at least.
+    public static let PhotonMainMenuShown = "PhotonMainMenuShown"
 }
 
 public protocol Prefs {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10509)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23042)

## :bulb: Description
Display the Menu CFR for fresh installs but only fot the users that have seen before the old menu

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

