### PR TITLE
Bugfix FXIOS-10641 Fix onboarding telemetry tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
@@ -26,18 +26,24 @@ class OnboardingTelemetryDelegationTests: XCTestCase {
     }
 
     func testOnboardingCard_viewDidAppear_viewSendsCardView() {
-        _ = createSubject()
+        let subject = createSubject()
+        guard let firstVC = subject.pageController.viewControllers?.first as? OnboardingBasicCardViewController else {
+            XCTFail("expected a view controller, but got nothing")
+            return
+        }
+        firstVC.viewDidAppear(true)
+
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
     }
 
     func testOnboardingCard_callsPrimaryButtonTap() {
         let subject = createSubject()
-        guard let result = subject.pageController.viewControllers?.first as? OnboardingBasicCardViewController else {
+        guard let firstVC = subject.pageController.viewControllers?.first as? OnboardingBasicCardViewController else {
             XCTFail("expected a view controller, but got nothing")
             return
         }
 
-        result.primaryAction()
+        firstVC.primaryAction()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
     }
@@ -62,7 +68,6 @@ class OnboardingTelemetryDelegationTests: XCTestCase {
         result.secondaryAction()
 
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.secondaryButtonTap)
-        testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView, expectedCount: 3)
     }
 
     func testOnboardingCard_callsCloseTap() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryDelegationTests.swift
@@ -21,15 +21,14 @@ class OnboardingTelemetryDelegationTests: XCTestCase {
 
     override func tearDown() {
         nimbusUtility = nil
+        DependencyHelperMock().reset()
         super.tearDown()
     }
-// TODO: FXIOS-10641 Update tests to work with iOS 18. viewDidAppear and viewWillAppear don't seem to fire
-// in a test environment anymore
-//    func testOnboardingCard_viewSendsCardView() {
-//        _ = createSubject()
-//
-//        testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
-//    }
+
+    func testOnboardingCard_viewDidAppear_viewSendsCardView() {
+        _ = createSubject()
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView)
+    }
 
     func testOnboardingCard_callsPrimaryButtonTap() {
         let subject = createSubject()
@@ -43,30 +42,28 @@ class OnboardingTelemetryDelegationTests: XCTestCase {
         testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.primaryButtonTap)
     }
 
-//    func testOnboardingCard_callsSecondaryButtonTap() {
-//        let subject = createSubject()
-//        guard let firstVC = subject.pageController.viewControllers?.first as? OnboardingBasicCardViewController else {
-//            XCTFail("expected a view controller, but got nothing")
-//            return
-//        }
-//        subject.advance(
-//            numberOfPages: 1,
-//            from: firstVC.viewModel.name,
-//            completionIfLastCard: { })
-//        subject.pageChanged(from: firstVC.viewModel.name)
-//        guard let result = subject.pageController
-//            .viewControllers?[subject.pageControl.currentPage] as? OnboardingBasicCardViewController else {
-//            XCTFail("expected a view controller, but got nothing")
-//            return
-//        }
-//
-//        result.secondaryAction()
-//
-//        testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.secondaryButtonTap)
-//        testEventMetricRecordingSuccess(
-//            metric: GleanMetrics.Onboarding.cardView,
-//            expectedCount: 3)
-//    }
+    func testOnboardingCard_callsSecondaryButtonTap() {
+        let subject = createSubject()
+        guard let firstVC = subject.pageController.viewControllers?.first as? OnboardingBasicCardViewController else {
+            XCTFail("expected a view controller, but got nothing")
+            return
+        }
+        subject.advance(
+            numberOfPages: 1,
+            from: firstVC.viewModel.name,
+            completionIfLastCard: { })
+        subject.pageChanged(from: firstVC.viewModel.name)
+        guard let result = subject.pageController
+            .viewControllers?[subject.pageControl.currentPage] as? OnboardingBasicCardViewController else {
+            XCTFail("expected a view controller, but got nothing")
+            return
+        }
+
+        result.secondaryAction()
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.secondaryButtonTap)
+        testEventMetricRecordingSuccess(metric: GleanMetrics.Onboarding.cardView, expectedCount: 3)
+    }
 
     func testOnboardingCard_callsCloseTap() {
         let subject = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryUtilityTests.swift
@@ -13,6 +13,12 @@ class OnboardingTelemetryUtilityTests: XCTestCase {
     override func setUp() {
         super.setUp()
         Glean.shared.resetGlean(clearStores: true)
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        DependencyHelperMock().reset()
+        super.tearDown()
     }
 
     // MARK: - Card View telemetry

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -1577,7 +1577,7 @@ extension XCTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) where ExtraObject: EventExtras {
-        XCTAssertNotNil(metric.testGetValue(), file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), "Should have value on event metric \(metric)", file: file, line: line)
         XCTAssertEqual(metric.testGetValue()!.count, expectedCount, file: file, line: line)
 
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
@@ -1590,7 +1590,7 @@ extension XCTestCase {
                                            value: Int32 = 1,
                                            file: StaticString = #file,
                                            line: UInt = #line) {
-        XCTAssertNotNil(metric.testGetValue(), file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), "Should have value on counter metric \(metric)", file: file, line: line)
         XCTAssertEqual(metric.testGetValue(), value, file: file, line: line)
 
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
@@ -1613,7 +1613,7 @@ extension XCTestCase {
                                    failureMessage: String,
                                    file: StaticString = #file,
                                    line: UInt = #line) {
-        XCTAssertNotNil(metric.testGetValue(), "Should have value on quantity metric", file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), "Should have value on quantity metric \(metric)", file: file, line: line)
         XCTAssertEqual(metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
 
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
@@ -1627,7 +1627,7 @@ extension XCTestCase {
                                  failureMessage: String,
                                  file: StaticString = #file,
                                  line: UInt = #line) {
-        XCTAssertNotNil(metric.testGetValue(), "Should have value on string metric", file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), "Should have value on string metric \(metric)", file: file, line: line)
         XCTAssertEqual(metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
 
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
@@ -1641,7 +1641,7 @@ extension XCTestCase {
                               failureMessage: String,
                               file: StaticString = #file,
                               line: UInt = #line) {
-        XCTAssertNotNil(metric.testGetValue(), "Should have value on url metric", file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), "Should have value on url metric \(metric)", file: file, line: line)
         XCTAssertEqual(metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
 
         XCTAssertEqual(metric.testGetNumRecordedErrors(ErrorType.invalidLabel), 0, file: file, line: line)
@@ -1655,7 +1655,7 @@ extension XCTestCase {
                                failureMessage: String,
                                file: StaticString = #file,
                                line: UInt = #line) {
-        XCTAssertNotNil(metric.testGetValue(), "Should have value on uuid metric", file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), "Should have value on uuid metric \(metric)", file: file, line: line)
         XCTAssertEqual(metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
     }
 
@@ -1664,7 +1664,7 @@ extension XCTestCase {
                                failureMessage: String,
                                file: StaticString = #file,
                                line: UInt = #line) {
-        XCTAssertNotNil(metric.testGetValue(), "Should have value on bool metric", file: file, line: line)
+        XCTAssertNotNil(metric.testGetValue(), "Should have value on bool metric \(metric)", file: file, line: line)
         XCTAssertEqual(metric.testGetValue(), expectedValue, failureMessage, file: file, line: line)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10641)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23291)

## :bulb: Description
Following work to enable Xcode 16, some onboarding telemetry tests where disabled.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

