### PR TITLE
Bugfix MTE-3933 [UI Tests Menu/Toolbar] testCustomSearchEngineDeletion works with Xcode 16 and menu refactor

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -647,7 +647,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.backAction = navigationControllerBackAction
         screenState.gesture(forAction: Action.RemoveCustomSearchEngine) {userSTate in
             // Screengraph will go back to main Settings screen. Manually tap on settings
-            app.tables[AccessibilityIdentifiers.Settings.tableViewController].staticTexts["Google"].tap()
             app.navigationBars[AccessibilityIdentifiers.Settings.Search.searchNavigationBar].buttons["Edit"].tap()
             if #unavailable(iOS 17) {
                 app.tables.buttons["Delete Mozilla Engine"].tap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
@@ -68,31 +68,24 @@ class ThirdPartySearchTest: BaseTestCase {
         app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
         app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
-        UIPasteboard.general.string = "window"
-        app.textFields.firstMatch.press(forDuration: 1)
-        app.otherElements["Paste"].tap()
+        app.textFields.firstMatch.typeText("window")
         mozWaitForElementToExist(app.scrollViews.otherElements.buttons["Mozilla Engine search"])
 
         // Need to go step by step to Search Settings. The ScreenGraph will fail to go to the Search Settings Screen
         app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
-        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].waitAndTap()
-        app.tables["Context Menu"].otherElements["Settings"].tap()
-        app.tables.staticTexts["Google"].waitAndTap()
+        navigator.nowAt(BrowserTab)
+        navigator.goto(SettingsScreen)
+        navigator.goto(SearchSettings)
 
-        // Action.RemoveCustomSearchEngine does not work on iOS 15
-        if #available(iOS 16, *) {
-            navigator.performAction(Action.RemoveCustomSearchEngine)
-            dismissSearchScreen()
+        navigator.performAction(Action.RemoveCustomSearchEngine)
+        dismissSearchScreen()
 
-            // Perform a search to check
-            app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
-            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
-            UIPasteboard.general.string = "window"
-            app.textFields.firstMatch.press(forDuration: 1)
-            app.staticTexts["Paste"].tap()
+        // Perform a search to check
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
+        app.textFields.firstMatch.typeText("window")
 
-            mozWaitForElementToNotExist(app.scrollViews.otherElements.buttons["Mozilla Engine search"])
-        }
+        mozWaitForElementToNotExist(app.scrollViews.otherElements.buttons["Mozilla Engine search"])
     }
 
     private func addCustomSearchEngine() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3933)

## :bulb: Description
All `ThirdPartySearchTest` should work with Xcode 16 and menu refactor. In addition, the test should work for iOS 15, 16, 17 and 18 now.


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

](https://github.com/mozilla-mobile/firefox-ios/compare/cs/MTE-3933-ThirdPartySearchTest?expand=1)