### PR TITLE
Add FXIOS-9639-[Native Error Page] added a11y for NIC error page

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -830,5 +830,12 @@ public struct AccessibilityIdentifiers {
         static let content = "PasswordGenerator.content"
         static let header = "PasswordGenerator.header"
     }
+
+    struct NativeErrorPage {
+        static let foxImage = "NativeErrorPage.foxImage"
+        static let titleLabel = "NativeErrorPage.titleLabel"
+        static let errorDescriptionLabel = "NativeErrorPage.errorDescriptionLabel"
+        static let reloadButton = "NativeErrorPage.reloadButton"
+    }
 }
 // swiftlint:enable line_length

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -71,25 +71,30 @@ final class NativeErrorPageViewController: UIViewController,
         stackView.distribution = .fill
     }
 
-    private lazy var logoImage: UIImageView = .build { imageView in
+    private lazy var foxImage: UIImageView = .build { imageView in
         imageView.image = UIImage(
             named: ImageIdentifiers.NativeErrorPage.noInternetConnection
         )
         imageView.contentMode = .scaleAspectFit
+        imageView.isAccessibilityElement = false
+        imageView.accessibilityIdentifier = AccessibilityIdentifiers.NativeErrorPage.foxImage
     }
 
     private lazy var titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = FXFontStyles.Bold.title2.scaledFont()
         label.numberOfLines = 0
-        label.textAlignment = .left
+        label.textAlignment = .natural
+        label.accessibilityIdentifier = AccessibilityIdentifiers.NativeErrorPage.titleLabel
+        label.accessibilityTraits = .header
     }
 
     private lazy var errorDescriptionLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
-        label.textAlignment = .left
+        label.textAlignment = .natural
+        label.accessibilityIdentifier = AccessibilityIdentifiers.NativeErrorPage.errorDescriptionLabel
     }
 
     private lazy var reloadButton: PrimaryRoundedButton = .build { button in
@@ -188,11 +193,10 @@ final class NativeErrorPageViewController: UIViewController,
         showViewForCurrentOrientation()
     }
 
-    // TODO: FXIOS-9639 #21237 [a11y] Verify accessibility for Voice Over, Dynamic text
     private func configureUI() {
         let viewModel = PrimaryRoundedButtonViewModel(
             title: .NativeErrorPage.ButtonLabel,
-            a11yIdentifier: ""
+            a11yIdentifier: AccessibilityIdentifiers.NativeErrorPage.reloadButton
         )
         reloadButton.configure(
             viewModel: viewModel
@@ -204,7 +208,7 @@ final class NativeErrorPageViewController: UIViewController,
         textStack.addArrangedSubview(errorDescriptionLabel)
         commonContainer.addArrangedSubview(textStack)
         commonContainer.addArrangedSubview(reloadButton)
-        scrollContainer.addArrangedSubview(logoImage)
+        scrollContainer.addArrangedSubview(foxImage)
         scrollContainer.addArrangedSubview(commonContainer)
         scrollView.addSubview(scrollContainer)
         view.addSubview(scrollView)
@@ -244,7 +248,7 @@ final class NativeErrorPageViewController: UIViewController,
                 equalTo: scrollView.bottomAnchor,
                 constant: self.isLandscape ? UX.landscapePadding.bottom : UX.portraitPadding.bottom
             ),
-            logoImage.widthAnchor.constraint(equalToConstant: UX.logoSizeWidth)
+            foxImage.widthAnchor.constraint(equalToConstant: UX.logoSizeWidth)
         ]
 
         iPadContraintsList = [
@@ -264,7 +268,7 @@ final class NativeErrorPageViewController: UIViewController,
                 equalTo: scrollView.bottomAnchor,
                 constant: UX.iPadPadding.bottom
             ),
-            logoImage.widthAnchor.constraint(equalToConstant: UX.logoSizeWidthiPad),
+            foxImage.widthAnchor.constraint(equalToConstant: UX.logoSizeWidthiPad),
             reloadButton.widthAnchor.constraint(
                 equalTo: commonContainer.widthAnchor,
                 multiplier: UX.reloadButtonIpadMultiplier


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9639)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21237)

## :bulb: Description

- Added accessibility identifiers and traits for labels and button on "no internet connection" error page.
- Renamed `logoImage` to `foxImage` for better readability.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

