### PR TITLE
Refactor MTE-3641 Performance Tests for Xcode 16

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1230,7 +1230,7 @@ workflows:
 
             ls /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test
 
-            xcrun xcresulttool graph --path $BITRISE_XCRESULT_PATH
+            xcrun xcresulttool graph --path $BITRISE_XCRESULT_PATH --legacy
             ls ..
             python3 xcresult_extract/xcresult_extract.py -project ../Client.xcodeproj -scheme Fennec
             cat data.txt

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1216,7 +1216,7 @@ workflows:
             # debug log
             set -x
             # get dependency
-            cd ./test-fixtures && git clone https://github.com/isabelrios/xcresult_extract.git
+            cd ./test-fixtures && git clone https://github.com/clarmso/xcresult_extract.git
 
             echo $BITRISE_XCRESULT_PATH
             ls


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3641)

## :bulb: Description
Performance Tests fail on Xcode 16 due to a change in `xcresulttool`. `--legacy` flag is required to work (for now!). 

Our usage of this command will be deprecated in the future. We can rework the reporting later.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

