### PR TITLE
[FXIOS-10712] Fix Fennec in simulator after running unit tests

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -254,7 +254,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         #if targetEnvironment(simulator) && MOZ_CHANNEL_FENNEC
         let key = "_FennecLaunchedUnitTestDelegate"
         guard let flagSet = UserDefaults.standard.value(forKey: key) as? Bool else { return }
-        if flagSet == true {
+        if flagSet {
             // Private API. This code is not present in release builds.
             application.openSessions.forEach {
                 application.perform(Selector(("_removeSessionFromSessionSet:")), with: $0)

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -109,7 +109,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    category: .lifecycle)
 
         // Fix iOS simulator builds for Fennec after running unit tests locally [FXIOS-10712]
-        _fixSimulatorDevBuild(application)
+        fixSimulatorDevBuild(application)
 
         pushNotificationSetup()
         appLaunchUtil?.setUpPostLaunchDependencies()
@@ -248,7 +248,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    private func _fixSimulatorDevBuild(_ application: UIApplication) {
+    private func fixSimulatorDevBuild(_ application: UIApplication) {
         // Corrects an issue for development when running Fennec target in
         // the simulator after having run unit tests locally.
         #if targetEnvironment(simulator) && MOZ_CHANNEL_FENNEC

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -253,14 +253,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // the simulator after having run unit tests locally.
         #if targetEnvironment(simulator) && MOZ_CHANNEL_FENNEC
         let key = "_FennecLaunchedUnitTestDelegate"
-        guard let flagSet = UserDefaults.standard.value(forKey: key) as? Bool else { return }
-        if flagSet {
-            // Private API. This code is not present in release builds.
-            application.openSessions.forEach {
-                application.perform(Selector(("_removeSessionFromSessionSet:")), with: $0)
-            }
-            UserDefaults.standard.removeObject(forKey: key)
+        guard let flagSet = UserDefaults.standard.value(forKey: key) as? Bool, flagSet else { return }
+        // Private API. This code is not present in release builds.
+        application.openSessions.forEach {
+            application.perform(Selector(("_removeSessionFromSessionSet:")), with: $0)
         }
+        UserDefaults.standard.removeObject(forKey: key)
         #endif
     }
 }

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -108,6 +108,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    level: .info,
                    category: .lifecycle)
 
+        // Fix iOS simulator builds for Fennec after running unit tests locally [FXIOS-10712]
+        _fixSimulatorDevBuild(application)
+
         pushNotificationSetup()
         appLaunchUtil?.setUpPostLaunchDependencies()
         backgroundWorkUtility = BackgroundFetchAndProcessingUtility()
@@ -243,6 +246,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let wallpaperManager = WallpaperManager()
             wallpaperManager.checkForUpdates()
         }
+    }
+
+    private func _fixSimulatorDevBuild(_ application: UIApplication) {
+        // Corrects an issue for development when running Fennec target in
+        // the simulator after having run unit tests locally.
+        #if targetEnvironment(simulator) && MOZ_CHANNEL_FENNEC
+        let key = "_FennecLaunchedUnitTestDelegate"
+        guard let flagSet = UserDefaults.standard.value(forKey: key) as? Bool else { return }
+        if flagSet == true {
+            // Private API. This code is not present in release builds.
+            application.openSessions.forEach {
+                application.perform(Selector(("_removeSessionFromSessionSet:")), with: $0)
+            }
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        #endif
     }
 }
 

--- a/firefox-ios/Client/Application/UnitTestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UnitTestAppDelegate.swift
@@ -15,6 +15,7 @@ final class UnitTestAppDelegate: UIResponder, UIApplicationDelegate {
         for sceneSession in application.openSessions {
             application.perform(Selector(("_removeSessionFromSessionSet:")), with: sceneSession)
         }
+        UserDefaults.standard.setValue(true, forKey: "_FennecLaunchedUnitTestDelegate")
         return true
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10712)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23416)

## :bulb: Description

Fixes development issue when running Fennec in the simulator after running Unit Tests. [This thread](https://gist.github.com/HiddenJester/e5409ce2ca823b0003c59ce11a494b1d) appears to have more context though I have not had a chance yet to dig into this deeply. Since the code change in this PR is effectively a no-op for release or device builds there shouldn't be any risk in this fix. I can't yet see any weird side effects with this fix in place apart from seeing the homepage launch blank, but it's unclear if that's exacerbated by this fix or not (this might just be [this bug](https://mozilla-hub.atlassian.net/browse/FXIOS-10622)).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

