### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from BrowserKit Components

### DIFF
--- a/BrowserKit/Sources/ContentBlockingGenerator/JsonHelper.swift
+++ b/BrowserKit/Sources/ContentBlockingGenerator/JsonHelper.swift
@@ -2,28 +2,49 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 struct JsonHelper {
+    private let logger: Logger
+
+    init(logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+    }
+
     func jsonEntityListFrom(filename: String) -> [String: Any] {
         let file = URL(fileURLWithPath: filename)
-
+        
         do {
             let data = try Data(contentsOf: file)
-            return try JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
+            if let jsonObject = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+                return jsonObject
+            } else {
+                logger.log("Invalid JSON format for parsing entity list as dictionary from the file \(filename)",
+                           level: .fatal,
+                           category: .storage)
+            }
         } catch {
             fatalError("Could not find entity file \(filename) at file \(file)")
         }
+        return [:]
     }
 
     func jsonListFrom(filename: String) -> [String] {
         let file = URL(fileURLWithPath: filename)
-
+        
         do {
             let data = try Data(contentsOf: file)
-            return try JSONSerialization.jsonObject(with: data, options: []) as! [String]
+            if let jsonObject = try JSONSerialization.jsonObject(with: data, options: []) as? [String] {
+                return jsonObject
+            } else {
+                logger.log("Invalid JSON format for parsing entity list as array from the file \(filename)",
+                           level: .info,
+                           category: .storage)
+            }
         } catch {
             fatalError("Could not find list file \(filename) at file \(file)")
         }
+        return []
     }
 }

--- a/BrowserKit/Sources/MenuKit/MenuTableView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuTableView.swift
@@ -21,10 +21,12 @@ class MenuTableView: UIView,
     private var tableView: UITableView
     private var menuData: [MenuSection]
     private var theme: Theme?
+    private let logger: Logger
 
     public var updateHeaderLineView: ((_ isHidden: Bool) -> Void)?
 
     override init(frame: CGRect) {
+        self.logger = DefaultLogger.shared
         tableView = UITableView(frame: .zero, style: .insetGrouped)
         menuData = []
         super.init(frame: .zero)
@@ -84,10 +86,15 @@ class MenuTableView: UIView,
         _ tableView: UITableView,
         cellForRowAt indexPath: IndexPath
     ) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(
+        guard let cell = tableView.dequeueReusableCell(
             withIdentifier: MenuCell.cellIdentifier,
             for: indexPath
-        ) as! MenuCell
+        ) as? MenuCell else {
+            logger.log("Failed tp dequeue MenuCell at indexPath: \(indexPath)",
+                       level: .warning,
+                       category: .lifecycle)
+            return UITableViewCell()
+        }
 
         cell.configureCellWith(model: menuData[indexPath.section].options[indexPath.row])
         if let theme { cell.applyTheme(theme: theme) }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
   - MockDContentBlockerParser
   - JsonHelper
   - MenuTableView
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

