### PR TITLE
Bugfix FXIOS - #23432- [BookmarkDetails] TextField keyboard not dismissed when tap on outside in AddNewBookmarks

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
@@ -219,6 +219,7 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
         }
 
         updateSaveButton()
+        dismissKeyBoardWhenTapOnOutsideTapGesture()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -331,6 +332,18 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
     private func isBookmarkItemURLValid() -> Bool {
         let url = URL(string: bookmarkItemURL ?? "", invalidCharacters: false)
         return url?.schemeIsValid == true && url?.host != nil
+    }
+
+    private func dismissKeyBoardWhenTapOnOutsideTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissTextFieldKeyboard))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+    }
+
+    // dismiss textField keyboard when tap on the outside view
+    @objc
+    private func dismissTextFieldKeyboard() {
+        view.endEditing(true)
     }
 
     // MARK: - Button Actions


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

This PR solved the textfield keyboard are dismissed when tap on outside view in AddNewBookmarks(LegacyBookmarkDetailsPanel)