### PR TITLE
Bugfix FXIOS-10506 [Toolbar Redesign] Reader view page doesn’t show lock icon after session restore

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -16,6 +16,7 @@ final class LocationView: UIView,
         static let gradientViewWidth: CGFloat = 40
         static let iconContainerCornerRadius: CGFloat = 8
         static let lockIconImageViewSize = CGSize(width: 40, height: 24)
+        static let iconContainerNoLockLeadingSpace: CGFloat = 16
     }
 
     private var urlAbsolutePath: String?
@@ -248,7 +249,10 @@ final class LocationView: UIView,
         removeContainerIcons()
         iconContainerStackView.addArrangedSubview(lockIconButton)
         updateURLTextFieldLeadingConstraint()
-        iconContainerStackViewLeadingConstraint?.constant = 0
+
+        let leadingConstraint = lockIconImageName == nil ? UX.iconContainerNoLockLeadingSpace : 0.0
+
+        iconContainerStackViewLeadingConstraint?.constant = leadingConstraint
         updateGradient()
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -268,6 +268,8 @@ struct AddressBarState: StateType, Equatable {
     private static func handleReaderModeStateChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
+        let lockIconImageName = toolbarAction.readerModeState == .active ? nil : state.lockIconImageName
+
         return AddressBarState(
             windowUUID: state.windowUUID,
             navigationActions: state.navigationActions,
@@ -279,7 +281,7 @@ struct AddressBarState: StateType, Equatable {
             borderPosition: state.borderPosition,
             url: state.url,
             searchTerm: state.searchTerm,
-            lockIconImageName: state.lockIconImageName,
+            lockIconImageName: lockIconImageName,
             lockIconNeedsTheming: state.lockIconNeedsTheming,
             safeListedURLImageName: state.safeListedURLImageName,
             isEditing: state.isEditing,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10506)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23031)

## :bulb: Description
Removes the lock icon when reader mode is active.
![Simulator Screenshot - iPhone 16 Pro Max - 2024-11-12 at 11 44 44](https://github.com/user-attachments/assets/503c7fcd-6e45-4ab3-9d7e-679077806f2e)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

