### PR TITLE
Bugfix FXIOS-10584 - [Toolbar Redesign] 20+ new homepage tabs are opened when I try to open just one new tab

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -257,15 +257,9 @@ public class BrowserAddressToolbar: UIView,
     }
 
     private func updateActionStack(stackView: UIStackView, toolbarElements: [ToolbarElement]) {
-        let existingButtons = stackView.arrangedSubviews.compactMap { $0 as? ToolbarButton }
         stackView.removeAllArrangedViews()
-
         toolbarElements.forEach { toolbarElement in
-            // find existing button or create new one
-            // we do this to avoid having a new button every time we re-configure the address toolbar
-            // as this can result in button taps not resulting in correct action because the action
-            // as the reference to an old and not displayed button (e.g. the menu that is displayed from the menu button)
-            let button = newOrExistingToolbarButton(for: toolbarElement, existingButtons: existingButtons)
+            let button = toolbarElement.numberOfTabs != nil ? TabNumberButton() : ToolbarButton()
             button.configure(element: toolbarElement)
             stackView.addArrangedSubview(button)
 
@@ -283,17 +277,6 @@ public class BrowserAddressToolbar: UIView,
                 toolbarDelegate?.configureContextualHint(self, for: button, with: contextualHintType)
             }
         }
-    }
-
-    private func newOrExistingToolbarButton(for element: ToolbarElement,
-                                            existingButtons: [ToolbarButton]) -> ToolbarButton {
-        let existingButton = existingButtons.first { $0.isButtonFor(toolbarElement: element) }
-
-        guard let existingButton else {
-            return element.numberOfTabs != nil ? TabNumberButton() : ToolbarButton()
-        }
-
-        return existingButton
     }
 
     private func updateActionSpacing() {

--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -47,7 +47,8 @@ class ToolbarButton: UIButton, ThemeApplicable {
         let image = imageConfiguredForRTL(for: element)
         let action = UIAction(title: element.a11yLabel,
                               image: image,
-                              handler: { _ in
+                              handler: { [weak self] _ in
+            guard let self else { return }
             element.onSelected?(self)
             UIAccessibility.post(notification: .announcement, argument: element.a11yLabel)
         })
@@ -100,17 +101,6 @@ class ToolbarButton: UIButton, ThemeApplicable {
 
         updatedConfiguration.background.backgroundColor = backgroundColorNormal
         configuration = updatedConfiguration
-    }
-
-    public func isButtonFor(toolbarElement: ToolbarElement) -> Bool {
-        guard let config = configuration else { return false }
-
-        return isSelected == toolbarElement.isSelected &&
-            config.image == imageConfiguredForRTL(for: toolbarElement) &&
-            isEnabled == toolbarElement.isEnabled &&
-            accessibilityIdentifier == toolbarElement.a11yId &&
-            accessibilityLabel == toolbarElement.a11yLabel &&
-            accessibilityHint == toolbarElement.a11yHint
     }
 
     private func addBadgeIcon(imageName: String) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10584)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23175)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- After investigating, I've found out that the bug was caused by this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/23023) that fixed [FXIOS-10500](https://mozilla-hub.atlassian.net/browse/FXIOS-10500). I'm not really 100% sure what was happening but we are dealing with references here and some kind of retain cycle was certainly occuring because after tapping the `+` (add new tab button) intermittently, 3, 4(a random number) of redux actions for opening a new tab were triggered. 

- While trying to find the cause of this bug, I found an even bigger memory leak for Toolbar Buttons that were never deallocated because `self` was captured in the action handler.

- Reverting the change from the PR mentioned above and fixing the leak seemed to solve both problems. [FXIOS-10500](https://mozilla-hub.atlassian.net/browse/FXIOS-10500) and the one addressed in this PR.

### Video
https://github.com/user-attachments/assets/3c211123-d9e4-4a2e-b89f-03754044e707

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)



[FXIOS-10500]: https://mozilla-hub.atlassian.net/browse/FXIOS-10500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-10500]: https://mozilla-hub.atlassian.net/browse/FXIOS-10500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ