### PR TITLE
Remove MTE-2697 Disable Firefox smoke tests in Github Actions

### DIFF
--- a/.github/workflows/firefox-ios-ui-tests.yml
+++ b/.github/workflows/firefox-ios-ui-tests.yml
@@ -2,9 +2,6 @@ name: "Firefox UI Tests"
     
 on:
     workflow_dispatch: {}
-    schedule:
-      - cron: "0 11 * * *"
-
 env:
     browser: firefox-ios
     xcode_version: 16.1


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-2697)

## :bulb: Description
Even after the Xcode 16 upgrade, Firefox smoke tests are still flaky. Let's turn them off for now.

The workflow is still available by dispatching it manually.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

