### PR TITLE
Refactor MTE-3857 Add a timeout before clicking on Clear Data website button

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
@@ -197,13 +197,13 @@ class AddressesTests: BaseTestCase {
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])
         if updateCountry {
             let addressInfo = ["Test2", "test address2", "city test2, 100000"]
-            for i in addressInfo {
-                mozWaitForElementToExist(app.staticTexts[i])
+            for index in addressInfo {
+                mozWaitForElementToExist(app.staticTexts[index])
             }
         } else {
             let addressInfo = ["Test2", "test address2", "city test2, AL, 100000"]
-            for i in addressInfo {
-                mozWaitForElementToExist(app.staticTexts[i])
+            for index in addressInfo {
+                mozWaitForElementToExist(app.staticTexts[index])
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
@@ -11,8 +11,8 @@ class DataManagementTests: BaseTestCase {
         // navigator.performAction(Action.AcceptClearAllWebsiteData)
         // We need to fix the method in FxScreenGraph file
         // but there are many linter issues on that file, so this is a quick fix
-        app.tables.cells["ClearAllWebsiteData"].staticTexts["Clear All Website Data"].waitAndTap()
-        app.alerts.buttons["OK"].waitAndTap()
+        app.tables.cells["ClearAllWebsiteData"].staticTexts["Clear All Website Data"].waitAndTap(timeout: TIMEOUT)
+        app.alerts.buttons["OK"].waitAndTap(timeout: TIMEOUT)
         XCTAssertEqual(app.cells.buttons.images.count, 0, "The Website data has not cleared correctly")
         // Navigate back to the browser
         mozWaitElementHittable(element: app.buttons["Data Management"], timeout: TIMEOUT)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3857)

## :bulb: Description
In bitrise the screen that contains the Clear Data Website button takes more time to be dispayed, so I add a timeout to be sure the test wait for the element and then click on it.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

