### PR TITLE
Bugfix FXIOS-10231 - Check `isProbablyReaderable` before parsing the document

### DIFF
--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderMode.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderMode.js
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 "use strict";
+import { isProbablyReaderable, Readability } from "@mozilla/readability";
 
 const DEBUG = false;
 
@@ -33,6 +34,11 @@ function checkReadability() {
       return;
     }
 
+    if(!isProbablyReaderable(document)) {
+      webkit.messageHandlers.readerModeMessageHandler.postMessage({Type: "ReaderModeStateChange", Value: "Unavailable"});
+      return;
+    }
+
     if ((document.location.protocol === "http:" || document.location.protocol === "https:") && document.location.pathname !== "/") {
       // Short circuit in case we already ran Readability. This mostly happens when going
       // back/forward: the page will be cached and the result will still be there.
@@ -42,8 +48,6 @@ function checkReadability() {
         webkit.messageHandlers.readerModeMessageHandler.postMessage({Type: "ReaderContentParsed", Value: readabilityResult});
         return;
       }
-
-      var {Readability} = require("@mozilla/readability");
 
       var uri = {
         spec: document.location.href,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10231)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22382)

## :bulb: Description
This PR:
- Adds guard using `isProbablyReaderable`. This allows us to skip documents that don't look like articles ( in this case google page ).
- Moves import outside of function.

**Before ( notice reader mode icon is shown )**

https://github.com/user-attachments/assets/59cbb928-4c27-43a5-b842-96d2407830bd

**After ( notice reader mode icon is shown )**

https://github.com/user-attachments/assets/c27c8c23-55ea-4434-9cae-8bec894fb46b




## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

