### PR TITLE
Add FXIOS-10593 [Sent from Firefox] Add Sent from Firefox to the FeatureFlagsDebugViewController

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -38,6 +38,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case closeRemoteTabs
     case reportSiteIssue
     case searchHighlights
+    case sentFromFirefox
     case splashScreen
     case unifiedSearch
     case toolbarRefactor
@@ -91,6 +92,8 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
             return FlagKeys.InactiveTabs
         case .jumpBackIn:
             return FlagKeys.JumpBackInSection
+        case .sentFromFirefox:
+            return FlagKeys.SentFromFirefox
         // Cases where users do not have the option to manipulate a setting.
         case .contextualHintForToolbar,
                 .bookmarksRefactor,

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -47,19 +47,20 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case trackingProtectionRefactor
     case zoomFeature
 
-    // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`
+    // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`. Add in alphabetical order.
     var debugKey: String? {
         switch self {
         case    .bookmarksRefactor,
                 .closeRemoteTabs,
-                .microsurvey,
                 .homepageRebuild,
                 .menuRefactor,
-                .trackingProtectionRefactor,
+                .microsurvey,
                 .nativeErrorPage,
+                .sentFromFirefox,
                 .toolbarRefactor,
-                .unifiedSearch,
-                .passwordGenerator:
+                .trackingProtectionRefactor,
+                .passwordGenerator,
+                .unifiedSearch:
             return rawValue + PrefsKeys.FeatureFlags.DebugSuffixKey
         default:
             return nil

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -95,6 +95,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 ) { [weak self] _ in
                     self?.reloadView()
                 },
+                FeatureFlagsBoolSetting(
+                    with: .sentFromFirefox,
+                    titleText: format(string: "Enable Sent from Firefox"),
+                    statusText: format(string: "Toggle to enable Sent from Firefox to append text to WhatsApp shares")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                }
             ]
         )
     }

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -88,6 +88,9 @@ final class NimbusFeatureFlagLayer {
         case .reportSiteIssue:
             return checkGeneralFeature(for: featureID, from: nimbus)
 
+        case .sentFromFirefox:
+            return checkSentFromFirefoxFeature(from: nimbus)
+
         case .splashScreen:
             return checkSplashScreenFeature(for: featureID, from: nimbus)
 
@@ -129,6 +132,11 @@ final class NimbusFeatureFlagLayer {
         case .reportSiteIssue: return config.reportSiteIssue.status
         default: return false
         }
+    }
+
+    private func checkSentFromFirefoxFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.sentFromFirefoxFeature.value()
+        return config.enabled
     }
 
     private func checkAwesomeBarFeature(for featureID: NimbusFeatureFlagID,

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -77,6 +77,7 @@ public struct PrefsKeys {
         public static let InactiveTabs = "InactiveTabsUserPrefsKey"
         public static let JumpBackInSection = "JumpBackInSectionUserPrefsKey"
         public static let SearchBarPosition = "SearchBarPositionUsersPrefsKey"
+        public static let SentFromFirefox = "SentFromFirefoxUserPrefsKey"
     }
 
     public struct SearchSettings {

--- a/firefox-ios/nimbus-features/sentFromFirefoxFeature.yaml
+++ b/firefox-ios/nimbus-features/sentFromFirefoxFeature.yaml
@@ -1,0 +1,18 @@
+# The configuration for the sentFromFirefoxFeature feature
+features:
+  sent-from-firefox-feature:
+    description: >
+      Adds additional promo text to links shared to WhatsApp.
+    variables:
+      enabled:
+        description: >
+          Controls whether promo text is added to WhatsApp shares and an on/off toggle is added to Settings.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: false

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -35,6 +35,7 @@ include:
   - nimbus-features/reduxSearchSettingsFeature.yaml
   - nimbus-features/remoteTabManagement.yaml
   - nimbus-features/searchFeature.yaml
+  - nimbus-features/sentFromFirefoxFeature.yaml
   - nimbus-features/splashScreenFeature.yaml
   - nimbus-features/spotlightSearchFeature.yaml
   - nimbus-features/tabTrayFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10593)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23197)

## :bulb: Description
This PR simply adds the Sent from Firefox feature to the `FeatureFlagsDebugViewController` so the debug options can be easily toggled within the app.

### Demo
This screen can be accessed from Settings > Reveal the debug menu > Feature Flags

<img width="300" alt="Screenshot 2024-11-18 at 10 33 03 AM" src="https://github.com/user-attachments/assets/96bde08d-cb85-4a7a-ad13-f88b1567a4e4">

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

