### PR TITLE
Bugfix FXIOS-10740 workaround for crashing on non-unique Sites in the HistoryPanel

### DIFF
--- a/BrowserKit/Sources/SiteImageView/Entities/SiteResource.swift
+++ b/BrowserKit/Sources/SiteImageView/Entities/SiteResource.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// The source of a favicon or hero image.
-public enum SiteResource: Codable {
+public enum SiteResource: Codable, Hashable {
     /// An image that may be downloaded over the network.
     /// - Parameter url: The URL of the image.
     case remoteURL(url: URL)
@@ -13,4 +13,14 @@ public enum SiteResource: Codable {
     /// - Parameter name: The name of the image.
     /// - Parameter forRemoteResource: The URL from which this bundled image was obtained. Can be cached for future requests.
     case bundleAsset(name: String, forRemoteResource: URL)
+
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case let .remoteURL(url):
+            hasher.combine(url)
+        case let .bundleAsset(name, forRemoteResource):
+            hasher.combine(name)
+            hasher.combine(forRemoteResource)
+        }
+    }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -4,7 +4,7 @@
 
 import Common
 import Foundation
-import WebKit
+@preconcurrency import WebKit
 
 class WKEngineSession: NSObject,
                        EngineSession,

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -669,7 +669,7 @@ extension RustPlaces {
                 // FIXME: FXIOS-10740 Workaround for an iOS 18 HistoryPanel crash with diffable data sources until we can
                 // get a unique GUID from application services (should be sent in the payload with synced history items)
                 let hashValue = "\(info.url)_\(info.timestamp)".hashValue
-                let site = Site(id: hasValue, url: info.url, title: title)
+                let site = Site(id: hashValue, url: info.url, title: title)
                 site.latestVisit = Visit(date: UInt64(info.timestamp) * 1000, type: info.visitType)
                 return site
             }.uniqued()

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -666,7 +666,10 @@ extension RustPlaces {
                     // as the title
                     title = info.url
                 }
-                let site = Site(url: info.url, title: title)
+                // FIXME: FXIOS-10740 Workaround for an iOS 18 HistoryPanel crash with diffable data sources until we can
+                // get a unique GUID from application services (should be sent in the payload with synced history items)
+                let hasValue = UUID().uuidString.hashValue
+                let site = Site(id: hasValue, url: info.url, title: title)
                 site.latestVisit = Visit(date: UInt64(info.timestamp) * 1000, type: info.visitType)
                 return site
             }.uniqued()

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -668,7 +668,7 @@ extension RustPlaces {
                 }
                 // FIXME: FXIOS-10740 Workaround for an iOS 18 HistoryPanel crash with diffable data sources until we can
                 // get a unique GUID from application services (should be sent in the payload with synced history items)
-                let hasValue = UUID().uuidString.hashValue
+                let hashValue = "\(info.url)_\(info.timestamp)".hashValue
                 let site = Site(id: hasValue, url: info.url, title: title)
                 site.latestVisit = Visit(date: UInt64(info.timestamp) * 1000, type: info.visitType)
                 return site

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -666,8 +666,7 @@ extension RustPlaces {
                     // as the title
                     title = info.url
                 }
-                // FIXME: FXIOS-10740 Workaround for an iOS 18 HistoryPanel crash with diffable data sources until we can
-                // get a unique GUID from application services (should be sent in the payload with synced history items)
+                // Note: FXIOS-10740 Necessary to have unique Site ID iOS 18 HistoryPanel crash with diffable data sources
                 let hashValue = "\(info.url)_\(info.timestamp)".hashValue
                 let site = Site(id: hashValue, url: info.url, title: title)
                 site.latestVisit = Visit(date: UInt64(info.timestamp) * 1000, type: info.visitType)

--- a/firefox-ios/Storage/Site.swift
+++ b/firefox-ios/Storage/Site.swift
@@ -91,10 +91,20 @@ open class Site: Identifiable {
 // MARK: - Hashable
 extension Site: Hashable {
      public func hash(into hasher: inout Hasher) {
+         // The == operator below must match the same requirements as this method
          hasher.combine(id)
+         hasher.combine(guid)
+         hasher.combine(title)
+         hasher.combine(url)
+         hasher.combine(faviconResource)
      }
 
      public static func == (lhs: Site, rhs: Site) -> Bool {
-         lhs.url == rhs.url
+         // The hash method above must match the same requirements as this operator
+         return lhs.id == rhs.id
+         && lhs.guid == rhs.guid
+         && lhs.title == rhs.title
+         && lhs.url == rhs.url
+         && lhs.faviconResource == rhs.faviconResource
      }
  }

--- a/firefox-ios/Storage/Site.swift
+++ b/firefox-ios/Storage/Site.swift
@@ -55,6 +55,11 @@ open class Site: Identifiable {
         self.init(url: url, title: title, bookmarked: false, guid: nil, faviconResource: nil)
     }
 
+    public convenience init(id: Int, url: String, title: String) {
+        self.init(url: url, title: title, bookmarked: false, guid: nil, faviconResource: nil)
+        self.id = id
+    }
+
     public init(url: String,
                 title: String,
                 bookmarked: Bool?,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -532,9 +532,6 @@ class HistoryTests: BaseTestCase {
     func testDeleteHistoryEntryBySwiping() {
         navigateToPage()
         navigator.goto(LibraryPanel_History)
-        waitForExistence(app.cells.staticTexts["http://example.com/"])
-        navigateToPage()
-        navigator.goto(LibraryPanel_History)
         mozWaitForElementToExist(app.cells.staticTexts["http://example.com/"])
         app.cells.staticTexts["http://example.com/"].firstMatch.swipeLeft()
         app.buttons["Delete"].waitAndTap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10740)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23448)

## :bulb: Description
Temporary workaround for non-unique Sites in the HistoryPanel. We should get a GUID that is unique from application services later... for now just force a unique UUID for each history item (not idea for diffable data sources of course).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

