### PR TITLE
Add FXIOS-10542 [Homepage] Navigation logic for top sites

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
@@ -9,10 +9,14 @@ import Redux
 /// Actions that are related to navigation from the user perspective
 class NavigationBrowserAction: Action {
     let url: URL?
+    let isGoogleTopSite: Bool?
+
     init(url: URL? = nil,
+         isGoogleTopSite: Bool? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
         self.url = url
+        self.isGoogleTopSite = isGoogleTopSite
         super.init(windowUUID: windowUUID,
                    actionType: actionType)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
@@ -17,12 +17,15 @@ enum BrowserNavigationDestination: Equatable {
 struct NavigationDestination: Equatable {
     let destination: BrowserNavigationDestination
     let url: URL?
+    let isGoogleTopSite: Bool?
 
     init(
         _ destination: BrowserNavigationDestination,
-        url: URL? = nil
+        url: URL? = nil,
+        isGoogleTopSite: Bool? = nil
     ) {
         self.destination = destination
         self.url = url
+        self.isGoogleTopSite = isGoogleTopSite
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -176,7 +176,11 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 windowUUID: state.windowUUID,
                 browserViewType: state.browserViewType,
                 microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
-                navigationDestination: NavigationDestination(.link, url: action.url)
+                navigationDestination: NavigationDestination(
+                    .link,
+                    url: action.url,
+                    isGoogleTopSite: action.isGoogleTopSite
+                )
             )
 
         default:

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2089,10 +2089,9 @@ class BrowserViewController: UIViewController,
                 logger.log("url should not be nil when navigating for a link type", level: .warning, category: .coordinator)
                 return
             }
-            // TODO: FXIOS-10165 - Pass in the proper values based on top sites and other homepage links
             navigationHandler?.navigateFromHomePanel(
                 to: url,
-                visitType: .bookmark,
+                visitType: .link,
                 isGoogleTopSite: type.isGoogleTopSite ?? false
             )
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2090,7 +2090,11 @@ class BrowserViewController: UIViewController,
                 return
             }
             // TODO: FXIOS-10165 - Pass in the proper values based on top sites and other homepage links
-            navigationHandler?.navigateFromHomePanel(to: url, visitType: .link, isGoogleTopSite: false)
+            navigationHandler?.navigateFromHomePanel(
+                to: url,
+                visitType: .bookmark,
+                isGoogleTopSite: type.isGoogleTopSite ?? false
+            )
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -371,6 +371,15 @@ final class HomepageViewController: UIViewController,
             return
         }
         switch item {
+        case .topSite(let state):
+            store.dispatch(
+                NavigationBrowserAction(
+                    url: state.site.url.asURL,
+                    isGoogleTopSite: state.isGoogleURL,
+                    windowUUID: self.windowUUID,
+                    actionType: NavigationBrowserActionType.tapOnCell
+                )
+            )
         case .pocket(let story):
             store.dispatch(
                 NavigationBrowserAction(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10542)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Add navigation logic similar to our pocket sites. More context in this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/22597).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots


https://github.com/user-attachments/assets/1fea467d-6045-47e2-b704-ba84e0db8d83

