### PR TITLE
Bugfix FXIOS-10696 Dismiss search bar when tap on the outside view in HistoryPanel

### DIFF
--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
@@ -27,6 +27,11 @@ extension HistoryPanel: UISearchBarDelegate {
         performSearch(term: searchText)
     }
 
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        bottomStackView.isHidden = true
+        searchBar.resignFirstResponder()
+    }
+
     func startSearchState() {
         updatePanelState(newState: .history(state: .search))
         bottomStackView.isHidden = false

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -862,7 +862,7 @@ extension HistoryPanel {
             }
         }
     }
-    
+
     private func setupSearchBarTapGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(removedSearchBarWhenTapOutside))
         tapGesture.cancelsTouchesInView = false
@@ -872,15 +872,14 @@ extension HistoryPanel {
 
 // MARK: - User action helpers
 extension HistoryPanel {
-    
     @objc
-    private func removedSearchBarWhenTapOutside() {
-        if !searchbar.isHidden {
+    private func removedSearchBarWhenTapOutside(_ sender: UITapGestureRecognizer) {
+        if !bottomStackView.isHidden && !bottomStackView.frame.contains(sender.location(in: view)) {
             bottomStackView.isHidden = true
-            searchbar.resignFirstResponder()
+            bottomStackView.resignFirstResponder()
         }
     }
-    
+
     func handleLeftTopButton() {
         updatePanelState(newState: .history(state: .mainView))
     }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -97,6 +97,7 @@ class HistoryPanel: UIViewController,
         searchbar.searchTextField.placeholder = self.viewModel.searchHistoryPlaceholder
         searchbar.returnKeyType = .go
         searchbar.delegate = self
+        searchbar.showsCancelButton = true
     }
 
     private lazy var tableView: UITableView = .build { [weak self] tableView in

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -866,7 +866,6 @@ extension HistoryPanel {
 
 // MARK: - User action helpers
 extension HistoryPanel {
-
     func handleLeftTopButton() {
         updatePanelState(newState: .history(state: .mainView))
     }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -176,7 +176,7 @@ class HistoryPanel: UIViewController,
         setupLayout()
         configureDataSource()
         applyTheme()
-
+        setupSearchBarTapGesture()
         // Update theme of already existing view
         bottomStackView.applyTheme(theme: currentTheme())
     }
@@ -862,10 +862,25 @@ extension HistoryPanel {
             }
         }
     }
+    
+    private func setupSearchBarTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(removedSearchBarWhenTapOutside))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+    }
 }
 
 // MARK: - User action helpers
 extension HistoryPanel {
+    
+    @objc
+    private func removedSearchBarWhenTapOutside() {
+        if !searchbar.isHidden {
+            bottomStackView.isHidden = true
+            searchbar.resignFirstResponder()
+        }
+    }
+    
     func handleLeftTopButton() {
         updatePanelState(newState: .history(state: .mainView))
     }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -177,7 +177,6 @@ class HistoryPanel: UIViewController,
         setupLayout()
         configureDataSource()
         applyTheme()
-        setupSearchBarTapGesture()
         // Update theme of already existing view
         bottomStackView.applyTheme(theme: currentTheme())
     }
@@ -863,23 +862,10 @@ extension HistoryPanel {
             }
         }
     }
-
-    private func setupSearchBarTapGesture() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(removedSearchBarWhenTapOutside))
-        tapGesture.cancelsTouchesInView = false
-        view.addGestureRecognizer(tapGesture)
-    }
 }
 
 // MARK: - User action helpers
 extension HistoryPanel {
-    @objc
-    private func removedSearchBarWhenTapOutside(_ sender: UITapGestureRecognizer) {
-        if !bottomStackView.isHidden && !bottomStackView.frame.contains(sender.location(in: view)) {
-            bottomStackView.isHidden = true
-            searchbar.resignFirstResponder()
-        }
-    }
 
     func handleLeftTopButton() {
         updatePanelState(newState: .history(state: .mainView))

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -876,7 +876,7 @@ extension HistoryPanel {
     private func removedSearchBarWhenTapOutside(_ sender: UITapGestureRecognizer) {
         if !bottomStackView.isHidden && !bottomStackView.frame.contains(sender.location(in: view)) {
             bottomStackView.isHidden = true
-            bottomStackView.resignFirstResponder()
+            searchbar.resignFirstResponder()
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10696)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23379)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

