### PR TITLE
Refactor FXIOS-9085 #20125 Rename legacy class to top tabs

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1547,7 +1547,7 @@
 		D82ED2641FEB3C420059570B /* DefaultSearchPrefsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82ED2631FEB3C420059570B /* DefaultSearchPrefsTests.swift */; };
 		D83822001FC7961D00303C12 /* DispatchQueueHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83821FF1FC7961D00303C12 /* DispatchQueueHelper.swift */; };
 		D863C8F21F68BFC20058D95F /* GradientProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */; };
-		D87F84AC20B891160091F2DA /* TabDisplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F84AB20B891160091F2DA /* TabDisplayManager.swift */; };
+		D87F84AC20B891160091F2DA /* TopTabDisplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F84AB20B891160091F2DA /* TopTabDisplayManager.swift */; };
 		D88C01B722B29EC200936951 /* ScreenGraphTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39012F271F8ED262002E3D31 /* ScreenGraphTest.swift */; };
 		D88FDA9F1F4E2B9200FD9709 /* PhotonActionSheetProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDA9E1F4E2B9200FD9709 /* PhotonActionSheetProtocol.swift */; };
 		D88FDAAF1F4E2BA000FD9709 /* PhotonActionSheetAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88FDAAE1F4E2BA000FD9709 /* PhotonActionSheetAnimator.swift */; };
@@ -8845,7 +8845,7 @@
 		D83821FF1FC7961D00303C12 /* DispatchQueueHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueHelper.swift; sourceTree = "<group>"; };
 		D84C455F8028E9B48004E77F /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		D863C8E31F68BFC20058D95F /* GradientProgressBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientProgressBar.swift; sourceTree = "<group>"; };
-		D87F84AB20B891160091F2DA /* TabDisplayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayManager.swift; sourceTree = "<group>"; };
+		D87F84AB20B891160091F2DA /* TopTabDisplayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabDisplayManager.swift; sourceTree = "<group>"; };
 		D88FDA9E1F4E2B9200FD9709 /* PhotonActionSheetProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetProtocol.swift; sourceTree = "<group>"; };
 		D88FDAAE1F4E2BA000FD9709 /* PhotonActionSheetAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetAnimator.swift; sourceTree = "<group>"; };
 		D8A74DD5B8E13E061C9C2C90 /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
@@ -13107,7 +13107,7 @@
 				D04D1B91209790B60074B35F /* Toast.swift */,
 				C4E3985F1D22C409004E89BA /* TopTabsLayout.swift */,
 				C45F44681D087DB600CB7EF0 /* TopTabsViewController.swift */,
-				D87F84AB20B891160091F2DA /* TabDisplayManager.swift */,
+				D87F84AB20B891160091F2DA /* TopTabDisplayManager.swift */,
 				C4E3983C1D21F1E7004E89BA /* TopTabCell.swift */,
 				E18BAAFC28E4A44500098AE2 /* TopTabFader.swift */,
 				8AD40FD227BB068F00672675 /* MainMenuActionHelper.swift */,
@@ -16190,7 +16190,7 @@
 				AB6FEA202AEA5CA200E7B2F2 /* FakespotAdView.swift in Sources */,
 				C87A121A28C2451A0097ED51 /* WallpaperMigrationUtility.swift in Sources */,
 				AB9CBC032C53B64C00102610 /* TrackingProtectionMiddleware.swift in Sources */,
-				D87F84AC20B891160091F2DA /* TabDisplayManager.swift in Sources */,
+				D87F84AC20B891160091F2DA /* TopTabDisplayManager.swift in Sources */,
 				D0C95EF6201A55A800E4E51C /* BrowserViewController+UIDropInteractionDelegate.swift in Sources */,
 				D31CF65C1CC1959A001D0BD0 /* PrivilegedRequest.swift in Sources */,
 				A55319BD2B5D5AE70051559F /* SearchSettingsMiddleware.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
@@ -62,7 +62,7 @@ struct TabDisplayOrder: Codable {
 
 /// This class is only used in top tabs, but it was used beforehand in the tab tray. Some clean up was done,
 /// but the code is not as clear as it could be since this class had multiple purposes.
-class LegacyTabDisplayManager: NSObject {
+class TopTabDisplayManager: NSObject {
     // MARK: - Variables
     private var performingChainedOperations = false
     var isInactiveViewExpanded = false
@@ -361,7 +361,7 @@ class LegacyTabDisplayManager: NSObject {
 }
 
 // MARK: - UICollectionViewDataSource
-extension LegacyTabDisplayManager: UICollectionViewDataSource {
+extension TopTabDisplayManager: UICollectionViewDataSource {
     @objc
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return dataStore.count
@@ -391,7 +391,7 @@ extension LegacyTabDisplayManager: UICollectionViewDataSource {
 }
 
 // MARK: - TabSelectionDelegate
-extension LegacyTabDisplayManager: TabSelectionDelegate {
+extension TopTabDisplayManager: TabSelectionDelegate {
     func didSelectTabAtIndex(_ index: Int) {
         guard let tab = dataStore.at(index) else { return }
         getTabs { [weak self] tabsToDisplay in
@@ -404,7 +404,7 @@ extension LegacyTabDisplayManager: TabSelectionDelegate {
 }
 
 // MARK: - UIDropInteractionDelegate
-extension LegacyTabDisplayManager: UIDropInteractionDelegate {
+extension TopTabDisplayManager: UIDropInteractionDelegate {
     func dropInteraction(
         _ interaction: UIDropInteraction,
         canHandle session: UIDropSession
@@ -441,7 +441,7 @@ extension LegacyTabDisplayManager: UIDropInteractionDelegate {
 }
 
 // MARK: - UICollectionViewDragDelegate
-extension LegacyTabDisplayManager: UICollectionViewDragDelegate {
+extension TopTabDisplayManager: UICollectionViewDragDelegate {
     // This is called when the user has long-pressed on a cell, please note that
     // `collectionView.hasActiveDrag` is not true until the user's finger moves.
     // This problem is mitigated by checking the collectionView for activated long
@@ -468,7 +468,7 @@ extension LegacyTabDisplayManager: UICollectionViewDragDelegate {
 }
 
 // MARK: - UICollectionViewDropDelegate
-extension LegacyTabDisplayManager: UICollectionViewDropDelegate {
+extension TopTabDisplayManager: UICollectionViewDropDelegate {
     private func dragPreviewParameters(
         _ collectionView: UICollectionView,
         dragPreviewParametersForItemAt indexPath: IndexPath
@@ -574,7 +574,7 @@ extension LegacyTabDisplayManager: UICollectionViewDropDelegate {
     }
 }
 
-extension LegacyTabDisplayManager: TabEventHandler {
+extension TopTabDisplayManager: TabEventHandler {
     var tabEventWindowResponseType: TabEventHandlerWindowResponseType { return .singleWindow(windowUUID) }
 
     private func getIndexPath(tab: Tab) -> IndexPath? {
@@ -590,7 +590,7 @@ extension LegacyTabDisplayManager: TabEventHandler {
 }
 
 // MARK: - TabManagerDelegate
-extension LegacyTabDisplayManager: TabManagerDelegate {
+extension TopTabDisplayManager: TabManagerDelegate {
     func tabManager(
         _ tabManager: TabManager,
         didAddTab tab: Tab,
@@ -703,7 +703,7 @@ extension LegacyTabDisplayManager: TabManagerDelegate {
     }
 }
 
-extension LegacyTabDisplayManager: Notifiable {
+extension TopTabDisplayManager: Notifiable {
     // MARK: - Notifiable protocol
     func handleNotifications(_ notification: Notification) {
         switch notification.name {

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -124,10 +124,10 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
         self.notificationCenter = notificationCenter
         super.init(nibName: nil, bundle: nil)
         topTabDisplayManager = TopTabDisplayManager(collectionView: self.collectionView,
-                                                       tabManager: self.tabManager,
-                                                       tabDisplayer: self,
-                                                       reuseID: TopTabCell.cellIdentifier,
-                                                       profile: profile)
+                                                    tabManager: self.tabManager,
+                                                    tabDisplayer: self,
+                                                    reuseID: TopTabCell.cellIdentifier,
+                                                    profile: profile)
         collectionView.dataSource = topTabDisplayManager
         collectionView.delegate = tabLayoutDelegate
     }

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -37,7 +37,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
     // MARK: - Properties
     let tabManager: TabManager
     weak var delegate: TopTabsDelegate?
-    private var topTabDisplayManager: LegacyTabDisplayManager!
+    private var topTabDisplayManager: TopTabDisplayManager!
     var tabCellIdentifier: TabDisplayerDelegate.TabCellIdentifier = TopTabCell.cellIdentifier
     var profile: Profile
     var themeManager: ThemeManager
@@ -123,7 +123,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
         super.init(nibName: nil, bundle: nil)
-        topTabDisplayManager = LegacyTabDisplayManager(collectionView: self.collectionView,
+        topTabDisplayManager = TopTabDisplayManager(collectionView: self.collectionView,
                                                        tabManager: self.tabManager,
                                                        tabDisplayer: self,
                                                        reuseID: TopTabCell.cellIdentifier,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9085)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20125)

## :bulb: Description
Renaming `LegacyTabDisplayManager` to `TopTabDisplayManager` since this class is only used in top tabs now. This also wasn't part of the tab tray refactor, so AFAIK this class will stay as is for now.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

