### PR TITLE
Bugfix FXIOS-10520 ⁃ [Menu][Accessibility] VoiceOver focus moves outside of the action sheet when the action sheet is open

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -547,9 +547,9 @@ class BrowserCoordinator: BaseCoordinator,
         guard !childCoordinators.contains(where: { $0 is MainMenuCoordinator }) else { return nil }
 
         let navigationController = DismissableNavigationViewController()
-        if navigationController.shouldUseiPadSetup() {
+        navigationController.modalPresentationStyle = .formSheet
+        if !navigationController.shouldUseiPadSetup() {
             navigationController.modalPresentationStyle = .formSheet
-        } else {
             navigationController.sheetPresentationController?.detents = [.medium(), .large()]
             navigationController.sheetPresentationController?.prefersGrabberVisible = true
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10520)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23060)

## :bulb: Description
Changed the modalPresentationStyle for iPhone, without affecting the UX or UI.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

