### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from Sistem services & Logging

### DIFF
--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -131,13 +131,10 @@ public class DefaultCrashManager: CrashManager {
             // Turn Sentry breadcrumbs off since we have our own log swizzling
             options.enableAutoBreadcrumbTracking = false
             options.beforeSend = { event in
-                if let crashReport = event.error.self as? CustomCrashReport {
-                    self.alterEventForCustomCrash(event: event, crash: crashReport)
-                } else {
-                    self.logger.log("Encountered an error that is not a CustomCrashReport: \(String(describing: event.error))",
-                                    level: .info,
-                                    category: .lifecycle)
+                guard let crashReport = event.error.self as? CustomCrashReport else {
+                    return event
                 }
+                self.alterEventForCustomCrash(event: event, crash: crashReport)
                 return event
             }
         })

--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -135,7 +135,7 @@ public class DefaultCrashManager: CrashManager {
                     self.alterEventForCustomCrash(event: event, crash: crashReport)
                 } else {
                     self.logger.log("Encountered an error that is not a CustomCrashReport: \(String(describing: event.error))",
-                                    level: .fatal,
+                                    level: .info,
                                     category: .lifecycle)
                 }
                 return event

--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -73,7 +73,6 @@ public class DefaultCrashManager: CrashManager {
     private var sentryWrapper: SentryWrapper
     private var isSimulator: Bool
     private var skipReleaseNameCheck: Bool
-    private let logger: Logger
 
     // Only enable app hang tracking in Beta for now
     private var shouldEnableAppHangTracking: Bool {
@@ -91,13 +90,11 @@ public class DefaultCrashManager: CrashManager {
     public init(appInfo: BrowserKitInformation = BrowserKitInformation.shared,
                 sentryWrapper: SentryWrapper = DefaultSentry(),
                 isSimulator: Bool = DeviceInfo.isSimulator(),
-                skipReleaseNameCheck: Bool = false,
-                logger: Logger = DefaultLogger.shared) {
+                skipReleaseNameCheck: Bool = false) {
         self.appInfo = appInfo
         self.sentryWrapper = sentryWrapper
         self.isSimulator = isSimulator
         self.skipReleaseNameCheck = skipReleaseNameCheck
-        self.logger = logger
     }
 
     // MARK: - CrashManager protocol

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -7,16 +7,10 @@ import UIKit
 import Shared
 
 class MenuBuilderHelper {
-    private let logger: Logger
-
     struct MenuIdentifiers {
         static let history = UIMenu.Identifier("com.mozilla.firefox.menus.history")
         static let bookmarks = UIMenu.Identifier("com.mozilla.firefox.menus.bookmarks")
         static let tools = UIMenu.Identifier("com.mozilla.firefox.menus.tools")
-    }
-
-    init(logger: Logger = DefaultLogger.shared) {
-        self.logger = logger
     }
 
     func mainMenu(for builder: UIMenuBuilder) {
@@ -74,13 +68,7 @@ class MenuBuilderHelper {
             ]
         )
         fileMenu.children.forEach {
-            guard let fileMenuKeyCommand = $0 as? UIKeyCommand else {
-                logger.log("Failed to cast file menu child to UIKeyCommand in MenuBuilderHelper class",
-                           level: .info,
-                           category: .lifecycle)
-                return
-            }
-            fileMenuKeyCommand.wantsPriorityOverSystemBehavior = true
+            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
         }
 
         let findMenu = UIMenu(
@@ -103,13 +91,7 @@ class MenuBuilderHelper {
             ]
         )
         findMenu.children.forEach {
-            guard let findMenuKeyCommand = $0 as? UIKeyCommand else {
-                logger.log("Failed to cast find menu child to UIKeyCommand in MenuBuilderHelper class",
-                           level: .info,
-                           category: .lifecycle)
-                return
-            }
-            findMenuKeyCommand.wantsPriorityOverSystemBehavior = true
+            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
         }
 
         var viewMenuChildren: [UIMenuElement] = [
@@ -156,13 +138,7 @@ class MenuBuilderHelper {
 
         let viewMenu = UIMenu(options: .displayInline, children: viewMenuChildren)
         viewMenu.children.forEach {
-            guard let viewMenuKeyCommand = $0 as? UIKeyCommand else {
-                logger.log("Failed to cast view menu child to UIKeyCommand in MenuBuilderHelper class",
-                           level: .info,
-                           category: .lifecycle)
-                return
-            }
-            viewMenuKeyCommand.wantsPriorityOverSystemBehavior = true
+            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
         }
 
         let historyMenu = UIMenu(
@@ -279,13 +255,7 @@ class MenuBuilderHelper {
         )
 
         windowMenu.children.forEach {
-            guard let windowMenuKeyCommand = $0 as? UIKeyCommand else {
-                logger.log("Failed to cast window menu child to UIKeyCommand in MenuBuilderHelper class",
-                           level: .info,
-                           category: .lifecycle)
-                return
-            }
-            windowMenuKeyCommand.wantsPriorityOverSystemBehavior = true
+            ($0 as? UIKeyCommand)?.wantsPriorityOverSystemBehavior = true
         }
 
         builder.insertChild(applicationMenu, atStartOfMenu: .application)

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Common
 import UIKit
 import Shared
 

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -9,14 +9,14 @@ import Shared
 class MenuBuilderHelper {
     private let logger: Logger
 
-    init(logger: Logger = DefaultLogger.shared) {
-        self.logger = logger
-    }
-
     struct MenuIdentifiers {
         static let history = UIMenu.Identifier("com.mozilla.firefox.menus.history")
         static let bookmarks = UIMenu.Identifier("com.mozilla.firefox.menus.bookmarks")
         static let tools = UIMenu.Identifier("com.mozilla.firefox.menus.tools")
+    }
+
+    init(logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
     }
 
     func mainMenu(for builder: UIMenuBuilder) {
@@ -76,8 +76,8 @@ class MenuBuilderHelper {
         fileMenu.children.forEach {
             guard let fileMenuKeyCommand = $0 as? UIKeyCommand else {
                 logger.log("Failed to cast file menu child to UIKeyCommand in MenuBuilderHelper class",
-                           level: .fatal,
-                           category: .library)
+                           level: .info,
+                           category: .lifecycle)
                 return
             }
             fileMenuKeyCommand.wantsPriorityOverSystemBehavior = true
@@ -105,8 +105,8 @@ class MenuBuilderHelper {
         findMenu.children.forEach {
             guard let findMenuKeyCommand = $0 as? UIKeyCommand else {
                 logger.log("Failed to cast find menu child to UIKeyCommand in MenuBuilderHelper class",
-                           level: .fatal,
-                           category: .library)
+                           level: .info,
+                           category: .lifecycle)
                 return
             }
             findMenuKeyCommand.wantsPriorityOverSystemBehavior = true
@@ -158,8 +158,8 @@ class MenuBuilderHelper {
         viewMenu.children.forEach {
             guard let viewMenuKeyCommand = $0 as? UIKeyCommand else {
                 logger.log("Failed to cast view menu child to UIKeyCommand in MenuBuilderHelper class",
-                           level: .fatal,
-                           category: .library)
+                           level: .info,
+                           category: .lifecycle)
                 return
             }
             viewMenuKeyCommand.wantsPriorityOverSystemBehavior = true
@@ -278,16 +278,14 @@ class MenuBuilderHelper {
             ]
         )
 
-        if #available(iOS 15, *) {
-            windowMenu.children.forEach {
-                guard let windowMenuKeyCommand = $0 as? UIKeyCommand else {
-                    logger.log("Failed to cast window menu child to UIKeyCommand in MenuBuilderHelper class",
-                               level: .fatal,
-                               category: .library)
-                    return
-                }
-                windowMenuKeyCommand.wantsPriorityOverSystemBehavior = true
+        windowMenu.children.forEach {
+            guard let windowMenuKeyCommand = $0 as? UIKeyCommand else {
+                logger.log("Failed to cast window menu child to UIKeyCommand in MenuBuilderHelper class",
+                           level: .info,
+                           category: .lifecycle)
+                return
             }
+            windowMenuKeyCommand.wantsPriorityOverSystemBehavior = true
         }
 
         builder.insertChild(applicationMenu, atStartOfMenu: .application)

--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -2,10 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import UIKit
 import Shared
 
 class MenuBuilderHelper {
+    private let logger: Logger
+
+    init(logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+    }
+
     struct MenuIdentifiers {
         static let history = UIMenu.Identifier("com.mozilla.firefox.menus.history")
         static let bookmarks = UIMenu.Identifier("com.mozilla.firefox.menus.bookmarks")
@@ -67,7 +74,13 @@ class MenuBuilderHelper {
             ]
         )
         fileMenu.children.forEach {
-            ($0 as! UIKeyCommand).wantsPriorityOverSystemBehavior = true
+            guard let fileMenuKeyCommand = $0 as? UIKeyCommand else {
+                logger.log("Failed to cast file menu child to UIKeyCommand in MenuBuilderHelper class",
+                           level: .fatal,
+                           category: .library)
+                return
+            }
+            fileMenuKeyCommand.wantsPriorityOverSystemBehavior = true
         }
 
         let findMenu = UIMenu(
@@ -90,7 +103,13 @@ class MenuBuilderHelper {
             ]
         )
         findMenu.children.forEach {
-            ($0 as! UIKeyCommand).wantsPriorityOverSystemBehavior = true
+            guard let findMenuKeyCommand = $0 as? UIKeyCommand else {
+                logger.log("Failed to cast find menu child to UIKeyCommand in MenuBuilderHelper class",
+                           level: .fatal,
+                           category: .library)
+                return
+            }
+            findMenuKeyCommand.wantsPriorityOverSystemBehavior = true
         }
 
         var viewMenuChildren: [UIMenuElement] = [
@@ -137,7 +156,13 @@ class MenuBuilderHelper {
 
         let viewMenu = UIMenu(options: .displayInline, children: viewMenuChildren)
         viewMenu.children.forEach {
-            ($0 as! UIKeyCommand).wantsPriorityOverSystemBehavior = true
+            guard let viewMenuKeyCommand = $0 as? UIKeyCommand else {
+                logger.log("Failed to cast view menu child to UIKeyCommand in MenuBuilderHelper class",
+                           level: .fatal,
+                           category: .library)
+                return
+            }
+            viewMenuKeyCommand.wantsPriorityOverSystemBehavior = true
         }
 
         let historyMenu = UIMenu(
@@ -255,7 +280,13 @@ class MenuBuilderHelper {
 
         if #available(iOS 15, *) {
             windowMenu.children.forEach {
-                ($0 as! UIKeyCommand).wantsPriorityOverSystemBehavior = true
+                guard let windowMenuKeyCommand = $0 as? UIKeyCommand else {
+                    logger.log("Failed to cast window menu child to UIKeyCommand in MenuBuilderHelper class",
+                               level: .fatal,
+                               category: .library)
+                    return
+                }
+                windowMenuKeyCommand.wantsPriorityOverSystemBehavior = true
             }
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
   - CrashManager
   - MenuBuilderHelper
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

