### PR TITLE
Add FXIOS-10609 [Native Error Page] Added flag to show no internet connection error page only

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -31,6 +31,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case menuRefactorHint
     case microsurvey
     case nativeErrorPage
+    case noInternetConnectionErrorPage
     case nightMode
     case passwordGenerator
     case preferSwitchToOpenTabOverDuplicate
@@ -56,6 +57,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .menuRefactor,
                 .microsurvey,
                 .nativeErrorPage,
+                .noInternetConnectionErrorPage,
                 .sentFromFirefox,
                 .toolbarRefactor,
                 .trackingProtectionRefactor,
@@ -112,6 +114,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .menuRefactor,
                 .menuRefactorHint,
                 .nativeErrorPage,
+                .noInternetConnectionErrorPage,
                 .nightMode,
                 .passwordGenerator,
                 .preferSwitchToOpenTabOverDuplicate,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -139,6 +139,11 @@ class BrowserViewController: UIViewController,
         return featureFlags.isFeatureEnabled(.nativeErrorPage, checking: .buildOnly)
     }
 
+    /// Temporary flag for showing no internet connection native error page only.
+    var isNICErrorPageEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.noInternetConnectionErrorPage, checking: .buildOnly)
+    }
+
     private var browserViewControllerState: BrowserViewControllerState?
 
     // Header stack view can contain the top url bar, top reader mode, top ZoomPageBar
@@ -1537,9 +1542,15 @@ class BrowserViewController: UIViewController,
             return
         }
 
+        /// Used for checking if current error code is for no internet connection
+        let validNICError = url?.absoluteString.contains(String(Int(
+            CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue))) ?? false
+
         if isAboutHomeURL {
             showEmbeddedHomepage(inline: true, isPrivate: tabManager.selectedTab?.isPrivate ?? false)
         } else if isErrorURL && isNativeErrorPageEnabled {
+            showEmbeddedNativeErrorPage()
+        } else if validNICError && isNICErrorPageEnabled {
             showEmbeddedNativeErrorPage()
         } else {
             showEmbeddedWebview()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1543,14 +1543,14 @@ class BrowserViewController: UIViewController,
         }
 
         /// Used for checking if current error code is for no internet connection
-        let validNICError = url?.absoluteString.contains(String(Int(
+        let isNICErrorCode = url?.absoluteString.contains(String(Int(
             CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue))) ?? false
 
         if isAboutHomeURL {
             showEmbeddedHomepage(inline: true, isPrivate: tabManager.selectedTab?.isPrivate ?? false)
         } else if isErrorURL && isNativeErrorPageEnabled {
             showEmbeddedNativeErrorPage()
-        } else if validNICError && isNICErrorPageEnabled {
+        } else if isNICErrorCode && isNICErrorPageEnabled {
             showEmbeddedNativeErrorPage()
         } else {
             showEmbeddedWebview()

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -33,7 +33,8 @@ class NativeErrorPageHelper {
             title = .NativeErrorPage.NoInternetConnection.TitleLabel
             description = .NativeErrorPage.NoInternetConnection.Description
         default:
-            break
+            title = .NativeErrorPage.NoInternetConnection.TitleLabel
+            description = .NativeErrorPage.NoInternetConnection.Description
         }
 
         let model = ErrorPageModel(errorTitle: title, errorDescription: description)

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -85,6 +85,7 @@ final class NativeErrorPageViewController: UIViewController,
         label.font = FXFontStyles.Bold.title2.scaledFont()
         label.numberOfLines = 0
         label.textAlignment = .natural
+        label.text = .NativeErrorPage.NoInternetConnection.TitleLabel
         label.accessibilityIdentifier = AccessibilityIdentifiers.NativeErrorPage.titleLabel
         label.accessibilityTraits = .header
     }
@@ -94,6 +95,7 @@ final class NativeErrorPageViewController: UIViewController,
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.textAlignment = .natural
+        label.text = .NativeErrorPage.NoInternetConnection.Description
         label.accessibilityIdentifier = AccessibilityIdentifiers.NativeErrorPage.errorDescriptionLabel
     }
 
@@ -133,8 +135,11 @@ final class NativeErrorPageViewController: UIViewController,
     // MARK: Redux
     func newState(state: NativeErrorPageState) {
         nativeErrorPageState = state
-        titleLabel.text = state.title
-        errorDescriptionLabel.text = state.description
+
+        if state.title != nil {
+            titleLabel.text = state.title
+            errorDescriptionLabel.text = state.description
+        }
     }
 
     func subscribeToRedux() {

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -75,6 +75,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
+                    with: .noInternetConnectionErrorPage,
+                    titleText: format(string: "Enable NIC Native Error Page"),
+                    statusText: format(string: "Toggle to display natively created no internet conneciton error page")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .toolbarRefactor,
                     titleText: format(string: "Toolbar Redesign"),
                     statusText: format(string: "Toggle to enable the toolbar redesign")

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -77,7 +77,7 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 FeatureFlagsBoolSetting(
                     with: .noInternetConnectionErrorPage,
                     titleText: format(string: "Enable NIC Native Error Page"),
-                    statusText: format(string: "Toggle to display natively created no internet conneciton error page")
+                    statusText: format(string: "Toggle to display natively created no internet connection error page")
                 ) { [weak self] _ in
                     self?.reloadView()
                 },

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -70,6 +70,9 @@ final class NimbusFeatureFlagLayer {
         case .nativeErrorPage:
             return checkNativeErrorPageFeature(from: nimbus)
 
+        case .noInternetConnectionErrorPage:
+            return checkNICErrorPageFeature(from: nimbus)
+
         case .nightMode:
             return checkNightModeFeature(from: nimbus)
 
@@ -349,5 +352,9 @@ final class NimbusFeatureFlagLayer {
 
     private func checkNativeErrorPageFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.nativeErrorPageFeature.value().enabled
+    }
+
+    private func checkNICErrorPageFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.nativeErrorPageFeature.value().noInternetConnectionError
     }
 }

--- a/firefox-ios/nimbus-features/nativeErrorPageFeature.yaml
+++ b/firefox-ios/nimbus-features/nativeErrorPageFeature.yaml
@@ -9,11 +9,18 @@ features:
           If true, the feature is active.
         type: Boolean
         default: false
+      no_internet_connection_error:
+        description: >
+          This feature is for managing the roll out of the no interet connection native error page feature
+        type: Boolean
+        default: false
 
     defaults:
       - channel: beta
         value:
           enabled: false
+          no_internet_connection_error: false
       - channel: developer
         value:
           enabled: false
+          no_internet_connection_error: false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10609)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23236)

## :bulb: Description
- Added `no_internet_connection_error` in `nativeErrorPageFeature.yaml`. This parameter is exclusively to show/hide new "no internet connection" error page. 
- Additionally added a check for no internet connection error code.
- Added default strings for error page.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

