### PR TITLE
Refactor FXIOS-10744 Cut out dead code from an old share tab experiment

### DIFF
--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -11,7 +11,6 @@ protocol TabTrayCoordinatorDelegate: AnyObject {
 
 protocol TabTrayNavigationHandler: AnyObject {
     func start(panelType: TabTrayPanelType, navigationController: UINavigationController)
-    func shareTab(url: URL, sourceView: UIView)
 }
 
 class TabTrayCoordinator: BaseCoordinator,
@@ -93,12 +92,6 @@ class TabTrayCoordinator: BaseCoordinator,
         add(child: remoteTabsCoordinator)
         remoteTabsCoordinator.parentCoordinator = self
         (navigationController.topViewController as? RemoteTabsPanel)?.remoteTabsDelegate = remoteTabsCoordinator
-    }
-
-    func shareTab(url: URL, sourceView: UIView) {
-        guard !childCoordinators.contains(where: { $0 is ShareExtensionCoordinator }) else { return }
-        let coordinator = makeShareExtensionCoordinator()
-        coordinator.start(url: url, sourceView: sourceView)
     }
 
     private func makeShareExtensionCoordinator() -> ShareExtensionCoordinator {

--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -94,18 +94,6 @@ class TabTrayCoordinator: BaseCoordinator,
         (navigationController.topViewController as? RemoteTabsPanel)?.remoteTabsDelegate = remoteTabsCoordinator
     }
 
-    private func makeShareExtensionCoordinator() -> ShareExtensionCoordinator {
-        let coordinator = ShareExtensionCoordinator(
-            alertContainer: UIView(),
-            router: router,
-            profile: profile,
-            parentCoordinator: self,
-            tabManager: tabManager
-        )
-        add(child: coordinator)
-        return coordinator
-    }
-
     // MARK: - ParentCoordinatorDelegate
     func didFinish(from childCoordinator: Coordinator) {
         TelemetryWrapper.recordEvent(category: .action,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -64,7 +64,6 @@ enum TabPanelViewActionType: ActionType {
     case learnMorePrivateMode
     case selectTab
     case hideUndoToast
-    case showShareSheet
 }
 
 class TabPanelMiddlewareAction: Action {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -18,7 +18,6 @@ struct TabTrayState: ScreenState, Equatable {
     var normalTabsCount: String
     var hasSyncableAccount: Bool
     var shouldDismiss: Bool
-    var shareURL: URL?
     var toastType: ToastType?
     var windowUUID: WindowUUID
     var showCloseConfirmation: Bool
@@ -45,7 +44,6 @@ struct TabTrayState: ScreenState, Equatable {
                   normalTabsCount: panelState.normalTabsCount,
                   hasSyncableAccount: panelState.hasSyncableAccount,
                   shouldDismiss: panelState.shouldDismiss,
-                  shareURL: panelState.shareURL,
                   toastType: panelState.toastType,
                   showCloseConfirmation: panelState.showCloseConfirmation)
     }
@@ -73,7 +71,6 @@ struct TabTrayState: ScreenState, Equatable {
          normalTabsCount: String,
          hasSyncableAccount: Bool,
          shouldDismiss: Bool = false,
-         shareURL: URL? = nil,
          toastType: ToastType? = nil,
          showCloseConfirmation: Bool = false) {
         self.windowUUID = windowUUID
@@ -82,7 +79,6 @@ struct TabTrayState: ScreenState, Equatable {
         self.normalTabsCount = normalTabsCount
         self.hasSyncableAccount = hasSyncableAccount
         self.shouldDismiss = shouldDismiss
-        self.shareURL = shareURL
         self.toastType = toastType
         self.showCloseConfirmation = showCloseConfirmation
     }
@@ -185,15 +181,6 @@ struct TabTrayState: ScreenState, Equatable {
 
     static func reduceTabPanelViewAction(action: TabPanelViewAction, state: TabTrayState) -> TabTrayState {
         switch action.actionType {
-        case TabPanelViewActionType.showShareSheet:
-            guard let shareURL = action.shareSheetURL else { return defaultState(from: state) }
-            return TabTrayState(windowUUID: state.windowUUID,
-                                isPrivateMode: state.isPrivateMode,
-                                selectedPanel: state.selectedPanel,
-                                normalTabsCount: state.normalTabsCount,
-                                hasSyncableAccount: state.hasSyncableAccount,
-                                shareURL: shareURL)
-
         case TabPanelViewActionType.closeAllTabs:
             return TabTrayState(windowUUID: state.windowUUID,
                                 isPrivateMode: state.isPrivateMode,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -299,10 +299,6 @@ class TabTrayViewController: UIViewController,
             delegate?.didFinish()
         }
 
-        if let url = tabTrayState.shareURL {
-            navigationHandler?.shareTab(url: url, sourceView: self.view)
-        }
-
         if tabTrayState.showCloseConfirmation {
             showCloseAllConfirmation()
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10744)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23462)

## :bulb: Description
It seems as if this code is no longer needed. It may have been put in place for an old experiment to share tabs from the tab tray. Now that this experiment is done, this code can be removed.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

