### PR TITLE
Bugfix FXIOS-10643 - Password Generator: Adjust Background Color

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -161,7 +161,7 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
     // MARK: - Themable
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
-        view.backgroundColor = theme.colors.layer1
+        view.backgroundColor = theme.colors.layer3
         descriptionLabel.textColor = theme.colors.textSecondary
         usePasswordButton.applyTheme(theme: theme)
         passwordField.applyTheme(theme: theme)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10643)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Changing password generator background color from layer1 to layer3 as per design's request.
Change:
<img width="200" alt="Close ButtonLight Mode Before" src="https://github.com/user-attachments/assets/288cfc8c-afcc-4cdb-87f1-f0668d46e5b1"><img width="200" alt="Screenshot 2024-11-21 at 2 02 16 PM" src="https://github.com/user-attachments/assets/f6a5b696-f8d9-428f-8e6b-5a7992b2a97d">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

