### PR TITLE
Add FXIOS-9684 [UnitTest] Add UnitTest for refreshDidBegin in RemoteTabsPanelState

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelStateTests.swift
@@ -68,6 +68,17 @@ final class RemoteTabPanelStateTests: XCTestCase {
         XCTAssertEqual(newState.devices[0].id, deviceId)
     }
 
+    func testTabsRefreshBeginStateChange() {
+        let initialState = createSubject()
+        let reducer = remoteTabsPanelReducer()
+
+        let action = RemoteTabsPanelAction(windowUUID: WindowUUID.XCTestDefaultUUID,
+                                           actionType: RemoteTabsPanelActionType.refreshDidBegin)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.refreshState, RemoteTabsPanelRefreshState.refreshing)
+    }
+
     func testTabsRefreshFailedStateChange() {
         let initialState = createSubject()
         let reducer = remoteTabsPanelReducer()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9684)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21301)

## :bulb: Description
Added UnitTest for refreshDidBegin in RemoteTabsPanelState
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

