### PR TITLE
Bugfix FXIOS-10422 ⁃ Incorrect toast message displayed when updating an address

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -379,9 +379,9 @@ extension String {
                     comment: "Toast message confirming that an address has been successfully updated."
                 )
                  public static let AddressUpdatedConfirmationV2 = MZLocalizedString(
-                    key: "Addresses.Toast.AddressUpdatedConfirmation.v132.v2",
+                    key: "Addresses.Toast.AddressUpdatedConfirmation.v133",
                     tableName: "EditAddress",
-                    value: "Address Saved",
+                    value: "Address Information Updated",
                     comment: "Toast message confirming that an address has been successfully updated."
                 )
                 public static let RemoveAddressTitle = MZLocalizedString(
@@ -7478,6 +7478,12 @@ extension String {
                 tableName: "PrivateBrowsing",
                 value: nil,
                 comment: "Accessiblity hint for toggling on/off private mode")
+            public static let AddressUpdatedConfirmationV2 = MZLocalizedString(
+               key: "Addresses.Toast.AddressUpdatedConfirmation.v132.v2",
+               tableName: "EditAddress",
+               value: "Address Saved",
+               comment: "Toast message confirming that an address has been successfully updated."
+           )
         }
         struct v133 {
             public static let LocationA11yLabel = MZLocalizedString(

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -379,7 +379,7 @@ extension String {
                     comment: "Toast message confirming that an address has been successfully updated."
                 )
                  public static let AddressUpdatedConfirmationV2 = MZLocalizedString(
-                    key: "Addresses.Toast.AddressUpdatedConfirmation.v133",
+                    key: "Addresses.Toast.AddressUpdatedConfirmation.v134",
                     tableName: "EditAddress",
                     value: "Address Information Updated",
                     comment: "Toast message confirming that an address has been successfully updated."

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
@@ -6,6 +6,7 @@ import Foundation
 
 class AddressesTests: BaseTestCase {
     let addressSavedTxt = "Address Saved"
+    let addressUpdatedTxt = "Address Information Updated"
     let savedAddressesTxt = "SAVED ADDRESSES"
     let removedAddressTxt = "Address Removed"
 
@@ -190,8 +191,8 @@ class AddressesTests: BaseTestCase {
         tapEdit()
         updateAddress(updateCountry: updateCountry, isPostalCode: isPostalCode)
         tapSave()
-        // The "Address saved" toast message is displayed
-        mozWaitForElementToExist(app.staticTexts[addressSavedTxt])
+        // The "Address Information Updated" toast message is displayed
+        mozWaitForElementToExist(app.staticTexts[addressUpdatedTxt])
         // The address is saved
         // Update with correct toast message after https://mozilla-hub.atlassian.net/browse/FXIOS-10422 is fixed
         mozWaitForElementToExist(app.staticTexts[savedAddressesTxt])


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10422)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22826)

## :bulb: Description
Changed the string for editing address toast message

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

