### PR TITLE
Bugfix FXIOS-10678 - [Toolbar Redesign] Add 8dp padding on the right of the URL

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -17,7 +17,6 @@ public class BrowserAddressToolbar: UIView,
                                     LocationViewDelegate,
                                     UIDragInteractionDelegate {
     private enum UX {
-        static let horizontalEdgeSpace: CGFloat = 16
         static let verticalEdgeSpace: CGFloat = 8
         static let horizontalSpace: CGFloat = 8
         static let cornerRadius: CGFloat = 8

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -40,10 +40,10 @@ final class LocationView: UIView,
         guard let text = urlTextField.text, let font = urlTextField.font else {
             return false
         }
-        let locationViewWidth = frame.width - (UX.horizontalSpace * 2)
-        let fontAttributes = [NSAttributedString.Key.font: font]
-        let urlTextFieldWidth = text.size(withAttributes: fontAttributes).width
-        return urlTextFieldWidth >= locationViewWidth
+        let locationViewVisibleWidth = frame.width - iconContainerStackView.frame.width - UX.horizontalSpace
+        let urlTextFieldWidth = text.size(withAttributes: [.font: font]).width
+
+        return urlTextFieldWidth >= locationViewVisibleWidth
     }
 
     private var dotWidth: CGFloat {
@@ -173,7 +173,7 @@ final class LocationView: UIView,
 
             urlTextField.topAnchor.constraint(equalTo: topAnchor),
             urlTextField.bottomAnchor.constraint(equalTo: bottomAnchor),
-            urlTextField.trailingAnchor.constraint(equalTo: trailingAnchor),
+            urlTextField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: UX.horizontalSpace),
 
             iconContainerBackgroundView.topAnchor.constraint(equalTo: urlTextField.topAnchor),
             iconContainerBackgroundView.bottomAnchor.constraint(equalTo: urlTextField.bottomAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10678)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23489)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Adds 8p of trailing padding for `urlTextField`.
- Adjusts the calculation of the location view visible width.

### Screenshot
![padding](https://github.com/user-attachments/assets/53915777-51aa-4ec9-aaac-276243feb4be)

 :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

