### PR TITLE
Bugfix FXIOS-10308 Incorrect connection type is displayed in ETP panel 

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -230,6 +230,10 @@ class BrowserCoordinator: BaseCoordinator,
     // MARK: - ETPCoordinatorSSLStatusDelegate
 
     var showHasOnlySecureContentInTrackingPanel: Bool {
+        if browserViewController.isToolbarRefactorEnabled {
+            return browserViewController.tabManager.selectedTab?.currentWebView()?.hasOnlySecureContent ?? false
+        }
+
         guard let bar = browserViewController.urlBar else { return false }
         return bar.locationView.hasSecureContent
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10308)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22581)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Found the culprit after trying out switching feature flags, there's no more urlBar if the toolbar refactor is enabled so I switched the check on the current webView's hasOnlySecureContent for this case
## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

