### PR TITLE
Add FXIOS-10717 [sponsored tiles] Add feature flag for unified ads API

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -42,6 +42,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case searchHighlights
     case sentFromFirefox
     case splashScreen
+    case unifiedAds
     case unifiedSearch
     case toolbarRefactor
     case toolbarOneTapNewTab
@@ -127,6 +128,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .feltPrivacyFeltDeletion,
                 .searchHighlights,
                 .splashScreen,
+                .unifiedAds,
                 .unifiedSearch,
                 .toolbarRefactor,
                 .toolbarOneTapNewTab,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -89,6 +89,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
+                    with: .unifiedAds,
+                    titleText: format(string: "Enable Unified Ads"),
+                    statusText: format(string: "Toggle to use unified ads API")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .unifiedSearch,
                     titleText: format(string: "Enable Unified Search"),
                     statusText: format(string: "Toggle to use unified search within the new toolbar")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -103,6 +103,9 @@ final class NimbusFeatureFlagLayer {
         case .toolbarRefactor:
             return checkToolbarRefactorFeature(from: nimbus)
 
+        case .unifiedAds:
+            return checkUnifiedAdsFeature(from: nimbus)
+
         case .unifiedSearch:
             return checkUnifiedSearchFeature(from: nimbus)
 
@@ -201,6 +204,11 @@ final class NimbusFeatureFlagLayer {
 
     private func checkToolbarRefactorFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.toolbarRefactorFeature.value()
+        return config.enabled
+    }
+
+    private func checkUnifiedAdsFeature(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.unifiedAds.value()
         return config.enabled
     }
 

--- a/firefox-ios/nimbus-features/unifiedAds.yaml
+++ b/firefox-ios/nimbus-features/unifiedAds.yaml
@@ -1,0 +1,18 @@
+# The configuration for the unifiedAds feature
+features:
+  unified-ads:
+    description: >
+      This property is for managing the roll out of the unified ads API
+    variables:
+      enabled:
+        description: >
+          If true, we will enable user to use the unified ads API
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: false

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -43,4 +43,5 @@ include:
   - nimbus-features/toolbarRefactorFeature.yaml
   - nimbus-features/tosFeature.yaml
   - nimbus-features/trackingProtectionRefactor.yaml
+  - nimbus-features/unifiedAds.yaml
   - nimbus-features/zoomFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10717)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23421)

## :bulb: Description
Adding a new feature flag for unified ads API that will be used for sponsored tiles API changes.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

