### PR TITLE
Bugfix FXIOS-10598 - [Unified Search] Keyboard does not reappear as expected after rotating and selecting from the bottom sheet

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -182,6 +182,7 @@ class AddressToolbarContainerModel: Equatable {
         lhs.url == rhs.url &&
         lhs.searchTerm == rhs.searchTerm &&
         lhs.isEditing == rhs.isEditing &&
+        lhs.shouldShowKeyboard == rhs.shouldShowKeyboard &&
         lhs.shouldSelectSearchTerm == rhs.shouldSelectSearchTerm &&
         lhs.shouldDisplayCompact == rhs.shouldDisplayCompact &&
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10598)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23209)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- The problem was that the actions were being dispatched, the state was changing but the model was the same. The `configure` method was not called in `private func updateModel(toolbarState: ToolbarState)` in `AddressToolbarContainer`.
- This PR adds `shouldShowKeyboard` property as part of the equatable function.

### Video
https://github.com/user-attachments/assets/59b1d892-8df3-4c8c-a712-521a86b43022
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

