### PR TITLE
Refactor FXIOS-10758 [Sponsored tiles] Create defaultURLSession

### DIFF
--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsCallbackTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsCallbackTelemetry.swift
@@ -16,9 +16,7 @@ class DefaultUnifiedAdsCallbackTelemetry: UnifiedAdsCallbackTelemetry {
     private var logger: Logger
 
     init(
-        networking: ContileNetworking = DefaultContileNetwork(
-            with: makeURLSession(userAgent: UserAgent.mobileUserAgent(),
-                                 configuration: URLSessionConfiguration.defaultMPTCP)),
+        networking: ContileNetworking = DefaultContileNetwork(with: NetworkUtils.defaultURLSession()),
         logger: Logger = DefaultLogger.shared
     ) {
         self.networking = networking
@@ -44,7 +42,7 @@ class DefaultUnifiedAdsCallbackTelemetry: UnifiedAdsCallbackTelemetry {
         }
 
         var request = URLRequest(url: url)
-        request.httpMethod = "GET"
+        request.httpMethod = HTTPMethod.get.rawValue
 
         networking.data(from: request) { [weak self] result in
             guard let self = self else { return }

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsProvider.swift
@@ -37,9 +37,7 @@ class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, FeatureFlagga
     }
 
     init(
-        networking: ContileNetworking = DefaultContileNetwork(
-            with: makeURLSession(userAgent: UserAgent.mobileUserAgent(),
-                                 configuration: URLSessionConfiguration.defaultMPTCP)),
+        networking: ContileNetworking = DefaultContileNetwork(with: NetworkUtils.defaultURLSession()),
         urlCache: URLCache = URLCache.shared,
         logger: Logger = DefaultLogger.shared
     ) {
@@ -95,9 +93,8 @@ class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, FeatureFlagga
         )
 
         var request = URLRequest(url: resourceEndpoint)
-        request.httpMethod = "POST"
+        request.httpMethod = HTTPMethod.post.rawValue
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 5
         request.cachePolicy = .reloadIgnoringLocalCacheData
 
         do {

--- a/firefox-ios/Shared/NetworkUtils.swift
+++ b/firefox-ios/Shared/NetworkUtils.swift
@@ -12,7 +12,7 @@ public struct NetworkUtils {
     }
 
     public static func defaultURLSession() -> URLSession {
-        let configuration = URLSessionConfiguration.ephemeral
+        let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = [
             "User-Agent": UserAgent.mobileUserAgent(),
             "Accept": DefaultRequestConstants.accept

--- a/firefox-ios/Shared/NetworkUtils.swift
+++ b/firefox-ios/Shared/NetworkUtils.swift
@@ -5,6 +5,24 @@
 import Foundation
 import Network
 
+public struct NetworkUtils {
+    private enum DefaultRequestConstants {
+        static let timeout: TimeInterval = 5
+        static let accept = "application/json"
+    }
+
+    public static func defaultURLSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpAdditionalHeaders = [
+            "User-Agent": UserAgent.mobileUserAgent(),
+            "Accept": DefaultRequestConstants.accept
+        ]
+        configuration.timeoutIntervalForRequest = DefaultRequestConstants.timeout
+        configuration.multipathServiceType = .handover
+        return URLSession(configuration: configuration)
+    }
+}
+
 public func makeURLSession(
     userAgent: String,
     configuration: URLSessionConfiguration,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10758)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23478)

## :bulb: Description
Found some improvement todo while working to debug the unified ads integration in sponsored tiles.
- Create a `NetworkUtils` instead of having some global `func`
- Replace http string with proper `HTTPMethod`, I didn't knew we had this object created

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

