### PR TITLE
Bugfix FXIOS-10670 - [Toolbar Redesign] Reader View button disappears after opening a link in a new tab 

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -258,7 +258,7 @@ struct AddressBarState: StateType, Equatable {
             shouldShowKeyboard: state.shouldShowKeyboard,
             shouldSelectSearchTerm: state.shouldSelectSearchTerm,
             isLoading: state.isLoading,
-            readerModeState: toolbarAction.readerModeState,
+            readerModeState: state.readerModeState,
             didStartTyping: state.didStartTyping,
             showQRPageAction: state.showQRPageAction,
             alternativeSearchEngine: state.alternativeSearchEngine


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10670)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23343)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Preserve previous state for reader mode in `handleNumberOfTabsChangedAction`.
## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

