### PR TITLE
Bugfix MTE-3641 Remove references for Xcode 15.x in readme

### DIFF
--- a/firefox-ios/README.md
+++ b/firefox-ios/README.md
@@ -4,7 +4,7 @@ This is the subdirectory that contains the Firefox for iOS application.
 
 ## Main branch
 
-Firefox for iOS works with [Xcode 15.4](https://developer.apple.com/download/all/?q=xcode), Swift 5.8 and supports iOS 15.0 and above.
+Firefox for iOS works with [Xcode 16.1](https://developer.apple.com/download/all/?q=xcode), Swift 5.6 and supports iOS 15.0 and above.
 
 Please make sure you aim your pull requests in the right direction.
 

--- a/focus-ios/README.md
+++ b/focus-ios/README.md
@@ -8,7 +8,7 @@ Download on the [App Store](https://itunes.apple.com/app/id1055677337).
 
 ## Main Branch
 
-This branch works with Xcode 15.4 and supports iOS 15.0 and newer.
+This branch works with Xcode 16.1 and supports iOS 15.0 and newer.
 
 Pull requests should be submitted with `main` as the base branch.
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3641)

## :bulb: Description
Update README with references to Xcode 16.1 instead of 15.x.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

