### PR TITLE
Add FXiOS-10522 [Homepage Rebuild] Add wallpaper selection to new homepage

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -584,9 +584,11 @@
 		612194E32CE507CF001664BB /* WallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */; };
 		612194E62CE50A93001664BB /* WallpaperAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E52CE50A93001664BB /* WallpaperAction.swift */; };
 		612194E82CE50A9B001664BB /* WallpaperState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E72CE50A9B001664BB /* WallpaperState.swift */; };
+		6139A2AE2CF66C5400F6A472 /* HomepageCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6139A2AD2CF66C5400F6A472 /* HomepageCoordinatorTests.swift */; };
 		619FE8932CE6595B004F83E2 /* WallpaperMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */; };
 		61A164492CE7BE84001D6058 /* WallpaperStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */; };
 		61A1644A2CE7BE8A001D6058 /* WallpaperMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A164472CE7BE3D001D6058 /* WallpaperMiddlewareTests.swift */; };
+		61B3D29F2CEFBE4400060526 /* HomepageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B3D29E2CEFBE4400060526 /* HomepageCoordinator.swift */; };
 		630FE1342C7FB42500D9D6B2 /* NativeErrorPageMockModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1302C7FB42500D9D6B2 /* NativeErrorPageMockModel.swift */; };
 		630FE1352C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1322C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift */; };
 		631A369F2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */; };
@@ -6888,11 +6890,13 @@
 		612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperBackgroundView.swift; sourceTree = "<group>"; };
 		612194E52CE50A93001664BB /* WallpaperAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperAction.swift; sourceTree = "<group>"; };
 		612194E72CE50A9B001664BB /* WallpaperState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperState.swift; sourceTree = "<group>"; };
+		6139A2AD2CF66C5400F6A472 /* HomepageCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageCoordinatorTests.swift; sourceTree = "<group>"; };
 		619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMiddleware.swift; sourceTree = "<group>"; };
 		61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperStateTests.swift; sourceTree = "<group>"; };
 		61A164472CE7BE3D001D6058 /* WallpaperMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMiddlewareTests.swift; sourceTree = "<group>"; };
 		61AE456BAD6B0041485EFF1E /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Shared.strings; sourceTree = "<group>"; };
 		61B340508D4D86B6519A165C /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = "id.lproj/Default Browser.strings"; sourceTree = "<group>"; };
+		61B3D29E2CEFBE4400060526 /* HomepageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageCoordinator.swift; sourceTree = "<group>"; };
 		61DA4B5AB7DA505B9C992F95 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		623648C2A7D09ECA31155208 /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ka; path = ka.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		625D4575B4794C49451D6990 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
@@ -11658,6 +11662,7 @@
 				C23889DE2A4EFCE500429673 /* ShareExtensionCoordinator.swift */,
 				21FBB4032ADECEFF002D9AB7 /* TabTray */,
 				B236204E2B86C56F000B1DE7 /* AddressAutofillCoordinator.swift */,
+				61B3D29E2CEFBE4400060526 /* HomepageCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -11686,6 +11691,7 @@
 				21FA8FAC2AE8561C0013B815 /* TabTray */,
 				C8E531C929E5F7D300E03FEF /* URLScannerTests.swift */,
 				C81C66C329F00D1000F6422F /* UserActivityRouteTests.swift */,
+				6139A2AD2CF66C5400F6A472 /* HomepageCoordinatorTests.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -16800,6 +16806,7 @@
 				43D16B7A29831C7F009F8279 /* CreditCardAutofillToggle.swift in Sources */,
 				C23889E12A4F3E7200429673 /* ParentCoordinatorDelegate.swift in Sources */,
 				8AD40FCD27BADC5C00672675 /* TabLocationContainerView.swift in Sources */,
+				61B3D29F2CEFBE4400060526 /* HomepageCoordinator.swift in Sources */,
 				8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */,
 				211046CD2A7D842A00A7309F /* TPAccessoryInfo.swift in Sources */,
 				8CEDF0802BFE138B00D2617B /* AddressProvider.swift in Sources */,
@@ -17345,6 +17352,7 @@
 				C8E1BC0A28085AA700C62964 /* NimbusFeatureFlagLayerTests.swift in Sources */,
 				F80D53CF2A09A3350047ED14 /* RustSyncManagerTests.swift in Sources */,
 				1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */,
+				6139A2AE2CF66C5400F6A472 /* HomepageCoordinatorTests.swift in Sources */,
 				43446CF02412DDBE00F5C643 /* UpdateViewModelTests.swift in Sources */,
 				E19443F62AF9413300964EA5 /* FakespotUtilsTests.swift in Sources */,
 				8A93F86829D373B0004159D9 /* MockNavigationController.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -581,6 +581,12 @@
 		602B3D6729B0E1DB0066DEF8 /* ConversionValueUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602B3D6629B0E1DB0066DEF8 /* ConversionValueUtil.swift */; };
 		60CE80C12667780D004026C7 /* CredentialListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CE80C02667780C004026C7 /* CredentialListPresenter.swift */; };
 		60D71AEC26AAF45E00355588 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D71AEB26AAF45E00355588 /* UIColorExtension.swift */; };
+		612194E32CE507CF001664BB /* WallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */; };
+		612194E62CE50A93001664BB /* WallpaperAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E52CE50A93001664BB /* WallpaperAction.swift */; };
+		612194E82CE50A9B001664BB /* WallpaperState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E72CE50A9B001664BB /* WallpaperState.swift */; };
+		619FE8932CE6595B004F83E2 /* WallpaperMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */; };
+		61A164492CE7BE84001D6058 /* WallpaperStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */; };
+		61A1644A2CE7BE8A001D6058 /* WallpaperMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A164472CE7BE3D001D6058 /* WallpaperMiddlewareTests.swift */; };
 		630FE1342C7FB42500D9D6B2 /* NativeErrorPageMockModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1302C7FB42500D9D6B2 /* NativeErrorPageMockModel.swift */; };
 		630FE1352C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1322C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift */; };
 		631A369F2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */; };
@@ -1581,7 +1587,7 @@
 		DF940A0C2A96352B00C1497D /* FakespotSettingsCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF940A0A2A96316D00C1497D /* FakespotSettingsCardViewModelTests.swift */; };
 		DFA51481275FFEE500266AA0 /* HistoryHighlightsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA51480275FFEE500266AA0 /* HistoryHighlightsManager.swift */; };
 		DFA51484276103A000266AA0 /* HistoryHighlightsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA514822761012D00266AA0 /* HistoryHighlightsManagerTests.swift */; };
-		DFACBF7F277B5F7B003D5F41 /* WallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF7E277B5F7B003D5F41 /* WallpaperBackgroundView.swift */; };
+		DFACBF7F277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF7E277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift */; };
 		DFACBF81277B916B003D5F41 /* ConfigurableGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF80277B916B003D5F41 /* ConfigurableGradientView.swift */; };
 		DFACBF85277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF84277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift */; };
 		DFACDFAA274D489B00A94EEC /* HistoryHighlightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACDFA9274D489B00A94EEC /* HistoryHighlightsViewModel.swift */; };
@@ -6879,6 +6885,12 @@
 		60CE80C02667780C004026C7 /* CredentialListPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialListPresenter.swift; sourceTree = "<group>"; };
 		60D71AEB26AAF45E00355588 /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		60E04CE89D47E52E0A886EAD /* hi-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hi-IN"; path = "hi-IN.lproj/Search.strings"; sourceTree = "<group>"; };
+		612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperBackgroundView.swift; sourceTree = "<group>"; };
+		612194E52CE50A93001664BB /* WallpaperAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperAction.swift; sourceTree = "<group>"; };
+		612194E72CE50A9B001664BB /* WallpaperState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperState.swift; sourceTree = "<group>"; };
+		619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMiddleware.swift; sourceTree = "<group>"; };
+		61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperStateTests.swift; sourceTree = "<group>"; };
+		61A164472CE7BE3D001D6058 /* WallpaperMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMiddlewareTests.swift; sourceTree = "<group>"; };
 		61AE456BAD6B0041485EFF1E /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Shared.strings; sourceTree = "<group>"; };
 		61B340508D4D86B6519A165C /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = "id.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		61DA4B5AB7DA505B9C992F95 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
@@ -9029,7 +9041,7 @@
 		DF940A0A2A96316D00C1497D /* FakespotSettingsCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakespotSettingsCardViewModelTests.swift; sourceTree = "<group>"; };
 		DFA51480275FFEE500266AA0 /* HistoryHighlightsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsManager.swift; sourceTree = "<group>"; };
 		DFA514822761012D00266AA0 /* HistoryHighlightsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsManagerTests.swift; sourceTree = "<group>"; };
-		DFACBF7E277B5F7B003D5F41 /* WallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperBackgroundView.swift; sourceTree = "<group>"; };
+		DFACBF7E277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyWallpaperBackgroundView.swift; sourceTree = "<group>"; };
 		DFACBF80277B916B003D5F41 /* ConfigurableGradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableGradientView.swift; sourceTree = "<group>"; };
 		DFACBF84277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesRowCountSettingsController.swift; sourceTree = "<group>"; };
 		DFACDFA9274D489B00A94EEC /* HistoryHighlightsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryHighlightsViewModel.swift; sourceTree = "<group>"; };
@@ -10905,6 +10917,34 @@
 			path = Generated;
 			sourceTree = "<group>";
 		};
+		612194E12CE50784001664BB /* Wallpaper */ = {
+			isa = PBXGroup;
+			children = (
+				612194E42CE50A7B001664BB /* Redux */,
+				612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */,
+			);
+			path = Wallpaper;
+			sourceTree = "<group>";
+		};
+		612194E42CE50A7B001664BB /* Redux */ = {
+			isa = PBXGroup;
+			children = (
+				612194E52CE50A93001664BB /* WallpaperAction.swift */,
+				612194E72CE50A9B001664BB /* WallpaperState.swift */,
+				619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */,
+			);
+			path = Redux;
+			sourceTree = "<group>";
+		};
+		61A164442CE7BDEF001D6058 /* Wallpaper */ = {
+			isa = PBXGroup;
+			children = (
+				61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */,
+				61A164472CE7BE3D001D6058 /* WallpaperMiddlewareTests.swift */,
+			);
+			path = Wallpaper;
+			sourceTree = "<group>";
+		};
 		630FE1312C7FB42500D9D6B2 /* Mock */ = {
 			isa = PBXGroup;
 			children = (
@@ -11142,6 +11182,7 @@
 				8A00BD862CAB3FE500680AF9 /* HomepageViewControllerTests.swift */,
 				8AA0A6662CAC745300AC7EB3 /* HomepageDiffableDataSourceTests.swift */,
 				8A6B79992CDBCE2E003C3077 /* TopSitesManagerTests.swift */,
+				61A164442CE7BDEF001D6058 /* Wallpaper */,
 			);
 			path = "Homepage Rebuild";
 			sourceTree = "<group>";
@@ -13565,7 +13606,7 @@
 		E1FF93E028A2E13600E6360E /* UI */ = {
 			isa = PBXGroup;
 			children = (
-				DFACBF7E277B5F7B003D5F41 /* WallpaperBackgroundView.swift */,
+				DFACBF7E277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift */,
 				E1FF93E128A2E55700E6360E /* WallpaperSelectorViewController.swift */,
 				E1FF93E328A2E74600E6360E /* WallpaperSelectorViewModel.swift */,
 				E19B38B228A42D5D00D8C541 /* WallpaperCollectionViewCell.swift */,
@@ -14297,6 +14338,7 @@
 			isa = PBXGroup;
 			children = (
 				8A7D08E12CAAF79F0035999C /* Homepage Rebuild */,
+				612194E12CE50784001664BB /* Wallpaper */,
 				8A0A1BA12B22010200E8706F /* PrivateHome */,
 				C834ACD028D3ACA900203AD1 /* Blurrable.swift */,
 				8AB5958628412B620090F4AE /* CustomizeHome */,
@@ -16173,7 +16215,7 @@
 				DF529E9F2AA86FF4003C5373 /* FakespotReviewQualityCardView.swift in Sources */,
 				1D0BA05C24F46A0400D731B5 /* TopSitesProvider.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
-				DFACBF7F277B5F7B003D5F41 /* WallpaperBackgroundView.swift in Sources */,
+				DFACBF7F277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift in Sources */,
 				8A7D08E32CAAF7C30035999C /* HomepageViewController.swift in Sources */,
 				D01017F5219CB6BD009CBB5A /* DownloadContentScript.swift in Sources */,
 				8A093D832A4B68940099ABA5 /* PrivacySettingsDelegate.swift in Sources */,
@@ -16388,6 +16430,7 @@
 				8A5D1CB02A30D740005AD35C /* SearchBarSetting.swift in Sources */,
 				EB9854FF2422686F0040F24B /* AppDelegate+PushNotifications.swift in Sources */,
 				DFACBF85277B9B5B003D5F41 /* TopSitesRowCountSettingsController.swift in Sources */,
+				612194E62CE50A93001664BB /* WallpaperAction.swift in Sources */,
 				9614BF4428AD1C6700D3F7EA /* AccountSyncHandler.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearchParser.swift in Sources */,
 				8A13FA8D2AD834FA007527AB /* BackgroundTabLoader.swift in Sources */,
@@ -16583,6 +16626,7 @@
 				E1CEC2022A28C3F100B177D5 /* LoginDetailCenteredTableViewCell.swift in Sources */,
 				C2D71B972A384F40003DEC7A /* ThemedSubtitleTableViewCell.swift in Sources */,
 				8A83B7462A264FA0002FF9AC /* SettingsCoordinator.swift in Sources */,
+				619FE8932CE6595B004F83E2 /* WallpaperMiddleware.swift in Sources */,
 				A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */,
 				8A97E6EA2C58487900F94793 /* AddressLocaleFeatureValidator.swift in Sources */,
 				AB3DB0C92B596739001D32CB /* AppStartupTelemetry.swift in Sources */,
@@ -16740,6 +16784,7 @@
 				9636D92C27F9E50100771F5E /* GleanPlumbMessageStore.swift in Sources */,
 				213B67A627CE682B000542F5 /* StartAtHomeHelper.swift in Sources */,
 				8A8629E2288096C40096DDB1 /* BookmarksFolderCell.swift in Sources */,
+				612194E82CE50A9B001664BB /* WallpaperState.swift in Sources */,
 				DAE6DF1B29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift in Sources */,
 				0EC57D082CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift in Sources */,
 				8AB8574A27D97CE90075C173 /* HomePanelDelegate.swift in Sources */,
@@ -16902,6 +16947,7 @@
 				1D558A5A2BEE7D07001EF527 /* WindowSimpleTabsCoordinator.swift in Sources */,
 				E6327A641BF6438E008D12E0 /* DebugSettingsBundleOptions.swift in Sources */,
 				F85C7EDD27109241004BDBA4 /* PasswordManagerOnboardingViewController.swift in Sources */,
+				612194E32CE507CF001664BB /* WallpaperBackgroundView.swift in Sources */,
 				D8FDEB57220CFE970069A582 /* UIImage+ImageEffects.m in Sources */,
 				0BDDB3462CA6E43A00D501DF /* BookmarksSaver.swift in Sources */,
 				EBB89506219398E500EB91A0 /* TabContentBlocker.swift in Sources */,
@@ -17152,6 +17198,7 @@
 				8A5BD95A28788A3D000FE773 /* TopSitesHelperTests.swift in Sources */,
 				C29B64832AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift in Sources */,
 				C8B41E0F29F0357300FE218A /* NimbusOnboardingFeatureLayerTests.swift in Sources */,
+				61A164492CE7BE84001D6058 /* WallpaperStateTests.swift in Sources */,
 				8A6B799D2CDBDAE4003C3077 /* MockContileProvider.swift in Sources */,
 				5AF6254728A58AC100A90253 /* MockHistoryHighlightsDataAdaptor.swift in Sources */,
 				8A7A26E329D4ACF300EA76F1 /* SceneCoordinatorTests.swift in Sources */,
@@ -17165,6 +17212,7 @@
 				8A33222227DFE658008F809E /* NimbusMock.swift in Sources */,
 				0B7FC3D32CAE811F005C5CCE /* DefaultBookmarksSaverTests.swift in Sources */,
 				8A8629E72880B7330096DDB1 /* LegacyBookmarksPanelTests.swift in Sources */,
+				61A1644A2CE7BE8A001D6058 /* WallpaperMiddlewareTests.swift in Sources */,
 				C8B394362A0ED55D00700E49 /* MockOnboardingCardDelegate.swift in Sources */,
 				8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */,
 				C787D8C32C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -134,8 +134,20 @@ class BrowserCoordinator: BaseCoordinator,
         screenshotService.screenshotableView = nil
     }
 
-    func showHomepage() {
-        let homepageController = self.homepageViewController ?? HomepageViewController(windowUUID: windowUUID)
+    func showHomepage(overlayManager: OverlayModeManager, isZeroSearch: Bool) {
+        let homepageCoordinator = childCoordinators[HomepageCoordinator.self] ?? HomepageCoordinator(
+            windowUUID: windowUUID,
+            profile: profile,
+            wallpaperManger: WallpaperManager(),
+            isZeroSearch: isZeroSearch,
+            router: router
+        )
+        add(child: homepageCoordinator)
+        let homepageController = self.homepageViewController ?? HomepageViewController(
+            windowUUID: windowUUID,
+            homepageDelegate: homepageCoordinator,
+            overlayManager: overlayManager
+        )
         guard browserViewController.embedContent(homepageController) else {
             logger.log("Unable to embed new homepage", level: .debug, category: .coordinator)
             return

--- a/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -24,7 +24,7 @@ protocol BrowserDelegate: AnyObject {
     )
 
     /// Show the new homepage to the user as part of the homepage rebuild project
-    func showHomepage()
+    func showHomepage(overlayManager: OverlayModeManager, isZeroSearch: Bool)
 
     /// Show the private homepage to the user as part of felt privacy
     func showPrivateHomepage(overlayManager: OverlayModeManager)

--- a/firefox-ios/Client/Coordinators/HomepageCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/HomepageCoordinator.swift
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import Shared
+
+protocol HompageDelegate: AnyObject {
+     func showWallpaperSelectionOnboarding(_ canPresentModally: Bool)
+}
+
+class HomepageCoordinator: BaseCoordinator, HompageDelegate {
+    private let windowUUID: WindowUUID
+    private let profile: Profile
+    private let wallpaperManager: WallpaperManagerInterface
+    private let isZeroSearch: Bool
+
+    init(
+        windowUUID: WindowUUID,
+        profile: Profile,
+        wallpaperManger: WallpaperManagerInterface,
+        isZeroSearch: Bool,
+        router: Router
+    ) {
+        self.windowUUID = windowUUID
+        self.profile = profile
+        self.wallpaperManager = wallpaperManger
+        self.isZeroSearch = isZeroSearch
+        super.init(router: router)
+        self.router = router
+    }
+
+    func showWallpaperSelectionOnboarding(_ canPresentModally: Bool) {
+        guard canPresentModally,
+              isZeroSearch,
+              !router.isPresenting,
+              wallpaperManager.canOnboardingBeShown(using: profile)
+        else { return }
+
+        let viewModel = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager)
+        let viewController = WallpaperSelectorViewController(viewModel: viewModel, windowUUID: windowUUID)
+        var bottomSheetViewModel = BottomSheetViewModel(
+            closeButtonA11yLabel: .CloseButtonTitle,
+            closeButtonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.closeButton
+        )
+        bottomSheetViewModel.shouldDismissForTapOutside = false
+        let bottomSheetVC = BottomSheetViewController(
+            viewModel: bottomSheetViewModel,
+            childViewController: viewController,
+            windowUUID: windowUUID
+        )
+
+        router.present(bottomSheetVC, animated: false, completion: nil)
+        wallpaperManager.onboardingSeen()
+    }
+}

--- a/firefox-ios/Client/Coordinators/Router/DefaultRouter.swift
+++ b/firefox-ios/Client/Coordinators/Router/DefaultRouter.swift
@@ -11,6 +11,10 @@ class DefaultRouter: NSObject, Router {
         return navigationController.viewControllers.first
     }
 
+    var isPresenting: Bool {
+        return navigationController.presentedViewController != nil
+    }
+
     var navigationController: NavigationController
 
     init(navigationController: NavigationController) {

--- a/firefox-ios/Client/Coordinators/Router/Router.swift
+++ b/firefox-ios/Client/Coordinators/Router/Router.swift
@@ -15,6 +15,9 @@ protocol Router: AnyObject, UINavigationControllerDelegate, UIAdaptivePresentati
     /// controller on the navigation controller stack
     var rootViewController: UIViewController? { get }
 
+    /// Boolean value indicating whether or not the router is presnting a view controller for a vertical flow
+    var isPresenting: Bool { get }
+
     /// Present a view controller for a vertical flow.
     /// - Parameters:
     ///   - viewController: The view controller to present

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1341,7 +1341,7 @@ class BrowserViewController: UIViewController,
         }
 
         if featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly) {
-            browserDelegate?.showHomepage()
+            browserDelegate?.showHomepage(overlayManager: overlayManager, isZeroSearch: inline)
         } else {
             browserDelegate?.showLegacyHomepage(
                 inline: inline,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -30,6 +30,7 @@ final class HomepageViewController: UIViewController,
     // MARK: - Private variables
     private var collectionView: UICollectionView?
     private var dataSource: HomepageDiffableDataSource?
+    // TODO: FXIOS-10541 will handle scrolling for wallpaper and other scroll issues
     private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
     private var layoutConfiguration = HomepageSectionLayoutProvider().createCompositionalLayout()
     private var logger: Logger
@@ -87,6 +88,11 @@ final class HomepageViewController: UIViewController,
 
         listenForThemeChange(view)
         applyTheme()
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        wallpaperView.updateImageForOrientationChange()
     }
 
     // MARK: - Redux

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -30,6 +30,7 @@ final class HomepageViewController: UIViewController,
     // MARK: - Private variables
     private var collectionView: UICollectionView?
     private var dataSource: HomepageDiffableDataSource?
+    private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
     private var layoutConfiguration = HomepageSectionLayoutProvider().createCompositionalLayout()
     private var logger: Logger
     private var homepageState: HomepageState
@@ -72,6 +73,7 @@ final class HomepageViewController: UIViewController,
     // MARK: - View lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureWallpaperView()
         setupLayout()
         configureCollectionView()
         configureDataSource()
@@ -109,6 +111,7 @@ final class HomepageViewController: UIViewController,
 
     func newState(state: HomepageState) {
         homepageState = state
+        wallpaperView.wallpaper = state.wallpaperState.wallpaper
         dataSource?.applyInitialSnapshot(state: state)
     }
 
@@ -128,6 +131,28 @@ final class HomepageViewController: UIViewController,
     }
 
     // MARK: - Layout
+    var statusBarFrame: CGRect? {
+        guard let keyWindow = UIWindow.keyWindow else { return nil }
+
+        return keyWindow.windowScene?.statusBarManager?.statusBarFrame
+    }
+
+    func configureWallpaperView() {
+        view.addSubview(wallpaperView)
+
+        // Constraint so wallpaper appears under the status bar
+        let wallpaperTopConstant: CGFloat = UIWindow.keyWindow?.safeAreaInsets.top ?? statusBarFrame?.height ?? 0
+
+        NSLayoutConstraint.activate([
+            wallpaperView.topAnchor.constraint(equalTo: view.topAnchor, constant: -wallpaperTopConstant),
+            wallpaperView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            wallpaperView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            wallpaperView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        view.sendSubviewToBack(wallpaperView)
+    }
+
     private func setupLayout() {
         guard let collectionView else {
             logger.log(

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -117,7 +117,7 @@ final class HomepageViewController: UIViewController,
 
     func newState(state: HomepageState) {
         homepageState = state
-        wallpaperView.wallpaper = state.wallpaperState.wallpaper
+        wallpaperView.wallpaperState = state.wallpaperState
         dataSource?.applyInitialSnapshot(state: state)
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -12,6 +12,7 @@ struct HomepageState: ScreenState, Equatable {
     var headerState: HeaderState
     var topSitesState: TopSitesSectionState
     var pocketState: PocketState
+    var wallpaperState: WallpaperState
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let homepageState = store.state.screenState(
@@ -27,7 +28,8 @@ struct HomepageState: ScreenState, Equatable {
             windowUUID: homepageState.windowUUID,
             headerState: homepageState.headerState,
             topSitesState: homepageState.topSitesState,
-            pocketState: homepageState.pocketState
+            pocketState: homepageState.pocketState,
+            wallpaperState: homepageState.wallpaperState
         )
     }
 
@@ -36,7 +38,8 @@ struct HomepageState: ScreenState, Equatable {
             windowUUID: windowUUID,
             headerState: HeaderState(windowUUID: windowUUID),
             topSitesState: TopSitesSectionState(windowUUID: windowUUID),
-            pocketState: PocketState(windowUUID: windowUUID)
+            pocketState: PocketState(windowUUID: windowUUID),
+            wallpaperState: WallpaperState(windowUUID: windowUUID)
         )
     }
 
@@ -44,12 +47,14 @@ struct HomepageState: ScreenState, Equatable {
         windowUUID: WindowUUID,
         headerState: HeaderState,
         topSitesState: TopSitesSectionState,
-        pocketState: PocketState
+        pocketState: PocketState,
+        wallpaperState: WallpaperState
     ) {
         self.windowUUID = windowUUID
         self.headerState = headerState
         self.topSitesState = topSitesState
         self.pocketState = pocketState
+        self.wallpaperState = wallpaperState
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -64,7 +69,8 @@ struct HomepageState: ScreenState, Equatable {
                 windowUUID: state.windowUUID,
                 headerState: HeaderState.reducer(state.headerState, action),
                 topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
-                pocketState: PocketState.reducer(state.pocketState, action)
+                pocketState: PocketState.reducer(state.pocketState, action),
+                wallpaperState: WallpaperState.reducer(state.wallpaperState, action)
             )
         default:
             return defaultState(from: state, action: action)
@@ -75,18 +81,21 @@ struct HomepageState: ScreenState, Equatable {
         var headerState = state.headerState
         var pocketState = state.pocketState
         var topSitesState = state.topSitesState
+        var wallpaperState = state.wallpaperState
 
         if let action {
             headerState = HeaderState.reducer(state.headerState, action)
             pocketState = PocketState.reducer(state.pocketState, action)
             topSitesState = TopSitesSectionState.reducer(state.topSitesState, action)
+            wallpaperState = WallpaperState.reducer(state.wallpaperState, action)
         }
 
         return HomepageState(
             windowUUID: state.windowUUID,
             headerState: headerState,
             topSitesState: topSitesState,
-            pocketState: pocketState
+            pocketState: pocketState,
+            wallpaperState: wallpaperState
         )
     }
 

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -476,9 +476,7 @@ class LegacyHomepageViewController:
               canModalBePresented
         else { return }
 
-        let viewModel = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager, openSettingsAction: {
-            self.homePanelDidRequestToOpenSettings(at: .wallpaper)
-        })
+        let viewModel = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager)
         let viewController = WallpaperSelectorViewController(viewModel: viewModel, windowUUID: windowUUID)
         var bottomSheetViewModel = BottomSheetViewModel(
             closeButtonA11yLabel: .CloseButtonTitle,

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -39,7 +39,7 @@ class LegacyHomepageViewController:
     private var tabManager: TabManager
     private var overlayManager: OverlayModeManager
     private var userDefaults: UserDefaultsInterface
-    private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
+    private lazy var wallpaperView: LegacyWallpaperBackgroundView = .build { _ in }
     private var jumpBackInContextualHintViewController: ContextualHintViewController
     private var syncTabContextualHintViewController: ContextualHintViewController
     private var collectionView: UICollectionView! = nil

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperAction.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Redux
+import Common
+
+final class WallpaperAction: Action {
+    let wallpaper: Wallpaper
+
+    init(wallpaper: Wallpaper,
+         windowUUID: WindowUUID,
+         actionType: any ActionType
+    ) {
+        self.wallpaper = wallpaper
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
+
+enum WallpaperActionType: ActionType {
+    case wallpaperSelected
+}
+
+enum WallpaperMiddlewareActionType: ActionType {
+    case wallpaperDidInitialize
+    case wallpaperDidChange
+}

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperAction.swift
@@ -7,13 +7,13 @@ import Redux
 import Common
 
 final class WallpaperAction: Action {
-    let wallpaper: Wallpaper
+    let wallpaperConfiguration: WallpaperConfiguration
 
-    init(wallpaper: Wallpaper,
+    init(wallpaperConfiguration: WallpaperConfiguration,
          windowUUID: WindowUUID,
          actionType: any ActionType
     ) {
-        self.wallpaper = wallpaper
+        self.wallpaperConfiguration = wallpaperConfiguration
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -6,9 +6,9 @@ import Common
 import Redux
 
 class WallpaperMiddleware {
-    private let wallpaperManager: WallpaperManager
+    private let wallpaperManager: WallpaperManagerInterface
 
-    init(wallpaperManager: WallpaperManager = WallpaperManager()) {
+    init(wallpaperManager: WallpaperManagerInterface = WallpaperManager()) {
         self.wallpaperManager = wallpaperManager
     }
 

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -9,13 +9,7 @@ class WallpaperMiddleware {
     private let wallpaperManager: WallpaperManagerInterface
     private var wallpaperConfiguration: WallpaperConfiguration {
         let currentWallpaper = wallpaperManager.currentWallpaper
-        return WallpaperConfiguration(
-            landscapeImage: currentWallpaper.landscape,
-            portraitImage: currentWallpaper.portrait,
-            textColor: currentWallpaper.textColor,
-            cardColor: currentWallpaper.cardColor,
-            logoTextColor: currentWallpaper.logoTextColor
-        )
+        return WallpaperConfiguration(wallpaper: currentWallpaper)
     }
 
     init(wallpaperManager: WallpaperManagerInterface = WallpaperManager()) {

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -23,7 +23,11 @@ class WallpaperMiddleware {
     private func resolveHomepageAction(action: HomepageAction, state: AppState) {
         switch action.actionType {
         case HomepageActionType.initialize:
-            let action = WallpaperAction(wallpaper: wallpaperManager.currentWallpaper, windowUUID: action.windowUUID, actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize)
+            let action = WallpaperAction(
+                wallpaper: wallpaperManager.currentWallpaper,
+                windowUUID: action.windowUUID,
+                actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
+            )
             store.dispatch(action)
         default:
             break
@@ -33,7 +37,11 @@ class WallpaperMiddleware {
     private func resolveWallpaperAction(action: WallpaperAction, state: AppState) {
         switch action.actionType {
         case WallpaperActionType.wallpaperSelected:
-            let action = WallpaperAction(wallpaper: wallpaperManager.currentWallpaper, windowUUID: action.windowUUID, actionType: WallpaperMiddlewareActionType.wallpaperDidChange)
+            let action = WallpaperAction(
+                wallpaper: wallpaperManager.currentWallpaper,
+                windowUUID: action.windowUUID,
+                actionType: WallpaperMiddlewareActionType.wallpaperDidChange
+            )
             store.dispatch(action)
         default:
             break

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+
+class WallpaperMiddleware {
+    private let wallpaperManager: WallpaperManager
+
+    init(wallpaperManager: WallpaperManager = WallpaperManager()) {
+        self.wallpaperManager = wallpaperManager
+    }
+
+    lazy var wallpaperProvider: Middleware<AppState> = { state, action in
+        if let action = action as? HomepageAction {
+            self.resolveHomepageAction(action: action, state: state)
+        } else if let action = action as? WallpaperAction {
+            self.resolveWallpaperAction(action: action, state: state)
+        }
+    }
+
+    private func resolveHomepageAction(action: HomepageAction, state: AppState) {
+        switch action.actionType {
+        case HomepageActionType.initialize:
+            let action = WallpaperAction(wallpaper: wallpaperManager.currentWallpaper, windowUUID: action.windowUUID, actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize)
+            store.dispatch(action)
+        default:
+            break
+        }
+    }
+
+    private func resolveWallpaperAction(action: WallpaperAction, state: AppState) {
+        switch action.actionType {
+        case WallpaperActionType.wallpaperSelected:
+            let action = WallpaperAction(wallpaper: wallpaperManager.currentWallpaper, windowUUID: action.windowUUID, actionType: WallpaperMiddlewareActionType.wallpaperDidChange)
+            store.dispatch(action)
+        default:
+            break
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -7,6 +7,16 @@ import Redux
 
 class WallpaperMiddleware {
     private let wallpaperManager: WallpaperManagerInterface
+    private var wallpaperConfiguration: WallpaperConfiguration {
+        let currentWallpaper = wallpaperManager.currentWallpaper
+        return WallpaperConfiguration(
+            landscapeImage: currentWallpaper.landscape,
+            portraitImage: currentWallpaper.portrait,
+            textColor: currentWallpaper.textColor,
+            cardColor: currentWallpaper.cardColor,
+            logoTextColor: currentWallpaper.logoTextColor
+        )
+    }
 
     init(wallpaperManager: WallpaperManagerInterface = WallpaperManager()) {
         self.wallpaperManager = wallpaperManager
@@ -24,7 +34,7 @@ class WallpaperMiddleware {
         switch action.actionType {
         case HomepageActionType.initialize:
             let action = WallpaperAction(
-                wallpaper: wallpaperManager.currentWallpaper,
+                wallpaperConfiguration: wallpaperConfiguration,
                 windowUUID: action.windowUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
             )
@@ -38,7 +48,7 @@ class WallpaperMiddleware {
         switch action.actionType {
         case WallpaperActionType.wallpaperSelected:
             let action = WallpaperAction(
-                wallpaper: wallpaperManager.currentWallpaper,
+                wallpaperConfiguration: wallpaperConfiguration,
                 windowUUID: action.windowUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidChange
             )

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
@@ -62,4 +62,14 @@ struct WallpaperConfiguration: Equatable {
         self.cardColor = cardColor
         self.logoTextColor = logoTextColor
     }
+
+    init(wallpaper: Wallpaper) {
+        self.init(
+            landscapeImage: wallpaper.landscape,
+            portraitImage: wallpaper.portrait,
+            textColor: wallpaper.textColor,
+            cardColor: wallpaper.cardColor,
+            logoTextColor: wallpaper.logoTextColor
+        )
+    }
  }

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
@@ -6,11 +6,11 @@ import Common
 
 struct WallpaperState: ScreenState, Equatable {
     var windowUUID: WindowUUID
-    var wallpaper: Wallpaper
+    let wallpaperConfiguration: WallpaperConfiguration
 
-    init(windowUUID: WindowUUID, wallpaper: Wallpaper = Wallpaper.defaultWallpaper) {
+    init(windowUUID: WindowUUID, wallpaperConfiguration: WallpaperConfiguration = WallpaperConfiguration()) {
         self.windowUUID = windowUUID
-        self.wallpaper = wallpaper
+        self.wallpaperConfiguration = wallpaperConfiguration
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -31,13 +31,35 @@ struct WallpaperState: ScreenState, Equatable {
         guard let wallpaperAction = action as? WallpaperAction else { return defaultState(from: state) }
         return WallpaperState(
             windowUUID: state.windowUUID,
-            wallpaper: wallpaperAction.wallpaper
+            wallpaperConfiguration: wallpaperAction.wallpaperConfiguration
         )
     }
 
    static func defaultState(from state: WallpaperState) -> WallpaperState {
         return WallpaperState(
-            windowUUID: state.windowUUID, wallpaper: state.wallpaper
+            windowUUID: state.windowUUID, wallpaperConfiguration: state.wallpaperConfiguration
         )
    }
 }
+
+struct WallpaperConfiguration: Equatable {
+    var landscapeImage: UIImage?
+    var portraitImage: UIImage?
+    var textColor: UIColor?
+    var cardColor: UIColor?
+    var logoTextColor: UIColor?
+
+    init(
+        landscapeImage: UIImage? = nil,
+        portraitImage: UIImage? = nil,
+        textColor: UIColor? = nil,
+        cardColor: UIColor? = nil,
+        logoTextColor: UIColor? = nil
+    ) {
+        self.landscapeImage = landscapeImage
+        self.portraitImage = portraitImage
+        self.textColor = textColor
+        self.cardColor = cardColor
+        self.logoTextColor = logoTextColor
+    }
+ }

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
@@ -19,9 +19,8 @@ struct WallpaperState: ScreenState, Equatable {
         }
 
         switch action.actionType {
-        case WallpaperMiddlewareActionType.wallpaperDidInitialize:
-            return handleWallpaperAction(action: action, state: state)
-        case WallpaperMiddlewareActionType.wallpaperDidChange:
+        case WallpaperMiddlewareActionType.wallpaperDidInitialize,
+                WallpaperMiddlewareActionType.wallpaperDidChange:
             return handleWallpaperAction(action: action, state: state)
         default:
             return defaultState(from: state)

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import Redux
+import Common
+
+struct WallpaperState: ScreenState, Equatable {
+    var windowUUID: WindowUUID
+    var wallpaper: Wallpaper
+
+    init(windowUUID: WindowUUID, wallpaper: Wallpaper = Wallpaper.defaultWallpaper) {
+        self.windowUUID = windowUUID
+        self.wallpaper = wallpaper
+    }
+
+    static let reducer: Reducer<Self> = { state, action in
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else {
+            return defaultState(from: state)
+        }
+
+        switch action.actionType {
+        case WallpaperMiddlewareActionType.wallpaperDidInitialize:
+            return handleWallpaperAction(action: action, state: state)
+        case WallpaperMiddlewareActionType.wallpaperDidChange:
+            return handleWallpaperAction(action: action, state: state)
+        default:
+            return defaultState(from: state)
+        }
+    }
+
+    private static func handleWallpaperAction(action: Action, state: WallpaperState) -> WallpaperState {
+        guard let wallpaperAction = action as? WallpaperAction else { return defaultState(from: state) }
+        return WallpaperState(
+            windowUUID: state.windowUUID,
+            wallpaper: wallpaperAction.wallpaper
+        )
+    }
+
+   static func defaultState(from state: WallpaperState) -> WallpaperState {
+        return WallpaperState(
+            windowUUID: state.windowUUID, wallpaper: state.wallpaper
+        )
+   }
+}

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/WallpaperBackgroundView.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/WallpaperBackgroundView.swift
@@ -15,7 +15,7 @@ class WallpaperBackgroundView: UIView {
     }
 
     // MARK: - Variables
-    var wallpaper: Wallpaper? {
+    var wallpaperState: WallpaperState? {
         didSet {
             updateImageToCurrentWallpaper()
         }
@@ -50,17 +50,19 @@ class WallpaperBackgroundView: UIView {
     }
 
     private func updateImageToCurrentWallpaper() {
-        guard let wallpaper = self.wallpaper else { return }
+        guard let state = wallpaperState else { return }
         ensureMainThread {
-            let currentWallpaperImage = self.currentWallpaperImage(from: wallpaper)
+            let currentWallpaperImage = self.currentWallpaperImage(from: state)
             UIView.animate(withDuration: 0.3) {
                 self.pictureView.image = currentWallpaperImage
             }
         }
     }
 
-    private func currentWallpaperImage(from wallpaper: Wallpaper) -> UIImage? {
+    private func currentWallpaperImage(from wallpaperState: WallpaperState) -> UIImage? {
         let isLandscape = UIDevice.current.orientation.isLandscape
-        return isLandscape ? wallpaper.landscape : wallpaper.portrait
+        return isLandscape ?
+        wallpaperState.wallpaperConfiguration.landscapeImage :
+         wallpaperState.wallpaperConfiguration.landscapeImage
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/WallpaperBackgroundView.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/WallpaperBackgroundView.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import Common
+import Redux
 
 class WallpaperBackgroundView: UIView {
     // MARK: - UI Elements
@@ -14,26 +15,21 @@ class WallpaperBackgroundView: UIView {
     }
 
     // MARK: - Variables
-    private var wallpaperManager = WallpaperManager()
-    var notificationCenter: NotificationProtocol = NotificationCenter.default
+    var wallpaper: Wallpaper? {
+        didSet {
+            updateImageToCurrentWallpaper()
+        }
+    }
 
     // MARK: - Initializers & Setup
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
-        setupNotifications(forObserver: self,
-                           observing: [.WallpaperDidChange])
-
-        updateImageToCurrentWallpaper()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        notificationCenter.removeObserver(self)
     }
 
     private func setupView() {
@@ -54,26 +50,17 @@ class WallpaperBackgroundView: UIView {
     }
 
     private func updateImageToCurrentWallpaper() {
+        guard let wallpaper = self.wallpaper else { return }
         ensureMainThread {
-            let currentWallpaper = self.currentWallpaperImage()
+            let currentWallpaperImage = self.currentWallpaperImage(from: wallpaper)
             UIView.animate(withDuration: 0.3) {
-                self.pictureView.image = currentWallpaper
+                self.pictureView.image = currentWallpaperImage
             }
         }
     }
 
-    private func currentWallpaperImage() -> UIImage? {
+    private func currentWallpaperImage(from wallpaper: Wallpaper) -> UIImage? {
         let isLandscape = UIDevice.current.orientation.isLandscape
-        return isLandscape ? wallpaperManager.currentWallpaper.landscape : wallpaperManager.currentWallpaper.portrait
-    }
-}
-
-// MARK: - Notifiable
-extension WallpaperBackgroundView: Notifiable {
-    func handleNotifications(_ notification: Notification) {
-        switch notification.name {
-        case .WallpaperDidChange: updateImageToCurrentWallpaper()
-        default: break
-        }
+        return isLandscape ? wallpaper.landscape : wallpaper.portrait
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
@@ -199,10 +199,7 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
     }
 
     private func addDefaultWallpaper(to availableCollections: [WallpaperCollection]) -> [WallpaperCollection] {
-        let defaultWallpaper = [Wallpaper(id: "fxDefault",
-                                          textColor: nil,
-                                          cardColor: nil,
-                                          logoTextColor: nil)]
+        let defaultWallpaper = [Wallpaper.defaultWallpaper]
 
         if availableCollections.isEmpty {
             return [WallpaperCollection(id: "classic-firefox",

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
@@ -50,6 +50,7 @@ struct Wallpaper: Equatable {
     var portraitID: String { return "\(id)\(deviceVersionID)\(fileId.portrait)" }
     var landscapeID: String { return "\(id)\(deviceVersionID)\(fileId.landscape)" }
 
+    // TODO: This is actually just a nil wallpaper. Make this clearer in FXIOS-10633
     static var defaultWallpaper: Wallpaper {
         return Wallpaper(
             id: Wallpaper.defaultWallpaperName,

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
@@ -49,12 +49,18 @@ struct Wallpaper: Equatable {
     var thumbnailID: String { return "\(id)\(fileId.thumbnail)" }
     var portraitID: String { return "\(id)\(deviceVersionID)\(fileId.portrait)" }
     var landscapeID: String { return "\(id)\(deviceVersionID)\(fileId.landscape)" }
-    private var deviceVersionID: String {
-        return UIDevice.current.userInterfaceIdiom == .pad ? fileId.iPad : fileId.iPhone
+
+    static var defaultWallpaper: Wallpaper {
+        return Wallpaper(
+            id: Wallpaper.defaultWallpaperName,
+            textColor: nil,
+            cardColor: nil,
+            logoTextColor: nil
+        )
     }
 
     var type: WallpaperType {
-        return id == "fxDefault" ? .defaultWallpaper : .other
+        return id == Wallpaper.defaultWallpaperName ? .defaultWallpaper : .other
     }
 
     var needsToFetchResources: Bool {
@@ -72,6 +78,11 @@ struct Wallpaper: Equatable {
 
     var landscape: UIImage? {
         return fetchResourceFor(imageType: .landscape)
+    }
+
+    private static var defaultWallpaperName = "fxDefault"
+    private var deviceVersionID: String {
+        return UIDevice.current.userInterfaceIdiom == .pad ? fileId.iPad : fileId.iPhone
     }
 
     // MARK: - Helper functions

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/LegacyWallpaperBackgroundView.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/LegacyWallpaperBackgroundView.swift
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+
+class LegacyWallpaperBackgroundView: UIView {
+    // MARK: - UI Elements
+    private lazy var pictureView: UIImageView = .build { imageView in
+        imageView.image = nil
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+    }
+
+    // MARK: - Variables
+    private var wallpaperManager = WallpaperManager()
+    var notificationCenter: NotificationProtocol = NotificationCenter.default
+
+    // MARK: - Initializers & Setup
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+        setupNotifications(forObserver: self,
+                           observing: [.WallpaperDidChange])
+
+        updateImageToCurrentWallpaper()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
+    private func setupView() {
+        backgroundColor = .clear
+        addSubview(pictureView)
+
+        NSLayoutConstraint.activate([
+            pictureView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            pictureView.topAnchor.constraint(equalTo: topAnchor),
+            pictureView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            pictureView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+
+    // MARK: - Methods
+    public func updateImageForOrientationChange() {
+        updateImageToCurrentWallpaper()
+    }
+
+    private func updateImageToCurrentWallpaper() {
+        ensureMainThread {
+            let currentWallpaper = self.currentWallpaperImage()
+            UIView.animate(withDuration: 0.3) {
+                self.pictureView.image = currentWallpaper
+            }
+        }
+    }
+
+    private func currentWallpaperImage() -> UIImage? {
+        let isLandscape = UIDevice.current.orientation.isLandscape
+        return isLandscape ? wallpaperManager.currentWallpaper.landscape : wallpaperManager.currentWallpaper.portrait
+    }
+}
+
+// MARK: - Notifiable
+extension LegacyWallpaperBackgroundView: Notifiable {
+    func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case .WallpaperDidChange: updateImageToCurrentWallpaper()
+        default: break
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewModel.swift
@@ -46,7 +46,6 @@ class WallpaperSelectorViewModel {
     private var wallpaperManager: WallpaperManagerInterface
     private var availableCollections: [WallpaperCollection]
     private var wallpaperItems = [WallpaperSelectorItem]()
-    var openSettingsAction: (() -> Void)
     var sectionLayout: WallpaperSelectorLayout = .compact // We use the compact layout as default
     var selectedIndexPath: IndexPath?
 
@@ -54,10 +53,9 @@ class WallpaperSelectorViewModel {
         return wallpaperItems.count
     }
 
-    init(wallpaperManager: WallpaperManagerInterface = WallpaperManager(), openSettingsAction: @escaping (() -> Void)) {
+    init(wallpaperManager: WallpaperManagerInterface = WallpaperManager()) {
         self.wallpaperManager = wallpaperManager
         self.availableCollections = wallpaperManager.availableCollections
-        self.openSettingsAction = openSettingsAction
         setupWallpapers()
         selectedIndexPath = initialSelectedIndexPath
     }

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperStorageUtility.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperStorageUtility.swift
@@ -97,10 +97,7 @@ struct WallpaperStorageUtility: WallpaperMetadataCodableProtocol {
             }
         }
 
-        return Wallpaper(id: "fxDefault",
-                         textColor: nil,
-                         cardColor: nil,
-                         logoTextColor: nil)
+        return Wallpaper.defaultWallpaper
     }
 
     public func fetchImageNamed(_ name: String) throws -> UIImage? {

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -74,7 +74,8 @@ let middlewares = [
     TrackingProtectionMiddleware().trackingProtectionProvider,
     PasswordGeneratorMiddleware().passwordGeneratorProvider,
     PocketMiddleware().pocketSectionProvider,
-    NativeErrorPageMiddleware().nativeErrorPageProvider
+    NativeErrorPageMiddleware().nativeErrorPageProvider,
+    WallpaperMiddleware().wallpaperProvider
 ]
 
 // In order for us to mock and test the middlewares easier,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -140,7 +140,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
     func testShowNewHomepage_setsProperViewController() {
         let subject = createSubject()
-        subject.showHomepage()
+        subject.showHomepage(overlayManager: overlayModeManager, isZeroSearch: false)
 
         XCTAssertNotNil(subject.homepageViewController)
         XCTAssertNil(subject.webviewController)
@@ -149,11 +149,11 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
     func testShowNewHomepage_hasSameInstance() {
         let subject = createSubject()
-        subject.showHomepage()
+        subject.showHomepage(overlayManager: overlayModeManager, isZeroSearch: false)
         let firstHomepage = subject.homepageViewController
         XCTAssertNotNil(subject.homepageViewController)
 
-        subject.showHomepage()
+        subject.showHomepage(overlayManager: overlayModeManager, isZeroSearch: false)
         let secondHomepage = subject.homepageViewController
         XCTAssertEqual(firstHomepage, secondHomepage)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/HomepageCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/HomepageCoordinatorTests.swift
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import ComponentLibrary
+@testable import Client
+
+class HomepageCoordinatorTests: XCTestCase {
+    var coordinator: HomepageCoordinator!
+    let profile = MockProfile()
+    let wallpaperManger = WallpaperManagerMock()
+    let router = MockRouter(navigationController: MockNavigationController())
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    func test_showWallpaperSelectionOnboarding_withNoZeroSearch_doesNotPresentWallpaperSelection() {
+        coordinator = HomepageCoordinator(
+            windowUUID: .XCTestDefaultUUID,
+            profile: profile,
+            wallpaperManger: wallpaperManger,
+            isZeroSearch: false,
+            router: router
+        )
+        coordinator.showWallpaperSelectionOnboarding(true)
+        XCTAssertNil(router.presentedViewController)
+    }
+
+    func test_showWallpaperSelectionOnboarding_withZeroSearch_doesPresentWallpaperSelection() {
+        coordinator = HomepageCoordinator(
+            windowUUID: .XCTestDefaultUUID,
+            profile: profile,
+            wallpaperManger: wallpaperManger,
+            isZeroSearch: true,
+            router: router
+        )
+        coordinator.showWallpaperSelectionOnboarding(true)
+        XCTAssertEqual(router.presentCalled, 1)
+        XCTAssertTrue(router.presentedViewController is BottomSheetViewController)
+    }
+
+    func test_showWallpaperSelectionOnboarding_withCanPresentModallyIsFalse_doesNotPresentWallpaperSelection() {
+        coordinator = HomepageCoordinator(
+            windowUUID: .XCTestDefaultUUID,
+            profile: profile,
+            wallpaperManger: wallpaperManger,
+            isZeroSearch: true,
+            router: router
+        )
+        coordinator.showWallpaperSelectionOnboarding(false)
+        XCTAssertNil(router.presentedViewController)
+    }
+
+    func test_showWallpaperSelectionOnboarding_RouterAlreadyPresnting_doesNotPresentWallpaperSelection() {
+        router.presentCalled = 1
+        coordinator = HomepageCoordinator(
+            windowUUID: .XCTestDefaultUUID,
+            profile: profile,
+            wallpaperManger: wallpaperManger,
+            isZeroSearch: true,
+            router: router
+        )
+        coordinator.showWallpaperSelectionOnboarding(true)
+        XCTAssertNil(router.presentedViewController)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -47,14 +47,14 @@ final class ContentContainerTests: XCTestCase {
 
     func testCanAddNewHomepage() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID)
+        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
 
         XCTAssertTrue(subject.canAdd(content: homepage))
     }
 
     func testCanAddNewHomepageOnceOnly() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID)
+        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
 
         subject.add(content: homepage)
         XCTAssertFalse(subject.canAdd(content: homepage))
@@ -127,7 +127,7 @@ final class ContentContainerTests: XCTestCase {
 
     func testHasNewHomepage_returnsTrueWhenAdded() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID)
+        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
         subject.add(content: homepage)
 
         XCTAssertTrue(subject.hasHomepage)
@@ -188,7 +188,7 @@ final class ContentContainerTests: XCTestCase {
 
     func testContentView_hasContentNewHomepage_viewIsNotNil() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID)
+        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
         subject.add(content: homepage)
         XCTAssertNotNil(subject.contentView)
     }
@@ -217,7 +217,7 @@ final class ContentContainerTests: XCTestCase {
 
     func test_update_hasNewHomepage_returnsTrue() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID)
+        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
         subject.update(content: homepage)
         XCTAssertTrue(subject.hasHomepage)
         XCTAssertFalse(subject.hasLegacyHomepage)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -78,11 +78,13 @@ final class HomepageViewControllerTests: XCTestCase {
     private func createSubject() -> HomepageViewController {
         let notificationCenter = MockNotificationCenter()
         let themeManager = MockThemeManager()
+        let mockOverlayManager = MockOverlayModeManager()
         mockNotificationCenter = notificationCenter
         mockThemeManager = themeManager
         let homepageViewController = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
             themeManager: themeManager,
+            overlayManager: mockOverlayManager,
             notificationCenter: notificationCenter
         )
         trackForMemoryLeaks(homepageViewController)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+class WallpaperMiddlewareTests: XCTestCase {
+    var mockStore: MockStoreForMiddleware<AppState>!
+    let wallpaperManager = WallpaperManagerMock()
+    let appState = AppState()
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        mockStore = MockStoreForMiddleware(state: appState)
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        StoreTestUtilityHelper.resetStore()
+    }
+
+    func test_hompageAction_returnsWallpaperManagerWallpaper() throws {
+        let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
+        let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
+        let expectation = XCTestExpectation(description: "Homepage action initialize dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.wallpaperProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? WallpaperAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? WallpaperMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, WallpaperMiddlewareActionType.wallpaperDidInitialize)
+        XCTAssertEqual(actionCalled.wallpaper.id, "fxDefault")
+    }
+
+    func test_wallpaperAction_returnsWallpaperManagerWallpaper() throws {
+        let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
+        let testWallpaper = Wallpaper(id: "test", textColor: .green, cardColor: .yellow, logoTextColor: .orange)
+        let action = WallpaperAction(wallpaper: testWallpaper, windowUUID: .XCTestDefaultUUID, actionType: WallpaperActionType.wallpaperSelected)
+        let expectation = XCTestExpectation(description: "Wallpaper selected action dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.wallpaperProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? WallpaperAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? WallpaperMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, WallpaperMiddlewareActionType.wallpaperDidChange)
+        // TODO: FXIOS-10522 will make this test more meaningful by actually configuring the new current wallpaper
+        XCTAssertEqual(actionCalled.wallpaper.id, "fxDefault")
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
@@ -48,7 +48,11 @@ class WallpaperMiddlewareTests: XCTestCase {
     func test_wallpaperAction_returnsWallpaperManagerWallpaper() throws {
         let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
         let testWallpaper = Wallpaper(id: "test", textColor: .green, cardColor: .yellow, logoTextColor: .orange)
-        let action = WallpaperAction(wallpaper: testWallpaper, windowUUID: .XCTestDefaultUUID, actionType: WallpaperActionType.wallpaperSelected)
+        let action = WallpaperAction(
+            wallpaper: testWallpaper,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WallpaperActionType.wallpaperSelected
+        )
         let expectation = XCTestExpectation(description: "Wallpaper selected action dispatched")
 
         mockStore.dispatchCalled = {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
@@ -7,35 +7,28 @@ import XCTest
 
 @testable import Client
 
-class WallpaperMiddlewareTests: XCTestCase {
+class WallpaperMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockStore: MockStoreForMiddleware<AppState>!
     let wallpaperManager = WallpaperManagerMock()
-    let appState = AppState()
+    var appState: AppState!
 
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
-        mockStore = MockStoreForMiddleware(state: appState)
-        StoreTestUtilityHelper.setupStore(with: mockStore)
+
+        setupStore()
     }
 
     override func tearDown() {
+        resetStore()
         super.tearDown()
-        StoreTestUtilityHelper.resetStore()
     }
 
     func test_hompageAction_returnsWallpaperManagerWallpaper() throws {
         let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
-        let expectation = XCTestExpectation(description: "Homepage action initialize dispatched")
-
-        mockStore.dispatchCalled = {
-            expectation.fulfill()
-        }
 
         subject.wallpaperProvider(appState, action)
-
-        wait(for: [expectation])
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? WallpaperAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? WallpaperMiddlewareActionType)
@@ -53,15 +46,8 @@ class WallpaperMiddlewareTests: XCTestCase {
             windowUUID: .XCTestDefaultUUID,
             actionType: WallpaperActionType.wallpaperSelected
         )
-        let expectation = XCTestExpectation(description: "Wallpaper selected action dispatched")
-
-        mockStore.dispatchCalled = {
-            expectation.fulfill()
-        }
 
         subject.wallpaperProvider(appState, action)
-
-        wait(for: [expectation])
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? WallpaperAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? WallpaperMiddlewareActionType)
@@ -70,5 +56,19 @@ class WallpaperMiddlewareTests: XCTestCase {
         XCTAssertEqual(actionType, WallpaperMiddlewareActionType.wallpaperDidChange)
         // TODO: FXIOS-10522 will make this test more meaningful by actually configuring the new current wallpaper
         XCTAssertEqual(actionCalled.wallpaper.id, "fxDefault")
+    }
+
+    func setupAppState() -> Client.AppState {
+        appState = AppState()
+        return appState
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperMiddlewareTests.swift
@@ -35,14 +35,14 @@ class WallpaperMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, WallpaperMiddlewareActionType.wallpaperDidInitialize)
-        XCTAssertEqual(actionCalled.wallpaper.id, "fxDefault")
+        XCTAssertEqual(actionCalled.wallpaperConfiguration.cardColor, .purple)
     }
 
     func test_wallpaperAction_returnsWallpaperManagerWallpaper() throws {
         let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
-        let testWallpaper = Wallpaper(id: "test", textColor: .green, cardColor: .yellow, logoTextColor: .orange)
+        let testWallpaper = WallpaperConfiguration()
         let action = WallpaperAction(
-            wallpaper: testWallpaper,
+            wallpaperConfiguration: testWallpaper,
             windowUUID: .XCTestDefaultUUID,
             actionType: WallpaperActionType.wallpaperSelected
         )
@@ -55,7 +55,7 @@ class WallpaperMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, WallpaperMiddlewareActionType.wallpaperDidChange)
         // TODO: FXIOS-10522 will make this test more meaningful by actually configuring the new current wallpaper
-        XCTAssertEqual(actionCalled.wallpaper.id, "fxDefault")
+        XCTAssertEqual(actionCalled.wallpaperConfiguration.cardColor, .purple)
     }
 
     func setupAppState() -> Client.AppState {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
@@ -8,56 +8,75 @@ import XCTest
 @testable import Client
 
 final class WallpaperStateTests: XCTestCase {
+    let image = UIImage.templateImageNamed(ImageIdentifiers.logo)
+
     func test_initialState_returnsExpectedState() {
         let initialState = createSubject()
 
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertEqual(initialState.wallpaper.id, "fxDefault")
-        XCTAssertNil(initialState.wallpaper.textColor)
-        XCTAssertNil(initialState.wallpaper.cardColor)
-        XCTAssertNil(initialState.wallpaper.logoTextColor)
+        XCTAssertNil(initialState.wallpaperConfiguration.landscapeImage)
+        XCTAssertNil(initialState.wallpaperConfiguration.portraitImage)
+        XCTAssertNil(initialState.wallpaperConfiguration.textColor)
+        XCTAssertNil(initialState.wallpaperConfiguration.cardColor)
+        XCTAssertNil(initialState.wallpaperConfiguration.logoTextColor)
     }
 
     func test_wallpaperDidInitialize_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = headerReducer()
 
-        let testWallpaper = Wallpaper(id: "123", textColor: .black, cardColor: .black, logoTextColor: .black)
+        let testWallpaper = WallpaperConfiguration(
+            landscapeImage: image,
+            portraitImage: image,
+            textColor: .black,
+            cardColor: .black,
+            logoTextColor: .black
+        )
+        
         let newState = reducer(
             initialState,
             WallpaperAction(
-                wallpaper: testWallpaper,
+                wallpaperConfiguration: testWallpaper,
                 windowUUID: .XCTestDefaultUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
             )
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertEqual(newState.wallpaper.id, "123")
-        XCTAssertEqual(newState.wallpaper.textColor, .black)
-        XCTAssertEqual(newState.wallpaper.cardColor, .black)
-        XCTAssertEqual(newState.wallpaper.logoTextColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.landscapeImage, image)
+        XCTAssertEqual(newState.wallpaperConfiguration.portraitImage, image)
+        XCTAssertEqual(newState.wallpaperConfiguration.textColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.cardColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.logoTextColor, .black)
     }
 
     func test_wallpaperDidChange_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = headerReducer()
 
-        let testWallpaper = Wallpaper(id: "123", textColor: .black, cardColor: .black, logoTextColor: .black)
+        let testWallpaper = WallpaperConfiguration(
+            landscapeImage: image,
+            portraitImage: image,
+            textColor: .black,
+            cardColor: .black,
+            logoTextColor: .black
+        )
+
         let newState = reducer(
             initialState,
             WallpaperAction(
-                wallpaper: testWallpaper,
+                wallpaperConfiguration: testWallpaper,
                 windowUUID: .XCTestDefaultUUID,
                 actionType: WallpaperMiddlewareActionType.wallpaperDidChange
             )
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertEqual(newState.wallpaper.id, "123")
-        XCTAssertEqual(newState.wallpaper.textColor, .black)
-        XCTAssertEqual(newState.wallpaper.cardColor, .black)
-        XCTAssertEqual(newState.wallpaper.logoTextColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.landscapeImage, image)
+        XCTAssertEqual(newState.wallpaperConfiguration.portraitImage, image)
+        XCTAssertEqual(newState.wallpaperConfiguration.textColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.cardColor, .black)
+        XCTAssertEqual(newState.wallpaperConfiguration.logoTextColor, .black)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+final class WallpaperStateTests: XCTestCase {
+    func test_initialState_returnsExpectedState() {
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(initialState.wallpaper.id, "fxDefault")
+        XCTAssertNil(initialState.wallpaper.textColor)
+        XCTAssertNil(initialState.wallpaper.cardColor)
+        XCTAssertNil(initialState.wallpaper.logoTextColor)
+    }
+
+    func test_wallpaperDidInitialize_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = headerReducer()
+
+        let testWallpaper = Wallpaper(id: "123", textColor: .black, cardColor: .black, logoTextColor: .black)
+        let newState = reducer(
+            initialState,
+            WallpaperAction(
+                wallpaper: testWallpaper,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.wallpaper.id, "123")
+        XCTAssertEqual(newState.wallpaper.textColor, .black)
+        XCTAssertEqual(newState.wallpaper.cardColor, .black)
+        XCTAssertEqual(newState.wallpaper.logoTextColor, .black)
+    }
+
+    func test_wallpaperDidChange_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = headerReducer()
+
+        let testWallpaper = Wallpaper(id: "123", textColor: .black, cardColor: .black, logoTextColor: .black)
+        let newState = reducer(
+            initialState,
+            WallpaperAction(
+                wallpaper: testWallpaper,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: WallpaperMiddlewareActionType.wallpaperDidChange
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.wallpaper.id, "123")
+        XCTAssertEqual(newState.wallpaper.textColor, .black)
+        XCTAssertEqual(newState.wallpaper.cardColor, .black)
+        XCTAssertEqual(newState.wallpaper.logoTextColor, .black)
+    }
+
+    // MARK: - Private
+    private func createSubject() -> WallpaperState {
+        return WallpaperState(windowUUID: .XCTestDefaultUUID)
+    }
+
+    private func headerReducer() -> Reducer<WallpaperState> {
+        return WallpaperState.reducer
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Wallpaper/WallpaperStateTests.swift
@@ -32,7 +32,7 @@ final class WallpaperStateTests: XCTestCase {
             cardColor: .black,
             logoTextColor: .black
         )
-        
+
         let newState = reducer(
             initialState,
             WallpaperAction(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
@@ -9,6 +9,10 @@ class MockRouter: NSObject, Router {
     var navigationController: NavigationController
     var rootViewController: UIViewController?
 
+    var isPresenting: Bool {
+        presentCalled != 0
+    }
+
     var presentedViewController: UIViewController?
     var presentCalled = 0
     var dismissCalled = 0

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Redux
 @testable import Client
+import XCTest
 
 protocol StoreTestUtility {
     func setupAppState() -> AppState

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/WallpaperManagerMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/WallpaperManagerMock.swift
@@ -24,6 +24,8 @@ class WallpaperManagerMock: WallpaperManagerInterface {
 
     func canOnboardingBeShown(using: Profile) -> Bool { return true }
 
+    func onboardingSeen() {}
+
     func setCurrentWallpaper(
         to wallpaper: Wallpaper,
         completion: @escaping (Result<Void, Error>) -> Void
@@ -41,12 +43,9 @@ class WallpaperManagerMock: WallpaperManagerInterface {
         completion(fetchResult)
     }
 
-    func removeUnusedAssets() {
-    }
+    func removeUnusedAssets() {}
 
-    func checkForUpdates() {
-    }
+    func checkForUpdates() {}
 
-    func migrateLegacyAssets() {
-    }
+    func migrateLegacyAssets() {}
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperSelectorViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperSelectorViewModelTests.swift
@@ -83,7 +83,7 @@ class WallpaperSelectorViewModelTests: XCTestCase {
 //    }
 
     func createSubject() -> WallpaperSelectorViewModel {
-        let subject = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager) { }
+        let subject = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager)
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10522)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23062)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Add `HomepageCoordinator` to manage navigation logic around presenting the wallpaper selection bottom sheet
- Add featureflagged logic to `WallpaperManager` to dispatch `wallpaperDidChange` action when a new wallpaper is selected 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

