### PR TITLE
Bugfix FXIOS-10622 Do not reload from origin for homepage internal URLs

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -705,7 +705,8 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
             }
         }
 
-        if let webView, webView.url != nil {
+        // Do not reload from origin for homepage internal URLs
+        if let webView, webView.url != nil && !(InternalURL(webView.url)?.isAboutHomeURL ?? true) {
             webView.reloadFromOrigin()
             logger.log("Reloaded zombified tab from origin",
                        level: .debug,

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -711,7 +711,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         }
 
         // Do not reload from origin for homepage internal URLs
-        if let webView, webView.url != nil && !(InternalURL(webView.url)?.isAboutHomeURL ?? true) {
+        if let webView, webView.url != nil && !(InternalURL(webView.url)?.isAboutHomeURL ?? false) {
             webView.reloadFromOrigin()
             logger.log("Reloaded zombified tab from origin",
                        level: .debug,

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -586,7 +586,12 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
 
     func restore(_ webView: WKWebView, interactionState: Data? = nil) {
         if let url = url {
-            webView.load(URLRequest(url: url))
+            if let internalURL = InternalURL(url),
+               internalURL.isAboutHomeURL {
+                webView.load(PrivilegedRequest(url: url) as URLRequest)
+            } else {
+                webView.load(URLRequest(url: url))
+            }
         }
 
         if let interactionState = interactionState {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10622)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23259)

## :bulb: Description
I stumbled on the blank page bug and so tried to debug it. It seems to be a repercussion of https://github.com/mozilla-mobile/firefox-ios/pull/23243 as Sorin said [here](https://mozilla.slack.com/archives/C05C9RET70F/p1732906038983579?thread_ts=1732903408.628029&cid=C05C9RET70F). 

Basically my understanding is that the homepage gets a `reloadFromOrigin` when it shouldn't (which result in the homepage being denied as it's not privileged). Reloading is part of the audio leak fix, but I think reloading with a restore, ensuring the homepage URL is loaded as a privileged request fixes the problem. I still need to confirm it does fix the problem since I made those changes, and even reverting I couldn't get the bug anymore :) Note; this change would go hand in hand with some modifications I made in PR #19079.

Anyhow, I might be missing some context here, so happy to chat about it!

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

