### PR TITLE
Refactor FXIOS-10576 Simplify the MockStoreForMiddleware and middleware test action type unwrapping

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
@@ -14,20 +14,20 @@ import Redux
 class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
     var state: State
 
-    /// Records the number of times dispatch is called, and the actions with which it is called. Check this property to
-    /// ensure that your middleware correctly dispatches the right action(s) in response to a given action.
-    var dispatchCalled: (numberOfTimes: Int, withActions: [Redux.Action]) = (0, [])
+    /// Records all actions dispatched to the mock store. Check this property to ensure that your middleware correctly
+    /// dispatches the right action(s), and the right count of actions, in response to a given action.
+    var dispatchedActions: [Redux.Action] = []
 
-    /// Used to confirm that a dispatch action completed, this is useful when the middleware is making an asynchronous call 
-    /// and we can use the completion to wait for an expectation to be fulfilled.
-    var dispatchCalledCompletion: (() -> Void)?
+    /// Called every time an action is dispatched to the mock store. Used to confirm that a dispatched action completed. This
+    /// is useful when the middleware is making an asynchronous call and we want to wait for an expectation to be fulfilled.
+    var dispatchCalled: (() -> Void)?
 
     init(state: State) {
         self.state = state
     }
 
     func subscribe<S>(_ subscriber: S) where S: Redux.StoreSubscriber, State == S.SubscriberStateType {
-        // TODO if you need it
+        // TODO: if you need it
     }
 
     func subscribe<SubState, S>(
@@ -38,22 +38,19 @@ class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
             ) -> Redux.Subscription<SubState>
         )?
     ) where SubState == S.SubscriberStateType, S: Redux.StoreSubscriber {
-        // TODO if you need it
+        // TODO: if you need it
     }
 
     func unsubscribe<S>(_ subscriber: S) where S: Redux.StoreSubscriber, State == S.SubscriberStateType {
-        // TODO if you need it
+        // TODO: if you need it
     }
 
     func unsubscribe(_ subscriber: any Redux.StoreSubscriber) {
-        // TODO if you need it
+        // TODO: if you need it
     }
 
     func dispatch(_ action: Redux.Action) {
-        var dispatchActions = dispatchCalled.withActions
-        dispatchActions.append(action)
-
-        dispatchCalled = (dispatchCalled.numberOfTimes + 1, dispatchActions)
-        dispatchCalledCompletion?()
+        dispatchedActions.append(action)
+        dispatchCalled?()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
@@ -42,12 +42,11 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.searchEngineSelectionProvider(AppState(), action)
 
-        guard let actionCalled = mockStore.dispatchCalled.withActions.first as? SearchEngineSelectionAction,
-              case SearchEngineSelectionActionType.didLoadSearchEngines = actionCalled.actionType else {
-            XCTFail("Unexpected action type dispatched")
-            return
-        }
-        XCTAssertEqual(mockStore.dispatchCalled.numberOfTimes, 1)
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? SearchEngineSelectionAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? SearchEngineSelectionActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, SearchEngineSelectionActionType.didLoadSearchEngines)
         XCTAssertEqual(actionCalled.searchEngines, mockSearchEngineModels)
     }
 
@@ -57,12 +56,11 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.searchEngineSelectionProvider(AppState(), action)
 
-        guard let actionCalled = mockStore.dispatchCalled.withActions.first as? ToolbarAction,
-              case ToolbarActionType.didStartEditingUrl = actionCalled.actionType else {
-            XCTFail("Unexpected action type dispatched")
-            return
-        }
-        XCTAssertEqual(mockStore.dispatchCalled.numberOfTimes, 1)
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, ToolbarActionType.didStartEditingUrl)
     }
 
     // MARK: - Helpers

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketMiddlewareTests.swift
@@ -23,12 +23,12 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
         super.tearDown()
     }
 
-    func test_initializeAction_getPocketData() {
+    func test_initializeAction_getPocketData() throws {
         let subject = createSubject(pocketManager: pocketManager)
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
         let expectation = XCTestExpectation(description: "Homepage action initialize dispatched")
 
-        mockStore.dispatchCalledCompletion = {
+        mockStore.dispatchCalled = {
             expectation.fulfill()
         }
 
@@ -36,23 +36,21 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
 
         wait(for: [expectation])
 
-        guard let actionCalled = mockStore.dispatchCalled.withActions.first as? PocketAction,
-              case PocketMiddlewareActionType.retrievedUpdatedStories = actionCalled.actionType else {
-            XCTFail("Unexpected action type dispatched, \(String(describing: mockStore.dispatchCalled.withActions.first))")
-            return
-        }
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? PocketAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? PocketMiddlewareActionType)
 
-        XCTAssertEqual(mockStore.dispatchCalled.numberOfTimes, 1)
+        XCTAssertEqual(actionType, PocketMiddlewareActionType.retrievedUpdatedStories)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionCalled.pocketStories?.count, 3)
         XCTAssertEqual(pocketManager.getPocketItemsCalled, 1)
     }
 
-    func test_enterForegroundAction_getPocketData() {
+    func test_enterForegroundAction_getPocketData() throws {
         let subject = createSubject(pocketManager: pocketManager)
         let action = PocketAction(windowUUID: .XCTestDefaultUUID, actionType: PocketActionType.enteredForeground)
 
         let expectation = XCTestExpectation(description: "Pocket action entered foreground dispatched")
-        mockStore.dispatchCalledCompletion = {
+        mockStore.dispatchCalled = {
             expectation.fulfill()
         }
 
@@ -60,14 +58,12 @@ final class PocketMiddlewareTests: XCTestCase, StoreTestUtility {
 
         wait(for: [expectation])
 
-        guard let actionCalled = mockStore.dispatchCalled.withActions.first as? PocketAction,
-              case PocketMiddlewareActionType.retrievedUpdatedStories = actionCalled.actionType else {
-            XCTFail("Unexpected action type dispatched, \(String(describing: mockStore.dispatchCalled.withActions.first))")
-            return
-        }
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? PocketAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? PocketMiddlewareActionType)
 
-        XCTAssertEqual(mockStore.dispatchCalled.numberOfTimes, 1)
-        XCTAssertTrue(mockStore.dispatchCalled.withActions.first is PocketAction)
+        XCTAssertEqual(actionType, PocketMiddlewareActionType.retrievedUpdatedStories)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertTrue(mockStore.dispatchedActions.first is PocketAction)
         XCTAssertEqual(actionCalled.pocketStories?.count, 3)
         XCTAssertEqual(pocketManager.getPocketItemsCalled, 1)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10576)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23163)

## :bulb: Description

This PR simplifies the `MockStoreForMiddleware` a little bit (the count was redundant), which lets us improve the naming. As well, simplify our middleware test action type guards using XCTUnwrap, which throws (and cancels the test execution) if the unwrapped action is the incorrect type. That means we mark our unit tests with the `throw` keyword.

### Demo
Here is an example of what it looks like if a test fails due to an incorrect type being dispatched to the store. Note that we can still easily use the type to access the action's variables with this method.

<img width="1716" alt="Screenshot 2024-11-15 at 12 32 55 PM" src="https://github.com/user-attachments/assets/b0513f4c-2177-4551-81d5-b668e44d0ba0">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

