### PR TITLE
Bugfix FXIOS-10637 - [Toolbar Redesign] - The lock icon does not update its color after changing the theme when returning to a website from homepage

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -468,11 +468,9 @@ final class LocationView: UIView,
         lockIconButton.backgroundColor = colors.layerSearch
         urlTextField.applyTheme(theme: theme)
         safeListedURLImageColor = colors.iconAccentBlue
+        lockIconButton.tintColor = colors.iconPrimary
+        lockIconImageColor = colors.iconPrimary
 
-        if lockIconNeedsTheming {
-            lockIconButton.tintColor = colors.iconPrimary
-            lockIconImageColor = colors.iconPrimary
-        }
         setLockIconImage()
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10637)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23285)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Removes `lockIconNeedsTheming` check in `applyTheme` to ensure the colors are always updated according to the latest theme. 
- We check for `lockIconNeedsTheming` already in `setLockIconImage`.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

