### PR TITLE
Bugfix FXIOS-10597 - When rotating the device, text entered into the toolbar disappears.

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -19,6 +19,9 @@ final class LocationView: UIView,
         static let iconContainerNoLockLeadingSpace: CGFloat = 16
     }
 
+    /// A static property to keep track of the text from a `LocationTextField` instance.
+    /// This ensures that the text is preserved and can be shared across different instances.
+    private static var persistentURLText = ""
     private var urlAbsolutePath: String?
     private var searchTerm: String?
     private var onTapLockIcon: ((UIButton) -> Void)?
@@ -60,7 +63,6 @@ final class LocationView: UIView,
     private lazy var gradientLayer = CAGradientLayer()
     private lazy var gradientView: UIView = .build()
 
-    private var clearButtonWidthConstraint: NSLayoutConstraint?
     private var urlTextFieldLeadingConstraint: NSLayoutConstraint?
     private var iconContainerStackViewLeadingConstraint: NSLayoutConstraint?
     private var lockIconWidthAnchor: NSLayoutConstraint?
@@ -280,7 +282,10 @@ final class LocationView: UIView,
 
         // Once the user started typing we should not update the text anymore as that interferes with
         // setting the autocomplete suggestions which is done using a delegate method.
-        guard !state.didStartTyping else { return }
+        guard !state.didStartTyping else {
+            if isEditing { urlTextField.text = LocationView.persistentURLText }
+            return
+        }
 
         let text = (state.searchTerm != nil) && state.isEditing ? state.searchTerm : state.url?.absoluteString
         urlTextField.text = text
@@ -400,10 +405,12 @@ final class LocationView: UIView,
 
     // MARK: - LocationTextFieldDelegate
     func locationTextField(_ textField: LocationTextField, didEnterText text: String) {
+        LocationView.persistentURLText = text
         delegate?.locationViewDidEnterText(text)
     }
 
     func locationTextFieldShouldReturn(_ textField: LocationTextField) -> Bool {
+        LocationView.persistentURLText = ""
         guard let text = textField.text else { return true }
         if !text.trimmingCharacters(in: .whitespaces).isEmpty {
             delegate?.locationViewDidSubmitText(text)
@@ -415,6 +422,7 @@ final class LocationView: UIView,
     }
 
     func locationTextFieldShouldClear(_ textField: LocationTextField) -> Bool {
+        LocationView.persistentURLText = ""
         delegate?.locationViewDidClearText()
         return true
     }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -142,16 +142,8 @@ final class LocationView: UIView,
     // MARK: - Layout
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        updateURLTextFieldForSizeClassChange(previousTraitCollection)
         DispatchQueue.main.async { [self] in
             formatAndTruncateURLTextField()
-        }
-    }
-
-    func updateURLTextFieldForSizeClassChange(_ previousTraitCollection: UITraitCollection?) {
-        if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass ||
-            previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {
-            if isEditing, urlAbsolutePath == nil { urlTextField.text = searchTerm }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -53,6 +53,7 @@ final class AddressToolbarContainer: UIView,
         return shouldDisplayCompact ? compactToolbar : regularToolbar
     }
 
+    private var searchTerm = ""
     private var shouldDisplayCompact = true
     private var isTransitioning = false {
         didSet {
@@ -207,6 +208,14 @@ final class AddressToolbarContainer: UIView,
 
             if shouldSwitchToolbars {
                 switchToolbars()
+                guard model?.shouldSelectSearchTerm == false else { return }
+                store.dispatch(
+                    ToolbarAction(
+                        searchTerm: searchTerm,
+                        windowUUID: windowUUID,
+                        actionType: ToolbarActionType.didSetSearchTerm
+                    )
+                )
             }
         }
     }
@@ -284,19 +293,17 @@ final class AddressToolbarContainer: UIView,
             } else if !searchTerm.isEmpty, toolbarState.addressToolbar.showQRPageAction {
                 let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.didEnterSearchTerm)
                 store.dispatch(action)
+            } else if !toolbarState.addressToolbar.didStartTyping {
+                let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.didStartTyping)
+                store.dispatch(action)
             }
-            let action = ToolbarAction(
-                url: nil,
-                searchTerm: searchTerm,
-                windowUUID: windowUUID,
-                actionType: ToolbarActionType.didStartTyping
-            )
-            store.dispatch(action)
         }
+        self.searchTerm = searchTerm
         delegate?.searchSuggestions(searchTerm: searchTerm)
     }
 
     func didClearSearch() {
+        searchTerm = ""
         delegate?.searchSuggestions(searchTerm: "")
 
         guard let windowUUID else { return }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -284,10 +284,14 @@ final class AddressToolbarContainer: UIView,
             } else if !searchTerm.isEmpty, toolbarState.addressToolbar.showQRPageAction {
                 let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.didEnterSearchTerm)
                 store.dispatch(action)
-            } else if !toolbarState.addressToolbar.didStartTyping {
-                let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.didStartTyping)
-                store.dispatch(action)
             }
+            let action = ToolbarAction(
+                url: nil,
+                searchTerm: searchTerm,
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.didStartTyping
+            )
+            store.dispatch(action)
         }
         delegate?.searchSuggestions(searchTerm: searchTerm)
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -6,7 +6,7 @@ import Common
 import ToolbarKit
 import Shared
 
-class AddressToolbarContainerModel: Equatable {
+final class AddressToolbarContainerModel: Equatable {
     let navigationActions: [ToolbarElement]
     let pageActions: [ToolbarElement]
     let browserActions: [ToolbarElement]

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -93,7 +93,7 @@ struct AddressBarState: StateType, Equatable {
             safeListedURLImageName: nil,
             isEditing: false,
             shouldShowKeyboard: true,
-            shouldSelectSearchTerm: true,
+            shouldSelectSearchTerm: false,
             isLoading: false,
             readerModeState: nil,
             didStartTyping: false,
@@ -199,6 +199,9 @@ struct AddressBarState: StateType, Equatable {
         case ToolbarActionType.didEnterSearchTerm:
             return handleDidEnterSearchTermAction(state: state, action: action)
 
+        case ToolbarActionType.didSetSearchTerm:
+            return handleDidSetSearchTermAction(state: state, action: action)
+
         case ToolbarActionType.didStartTyping:
             return handleDidStartTypingAction(state: state, action: action)
 
@@ -231,7 +234,7 @@ struct AddressBarState: StateType, Equatable {
             safeListedURLImageName: nil,
             isEditing: false,
             shouldShowKeyboard: true,
-            shouldSelectSearchTerm: true,
+            shouldSelectSearchTerm: false,
             isLoading: false,
             readerModeState: nil,
             didStartTyping: false,
@@ -542,7 +545,7 @@ struct AddressBarState: StateType, Equatable {
             safeListedURLImageName: state.safeListedURLImageName,
             isEditing: false,
             shouldShowKeyboard: true,
-            shouldSelectSearchTerm: true,
+            shouldSelectSearchTerm: false,
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: false,
@@ -651,7 +654,7 @@ struct AddressBarState: StateType, Equatable {
             safeListedURLImageName: state.safeListedURLImageName,
             isEditing: true,
             shouldShowKeyboard: state.shouldShowKeyboard,
-            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            shouldSelectSearchTerm: false,
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: true,
@@ -679,7 +682,7 @@ struct AddressBarState: StateType, Equatable {
             safeListedURLImageName: state.safeListedURLImageName,
             isEditing: true,
             shouldShowKeyboard: state.shouldShowKeyboard,
-            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            shouldSelectSearchTerm: false,
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: true,
@@ -688,7 +691,7 @@ struct AddressBarState: StateType, Equatable {
         )
     }
 
-    private static func handleDidStartTypingAction(state: Self, action: Action) -> Self {
+    private static func handleDidSetSearchTermAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         return AddressBarState(
@@ -697,7 +700,7 @@ struct AddressBarState: StateType, Equatable {
             pageActions: state.pageActions,
             browserActions: state.browserActions,
             borderPosition: state.borderPosition,
-            url: toolbarAction.url,
+            url: state.url,
             searchTerm: toolbarAction.searchTerm,
             lockIconImageName: state.lockIconImageName,
             lockIconNeedsTheming: state.lockIconNeedsTheming,
@@ -705,6 +708,31 @@ struct AddressBarState: StateType, Equatable {
             isEditing: state.isEditing,
             shouldShowKeyboard: state.shouldShowKeyboard,
             shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            didStartTyping: false,
+            showQRPageAction: state.showQRPageAction,
+            alternativeSearchEngine: state.alternativeSearchEngine
+        )
+    }
+
+    private static func handleDidStartTypingAction(state: Self, action: Action) -> Self {
+        guard action is ToolbarAction else { return defaultState(from: state) }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            pageActions: state.pageActions,
+            browserActions: state.browserActions,
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: false,
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             didStartTyping: true,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -391,7 +391,7 @@ struct AddressBarState: StateType, Equatable {
             browserActions: browserActions(action: toolbarAction, addressBarState: state),
             borderPosition: state.borderPosition,
             url: state.url,
-            searchTerm: nil,
+            searchTerm: state.searchTerm,
             lockIconImageName: state.lockIconImageName,
             lockIconNeedsTheming: state.lockIconNeedsTheming,
             safeListedURLImageName: state.safeListedURLImageName,
@@ -689,7 +689,7 @@ struct AddressBarState: StateType, Equatable {
     }
 
     private static func handleDidStartTypingAction(state: Self, action: Action) -> Self {
-        guard action is ToolbarAction else { return defaultState(from: state) }
+        guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         return AddressBarState(
             windowUUID: state.windowUUID,
@@ -697,8 +697,8 @@ struct AddressBarState: StateType, Equatable {
             pageActions: state.pageActions,
             browserActions: state.browserActions,
             borderPosition: state.borderPosition,
-            url: state.url,
-            searchTerm: state.searchTerm,
+            url: toolbarAction.url,
+            searchTerm: toolbarAction.searchTerm,
             lockIconImageName: state.lockIconImageName,
             lockIconNeedsTheming: state.lockIconNeedsTheming,
             safeListedURLImageName: state.safeListedURLImageName,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -93,6 +93,7 @@ enum ToolbarActionType: ActionType {
     case clearSearch
     case didDeleteSearchTerm
     case didEnterSearchTerm
+    case didSetSearchTerm
     case didStartTyping
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -117,7 +117,7 @@ struct ToolbarState: ScreenState, Equatable {
             ToolbarActionType.hideKeyboard, ToolbarActionType.websiteLoadingStateDidChange,
             ToolbarActionType.searchEngineDidChange, ToolbarActionType.clearSearch,
             ToolbarActionType.didDeleteSearchTerm, ToolbarActionType.didEnterSearchTerm,
-            ToolbarActionType.didStartTyping:
+            ToolbarActionType.didSetSearchTerm, ToolbarActionType.didStartTyping:
             return handleToolbarUpdates(state: state, action: action)
 
         case ToolbarActionType.showMenuWarningBadge:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -38,7 +38,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertNil(initialState.safeListedURLImageName)
         XCTAssertFalse(initialState.isEditing)
         XCTAssertTrue(initialState.shouldShowKeyboard)
-        XCTAssertTrue(initialState.shouldSelectSearchTerm)
+        XCTAssertFalse(initialState.shouldSelectSearchTerm)
         XCTAssertFalse(initialState.isLoading)
         XCTAssertNil(initialState.readerModeState)
         XCTAssertFalse(initialState.didStartTyping)
@@ -76,7 +76,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertNil(newState.safeListedURLImageName)
         XCTAssertFalse(newState.isEditing)
         XCTAssertTrue(newState.shouldShowKeyboard)
-        XCTAssertTrue(newState.shouldSelectSearchTerm)
+        XCTAssertFalse(newState.shouldSelectSearchTerm)
         XCTAssertFalse(newState.isLoading)
         XCTAssertNil(newState.readerModeState)
         XCTAssertFalse(newState.didStartTyping)
@@ -454,7 +454,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.searchTerm, nil)
         XCTAssertFalse(newState.isEditing)
         XCTAssertTrue(newState.shouldShowKeyboard)
-        XCTAssertTrue(newState.shouldSelectSearchTerm)
+        XCTAssertFalse(newState.shouldSelectSearchTerm)
         XCTAssertFalse(newState.didStartTyping)
         XCTAssertTrue(newState.showQRPageAction)
     }
@@ -488,7 +488,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.searchTerm, nil)
         XCTAssertFalse(newState.isEditing)
         XCTAssertTrue(newState.shouldShowKeyboard)
-        XCTAssertTrue(newState.shouldSelectSearchTerm)
+        XCTAssertFalse(newState.shouldSelectSearchTerm)
         XCTAssertFalse(newState.didStartTyping)
         XCTAssertFalse(newState.showQRPageAction)
     }
@@ -586,6 +586,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(newState.isEditing)
         XCTAssertTrue(newState.didStartTyping)
         XCTAssertTrue(newState.showQRPageAction)
+        XCTAssertFalse(newState.shouldSelectSearchTerm)
     }
 
     func test_didEnterSearchTermAction_returnsExpectedState() {
@@ -605,6 +606,26 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(newState.isEditing)
         XCTAssertTrue(newState.didStartTyping)
         XCTAssertFalse(newState.showQRPageAction)
+        XCTAssertFalse(newState.shouldSelectSearchTerm)
+    }
+
+    func test_didSetSearchTermAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = addressBarReducer()
+        let searchTerm = "Search Term"
+
+        let newState = reducer(
+            initialState,
+            ToolbarAction(
+                searchTerm: searchTerm,
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.didSetSearchTerm
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, windowUUID)
+        XCTAssertEqual(newState.searchTerm, searchTerm)
+        XCTAssertFalse(newState.didStartTyping)
     }
 
     func test_didStartTypingAction_returnsExpectedState() {
@@ -621,6 +642,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
         XCTAssertTrue(newState.didStartTyping)
+        XCTAssertFalse(newState.shouldSelectSearchTerm)
     }
 
     // MARK: - Private


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10597)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23208)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- We have two `BrowserAddressToolbar` instances for `regular` and `compact` sizes. When rotating the device, these instances switch between each other, causing the text entered in one instance to be lost.
- This PR preserves the text in the `urlTextField` using redux.

### Video
https://github.com/user-attachments/assets/ad42a6b4-b950-4243-bafb-10e488dd1706


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

