### PR TITLE
Bugfix MTE-3893 Profile for TPS needed for OAuth

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/conftest.py
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/conftest.py
@@ -90,6 +90,8 @@ def tps_profile(pytestconfig, tps_addon, tps_config, tps_log, fxa_urls):
         'extensions.update.enabled': False,
         'extensions.update.notifyUser': False,
         'identity.fxaccounts.autoconfig.uri': fxa_urls['content'],
+        'identity.fxaccounts.contextParam': 'fx_desktop_v3',
+        'identity.fxaccounts.oauth.enabled': False,
         'testing.tps.skipPingValidation': True,
         'services.sync.firstSync': 'notReady',
         'services.sync.lastversion': '1.0',


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3893)

## :bulb: Description
TPS could not sync the history, bookmarks, passwords and tabs to the stage Mozilla Account servers starting Nov 23. A setting in the profile is required as a workaround for the new work in effect.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1933503

I have tested the change locally and confirmed that TPS could sync again.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

