### PR TITLE
Refactor FXIOS-10522 [Wallpapers] [Homepage] Add wallpaper selection to new homepage

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -605,9 +605,11 @@
 		612194E32CE507CF001664BB /* WallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */; };
 		612194E62CE50A93001664BB /* WallpaperAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E52CE50A93001664BB /* WallpaperAction.swift */; };
 		612194E82CE50A9B001664BB /* WallpaperState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612194E72CE50A9B001664BB /* WallpaperState.swift */; };
+		6139A2AE2CF66C5400F6A472 /* HomepageCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6139A2AD2CF66C5400F6A472 /* HomepageCoordinatorTests.swift */; };
 		619FE8932CE6595B004F83E2 /* WallpaperMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */; };
 		61A164492CE7BE84001D6058 /* WallpaperStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */; };
 		61A1644A2CE7BE8A001D6058 /* WallpaperMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A164472CE7BE3D001D6058 /* WallpaperMiddlewareTests.swift */; };
+		61B3D29F2CEFBE4400060526 /* HomepageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B3D29E2CEFBE4400060526 /* HomepageCoordinator.swift */; };
 		630FE1352C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1322C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift */; };
 		631A369F2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */; };
 		631A36A32CC0B2470044DFEB /* NativeErrorPageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A36A22CC0B2470044DFEB /* NativeErrorPageHelper.swift */; };
@@ -6925,11 +6927,13 @@
 		612194E22CE507CF001664BB /* WallpaperBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperBackgroundView.swift; sourceTree = "<group>"; };
 		612194E52CE50A93001664BB /* WallpaperAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperAction.swift; sourceTree = "<group>"; };
 		612194E72CE50A9B001664BB /* WallpaperState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperState.swift; sourceTree = "<group>"; };
+		6139A2AD2CF66C5400F6A472 /* HomepageCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageCoordinatorTests.swift; sourceTree = "<group>"; };
 		619FE8922CE6595B004F83E2 /* WallpaperMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMiddleware.swift; sourceTree = "<group>"; };
 		61A164452CE7BE1A001D6058 /* WallpaperStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperStateTests.swift; sourceTree = "<group>"; };
 		61A164472CE7BE3D001D6058 /* WallpaperMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMiddlewareTests.swift; sourceTree = "<group>"; };
 		61AE456BAD6B0041485EFF1E /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Shared.strings; sourceTree = "<group>"; };
 		61B340508D4D86B6519A165C /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = "id.lproj/Default Browser.strings"; sourceTree = "<group>"; };
+		61B3D29E2CEFBE4400060526 /* HomepageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageCoordinator.swift; sourceTree = "<group>"; };
 		61DA4B5AB7DA505B9C992F95 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		623648C2A7D09ECA31155208 /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ka; path = ka.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		625D4575B4794C49451D6990 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
@@ -11686,6 +11690,7 @@
 				C23889DE2A4EFCE500429673 /* ShareExtensionCoordinator.swift */,
 				21FBB4032ADECEFF002D9AB7 /* TabTray */,
 				B236204E2B86C56F000B1DE7 /* AddressAutofillCoordinator.swift */,
+				61B3D29E2CEFBE4400060526 /* HomepageCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -11714,6 +11719,7 @@
 				21FA8FAC2AE8561C0013B815 /* TabTray */,
 				C8E531C929E5F7D300E03FEF /* URLScannerTests.swift */,
 				C81C66C329F00D1000F6422F /* UserActivityRouteTests.swift */,
+				6139A2AD2CF66C5400F6A472 /* HomepageCoordinatorTests.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -16844,6 +16850,7 @@
 				43D16B7A29831C7F009F8279 /* CreditCardAutofillToggle.swift in Sources */,
 				C23889E12A4F3E7200429673 /* ParentCoordinatorDelegate.swift in Sources */,
 				8AD40FCD27BADC5C00672675 /* TabLocationContainerView.swift in Sources */,
+				61B3D29F2CEFBE4400060526 /* HomepageCoordinator.swift in Sources */,
 				8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */,
 				211046CD2A7D842A00A7309F /* TPAccessoryInfo.swift in Sources */,
 				8CEDF0802BFE138B00D2617B /* AddressProvider.swift in Sources */,
@@ -17393,6 +17400,7 @@
 				C8E1BC0A28085AA700C62964 /* NimbusFeatureFlagLayerTests.swift in Sources */,
 				F80D53CF2A09A3350047ED14 /* RustSyncManagerTests.swift in Sources */,
 				1D3C90882ACE1AF400304C87 /* RemoteTabPanelTests.swift in Sources */,
+				6139A2AE2CF66C5400F6A472 /* HomepageCoordinatorTests.swift in Sources */,
 				43446CF02412DDBE00F5C643 /* UpdateViewModelTests.swift in Sources */,
 				E19443F62AF9413300964EA5 /* FakespotUtilsTests.swift in Sources */,
 				8A93F86829D373B0004159D9 /* MockNavigationController.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -141,7 +141,6 @@ class BrowserCoordinator: BaseCoordinator,
         let homepageCoordinator = childCoordinators[HomepageCoordinator.self] ?? HomepageCoordinator(
             windowUUID: windowUUID,
             profile: profile,
-            wallpaperManger: WallpaperManager(),
             isZeroSearch: isZeroSearch,
             router: router
         )

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -137,8 +137,20 @@ class BrowserCoordinator: BaseCoordinator,
         screenshotService.screenshotableView = nil
     }
 
-    func showHomepage() {
-        let homepageController = self.homepageViewController ?? HomepageViewController(windowUUID: windowUUID)
+    func showHomepage(overlayManager: OverlayModeManager, isZeroSearch: Bool) {
+        let homepageCoordinator = childCoordinators[HomepageCoordinator.self] ?? HomepageCoordinator(
+            windowUUID: windowUUID,
+            profile: profile,
+            wallpaperManger: WallpaperManager(),
+            isZeroSearch: isZeroSearch,
+            router: router
+        )
+        add(child: homepageCoordinator)
+        let homepageController = self.homepageViewController ?? HomepageViewController(
+            windowUUID: windowUUID,
+            homepageDelegate: homepageCoordinator,
+            overlayManager: overlayManager
+        )
         guard browserViewController.embedContent(homepageController) else {
             logger.log("Unable to embed new homepage", level: .debug, category: .coordinator)
             return

--- a/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -24,7 +24,7 @@ protocol BrowserDelegate: AnyObject {
     )
 
     /// Show the new homepage to the user as part of the homepage rebuild project
-    func showHomepage()
+    func showHomepage(overlayManager: OverlayModeManager, isZeroSearch: Bool)
 
     /// Show the private homepage to the user as part of felt privacy
     func showPrivateHomepage(overlayManager: OverlayModeManager)

--- a/firefox-ios/Client/Coordinators/HomepageCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/HomepageCoordinator.swift
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import Shared
+
+protocol HompageDelegate: AnyObject {
+     func showWallpaperSelectionOnboarding(_ canPresentModally: Bool)
+}
+
+class HomepageCoordinator: BaseCoordinator, HompageDelegate {
+    private let windowUUID: WindowUUID
+    private let profile: Profile
+    private let wallpaperManager: WallpaperManagerInterface
+    private let isZeroSearch: Bool
+
+    init(
+        windowUUID: WindowUUID,
+        profile: Profile,
+        wallpaperManger: WallpaperManagerInterface,
+        isZeroSearch: Bool,
+        router: Router
+    ) {
+        self.windowUUID = windowUUID
+        self.profile = profile
+        self.wallpaperManager = wallpaperManger
+        self.isZeroSearch = isZeroSearch
+        super.init(router: router)
+        self.router = router
+    }
+
+    func showWallpaperSelectionOnboarding(_ canPresentModally: Bool) {
+        guard canPresentModally,
+              isZeroSearch,
+              !router.isPresenting,
+              wallpaperManager.canOnboardingBeShown(using: profile)
+        else { return }
+
+        let viewModel = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager)
+        let viewController = WallpaperSelectorViewController(viewModel: viewModel, windowUUID: windowUUID)
+        var bottomSheetViewModel = BottomSheetViewModel(
+            closeButtonA11yLabel: .CloseButtonTitle,
+            closeButtonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.closeButton
+        )
+        bottomSheetViewModel.shouldDismissForTapOutside = false
+        let bottomSheetVC = BottomSheetViewController(
+            viewModel: bottomSheetViewModel,
+            childViewController: viewController,
+            windowUUID: windowUUID
+        )
+
+        router.present(bottomSheetVC, animated: false, completion: nil)
+        wallpaperManager.onboardingSeen()
+    }
+}

--- a/firefox-ios/Client/Coordinators/HomepageCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/HomepageCoordinator.swift
@@ -6,11 +6,11 @@ import Common
 import ComponentLibrary
 import Shared
 
-protocol HompageDelegate: AnyObject {
+protocol HomepageDelegate: AnyObject {
      func showWallpaperSelectionOnboarding(_ canPresentModally: Bool)
 }
 
-class HomepageCoordinator: BaseCoordinator, HompageDelegate {
+class HomepageCoordinator: BaseCoordinator, HomepageDelegate {
     private let windowUUID: WindowUUID
     private let profile: Profile
     private let wallpaperManager: WallpaperManagerInterface
@@ -19,13 +19,13 @@ class HomepageCoordinator: BaseCoordinator, HompageDelegate {
     init(
         windowUUID: WindowUUID,
         profile: Profile,
-        wallpaperManger: WallpaperManagerInterface,
+        wallpaperManager: WallpaperManagerInterface = WallpaperManager(),
         isZeroSearch: Bool,
         router: Router
     ) {
         self.windowUUID = windowUUID
         self.profile = profile
-        self.wallpaperManager = wallpaperManger
+        self.wallpaperManager = wallpaperManager
         self.isZeroSearch = isZeroSearch
         super.init(router: router)
         self.router = router

--- a/firefox-ios/Client/Coordinators/Router/DefaultRouter.swift
+++ b/firefox-ios/Client/Coordinators/Router/DefaultRouter.swift
@@ -11,6 +11,10 @@ class DefaultRouter: NSObject, Router {
         return navigationController.viewControllers.first
     }
 
+    var isPresenting: Bool {
+        return navigationController.presentedViewController != nil
+    }
+
     var navigationController: NavigationController
 
     init(navigationController: NavigationController) {

--- a/firefox-ios/Client/Coordinators/Router/Router.swift
+++ b/firefox-ios/Client/Coordinators/Router/Router.swift
@@ -15,7 +15,7 @@ protocol Router: AnyObject, UINavigationControllerDelegate, UIAdaptivePresentati
     /// controller on the navigation controller stack
     var rootViewController: UIViewController? { get }
 
-    /// Boolean value indicating whether or not the router is presnting a view controller for a vertical flow
+    /// Boolean value indicating whether or not the router is presenting a view controller for a vertical flow
     var isPresenting: Bool { get }
 
     /// Present a view controller for a vertical flow.

--- a/firefox-ios/Client/Coordinators/Router/Router.swift
+++ b/firefox-ios/Client/Coordinators/Router/Router.swift
@@ -15,6 +15,9 @@ protocol Router: AnyObject, UINavigationControllerDelegate, UIAdaptivePresentati
     /// controller on the navigation controller stack
     var rootViewController: UIViewController? { get }
 
+    /// Boolean value indicating whether or not the router is presnting a view controller for a vertical flow
+    var isPresenting: Bool { get }
+
     /// Present a view controller for a vertical flow.
     /// - Parameters:
     ///   - viewController: The view controller to present

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1352,7 +1352,7 @@ class BrowserViewController: UIViewController,
         }
 
         if featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly) {
-            browserDelegate?.showHomepage()
+            browserDelegate?.showHomepage(overlayManager: overlayManager, isZeroSearch: inline)
         } else {
             browserDelegate?.showLegacyHomepage(
                 inline: inline,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -28,7 +28,7 @@ final class HomepageViewController: UIViewController,
 
     // MARK: - Private variables
     private typealias a11y = AccessibilityIdentifiers.FirefoxHomepage
-    private weak var hompageDelegate: HompageDelegate?
+    private weak var homepageDelegate: HomepageDelegate?
     private var collectionView: UICollectionView?
     private var dataSource: HomepageDiffableDataSource?
     // TODO: FXIOS-10541 will handle scrolling for wallpaper and other scroll issues
@@ -44,14 +44,14 @@ final class HomepageViewController: UIViewController,
 
     // MARK: - Initializers
     init(windowUUID: WindowUUID,
-         homepageDelegate: HompageDelegate? = nil,
+         homepageDelegate: HomepageDelegate? = nil,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          overlayManager: OverlayModeManager,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          logger: Logger = DefaultLogger.shared
     ) {
         self.windowUUID = windowUUID
-        self.hompageDelegate = homepageDelegate
+        self.homepageDelegate = homepageDelegate
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
         self.overlayManager = overlayManager
@@ -103,7 +103,7 @@ final class HomepageViewController: UIViewController,
             guard let self = self else { return }
             // TODO: FXIOS-10312 Possibly move overlay mode to Redux
             let canPresentModally = !self.overlayManager.inOverlayMode
-            self.hompageDelegate?.showWallpaperSelectionOnboarding(canPresentModally)
+            self.homepageDelegate?.showWallpaperSelectionOnboarding(canPresentModally)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -484,9 +484,7 @@ class LegacyHomepageViewController:
               canModalBePresented
         else { return }
 
-        let viewModel = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager, openSettingsAction: {
-            self.homePanelDidRequestToOpenSettings(at: .wallpaper)
-        })
+        let viewModel = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager)
         let viewController = WallpaperSelectorViewController(viewModel: viewModel, windowUUID: windowUUID)
         var bottomSheetViewModel = BottomSheetViewModel(
             closeButtonA11yLabel: .CloseButtonTitle,

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperMiddleware.swift
@@ -9,13 +9,7 @@ class WallpaperMiddleware {
     private let wallpaperManager: WallpaperManagerInterface
     private var wallpaperConfiguration: WallpaperConfiguration {
         let currentWallpaper = wallpaperManager.currentWallpaper
-        return WallpaperConfiguration(
-            landscapeImage: currentWallpaper.landscape,
-            portraitImage: currentWallpaper.portrait,
-            textColor: currentWallpaper.textColor,
-            cardColor: currentWallpaper.cardColor,
-            logoTextColor: currentWallpaper.logoTextColor
-        )
+        return WallpaperConfiguration(wallpaper: currentWallpaper)
     }
 
     init(wallpaperManager: WallpaperManagerInterface = WallpaperManager()) {

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
@@ -62,4 +62,14 @@ struct WallpaperConfiguration: Equatable {
         self.cardColor = cardColor
         self.logoTextColor = logoTextColor
     }
+
+    init(wallpaper: Wallpaper) {
+        self.init(
+            landscapeImage: wallpaper.landscape,
+            portraitImage: wallpaper.portrait,
+            textColor: wallpaper.textColor,
+            cardColor: wallpaper.cardColor,
+            logoTextColor: wallpaper.logoTextColor
+        )
+    }
  }

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewModel.swift
@@ -46,7 +46,6 @@ class WallpaperSelectorViewModel {
     private var wallpaperManager: WallpaperManagerInterface
     private var availableCollections: [WallpaperCollection]
     private var wallpaperItems = [WallpaperSelectorItem]()
-    var openSettingsAction: (() -> Void)
     var sectionLayout: WallpaperSelectorLayout = .compact // We use the compact layout as default
     var selectedIndexPath: IndexPath?
 
@@ -54,10 +53,9 @@ class WallpaperSelectorViewModel {
         return wallpaperItems.count
     }
 
-    init(wallpaperManager: WallpaperManagerInterface = WallpaperManager(), openSettingsAction: @escaping (() -> Void)) {
+    init(wallpaperManager: WallpaperManagerInterface = WallpaperManager()) {
         self.wallpaperManager = wallpaperManager
         self.availableCollections = wallpaperManager.availableCollections
-        self.openSettingsAction = openSettingsAction
         setupWallpapers()
         selectedIndexPath = initialSelectedIndexPath
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -140,7 +140,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
     func testShowNewHomepage_setsProperViewController() {
         let subject = createSubject()
-        subject.showHomepage()
+        subject.showHomepage(overlayManager: overlayModeManager, isZeroSearch: false)
 
         XCTAssertNotNil(subject.homepageViewController)
         XCTAssertNil(subject.webviewController)
@@ -149,11 +149,11 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
     func testShowNewHomepage_hasSameInstance() {
         let subject = createSubject()
-        subject.showHomepage()
+        subject.showHomepage(overlayManager: overlayModeManager, isZeroSearch: false)
         let firstHomepage = subject.homepageViewController
         XCTAssertNotNil(subject.homepageViewController)
 
-        subject.showHomepage()
+        subject.showHomepage(overlayManager: overlayModeManager, isZeroSearch: false)
         let secondHomepage = subject.homepageViewController
         XCTAssertEqual(firstHomepage, secondHomepage)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/HomepageCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/HomepageCoordinatorTests.swift
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import ComponentLibrary
+@testable import Client
+
+class HomepageCoordinatorTests: XCTestCase {
+    var coordinator: HomepageCoordinator!
+    let profile = MockProfile()
+    let wallpaperManger = WallpaperManagerMock()
+    let router = MockRouter(navigationController: MockNavigationController())
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    func test_showWallpaperSelectionOnboarding_withNoZeroSearch_doesNotPresentWallpaperSelection() {
+        coordinator = HomepageCoordinator(
+            windowUUID: .XCTestDefaultUUID,
+            profile: profile,
+            wallpaperManger: wallpaperManger,
+            isZeroSearch: false,
+            router: router
+        )
+        coordinator.showWallpaperSelectionOnboarding(true)
+        XCTAssertNil(router.presentedViewController)
+    }
+
+    func test_showWallpaperSelectionOnboarding_withZeroSearch_doesPresentWallpaperSelection() {
+        coordinator = HomepageCoordinator(
+            windowUUID: .XCTestDefaultUUID,
+            profile: profile,
+            wallpaperManger: wallpaperManger,
+            isZeroSearch: true,
+            router: router
+        )
+        coordinator.showWallpaperSelectionOnboarding(true)
+        XCTAssertEqual(router.presentCalled, 1)
+        XCTAssertTrue(router.presentedViewController is BottomSheetViewController)
+    }
+
+    func test_showWallpaperSelectionOnboarding_withCanPresentModallyIsFalse_doesNotPresentWallpaperSelection() {
+        coordinator = HomepageCoordinator(
+            windowUUID: .XCTestDefaultUUID,
+            profile: profile,
+            wallpaperManger: wallpaperManger,
+            isZeroSearch: true,
+            router: router
+        )
+        coordinator.showWallpaperSelectionOnboarding(false)
+        XCTAssertNil(router.presentedViewController)
+    }
+
+    func test_showWallpaperSelectionOnboarding_RouterAlreadyPresnting_doesNotPresentWallpaperSelection() {
+        router.presentCalled = 1
+        coordinator = HomepageCoordinator(
+            windowUUID: .XCTestDefaultUUID,
+            profile: profile,
+            wallpaperManger: wallpaperManger,
+            isZeroSearch: true,
+            router: router
+        )
+        coordinator.showWallpaperSelectionOnboarding(true)
+        XCTAssertNil(router.presentedViewController)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/HomepageCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/HomepageCoordinatorTests.swift
@@ -7,62 +7,76 @@ import ComponentLibrary
 @testable import Client
 
 class HomepageCoordinatorTests: XCTestCase {
-    var coordinator: HomepageCoordinator!
-    let profile = MockProfile()
-    let wallpaperManager = WallpaperManagerMock()
-    let router = MockRouter(navigationController: MockNavigationController())
+    var profile: MockProfile!
+    var wallpaperManager: WallpaperManagerMock!
+    var router: MockRouter!
 
     override func setUp() {
         super.setUp()
+        profile = MockProfile()
+        wallpaperManager = WallpaperManagerMock()
+        router = MockRouter(navigationController: MockNavigationController())
         DependencyHelperMock().bootstrapDependencies()
     }
 
+    override func tearDown() {
+        super.tearDown()
+        DependencyHelperMock().reset()
+        profile = nil
+        wallpaperManager = nil
+        router = nil
+    }
+
     func test_showWallpaperSelectionOnboarding_withNoZeroSearch_doesNotPresentWallpaperSelection() {
-        coordinator = HomepageCoordinator(
+        let coordinator = HomepageCoordinator(
             windowUUID: .XCTestDefaultUUID,
             profile: profile,
-            wallpaperManger: wallpaperManger,
+            wallpaperManager: wallpaperManager,
             isZeroSearch: false,
             router: router
         )
+        trackForMemoryLeaks(coordinator)
         coordinator.showWallpaperSelectionOnboarding(true)
         XCTAssertNil(router.presentedViewController)
     }
 
     func test_showWallpaperSelectionOnboarding_withZeroSearch_doesPresentWallpaperSelection() {
-        coordinator = HomepageCoordinator(
+        let coordinator = HomepageCoordinator(
             windowUUID: .XCTestDefaultUUID,
             profile: profile,
-            wallpaperManger: wallpaperManger,
+            wallpaperManager: wallpaperManager,
             isZeroSearch: true,
             router: router
         )
+        trackForMemoryLeaks(coordinator)
         coordinator.showWallpaperSelectionOnboarding(true)
         XCTAssertEqual(router.presentCalled, 1)
         XCTAssertTrue(router.presentedViewController is BottomSheetViewController)
     }
 
     func test_showWallpaperSelectionOnboarding_withCanPresentModallyIsFalse_doesNotPresentWallpaperSelection() {
-        coordinator = HomepageCoordinator(
+        let coordinator = HomepageCoordinator(
             windowUUID: .XCTestDefaultUUID,
             profile: profile,
-            wallpaperManger: wallpaperManger,
+            wallpaperManager: wallpaperManager,
             isZeroSearch: true,
             router: router
         )
+        trackForMemoryLeaks(coordinator)
         coordinator.showWallpaperSelectionOnboarding(false)
         XCTAssertNil(router.presentedViewController)
     }
 
     func test_showWallpaperSelectionOnboarding_RouterAlreadyPresenting_doesNotPresentWallpaperSelection() {
         router.presentCalled = 1
-        coordinator = HomepageCoordinator(
+        let coordinator = HomepageCoordinator(
             windowUUID: .XCTestDefaultUUID,
             profile: profile,
-            wallpaperManger: wallpaperManger,
+            wallpaperManager: wallpaperManager,
             isZeroSearch: true,
             router: router
         )
+        trackForMemoryLeaks(coordinator)
         coordinator.showWallpaperSelectionOnboarding(true)
         XCTAssertNil(router.presentedViewController)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/HomepageCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/HomepageCoordinatorTests.swift
@@ -28,26 +28,14 @@ class HomepageCoordinatorTests: XCTestCase {
     }
 
     func test_showWallpaperSelectionOnboarding_withNoZeroSearch_doesNotPresentWallpaperSelection() {
-        let coordinator = HomepageCoordinator(
-            windowUUID: .XCTestDefaultUUID,
-            profile: profile,
-            wallpaperManager: wallpaperManager,
-            isZeroSearch: false,
-            router: router
-        )
+        let coordinator = createSubjectAndTrackForMemoryLeaks(isZeroSearch: false)
         trackForMemoryLeaks(coordinator)
         coordinator.showWallpaperSelectionOnboarding(true)
         XCTAssertNil(router.presentedViewController)
     }
 
     func test_showWallpaperSelectionOnboarding_withZeroSearch_doesPresentWallpaperSelection() {
-        let coordinator = HomepageCoordinator(
-            windowUUID: .XCTestDefaultUUID,
-            profile: profile,
-            wallpaperManager: wallpaperManager,
-            isZeroSearch: true,
-            router: router
-        )
+        let coordinator = createSubjectAndTrackForMemoryLeaks(isZeroSearch: true)
         trackForMemoryLeaks(coordinator)
         coordinator.showWallpaperSelectionOnboarding(true)
         XCTAssertEqual(router.presentCalled, 1)
@@ -55,13 +43,7 @@ class HomepageCoordinatorTests: XCTestCase {
     }
 
     func test_showWallpaperSelectionOnboarding_withCanPresentModallyIsFalse_doesNotPresentWallpaperSelection() {
-        let coordinator = HomepageCoordinator(
-            windowUUID: .XCTestDefaultUUID,
-            profile: profile,
-            wallpaperManager: wallpaperManager,
-            isZeroSearch: true,
-            router: router
-        )
+        let coordinator = createSubjectAndTrackForMemoryLeaks(isZeroSearch: true)
         trackForMemoryLeaks(coordinator)
         coordinator.showWallpaperSelectionOnboarding(false)
         XCTAssertNil(router.presentedViewController)
@@ -69,15 +51,20 @@ class HomepageCoordinatorTests: XCTestCase {
 
     func test_showWallpaperSelectionOnboarding_RouterAlreadyPresenting_doesNotPresentWallpaperSelection() {
         router.presentCalled = 1
+        let coordinator = createSubjectAndTrackForMemoryLeaks(isZeroSearch: true)
+        coordinator.showWallpaperSelectionOnboarding(true)
+        XCTAssertNil(router.presentedViewController)
+    }
+
+    private func createSubjectAndTrackForMemoryLeaks(isZeroSearch: Bool) -> HomepageCoordinator {
         let coordinator = HomepageCoordinator(
             windowUUID: .XCTestDefaultUUID,
             profile: profile,
             wallpaperManager: wallpaperManager,
-            isZeroSearch: true,
+            isZeroSearch: isZeroSearch,
             router: router
         )
         trackForMemoryLeaks(coordinator)
-        coordinator.showWallpaperSelectionOnboarding(true)
-        XCTAssertNil(router.presentedViewController)
+        return coordinator
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/HomepageCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/HomepageCoordinatorTests.swift
@@ -9,7 +9,7 @@ import ComponentLibrary
 class HomepageCoordinatorTests: XCTestCase {
     var coordinator: HomepageCoordinator!
     let profile = MockProfile()
-    let wallpaperManger = WallpaperManagerMock()
+    let wallpaperManager = WallpaperManagerMock()
     let router = MockRouter(navigationController: MockNavigationController())
 
     override func setUp() {
@@ -54,7 +54,7 @@ class HomepageCoordinatorTests: XCTestCase {
         XCTAssertNil(router.presentedViewController)
     }
 
-    func test_showWallpaperSelectionOnboarding_RouterAlreadyPresnting_doesNotPresentWallpaperSelection() {
+    func test_showWallpaperSelectionOnboarding_RouterAlreadyPresenting_doesNotPresentWallpaperSelection() {
         router.presentCalled = 1
         coordinator = HomepageCoordinator(
             windowUUID: .XCTestDefaultUUID,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -47,14 +47,14 @@ final class ContentContainerTests: XCTestCase {
 
     func testCanAddNewHomepage() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID)
+        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
 
         XCTAssertTrue(subject.canAdd(content: homepage))
     }
 
     func testCanAddNewHomepageOnceOnly() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID)
+        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
 
         subject.add(content: homepage)
         XCTAssertFalse(subject.canAdd(content: homepage))
@@ -127,7 +127,7 @@ final class ContentContainerTests: XCTestCase {
 
     func testHasNewHomepage_returnsTrueWhenAdded() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID)
+        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
         subject.add(content: homepage)
 
         XCTAssertTrue(subject.hasHomepage)
@@ -188,7 +188,7 @@ final class ContentContainerTests: XCTestCase {
 
     func testContentView_hasContentNewHomepage_viewIsNotNil() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID)
+        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
         subject.add(content: homepage)
         XCTAssertNotNil(subject.contentView)
     }
@@ -217,7 +217,7 @@ final class ContentContainerTests: XCTestCase {
 
     func test_update_hasNewHomepage_returnsTrue() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID)
+        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
         subject.update(content: homepage)
         XCTAssertTrue(subject.hasHomepage)
         XCTAssertFalse(subject.hasLegacyHomepage)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -78,11 +78,13 @@ final class HomepageViewControllerTests: XCTestCase {
     private func createSubject() -> HomepageViewController {
         let notificationCenter = MockNotificationCenter()
         let themeManager = MockThemeManager()
+        let mockOverlayManager = MockOverlayModeManager()
         mockNotificationCenter = notificationCenter
         mockThemeManager = themeManager
         let homepageViewController = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
             themeManager: themeManager,
+            overlayManager: mockOverlayManager,
             notificationCenter: notificationCenter
         )
         trackForMemoryLeaks(homepageViewController)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
@@ -9,6 +9,10 @@ class MockRouter: NSObject, Router {
     var navigationController: NavigationController
     var rootViewController: UIViewController?
 
+    var isPresenting: Bool {
+        presentCalled != 0
+    }
+
     var presentedViewController: UIViewController?
     var presentCalled = 0
     var dismissCalled = 0

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockRouter.swift
@@ -10,7 +10,7 @@ class MockRouter: NSObject, Router {
     var rootViewController: UIViewController?
 
     var isPresenting: Bool {
-        presentCalled != 0
+        return presentCalled != 0
     }
 
     var presentedViewController: UIViewController?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/WallpaperManagerMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/WallpaperManagerMock.swift
@@ -24,6 +24,8 @@ class WallpaperManagerMock: WallpaperManagerInterface {
 
     func canOnboardingBeShown(using: Profile) -> Bool { return true }
 
+    func onboardingSeen() {}
+
     func setCurrentWallpaper(
         to wallpaper: Wallpaper,
         completion: @escaping (Result<Void, Error>) -> Void
@@ -41,12 +43,9 @@ class WallpaperManagerMock: WallpaperManagerInterface {
         completion(fetchResult)
     }
 
-    func removeUnusedAssets() {
-    }
+    func removeUnusedAssets() {}
 
-    func checkForUpdates() {
-    }
+    func checkForUpdates() {}
 
-    func migrateLegacyAssets() {
-    }
+    func migrateLegacyAssets() {}
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperSelectorViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperSelectorViewModelTests.swift
@@ -83,7 +83,7 @@ class WallpaperSelectorViewModelTests: XCTestCase {
 //    }
 
     func createSubject() -> WallpaperSelectorViewModel {
-        let subject = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager) { }
+        let subject = WallpaperSelectorViewModel(wallpaperManager: wallpaperManager)
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10522)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23062)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Add `HomepageCoordinator` to manage navigation logic around presenting the wallpaper selection bottom sheet
- Add featureflagged logic to `WallpaperManager` to dispatch `wallpaperDidChange` action when a new wallpaper is selected 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
