### PR TITLE
Bugfix FXIOS-10646 Ensure we do not change Menu > Share behaviour to Messages

### DIFF
--- a/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
@@ -50,7 +50,7 @@ class ShareExtensionCoordinator: BaseCoordinator,
     ) {
         let shareExtension = ShareExtensionHelper(
             url: url,
-            title: title ?? tabManager.selectedTab?.title,
+            title: title,
             tab: tabManager.selectedTab)
         let controller = shareExtension.createActivityViewController(
             tabManager.selectedTab?.webView

--- a/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
@@ -50,6 +50,8 @@ class ShareExtensionCoordinator: BaseCoordinator,
     ) {
         let shareExtension = ShareExtensionHelper(
             url: url,
+            // FXIOS-10646: We only want to pass a non-nil title here for the Info Card Referral experiment. Refactoring is
+            // needed in the ShareExtensionHelper to make it properly extensible to multiple share use cases like this.
             title: title,
             tab: tabManager.selectedTab)
         let controller = shareExtension.createActivityViewController(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10646)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23298)

## :bulb: Description
This PR partially reverts a change to sharing to accommodate the Info Card Referral project. This change avoids appending website titles to any link shared from the app (specifically to Messages for feature parity with Safari).


## Demo
### Before
Undesired behaviour when sharing a website URL from Menu > Share:

<img src="https://github.com/user-attachments/assets/275715dc-620d-4c47-b6ab-bc8a7353318d" width=300>

### After
Desired behaviour when sharing a website URL from Menu > Share:

<img src="https://github.com/user-attachments/assets/94e50b3e-02cf-41af-9855-c33c25aabf83" width=300>


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

