### PR TITLE
Bugfix MTE-3641 Use Xcode 15 for L10nBuild and L10nScreenshotTest

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -754,7 +754,6 @@ workflows:
         stack: osx-xcode-16.1.x
         machine_type_id: g2-m1.8core
   L10nBuild:
-    
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
@@ -844,8 +843,11 @@ workflows:
     description: >-
       This Workflow is to run L10n tests in one locale and then share the bundle with
       the rest of the builds
+    meta:
+      bitrise.io:
+        stack: osx-xcode-15.4.x
+        machine_type_id: g2-m1.8core
   L10nScreenshotsTests:
-    stack: osx-xcode-15.4.x
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
@@ -886,6 +888,10 @@ workflows:
       BITRISE_SCHEME: L10nSnapshotTest
     description: >-
       This Workflow is to run L10n tests for all locales
+    meta:
+      bitrise.io:
+        stack: osx-xcode-15.4.x
+        machine_type_id: g2-m1.8core
   SPM_Deploy_Prod_Beta:
     steps:
     - activate-ssh-key@4.1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -822,7 +822,7 @@ workflows:
             set -e
             # debug log
             set -x
-            gem install fastlane -v 2.219.0
+            gem install fastlane -v 2.225.0
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -754,6 +754,7 @@ workflows:
         stack: osx-xcode-16.1.x
         machine_type_id: g2-m1.8core
   L10nBuild:
+    stack: osx-xcode-15.4.x
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
@@ -822,7 +823,7 @@ workflows:
             set -e
             # debug log
             set -x
-            gem install fastlane -v 2.225.0
+            gem install fastlane -v 2.219.0
             fastlane -version
 
             ./firefox-ios/l10n-screenshots.sh en-US
@@ -844,6 +845,7 @@ workflows:
       This Workflow is to run L10n tests in one locale and then share the bundle with
       the rest of the builds
   L10nScreenshotsTests:
+    stack: osx-xcode-15.4.x
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -754,7 +754,7 @@ workflows:
         stack: osx-xcode-16.1.x
         machine_type_id: g2-m1.8core
   L10nBuild:
-    stack: osx-xcode-15.4.x
+    
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
@@ -2129,5 +2129,5 @@ trigger_map:
 
 meta:
   bitrise.io:
-    stack: osx-xcode-16.1.x-edge
+    stack: osx-xcode-16.1.x
     machine_type_id: g2-m1.8core

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2127,5 +2127,5 @@ trigger_map:
 
 meta:
   bitrise.io:
-    stack: osx-xcode-16.1.x
+    stack: osx-xcode-16.1.x-edge
     machine_type_id: g2-m1.8core

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -140,4 +140,11 @@ extension XCUIElement {
         L10nBaseSnapshotTests().mozWaitForElementToExist(self, timeout: timeout)
         self.tap()
     }
+
+    /// Waits for the UI element and then taps and types the provided text if it exists.
+    func tapAndTypeText(_ text: String, timeout: TimeInterval? = TIMEOUT) {
+        L10nBaseSnapshotTests().mozWaitForElementToExist(self, timeout: timeout)
+        self.tap()
+        self.typeText(text)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -188,7 +188,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func testETPperSite() {
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.nowAt(NewTabScreen)
         // Enable Strict ETP
         navigator.goto(TrackingProtectionSettings)
@@ -200,7 +200,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         // Website without blocked elements
         navigator.openURL(loremIpsumURL)
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection], timeout: 5)
+        // mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
         navigator.goto(TrackingProtectionContextMenuDetails)
         snapshot("TrackingProtectionEnabledPerSite-01")
 
@@ -212,7 +212,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func testSettingsETP() {
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.nowAt(NewTabScreen)
         navigator.goto(TrackingProtectionSettings)
 
@@ -232,7 +232,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     func testMenuOnTopSites() {
         typealias homeTabBannerA11y = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner
 
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
         snapshot("MenuOnTopSites-01")
@@ -248,7 +248,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
     @MainActor
     func testSettings() {
         let table = app.tables.element(boundBy: 0)
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         table.forEachScreen { i in
@@ -265,7 +265,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func testPrivateBrowsingTabsEmptyState() {
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         snapshot("PrivateBrowsingTabsEmptyState-01")
@@ -273,7 +273,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
     @MainActor
     func testTakeMarketingScreenshots() {
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         snapshot("00TopSites")
 
         // go to synced tabs home screen
@@ -292,7 +292,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
         // perform a search but don't complete (we're testing autocomplete here)
         navigator.createNewTab()
-        mozWaitForElementToExist(app.textFields["url"], timeout: 10)
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
         app.typeText("firef")
         sleep(2)
         snapshot("01SearchResults")

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -70,7 +70,7 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
         app.buttons["\(rootA11yId)PrimaryButton"].tap()
         currentScreen += 1
-        mozWaitForElementToExist(app.textFields["url"])
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
         mozWaitForElementToExist(app.webViews["contentView"])
         snapshot("Homescreen-first-visit")
     }

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -200,7 +200,6 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         // Website without blocked elements
         navigator.openURL(loremIpsumURL)
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-        // mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.trackingProtection])
         navigator.goto(TrackingProtectionContextMenuDetails)
         snapshot("TrackingProtectionEnabledPerSite-01")
 

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -9,7 +9,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
     @MainActor
     func testPanelsEmptyState() {
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_Bookmarks)
         snapshot("PanelsEmptyState-LibraryPanels.Bookmarks")
@@ -28,7 +28,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
 
         // Select some text and long press to find the option
-        mozWaitForElementToExist(app.webViews.element(boundBy: 0).staticTexts.element(boundBy: 0), timeout: 10)
+        mozWaitForElementToExist(app.webViews.element(boundBy: 0).staticTexts.element(boundBy: 0))
         app.webViews.element(boundBy: 0).staticTexts.element(boundBy: 0).press(forDuration: 1)
         snapshot("LongPressTextOptions-01")
         if app.menuItems["show.next.items.menu.button"].exists {
@@ -82,7 +82,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     func testPageMenuOnWebPage() {
         navigator.openURL(loremIpsumURL)
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 15)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.goto(BrowserTabMenu)
         snapshot("MenuOnWebPage-03")
     }
@@ -90,12 +90,12 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
     @MainActor
     func testFxASignInPage() {
         navigator.openURL(loremIpsumURL)
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.nowAt(NewTabScreen)
         navigator.goto(BrowserTabMenu)
-        mozWaitForElementToExist(app.tables.otherElements[StandardImageIdentifiers.Large.sync], timeout: 5)
+        mozWaitForElementToExist(app.tables.otherElements[StandardImageIdentifiers.Large.sync])
         navigator.goto(Intro_FxASignin)
-        mozWaitForElementToExist(app.navigationBars.staticTexts["FxASingin.navBar"], timeout: 10)
+        mozWaitForElementToExist(app.navigationBars.staticTexts["FxASingin.navBar"])
         snapshot("FxASignInScreen-01")
     }
 
@@ -122,7 +122,7 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         let key = 15
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
-        mozWaitForElementToExist(app.cells["Search"], timeout: 5)
+        mozWaitForElementToExist(app.cells["Search"])
         app.cells["Search"].swipeUp()
         app.cells["Logins"].waitAndTap(timeout: 15)
 

--- a/firefox-ios/l10n-screenshots.sh
+++ b/firefox-ios/l10n-screenshots.sh
@@ -38,9 +38,9 @@ for lang in $LOCALES; do
         --skip_open_summary \
         --xcargs "-maximum-parallel-testing-workers 2" \
         --derived_data_path l10n-screenshots-dd \
-        --ios_version "17.5" \
+        --ios_version "18.1" \
         --erase_simulator --localize_simulator \
-        --devices "iPhone 15" --languages "$lang" \
+        --devices "iPhone 16" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \
         $EXTRA_FAST_LANE_ARGS
     echo "Fastlane exited with code: $?"

--- a/firefox-ios/l10n-screenshots.sh
+++ b/firefox-ios/l10n-screenshots.sh
@@ -38,7 +38,7 @@ for lang in $LOCALES; do
         --skip_open_summary \
         --xcargs "-maximum-parallel-testing-workers 2" \
         --derived_data_path l10n-screenshots-dd \
-        --ios_version "18.0" \
+        --ios_version "18.1" \
         --erase_simulator --localize_simulator \
         --devices "iPhone 16" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \

--- a/firefox-ios/l10n-screenshots.sh
+++ b/firefox-ios/l10n-screenshots.sh
@@ -38,7 +38,7 @@ for lang in $LOCALES; do
         --skip_open_summary \
         --xcargs "-maximum-parallel-testing-workers 2" \
         --derived_data_path l10n-screenshots-dd \
-        --ios_version "18.1" \
+        --ios_version "18.0" \
         --erase_simulator --localize_simulator \
         --devices "iPhone 16" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \

--- a/firefox-ios/l10n-screenshots.sh
+++ b/firefox-ios/l10n-screenshots.sh
@@ -40,7 +40,7 @@ for lang in $LOCALES; do
         --derived_data_path l10n-screenshots-dd \
         --ios_version "18.1" \
         --erase_simulator --localize_simulator \
-        --devices "iPhone 16" --languages "$lang" \
+        --devices "iPhone 16 (18.1)" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \
         $EXTRA_FAST_LANE_ARGS
     echo "Fastlane exited with code: $?"

--- a/firefox-ios/l10n-screenshots.sh
+++ b/firefox-ios/l10n-screenshots.sh
@@ -40,7 +40,7 @@ for lang in $LOCALES; do
         --derived_data_path l10n-screenshots-dd \
         --ios_version "18.1" \
         --erase_simulator --localize_simulator \
-        --devices "iPhone 16 (18.1)" --languages "$lang" \
+        --devices "iPhone 16 Pro" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \
         $EXTRA_FAST_LANE_ARGS
     echo "Fastlane exited with code: $?"

--- a/firefox-ios/l10n-screenshots.sh
+++ b/firefox-ios/l10n-screenshots.sh
@@ -38,9 +38,9 @@ for lang in $LOCALES; do
         --skip_open_summary \
         --xcargs "-maximum-parallel-testing-workers 2" \
         --derived_data_path l10n-screenshots-dd \
-        --ios_version "18.1" \
+        --ios_version "17.5" \
         --erase_simulator --localize_simulator \
-        --devices "iPhone 16 Pro" --languages "$lang" \
+        --devices "iPhone 15" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \
         $EXTRA_FAST_LANE_ARGS
     echo "Fastlane exited with code: $?"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3641)

## :bulb: Description
`fastlane` does not work with Xcode 16 at the moment. Let's stay in Xcode 15 just for the L10n screenshots.

Bitrise L10nBuild: https://app.bitrise.io/build/73949e8e-f035-4762-b4f3-9acaa00aed44?tab=log 🎉 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

