### PR TITLE
Bugfix FXIOS App hangs while opening Tab Tray when there are many tabs open

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SwipeAnimator.swift
+++ b/firefox-ios/Client/Frontend/Browser/SwipeAnimator.swift
@@ -75,13 +75,15 @@ extension SwipeAnimator {
         // Calculate the edge to calculate distance from
         let translation = velocity.x >= 0 ? animatingView.frame.width : -animatingView.frame.width
         let timeStep = TimeInterval(abs(translation) / speed)
-        self.delegate?.swipeAnimator(self)
         UIView.animate(
             withDuration: timeStep,
             animations: {
                 animatingView.transform = self.transformForTranslation(translation)
                 animatingView.alpha = self.alphaForDistanceFromCenter(abs(translation))
-            }, completion: { finished in
+            }, completion: { [weak self] finished in
+                if let self {
+                    delegate?.swipeAnimator(self)
+                }
                 if finished {
                     animatingView.alpha = 0
                 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -40,7 +40,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
 
     private lazy var smallFaviconView: FaviconImageView = .build()
     private lazy var favicon: FaviconImageView = .build()
-    private var headerView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
+    private lazy var headerView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
 
     // MARK: - UI
 
@@ -82,8 +82,8 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.animator = SwipeAnimator(animatingView: self)
-        self.closeButton.addTarget(self, action: #selector(close), for: .touchUpInside)
+        animator = SwipeAnimator(animatingView: self)
+        closeButton.addTarget(self, action: #selector(close), for: .touchUpInside)
 
         contentView.addSubview(backgroundHolder)
 
@@ -92,14 +92,14 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
 
         accessibilityCustomActions = [
             UIAccessibilityCustomAction(name: .TabTrayCloseAccessibilityCustomAction,
-                                        target: self.animator,
+                                        target: animator,
                                         selector: #selector(SwipeAnimator.closeWithoutGesture))
         ]
 
         headerView.translatesAutoresizingMaskIntoConstraints = false
-        headerView.contentView.addSubview(self.closeButton)
-        headerView.contentView.addSubview(self.titleText)
-        headerView.contentView.addSubview(self.favicon)
+        headerView.contentView.addSubview(closeButton)
+        headerView.contentView.addSubview(titleText)
+        headerView.contentView.addSubview(favicon)
 
         setupConstraints()
     }
@@ -112,7 +112,7 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         self.delegate = delegate
 
         if let swipeAnimatorDelegate = delegate as? SwipeAnimatorDelegate {
-            self.animator?.delegate = swipeAnimatorDelegate
+            animator?.delegate = swipeAnimatorDelegate
         }
 
         animator?.animateBackToCenter()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -72,7 +72,7 @@ class TabDisplayPanelViewController: UIViewController,
         super.viewWillAppear(animated)
 
         if !viewHasAppeared {
-            tabDisplayView.layoutIfNeeded()
+            //             tabDisplayView.layoutIfNeeded()
             store.dispatch(TabPanelViewAction(panelType: panelType,
                                               windowUUID: windowUUID,
                                               actionType: TabPanelViewActionType.tabPanelWillAppear))
@@ -162,9 +162,11 @@ class TabDisplayPanelViewController: UIViewController,
     }
 
     func newState(state: TabsPanelState) {
+        if tabsState != state {
+            tabDisplayView.newState(state: state)
+        }
+        shouldShowEmptyView(state.isPrivateTabsEmpty)
         tabsState = state
-        tabDisplayView.newState(state: tabsState)
-        shouldShowEmptyView(tabsState.isPrivateTabsEmpty)
     }
 
     // MARK: EmptyPrivateTabsViewDelegate

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -72,7 +72,6 @@ class TabDisplayPanelViewController: UIViewController,
         super.viewWillAppear(animated)
 
         if !viewHasAppeared {
-            //             tabDisplayView.layoutIfNeeded()
             store.dispatch(TabPanelViewAction(panelType: panelType,
                                               windowUUID: windowUUID,
                                               actionType: TabPanelViewActionType.tabPanelWillAppear))
@@ -162,7 +161,7 @@ class TabDisplayPanelViewController: UIViewController,
     }
 
     func newState(state: TabsPanelState) {
-        if tabsState != state {
+        if state != tabsState {
             tabDisplayView.newState(state: state)
         }
         shouldShowEmptyView(state.isPrivateTabsEmpty)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -127,19 +127,14 @@ class TabDisplayView: UIView,
     private func scrollToTab(_ scrollState: TabsPanelState.ScrollState) {
         let section: Int = scrollState.isInactiveTabSection ? 0 : 1
         let indexPath = IndexPath(row: scrollState.toIndex, section: section)
-
-        // We cannot get the visible cells unless all layout operations have finished finished (e.g. after `reloadData()`)
-        collectionView.layoutIfNeeded()
-
-        // Only scroll to the view if it is not visible.
-        guard !collectionView.indexPathsForFullyVisibleItems.contains(indexPath) else { return }
-
-        // Scrolling to an invalid cell will crash the app, so check indexPath first
-        guard collectionView.isValid(indexPath: indexPath) else { return }
-
-        collectionView.scrollToItem(at: indexPath,
-                                    at: .centeredVertically,
-                                    animated: scrollState.withAnimation)
+        // Piping this into main thread let the collection view finish its layout process
+        DispatchQueue.main.async {
+            guard !self.collectionView.indexPathsForFullyVisibleItems.contains(indexPath) else { return }
+            guard self.collectionView.isValid(indexPath: indexPath) else { return }
+            self.collectionView.scrollToItem(at: indexPath,
+                                             at: .centeredVertically,
+                                             animated: scrollState.withAnimation)
+        }
     }
 
     private func configureDataSource() {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -291,21 +291,23 @@ class TabTrayViewController: UIViewController,
     }
 
     func newState(state: TabTrayState) {
-        tabTrayState = state
+        defer {
+            tabTrayState = state
+        }
         if state.normalTabsCount != tabTrayState.normalTabsCount {
             updateTabCountImage(count: state.normalTabsCount)
         }
         segmentedControl.selectedSegmentIndex = state.selectedPanel.rawValue
 
-        if tabTrayState.shouldDismiss {
+        if state.shouldDismiss {
             delegate?.didFinish()
         }
 
-        if let url = tabTrayState.shareURL {
+        if let url = state.shareURL {
             navigationHandler?.shareTab(url: url, sourceView: self.view)
         }
 
-        if tabTrayState.showCloseConfirmation {
+        if state.showCloseConfirmation {
             showCloseAllConfirmation()
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -292,7 +292,9 @@ class TabTrayViewController: UIViewController,
 
     func newState(state: TabTrayState) {
         tabTrayState = state
-        updateTabCountImage(count: state.normalTabsCount)
+        if state.normalTabsCount != tabTrayState.normalTabsCount {
+            updateTabCountImage(count: state.normalTabsCount)
+        }
         segmentedControl.selectedSegmentIndex = state.selectedPanel.rawValue
 
         if tabTrayState.shouldDismiss {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Bug fix App hang while opening the tab tray that is mainly caused by the `TabTrayDisplayView.newState` being called many times. Optimize `scrollToTab` method to wait for the collection view layout to finish, instead of forcing layout.
Bug fix swipe gesture to delete tab flashing back to normal position after the tab was dismissed.

Here is the link of the currently tracked app hangs [Spreadsheet](https://docs.google.com/spreadsheets/d/12aDe29FdszMCnusN0T8Jmfs4xsuObc2o5y_-utcpQRM/edit?usp=sharing) 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

