### PR TITLE
Add FXIOS-10460 [Homepage] Context Menu Navigation

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -818,6 +818,7 @@
 		8A5D1CBD2A30DC4E005AD35C /* AccountStatusSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5D1CBC2A30DC4E005AD35C /* AccountStatusSetting.swift */; };
 		8A5D1CBF2A30DC75005AD35C /* SyncNowSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5D1CBE2A30DC75005AD35C /* SyncNowSetting.swift */; };
 		8A5D1CC12A30DCA4005AD35C /* SettingDisclosureUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5D1CC02A30DCA4005AD35C /* SettingDisclosureUtility.swift */; };
+		8A62B15D2CED408B0045F46E /* ContextMenuState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A62B15C2CED408B0045F46E /* ContextMenuState.swift */; };
 		8A635ECD289437A8006378BA /* SyncedTabCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A635ECC289437A8006378BA /* SyncedTabCellTests.swift */; };
 		8A6904802B97BBAE00E30047 /* SplashScreenAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A69047F2B97BBAE00E30047 /* SplashScreenAnimation.swift */; };
 		8A6A796D27F773550022D6C6 /* HomepageContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6A796C27F773550022D6C6 /* HomepageContextMenuHelper.swift */; };
@@ -7301,6 +7302,7 @@
 		8A5D1CBC2A30DC4E005AD35C /* AccountStatusSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountStatusSetting.swift; sourceTree = "<group>"; };
 		8A5D1CBE2A30DC75005AD35C /* SyncNowSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncNowSetting.swift; sourceTree = "<group>"; };
 		8A5D1CC02A30DCA4005AD35C /* SettingDisclosureUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingDisclosureUtility.swift; sourceTree = "<group>"; };
+		8A62B15C2CED408B0045F46E /* ContextMenuState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuState.swift; sourceTree = "<group>"; };
 		8A635ECC289437A8006378BA /* SyncedTabCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncedTabCellTests.swift; sourceTree = "<group>"; };
 		8A69047F2B97BBAE00E30047 /* SplashScreenAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreenAnimation.swift; sourceTree = "<group>"; };
 		8A6A796C27F773550022D6C6 /* HomepageContextMenuHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageContextMenuHelper.swift; sourceTree = "<group>"; };
@@ -11413,6 +11415,14 @@
 			path = Account;
 			sourceTree = "<group>";
 		};
+		8A62B15B2CED40800045F46E /* ContextMenu */ = {
+			isa = PBXGroup;
+			children = (
+				8A62B15C2CED408B0045F46E /* ContextMenuState.swift */,
+			);
+			path = ContextMenu;
+			sourceTree = "<group>";
+		};
 		8A6904812B97BC2000E30047 /* SplashScreenAnimation */ = {
 			isa = PBXGroup;
 			children = (
@@ -11455,6 +11465,7 @@
 		8A7D08E12CAAF79F0035999C /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
+				8A62B15B2CED40800045F46E /* ContextMenu */,
 				8A454D3D2CB9B896009436D9 /* TopSites */,
 				8A454D2A2CB7079A009436D9 /* Header */,
 				8ABDBAA42CB6BF3A00B51F63 /* Pocket */,
@@ -16014,6 +16025,7 @@
 				215B457F27D7FD4B00E5E800 /* LegacyTabGroupData.swift in Sources */,
 				E12BD0B028AC3A7E0029AAF0 /* UIEdgeInsets+Extension.swift in Sources */,
 				C2D80BE72AADE38100CDF7A9 /* CredentialAutofillCoordinator.swift in Sources */,
+				8A62B15D2CED408B0045F46E /* ContextMenuState.swift in Sources */,
 				C8BE692729BA2FBB0015C4A2 /* SurveySurfaceInfoModel.swift in Sources */,
 				D0152245229855A8009DE753 /* OneLineTableViewCell.swift in Sources */,
 				8AAAB0592C1B7240008830B3 /* MockRustFirefoxSuggest.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -157,6 +157,16 @@ class BrowserCoordinator: BaseCoordinator,
         browserViewController.homePanel(didSelectURL: url, visitType: visitType, isGoogleTopSite: isGoogleTopSite)
     }
 
+    func showContextMenu() {
+        // TODO: FXIOS-10613 - Add proper context menu actions
+        let state = ContextMenuState()
+        let viewModel = PhotonActionSheetViewModel(actions: state.actions,
+                                                   modalStyle: .overFullScreen)
+        let sheet = PhotonActionSheet(viewModel: viewModel, windowUUID: windowUUID)
+        sheet.modalTransitionStyle = .crossDissolve
+        present(sheet, animated: true)
+    }
+
     // MARK: - PrivateHomepageDelegate
     func homePanelDidRequestToOpenInNewTab(with url: URL, isPrivate: Bool, selectNewTab: Bool) {
         browserViewController.homePanelDidRequestToOpenInNewTab(

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -104,6 +104,9 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 
     /// Navigates from home page to a new link
     func navigateFromHomePanel(to url: URL, visitType: VisitType, isGoogleTopSite: Bool)
+
+    /// Navigates to our custom context menu (Photon Action Sheet)
+    func showContextMenu()
 }
 
 extension BrowserNavigationHandler {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
@@ -26,4 +26,5 @@ enum NavigationBrowserActionType: ActionType {
     case tapOnCustomizeHomepage
     case tapOnCell
     case tapOnLink
+    case longPressOnCell
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
@@ -11,6 +11,9 @@ enum BrowserNavigationDestination: Equatable {
 
     // Webpage views
     case link
+
+    // Context menu views
+    case contextMenu
 }
 
 /// This type exists as a field on the BrowserViewControllerState

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -183,6 +183,17 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 )
             )
 
+        case NavigationBrowserActionType.longPressOnCell:
+            return BrowserViewControllerState(
+                searchScreenState: state.searchScreenState,
+                showDataClearanceFlow: state.showDataClearanceFlow,
+                fakespotState: FakespotState.reducer(state.fakespotState, action),
+                windowUUID: state.windowUUID,
+                browserViewType: state.browserViewType,
+                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
+                navigationDestination: NavigationDestination(.contextMenu)
+            )
+
         default:
             return defaultState(from: state, action: action)
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2084,6 +2084,8 @@ class BrowserViewController: UIViewController,
 
     private func handleNavigation(to type: NavigationDestination) {
         switch type.destination {
+        case .contextMenu:
+            navigationHandler?.showContextMenu()
         case .customizeHomepage:
             navigationHandler?.show(settings: .homePage)
         case .link:

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -5,6 +5,10 @@
 import Common
 import Foundation
 
+/// State to populate actions for the `PhotonActionSheet` view
+/// Ideally, we want that view to subscribe to the store and update its state following the redux pattern
+/// For now, we will instantiate this state and populate the associated view model instead to avoid
+/// increasing scope of homepage rebuild project.
 struct ContextMenuState {
     var actions: [[PhotonRowActions]] = [[]]
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+
+struct ContextMenuState {
+    var actions: [[PhotonRowActions]] = [[]]
+
+    init() {
+        actions = [[getTemporaryAction()]]
+    }
+    // TODO: FXIOS-10613 - Update with proper actions
+    private func getTemporaryAction() -> PhotonRowActions {
+        return SingleActionViewModel(
+            title: .OpenInNewTabContextMenuTitle,
+            iconString: StandardImageIdentifiers.Large.plus,
+            tapHandler: { _ in
+            }).items
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -164,6 +164,7 @@ final class HomepageViewController: UIViewController,
         )
 
         collectionView.keyboardDismissMode = .onDrag
+        collectionView.addGestureRecognizer(longPressRecognizer)
         collectionView.showsVerticalScrollIndicator = false
         collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         collectionView.backgroundColor = .clear
@@ -331,6 +332,18 @@ final class HomepageViewController: UIViewController,
         }
     }
 
+    // MARK: Long Press (Photon Action Sheet)
+    private lazy var longPressRecognizer: UILongPressGestureRecognizer = {
+        return UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress))
+    }()
+
+    @objc
+    fileprivate func handleLongPress(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {
+        guard longPressGestureRecognizer.state == .began else { return }
+        // TODO: FXIOS-10613 - Pass proper action data to context menu
+        navigateToContextMenu()
+    }
+
     // MARK: Dispatch Actions
     private func toggleHomepageMode() {
         store.dispatch(
@@ -356,6 +369,15 @@ final class HomepageViewController: UIViewController,
                 url: homepageState.pocketState.footerURL,
                 windowUUID: self.windowUUID,
                 actionType: NavigationBrowserActionType.tapOnLink
+            )
+        )
+    }
+
+    private func navigateToContextMenu() {
+        store.dispatch(
+            NavigationBrowserAction(
+                windowUUID: windowUUID,
+                actionType: NavigationBrowserActionType.longPressOnCell
             )
         )
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -35,6 +35,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
     var showMainMenuCalled = 0
     var showPasswordGeneratorCalled = 0
     var navigateFromHomePanelCalled = 0
+    var showContextMenuCalled = 0
 
     func show(settings: Client.Route.SettingsSection, onDismiss: (() -> Void)?) {
         showSettingsCalled += 1
@@ -121,6 +122,10 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
 
     func navigateFromHomePanel(to url: URL, visitType: VisitType, isGoogleTopSite: Bool) {
         navigateFromHomePanelCalled += 1
+    }
+
+    func showContextMenu() {
+        showContextMenuCalled += 1
     }
 
     func dismissFakespotModal(animated: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10460)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22888)

## :bulb: Description
Add navigation foundation to show the context menu / photon action sheet. 
- Handle long press action and dispatch a navigation action for the context menu
- Added new method to coordinator to `showContextMenu` this will create the `ContextMenuState` which will be use to populate the viewModel used for the `PhotonActionSheet` view
- Created new `ContextMenuState` which will hold action logic.

Next PRs (after PTO) will include specific actions for pocket and top sites. Tests will be added for the context menu state, UI tests will be added at a later date to test the navigation.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
https://github.com/user-attachments/assets/7696d708-5e8d-422c-9fd4-fd33d0ef76f1
