### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from Storage and Data Models

### DIFF
--- a/firefox-ios/RustFxA/RustFirefoxAccounts.swift
+++ b/firefox-ios/RustFxA/RustFirefoxAccounts.swift
@@ -181,7 +181,9 @@ open class RustFirefoxAccounts {
             deviceType: type,
             capabilities: capabilities
         )
-        let accessGroupPrefix = Bundle.main.object(forInfoDictionaryKey: "MozDevelopmentTeam") as! String
+        guard let accessGroupPrefix = Bundle.main.object(forInfoDictionaryKey: "MozDevelopmentTeam") as? String else {
+            fatalError("Missing or invalid 'MozDevelopmentTeam' key in Info.plist")
+        }
         let accessGroupIdentifier = AppInfo.keychainAccessGroupWithPrefix(accessGroupPrefix)
 
         return FxAccountManager(

--- a/firefox-ios/Storage/DiskImageStore.swift
+++ b/firefox-ios/Storage/DiskImageStore.swift
@@ -55,7 +55,13 @@ public actor DefaultDiskImageStore: DiskImageStore {
         var keys = [String]()
         if let fileEnumerator = FileManager.default.enumerator(atPath: filesDir) {
             for file in fileEnumerator {
-                keys.append(file as! String)
+                if let fileName = file as? String {
+                    keys.append(fileName)
+                } else {
+                    logger.log("Non-string item encountered while enumerating files",
+                               level: .fatal,
+                               category: .storage)
+                }
             }
         }
         self.keys = Set(keys)

--- a/firefox-ios/Storage/SQL/BrowserSchema.swift
+++ b/firefox-ios/Storage/SQL/BrowserSchema.swift
@@ -1035,8 +1035,7 @@ open class BrowserSchema: Schema {
                                        factory: { row in
                 if let url = row["url"] as? String {
                     return url
-                }
-                else {
+                } else {
                     self.logger.log("Unexpected value for 'url'. Expected a String but got \(type(of: row["url"]))",
                                     level: .warning,
                                     category: .storage)

--- a/firefox-ios/Storage/SQL/BrowserSchema.swift
+++ b/firefox-ios/Storage/SQL/BrowserSchema.swift
@@ -1032,7 +1032,17 @@ open class BrowserSchema: Schema {
             }
 
             let urls = db.executeQuery("SELECT DISTINCT url FROM history WHERE url IS NOT NULL",
-                                       factory: { $0["url"] as! String })
+                                       factory: { row in
+                if let url = row["url"] as? String {
+                    return url
+                }
+                else {
+                    self.logger.log("Unexpected value for 'url'. Expected a String but got \(type(of: row["url"]))",
+                                    level: .warning,
+                                    category: .storage)
+                    return ""
+                }
+            })
             if !fillDomainNamesFromCursor(urls, db: db) {
                 return false
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
   - DiskImageStore
   - BrowserSchema
   - RustFirefoxAccounts
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

