### PR TITLE
Refactor MTE-3857 Fix for the alert not displayed

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
@@ -8,7 +8,11 @@ class DataManagementTests: BaseTestCase {
     func cleanAllData() {
         navigator.goto(WebsiteDataSettings)
         mozWaitForElementToExist(app.tables.otherElements["Website Data"])
-        navigator.performAction(Action.AcceptClearAllWebsiteData)
+        // navigator.performAction(Action.AcceptClearAllWebsiteData)
+        // We need to fix the method in FxScreenGraph file
+        // but there are many linter issues on that file, so this is a quick fix
+        app.tables.cells["ClearAllWebsiteData"].staticTexts["Clear All Website Data"].waitAndTap()
+        app.alerts.buttons["OK"].waitAndTap()
         XCTAssertEqual(app.cells.buttons.images.count, 0, "The Website data has not cleared correctly")
         // Navigate back to the browser
         mozWaitElementHittable(element: app.buttons["Data Management"], timeout: TIMEOUT)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3857)

## :bulb: Description
We noticed that the test testWebSiteDataEnterFirstTime failed due to the alert not displayed. I think that on bitrise the tests are running slowly, so I add .waitAndTap() method. 

## :pencil: Checklist
You have to check all boxes before merging
- [X ] Filled in the above information (tickets numbers and description of your work)
- [X ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

