### PR TITLE
Refactor - Update bookmark folder strings

### DIFF
--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3318,27 +3318,27 @@ extension String {
         key: "Mobile Bookmarks",
         tableName: "Storage",
         value: nil,
-        comment: "The legacy title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
+        comment: "The legacy title of the folder that contains mobile bookmarks.")
     public static let BookmarksFolderTitleMobile = MZLocalizedString(
         key: "Bookmarks",
         tableName: "Storage",
         value: nil,
-        comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
+        comment: "The title of the folder that contains mobile bookmarks.")
     public static let BookmarksFolderTitleMenu = MZLocalizedString(
         key: "Bookmarks Menu",
         tableName: "Storage",
         value: nil,
-        comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
+        comment: "The name of the folder that contains desktop bookmarks in the menu.")
     public static let BookmarksFolderTitleToolbar = MZLocalizedString(
         key: "Bookmarks Toolbar",
         tableName: "Storage",
         value: nil,
-        comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
+        comment: "The name of the folder that contains desktop bookmarks in the toolbar.")
     public static let BookmarksFolderTitleUnsorted = MZLocalizedString(
         key: "Unsorted Bookmarks",
         tableName: "Storage",
         value: nil,
-        comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
+        comment: "The name of the folder that contains unsorted desktop bookmarks.")
 }
 
 // MARK: - Bookmark Management


### PR DESCRIPTION
## :bulb: Description
Updated the the comment, by removing "This should match bookmarks.folder.mobile.label on Android." Since Localizers don’t refer to connections among strings like this.

Requested on the string import PR: [https://github.com/mozilla-l10n/firefoxios-l10n/pull/251](https://github.com/mozilla-l10n/firefoxios-l10n/pull/251)


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

