### PR TITLE
Bugfix FXIOS-10335 Fix audio/video leak after closing tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3819,18 +3819,20 @@ extension BrowserViewController: TabManagerDelegate {
 
         scrollController.tab = selectedTab
 
-        if !selectedTab.isFxHomeTab,
-           let webView = selectedTab.webView {
+        var needsReload = false
+        if let webView = selectedTab.webView {
             webView.accessibilityLabel = .WebViewAccessibilityLabel
             webView.accessibilityIdentifier = "contentView"
             webView.accessibilityElementsHidden = false
 
             browserDelegate?.show(webView: webView)
-
+            if selectedTab.isFxHomeTab {
+                needsReload = true
+            }
             if webView.url == nil {
                 // The webView can go gray if it was zombified due to memory pressure.
                 // When this happens, the URL is nil, so try restoring the page upon selection.
-                selectedTab.reload()
+                needsReload = true
             }
         }
 
@@ -3885,8 +3887,11 @@ extension BrowserViewController: TabManagerDelegate {
 
        /// If the selectedTab is showing an error page trigger a reload
         if let url = selectedTab.url, let internalUrl = InternalURL(url), internalUrl.isErrorPage {
+            needsReload = true
+        }
+
+        if needsReload {
             selectedTab.reloadPage()
-            return
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10335)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22652)

## :bulb: Description

⚠️ For additional notes please see the linked Jira. This is a quick initial fix. I'm hoping to get extra eyes and regression testing on this. We are also still leaking a `Tab` object however I believe we can live with that if needed for v133, the critical leak is the `WKWebView` which causes audio/video for closed tabs to continue playing.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

