### PR TITLE
Add FXiOS-10521 [Homescreen Rebuild] Add wallpaper to new homescreen

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -581,6 +581,12 @@
 		602B3D6729B0E1DB0066DEF8 /* ConversionValueUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602B3D6629B0E1DB0066DEF8 /* ConversionValueUtil.swift */; };
 		60CE80C12667780D004026C7 /* CredentialListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CE80C02667780C004026C7 /* CredentialListPresenter.swift */; };
 		60D71AEC26AAF45E00355588 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D71AEB26AAF45E00355588 /* UIColorExtension.swift */; };
+		612194E32CE507CF001664BB /* WallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */; };
+		612194E62CE50A93001664BB /* WallpaperAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E52CE50A93001664BB /* WallpaperAction.swift */; };
+		612194E82CE50A9B001664BB /* WallpaperState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E72CE50A9B001664BB /* WallpaperState.swift */; };
+		619FE8932CE6595B004F83E2 /* WallpaperMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */; };
+		61A164492CE7BE84001D6058 /* WallpaperStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */; };
+		61A1644A2CE7BE8A001D6058 /* WallpaperMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A164472CE7BE3D001D6058 /* WallpaperMiddlewareTests.swift */; };
 		630FE1342C7FB42500D9D6B2 /* NativeErrorPageMockModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1302C7FB42500D9D6B2 /* NativeErrorPageMockModel.swift */; };
 		630FE1352C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1322C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift */; };
 		631A369F2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */; };
@@ -1581,7 +1587,7 @@
 		DF940A0C2A96352B00C1497D /* FakespotSettingsCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF940A0A2A96316D00C1497D /* FakespotSettingsCardViewModelTests.swift */; };
 		DFA51481275FFEE500266AA0 /* HistoryHighlightsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA51480275FFEE500266AA0 /* HistoryHighlightsManager.swift */; };
 		DFA51484276103A000266AA0 /* HistoryHighlightsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA514822761012D00266AA0 /* HistoryHighlightsManagerTests.swift */; };
-		DFACBF7F277B5F7B003D5F41 /* WallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF7E277B5F7B003D5F41 /* WallpaperBackgroundView.swift */; };
+		DFACBF7F277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF7E277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift */; };
 		DFACBF81277B916B003D5F41 /* ConfigurableGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF80277B916B003D5F41 /* ConfigurableGradientView.swift */; };
 		DFACBF85277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF84277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift */; };
 		DFACDFAA274D489B00A94EEC /* HistoryHighlightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACDFA9274D489B00A94EEC /* HistoryHighlightsViewModel.swift */; };
@@ -6879,6 +6885,12 @@
 		60CE80C02667780C004026C7 /* CredentialListPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialListPresenter.swift; sourceTree = "<group>"; };
 		60D71AEB26AAF45E00355588 /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		60E04CE89D47E52E0A886EAD /* hi-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hi-IN"; path = "hi-IN.lproj/Search.strings"; sourceTree = "<group>"; };
+		612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperBackgroundView.swift; sourceTree = "<group>"; };
+		612194E52CE50A93001664BB /* WallpaperAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperAction.swift; sourceTree = "<group>"; };
+		612194E72CE50A9B001664BB /* WallpaperState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperState.swift; sourceTree = "<group>"; };
+		619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMiddleware.swift; sourceTree = "<group>"; };
+		61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperStateTests.swift; sourceTree = "<group>"; };
+		61A164472CE7BE3D001D6058 /* WallpaperMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMiddlewareTests.swift; sourceTree = "<group>"; };
 		61AE456BAD6B0041485EFF1E /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Shared.strings; sourceTree = "<group>"; };
 		61B340508D4D86B6519A165C /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = "id.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		61DA4B5AB7DA505B9C992F95 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
@@ -9029,7 +9041,7 @@
 		DF940A0A2A96316D00C1497D /* FakespotSettingsCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakespotSettingsCardViewModelTests.swift; sourceTree = "<group>"; };
 		DFA51480275FFEE500266AA0 /* HistoryHighlightsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsManager.swift; sourceTree = "<group>"; };
 		DFA514822761012D00266AA0 /* HistoryHighlightsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsManagerTests.swift; sourceTree = "<group>"; };
-		DFACBF7E277B5F7B003D5F41 /* WallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperBackgroundView.swift; sourceTree = "<group>"; };
+		DFACBF7E277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyWallpaperBackgroundView.swift; sourceTree = "<group>"; };
 		DFACBF80277B916B003D5F41 /* ConfigurableGradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableGradientView.swift; sourceTree = "<group>"; };
 		DFACBF84277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesRowCountSettingsController.swift; sourceTree = "<group>"; };
 		DFACDFA9274D489B00A94EEC /* HistoryHighlightsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsViewModel.swift; sourceTree = "<group>"; };
@@ -10905,6 +10917,34 @@
 			path = Generated;
 			sourceTree = "<group>";
 		};
+		612194E12CE50784001664BB /* Wallpaper */ = {
+			isa = PBXGroup;
+			children = (
+				612194E42CE50A7B001664BB /* Redux */,
+				612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */,
+			);
+			path = Wallpaper;
+			sourceTree = "<group>";
+		};
+		612194E42CE50A7B001664BB /* Redux */ = {
+			isa = PBXGroup;
+			children = (
+				612194E52CE50A93001664BB /* WallpaperAction.swift */,
+				612194E72CE50A9B001664BB /* WallpaperState.swift */,
+				619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */,
+			);
+			path = Redux;
+			sourceTree = "<group>";
+		};
+		61A164442CE7BDEF001D6058 /* Wallpaper */ = {
+			isa = PBXGroup;
+			children = (
+				61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */,
+				61A164472CE7BE3D001D6058 /* WallpaperMiddlewareTests.swift */,
+			);
+			path = Wallpaper;
+			sourceTree = "<group>";
+		};
 		630FE1312C7FB42500D9D6B2 /* Mock */ = {
 			isa = PBXGroup;
 			children = (
@@ -11142,6 +11182,7 @@
 				8A00BD862CAB3FE500680AF9 /* HomepageViewControllerTests.swift */,
 				8AA0A6662CAC745300AC7EB3 /* HomepageDiffableDataSourceTests.swift */,
 				8A6B79992CDBCE2E003C3077 /* TopSitesManagerTests.swift */,
+				61A164442CE7BDEF001D6058 /* Wallpaper */,
 			);
 			path = "Homepage Rebuild";
 			sourceTree = "<group>";
@@ -13565,7 +13606,7 @@
 		E1FF93E028A2E13600E6360E /* UI */ = {
 			isa = PBXGroup;
 			children = (
-				DFACBF7E277B5F7B003D5F41 /* WallpaperBackgroundView.swift */,
+				DFACBF7E277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift */,
 				E1FF93E128A2E55700E6360E /* WallpaperSelectorViewController.swift */,
 				E1FF93E328A2E74600E6360E /* WallpaperSelectorViewModel.swift */,
 				E19B38B228A42D5D00D8C541 /* WallpaperCollectionViewCell.swift */,
@@ -14297,6 +14338,7 @@
 			isa = PBXGroup;
 			children = (
 				8A7D08E12CAAF79F0035999C /* Homepage Rebuild */,
+				612194E12CE50784001664BB /* Wallpaper */,
 				8A0A1BA12B22010200E8706F /* PrivateHome */,
 				C834ACD028D3ACA900203AD1 /* Blurrable.swift */,
 				8AB5958628412B620090F4AE /* CustomizeHome */,
@@ -16173,7 +16215,7 @@
 				DF529E9F2AA86FF4003C5373 /* FakespotReviewQualityCardView.swift in Sources */,
 				1D0BA05C24F46A0400D731B5 /* TopSitesProvider.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
-				DFACBF7F277B5F7B003D5F41 /* WallpaperBackgroundView.swift in Sources */,
+				DFACBF7F277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift in Sources */,
 				8A7D08E32CAAF7C30035999C /* HomepageViewController.swift in Sources */,
 				D01017F5219CB6BD009CBB5A /* DownloadContentScript.swift in Sources */,
 				8A093D832A4B68940099ABA5 /* PrivacySettingsDelegate.swift in Sources */,
@@ -16388,6 +16430,7 @@
 				8A5D1CB02A30D740005AD35C /* SearchBarSetting.swift in Sources */,
 				EB9854FF2422686F0040F24B /* AppDelegate+PushNotifications.swift in Sources */,
 				DFACBF85277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift in Sources */,
+				612194E62CE50A93001664BB /* WallpaperAction.swift in Sources */,
 				9614BF4428AD1C6700D3F7EA /* AccountSyncHandler.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearchParser.swift in Sources */,
 				8A13FA8D2AD834FA007527AB /* BackgroundTabLoader.swift in Sources */,
@@ -16583,6 +16626,7 @@
 				E1CEC2022A28C3F100B177D5 /* LoginDetailCenteredTableViewCell.swift in Sources */,
 				C2D71B972A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift in Sources */,
 				8A83B7462A264FA0002FF9AC /* SettingsCoordinator.swift in Sources */,
+				619FE8932CE6595B004F83E2 /* WallpaperMiddleware.swift in Sources */,
 				A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */,
 				8A97E6EA2C58487900F94793 /* AddressLocaleFeatureValidator.swift in Sources */,
 				AB3DB0C92B596739001D32CB /* AppStartupTelemetry.swift in Sources */,
@@ -16740,6 +16784,7 @@
 				9636D92C27F9E50100771F5E /* GleanPlumbMessageStore.swift in Sources */,
 				213B67A627CE682B000542F5 /* StartAtHomeHelper.swift in Sources */,
 				8A8629E2288096C40096DDB1 /* BookmarksFolderCell.swift in Sources */,
+				612194E82CE50A9B001664BB /* WallpaperState.swift in Sources */,
 				DAE6DF1B29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift in Sources */,
 				0EC57D082CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift in Sources */,
 				8AB8574A27D97CE90075C173 /* HomePanelDelegate.swift in Sources */,
@@ -16902,6 +16947,7 @@
 				1D558A5A2BEE7D07001EF527 /* WindowSimpleTabsCoordinator.swift in Sources */,
 				E6327A641BF6438E008D12E0 /* DebugSettingsBundleOptions.swift in Sources */,
 				F85C7EDD27109241004BDBA4 /* PasswordManagerOnboardingViewController.swift in Sources */,
+				612194E32CE507CF001664BB /* WallpaperBackgroundView.swift in Sources */,
 				D8FDEB57220CFE970069A582 /* UIImage+ImageEffects.m in Sources */,
 				0BDDB3462CA6E43A00D501DF /* BookmarksSaver.swift in Sources */,
 				EBB89506219398E500EB91A0 /* TabContentBlocker.swift in Sources */,
@@ -17152,6 +17198,7 @@
 				8A5BD95A28788A3D000FE773 /* TopSitesHelperTests.swift in Sources */,
 				C29B64832AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift in Sources */,
 				C8B41E0F29F0357300FE218A /* NimbusOnboardingFeatureLayerTests.swift in Sources */,
+				61A164492CE7BE84001D6058 /* WallpaperStateTests.swift in Sources */,
 				8A6B799D2CDBDAE4003C3077 /* MockContileProvider.swift in Sources */,
 				5AF6254728A58AC100A90253 /* MockHistoryHighlightsDataAdaptor.swift in Sources */,
 				8A7A26E329D4ACF300EA76F1 /* SceneCoordinatorTests.swift in Sources */,
@@ -17165,6 +17212,7 @@
 				8A33222227DFE658008F809E /* NimbusMock.swift in Sources */,
 				0B7FC3D32CAE811F005C5CCE /* DefaultBookmarksSaverTests.swift in Sources */,
 				8A8629E72880B7330096DDB1 /* LegacyBookmarksPanelTests.swift in Sources */,
+				61A1644A2CE7BE8A001D6058 /* WallpaperMiddlewareTests.swift in Sources */,
 				C8B394362A0ED55D00700E49 /* MockOnboardingCardDelegate.swift in Sources */,
 				8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */,
 				C787D8C32C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -30,6 +30,7 @@ final class HomepageViewController: UIViewController,
     // MARK: - Private variables
     private var collectionView: UICollectionView?
     private var dataSource: HomepageDiffableDataSource?
+    // TODO: FXIOS-10541 will handle scrolling for wallpaper and other scroll issues
     private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
     private var layoutConfiguration = HomepageSectionLayoutProvider().createCompositionalLayout()
     private var logger: Logger
@@ -87,6 +88,11 @@ final class HomepageViewController: UIViewController,
 
         listenForThemeChange(view)
         applyTheme()
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        wallpaperView.updateImageForOrientationChange()
     }
 
     // MARK: - Redux

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -30,6 +30,7 @@ final class HomepageViewController: UIViewController,
     // MARK: - Private variables
     private var collectionView: UICollectionView?
     private var dataSource: HomepageDiffableDataSource?
+    private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
     private var layoutConfiguration = HomepageSectionLayoutProvider().createCompositionalLayout()
     private var logger: Logger
     private var homepageState: HomepageState
@@ -72,6 +73,7 @@ final class HomepageViewController: UIViewController,
     // MARK: - View lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureWallpaperView()
         setupLayout()
         configureCollectionView()
         configureDataSource()
@@ -109,6 +111,7 @@ final class HomepageViewController: UIViewController,
 
     func newState(state: HomepageState) {
         homepageState = state
+        wallpaperView.wallpaper = state.wallpaperState.wallpaper
         dataSource?.applyInitialSnapshot(state: state)
     }
 
@@ -128,6 +131,28 @@ final class HomepageViewController: UIViewController,
     }
 
     // MARK: - Layout
+    var statusBarFrame: CGRect? {
+        guard let keyWindow = UIWindow.keyWindow else { return nil }
+
+        return keyWindow.windowScene?.statusBarManager?.statusBarFrame
+    }
+
+    func configureWallpaperView() {
+        view.addSubview(wallpaperView)
+
+        // Constraint so wallpaper appears under the status bar
+        let wallpaperTopConstant: CGFloat = UIWindow.keyWindow?.safeAreaInsets.top ?? statusBarFrame?.height ?? 0
+
+        NSLayoutConstraint.activate([
+            wallpaperView.topAnchor.constraint(equalTo: view.topAnchor, constant: -wallpaperTopConstant),
+            wallpaperView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            wallpaperView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            wallpaperView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        view.sendSubviewToBack(wallpaperView)
+    }
+
     private func setupLayout() {
         guard let collectionView else {
             logger.log(

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -117,7 +117,7 @@ final class HomepageViewController: UIViewController,
 
     func newState(state: HomepageState) {
         homepageState = state
-        wallpaperView.wallpaper = state.wallpaperState.wallpaper
+        wallpaperView.wallpaperState = state.wallpaperState
         dataSource?.applyInitialSnapshot(state: state)
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -12,6 +12,7 @@ struct HomepageState: ScreenState, Equatable {
     var headerState: HeaderState
     var topSitesState: TopSitesSectionState
     var pocketState: PocketState
+    var wallpaperState: WallpaperState
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let homepageState = store.state.screenState(
@@ -27,7 +28,8 @@ struct HomepageState: ScreenState, Equatable {
             windowUUID: homepageState.windowUUID,
             headerState: homepageState.headerState,
             topSitesState: homepageState.topSitesState,
-            pocketState: homepageState.pocketState
+            pocketState: homepageState.pocketState,
+            wallpaperState: homepageState.wallpaperState
         )
     }
 
@@ -36,7 +38,8 @@ struct HomepageState: ScreenState, Equatable {
             windowUUID: windowUUID,
             headerState: HeaderState(windowUUID: windowUUID),
             topSitesState: TopSitesSectionState(windowUUID: windowUUID),
-            pocketState: PocketState(windowUUID: windowUUID)
+            pocketState: PocketState(windowUUID: windowUUID),
+            wallpaperState: WallpaperState(windowUUID: windowUUID)
         )
     }
 
@@ -44,12 +47,14 @@ struct HomepageState: ScreenState, Equatable {
         windowUUID: WindowUUID,
         headerState: HeaderState,
         topSitesState: TopSitesSectionState,
-        pocketState: PocketState
+        pocketState: PocketState,
+        wallpaperState: WallpaperState
     ) {
         self.windowUUID = windowUUID
         self.headerState = headerState
         self.topSitesState = topSitesState
         self.pocketState = pocketState
+        self.wallpaperState = wallpaperState
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -64,7 +69,8 @@ struct HomepageState: ScreenState, Equatable {
                 windowUUID: state.windowUUID,
                 headerState: HeaderState.reducer(state.headerState, action),
                 topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
-                pocketState: PocketState.reducer(state.pocketState, action)
+                pocketState: PocketState.reducer(state.pocketState, action),
+                wallpaperState: WallpaperState.reducer(state.wallpaperState, action)
             )
         default:
             return defaultState(from: state, action: action)
@@ -75,18 +81,21 @@ struct HomepageState: ScreenState, Equatable {
         var headerState = state.headerState
         var pocketState = state.pocketState
         var topSitesState = state.topSitesState
+        var wallpaperState = state.wallpaperState
 
         if let action {
             headerState = HeaderState.reducer(state.headerState, action)
             pocketState = PocketState.reducer(state.pocketState, action)
             topSitesState = TopSitesSectionState.reducer(state.topSitesState, action)
+            wallpaperState = WallpaperState.reducer(state.wallpaperState, action)
         }
 
         return HomepageState(
             windowUUID: state.windowUUID,
             headerState: headerState,
             topSitesState: topSitesState,
-            pocketState: pocketState
+            pocketState: pocketState,
+            wallpaperState: wallpaperState
         )
     }
 

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -39,7 +39,7 @@ class LegacyHomepageViewController:
     private var tabManager: TabManager
     private var overlayManager: OverlayModeManager
     private var userDefaults: UserDefaultsInterface
-    private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
+    private lazy var wallpaperView: LegacyWallpaperBackgroundView = .build { _ in }
     private var jumpBackInContextualHintViewController: ContextualHintViewController
     private var syncTabContextualHintViewController: ContextualHintViewController
     private var collectionView: UICollectionView! = nil

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperAction.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Redux
+import Common
+
+final class WallpaperAction: Action {
+    let wallpaper: Wallpaper
+
+    init(wallpaper: Wallpaper,
+         windowUUID: WindowUUID,
+         actionType: any ActionType
+    ) {
+        self.wallpaper = wallpaper
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
+
+enum WallpaperActionType: ActionType {
+    case wallpaperSelected
+}
+
+enum WallpaperMiddlewareActionType: ActionType {
+    case wallpaperDidInitialize
+    case wallpaperDidChange
+}

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperAction.swift
@@ -7,13 +7,13 @@ import Redux
 import Common
 
 final class WallpaperAction: Action {
-    let wallpaper: Wallpaper
+    let wallpaperConfiguration: WallpaperConfiguration
 
-    init(wallpaper: Wallpaper,
+    init(wallpaperConfiguration: WallpaperConfiguration,
          windowUUID: WindowUUID,
          actionType: any ActionType
     ) {
-        self.wallpaper = wallpaper
+        self.wallpaperConfiguration = wallpaperConfiguration
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -6,9 +6,9 @@ import Common
 import Redux
 
 class WallpaperMiddleware {
-    private let wallpaperManager: WallpaperManager
+    private let wallpaperManager: WallpaperManagerInterface
 
-    init(wallpaperManager: WallpaperManager = WallpaperManager()) {
+    init(wallpaperManager: WallpaperManagerInterface = WallpaperManager()) {
         self.wallpaperManager = wallpaperManager
     }
 

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -23,7 +23,11 @@ class WallpaperMiddleware {
     private func resolveHomepageAction(action: HomepageAction, state: AppState) {
         switch action.actionType {
         case HomepageActionType.initialize:
-            let action = WallpaperAction(wallpaper: wallpaperManager.currentWallpaper, windowUUID: action.windowUUID, actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize)
+            let action = WallpaperAction(
+                wallpaper: wallpaperManager.currentWallpaper,
+                windowUUID: action.windowUUID,
+                actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
+            )
             store.dispatch(action)
         default:
             break
@@ -33,7 +37,11 @@ class WallpaperMiddleware {
     private func resolveWallpaperAction(action: WallpaperAction, state: AppState) {
         switch action.actionType {
         case WallpaperActionType.wallpaperSelected:
-            let action = WallpaperAction(wallpaper: wallpaperManager.currentWallpaper, windowUUID: action.windowUUID, actionType: WallpaperMiddlewareActionType.wallpaperDidChange)
+            let action = WallpaperAction(
+                wallpaper: wallpaperManager.currentWallpaper,
+                windowUUID: action.windowUUID,
+                actionType: WallpaperMiddlewareActionType.wallpaperDidChange
+            )
             store.dispatch(action)
         default:
             break

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+
+class WallpaperMiddleware {
+    private let wallpaperManager: WallpaperManager
+
+    init(wallpaperManager: WallpaperManager = WallpaperManager()) {
+        self.wallpaperManager = wallpaperManager
+    }
+
+    lazy var wallpaperProvider: Middleware<AppState> = { state, action in
+        if let action = action as? HomepageAction {
+            self.resolveHomepageAction(action: action, state: state)
+        } else if let action = action as? WallpaperAction {
+            self.resolveWallpaperAction(action: action, state: state)
+        }
+    }
+
+    private func resolveHomepageAction(action: HomepageAction, state: AppState) {
+        switch action.actionType {
+        case HomepageActionType.initialize:
+            let action = WallpaperAction(wallpaper: wallpaperManager.currentWallpaper, windowUUID: action.windowUUID, actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize)
+            store.dispatch(action)
+        default:
+            break
+        }
+    }
+
+    private func resolveWallpaperAction(action: WallpaperAction, state: AppState) {
+        switch action.actionType {
+        case WallpaperActionType.wallpaperSelected:
+            let action = WallpaperAction(wallpaper: wallpaperManager.currentWallpaper, windowUUID: action.windowUUID, actionType: WallpaperMiddlewareActionType.wallpaperDidChange)
+            store.dispatch(action)
+        default:
+            break
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -7,6 +7,16 @@ import Redux
 
 class WallpaperMiddleware {
     private let wallpaperManager: WallpaperManagerInterface
+    private var wallpaperConfiguration: WallpaperConfiguration {
+        let currentWallpaper = wallpaperManager.currentWallpaper
+        return WallpaperConfiguration(
+            landscapeImage: currentWallpaper.landscape,
+            portraitImage: currentWallpaper.portrait,
+            textColor: currentWallpaper.textColor,
+            cardColor: currentWallpaper.cardColor,
+            logoTextColor: currentWallpaper.logoTextColor
+        )
+    }
 
     init(wallpaperManager: WallpaperManagerInterface = WallpaperManager()) {
         self.wallpaperManager = wallpaperManager
@@ -24,7 +34,7 @@ class WallpaperMiddleware {
         switch action.actionType {
         case HomepageActionType.initialize:
             let action = WallpaperAction(
-                wallpaper: wallpaperManager.currentWallpaper,
+                wallpaperConfiguration: wallpaperConfiguration,
                 windowUUID: action.windowUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
             )
@@ -38,7 +48,7 @@ class WallpaperMiddleware {
         switch action.actionType {
         case WallpaperActionType.wallpaperSelected:
             let action = WallpaperAction(
-                wallpaper: wallpaperManager.currentWallpaper,
+                wallpaperConfiguration: wallpaperConfiguration,
                 windowUUID: action.windowUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidChange
             )

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
@@ -6,11 +6,11 @@ import Common
 
 struct WallpaperState: ScreenState, Equatable {
     var windowUUID: WindowUUID
-    var wallpaper: Wallpaper
+    let wallpaperConfiguration: WallpaperConfiguration
 
-    init(windowUUID: WindowUUID, wallpaper: Wallpaper = Wallpaper.defaultWallpaper) {
+    init(windowUUID: WindowUUID, wallpaperConfiguration: WallpaperConfiguration = WallpaperConfiguration()) {
         self.windowUUID = windowUUID
-        self.wallpaper = wallpaper
+        self.wallpaperConfiguration = wallpaperConfiguration
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -31,13 +31,35 @@ struct WallpaperState: ScreenState, Equatable {
         guard let wallpaperAction = action as? WallpaperAction else { return defaultState(from: state) }
         return WallpaperState(
             windowUUID: state.windowUUID,
-            wallpaper: wallpaperAction.wallpaper
+            wallpaperConfiguration: wallpaperAction.wallpaperConfiguration
         )
     }
 
    static func defaultState(from state: WallpaperState) -> WallpaperState {
         return WallpaperState(
-            windowUUID: state.windowUUID, wallpaper: state.wallpaper
+            windowUUID: state.windowUUID, wallpaperConfiguration: state.wallpaperConfiguration
         )
    }
 }
+
+struct WallpaperConfiguration: Equatable {
+    var landscapeImage: UIImage?
+    var portraitImage: UIImage?
+    var textColor: UIColor?
+    var cardColor: UIColor?
+    var logoTextColor: UIColor?
+
+    init(
+        landscapeImage: UIImage? = nil,
+        portraitImage: UIImage? = nil,
+        textColor: UIColor? = nil,
+        cardColor: UIColor? = nil,
+        logoTextColor: UIColor? = nil
+    ) {
+        self.landscapeImage = landscapeImage
+        self.portraitImage = portraitImage
+        self.textColor = textColor
+        self.cardColor = cardColor
+        self.logoTextColor = logoTextColor
+    }
+ }

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
@@ -19,9 +19,8 @@ struct WallpaperState: ScreenState, Equatable {
         }
 
         switch action.actionType {
-        case WallpaperMiddlewareActionType.wallpaperDidInitialize:
-            return handleWallpaperAction(action: action, state: state)
-        case WallpaperMiddlewareActionType.wallpaperDidChange:
+        case WallpaperMiddlewareActionType.wallpaperDidInitialize,
+                WallpaperMiddlewareActionType.wallpaperDidChange:
             return handleWallpaperAction(action: action, state: state)
         default:
             return defaultState(from: state)

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import Redux
+import Common
+
+struct WallpaperState: ScreenState, Equatable {
+    var windowUUID: WindowUUID
+    var wallpaper: Wallpaper
+
+    init(windowUUID: WindowUUID, wallpaper: Wallpaper = Wallpaper.defaultWallpaper) {
+        self.windowUUID = windowUUID
+        self.wallpaper = wallpaper
+    }
+
+    static let reducer: Reducer<Self> = { state, action in
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else {
+            return defaultState(from: state)
+        }
+
+        switch action.actionType {
+        case WallpaperMiddlewareActionType.wallpaperDidInitialize:
+            return handleWallpaperAction(action: action, state: state)
+        case WallpaperMiddlewareActionType.wallpaperDidChange:
+            return handleWallpaperAction(action: action, state: state)
+        default:
+            return defaultState(from: state)
+        }
+    }
+
+    private static func handleWallpaperAction(action: Action, state: WallpaperState) -> WallpaperState {
+        guard let wallpaperAction = action as? WallpaperAction else { return defaultState(from: state) }
+        return WallpaperState(
+            windowUUID: state.windowUUID,
+            wallpaper: wallpaperAction.wallpaper
+        )
+    }
+
+   static func defaultState(from state: WallpaperState) -> WallpaperState {
+        return WallpaperState(
+            windowUUID: state.windowUUID, wallpaper: state.wallpaper
+        )
+   }
+}

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/WallpaperBackgroundView.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/WallpaperBackgroundView.swift
@@ -15,7 +15,7 @@ class WallpaperBackgroundView: UIView {
     }
 
     // MARK: - Variables
-    var wallpaper: Wallpaper? {
+    var wallpaperState: WallpaperState? {
         didSet {
             updateImageToCurrentWallpaper()
         }
@@ -50,17 +50,19 @@ class WallpaperBackgroundView: UIView {
     }
 
     private func updateImageToCurrentWallpaper() {
-        guard let wallpaper = self.wallpaper else { return }
+        guard let state = wallpaperState else { return }
         ensureMainThread {
-            let currentWallpaperImage = self.currentWallpaperImage(from: wallpaper)
+            let currentWallpaperImage = self.currentWallpaperImage(from: state)
             UIView.animate(withDuration: 0.3) {
                 self.pictureView.image = currentWallpaperImage
             }
         }
     }
 
-    private func currentWallpaperImage(from wallpaper: Wallpaper) -> UIImage? {
+    private func currentWallpaperImage(from wallpaperState: WallpaperState) -> UIImage? {
         let isLandscape = UIDevice.current.orientation.isLandscape
-        return isLandscape ? wallpaper.landscape : wallpaper.portrait
+        return isLandscape ?
+        wallpaperState.wallpaperConfiguration.landscapeImage :
+         wallpaperState.wallpaperConfiguration.landscapeImage
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/WallpaperBackgroundView.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/WallpaperBackgroundView.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import Common
+import Redux
 
 class WallpaperBackgroundView: UIView {
     // MARK: - UI Elements
@@ -14,26 +15,21 @@ class WallpaperBackgroundView: UIView {
     }
 
     // MARK: - Variables
-    private var wallpaperManager = WallpaperManager()
-    var notificationCenter: NotificationProtocol = NotificationCenter.default
+    var wallpaper: Wallpaper? {
+        didSet {
+            updateImageToCurrentWallpaper()
+        }
+    }
 
     // MARK: - Initializers & Setup
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
-        setupNotifications(forObserver: self,
-                           observing: [.WallpaperDidChange])
-
-        updateImageToCurrentWallpaper()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        notificationCenter.removeObserver(self)
     }
 
     private func setupView() {
@@ -54,26 +50,17 @@ class WallpaperBackgroundView: UIView {
     }
 
     private func updateImageToCurrentWallpaper() {
+        guard let wallpaper = self.wallpaper else { return }
         ensureMainThread {
-            let currentWallpaper = self.currentWallpaperImage()
+            let currentWallpaperImage = self.currentWallpaperImage(from: wallpaper)
             UIView.animate(withDuration: 0.3) {
-                self.pictureView.image = currentWallpaper
+                self.pictureView.image = currentWallpaperImage
             }
         }
     }
 
-    private func currentWallpaperImage() -> UIImage? {
+    private func currentWallpaperImage(from wallpaper: Wallpaper) -> UIImage? {
         let isLandscape = UIDevice.current.orientation.isLandscape
-        return isLandscape ? wallpaperManager.currentWallpaper.landscape : wallpaperManager.currentWallpaper.portrait
-    }
-}
-
-// MARK: - Notifiable
-extension WallpaperBackgroundView: Notifiable {
-    func handleNotifications(_ notification: Notification) {
-        switch notification.name {
-        case .WallpaperDidChange: updateImageToCurrentWallpaper()
-        default: break
-        }
+        return isLandscape ? wallpaper.landscape : wallpaper.portrait
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
@@ -199,10 +199,7 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
     }
 
     private func addDefaultWallpaper(to availableCollections: [WallpaperCollection]) -> [WallpaperCollection] {
-        let defaultWallpaper = [Wallpaper(id: "fxDefault",
-                                          textColor: nil,
-                                          cardColor: nil,
-                                          logoTextColor: nil)]
+        let defaultWallpaper = [Wallpaper.defaultWallpaper]
 
         if availableCollections.isEmpty {
             return [WallpaperCollection(id: "classic-firefox",

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
@@ -50,6 +50,7 @@ struct Wallpaper: Equatable {
     var portraitID: String { return "\(id)\(deviceVersionID)\(fileId.portrait)" }
     var landscapeID: String { return "\(id)\(deviceVersionID)\(fileId.landscape)" }
 
+    // TODO: This is actually just a nil wallpaper. Make this clearer in FXIOS-10633
     static var defaultWallpaper: Wallpaper {
         return Wallpaper(
             id: Wallpaper.defaultWallpaperName,

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
@@ -49,12 +49,18 @@ struct Wallpaper: Equatable {
     var thumbnailID: String { return "\(id)\(fileId.thumbnail)" }
     var portraitID: String { return "\(id)\(deviceVersionID)\(fileId.portrait)" }
     var landscapeID: String { return "\(id)\(deviceVersionID)\(fileId.landscape)" }
-    private var deviceVersionID: String {
-        return UIDevice.current.userInterfaceIdiom == .pad ? fileId.iPad : fileId.iPhone
+
+    static var defaultWallpaper: Wallpaper {
+        return Wallpaper(
+            id: Wallpaper.defaultWallpaperName,
+            textColor: nil,
+            cardColor: nil,
+            logoTextColor: nil
+        )
     }
 
     var type: WallpaperType {
-        return id == "fxDefault" ? .defaultWallpaper : .other
+        return id == Wallpaper.defaultWallpaperName ? .defaultWallpaper : .other
     }
 
     var needsToFetchResources: Bool {
@@ -72,6 +78,11 @@ struct Wallpaper: Equatable {
 
     var landscape: UIImage? {
         return fetchResourceFor(imageType: .landscape)
+    }
+
+    private static var defaultWallpaperName = "fxDefault"
+    private var deviceVersionID: String {
+        return UIDevice.current.userInterfaceIdiom == .pad ? fileId.iPad : fileId.iPhone
     }
 
     // MARK: - Helper functions

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/LegacyWallpaperBackgroundView.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/LegacyWallpaperBackgroundView.swift
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+
+class LegacyWallpaperBackgroundView: UIView {
+    // MARK: - UI Elements
+    private lazy var pictureView: UIImageView = .build { imageView in
+        imageView.image = nil
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+    }
+
+    // MARK: - Variables
+    private var wallpaperManager = WallpaperManager()
+    var notificationCenter: NotificationProtocol = NotificationCenter.default
+
+    // MARK: - Initializers & Setup
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+        setupNotifications(forObserver: self,
+                           observing: [.WallpaperDidChange])
+
+        updateImageToCurrentWallpaper()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
+    private func setupView() {
+        backgroundColor = .clear
+        addSubview(pictureView)
+
+        NSLayoutConstraint.activate([
+            pictureView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            pictureView.topAnchor.constraint(equalTo: topAnchor),
+            pictureView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            pictureView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+
+    // MARK: - Methods
+    public func updateImageForOrientationChange() {
+        updateImageToCurrentWallpaper()
+    }
+
+    private func updateImageToCurrentWallpaper() {
+        ensureMainThread {
+            let currentWallpaper = self.currentWallpaperImage()
+            UIView.animate(withDuration: 0.3) {
+                self.pictureView.image = currentWallpaper
+            }
+        }
+    }
+
+    private func currentWallpaperImage() -> UIImage? {
+        let isLandscape = UIDevice.current.orientation.isLandscape
+        return isLandscape ? wallpaperManager.currentWallpaper.landscape : wallpaperManager.currentWallpaper.portrait
+    }
+}
+
+// MARK: - Notifiable
+extension LegacyWallpaperBackgroundView: Notifiable {
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case .WallpaperDidChange: updateImageToCurrentWallpaper()
+        default: break
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperStorageUtility.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperStorageUtility.swift
@@ -97,10 +97,7 @@ struct WallpaperStorageUtility: WallpaperMetadataCodableProtocol {
             }
         }
 
-        return Wallpaper(id: "fxDefault",
-                         textColor: nil,
-                         cardColor: nil,
-                         logoTextColor: nil)
+        return Wallpaper.defaultWallpaper
     }
 
     public func fetchImageNamed(_ name: String) throws -> UIImage? {

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -74,7 +74,8 @@ let middlewares = [
     TrackingProtectionMiddleware().trackingProtectionProvider,
     PasswordGeneratorMiddleware().passwordGeneratorProvider,
     PocketMiddleware().pocketSectionProvider,
-    NativeErrorPageMiddleware().nativeErrorPageProvider
+    NativeErrorPageMiddleware().nativeErrorPageProvider,
+    WallpaperMiddleware().wallpaperProvider
 ]
 
 // In order for us to mock and test the middlewares easier,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+class WallpaperMiddlewareTests: XCTestCase {
+    var mockStore: MockStoreForMiddleware<AppState>!
+    let wallpaperManager = WallpaperManagerMock()
+    let appState = AppState()
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        mockStore = MockStoreForMiddleware(state: appState)
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        StoreTestUtilityHelper.resetStore()
+    }
+
+    func test_hompageAction_returnsWallpaperManagerWallpaper() throws {
+        let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
+        let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
+        let expectation = XCTestExpectation(description: "Homepage action initialize dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.wallpaperProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? WallpaperAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? WallpaperMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, WallpaperMiddlewareActionType.wallpaperDidInitialize)
+        XCTAssertEqual(actionCalled.wallpaper.id, "fxDefault")
+    }
+
+    func test_wallpaperAction_returnsWallpaperManagerWallpaper() throws {
+        let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
+        let testWallpaper = Wallpaper(id: "test", textColor: .green, cardColor: .yellow, logoTextColor: .orange)
+        let action = WallpaperAction(wallpaper: testWallpaper, windowUUID: .XCTestDefaultUUID, actionType: WallpaperActionType.wallpaperSelected)
+        let expectation = XCTestExpectation(description: "Wallpaper selected action dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.wallpaperProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? WallpaperAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? WallpaperMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, WallpaperMiddlewareActionType.wallpaperDidChange)
+        // TODO: FXIOS-10522 will make this test more meaningful by actually configuring the new current wallpaper
+        XCTAssertEqual(actionCalled.wallpaper.id, "fxDefault")
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
@@ -48,7 +48,11 @@ class WallpaperMiddlewareTests: XCTestCase {
     func test_wallpaperAction_returnsWallpaperManagerWallpaper() throws {
         let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
         let testWallpaper = Wallpaper(id: "test", textColor: .green, cardColor: .yellow, logoTextColor: .orange)
-        let action = WallpaperAction(wallpaper: testWallpaper, windowUUID: .XCTestDefaultUUID, actionType: WallpaperActionType.wallpaperSelected)
+        let action = WallpaperAction(
+            wallpaper: testWallpaper,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WallpaperActionType.wallpaperSelected
+        )
         let expectation = XCTestExpectation(description: "Wallpaper selected action dispatched")
 
         mockStore.dispatchCalled = {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
@@ -7,35 +7,28 @@ import XCTest
 
 @testable import Client
 
-class WallpaperMiddlewareTests: XCTestCase {
+class WallpaperMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockStore: MockStoreForMiddleware<AppState>!
     let wallpaperManager = WallpaperManagerMock()
-    let appState = AppState()
+    var appState: AppState!
 
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
-        mockStore = MockStoreForMiddleware(state: appState)
-        StoreTestUtilityHelper.setupStore(with: mockStore)
+
+        setupStore()
     }
 
     override func tearDown() {
+        resetStore()
         super.tearDown()
-        StoreTestUtilityHelper.resetStore()
     }
 
     func test_hompageAction_returnsWallpaperManagerWallpaper() throws {
         let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
-        let expectation = XCTestExpectation(description: "Homepage action initialize dispatched")
-
-        mockStore.dispatchCalled = {
-            expectation.fulfill()
-        }
 
         subject.wallpaperProvider(appState, action)
-
-        wait(for: [expectation])
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? WallpaperAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? WallpaperMiddlewareActionType)
@@ -53,15 +46,8 @@ class WallpaperMiddlewareTests: XCTestCase {
             windowUUID: .XCTestDefaultUUID,
             actionType: WallpaperActionType.wallpaperSelected
         )
-        let expectation = XCTestExpectation(description: "Wallpaper selected action dispatched")
-
-        mockStore.dispatchCalled = {
-            expectation.fulfill()
-        }
 
         subject.wallpaperProvider(appState, action)
-
-        wait(for: [expectation])
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? WallpaperAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? WallpaperMiddlewareActionType)
@@ -70,5 +56,19 @@ class WallpaperMiddlewareTests: XCTestCase {
         XCTAssertEqual(actionType, WallpaperMiddlewareActionType.wallpaperDidChange)
         // TODO: FXIOS-10522 will make this test more meaningful by actually configuring the new current wallpaper
         XCTAssertEqual(actionCalled.wallpaper.id, "fxDefault")
+    }
+
+    func setupAppState() -> Client.AppState {
+        appState = AppState()
+        return appState
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
@@ -35,14 +35,14 @@ class WallpaperMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, WallpaperMiddlewareActionType.wallpaperDidInitialize)
-        XCTAssertEqual(actionCalled.wallpaper.id, "fxDefault")
+        XCTAssertEqual(actionCalled.wallpaperConfiguration.cardColor, .purple)
     }
 
     func test_wallpaperAction_returnsWallpaperManagerWallpaper() throws {
         let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
-        let testWallpaper = Wallpaper(id: "test", textColor: .green, cardColor: .yellow, logoTextColor: .orange)
+        let testWallpaper = WallpaperConfiguration()
         let action = WallpaperAction(
-            wallpaper: testWallpaper,
+            wallpaperConfiguration: testWallpaper,
             windowUUID: .XCTestDefaultUUID,
             actionType: WallpaperActionType.wallpaperSelected
         )
@@ -55,7 +55,7 @@ class WallpaperMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, WallpaperMiddlewareActionType.wallpaperDidChange)
         // TODO: FXIOS-10522 will make this test more meaningful by actually configuring the new current wallpaper
-        XCTAssertEqual(actionCalled.wallpaper.id, "fxDefault")
+        XCTAssertEqual(actionCalled.wallpaperConfiguration.cardColor, .purple)
     }
 
     func setupAppState() -> Client.AppState {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
@@ -8,56 +8,75 @@ import XCTest
 @testable import Client
 
 final class WallpaperStateTests: XCTestCase {
+    let image = UIImage.templateImageNamed(ImageIdentifiers.logo)
+
     func test_initialState_returnsExpectedState() {
         let initialState = createSubject()
 
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertEqual(initialState.wallpaper.id, "fxDefault")
-        XCTAssertNil(initialState.wallpaper.textColor)
-        XCTAssertNil(initialState.wallpaper.cardColor)
-        XCTAssertNil(initialState.wallpaper.logoTextColor)
+        XCTAssertNil(initialState.wallpaperConfiguration.landscapeImage)
+        XCTAssertNil(initialState.wallpaperConfiguration.portraitImage)
+        XCTAssertNil(initialState.wallpaperConfiguration.textColor)
+        XCTAssertNil(initialState.wallpaperConfiguration.cardColor)
+        XCTAssertNil(initialState.wallpaperConfiguration.logoTextColor)
     }
 
     func test_wallpaperDidInitialize_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = headerReducer()
 
-        let testWallpaper = Wallpaper(id: "123", textColor: .black, cardColor: .black, logoTextColor: .black)
+        let testWallpaper = WallpaperConfiguration(
+            landscapeImage: image,
+            portraitImage: image,
+            textColor: .black,
+            cardColor: .black,
+            logoTextColor: .black
+        )
+        
         let newState = reducer(
             initialState,
             WallpaperAction(
-                wallpaper: testWallpaper,
+                wallpaperConfiguration: testWallpaper,
                 windowUUID: .XCTestDefaultUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
             )
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertEqual(newState.wallpaper.id, "123")
-        XCTAssertEqual(newState.wallpaper.textColor, .black)
-        XCTAssertEqual(newState.wallpaper.cardColor, .black)
-        XCTAssertEqual(newState.wallpaper.logoTextColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.landscapeImage, image)
+        XCTAssertEqual(newState.wallpaperConfiguration.portraitImage, image)
+        XCTAssertEqual(newState.wallpaperConfiguration.textColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.cardColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.logoTextColor, .black)
     }
 
     func test_wallpaperDidChange_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = headerReducer()
 
-        let testWallpaper = Wallpaper(id: "123", textColor: .black, cardColor: .black, logoTextColor: .black)
+        let testWallpaper = WallpaperConfiguration(
+            landscapeImage: image,
+            portraitImage: image,
+            textColor: .black,
+            cardColor: .black,
+            logoTextColor: .black
+        )
+
         let newState = reducer(
             initialState,
             WallpaperAction(
-                wallpaper: testWallpaper,
+                wallpaperConfiguration: testWallpaper,
                 windowUUID: .XCTestDefaultUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidChange
             )
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertEqual(newState.wallpaper.id, "123")
-        XCTAssertEqual(newState.wallpaper.textColor, .black)
-        XCTAssertEqual(newState.wallpaper.cardColor, .black)
-        XCTAssertEqual(newState.wallpaper.logoTextColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.landscapeImage, image)
+        XCTAssertEqual(newState.wallpaperConfiguration.portraitImage, image)
+        XCTAssertEqual(newState.wallpaperConfiguration.textColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.cardColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.logoTextColor, .black)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+final class WallpaperStateTests: XCTestCase {
+    func test_initialState_returnsExpectedState() {
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(initialState.wallpaper.id, "fxDefault")
+        XCTAssertNil(initialState.wallpaper.textColor)
+        XCTAssertNil(initialState.wallpaper.cardColor)
+        XCTAssertNil(initialState.wallpaper.logoTextColor)
+    }
+
+    func test_wallpaperDidInitialize_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = headerReducer()
+
+        let testWallpaper = Wallpaper(id: "123", textColor: .black, cardColor: .black, logoTextColor: .black)
+        let newState = reducer(
+            initialState,
+            WallpaperAction(
+                wallpaper: testWallpaper,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.wallpaper.id, "123")
+        XCTAssertEqual(newState.wallpaper.textColor, .black)
+        XCTAssertEqual(newState.wallpaper.cardColor, .black)
+        XCTAssertEqual(newState.wallpaper.logoTextColor, .black)
+    }
+
+    func test_wallpaperDidChange_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = headerReducer()
+
+        let testWallpaper = Wallpaper(id: "123", textColor: .black, cardColor: .black, logoTextColor: .black)
+        let newState = reducer(
+            initialState,
+            WallpaperAction(
+                wallpaper: testWallpaper,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: WallpaperMiddlewareActionType.wallpaperDidChange
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.wallpaper.id, "123")
+        XCTAssertEqual(newState.wallpaper.textColor, .black)
+        XCTAssertEqual(newState.wallpaper.cardColor, .black)
+        XCTAssertEqual(newState.wallpaper.logoTextColor, .black)
+    }
+
+    // MARK: - Private
+    private func createSubject() -> WallpaperState {
+        return WallpaperState(windowUUID: .XCTestDefaultUUID)
+    }
+
+    private func headerReducer() -> Reducer<WallpaperState> {
+        return WallpaperState.reducer
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
@@ -32,7 +32,7 @@ final class WallpaperStateTests: XCTestCase {
             cardColor: .black,
             logoTextColor: .black
         )
-        
+
         let newState = reducer(
             initialState,
             WallpaperAction(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Redux
 @testable import Client
+import XCTest
 
 protocol StoreTestUtility {
     func setupAppState() -> AppState


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10521)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23061)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
**Move wallpaper to new homescreen**
- Duplicate `WallpaperView` and move existing `WallpaperView` to `LegacyWallpaperView`
- Remove notification logic for `wallpaperDidChange` as this will be handled by redux

**Add redux for wallpaper actions like initial load and changing the wallpaper**
- `WallpaperAction`
- `WallpaperMiddleware` as interface for `WallpaperManager`
- `WallpaperManager` is still being interacted directly everywhere other than the new home screen
- `WallpaperState` as as sub-state for `HomepageState`

**TODO:**
- Handle scrolling for custom wallpaper
- Handle actual wallpaper selection in new redux flow

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

