### PR TITLE
Bugfix FXIOS-10459 #22885 ⁃ [Menu] The accounts list item on the menu doesn't update right after signing in

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -134,14 +134,15 @@ struct MainMenuState: ScreenState, Equatable {
                 accountIcon: state.accountIcon
             )
         case MainMenuMiddlewareActionType.updateAccountHeader:
-            guard let action = action as? MainMenuAction
+            guard let action = action as? MainMenuAction,
+                  let accountData = action.accountData
             else { return defaultState(from: state) }
 
             return MainMenuState(
                 windowUUID: state.windowUUID,
                 menuElements: state.menuElements,
                 currentTabInfo: state.currentTabInfo,
-                accountData: action.accountData,
+                accountData: accountData,
                 accountIcon: action.accountIcon
             )
         case MainMenuActionType.updateCurrentTabInfo:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10459)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22885)

## :bulb: Description
Did an improvement for fetching the account data on the showScreen action instead of the viewDidLoad
Also fixed an issue for sign out flow.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

