### PR TITLE
Add FXIOS-10525 [Sent from Firefox] Add new settings toggle for the Sent From Firefox share test

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1861,6 +1861,7 @@
 		ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */; };
 		ED6C8DAC2CE6A4BB00D7F7F3 /* Sentry-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = ED6C8DAB2CE6A4BB00D7F7F3 /* Sentry-Dynamic */; };
 		ED70CD812CE3BD2C0018761B /* MockStoreForMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */; };
+		ED9FD5DB2CEBB5EA00E906A3 /* SentFromFirefoxSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9FD5DA2CEBB5EA00E906A3 /* SentFromFirefoxSetting.swift */; };
 		EDC3C2562CCAC9CB005A047F /* SearchEnginesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3C2552CCAC9CB005A047F /* SearchEnginesManager.swift */; };
 		EDC3D34F2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EDC3D34E2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets */; };
 		EDC3D3552CB70A3F00C62DE3 /* OpenSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */; };
@@ -9305,6 +9306,7 @@
 		ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinatorTests.swift; sourceTree = "<group>"; };
 		ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreForMiddleware.swift; sourceTree = "<group>"; };
 		ED84423D8666C751BBFC76AC /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Storage.strings; sourceTree = "<group>"; };
+		ED9FD5DA2CEBB5EA00E906A3 /* SentFromFirefoxSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentFromFirefoxSetting.swift; sourceTree = "<group>"; };
 		EDA240A8BBFD0A19FB2C3D7E /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Intro.strings; sourceTree = "<group>"; };
 		EDB94DDC89DE1F2C624C9841 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		EDBE49119AB71D7076BC2CA3 /* zh-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/Menu.strings"; sourceTree = "<group>"; };
@@ -11812,6 +11814,7 @@
 				8ADAE4252A33A13B007BF926 /* OpenSupportPageSetting.swift */,
 				8ADAE4212A33A113007BF926 /* SendAnonymousUsageDataSetting.swift */,
 				8ADAE41F2A33A0FD007BF926 /* SendFeedbackSetting.swift */,
+				ED9FD5DA2CEBB5EA00E906A3 /* SentFromFirefoxSetting.swift */,
 				8ADAE41D2A33A0E2007BF926 /* ShowIntroductionSetting.swift */,
 				8ADAE4232A33A126007BF926 /* StudiesToggleSetting.swift */,
 				8A720C612A4CBB370003018A /* SupportSettingsDelegate.swift */,
@@ -16280,6 +16283,7 @@
 				2C49854E206173C800893DAE /* photon-colors.swift in Sources */,
 				B2999FF72B194ADE00F0FEC1 /* FormAutofillPayloadType.swift in Sources */,
 				8A285B08294A5D4C00149B0F /* HomepageHeroImageViewModel.swift in Sources */,
+				ED9FD5DB2CEBB5EA00E906A3 /* SentFromFirefoxSetting.swift in Sources */,
 				8C92DE8B2A711ED60090BD28 /* FakespotClient.swift in Sources */,
 				8AC1065F28D0CD700013263A /* OpenQLPreviewHelper.swift in Sources */,
 				EBA3B2C32268F16300728BDB /* PhotonActionSheetView.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -699,6 +699,10 @@ public struct AccessibilityIdentifiers {
             static let title = "ShowTour"
         }
 
+        struct SentFromFirefox {
+            static let whatsApp = "SentFromFirefox.WhatsApp"
+        }
+
         struct SendFeedback {
             static let title = "SendFeedback"
         }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -356,21 +356,32 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
     private func getSupportSettings() -> [SettingSection] {
         guard let sendAnonymousUsageDataSetting, let studiesToggleSetting else { return [] }
-        let supportSettings = [
+        let isSentFromFirefoxEnabled = featureFlags.isFeatureEnabled(.sentFromFirefox, checking: .buildOnly)
+
+        var supportSettings = [
             ShowIntroductionSetting(settings: self, settingsDelegate: self),
             SendFeedbackSetting(settingsDelegate: parentCoordinator),
-            SentFromFirefoxSetting(
-                prefs: profile.prefs,
-                delegate: settingsDelegate,
-                theme: themeManager.getCurrentTheme(for: windowUUID),
-                settingsDelegate: parentCoordinator
-            ),
+        ]
+
+        // Only add this toggle to the Settings if Sent from Firefox feature flag is enabled
+        if isSentFromFirefoxEnabled {
+            supportSettings.append(
+                SentFromFirefoxSetting(
+                    prefs: profile.prefs,
+                    delegate: settingsDelegate,
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    settingsDelegate: parentCoordinator
+                )
+            )
+        }
+
+        supportSettings.append(contentsOf: [
             sendAnonymousUsageDataSetting,
             studiesToggleSetting,
             OpenSupportPageSetting(delegate: settingsDelegate,
                                    theme: themeManager.getCurrentTheme(for: windowUUID),
                                    settingsDelegate: parentCoordinator),
-        ]
+        ])
 
         return [SettingSection(title: NSAttributedString(string: .AppSettingsSupport),
                                children: supportSettings)]

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -359,6 +359,12 @@ class AppSettingsTableViewController: SettingsTableViewController,
         let supportSettings = [
             ShowIntroductionSetting(settings: self, settingsDelegate: self),
             SendFeedbackSetting(settingsDelegate: parentCoordinator),
+            SentFromFirefoxSetting(
+                prefs: profile.prefs,
+                delegate: settingsDelegate,
+                theme: themeManager.getCurrentTheme(for: windowUUID),
+                settingsDelegate: parentCoordinator
+            ),
             sendAnonymousUsageDataSetting,
             studiesToggleSetting,
             OpenSupportPageSetting(delegate: settingsDelegate,

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SentFromFirefoxSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SentFromFirefoxSetting.swift
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Shared
+
+class SentFromFirefoxSetting: BoolSetting {
+    private weak var settingsDelegate: SupportSettingsDelegate?
+
+    init(prefs: Prefs,
+         delegate: SettingsDelegate?,
+         theme: Theme,
+         settingsDelegate: SupportSettingsDelegate?) {
+        let titleString = String.localizedStringWithFormat(.SentFromFirefox.SocialShare.SocialSettingsToggleTitle,
+                                                           AppName.shortName.rawValue,
+                                                           String.SentFromFirefox.SocialMediaApp.WhatsApp)
+        let subtitleString = String.localizedStringWithFormat(.SentFromFirefox.SocialShare.SocialSettingsToggleSubtitle,
+                                                              AppName.shortName.rawValue,
+                                                              String.SentFromFirefox.SocialMediaApp.WhatsApp)
+
+        let titleAttributedString = NSAttributedString(string: titleString)
+        let subtitleAttributedString = NSAttributedString(
+            string: subtitleString,
+            attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textSecondary]
+        )
+
+        self.settingsDelegate = settingsDelegate
+
+        super.init(
+            prefs: prefs,
+            prefKey: AppConstants.prefStudiesToggle,
+            defaultValue: true,
+            attributedTitleText: titleAttributedString,
+            attributedStatusText: subtitleAttributedString,
+            settingDidChange: { toValue in
+                // TODO
+            }
+        )
+    }
+
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.SentFromFirefox.whatsApp
+    }
+}

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SentFromFirefoxSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SentFromFirefoxSetting.swift
@@ -6,7 +6,7 @@ import Common
 import Foundation
 import Shared
 
-class SentFromFirefoxSetting: BoolSetting {
+final class SentFromFirefoxSetting: BoolSetting {
     private weak var settingsDelegate: SupportSettingsDelegate?
 
     init(prefs: Prefs,

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SentFromFirefoxSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SentFromFirefoxSetting.swift
@@ -35,7 +35,7 @@ class SentFromFirefoxSetting: BoolSetting {
             attributedTitleText: titleAttributedString,
             attributedStatusText: subtitleAttributedString,
             settingDidChange: { toValue in
-                // TODO
+                // TODO: FXIOS-10582 enable/disable experimentation
             }
         )
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SentFromFirefoxSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SentFromFirefoxSetting.swift
@@ -30,7 +30,7 @@ class SentFromFirefoxSetting: BoolSetting {
 
         super.init(
             prefs: prefs,
-            prefKey: AppConstants.prefStudiesToggle,
+            prefKey: PrefsKeys.Settings.sentFromFirefoxWhatsApp,
             defaultValue: true,
             attributedTitleText: titleAttributedString,
             attributedStatusText: subtitleAttributedString,

--- a/firefox-ios/Shared/Prefs.swift
+++ b/firefox-ios/Shared/Prefs.swift
@@ -122,6 +122,7 @@ public struct PrefsKeys {
     // Firefox settings
     public struct Settings {
         public static let closePrivateTabs = "ClosePrivateTabs"
+        public static let sentFromFirefoxWhatsApp = "SentFromFirefoxWhatsApp"
     }
 
     // Activity Stream


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10525)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23067)

## :bulb: Description
This PR adds a new toggle to the Settings screen to enable or disable the Sent from Firefox feature ("Include Firefox Download Link...")

This toggle only appears if you have enabled Sent from Firefox from the debug settings. It should disappear from Settings if the feature flag is disabled.

<img width="517" alt="Screenshot 2024-11-18 at 12 58 13 PM" src="https://github.com/user-attachments/assets/3ae51fa5-4559-41f9-8d25-a4599b4844a9">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

