### PR TITLE
Add FXIOS-10603 Telemetry for pull refresh easter egg

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
@@ -133,6 +133,7 @@ class PullRefreshView: UIView,
             self.progressContainerView.backgroundColor = .clear
             self.progressContainerView.transform = .identity
             self.progressView.transform = .identity
+            TelemetryWrapper.shared.recordEvent(category: .action, method: .pull, object: .reload)
             self.onRefreshCallback()
         })
     }
@@ -168,6 +169,7 @@ class PullRefreshView: UIView,
 
     private func showEasterEgg() {
         guard let easterEggGif else { return }
+        TelemetryWrapper.shared.recordEvent(category: .action, method: .detect, object: .showPullRefreshEasterEgg)
         easterEggGif.isHidden = false
         let angle = atan2(easterEggGif.transform.b, easterEggGif.transform.a)
         UIView.animate(withDuration: UX.defaultAnimationDuration) {

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -332,6 +332,7 @@ extension TelemetryWrapper {
         case downloadNowButton = "download-now-button"
         case downloadsPanel = "downloads-panel"
         case defaultSearchEngine = "default-search-engine"
+        case showPullRefreshEasterEgg = "show-pull-refresh-easter-egg"
         // MARK: Fakespot
         case shoppingButton = "shopping-button"
         case shoppingBottomSheet = "shopping-bottom-sheet"
@@ -911,8 +912,10 @@ extension TelemetryWrapper {
             GleanMetrics.Tabs.pressTabToolbar.record()
         case (.action, .press, .tab, _, _):
             GleanMetrics.Tabs.pressTopTab.record()
-        case(.action, .pull, .reload, _, _):
-            GleanMetrics.Tabs.pullToRefresh.add()
+        case (.action, .pull, .reload, _, _):
+            GleanMetrics.Tabs.pullToRefresh.record()
+        case (.action, .detect, .showPullRefreshEasterEgg, _, _):
+            GleanMetrics.Tabs.pullToRefreshEasterEgg.record()
         case(.action, .navigate, .tab, _, _):
             GleanMetrics.Tabs.normalAndPrivateUriCount.add()
         case(.action, .tap, .navigateTabHistoryBack, _, _), (.action, .press, .navigateTabHistoryBack, _, _):

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -3776,10 +3776,9 @@ tabs:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-01-01"
   pull_to_refresh:
-    type: counter
+    type: event
     description: |
-      Record the number of times a user pulls down
-      on a page to reload.
+      Record event when user has executed pull to refresh.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/9118
     data_reviews:
@@ -3787,6 +3786,17 @@ tabs:
       - https://github.com/mozilla-mobile/firefox-ios/pull/9673
       - https://github.com/mozilla-mobile/firefox-ios/pull/12334
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-01-01"
+  pull_to_refresh_easter_egg:
+    type: event
+    description: |
+      Record event when user has discovered the Easter egg.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/9118
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/9136
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-01-01"

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -3780,12 +3780,13 @@ tabs:
     description: |
       Record event when user has executed pull to refresh.
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/9118
+      - https://github.com/mozilla-mobile/firefox-ios/issues/23225
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/9136
       - https://github.com/mozilla-mobile/firefox-ios/pull/9673
       - https://github.com/mozilla-mobile/firefox-ios/pull/12334
       - https://github.com/mozilla-mobile/firefox-ios/pull/14102
+      - https://github.com/mozilla-mobile/firefox-ios/pull/23252
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-01-01"
@@ -3794,9 +3795,9 @@ tabs:
     description: |
       Record event when user has discovered the Easter egg.
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/9118
+      - https://github.com/mozilla-mobile/firefox-ios/issues/23225
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/9136
+      - https://github.com/mozilla-mobile/firefox-ios/pull/23252
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-01-01"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10603)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23225)

## :bulb: Description
Add Telemetry for pull refresh easter egg and change pull refresh telemetry to event type.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
