### PR TITLE
Update FXIOS-9851 [Native Error Page] tab tray screenshot for new error pages

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -504,13 +504,9 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         let isAboutHomeURL = InternalURL(action.selectedTabURL)?.isAboutHomeURL ?? false
         var browserViewType = BrowserViewType.normalHomepage
         let isPrivateBrowsing = action.isPrivateBrowsing ?? false
-        let isNativeErrorPage = action.isNativeErrorPage ?? false
-        let isErrorURL = InternalURL(action.selectedTabURL)?.isErrorPage ?? false
 
         if isAboutHomeURL {
             browserViewType = isPrivateBrowsing ? .privateHomepage : .normalHomepage
-        } else if isNativeErrorPage && isErrorURL {
-            browserViewType = .nativeErrorPage
         } else {
             browserViewType = .webview
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewType.swift
@@ -5,7 +5,6 @@
 import Foundation
 
 enum BrowserViewType {
-    case nativeErrorPage
     case normalHomepage
     case privateHomepage
     case webview

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -166,7 +166,7 @@ class BrowserViewController: UIViewController,
     // The content stack view contains the contentContainer with homepage or browser and the shopping sidebar
     var contentStackView: SidebarEnabledView = .build()
 
-    // The content container contains the homepage or webview. Embedded by the coordinator.
+    // The content container contains the homepage, error page or webview. Embedded by the coordinator.
     var contentContainer: ContentContainer = .build { _ in }
 
     lazy var isBottomSearchBar: Bool = {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1505,8 +1505,6 @@ class BrowserViewController: UIViewController,
                    category: .coordinator)
 
         switch browserViewType {
-        case .nativeErrorPage:
-            showEmbeddedNativeErrorPage()
         case .normalHomepage:
             showEmbeddedHomepage(inline: true, isPrivate: false)
         case .privateHomepage:

--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -36,18 +36,27 @@ class ScreenshotHelper {
 
         /// Added check for native error pages.
         let isNativeErrorPage = controller?.contentContainer.hasNativeErrorPage ?? false
+
         /// If the tab is the homepage, take a screenshot of the homepage view.
         /// This is done by accessing the content view from the content container.
         /// The screenshot is then set for the tab, and a TabEvent is posted to indicate
         /// that a screenshot has been set for the homepage.
-        if tab.isFxHomeTab || isNativeErrorPage {
+        if tab.isFxHomeTab {
             if let homeview = controller?.contentContainer.contentView {
                 let screenshot = homeview.screenshot(quality: UIConstants.ActiveScreenshotQuality)
                 tab.hasHomeScreenshot = true
                 tab.setScreenshot(screenshot)
                 TabEvent.post(.didSetScreenshot(isHome: true), for: tab)
             }
-        // Handle webview screenshots
+            // Handle error page screenshots
+        } else if isNativeErrorPage {
+            if let view = controller?.contentContainer.contentView {
+                let screenshot = view.screenshot(quality: UIConstants.ActiveScreenshotQuality)
+                tab.hasHomeScreenshot = false
+                tab.setScreenshot(screenshot)
+                TabEvent.post(.didSetScreenshot(isHome: false), for: tab)
+            }
+            // Handle webview screenshots
         } else {
             let configuration = WKSnapshotConfiguration()
             // This is for a bug in certain iOS 13 versions, snapshots cannot be taken

--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -34,11 +34,13 @@ class ScreenshotHelper {
         /// Handle home page snapshots, can not use Apple API snapshot function for this
         guard controller != nil else { return }
 
+        /// Added check for native error pages.
+        let isNativeErrorPage = controller?.contentContainer.hasNativeErrorPage ?? false
         /// If the tab is the homepage, take a screenshot of the homepage view.
         /// This is done by accessing the content view from the content container.
         /// The screenshot is then set for the tab, and a TabEvent is posted to indicate
         /// that a screenshot has been set for the homepage.
-        if tab.isFxHomeTab {
+        if tab.isFxHomeTab || isNativeErrorPage {
             if let homeview = controller?.contentContainer.contentView {
                 let screenshot = homeview.screenshot(quality: UIConstants.ActiveScreenshotQuality)
                 tab.hasHomeScreenshot = true

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -54,20 +54,6 @@ final class BrowserViewControllerStateTests: XCTestCase {
         XCTAssertEqual(newState.displayView, .dataClearance)
     }
 
-    func testUpdateSelectedTabAction() {
-        let initialState = createSubject()
-        let reducer = browserViewControllerReducer()
-
-        XCTAssertEqual(initialState.browserViewType, .normalHomepage)
-
-        let action = getGeneralBrowserAction(selectedTabURL: URL(string: "internal://local/errorpage"),
-                                             isNativeErrorPage: true,
-                                             for: .updateSelectedTab)
-        let newState = reducer(initialState, action)
-
-        XCTAssertEqual(newState.browserViewType, .nativeErrorPage)
-    }
-
     func testShowPasswordGeneratorAction() {
         let initialState = createSubject()
         let reducer = browserViewControllerReducer()


### PR DESCRIPTION


## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9851)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21628)

## :bulb: Description
- Update screenshot logic for tab tray thumbnail.
- Removed the `nativeErrorPage` case from `BrowserViewType` as it is no longer needed.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

