### PR TITLE
Bugfix FXIOS-10595 Settings screen: "Learn More" links in Send Usage Feedback & Studies descriptions are not tappable

### DIFF
--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -23,7 +23,7 @@ class SettingsCoordinator: BaseCoordinator,
                            AboutSettingsDelegate,
                            ParentCoordinatorDelegate,
                            QRCodeNavigationHandler {
-    var settingsViewController: AppSettingsScreen
+    var settingsViewController: AppSettingsScreen?
     private let wallpaperManager: WallpaperManagerInterface
     private let profile: Profile
     private let tabManager: TabManager
@@ -40,13 +40,15 @@ class SettingsCoordinator: BaseCoordinator,
         self.profile = profile
         self.tabManager = tabManager
         self.themeManager = themeManager
-        self.settingsViewController = AppSettingsTableViewController(with: profile,
-                                                                     and: tabManager)
         super.init(router: router)
 
+        // It's important we initialize AppSettingsTableViewController with a settingsDelegate and parentCoordinator
+        let settingsViewController = AppSettingsTableViewController(with: profile,
+                                                                    and: tabManager,
+                                                                    settingsDelegate: self,
+                                                                    parentCoordinator: self)
+        self.settingsViewController = settingsViewController
         router.setRootViewController(settingsViewController)
-        settingsViewController.settingsDelegate = self
-        settingsViewController.parentCoordinator = self
     }
 
     func start(with settingsSection: Route.SettingsSection) {
@@ -55,7 +57,8 @@ class SettingsCoordinator: BaseCoordinator,
         if let viewController = getSettingsViewController(settingsSection: settingsSection) {
             router.push(viewController)
         } else {
-            settingsViewController.handle(route: settingsSection)
+            assert(settingsViewController != nil)
+            settingsViewController?.handle(route: settingsSection)
         }
     }
 
@@ -406,7 +409,8 @@ class SettingsCoordinator: BaseCoordinator,
     // MARK: - AboutSettingsDelegate
 
     func pressedRateApp() {
-        settingsViewController.handle(route: .rateApp)
+        assert(settingsViewController != nil)
+        settingsViewController?.handle(route: .rateApp)
     }
 
     func pressedLicense(url: URL, title: NSAttributedString) {

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -59,7 +59,8 @@ class AppSettingsTableViewController: SettingsTableViewController,
     // MARK: - Initializers
     init(with profile: Profile,
          and tabManager: TabManager,
-         delegate: SettingsDelegate? = nil,
+         settingsDelegate: SettingsDelegate,
+         parentCoordinator: SettingsFlowDelegate,
          appAuthenticator: AppAuthenticationProtocol = AppAuthenticator(),
          applicationHelper: ApplicationHelper = DefaultApplicationHelper(),
          logger: Logger = DefaultLogger.shared) {
@@ -70,7 +71,8 @@ class AppSettingsTableViewController: SettingsTableViewController,
         super.init(windowUUID: tabManager.windowUUID)
         self.profile = profile
         self.tabManager = tabManager
-        self.settingsDelegate = delegate
+        self.settingsDelegate = settingsDelegate
+        self.parentCoordinator = parentCoordinator
         setupNavigationBar()
         setupDataSettings()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -210,8 +210,8 @@ final class SettingsCoordinatorTests: XCTestCase {
     func testDelegatesAreSet() {
         let subject = createSubject()
 
-        XCTAssertNotNil(subject.settingsViewController.settingsDelegate)
-        XCTAssertNotNil(subject.settingsViewController.parentCoordinator)
+        XCTAssertNotNil(subject.settingsViewController?.settingsDelegate)
+        XCTAssertNotNil(subject.settingsViewController?.parentCoordinator)
     }
 
     func testHandleRouteCalled_whenCreditCardRouteIsSet() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -12,6 +12,8 @@ class AppSettingsTableViewControllerTests: XCTestCase {
     private var appAuthenticator: MockAppAuthenticator!
     private var delegate: MockSettingsFlowDelegate!
     private var applicationHelper: MockApplicationHelper!
+    private var mockSettingsDelegate: MockSettingsDelegate!
+    private var mockParentCoordinator: MockSettingsFlowDelegate!
 
     override func setUp() {
         super.setUp()
@@ -23,6 +25,8 @@ class AppSettingsTableViewControllerTests: XCTestCase {
         self.appAuthenticator = MockAppAuthenticator()
         self.delegate = MockSettingsFlowDelegate()
         self.applicationHelper = MockApplicationHelper()
+        self.mockSettingsDelegate = MockSettingsDelegate()
+        self.mockParentCoordinator = MockSettingsFlowDelegate()
     }
 
     override func tearDown() {
@@ -117,10 +121,21 @@ class AppSettingsTableViewControllerTests: XCTestCase {
         XCTAssertEqual(delegate.showExperimentsCalled, 1)
     }
 
+    func testDelegatesAreSet() {
+        let subject = createSubject()
+
+        // NOTE: The subject holds a weak reference to these delegates, so we have to store them for the length of the test
+        // duration, or else they will deallocate before the following assertion checks.
+        XCTAssertNotNil(subject.settingsDelegate)
+        XCTAssertNotNil(subject.parentCoordinator)
+    }
+
     // MARK: - Helper
     private func createSubject() -> AppSettingsTableViewController {
         let subject = AppSettingsTableViewController(with: profile,
                                                      and: tabManager,
+                                                     settingsDelegate: mockSettingsDelegate,
+                                                     parentCoordinator: mockParentCoordinator,
                                                      appAuthenticator: appAuthenticator,
                                                      applicationHelper: applicationHelper)
         trackForMemoryLeaks(subject)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10595)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23205)

## :bulb: Description
Not sure what happened, but it looks like due to timing at initialization the settings delegate and parent coordinator were both nil. So we need to enforce they are passed at initialization time.

Both Settings toggles with a "learn more" link are now properly tappable and show the correct websites.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

