### PR TITLE
Add FXIOS-10007 [Bookmarks Evolution] Add sign in button to empty state

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -473,6 +473,10 @@ public struct AccessibilityIdentifiers {
             static let tableView = "Bookmarks List"
             static let titleTextField = "BookmarkDetail.titleTextField"
             static let urlTextField = "BookmarkDetail.urlTextField"
+
+            struct EmptyState {
+                static let signInButton = "BookmarksPanel.RootEmptyState.signInButton"
+            }
         }
 
         struct HistoryPanel {

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -222,7 +222,6 @@ class BookmarksCoordinator: BaseCoordinator,
 
     private func makeSignInController() -> UIViewController {
         let fxaParams = FxALaunchParams(entrypoint: .libraryPanel, query: [:])
-        // NEED TO CHANGE PARENT TYPE
         let viewController = FirefoxAccountSignInViewController(profile: profile,
                                                                 parentType: .library,
                                                                 deepLinkParams: fxaParams,
@@ -258,5 +257,6 @@ class BookmarksCoordinator: BaseCoordinator,
     @objc
     private func dismissFxAViewController() {
         fxAccountViewController?.dismissVC()
+        fxAccountViewController = nil
     }
 }

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -224,7 +224,7 @@ class BookmarksCoordinator: BaseCoordinator,
         let fxaParams = FxALaunchParams(entrypoint: .libraryPanel, query: [:])
         // NEED TO CHANGE PARENT TYPE
         let viewController = FirefoxAccountSignInViewController(profile: profile,
-                                                                parentType: .tabTray,
+                                                                parentType: .library,
                                                                 deepLinkParams: fxaParams,
                                                                 windowUUID: windowUUID)
         viewController.qrCodeNavigationHandler = self
@@ -235,9 +235,6 @@ class BookmarksCoordinator: BaseCoordinator,
             action: #selector(dismissFxAViewController)
         )
         viewController.navigationItem.leftBarButtonItem = buttonItem
-        viewController.shouldReload = { [weak self] in
-            self?.reloadLastBookmarksController()
-        }
         let navController = ThemedNavigationController(rootViewController: viewController, windowUUID: windowUUID)
         fxAccountViewController = viewController
         return navController

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -235,8 +235,8 @@ class BookmarksCoordinator: BaseCoordinator,
             action: #selector(dismissFxAViewController)
         )
         viewController.navigationItem.leftBarButtonItem = buttonItem
-        viewController.shouldReload = {
-            self.reloadLastBookmarksController()
+        viewController.shouldReload = { [weak self] in
+            self?.reloadLastBookmarksController()
         }
         let navController = ThemedNavigationController(rootViewController: viewController, windowUUID: windowUUID)
         fxAccountViewController = viewController

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -18,6 +18,8 @@ protocol BookmarksCoordinatorDelegate: AnyObject, LibraryPanelCoordinatorDelegat
         parentBookmarkFolder: FxBookmarkNode,
         updatePanelState: ((LibraryPanelSubState) -> Void)?
     )
+
+    func showSignIn()
 }
 
 extension BookmarksCoordinatorDelegate {
@@ -36,12 +38,15 @@ extension BookmarksCoordinatorDelegate {
 
 class BookmarksCoordinator: BaseCoordinator,
                             BookmarksCoordinatorDelegate,
-                            BookmarksRefactorFeatureFlagProvider {
+                            QRCodeNavigationHandler,
+                            BookmarksRefactorFeatureFlagProvider,
+                            ParentCoordinatorDelegate {
     // MARK: - Properties
 
     private let profile: Profile
     private weak var parentCoordinator: LibraryCoordinatorDelegate?
     private weak var navigationHandler: LibraryNavigationHandler?
+    private var fxAccountViewController: FirefoxAccountSignInViewController?
     private let windowUUID: WindowUUID
 
     // MARK: - Initializers
@@ -115,8 +120,42 @@ class BookmarksCoordinator: BaseCoordinator,
         }
     }
 
+    func showSignIn() {
+        let controller = makeSignInController()
+        router.present(controller)
+    }
+
     func shareLibraryItem(url: URL, sourceView: UIView) {
         navigationHandler?.shareLibraryItem(url: url, sourceView: sourceView)
+    }
+
+    // MARK: - QRCodeNavigationHandler
+
+    func showQRCode(delegate: QRCodeViewControllerDelegate, rootNavigationController: UINavigationController?) {
+        var coordinator: QRCodeCoordinator
+        if let qrCodeCoordinator = childCoordinators.first(where: { $0 is QRCodeCoordinator }) as? QRCodeCoordinator {
+            coordinator = qrCodeCoordinator
+        } else {
+            if rootNavigationController != nil {
+                coordinator = QRCodeCoordinator(
+                    parentCoordinator: self,
+                    router: DefaultRouter(navigationController: rootNavigationController!)
+                )
+            } else {
+                coordinator = QRCodeCoordinator(
+                    parentCoordinator: self,
+                    router: router
+                )
+            }
+            add(child: coordinator)
+        }
+        coordinator.showQRCode(delegate: delegate)
+    }
+
+    // MARK: - ParentCoordinatorDelegate
+
+    func didFinish(from childCoordinator: Coordinator) {
+        remove(child: childCoordinator)
     }
 
     // MARK: - Factory
@@ -181,6 +220,29 @@ class BookmarksCoordinator: BaseCoordinator,
         return controller
     }
 
+    private func makeSignInController() -> UIViewController {
+        let fxaParams = FxALaunchParams(entrypoint: .libraryPanel, query: [:])
+        // NEED TO CHANGE PARENT TYPE
+        let viewController = FirefoxAccountSignInViewController(profile: profile,
+                                                                parentType: .tabTray,
+                                                                deepLinkParams: fxaParams,
+                                                                windowUUID: windowUUID)
+        viewController.qrCodeNavigationHandler = self
+        let buttonItem = UIBarButtonItem(
+            title: .CloseButtonTitle,
+            style: .plain,
+            target: self,
+            action: #selector(dismissFxAViewController)
+        )
+        viewController.navigationItem.leftBarButtonItem = buttonItem
+        viewController.shouldReload = {
+            self.reloadLastBookmarksController()
+        }
+        let navController = ThemedNavigationController(rootViewController: viewController, windowUUID: windowUUID)
+        fxAccountViewController = viewController
+        return navController
+    }
+
     private func reloadLastBookmarksController() {
         guard let rootBookmarkController = router.navigationController.viewControllers.last
                 as? BookmarksViewController
@@ -194,5 +256,10 @@ class BookmarksCoordinator: BaseCoordinator,
     private func setBackBarButtonItemTitle(_ title: String) {
         let backBarButton = UIBarButtonItem(title: title)
         router.navigationController.viewControllers.last?.navigationItem.backBarButtonItem = backBarButton
+    }
+
+    @objc
+    private func dismissFxAViewController() {
+        fxAccountViewController?.dismissVC()
     }
 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
@@ -4,15 +4,18 @@
 
 import Foundation
 import Common
+import ComponentLibrary
 
 final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
     private struct UX {
-        static let a11yTopMargin: CGFloat = 16
+        static let A11yTopMargin: CGFloat = 16
         static let TitleTopMargin: CGFloat = 16
         static let BodyTopMargin: CGFloat = 8
+        static let ButtonTopMargin: CGFloat = 16
         static let ContentLeftRightMargins: CGFloat = 16
         static let StackViewWidthMultiplier: CGFloat = 0.9
-        static let imageWidth: CGFloat = 200
+        static let ImageWidth: CGFloat = 200
+        static let SignInButtonMaxWidth: CGFloat = 306
     }
 
     private lazy var logoImage: UIImageView = .build { imageView in
@@ -33,6 +36,15 @@ final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
         label.adjustsFontForContentSizeCategory = true
     }
 
+    private lazy var signInButton: PrimaryRoundedButton = .build { button in
+        let viewModel = PrimaryRoundedButtonViewModel(
+            title: .Bookmarks.EmptyState.Root.ButtonTitle,
+            a11yIdentifier: AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.EmptyState.signInButton
+        )
+        button.configure(viewModel: viewModel)
+        button.addTarget(self, action: #selector(self.didTapSignIn), for: .touchUpInside)
+    }
+
     private lazy var stackViewWrapper: UIStackView = .build { stackView in
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
@@ -50,10 +62,11 @@ final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(isRoot: Bool) {
+    func configure(isRoot: Bool, isSignedIn: Bool) {
         titleLabel.text = isRoot ? .Bookmarks.EmptyState.Root.Title : .Bookmarks.EmptyState.Nested.Title
         bodyLabel.text = isRoot ? .Bookmarks.EmptyState.Root.Body : .Bookmarks.EmptyState.Nested.Body
         logoImage.image = UIImage(named: isRoot ? ImageIdentifiers.noBookmarksInRoot : ImageIdentifiers.noBookmarksInFolder)
+        signInButton.isHidden = !isRoot || isSignedIn
     }
 
     private func setupLayout() {
@@ -62,11 +75,13 @@ final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
         stackViewWrapper.addArrangedSubview(titleLabel)
         stackViewWrapper.setCustomSpacing(UX.BodyTopMargin, after: titleLabel)
         stackViewWrapper.addArrangedSubview(bodyLabel)
+        stackViewWrapper.setCustomSpacing(UX.ButtonTopMargin, after: bodyLabel)
+        stackViewWrapper.addArrangedSubview(signInButton)
         addSubview(stackViewWrapper)
 
         let aspectRatio = (logoImage.image?.size.height ?? 1) / (logoImage.image?.size.width ?? 1)
         NSLayoutConstraint.activate([
-            stackViewWrapper.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: UX.a11yTopMargin),
+            stackViewWrapper.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: UX.A11yTopMargin),
             stackViewWrapper.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
             stackViewWrapper.centerXAnchor.constraint(equalTo: centerXAnchor),
             stackViewWrapper.centerYAnchor.constraint(equalTo: centerYAnchor),
@@ -82,14 +97,21 @@ final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
             bodyLabel.trailingAnchor.constraint(
                 equalTo: stackViewWrapper.trailingAnchor, constant: -UX.ContentLeftRightMargins),
 
-            logoImage.widthAnchor.constraint(equalToConstant: UX.imageWidth),
+            signInButton.widthAnchor.constraint(equalToConstant: UX.SignInButtonMaxWidth),
+
+            logoImage.widthAnchor.constraint(equalToConstant: UX.ImageWidth),
             logoImage.heightAnchor.constraint(equalTo: logoImage.widthAnchor, multiplier: aspectRatio)
         ])
     }
+
+    // MARK: Actions
+     @objc
+     private func didTapSignIn() {}
 
     // MARK: ThemeApplicable
     func applyTheme(theme: Theme) {
         titleLabel.textColor = theme.colors.textPrimary
         bodyLabel.textColor = theme.colors.textPrimary
+        signInButton.applyTheme(theme: theme)
     }
 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
@@ -16,7 +16,10 @@ final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
         static let StackViewWidthMultiplier: CGFloat = 0.9
         static let ImageWidth: CGFloat = 200
         static let SignInButtonMaxWidth: CGFloat = 306
+        static let signInButtonMaxWidth: CGFloat = 306
     }
+
+    var signInAction: (() -> Void)?
 
     private lazy var logoImage: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
@@ -105,8 +108,10 @@ final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
     }
 
     // MARK: Actions
-     @objc
-     private func didTapSignIn() {}
+    @objc
+    private func didTapSignIn() {
+        signInAction?()
+    }
 
     // MARK: ThemeApplicable
     func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
@@ -8,14 +8,13 @@ import ComponentLibrary
 
 final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
     private struct UX {
-        static let A11yTopMargin: CGFloat = 16
-        static let TitleTopMargin: CGFloat = 16
-        static let BodyTopMargin: CGFloat = 8
-        static let ButtonTopMargin: CGFloat = 16
-        static let ContentLeftRightMargins: CGFloat = 16
-        static let StackViewWidthMultiplier: CGFloat = 0.9
-        static let ImageWidth: CGFloat = 200
-        static let SignInButtonMaxWidth: CGFloat = 306
+        static let a11yTopMargin: CGFloat = 16
+        static let titleTopMargin: CGFloat = 16
+        static let bodyTopMargin: CGFloat = 8
+        static let buttonTopMargin: CGFloat = 16
+        static let contentLeftRightMargins: CGFloat = 16
+        static let stackViewWidthMultiplier: CGFloat = 0.9
+        static let imageWidth: CGFloat = 200
         static let signInButtonMaxWidth: CGFloat = 306
     }
 
@@ -74,35 +73,35 @@ final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
 
     private func setupLayout() {
         stackViewWrapper.addArrangedSubview(logoImage)
-        stackViewWrapper.setCustomSpacing(UX.TitleTopMargin, after: logoImage)
+        stackViewWrapper.setCustomSpacing(UX.titleTopMargin, after: logoImage)
         stackViewWrapper.addArrangedSubview(titleLabel)
-        stackViewWrapper.setCustomSpacing(UX.BodyTopMargin, after: titleLabel)
+        stackViewWrapper.setCustomSpacing(UX.bodyTopMargin, after: titleLabel)
         stackViewWrapper.addArrangedSubview(bodyLabel)
-        stackViewWrapper.setCustomSpacing(UX.ButtonTopMargin, after: bodyLabel)
+        stackViewWrapper.setCustomSpacing(UX.buttonTopMargin, after: bodyLabel)
         stackViewWrapper.addArrangedSubview(signInButton)
         addSubview(stackViewWrapper)
 
         let aspectRatio = (logoImage.image?.size.height ?? 1) / (logoImage.image?.size.width ?? 1)
         NSLayoutConstraint.activate([
-            stackViewWrapper.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: UX.A11yTopMargin),
+            stackViewWrapper.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: UX.a11yTopMargin),
             stackViewWrapper.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
             stackViewWrapper.centerXAnchor.constraint(equalTo: centerXAnchor),
             stackViewWrapper.centerYAnchor.constraint(equalTo: centerYAnchor),
-            stackViewWrapper.widthAnchor.constraint(equalTo: widthAnchor, multiplier: UX.StackViewWidthMultiplier),
+            stackViewWrapper.widthAnchor.constraint(equalTo: widthAnchor, multiplier: UX.stackViewWidthMultiplier),
 
             titleLabel.leadingAnchor.constraint(
-                equalTo: stackViewWrapper.leadingAnchor, constant: UX.ContentLeftRightMargins),
+                equalTo: stackViewWrapper.leadingAnchor, constant: UX.contentLeftRightMargins),
             titleLabel.trailingAnchor.constraint(
-                equalTo: stackViewWrapper.trailingAnchor, constant: -UX.ContentLeftRightMargins),
+                equalTo: stackViewWrapper.trailingAnchor, constant: -UX.contentLeftRightMargins),
 
             bodyLabel.leadingAnchor.constraint(
-                equalTo: stackViewWrapper.leadingAnchor, constant: UX.ContentLeftRightMargins),
+                equalTo: stackViewWrapper.leadingAnchor, constant: UX.contentLeftRightMargins),
             bodyLabel.trailingAnchor.constraint(
-                equalTo: stackViewWrapper.trailingAnchor, constant: -UX.ContentLeftRightMargins),
+                equalTo: stackViewWrapper.trailingAnchor, constant: -UX.contentLeftRightMargins),
 
-            signInButton.widthAnchor.constraint(equalToConstant: UX.SignInButtonMaxWidth),
+            signInButton.widthAnchor.constraint(equalToConstant: UX.signInButtonMaxWidth),
 
-            logoImage.widthAnchor.constraint(equalToConstant: UX.ImageWidth),
+            logoImage.widthAnchor.constraint(equalToConstant: UX.imageWidth),
             logoImage.heightAnchor.constraint(equalTo: logoImage.widthAnchor, multiplier: aspectRatio)
         ])
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -82,7 +82,11 @@ class BookmarksViewController: SiteTableViewController,
         return button
     }()
 
-    private lazy var emptyStateView: BookmarksFolderEmptyStateView = .build()
+    private lazy var emptyStateView: BookmarksFolderEmptyStateView = .build { emptyStateView in
+        emptyStateView.signInAction = { [weak self] in
+            self?.bookmarkCoordinatorDelegate?.showSignIn()
+        }
+    }
 
     private lazy var a11yEmptyStateScrollView: UIScrollView = .build()
 
@@ -126,6 +130,10 @@ class BookmarksViewController: SiteTableViewController,
         tableView.dragInteractionEnabled = false
 
         setupEmptyStateView()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -320,7 +328,7 @@ class BookmarksViewController: SiteTableViewController,
         a11yEmptyStateScrollView.isHidden = !viewModel.bookmarkNodes.isEmpty
         if !a11yEmptyStateScrollView.isHidden {
             let isRoot = viewModel.bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID
-            let isSignedIn = RustFirefoxAccounts.shared.userProfile != nil
+            let isSignedIn = profile.hasAccount()
             emptyStateView.configure(isRoot: isRoot, isSignedIn: isSignedIn)
         }
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -143,13 +143,11 @@ class BookmarksViewController: SiteTableViewController,
 
     override func reloadData() {
         viewModel.reloadData { [weak self] in
-            DispatchQueue.main.async {
-                self?.tableView.reloadData()
-                if self?.viewModel.shouldFlashRow ?? false {
-                    self?.flashRow()
-                }
-                self?.updateEmptyState()
+            self?.tableView.reloadData()
+            if self?.viewModel.shouldFlashRow ?? false {
+                self?.flashRow()
             }
+            self?.updateEmptyState()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -7,6 +7,7 @@ import UIKit
 import Storage
 import Shared
 import SiteImageView
+import Account
 
 import class MozillaAppServices.BookmarkItemData
 import class MozillaAppServices.BookmarkSeparatorData
@@ -319,7 +320,8 @@ class BookmarksViewController: SiteTableViewController,
         a11yEmptyStateScrollView.isHidden = !viewModel.bookmarkNodes.isEmpty
         if !a11yEmptyStateScrollView.isHidden {
             let isRoot = viewModel.bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID
-            emptyStateView.configure(isRoot: isRoot)
+            let isSignedIn = RustFirefoxAccounts.shared.userProfile != nil
+            emptyStateView.configure(isRoot: isRoot, isSignedIn: isSignedIn)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -7,7 +7,6 @@ import UIKit
 import Storage
 import Shared
 import SiteImageView
-import Account
 
 import class MozillaAppServices.BookmarkItemData
 import class MozillaAppServices.BookmarkSeparatorData
@@ -103,7 +102,7 @@ class BookmarksViewController: SiteTableViewController,
         self.bookmarksHandler = viewModel.profile.places
         super.init(profile: viewModel.profile, windowUUID: windowUUID)
 
-        setupNotifications(forObserver: self, observing: [.FirefoxAccountChanged])
+        setupNotifications(forObserver: self, observing: [.FirefoxAccountChanged, .ProfileDidFinishSyncing])
 
         tableView.register(cellType: OneLineTableViewCell.self)
         tableView.register(cellType: SeparatorTableViewCell.self)
@@ -121,13 +120,6 @@ class BookmarksViewController: SiteTableViewController,
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(profileFinishedSyncing),
-            name: .ProfileDidFinishSyncing,
-            object: nil
-        )
 
         let tableViewLongPressRecognizer = UILongPressGestureRecognizer(target: self,
                                                                         action: #selector(didLongPressTableView))
@@ -336,11 +328,6 @@ class BookmarksViewController: SiteTableViewController,
             let isSignedIn = profile.hasAccount()
             emptyStateView.configure(isRoot: isRoot, isSignedIn: isSignedIn)
         }
-    }
-
-    @objc
-    private func profileFinishedSyncing() {
-        reloadData()
     }
 
     // MARK: - Long press
@@ -593,7 +580,7 @@ extension BookmarksViewController: LibraryPanelContextMenu {
 extension BookmarksViewController: Notifiable {
     func handleNotifications(_ notification: Notification) {
         switch notification.name {
-        case .FirefoxAccountChanged:
+        case .FirefoxAccountChanged, .ProfileDidFinishSyncing:
             reloadData()
         default:
             break

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -143,11 +143,13 @@ class BookmarksViewController: SiteTableViewController,
 
     override func reloadData() {
         viewModel.reloadData { [weak self] in
-            self?.tableView.reloadData()
-            if self?.viewModel.shouldFlashRow ?? false {
-                self?.flashRow()
+            DispatchQueue.main.async {
+                self?.tableView.reloadData()
+                if self?.viewModel.shouldFlashRow ?? false {
+                    self?.flashRow()
+                }
+                self?.updateEmptyState()
             }
-            self?.updateEmptyState()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -132,10 +132,6 @@ class BookmarksViewController: SiteTableViewController,
         setupEmptyStateView()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-    }
-
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -122,6 +122,13 @@ class BookmarksViewController: SiteTableViewController,
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(profileFinishedSyncing),
+            name: .ProfileDidFinishSyncing,
+            object: nil
+        )
+
         let tableViewLongPressRecognizer = UILongPressGestureRecognizer(target: self,
                                                                         action: #selector(didLongPressTableView))
         tableView.addGestureRecognizer(tableViewLongPressRecognizer)
@@ -144,11 +151,13 @@ class BookmarksViewController: SiteTableViewController,
 
     override func reloadData() {
         viewModel.reloadData { [weak self] in
-            self?.tableView.reloadData()
-            if self?.viewModel.shouldFlashRow ?? false {
-                self?.flashRow()
+            DispatchQueue.main.async {
+                self?.tableView.reloadData()
+                if self?.viewModel.shouldFlashRow ?? false {
+                    self?.flashRow()
+                }
+                self?.updateEmptyState()
             }
-            self?.updateEmptyState()
         }
     }
 
@@ -327,6 +336,11 @@ class BookmarksViewController: SiteTableViewController,
             let isSignedIn = profile.hasAccount()
             emptyStateView.configure(isRoot: isRoot, isSignedIn: isSignedIn)
         }
+    }
+
+    @objc
+    private func profileFinishedSyncing() {
+        reloadData()
     }
 
     // MARK: - Long press

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
@@ -117,16 +117,18 @@ class BookmarksPanelViewModel: BookmarksRefactorFeatureFlagProvider {
                 // Create a local "Desktop bookmarks" folder only if there exists a bookmark in one of it's nested
                 // subfolders
                 self.bookmarksHandler.countBookmarksInTrees(folderGuids: BookmarkRoots.DesktopRoots.map { $0 }) { result in
-                    switch result {
-                    case .success(let bookmarkCount):
+                    DispatchQueue.main.async {
+                        switch result {
+                        case .success(let bookmarkCount):
                             if bookmarkCount > 0 || !self.isBookmarkRefactorEnabled {
                                 let desktopFolder = LocalDesktopFolder()
                                 self.bookmarkNodes.insert(desktopFolder, at: 0)
                             }
-                    case .failure(let error):
+                        case .failure(let error):
                             self.logger.log("Error counting bookmarks: \(error)", level: .debug, category: .library)
+                        }
+                        completion()
                     }
-                    completion()
                 }
             }
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
@@ -117,18 +117,16 @@ class BookmarksPanelViewModel: BookmarksRefactorFeatureFlagProvider {
                 // Create a local "Desktop bookmarks" folder only if there exists a bookmark in one of it's nested
                 // subfolders
                 self.bookmarksHandler.countBookmarksInTrees(folderGuids: BookmarkRoots.DesktopRoots.map { $0 }) { result in
-                    DispatchQueue.main.async {
-                        switch result {
-                        case .success(let bookmarkCount):
+                    switch result {
+                    case .success(let bookmarkCount):
                             if bookmarkCount > 0 || !self.isBookmarkRefactorEnabled {
                                 let desktopFolder = LocalDesktopFolder()
                                 self.bookmarkNodes.insert(desktopFolder, at: 0)
                             }
-                        case .failure(let error):
+                    case .failure(let error):
                             self.logger.log("Error counting bookmarks: \(error)", level: .debug, category: .library)
-                        }
-                        completion()
                     }
+                    completion()
                 }
             }
     }

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -195,7 +195,7 @@ extension String {
                     key: "Bookmarks.EmptyState.Root.ButtonTitle.v135",
                     tableName: "Bookmarks",
                     value: "Sign in to Sync",
-                    comment: "The button title for the sign in button on the placeholder screen shown when there are no saved bookmarks, located at the root level of the bookmarks panel within the libray modal. This button starts the initiates allowing users to sign in to their Mozilla Account to sync data")
+                    comment: "The button title for the sign in button on the placeholder screen shown when there are no saved bookmarks, located at the root level of the bookmarks panel within the library modal. This button triggers the sign in flow, allowing users to sign in to their Mozilla Account to sync data")
             }
             public struct Nested {
                 public static let Title = MZLocalizedString(

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -191,6 +191,11 @@ extension String {
                     tableName: "Bookmarks",
                     value: "Save sites as you browse. We’ll also grab bookmarks from other synced devices.",
                     comment: "The body text for the placeholder screen shown when there are no saved bookmarks, located at the root level of the bookmarks panel within the libray modal")
+                public static let ButtonTitle = MZLocalizedString(
+                    key: "Bookmarks.EmptyState.Root.ButtonTitle.v135",
+                    tableName: "Bookmarks",
+                    value: "Sign in to Sync",
+                    comment: "The button title for the sign in button on the placeholder screen shown when there are no saved bookmarks, located at the root level of the bookmarks panel within the libray modal. This button starts the initiates allowing users to sign in to their Mozilla Account to sync data")
             }
             public struct Nested {
                 public static let Title = MZLocalizedString(

--- a/firefox-ios/Client/Telemetry/ReferringPage.swift
+++ b/firefox-ios/Client/Telemetry/ReferringPage.swift
@@ -11,4 +11,5 @@ enum ReferringPage: Equatable {
     case settings
     case none
     case tabTray
+    case library
 }

--- a/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
@@ -17,6 +17,7 @@ enum FxASignInParentType {
     case onboarding
     case upgrade
     case tabTray
+    case library
 }
 
 /// ViewController handling Sign In through QR Code or Email address
@@ -147,6 +148,9 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         case .tabTray:
             self.telemetryObject = .tabTray
             self.fxaDismissStyle = .popToTabTray
+        case .library:
+            self.telemetryObject = .libraryPanel
+            self.fxaDismissStyle = .dismiss
         }
         self.logger = logger
         self.notificationCenter = notificationCenter
@@ -361,6 +365,9 @@ extension FirefoxAccountSignInViewController {
             case .tabTray:
                 parentType = .tabTray
                 object = .tabTray
+            case .library:
+                parentType = .library
+                object = .libraryPanel
             }
 
             let signInVC = FirefoxAccountSignInViewController(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
@@ -68,6 +68,14 @@ final class BookmarksCoordinatorTests: XCTestCase {
         XCTAssertEqual(router.pushCalled, 1)
     }
 
+    func testShowSignInViewController() {
+        let subject = createSubject()
+
+        subject.showSignIn()
+        XCTAssertTrue(router.pushedViewController is FirefoxAccountSignInViewController)
+        XCTAssertEqual(router.pushCalled, 1)
+    }
+
     func testShowShareExtension_callsNavigationHandlerShareFunction() {
         let subject = createSubject()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
@@ -72,8 +72,9 @@ final class BookmarksCoordinatorTests: XCTestCase {
         let subject = createSubject()
 
         subject.showSignIn()
-        XCTAssertTrue(router.pushedViewController is FirefoxAccountSignInViewController)
-        XCTAssertEqual(router.pushCalled, 1)
+        let presentedViewController = router.presentedViewController as? UINavigationController
+        XCTAssertTrue(presentedViewController?.visibleViewController is FirefoxAccountSignInViewController)
+        XCTAssertEqual(router.presentCalled, 1)
     }
 
     func testShowShareExtension_callsNavigationHandlerShareFunction() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
@@ -96,9 +96,8 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
             position: 0
         ).uponQueue(.main) { _ in
             self.profile.places.countBookmarksInTrees(folderGuids: [BookmarkRoots.MenuFolderGUID]) { result in
-                DispatchQueue.main.async {
-                    switch result {
-                    case .success(let bookmarkCount):
+                switch result {
+                case .success(let bookmarkCount):
                         XCTAssertEqual(bookmarkCount, 1, "Menu folder contains one bookmark")
 
                         subject.reloadData {
@@ -106,10 +105,9 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
                             XCTAssertEqual(subject.bookmarkNodes.count, 1, "Mobile folder contains the local desktop folder")
                             expectation.fulfill()
                         }
-                    case .failure(let error):
+                case .failure(let error):
                         XCTFail("Failed to count bookmarks: \(error)")
                         expectation.fulfill()
-                    }
                 }
             }
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
@@ -98,9 +98,8 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
             position: 0
         ).uponQueue(.main) { _ in
             self.profile.places.countBookmarksInTrees(folderGuids: [BookmarkRoots.MenuFolderGUID]) { result in
-                DispatchQueue.main.async {
-                    switch result {
-                    case .success(let bookmarkCount):
+                switch result {
+                case .success(let bookmarkCount):
                         XCTAssertEqual(bookmarkCount, 1, "Menu folder contains one bookmark")
 
                         subject.reloadData {
@@ -108,10 +107,9 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
                             XCTAssertEqual(subject.bookmarkNodes.count, 1, "Mobile folder contains the local desktop folder")
                             expectation.fulfill()
                         }
-                    case .failure(let error):
+                case .failure(let error):
                         XCTFail("Failed to count bookmarks: \(error)")
                         expectation.fulfill()
-                    }
                 }
             }
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
@@ -98,8 +98,9 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
             position: 0
         ).uponQueue(.main) { _ in
             self.profile.places.countBookmarksInTrees(folderGuids: [BookmarkRoots.MenuFolderGUID]) { result in
-                switch result {
-                case .success(let bookmarkCount):
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success(let bookmarkCount):
                         XCTAssertEqual(bookmarkCount, 1, "Menu folder contains one bookmark")
 
                         subject.reloadData {
@@ -107,9 +108,10 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
                             XCTAssertEqual(subject.bookmarkNodes.count, 1, "Mobile folder contains the local desktop folder")
                             expectation.fulfill()
                         }
-                case .failure(let error):
+                    case .failure(let error):
                         XCTFail("Failed to count bookmarks: \(error)")
                         expectation.fulfill()
+                    }
                 }
             }
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
@@ -15,6 +15,7 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
     override func setUp() {
         super.setUp()
         profile = MockProfile()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
     }
 
     override func tearDown() {
@@ -58,7 +59,6 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
 
     func testShouldReload_whenMobileEmptyBookmarks() throws {
         profile.reopen()
-        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
         let expectation = expectation(description: "Subject reloaded")
         subject.reloadData {
@@ -71,7 +71,6 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
 
     func testShouldReload_whenMobileEmptyBookmarksWithBookmarksRefactor() throws {
         profile.reopen()
-        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         featureFlags.set(feature: .bookmarksRefactor, to: true, isDebug: true)
         let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
         let expectation = expectation(description: "Subject reloaded")
@@ -85,7 +84,6 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
 
     func testShouldReload_whenDesktopBookmarksExist() throws {
         profile.reopen()
-        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
         featureFlags.set(feature: .bookmarksRefactor, to: true)
         let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
 

--- a/firefox-ios/nimbus-features/bookmarkRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/bookmarkRefactorFeature.yaml
@@ -14,5 +14,5 @@ features:
           enabled: false
       - channel: developer
         value:
-          enabled: false
+          enabled: true
 

--- a/firefox-ios/nimbus-features/bookmarkRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/bookmarkRefactorFeature.yaml
@@ -14,5 +14,5 @@ features:
           enabled: false
       - channel: developer
         value:
-          enabled: true
+          enabled: false
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10007)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21127)

## :bulb: Description
- Add sign in button to bookmarks root folder empty state to present Mozilla account sign in flow

### 📝 Notes: 
- `FirefoxAccountSignInViewController` is presented as a fullscreen modal for consistency with the remote tabs panel sign in flow

### 📷 Screenshots

<img width="559" alt="Screenshot 2024-12-02 at 1 36 56 PM" src="https://github.com/user-attachments/assets/f5bdfa47-f3f1-4bfc-aeec-02c5d756d02d">


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

