### PR TITLE
Bugfix FXIOS-10720 After closing, do not retain a QLPreviewController's related TemporaryDocument inside a Tab

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -341,6 +341,9 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable {
     // point to a tempfile containing the content so it can be shared to external applications.
     var temporaryDocument: TemporaryDocument?
 
+    /// Used to retain a reference to an AR 3D model preview until display ends
+    var quickLookPreviewHelper: OpenQLPreviewHelper?
+
     /// Returns true if this tab's URL is known, and it's longer than we want to store.
     var urlIsTooLong: Bool {
         guard let url = self.url else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10720)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23424)

## :bulb: Description
Currently there's a small edge case when sharing content from the app related to AR / 3D models.

### Buggy Behaviour

If you view a model, we use the [QLPreviewController](https://developer.apple.com/documentation/quicklook/qlpreviewcontroller) to present a special view controller over the current webpage. If you dismiss this view controller, then go to Menu > Share, you will share the file instead of the web link, which is unexpected.

### Fixes
There are multiple code paths which create a `TemporaryDocument` on the `Tab`, including this one for downloading and previewing AR models. To untangle some of these code paths and to make share behaviour more explicit, we're separating out AR viewing not to use the same `TemporaryDocument` as PDFs and other file types which do not show a `QLPreviewController`.

### Implementation
To do this, this PR instead stores the `OpenQLPreviewHelper` on the Tab and does not set the `Tab`'s `TemporaryDocument`. Also note: any `TemporaryDocument` or `OpenQLPreviewHelper` initialized in that BVC method are deallocated once the function ends, so we need to retain it inside the `Tab` or we won't have a 3D model to display or any `OpenQLPreviewHelper` instance to listen to calls to the delegate methods. This is because `TemporaryDocument`'s deinit deletes the underlying temporary file from the file system.

### Testing Notes

You can test with AR models using this webpage: https://usdz-iframe-test.glitch.me/

### Working Demo

https://github.com/user-attachments/assets/ce452f55-5b18-4603-ba14-fbab1cce0c1c


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

