### PR TITLE
Refactor FXIOS-10669 [Sent from Firefox] Improve share "extension" type names and add documentation

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1236,7 +1236,7 @@
 		C2200A6A2B7D148C00DC062A /* ContentBlockerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2200A692B7D148C00DC062A /* ContentBlockerTests.swift */; };
 		C22753402A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C227533F2A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift */; };
 		C2296FCC2A601C190046ECA6 /* IntensityVisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2296FCB2A601C190046ECA6 /* IntensityVisualEffectView.swift */; };
-		C23889DF2A4EFCE500429673 /* ShareExtensionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889DE2A4EFCE500429673 /* ShareExtensionCoordinator.swift */; };
+		C23889DF2A4EFCE500429673 /* ShareSheetCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889DE2A4EFCE500429673 /* ShareSheetCoordinator.swift */; };
 		C23889E12A4F3E7200429673 /* ParentCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889E02A4F3E7200429673 /* ParentCoordinatorDelegate.swift */; };
 		C23889E32A50319A00429673 /* ShareExtensionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889E22A50319A00429673 /* ShareExtensionCoordinatorTests.swift */; };
 		C23889E52A50329200429673 /* MockParentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889E42A50329200429673 /* MockParentCoordinator.swift */; };
@@ -8269,7 +8269,7 @@
 		C2200A692B7D148C00DC062A /* ContentBlockerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockerTests.swift; sourceTree = "<group>"; };
 		C227533F2A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebsiteDataManagementViewModel.swift; sourceTree = "<group>"; };
 		C2296FCB2A601C190046ECA6 /* IntensityVisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntensityVisualEffectView.swift; sourceTree = "<group>"; };
-		C23889DE2A4EFCE500429673 /* ShareExtensionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionCoordinator.swift; sourceTree = "<group>"; };
+		C23889DE2A4EFCE500429673 /* ShareSheetCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheetCoordinator.swift; sourceTree = "<group>"; };
 		C23889E02A4F3E7200429673 /* ParentCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		C23889E22A50319A00429673 /* ShareExtensionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionCoordinatorTests.swift; sourceTree = "<group>"; };
 		C23889E42A50329200429673 /* MockParentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockParentCoordinator.swift; sourceTree = "<group>"; };
@@ -11697,7 +11697,7 @@
 				8A93F86E29D3A147004159D9 /* Router */,
 				8AF10D8D29D773FC0086351D /* Scene */,
 				8A83B7452A264FA0002FF9AC /* SettingsCoordinator.swift */,
-				C23889DE2A4EFCE500429673 /* ShareExtensionCoordinator.swift */,
+				C23889DE2A4EFCE500429673 /* ShareSheetCoordinator.swift */,
 				21FBB4032ADECEFF002D9AB7 /* TabTray */,
 				B236204E2B86C56F000B1DE7 /* AddressAutofillCoordinator.swift */,
 				61B3D29E2CEFBE4400060526 /* HomepageCoordinator.swift */,
@@ -16223,7 +16223,7 @@
 				5A3A7DCE2886F7880065F81A /* BookmarksDataAdaptor.swift in Sources */,
 				C80E1A102A0943640025B9E1 /* UIFont+Extension.swift in Sources */,
 				C8680C5728BFDF7F00BC902A /* WallpaperThumbnailUtility.swift in Sources */,
-				C23889DF2A4EFCE500429673 /* ShareExtensionCoordinator.swift in Sources */,
+				C23889DF2A4EFCE500429673 /* ShareSheetCoordinator.swift in Sources */,
 				8AE80BBE2891C21A00BC12EA /* JumpBackInSyncedTab.swift in Sources */,
 				8C6F94652A972EB300415FF6 /* FakespotAdjustRatingView.swift in Sources */,
 				0A93C8AC2C870E7100BEA143 /* TrackingProtectionToggleView.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1238,7 +1238,7 @@
 		C2296FCC2A601C190046ECA6 /* IntensityVisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2296FCB2A601C190046ECA6 /* IntensityVisualEffectView.swift */; };
 		C23889DF2A4EFCE500429673 /* ShareSheetCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889DE2A4EFCE500429673 /* ShareSheetCoordinator.swift */; };
 		C23889E12A4F3E7200429673 /* ParentCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889E02A4F3E7200429673 /* ParentCoordinatorDelegate.swift */; };
-		C23889E32A50319A00429673 /* ShareExtensionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889E22A50319A00429673 /* ShareExtensionCoordinatorTests.swift */; };
+		C23889E32A50319A00429673 /* ShareSheetCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889E22A50319A00429673 /* ShareSheetCoordinatorTests.swift */; };
 		C23889E52A50329200429673 /* MockParentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889E42A50329200429673 /* MockParentCoordinator.swift */; };
 		C2446B312A856D13000C527D /* MockLibraryCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2446B302A856D13000C527D /* MockLibraryCoordinatorDelegate.swift */; };
 		C2506C932A6A863600F2B76E /* HistoryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2506C922A6A863600F2B76E /* HistoryCoordinator.swift */; };
@@ -8271,7 +8271,7 @@
 		C2296FCB2A601C190046ECA6 /* IntensityVisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntensityVisualEffectView.swift; sourceTree = "<group>"; };
 		C23889DE2A4EFCE500429673 /* ShareSheetCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheetCoordinator.swift; sourceTree = "<group>"; };
 		C23889E02A4F3E7200429673 /* ParentCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentCoordinatorDelegate.swift; sourceTree = "<group>"; };
-		C23889E22A50319A00429673 /* ShareExtensionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionCoordinatorTests.swift; sourceTree = "<group>"; };
+		C23889E22A50319A00429673 /* ShareSheetCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheetCoordinatorTests.swift; sourceTree = "<group>"; };
 		C23889E42A50329200429673 /* MockParentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockParentCoordinator.swift; sourceTree = "<group>"; };
 		C2446B302A856D13000C527D /* MockLibraryCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLibraryCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		C2506C922A6A863600F2B76E /* HistoryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCoordinator.swift; sourceTree = "<group>"; };
@@ -11724,7 +11724,7 @@
 				C8EDDBEF29DD83FC003A4C07 /* RouteTests.swift */,
 				8A7A26E229D4ACF300EA76F1 /* SceneCoordinatorTests.swift */,
 				8A83B7492A265044002FF9AC /* SettingsCoordinatorTests.swift */,
-				C23889E22A50319A00429673 /* ShareExtensionCoordinatorTests.swift */,
+				C23889E22A50319A00429673 /* ShareSheetCoordinatorTests.swift */,
 				C8E531CB29E72A2F00E03FEF /* ShortcutRouteTests.swift */,
 				21FA8FAC2AE8561C0013B815 /* TabTray */,
 				C8E531C929E5F7D300E03FEF /* URLScannerTests.swift */,
@@ -17379,7 +17379,7 @@
 				8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewProviderTests.swift in Sources */,
 				5A81C5DD2A4C981A00BE88C2 /* PasswordManagerCoordinatorTests.swift in Sources */,
 				C8699153289177FB007ACC5C /* WallpaperDataServiceTests.swift in Sources */,
-				C23889E32A50319A00429673 /* ShareExtensionCoordinatorTests.swift in Sources */,
+				C23889E32A50319A00429673 /* ShareSheetCoordinatorTests.swift in Sources */,
 				E1312FD129D237EE008DDA85 /* NotificationSurfaceManagerTests.swift in Sources */,
 				21371FA228A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift in Sources */,
 				814B71FF2CBEDC3B001B134A /* MainMenuDetailsStateTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1505,7 +1505,7 @@
 		D38F02D11C05127100175932 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38F02D01C05127100175932 /* Authenticator.swift */; };
 		D38F03701C06387900175932 /* AuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38F036F1C06387900175932 /* AuthenticationTests.swift */; };
 		D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3968F241A38FE8500CEFD3B /* TabManager.swift */; };
-		D3972BF31C22412B00035B87 /* ShareExtensionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3972BF11C22412B00035B87 /* ShareExtensionHelper.swift */; };
+		D3972BF31C22412B00035B87 /* ShareManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3972BF11C22412B00035B87 /* ShareManager.swift */; };
 		D3972BF41C22412B00035B87 /* TitleActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3972BF21C22412B00035B87 /* TitleActivityItemProvider.swift */; };
 		D39FA16C1A83E17800EE869C /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D39FA16B1A83E17800EE869C /* CoreGraphics.framework */; };
 		D39FA1811A83E84900EE869C /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39FA1801A83E84900EE869C /* Global.swift */; };
@@ -8632,7 +8632,7 @@
 		D38F02D01C05127100175932 /* Authenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Authenticator.swift; sourceTree = "<group>"; };
 		D38F036F1C06387900175932 /* AuthenticationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationTests.swift; sourceTree = "<group>"; };
 		D3968F241A38FE8500CEFD3B /* TabManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabManager.swift; sourceTree = "<group>"; };
-		D3972BF11C22412B00035B87 /* ShareExtensionHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShareExtensionHelper.swift; sourceTree = "<group>"; };
+		D3972BF11C22412B00035B87 /* ShareManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShareManager.swift; sourceTree = "<group>"; };
 		D3972BF21C22412B00035B87 /* TitleActivityItemProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TitleActivityItemProvider.swift; sourceTree = "<group>"; };
 		D39FA15F1A83E0EC00EE869C /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D39FA1621A83E0EC00EE869C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -13203,7 +13203,7 @@
 				2128E27D2934F78600FB91BE /* CustomAppActivity.swift */,
 				2128E27A292E624400FB91BE /* SendToDeviceActivity.swift */,
 				E1AFBAF8292EA0330065E35E /* SendToDeviceHelper.swift */,
-				D3972BF11C22412B00035B87 /* ShareExtensionHelper.swift */,
+				D3972BF11C22412B00035B87 /* ShareManager.swift */,
 				ED7A08DA2CF674730035EC8F /* ShareMessage.swift */,
 				ED7A08DC2CF6749B0035EC8F /* ShareType.swift */,
 				ED7A08DE2CF674BA0035EC8F /* ShareTab.swift */,
@@ -16963,7 +16963,7 @@
 				59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */,
 				C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */,
 				D5D237782640BBA600326204 /* ExperimentsSettingsViewController.swift in Sources */,
-				D3972BF31C22412B00035B87 /* ShareExtensionHelper.swift in Sources */,
+				D3972BF31C22412B00035B87 /* ShareManager.swift in Sources */,
 				8AB30ECA2B6C03C700BD9A9B /* DataClearanceAnimation.swift in Sources */,
 				8A19ACB62A3290F9001C2147 /* NotificationsSetting.swift in Sources */,
 				43D16B8229831E6A009F8279 /* CreditCardInputField.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -301,8 +301,11 @@ class BrowserCoordinator: BaseCoordinator,
         case let .searchURL(url, tabId):
             handle(searchURL: url, tabId: tabId)
 
-        case let .sharesheet(url, title):
-            showShareSheet(with: url, title: title)
+        case .sharesheet:
+            // FIXME: Implement with real data, (shareType, shareMessage)
+            let tempURL = URL(string: "https://www.google.ca")
+            let tempTitle = "Test Title"
+            showShareSheet(with: tempURL, title: tempTitle)
 
         case let .glean(url):
             glean.handleDeeplinkUrl(url: url)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -302,10 +302,11 @@ class BrowserCoordinator: BaseCoordinator,
             handle(searchURL: url, tabId: tabId)
 
         case .sharesheet:
-            // FIXME: Implement with real data, (shareType, shareMessage)
-            let tempURL = URL(string: "https://www.google.ca")
-            let tempTitle = "Test Title"
-            showShareSheet(with: tempURL, title: tempTitle)
+            // FIXME: FXIOS-10669 Implement with real data, (shareType, shareMessage)
+//            let tempURL = URL(string: "https://www.google.ca")
+//            let tempTitle = "Test Title"
+//            showShareSheet(with: tempURL, title: tempTitle)
+            break
 
         case let .glean(url):
             glean.handleDeeplinkUrl(url: url)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -639,6 +639,22 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - BrowserNavigationHandler
 
+    func showShareSheet(url: URL,
+                        title: String?,
+                        sourceView: UIView,
+                        sourceRect: CGRect?,
+                        toastContainer: UIView,
+                        popoverArrowDirection: UIPopoverArrowDirection) {
+        startShareSheetCoordinator(
+            url: url,
+            title: title,
+            sourceView: sourceView,
+            sourceRect: sourceRect,
+            toastContainer: toastContainer,
+            popoverArrowDirection: popoverArrowDirection
+        )
+    }
+
     func show(settings: Route.SettingsSection, onDismiss: (() -> Void)? = nil) {
         presentWithModalDismissIfNeeded {
             self.handleSettings(with: settings, onDismiss: onDismiss)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1039,8 +1039,6 @@ class BrowserCoordinator: BaseCoordinator,
     // MARK: - Private helpers
 
     private func showShareSheet(with url: URL?, title: String?) {
-        // Note: From New Menu > Share
-        // Note: From deeplinks ( > sharesheet route)
         guard let url else { return }
 
         let showShareSheet = { url in

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -722,7 +722,7 @@ class BrowserCoordinator: BaseCoordinator,
         return coordinator
     }
 
-    func showShareExtension(
+    func startShareSheetCoordinator(
         url: URL,
         title: String?,
         sourceView: UIView,
@@ -1042,10 +1042,11 @@ class BrowserCoordinator: BaseCoordinator,
         guard let url else { return }
 
         let showShareSheet = { url in
-            self.showShareExtension(
+            self.startShareSheetCoordinator(
                 url: url,
                 title: title,
                 sourceView: self.browserViewController.addressToolbarContainer,
+                sourceRect: nil,
                 toastContainer: self.browserViewController.contentContainer,
                 popoverArrowDirection: .any
             )

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -729,21 +729,21 @@ class BrowserCoordinator: BaseCoordinator,
         toastContainer: UIView,
         popoverArrowDirection: UIPopoverArrowDirection
     ) {
-        guard childCoordinators.first(where: { $0 is ShareExtensionCoordinator }) as? ShareExtensionCoordinator == nil
+        guard childCoordinators.first(where: { $0 is ShareSheetCoordinator }) as? ShareSheetCoordinator == nil
         else {
             // If this case is hitted it means the share extension coordinator wasn't removed
             // correctly in the previous session.
             return
         }
-        let shareExtensionCoordinator = ShareExtensionCoordinator(
+        let shareSheetCoordinator = ShareSheetCoordinator(
             alertContainer: toastContainer,
             router: router,
             profile: profile,
             parentCoordinator: self,
             tabManager: tabManager
         )
-        add(child: shareExtensionCoordinator)
-        shareExtensionCoordinator.start(
+        add(child: shareSheetCoordinator)
+        shareSheetCoordinator.start(
             url: url,
             title: title,
             sourceView: sourceView,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -109,24 +109,6 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 }
 
 extension BrowserNavigationHandler {
-    func showShareSheet(
-        url: URL,
-        title: String? = nil,
-        sourceView: UIView,
-        sourceRect: CGRect? = nil,
-        toastContainer: UIView,
-        popoverArrowDirection: UIPopoverArrowDirection = .up
-    ) {
-        showShareSheet(
-            url: url,
-            title: title,
-            sourceView: sourceView,
-            sourceRect: sourceRect,
-            toastContainer: toastContainer,
-            popoverArrowDirection: popoverArrowDirection
-        )
-    }
-
     func show(settings: Route.SettingsSection) {
         show(settings: settings, onDismiss: nil)
     }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -25,20 +25,19 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     /// - Parameter homepanelSection: The section to be displayed.
     func show(homepanelSection: Route.HomepanelSection)
 
-    /// Shows the share extension.
+    /// Shows the share sheet.
     ///
     /// - Parameter url: The url to be shared.
     /// - Parameter sourceView: The reference view to show the popoverViewController.
-    /// - Parameter sourceRect: An optional rect to use for ipad popover presentation
-    /// - Parameter toastContainer: The view in which is displayed the toast results
-    ///                             from actions in the share extension
+    /// - Parameter sourceRect: An optional rect to use for ipad popover presentation.
+    /// - Parameter toastContainer: The view in which is displayed the toast results from actions in the share extension.
     /// - Parameter popoverArrowDirection: The arrow direction for the view controller presented as popover.
-    func showShareExtension(url: URL,
-                            title: String?,
-                            sourceView: UIView,
-                            sourceRect: CGRect?,
-                            toastContainer: UIView,
-                            popoverArrowDirection: UIPopoverArrowDirection)
+    func showShareSheet(url: URL,
+                        title: String?,
+                        sourceView: UIView,
+                        sourceRect: CGRect?,
+                        toastContainer: UIView,
+                        popoverArrowDirection: UIPopoverArrowDirection)
 
     /// Initiates the modal presentation of the Fakespot flow for analyzing the authenticity of a product's reviews.
     /// - Parameter productURL: The URL of the product for which the reviews will be analyzed.
@@ -110,7 +109,7 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 }
 
 extension BrowserNavigationHandler {
-    func showShareExtension(
+    func showShareSheet(
         url: URL,
         title: String? = nil,
         sourceView: UIView,
@@ -118,7 +117,7 @@ extension BrowserNavigationHandler {
         toastContainer: UIView,
         popoverArrowDirection: UIPopoverArrowDirection = .up
     ) {
-        showShareExtension(
+        showShareSheet(
             url: url,
             title: title,
             sourceView: sourceView,

--- a/firefox-ios/Client/Coordinators/Library/DownloadsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/DownloadsCoordinator.swift
@@ -49,13 +49,13 @@ class DownloadsCoordinator: BaseCoordinator,
     }
 
     private func startShare(file: DownloadedFile, sourceView: UIView) {
-        guard !childCoordinators.contains(where: { $0 is ShareExtensionCoordinator }) else { return }
-        let coordinator = makeShareExtensionCoordinator()
+        guard !childCoordinators.contains(where: { $0 is ShareSheetCoordinator }) else { return }
+        let coordinator = makeShareSheetCoordinator()
         coordinator.start(url: file.path, sourceView: sourceView)
     }
 
-    private func makeShareExtensionCoordinator() -> ShareExtensionCoordinator {
-        let coordinator = ShareExtensionCoordinator(
+    private func makeShareSheetCoordinator() -> ShareSheetCoordinator {
+        let coordinator = ShareSheetCoordinator(
             alertContainer: UIView(),
             router: router,
             profile: profile,

--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -92,8 +92,8 @@ class LibraryCoordinator: BaseCoordinator,
     }
 
     func shareLibraryItem(url: URL, sourceView: UIView) {
-        guard !childCoordinators.contains(where: { $0 is ShareExtensionCoordinator }) else { return }
-        let coordinator = makeShareExtensionCoordinator()
+        guard !childCoordinators.contains(where: { $0 is ShareSheetCoordinator }) else { return }
+        let coordinator = makeShareSheetCoordinator()
         coordinator.start(url: url, sourceView: sourceView)
     }
 
@@ -166,8 +166,8 @@ class LibraryCoordinator: BaseCoordinator,
         remove(child: childCoordinator)
     }
 
-    private func makeShareExtensionCoordinator() -> ShareExtensionCoordinator {
-        let coordinator = ShareExtensionCoordinator(
+    private func makeShareSheetCoordinator() -> ShareSheetCoordinator {
+        let coordinator = ShareSheetCoordinator(
             alertContainer: UIView(),
             router: router,
             profile: profile,

--- a/firefox-ios/Client/Coordinators/Router/Route.swift
+++ b/firefox-ios/Client/Coordinators/Router/Route.swift
@@ -66,12 +66,12 @@ enum Route: Equatable {
     ///                      settings to be displayed.
     case defaultBrowser(section: DefaultBrowserSection)
 
-    /// A route for opening a share sheet with a URL and an optional message.
+    /// A route for opening a share sheet with share content and an optional accompanying message.
     ///
     /// - Parameters:
-    ///   - url: The `URL` object to be shared from the share sheet.
-    ///   - title: An optional string to be used as the message in the share sheet.
-    case sharesheet(url: URL, title: String?)
+    ///   - shareType: The content to be shared.
+    ///   - shareMessage: An optional plain text share message to be shared.
+    case sharesheet(shareType: ShareType, shareMessage: ShareMessage?)
 
     /// An enumeration representing different sections of the home panel.
     enum HomepanelSection: String, CaseIterable, Equatable {

--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -123,13 +123,20 @@ final class RouteBuilder {
                 return nil
 
             case .sharesheet:
-                let linkString = urlScanner.value(query: "url")
-                let titleText = urlScanner.value(query: "title")
-                if let link = linkString, let url = URL(string: link) {
-                  return .sharesheet(url: url, title: titleText)
-                } else {
+                guard let shareURLString = urlScanner.value(query: "url"),
+                      let shareURL = URL(string: shareURLString) else {
+                    assertionFailure("Should not be trying to share a bad URL")
                     return nil
                 }
+
+                // Pass optional share message and subtitle here
+                var shareMessage: ShareMessage?
+                if let titleText = urlScanner.value(query: "title") {
+                    shareMessage = ShareMessage(message: titleText, subtitle: nil)
+                }
+
+                // Deeplinks cannot have an associated tab or file, so this must be a website URL `.site` share
+                return .sharesheet(shareType: .site(url: shareURL), shareMessage: shareMessage)
             }
         } else if urlScanner.isHTTPScheme {
             TelemetryWrapper.gleanRecordEvent(category: .action, method: .open, object: .asDefaultBrowser)

--- a/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
@@ -50,7 +50,7 @@ class ShareExtensionCoordinator: BaseCoordinator,
     ) {
         let shareExtension = ShareExtensionHelper(
             url: url,
-            // FXIOS-10646: We only want to pass a non-nil title here for the Info Card Referral experiment. Refactoring is
+            // FXIOS-10669: We only want to pass a non-nil title here for the Info Card Referral experiment. Refactoring is
             // needed in the ShareExtensionHelper to make it properly extensible to multiple share use cases like this.
             title: title,
             tab: tabManager.selectedTab)

--- a/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareExtensionCoordinator.swift
@@ -48,7 +48,7 @@ class ShareExtensionCoordinator: BaseCoordinator,
         sourceRect: CGRect? = nil,
         popoverArrowDirection: UIPopoverArrowDirection = .up
     ) {
-        let shareExtension = ShareExtensionHelper(
+        let shareExtension = ShareManager(
             url: url,
             // FXIOS-10669: We only want to pass a non-nil title here for the Info Card Referral experiment. Refactoring is
             // needed in the ShareExtensionHelper to make it properly extensible to multiple share use cases like this.

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -7,10 +7,10 @@ import Common
 import Shared
 import Storage
 
-class ShareExtensionCoordinator: BaseCoordinator,
-                                 DevicePickerViewControllerDelegate,
-                                 InstructionsViewDelegate,
-                                 JSPromptAlertControllerDelegate {
+class ShareSheetCoordinator: BaseCoordinator,
+                             DevicePickerViewControllerDelegate,
+                             InstructionsViewDelegate,
+                             JSPromptAlertControllerDelegate {
     // MARK: - Properties
 
     private let tabManager: TabManager

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -40,7 +40,7 @@ class ShareSheetCoordinator: BaseCoordinator,
 
     // MARK: - Methods
 
-    /// Presents the Share extension from the source view
+    /// Presents the share sheet from the source view
     func start(
         url: URL,
         title: String? = nil,
@@ -48,17 +48,17 @@ class ShareSheetCoordinator: BaseCoordinator,
         sourceRect: CGRect? = nil,
         popoverArrowDirection: UIPopoverArrowDirection = .up
     ) {
-        let shareExtension = ShareManager(
+        let shareManager = ShareManager(
             url: url,
             // FXIOS-10669: We only want to pass a non-nil title here for the Info Card Referral experiment. Refactoring is
-            // needed in the ShareExtensionHelper to make it properly extensible to multiple share use cases like this.
+            // needed in the ShareManager to make it properly extensible to multiple share use cases like this.
             title: title,
             tab: tabManager.selectedTab)
-        let controller = shareExtension.createActivityViewController(
+        let controller = shareManager.createActivityViewController(
             tabManager.selectedTab?.webView
         ) { [weak self] completed, activityType in
             guard let self = self else { return }
-            self.handleShareExtensionCompletion(activityType: activityType, url: url)
+            self.handleShareSheetCompletion(activityType: activityType, url: url)
         }
         if let popoverPresentationController = controller.popoverPresentationController {
             popoverPresentationController.sourceView = sourceView
@@ -75,7 +75,7 @@ class ShareSheetCoordinator: BaseCoordinator,
         }
     }
 
-    private func handleShareExtensionCompletion(
+    private func handleShareSheetCompletion(
         activityType: UIActivity.ActivityType?,
         url: URL
     ) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
@@ -118,6 +118,7 @@ class ActionProviderBuilder {
             let point = webView.convert(helper.touchPoint, to: view)
             navigationHandler?.showShareSheet(
                 url: url,
+                title: nil,
                 sourceView: view,
                 sourceRect: CGRect(origin: point, size: CGSize(width: 10.0, height: 10.0)),
                 toastContainer: contentContainer,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
@@ -116,7 +116,7 @@ class ActionProviderBuilder {
 
             // This is only used on ipad for positioning the popover. On iPhone it is an action sheet.
             let point = webView.convert(helper.touchPoint, to: view)
-            navigationHandler?.showShareExtension(
+            navigationHandler?.showShareSheet(
                 url: url,
                 sourceView: view,
                 sourceRect: CGRect(origin: point, size: CGSize(width: 10.0, height: 10.0)),

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2342,7 +2342,9 @@ class BrowserViewController: UIViewController,
         if let selectedTab = tabManager.selectedTab, let tabUrl = selectedTab.canonicalURL?.displayURL {
             navigationHandler?.showShareSheet(
                 url: tabUrl,
+                title: nil,
                 sourceView: view,
+                sourceRect: nil,
                 toastContainer: contentContainer,
                 popoverArrowDirection: isBottomSearchBar ? .down : .up)
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2340,7 +2340,7 @@ class BrowserViewController: UIViewController,
         }
 
         if let selectedTab = tabManager.selectedTab, let tabUrl = selectedTab.canonicalURL?.displayURL {
-            navigationHandler?.showShareExtension(
+            navigationHandler?.showShareSheet(
                 url: tabUrl,
                 sourceView: view,
                 toastContainer: contentContainer,

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -570,7 +570,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     // MARK: Share
-    
+
     /// This action is called when the user taps Menu > Share for a file URL opened in the current active tab (e.g. by
     /// viewing a file from the Downloads Panel)
     private func getShareFileAction() -> PhotonRowActions {
@@ -583,7 +583,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             self.share(fileURL: url, buttonView: self.buttonView)
         }.items
     }
-    
+
     /// This action is called when the user taps Menu > Share for a website URL in the current active tab.
     private func getShareAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .LegacyAppMenu.Share,

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -593,7 +593,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
 
             guard let temporaryDocument = tab.temporaryDocument else {
-                self.navigationHandler?.showShareExtension(
+                self.navigationHandler?.showShareSheet(
                     url: url,
                     sourceView: self.buttonView,
                     toastContainer: self.toastContainer,
@@ -609,7 +609,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                        tempDocURL.isFileURL {
                         self.share(fileURL: tempDocURL, buttonView: self.buttonView)
                     } else {
-                        self.navigationHandler?.showShareExtension(
+                        self.navigationHandler?.showShareSheet(
                             url: url,
                             sourceView: self.buttonView,
                             toastContainer: self.toastContainer,
@@ -637,7 +637,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     /// non-HTML MIME type currently opened in the webView, such as a PDF).
     private func share(fileURL: URL, buttonView: UIView) {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
-        navigationHandler?.showShareExtension(
+        navigationHandler?.showShareSheet(
             url: fileURL,
             sourceView: buttonView,
             toastContainer: toastContainer,

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -595,7 +595,9 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             guard let temporaryDocument = tab.temporaryDocument else {
                 self.navigationHandler?.showShareSheet(
                     url: url,
+                    title: nil,
                     sourceView: self.buttonView,
+                    sourceRect: nil,
                     toastContainer: self.toastContainer,
                     popoverArrowDirection: .any)
                 return
@@ -611,7 +613,9 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                     } else {
                         self.navigationHandler?.showShareSheet(
                             url: url,
+                            title: nil,
                             sourceView: self.buttonView,
+                            sourceRect: nil,
                             toastContainer: self.toastContainer,
                             popoverArrowDirection: .any)
                     }
@@ -639,7 +643,9 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
         navigationHandler?.showShareSheet(
             url: fileURL,
+            title: nil,
             sourceView: buttonView,
+            sourceRect: nil,
             toastContainer: toastContainer,
             popoverArrowDirection: .any)
     }

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -570,7 +570,9 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     }
 
     // MARK: Share
-
+    
+    /// This action is called when the user taps Menu > Share for a file URL opened in the current active tab (e.g. by
+    /// viewing a file from the Downloads Panel)
     private func getShareFileAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .LegacyAppMenu.AppMenuSharePageTitleString,
                                      iconString: StandardImageIdentifiers.Large.share) { _ in
@@ -581,7 +583,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             self.share(fileURL: url, buttonView: self.buttonView)
         }.items
     }
-
+    
+    /// This action is called when the user taps Menu > Share for a website URL in the current active tab.
     private func getShareAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .LegacyAppMenu.Share,
                                      iconString: StandardImageIdentifiers.Large.share) { _ in
@@ -630,7 +633,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         }.items
     }
 
-    // Main menu option Share page with when opening a file
+    /// Share the URL of a downloaded file (e.g. either a user-downloaded file being viewed in the webView, or a link with a
+    /// non-HTML MIME type currently opened in the webView, such as a PDF).
     private func share(fileURL: URL, buttonView: UIView) {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
         navigationHandler?.showShareExtension(

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -250,7 +250,9 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
 
             self.browserNavigationHandler?.showShareSheet(
                 url: url,
+                title: nil,
                 sourceView: sourceView ?? UIView(),
+                sourceRect: nil,
                 toastContainer: self.toastContainer,
                 popoverArrowDirection: [.up, .down, .left])
         }).items

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -248,7 +248,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
                                      tapHandler: { _ in
             guard let url = URL(string: site.url, invalidCharacters: false) else { return }
 
-            self.browserNavigationHandler?.showShareExtension(
+            self.browserNavigationHandler?.showShareSheet(
                 url: url,
                 sourceView: sourceView ?? UIView(),
                 toastContainer: self.toastContainer,

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -236,7 +236,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
         })
     }
 
-    /// Handles share from Long press on Pocket article
+    /// Handles share from long press on pocket articles, jump back in websites, bookmarks, etc. on the home screen.
     /// - Parameters:
     ///   - site: Site for pocket article
     ///   - sourceView: View to show the popover

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -156,7 +156,7 @@ class DownloadsPanel: UIViewController,
     }
 
     private func shareDownloadedFile(_ downloadedFile: DownloadedFile, indexPath: IndexPath) {
-        let helper = ShareExtensionHelper(url: downloadedFile.path, tab: nil)
+        let helper = ShareManager(url: downloadedFile.path, tab: nil)
         let controller = helper.createActivityViewController { _, _ in }
 
         if let popoverPresentationController = controller.popoverPresentationController {

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -369,6 +369,7 @@ class DownloadsPanel: UIViewController,
             style: .destructive,
             title: .TabsTray.DownloadsPanel.DeleteTitle
         ) { [weak self] (_, _, completion) in
+            // Swipe > delete action
             guard let strongSelf = self else { completion(false); return }
 
             if let downloadedFile = strongSelf.viewModel.downloadedFileForIndexPath(indexPath),
@@ -394,6 +395,7 @@ class DownloadsPanel: UIViewController,
             style: .normal,
             title: .TabsTray.DownloadsPanel.ShareTitle
         ) { [weak self] (_, view, completion) in
+            // Swipe > share action (which is different from the row selection share behaviour)
             guard let strongSelf = self else { completion(false); return }
 
             view.backgroundColor = strongSelf.view.tintColor

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -8,7 +8,7 @@ import MobileCoreServices
 import WebKit
 import UniformTypeIdentifiers
 
-class ShareExtensionHelper: NSObject, FeatureFlaggable {
+class ShareManager: NSObject, FeatureFlaggable {
     private weak var selectedTab: Tab?
 
     private let url: URL
@@ -125,7 +125,7 @@ class ShareExtensionHelper: NSObject, FeatureFlaggable {
     }
 }
 
-extension ShareExtensionHelper: UIActivityItemSource {
+extension ShareManager: UIActivityItemSource {
     func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
         return url
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -245,8 +245,11 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
             url: URL(
                 string: "https://www.google.com"
             )!,
+            title: nil,
             sourceView: UIView(),
-            toastContainer: UIView()
+            sourceRect: CGRect(),
+            toastContainer: UIView(),
+            popoverArrowDirection: .up
         )
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
@@ -264,7 +267,9 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
             )!,
             title: "TEST TITLE",
             sourceView: UIView(),
-            toastContainer: UIView()
+            sourceRect: CGRect(),
+            toastContainer: UIView(),
+            popoverArrowDirection: .up
         )
 
         XCTAssertEqual(subject.childCoordinators.count, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -250,7 +250,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         )
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
-        XCTAssertTrue(subject.childCoordinators.first is ShareExtensionCoordinator)
+        XCTAssertTrue(subject.childCoordinators.first is ShareSheetCoordinator)
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertTrue(mockRouter.presentedViewController is UIActivityViewController)
     }
@@ -268,7 +268,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         )
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
-        XCTAssertTrue(subject.childCoordinators.first is ShareExtensionCoordinator)
+        XCTAssertTrue(subject.childCoordinators.first is ShareSheetCoordinator)
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertTrue(mockRouter.presentedViewController is UIActivityViewController)
     }
@@ -388,7 +388,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
     func testRemoveChildCoordinator_whenDidFinishCalled() {
         let subject = createSubject()
-        let childCoordinator = ShareExtensionCoordinator(
+        let childCoordinator = ShareSheetCoordinator(
             alertContainer: UIView(),
             router: mockRouter,
             profile: profile,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -238,10 +238,10 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         }
     }
 
-    func testShowShareExtension_addsShareExtensionCoordinator() {
+    func testShowShareSheet_addsShareSheetCoordinator() {
         let subject = createSubject()
 
-        subject.showShareExtension(
+        subject.showShareSheet(
             url: URL(
                 string: "https://www.google.com"
             )!,
@@ -255,10 +255,10 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(mockRouter.presentedViewController is UIActivityViewController)
     }
 
-    func testShowShareExtension_addsShareExtensionCoordinatorWithTitle() {
+    func testShowShareSheet_addsShareSheetCoordinatorWithTitle() {
         let subject = createSubject()
 
-        subject.showShareExtension(
+        subject.showShareSheet(
             url: URL(
                 string: "https://www.google.com"
             )!,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
@@ -114,7 +114,7 @@ final class BookmarksCoordinatorTests: XCTestCase {
         XCTAssertEqual(subject.childCoordinators.count, 0)
     }
 
-    func testShowShareExtension_callsNavigationHandlerShareFunction() {
+    func testShowShareSheet_callsNavigationHandlerShareFunction() {
         let subject = createSubject()
 
         subject.shareLibraryItem(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/HistoryCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/HistoryCoordinatorTests.swift
@@ -60,7 +60,7 @@ final class HistoryCoordinatorTests: XCTestCase {
         XCTAssertEqual(notificationCenter.postCallCount, 1)
     }
 
-    func testShowShareExtension_callsNavigationHandlerShareFunction() {
+    func testShowShareSheet_callsNavigationHandlerShareFunction() {
         let subject = createSubject()
 
         subject.shareLibraryItem(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/LibraryCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/LibraryCoordinatorTests.swift
@@ -96,7 +96,7 @@ final class LibraryCoordinatorTests: XCTestCase {
         XCTAssertEqual(delegate.didFinishSettingsCalled, 1)
     }
 
-    func testShowShareExtension_addsShareExtensionCoordinator() {
+    func testShowShareSheet_addsShareSheetCoordinator() {
         let subject = createSubject()
 
         subject.shareLibraryItem(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/LibraryCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/LibraryCoordinatorTests.swift
@@ -107,7 +107,7 @@ final class LibraryCoordinatorTests: XCTestCase {
         )
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
-        XCTAssertTrue(subject.childCoordinators.first is ShareExtensionCoordinator)
+        XCTAssertTrue(subject.childCoordinators.first is ShareSheetCoordinator)
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertTrue(mockRouter.presentedViewController is UIActivityViewController)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/ReadingListCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/ReadingListCoordinatorTests.swift
@@ -40,7 +40,7 @@ final class ReadingListCoordinatorTests: XCTestCase {
         XCTAssertEqual(parentCoordinator.lastOpenedURL, urlToOpen)
     }
 
-    func testShowShareExtension_callsNavigationHandlerShareFunction() {
+    func testShowShareSheet_callsNavigationHandlerShareFunction() {
         let subject = createSubject()
 
         subject.shareLibraryItem(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -20,7 +20,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
     var showLibraryCalled = 0
     var showHomepanelSectionCalled = 0
     var showEnhancedTrackingProtectionCalled = 0
-    var showShareExtensionCalled = 0
+    var showShareSheetCalled = 0
     var showTabTrayCalled = 0
     var showQrCodeCalled = 0
     var didFinishCalled = 0
@@ -65,13 +65,15 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
         showCreditCardAutofillCalled += 1
     }
 
-    func showShareExtension(
+    func showShareSheet(
         url: URL,
+        title: String?,
         sourceView: UIView,
+        sourceRect: CGRect?,
         toastContainer: UIView,
         popoverArrowDirection: UIPopoverArrowDirection
     ) {
-        showShareExtensionCalled += 1
+        showShareSheetCalled += 1
     }
 
     func show(homepanelSection: Route.HomepanelSection) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -348,21 +348,27 @@ class RouteTests: XCTestCase {
     }
 
     func testShareSheetRouteUrlOnly() {
+        let testURL = URL(string: "https://www.google.com")!
+        let shareURL = URL(string: "firefox://share-sheet?url=\(testURL.absoluteString)")!
         let subject = createSubject()
-        let url = URL(string: "firefox://share-sheet?url=https://www.google.com")!
 
-        let route = subject.makeRoute(url: url)
+        let route = subject.makeRoute(url: shareURL)
 
-        XCTAssertEqual(route, .sharesheet(url: URL(string: "https://www.google.com")!, title: nil))
+        XCTAssertEqual(route, .sharesheet(shareType: .site(url: testURL), shareMessage: nil))
     }
 
     func testShareSheetRouteUrlAndTitle() {
+        let testURL = URL(string: "https://www.google.com")!
+        let testTitle = "TEST TITLE"
+        let shareURL = URL(string: "firefox://share-sheet?url=\(testURL.absoluteString)&title=\(testTitle)")!
+
         let subject = createSubject()
-        let url = URL(string: "firefox://share-sheet?url=https://www.google.com&title=TEST TITLE")!
 
-        let route = subject.makeRoute(url: url)
+        let route = subject.makeRoute(url: shareURL)
 
-        XCTAssertEqual(route, .sharesheet(url: URL(string: "https://www.google.com")!, title: "TEST TITLE"))
+        let expectedShareType = ShareType.site(url: testURL)
+        let expectedShareMessage = ShareMessage(message: testTitle, subtitle: nil)
+        XCTAssertEqual(route, .sharesheet(shareType: expectedShareType, shareMessage: expectedShareMessage))
     }
 
     // MARK: - AppAction

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShareSheetCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShareSheetCoordinatorTests.swift
@@ -5,7 +5,7 @@
 import XCTest
 @testable import Client
 
-final class ShareExtensionCoordinatorTests: XCTestCase {
+final class ShareSheetCoordinatorTests: XCTestCase {
     private var parentCoordinator: MockParentCoordinator!
     private var mockRouter: MockRouter!
 
@@ -72,9 +72,9 @@ final class ShareExtensionCoordinatorTests: XCTestCase {
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
     }
 
-    private func createSubject() -> ShareExtensionCoordinator {
+    private func createSubject() -> ShareSheetCoordinator {
         mockRouter = MockRouter(navigationController: UINavigationController())
-        let subject = ShareExtensionCoordinator(
+        let subject = ShareSheetCoordinator(
             alertContainer: UIView(),
             router: mockRouter,
             profile: MockProfile(),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10669)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23340)

## :bulb: Description
This PR is part of the Sent from Firefox / Info Card Referral experiment work, which involves refactoring our old share sheet code.

This PR:
- Renames ShareExtensionHelper -> ShareManager
- Renames ShareExtensionCoordinator -> ShareSheetCoordinator
- Updates related naming for any variables, properties, functions, etc. with the word "shareExtension"
- Adds documentation
- Updates the `sharesheet` route to take a `ShareType` and `ShareMessage` instead of a URL and title

Note: The .sharesheet route was only just added for the Info Card Referral experiment here (https://github.com/mozilla-mobile/firefox-ios/pull/23094/files) and isn't in use yet. My next PR will hook things up again, I just didn't want too much clutter.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

