### PR TITLE
Fixes MTE-3869 - for flaky addresses smoke tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
@@ -163,9 +163,9 @@ class AddressesTests: BaseTestCase {
         addNewAddress()
         tapSave()
         if iPad() {
-            app.collectionViews.buttons.element(boundBy: 0).waitAndTap()
+            app.collectionViews.buttons.element(boundBy: 0).tapWithRetry()
         } else {
-            app.collectionViews.buttons.element(boundBy: 1).waitAndTap()
+            app.collectionViews.buttons.element(boundBy: 1).tapWithRetry()
         }
         // Update the all addresses fields
         tapEdit()
@@ -182,9 +182,9 @@ class AddressesTests: BaseTestCase {
     private func updateFieldsWithWithoutState(updateCountry: Bool, isPostalCode: Bool) {
         // Choose to update an address
         if iPad() {
-            app.collectionViews.buttons.element(boundBy: 0).waitAndTap()
+            app.collectionViews.buttons.element(boundBy: 0).tapWithRetry()
         } else {
-            app.collectionViews.buttons.element(boundBy: 1).waitAndTap()
+            app.collectionViews.buttons.element(boundBy: 1).tapWithRetry()
         }
         // Update the all addresses fields
         tapEdit()
@@ -319,7 +319,7 @@ class AddressesTests: BaseTestCase {
     }
 
     private func tapSave() {
-        app.buttons["Save"].waitAndTap()
+        app.buttons["Save"].tapWithRetry()
     }
 
     private func tapEdit() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -565,6 +565,18 @@ extension XCUIElement {
         self.tap()
         self.typeText(text)
     }
+
+    func tapWithRetry() {
+        waitAndTap()
+        var nrOfTaps = 5
+        while self.isHittable && nrOfTaps > 0 {
+            tap(force: true)
+            nrOfTaps -= 1
+        }
+        if self.isHittable {
+            XCTFail("\(self) was not tapped")
+        }
+    }
 }
 
 extension XCUIElementQuery {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3858
https://mozilla-hub.atlassian.net/browse/MTE-3869

## :bulb: Description
This PR attempts to fix a strange behaviour on bitrise for addresses smoke tests.
After pressing save when adding a new address the booting screen of the OS appears.
The screen stays opened for 3-4 seconds and then the app gets back in focus.
This issue cannot be reproduced locally.
The solution found is to retry tapping on the element that is not visible until it gets visible.
These tests will be monitored in the future.


