### PR TITLE
Bugfix FXIOS-10642 #23292 Fix Siteimageview ImageHandlerTests

### DIFF
--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
@@ -106,7 +106,7 @@ final class ImageHandlerTests: XCTestCase {
         let resource: SiteResource = .bundleAsset(name: "facebook", forRemoteResource: siteURL)
         let model = SiteImageModel(id: UUID(), imageType: .favicon, siteURL: siteURL, siteResource: resource)
         let image = await subject.fetchFavicon(imageModel: model)
-        
+
         let siteImageBundle = Bundle.allBundles.first {
             return $0.bundleIdentifier?.contains("browserkit.SiteImageView.resources") ?? false
         }!

--- a/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/ImageProcessing/ImageHandlerTests.swift
@@ -63,61 +63,60 @@ final class ImageHandlerTests: XCTestCase {
         XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
     }
 
-    // TODO: FXIOS-10642, loading images from the bundle this way doesn't work in XCode 16
-//    func testFavicon_whenSiteResourceNil_imageIsInBundle_noCachedImage_returnsBundleImage() async {
-//        // provide this site url, since the cache key is "google" and default favicons are store with cacheKey as name
-//        // in bundle
-//        let siteURL = URL(string: "https://www.google.com")!
-//        let subject = createSubject()
-//        let model = SiteImageModel(id: UUID(), imageType: .favicon, siteURL: siteURL)
-//        let image = await subject.fetchFavicon(imageModel: model)
-//
-//        let siteImageBundle = Bundle.allBundles.first {
-//            return $0.bundleIdentifier?.contains("SiteImageView-resources") ?? false
-//        }!
-//        let expectedImage = UIImage(named: "google", in: siteImageBundle, with: nil)
-//        XCTAssertEqual(expectedImage, image)
-//        XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
-//        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
-//        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
-//        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
-//    }
-//
-//    func testFavicon_whenSiteResourceNil_imageIsInBundle_cachedImagePresent_returnsBundleImage() async {
-//        let siteURL = URL(string: "https://www.google.com")!
-//        siteImageCache.image = UIImage()
-//        let subject = createSubject()
-//        let model = SiteImageModel(id: UUID(), imageType: .favicon, siteURL: siteURL)
-//        let image = await subject.fetchFavicon(imageModel: model)
-//
-//        let siteImageBundle = Bundle.allBundles.first {
-//            return $0.bundleIdentifier?.contains("SiteImageView-resources") ?? false
-//        }!
-//        let expectedImage = UIImage(named: "google", in: siteImageBundle, with: nil)
-//        XCTAssertEqual(expectedImage, image)
-//        XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
-//        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
-//        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
-//        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
-//    }
-//
-//    func testFavicon_whenSiteResourceIsInBundle_returnsBundleImage() async {
-//        let siteURL = URL(string: "https://www.facebook.com")!
-//        let subject = createSubject()
-//        let resource: SiteResource = .bundleAsset(name: "facebook", forRemoteResource: siteURL)
-//        let model = SiteImageModel(id: UUID(), imageType: .favicon, siteURL: siteURL, siteResource: resource)
-//        let image = await subject.fetchFavicon(imageModel: model)
-//
-//        let siteImageBundle = Bundle.allBundles.first {
-//            return $0.bundleIdentifier?.contains("SiteImageView-resources") ?? false
-//        }!
-//        let expectedImage = UIImage(named: "facebook", in: siteImageBundle, with: nil)
-//        XCTAssertEqual(expectedImage, image)
-//        XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
-//        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
-//        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
-//        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
-//    }
+    func testFavicon_whenSiteResourceNil_imageIsInBundle_noCachedImage_returnsBundleImage() async {
+        // provide this site url, since the cache key is "google" and default favicons are store with cacheKey as name
+        // in bundle
+        let siteURL = URL(string: "https://www.google.com")!
+        let subject = createSubject()
+        let model = SiteImageModel(id: UUID(), imageType: .favicon, siteURL: siteURL)
+        let image = await subject.fetchFavicon(imageModel: model)
+
+        let siteImageBundle = Bundle.allBundles.first {
+            return $0.bundleIdentifier?.contains("browserkit.SiteImageView.resources") ?? false
+        }!
+        let expectedImage = UIImage(named: "google", in: siteImageBundle, with: nil)
+        XCTAssertEqual(expectedImage, image)
+        XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
+        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
+    }
+
+    func testFavicon_whenSiteResourceNil_imageIsInBundle_cachedImagePresent_returnsBundleImage() async {
+        let siteURL = URL(string: "https://www.google.com")!
+        siteImageCache.image = UIImage()
+        let subject = createSubject()
+        let model = SiteImageModel(id: UUID(), imageType: .favicon, siteURL: siteURL)
+        let image = await subject.fetchFavicon(imageModel: model)
+
+        let siteImageBundle = Bundle.allBundles.first {
+            return $0.bundleIdentifier?.contains("browserkit.SiteImageView.resources") ?? false
+        }!
+        let expectedImage = UIImage(named: "google", in: siteImageBundle, with: nil)
+        XCTAssertEqual(expectedImage, image)
+        XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
+        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
+    }
+
+    func testFavicon_whenSiteResourceIsInBundle_returnsBundleImage() async {
+        let siteURL = URL(string: "https://www.facebook.com")!
+        let subject = createSubject()
+        let resource: SiteResource = .bundleAsset(name: "facebook", forRemoteResource: siteURL)
+        let model = SiteImageModel(id: UUID(), imageType: .favicon, siteURL: siteURL, siteResource: resource)
+        let image = await subject.fetchFavicon(imageModel: model)
+        
+        let siteImageBundle = Bundle.allBundles.first {
+            return $0.bundleIdentifier?.contains("browserkit.SiteImageView.resources") ?? false
+        }!
+        let expectedImage = UIImage(named: "facebook", in: siteImageBundle, with: nil)
+        XCTAssertEqual(expectedImage, image)
+        XCTAssertEqual(siteImageCache.cacheImageCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageSucceedCalled, 0)
+        XCTAssertEqual(faviconFetcher.fetchImageFailedCalled, 0)
+        XCTAssertEqual(letterImageGenerator.generateLetterImageCalled, 0)
+    }
 
     func testFavicon_whenNoImages_returnsFallbackLetterFavicon_forHardcodedFaviconURL() async {
         let subject = createSubject()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10642)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23292)

## :bulb: Description
Following update to Xcode 16 in https://github.com/mozilla-mobile/firefox-ios/pull/23211, some site image view tests where failing due to bundle changes. It seems the bundle name has changed from `"SiteImageView-resources"` to `"browserkit.SiteImageView.resources"`, and with this small change it works locally. Let's see how this does on the CI 👀 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

