### PR TITLE
Add FXIOS-10524 [Sent From Firefox] Add share link text and settings toggle strings

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -4472,13 +4472,13 @@ extension String {
                 comment: "When a user shares a link to social media, this is the shared text they'll see in the social media app. The first parameter is the shared website's URL. The second parameter is the Firefox app name. The third parameter is the link to download the Firefox app.")
 
             public static let SocialSettingsToggleTitle = MZLocalizedString(
-                key: "SentFromFirefox.SocialShare.WhatsApp.SettingsToggle.Title.v134",
+                key: "SentFromFirefox.SocialShare.SettingsToggle.Title.v134",
                 tableName: "SocialShare",
                 value: "Include %1$@ Download Link on %2$@ Shares",
                 comment: "On the Settings screen, this is the title text for a toggle which controls adding additional text to links shared to social media. The first parameter is the Firefox app name. The second parameter is the social media app name (e.g. WhatsApp).")
 
             public static let SocialSettingsToggleSubtitle = MZLocalizedString(
-                key: "SentFromFirefox.SocialShare.WhatsApp.SettingsToggle.Subtitle.v134",
+                key: "SentFromFirefox.SocialShare.SettingsToggle.Subtitle.v134",
                 tableName: "SocialShare",
                 value: "Spread the word about %1$@ every time you share a link on %2$@.",
                 comment: "On the Settings screen, this is the subtitle text for a toggle which controls adding additional text to links shared to social media. The first parameter is the Firefox app name. The second parameter is the social media app name (e.g. WhatsApp).")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10524)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23066)

## :bulb: Description
This PR adds share text strings and a new settings toggle title and subtitle strings for the v134 string freeze.

Simple [Figma link](https://www.figma.com/design/VeP4ATIYWQtHfs458h3ING/Shared-from-Firefox-Mobile-Experiment-Q32024?node-id=7721-5418&node-type=instance&m=dev) for context on these new strings.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

