### PR TITLE
Add MTE-3641 Focus full functional tests on Github Actions.

### DIFF
--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -55,7 +55,7 @@ jobs:
             fail-fast: false
             max-parallel: 1
             matrix:
-                xcodebuild_test_plan: ['SmokeTest'] # , 'FullFunctionalTests']
+                xcodebuild_test_plan: ['SmokeTest', 'FullFunctionalTests']
                 ios_simulator: [ 'iPhone 16', 'iPad (10th generation)']
         steps:
             - name: Check out source code


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3641)

## :bulb: Description

With the Xcode 16.1 upgrade work, we should be able to turn off *all* focus related jobs on MacStadium/Jenkins. Moving all focus workflows to Github Actions frees up disk space on MacStadium so that the Firefox jobs can run consistently.

Test run: https://github.com/mozilla-mobile/firefox-ios/actions/runs/11984625480

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

