### PR TITLE
Add FXIOS-9521 ⁃ Calendar Invites from Fx do not Render on iCal

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuCell.swift
@@ -8,10 +8,10 @@ import UIKit
 
 public class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private struct UX {
-        static let contentMargin: CGFloat = 11
+        static let contentMargin: CGFloat = 12
         static let iconSize: CGFloat = 24
         static let largeIconSize: CGFloat = 48
-        static let contentSpacing: CGFloat = 5
+        static let contentSpacing: CGFloat = 3
         static let noDescriptionContentSpacing: CGFloat = 0
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -8,6 +8,7 @@ import Common
 import Shared
 import UIKit
 import Photos
+import SafariServices
 
 // MARK: - WKUIDelegate
 extension BrowserViewController: WKUIDelegate {
@@ -654,6 +655,21 @@ extension BrowserViewController: WKNavigationDelegate {
                 tab.temporaryDocument = nil
                 // We don't have a temporary document, fallthrough
             }
+        }
+
+        if let url = responseURL, tabManager[webView]?.mimeType == MIMEType.Calendar, let domain = url.baseDomain {
+            let alert = UIAlertController(title: .Alerts.AddToCalendar.Title,
+                                          message: String(format: .Alerts.AddToCalendar.Body, domain),
+                                          preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: .Alerts.AddToCalendar.CancelButton, style: .default))
+            alert.addAction(UIAlertAction(title: .Alerts.AddToCalendar.AddButton,
+                                          style: .default,
+                                          handler: { _ in
+                let safariVC = SFSafariViewController(url: url)
+                safariVC.modalPresentationStyle = .fullScreen
+                self.present(safariVC, animated: true, completion: nil)
+            }))
+            present(alert, animated: true)
         }
 
         // Check if this response should be downloaded.

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -102,6 +102,29 @@ extension String {
                 value: "Cancel",
                 comment: "When tapping the fire icon in private mode, an alert comes up asking to confirm if you want to delete all browsing data and end your private session. This is the cancel action for the alert, cancelling ending your session.")
         }
+
+        public struct AddToCalendar {
+            public static let Title = MZLocalizedString(
+                key: "Alerts.AddToCalendar.Title.v133",
+                tableName: "Alerts",
+                value: "Add to calendar?",
+                comment: "When tapping on a link, on a website in order to download a file and that file is a calendar file, an alert comes up asking to confirm if you want to add the event to the device calendar. This is the title for the alert.")
+            public static let Body = MZLocalizedString(
+                key: "Alerts.AddToCalendar.Body.v133",
+                tableName: "Alerts",
+                value: "%@ is asking to download a file and add an event to your calendar.",
+                comment: "When tapping on a link, on a website in order to download a file and that file is a calendar file, an alert comes up asking to confirm if you want to add the event to the device calendar. This is the body message for the alert. %@ is the name/domain of the website, for example 'google.com'")
+            public static let AddButton = MZLocalizedString(
+                key: "Alerts.AddToCalendar.Button.Add.v133",
+                tableName: "Alerts",
+                value: "Add",
+                comment: "When tapping on a link, on a website in order to download a file and that file is a calendar file, an alert comes up asking to confirm if you want to add the event to the device calendar. This is the affirmative action for the alert, confirming that you do want to add the event to the calendar.")
+            public static let CancelButton = MZLocalizedString(
+                key: "Alerts.FeltDeletion.Button.Cancel.v133",
+                tableName: "Alerts",
+                value: "Cancel",
+                comment: "When tapping on a link, on a website in order to download a file and that file is a calendar file, an alert comes up asking to confirm if you want to add the event to the device calendar. This is the cancel action for the alert, cancelling the action to add the event to the calendar.")
+        }
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9521)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21076)

## :bulb: Description
Added a way to display the calendar files, from websites, in Safari, to be able to add the event to the device calendar.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

