### PR TITLE
Refactor FXIOS-10467 - Remove force_cast violations from BrowserKit and firefox-ios

### DIFF
--- a/BrowserKit/Sources/Common/DependencyInjection/AppContainer.swift
+++ b/BrowserKit/Sources/Common/DependencyInjection/AppContainer.swift
@@ -17,7 +17,10 @@ public class AppContainer: ServiceProvider {
     /// Any services needed by the client can be resolved by calling this.
     public func resolve<T>() -> T {
         do {
-            return try container.resolve(T.self) as! T
+            guard let service = try container.resolve(T.self) as? T else {
+                fatalError("Failed to cast resolved service to type \(T.self)")
+            }
+            return service
         } catch {
             // If a service we thought was registered can't be resolved, this is likely an issue within
             // bootstrapping. Double check your registrations and their types.

--- a/BrowserKit/Sources/UnifiedSearchKit/SearchEngineTableView.swift
+++ b/BrowserKit/Sources/UnifiedSearchKit/SearchEngineTableView.swift
@@ -72,10 +72,12 @@ public final class SearchEngineTableView: UIView,
     }
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(
+        guard let cell = tableView.dequeueReusableCell(
             withIdentifier: SearchEngineCell.cellIdentifier,
             for: indexPath
-        ) as! SearchEngineCell
+        ) as? SearchEngineCell else {
+            return UITableViewCell()
+        }
 
         cell.configureCellWith(model: searchEngineData[indexPath.section].options[indexPath.row])
         if let theme { cell.applyTheme(theme: theme) }

--- a/BrowserKit/Tests/WebEngineTests/WKUserScriptManagerTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKUserScriptManagerTests.swift
@@ -17,7 +17,10 @@ final class WKUserScriptManagerTests: XCTestCase {
         let subject = createSubject()
 
         subject.injectUserScriptsIntoWebView(webview)
-        let config = webview.engineConfiguration as! MockWKEngineConfiguration
+        guard let config = webview.engineConfiguration as? MockWKEngineConfiguration else {
+            XCTFail("Failed to cast webview engine configuration to MockWKEngineConfiguration")
+            return
+        }
         XCTAssertEqual(config.addUserScriptCalled, 8)
     }
 

--- a/firefox-ios/Extensions/NotificationService/NotificationService.swift
+++ b/firefox-ios/Extensions/NotificationService/NotificationService.swift
@@ -14,6 +14,15 @@ import class MozillaAppServices.Viaduct
 class NotificationService: UNNotificationServiceExtension {
     var display: SyncDataDisplay?
     var profile: BrowserProfile?
+    private let logger: Logger
+
+    init(display: SyncDataDisplay? = nil,
+         profile: BrowserProfile? = nil,
+         logger: Logger = DefaultLogger.shared) {
+        self.display = display
+        self.profile = profile
+        self.logger = logger
+    }
 
     // This is run when an APNS notification with `mutable-content` is received.
     // If the app is backgrounded, then the alert notification is displayed.
@@ -30,7 +39,12 @@ class NotificationService: UNNotificationServiceExtension {
 
         let userInfo = request.content.userInfo
 
-        let content = request.content.mutableCopy() as! UNMutableNotificationContent
+        guard let content = request.content.mutableCopy() as? UNMutableNotificationContent else {
+            logger.log("Unable to create a mutable copy of UNNotificationContent from the notification request",
+                       level: .info,
+                       category: .lifecycle)
+            return
+        }
 
         if self.profile == nil {
             self.profile = BrowserProfile(localName: "profile")

--- a/firefox-ios/Extensions/NotificationService/NotificationService.swift
+++ b/firefox-ios/Extensions/NotificationService/NotificationService.swift
@@ -14,15 +14,6 @@ import class MozillaAppServices.Viaduct
 class NotificationService: UNNotificationServiceExtension {
     var display: SyncDataDisplay?
     var profile: BrowserProfile?
-    private let logger: Logger
-
-    init(display: SyncDataDisplay? = nil,
-         profile: BrowserProfile? = nil,
-         logger: Logger = DefaultLogger.shared) {
-        self.display = display
-        self.profile = profile
-        self.logger = logger
-    }
 
     // This is run when an APNS notification with `mutable-content` is received.
     // If the app is backgrounded, then the alert notification is displayed.
@@ -40,9 +31,7 @@ class NotificationService: UNNotificationServiceExtension {
         let userInfo = request.content.userInfo
 
         guard let content = request.content.mutableCopy() as? UNMutableNotificationContent else {
-            logger.log("Unable to create a mutable copy of UNNotificationContent from the notification request",
-                       level: .info,
-                       category: .lifecycle)
+            contentHandler(request.content)
             return
         }
 

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestBrowserDB.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestBrowserDB.swift
@@ -129,8 +129,14 @@ class TestBrowserDB: XCTestCase {
 
         // But now it's been reopened, it's not the same -shm!
         let shmBAttributes = try files.attributesForFileAt(relativePath: "foo.db-shm")
-        let creationB = shmBAttributes[FileAttributeKey.creationDate] as! Date
-        let inodeB = (shmBAttributes[FileAttributeKey.systemFileNumber] as! NSNumber).uintValue
+        guard let creationB = shmBAttributes[FileAttributeKey.creationDate] as? Date else {
+            XCTFail("Failed to cast value for key 'creationDate' to Date.")
+            return
+        }
+        guard let inodeB = (shmBAttributes[FileAttributeKey.systemFileNumber] as? NSNumber)?.uintValue else {
+            XCTFail("Failed to cast value for key 'systemFileNumber' to NSNumber.")
+            return
+        }
         XCTAssertTrue(creationA.compare(creationB) != ComparisonResult.orderedDescending)
         XCTAssertNotEqual(inodeA, inodeB)
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -107,8 +107,12 @@ class JumpBackInTests: BaseTestCase {
         app.cells["JumpBackInCell"].staticTexts["Wikipedia"].firstMatch.tap()
 
         // The view is switched to the twitter tab
-        let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].value as! String
-        XCTAssertEqual(url, "wikipedia.org")
+        if let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].value as? String {
+            XCTAssertEqual(url, "wikipedia.org")
+        } else {
+            XCTFail("Failed to retrieve the URL string from the address toolbar")
+            return
+        }
 
         // Open a new tab in normal browsing
         navigator.goto(TabTray)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -108,7 +108,7 @@ class JumpBackInTests: BaseTestCase {
 
         // The view is switched to the twitter tab
         if let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].value as? String {
-            XCTAssertEqual(url, "wikipedia.org")
+            XCTAssertEqual(url, "wikipedia.org", "The URL retrieved from the address toolbar does not match the expected value")
         } else {
             XCTFail("Failed to retrieve the URL string from the address toolbar")
             return


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10467)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22916)

## :bulb: Description
- This PR remove `force_cast` violations from: 
   - NotificationService
   - AppContainer
   - TestBrowserDB
   - JumpBackInTests
   - WKUserScriptManagerTests
   - SearchEngineTableView
- This PR is part of a series aimed at adding a new SwiftLint rule in the project, as described in #22916

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

