### PR TITLE
Bugfix FXIOS - #23344 [BookMarksPanel] Bottom Done button is not enabled after tap the cancel navigation in add new BookMarks

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
@@ -61,6 +61,7 @@ class LegacyBookmarksPanel: SiteTableViewController,
             return [flexibleSpace, bottomRightButton]
         case .bookmarks(state: .inFolderEditMode):
             bottomRightButton.title = String.AppSettingsDone
+            bottomRightButton.isEnabled = true
             return [bottomLeftButton, flexibleSpace, bottomRightButton]
         case .bookmarks(state: .itemEditMode):
             bottomRightButton.title = String.AppSettingsDone

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -862,7 +862,7 @@ extension HistoryPanel {
             }
         }
     }
-    
+
     private func setupSearchBarTapGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(removedSearchBarWhenTapOutside))
         tapGesture.cancelsTouchesInView = false
@@ -872,15 +872,14 @@ extension HistoryPanel {
 
 // MARK: - User action helpers
 extension HistoryPanel {
-    
     @objc
-    private func removedSearchBarWhenTapOutside() {
-        if !searchbar.isHidden {
+    private func removedSearchBarWhenTapOutside(_ sender: UITapGestureRecognizer) {
+        if !bottomStackView.isHidden && !bottomStackView.frame.contains(sender.location(in: view)) {
             bottomStackView.isHidden = true
-            searchbar.resignFirstResponder()
+            bottomStackView.resignFirstResponder()
         }
     }
-    
+
     func handleLeftTopButton() {
         updatePanelState(newState: .history(state: .mainView))
     }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -176,7 +176,7 @@ class HistoryPanel: UIViewController,
         setupLayout()
         configureDataSource()
         applyTheme()
-
+        setupSearchBarTapGesture()
         // Update theme of already existing view
         bottomStackView.applyTheme(theme: currentTheme())
     }
@@ -862,10 +862,25 @@ extension HistoryPanel {
             }
         }
     }
+    
+    private func setupSearchBarTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(removedSearchBarWhenTapOutside))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+    }
 }
 
 // MARK: - User action helpers
 extension HistoryPanel {
+    
+    @objc
+    private func removedSearchBarWhenTapOutside() {
+        if !searchbar.isHidden {
+            bottomStackView.isHidden = true
+            searchbar.resignFirstResponder()
+        }
+    }
+    
     func handleLeftTopButton() {
         updatePanelState(newState: .history(state: .mainView))
     }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -876,7 +876,7 @@ extension HistoryPanel {
     private func removedSearchBarWhenTapOutside(_ sender: UITapGestureRecognizer) {
         if !bottomStackView.isHidden && !bottomStackView.frame.contains(sender.location(in: view)) {
             bottomStackView.isHidden = true
-            bottomStackView.resignFirstResponder()
+            searchbar.resignFirstResponder()
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

https://github.com/user-attachments/assets/33838e50-ca5b-443e-bf8f-5f4b00257bf7

See in this video after tap the cancel button the bottom done button is not enabled
