### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from Utilities and applications support

### DIFF
--- a/firefox-ios/Client/Application/BackgroundNotificationSurfaceUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundNotificationSurfaceUtility.swift
@@ -56,7 +56,13 @@ class BackgroundNotificationSurfaceUtility: BackgroundUtilityProtocol {
     // MARK: Private
     private func setUp() {
         BGTaskScheduler.shared.register(forTaskWithIdentifier: taskIdentifier, using: nil) { task in
-            self.handleAppRefresh(task: task as! BGAppRefreshTask)
+            guard let backgroundRefreshTask = task as? BGAppRefreshTask else {
+                self.logger.log("Failed to cast task to BGAppRefreshTask",
+                                level: .fatal,
+                                category: .lifecycle)
+                return
+            }
+            self.handleAppRefresh(task: backgroundRefreshTask)
 
             // Schedule a new refresh task.
             self.scheduleTaskOnAppBackground()

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -147,7 +147,10 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
 
         let enumerator = FileManager.default.enumerator(atPath: dirForTestProfile)
         guard let filePaths = enumerator?.allObjects as? [String] else {
-            fatalError("Failed to cast enumerator.allObjects to [String] during filePaths extraction")
+            logger.log("Failed to retrieve file paths during database configuration in UITestAppDelegate class",
+                       level: .info,
+                       category: .lifecycle)
+            return
         }
         filePaths.filter { $0.contains(".db") }.forEach { item in
             try? FileManager.default.removeItem(

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -146,7 +146,9 @@ class UITestAppDelegate: AppDelegate, FeatureFlaggable {
         let output = URL(fileURLWithPath: "\(dirForTestProfile)/places.db")
 
         let enumerator = FileManager.default.enumerator(atPath: dirForTestProfile)
-        let filePaths = enumerator?.allObjects as! [String]
+        guard let filePaths = enumerator?.allObjects as? [String] else {
+            fatalError("Failed to cast enumerator.allObjects to [String] during filePaths extraction")
+        }
         filePaths.filter { $0.contains(".db") }.forEach { item in
             try? FileManager.default.removeItem(
                 at: URL(fileURLWithPath: "\(dirForTestProfile)/\(item)")

--- a/firefox-ios/Client/Frontend/Share/TitleActivityItemProvider.swift
+++ b/firefox-ios/Client/Frontend/Share/TitleActivityItemProvider.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 /// This Activity Item Provider subclass does two things that are non-standard behaviour:
@@ -15,12 +16,15 @@ import Foundation
 /// Note that not all applications use the Subject. For example OmniFocus ignores it, so we need to do both.
 
 class TitleActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
+    private let logger: Logger
+
     static let activityTypesToIgnore = [
         UIActivity.ActivityType.copyToPasteboard,
         UIActivity.ActivityType.message,
         UIActivity.ActivityType.mail]
 
-    init(title: String) {
+    init(title: String, logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
         super.init(placeholderItem: title)
     }
 
@@ -30,13 +34,26 @@ class TitleActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
                 return NSNull()
             }
         }
-        return placeholderItem! as AnyObject
+        if let item = placeholderItem as? AnyObject {
+            return item
+        } else {
+            logger.log("placeholderItem is not of expected type AnyObject",
+                       level: .fatal,
+                       category: .library)
+            return NSNull()
+        }
     }
 
     override func activityViewController(
         _ activityViewController: UIActivityViewController,
         subjectForActivityType activityType: UIActivity.ActivityType?
     ) -> String {
-        return placeholderItem as! String
+        guard let placeholderString = placeholderItem as? String else {
+            logger.log("Failed to cast placeholderItem to String",
+                       level: .fatal,
+                       category: .library)
+            return ""
+        }
+        return placeholderString
     }
 }

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetViewModel.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Storage
 import UIKit
 
@@ -15,6 +16,7 @@ class PhotonActionSheetViewModel: FeatureFlaggable {
     // MARK: - Properties
     var actions: [[PhotonRowActions]]
     var modalStyle: UIModalPresentationStyle
+    private let logger: Logger
 
     var closeButtonTitle: String?
     var site: Site?
@@ -42,10 +44,12 @@ class PhotonActionSheetViewModel: FeatureFlaggable {
     // MARK: - Initializers
     init(actions: [[PhotonRowActions]],
          site: Site? = nil,
-         modalStyle: UIModalPresentationStyle) {
+         modalStyle: UIModalPresentationStyle,
+         logger: Logger = DefaultLogger.shared) {
         self.actions = actions
         self.site = site
         self.modalStyle = modalStyle
+        self.logger = logger
     }
 
     init(actions: [[PhotonRowActions]],
@@ -53,7 +57,8 @@ class PhotonActionSheetViewModel: FeatureFlaggable {
          title: String? = nil,
          modalStyle: UIModalPresentationStyle,
          isMainMenu: Bool = false,
-         isMainMenuInverted: Bool = false) {
+         isMainMenuInverted: Bool = false,
+         logger: Logger = DefaultLogger.shared) {
         self.actions = actions
         self.closeButtonTitle = closeButtonTitle
         self.title = title
@@ -61,6 +66,7 @@ class PhotonActionSheetViewModel: FeatureFlaggable {
 
         self.isMainMenu = isMainMenu
         self.isMainMenuInverted = isMainMenuInverted
+        self.logger = logger
         setMainMenuStyle()
     }
 
@@ -103,8 +109,14 @@ class PhotonActionSheetViewModel: FeatureFlaggable {
         switch sheetStyle {
         case .site:
             guard let site = site else { break }
-            let header = tableView.dequeueReusableHeaderFooterView(
-                withIdentifier: PhotonActionSheetSiteHeaderView.cellIdentifier) as! PhotonActionSheetSiteHeaderView
+            guard let header = tableView.dequeueReusableHeaderFooterView(
+                withIdentifier: PhotonActionSheetSiteHeaderView.cellIdentifier
+            ) as? PhotonActionSheetSiteHeaderView else {
+                logger.log("Failed to dequeue PhotonActionSheetSiteHeaderView",
+                           level: .fatal,
+                           category: .library)
+                return UIView()
+            }
             header.configure(with: site)
             return header
 
@@ -114,9 +126,14 @@ class PhotonActionSheetViewModel: FeatureFlaggable {
                 return tableView.dequeueReusableHeaderFooterView(
                     withIdentifier: PhotonActionSheetLineSeparator.cellIdentifier)
             } else {
-                let header = tableView.dequeueReusableHeaderFooterView(
+                guard let header = tableView.dequeueReusableHeaderFooterView(
                     withIdentifier: PhotonActionSheetTitleHeaderView.cellIdentifier
-                ) as! PhotonActionSheetTitleHeaderView
+                ) as? PhotonActionSheetTitleHeaderView else {
+                    logger.log("Failed to dequeue PhotonActionSheetTitleHeaderView",
+                               level: .fatal,
+                               category: .library)
+                    return UIView()
+                }
                 header.configure(with: title)
                 return header
             }

--- a/firefox-ios/Client/Utils/ConfigurableGradientView.swift
+++ b/firefox-ios/Client/Utils/ConfigurableGradientView.swift
@@ -2,11 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 /// A view whose primary modifiable layer is a gradient layer
 public class ConfigurableGradientView: UIView {
-    init() {
+    private let logger: Logger
+
+    init(logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
         super.init(frame: .zero)
     }
 
@@ -16,7 +20,13 @@ public class ConfigurableGradientView: UIView {
     }
 
     private var gradientLayer: CAGradientLayer {
-        return layer as! CAGradientLayer
+        guard let gradientLayer = layer as? CAGradientLayer else {
+            logger.log("Failed to cast layer to CAGradientLayer in ConfigurableGradientView class",
+                       level: .fatal,
+                       category: .library)
+            return CAGradientLayer()
+        }
+        return gradientLayer
     }
 
     override public class var layerClass: AnyClass {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
   - PhotonActionSheetViewModel
   - TitleActivityItemProvider
   - ConfigurableGradientView
   - UITestAppDelegate
   - BackgroundNotificationSurfaceUtility
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

