### PR TITLE
Bugfix FXIOS-10566 - Password Generator: Incorrect Announcement of "Use Strong Password" Button

### DIFF
--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -136,8 +136,8 @@ class AccessoryViewProvider: UIView, Themeable, InjectedThemeUUIDIdentifiable {
                 self?.tappedUseStrongPasswordButton()
             })
         accessoryView.accessibilityTraits = .button
-        accessoryView.accessibilityLabel = .PasswordAutofill.UseSavedPasswordFromKeyboard
-        accessoryView.accessibilityIdentifier = AccessibilityIdentifiers.Autofill.footerPrimaryAction
+        accessoryView.accessibilityLabel = .PasswordGenerator.KeyboardAccessoryButtonLabel
+        accessoryView.accessibilityIdentifier = AccessibilityIdentifiers.PasswordGenerator.keyboardButton
         accessoryView.isAccessibilityElement = true
         return accessoryView
     }()

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -831,6 +831,7 @@ public struct AccessibilityIdentifiers {
         static let passwordlabel = "PasswordGenerator.passwordLabel"
         static let content = "PasswordGenerator.content"
         static let header = "PasswordGenerator.header"
+        static let keyboardButton = "PasswordGenerator.keyboardButton"
     }
 
     struct NativeErrorPage {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10566)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23136)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Changed the accessibility label and identifier associated with the keyboard accessory button for "Use Strong Password" to fix the bug. 
<img width="348" alt="image" src="https://github.com/user-attachments/assets/6adf6800-3b25-427c-a04f-236488601838">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

