### PR TITLE
Refactor FXIOS-9855 #21636 Flaky tests

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
@@ -89,7 +89,7 @@ class CreditCardBottomSheetViewModel {
         self.state = state
         self.logger = logger
         creditCards = [CreditCard]()
-        updateCreditCardList({ _ in })
+        updateCreditCardList { _ in }
         if creditCard != nil {
             self.creditCard = creditCard
             self.decryptedCreditCard = decryptedCreditCard
@@ -100,12 +100,13 @@ class CreditCardBottomSheetViewModel {
     }
 
     // MARK: Main Button Action
-    public func didTapMainButton(completion: @escaping (Error?) -> Void) {
+    public func didTapMainButton(queue: DispatchQueueInterface = DispatchQueue.main,
+                                 completion: @escaping (Error?) -> Void) {
         let decryptedCard = getPlainCreditCardValues(bottomSheetState: state)
         switch state {
         case .save:
             saveCreditCard(with: decryptedCard) { _, error in
-                DispatchQueue.main.async {
+                queue.async {
                     guard let error = error else {
                         completion(nil)
                         return
@@ -119,7 +120,7 @@ class CreditCardBottomSheetViewModel {
         case .update:
             updateCreditCard(for: creditCard?.guid,
                              with: decryptedCard) { _, error in
-                DispatchQueue.main.async {
+                queue.async {
                     guard let error = error else {
                         completion(nil)
                         return
@@ -292,7 +293,7 @@ class CreditCardBottomSheetViewModel {
         return decryptedCardNum ?? ""
     }
 
-    private func listStoredCreditCards(_ completionHandler: @escaping ([CreditCard]?) -> Void) {
+    private func listStoredCreditCards(completionHandler: @escaping ([CreditCard]?) -> Void) {
         autofill.listCreditCards(completion: { creditCards, error in
             guard let creditCards = creditCards,
                   error == nil else {
@@ -303,10 +304,11 @@ class CreditCardBottomSheetViewModel {
         })
     }
 
-    func updateCreditCardList(_ completionHandler: @escaping ([CreditCard]?) -> Void) {
+    func updateCreditCardList(queue: DispatchQueueInterface = DispatchQueue.main,
+                              completionHandler: @escaping ([CreditCard]?) -> Void) {
         if state == .selectSavedCard {
             listStoredCreditCards { [weak self] cards in
-                DispatchQueue.main.async {
+                queue.async {
                     self?.creditCards = cards
                     completionHandler(cards)
                 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
@@ -2,412 +2,414 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-// import MozillaAppServices
-// import Shared
-// import Storage
-// import UIKit
-// import XCTest
-//
-// @testable import Client
+import MozillaAppServices
+import Shared
+import Storage
+import UIKit
+import XCTest
 
-// class CreditCardBottomSheetViewModelTests: XCTestCase {
-//    private var viewModel: CreditCardBottomSheetViewModel?
-//    private var mockAutofill: MockCreditCardProvider?
-//    private var samplePlainTextCard = UnencryptedCreditCardFields(ccName: "Allen Burges",
-//                                                                  ccNumber: "4111111111111111",
-//                                                                  ccNumberLast4: "1111",
-//                                                                  ccExpMonth: 3,
-//                                                                  ccExpYear: 2043,
-//                                                                  ccType: "VISA")
-//
-//    private var samplePlainTextUpdateCard = UnencryptedCreditCardFields(ccName: "Allen Burgers",
-//                                                                        ccNumber: "4111111111111111",
-//                                                                        ccNumberLast4: "1111",
-//                                                                        ccExpMonth: 09,
-//                                                                        ccExpYear: 2056,
-//                                                                        ccType: "VISA")
-//    private var sampleCreditCard = CreditCard(guid: "1",
-//                                              ccName: "Allen Burges",
-//                                              ccNumberEnc: "4111111111111111",
-//                                              ccNumberLast4: "1111",
-//                                              ccExpMonth: 3,
-//                                              ccExpYear: 2043,
-//                                              ccType: "VISA",
-//                                              timeCreated: 1234678,
-//                                              timeLastUsed: nil,
-//                                              timeLastModified: 123123,
-//                                              timesUsed: 123123)
-//
-//    override func setUpWithError() throws {
-//        try super.setUpWithError()
-//        mockAutofill = MockCreditCardProvider()
-//        let autofill = try XCTUnwrap(mockAutofill)
-//        viewModel = CreditCardBottomSheetViewModel(
-//            creditCardProvider: autofill,
-//            creditCard: sampleCreditCard,
-//            decryptedCreditCard: samplePlainTextCard,
-//            state: CreditCardBottomSheetState.save
-//        )
-//    }
-//
-//    override func tearDown() {
-//        mockAutofill = nil
-//        viewModel = nil
-//        super.tearDown()
-//    }
-//
-//    // MARK: - Test Cases
-//    func test_saveCreditCard_callsAddCreditCard() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//        let autofill = try XCTUnwrap(mockAutofill)
-//
-//        let expectation = expectation(description: "wait for credit card fields to be saved")
-//        let decryptedCreditCard = try XCTUnwrap(subject.getPlainCreditCardValues(bottomSheetState: .save))
-//        // Make sure the year saved is a 4 digit year and not 2 digit
-//        // 2000 because that is our current period
-//        XCTAssertTrue(decryptedCreditCard.ccExpYear > 2000)
-//        subject.saveCreditCard(with: decryptedCreditCard) { creditCard, error in
-//            XCTAssertEqual(autofill.addCreditCardCalledCount, 1)
-//            expectation.fulfill()
-//        }
-//        waitForExpectations(timeout: 1.0)
-//    }
-//
-//    func test_saveAndUpdateCreditCard_callsProperAutofillMethods() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//        let autofill = try XCTUnwrap(mockAutofill)
-//
-//        subject.state = .save
-//        let expectationSave = expectation(description: "wait for credit card fields to be saved")
-//        let expectationUpdate = expectation(description: "wait for credit card fields to be updated")
-//
-//        subject.saveCreditCard(with: samplePlainTextCard) { creditCard, error in
-//            XCTAssertEqual(autofill.addCreditCardCalledCount, 1)
-//            expectationSave.fulfill()
-//            subject.state = .update
-//            subject.updateCreditCard(for: creditCard?.guid,
-//                                     with: self.samplePlainTextCard
-//            ) { didUpdate, error in
-//                XCTAssertEqual(autofill.updateCreditCardCalledCount, 1)
-//                expectationUpdate.fulfill()
-//            }
-//        }
-//        waitForExpectations(timeout: 6.0)
-//    }
-//
-//    func testViewSetupForRememberCreditCard() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.state = .save
-//        XCTAssertTrue(subject.state.yesButtonTitle == .CreditCard.RememberCreditCard.MainButtonTitle)
-//        XCTAssertTrue(subject.state.notNowButtonTitle == .CreditCard.RememberCreditCard.SecondaryButtonTitle)
-//        XCTAssertTrue(subject.state.header == String(
-//            format: String.CreditCard.RememberCreditCard.Header,
-//            AppName.shortName.rawValue))
-//        XCTAssertTrue(subject.state.title == .CreditCard.RememberCreditCard.MainTitle)
-//    }
-//
-//    func testViewSetupForUpdateCreditCard() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.state = .update
-//        XCTAssertTrue(subject.state.yesButtonTitle == .CreditCard.UpdateCreditCard.MainButtonTitle)
-//        XCTAssertTrue(subject.state.notNowButtonTitle == .CreditCard.UpdateCreditCard.SecondaryButtonTitle)
-//        XCTAssertTrue(subject.state.title == .CreditCard.UpdateCreditCard.MainTitle)
-//    }
-//
-//    // Update the test to also account for save and selected card flow
-//    // Ticket: FXIOS-6719
-//    func test_save_getPlainCreditCardValues() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.state = .save
-//        let value = try XCTUnwrap(subject.getPlainCreditCardValues(bottomSheetState: .save))
-//        XCTAssertEqual(value.ccName, samplePlainTextCard.ccName)
-//        XCTAssertEqual(value.ccExpMonth, samplePlainTextCard.ccExpMonth)
-//        XCTAssertEqual(value.ccNumberLast4, samplePlainTextCard.ccNumberLast4)
-//        XCTAssertEqual(value.ccType, samplePlainTextCard.ccType)
-//        // Make sure the year saved is a 4 digit year and not 2 digit
-//        // 2000 because that is our current period
-//        XCTAssertTrue(value.ccExpYear > 2000)
-//    }
-//
-//    func test_getPlainCreditCardValues_NilDecryptedCard() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.state = .save
-//        subject.decryptedCreditCard = nil
-//        let value = subject.getPlainCreditCardValues(bottomSheetState: .save)
-//        XCTAssertNil(value)
-//    }
-//
-//    func test_getConvertedCreditCardValues_MasterCard() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.state = .save
-//        let masterCard = UnencryptedCreditCardFields(ccName: "John Doe",
-//                                                     ccNumber: "5555555555554444",
-//                                                     ccNumberLast4: "4444",
-//                                                     ccExpMonth: 12,
-//                                                     ccExpYear: 2023,
-//                                                     ccType: "MasterCard")
-//        subject.decryptedCreditCard = masterCard
-//        let value = subject.getConvertedCreditCardValues(
-//            bottomSheetState: .save,
-//            ccNumberDecrypted: masterCard.ccNumber
-//        )
-//        let cardValue = try XCTUnwrap(value)
-//        XCTAssertEqual(cardValue.ccType, "MasterCard")
-//    }
-//
-//    func test_getPlainCreditCardValues_InvalidMonth() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.state = .save
-//        let invalidCard = UnencryptedCreditCardFields(ccName: "Jane Smith",
-//                                                      ccNumber: "4111111111111111",
-//                                                      ccNumberLast4: "1111",
-//                                                      ccExpMonth: 13, // Invalid month
-//                                                      ccExpYear: 2023,
-//                                                      ccType: "VISA")
-//        subject.decryptedCreditCard = invalidCard
-//        let value = subject.getPlainCreditCardValues(bottomSheetState: .save)
-//        XCTAssertNotNil(value)
-//    }
-//
-//    func test_getConvertedCreditCardValues_UpcomingExpiry() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.state = .save
-//        let currentDate = Date()
-//        let calendar = Calendar.current
-//        let upcomingMonth = calendar.component(.month, from: currentDate) + 1
-//        let upcomingYear = calendar.component(.year, from: currentDate)
-//        let upcomingExpiryCard = UnencryptedCreditCardFields(ccName: "Jane Smith",
-//                                                             ccNumber: "4111111111111111",
-//                                                             ccNumberLast4: "1111",
-//                                                             ccExpMonth: Int64(upcomingMonth),
-//                                                             ccExpYear: Int64(upcomingYear),
-//                                                             ccType: "VISA")
-//        subject.decryptedCreditCard = upcomingExpiryCard
-//        let value = try XCTUnwrap(subject.getConvertedCreditCardValues(
-//            bottomSheetState: .save,
-//            ccNumberDecrypted: upcomingExpiryCard.ccNumber
-//        ))
-//        XCTAssertEqual(value.ccExpMonth, Int64(upcomingMonth))
-//        XCTAssertEqual(value.ccExpYear, Int64(upcomingYear))
-//    }
-//
-//    func test_getConvertedCreditCardValues_WhenStateIsSelectAndRowIsOutOfBounds() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.state = .selectSavedCard
-//        let result = subject.getConvertedCreditCardValues(bottomSheetState: .selectSavedCard,
-//                                                          ccNumberDecrypted: "1234567890123456",
-//                                                          row: 9999)
-//        XCTAssertNil(result)
-//    }
-//
-//    func test_select_PlainCreditCard_WithNegativeRow() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.state = .selectSavedCard
-//        subject.creditCards = [sampleCreditCard]
-//        let value = subject.getPlainCreditCardValues(bottomSheetState: .selectSavedCard, row: -1)
-//        XCTAssertNil(value)
-//    }
-//
-//    func test_save_getConvertedCreditCardValues() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.state = .save
-//        let value = try XCTUnwrap(
-//            subject.getConvertedCreditCardValues(
-//                bottomSheetState: .save,
-//                ccNumberDecrypted: ""
-//            )
-//        )
-//
-//        XCTAssertEqual(value.ccName, samplePlainTextCard.ccName)
-//        XCTAssertEqual(value.ccExpMonth, samplePlainTextCard.ccExpMonth)
-//        XCTAssertEqual(value.ccNumberLast4, samplePlainTextCard.ccNumberLast4)
-//        XCTAssertEqual(value.ccType, samplePlainTextCard.ccType)
-//    }
-//
-//    func test_update_getConvertedCreditCardValues() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.creditCard = sampleCreditCard
-//        subject.decryptedCreditCard = samplePlainTextCard
-//
-//        // convert the saved credit card and check values
-//        let decryptedCCNumber = "4111111111111111"
-//        let value = try XCTUnwrap(
-//            subject.getConvertedCreditCardValues(
-//                bottomSheetState: .update,
-//                ccNumberDecrypted: decryptedCCNumber
-//            )
-//        )
-//        XCTAssertEqual(value.ccName, self.samplePlainTextCard.ccName)
-//        XCTAssertEqual(value.ccExpMonth, self.samplePlainTextCard.ccExpMonth)
-//        XCTAssertEqual(value.ccNumberLast4, self.samplePlainTextCard.ccNumberLast4)
-//        XCTAssertEqual(value.ccType, self.samplePlainTextCard.ccType)
-//    }
-//
-//    func test_update_selectConvertedCreditCardValues_ForSpecificRow() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.creditCards = [sampleCreditCard]
-//
-//        let value = try XCTUnwrap(
-//            subject.getConvertedCreditCardValues(
-//                bottomSheetState: .selectSavedCard,
-//                ccNumberDecrypted: "",
-//                row: 0
-//            )
-//        )
-//        XCTAssertEqual(value.ccName, self.samplePlainTextCard.ccName)
-//        XCTAssertEqual(value.ccExpMonth, self.samplePlainTextCard.ccExpMonth)
-//        XCTAssertEqual(value.ccNumberLast4, self.samplePlainTextCard.ccNumberLast4)
-//        XCTAssertEqual(value.ccType, self.samplePlainTextCard.ccType)
-//    }
-//
-//    func test_update_selectConvertedCreditCardValues_ForInvalidRow() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.creditCards = [sampleCreditCard]
-//
-//        let value = subject.getConvertedCreditCardValues(
-//            bottomSheetState: .selectSavedCard,
-//            ccNumberDecrypted: ""
-//        )
-//        XCTAssertNil(value)
-//    }
-//
-//    func test_update_selectConvertedCreditCardValues_ForMinusRow() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.creditCards = [sampleCreditCard]
-//
-//        let value = subject.getConvertedCreditCardValues(
-//            bottomSheetState: .selectSavedCard,
-//            ccNumberDecrypted: "",
-//            row: -1
-//        )
-//        XCTAssertNil(value)
-//    }
-//
-//    func test_update_selectConvertedCreditCardValues_ForEmptyCreditCards() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        subject.creditCards = []
-//
-//        let value = subject.getConvertedCreditCardValues(
-//            bottomSheetState: .selectSavedCard,
-//            ccNumberDecrypted: "",
-//            row: 1
-//        )
-//        XCTAssertNil(value)
-//    }
-//
-//    func test_updateDecryptedCreditCard() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        let sampleCreditCardVal = sampleCreditCard
-//        let updatedName = "Red Dragon"
-//        let updatedMonth: Int64 = 12
-//        let updatedYear: Int64 = 2048
-//        let newUnencryptedCreditCard = UnencryptedCreditCardFields(ccName: updatedName,
-//                                                                   ccNumber: sampleCreditCardVal.ccNumberEnc,
-//                                                                   ccNumberLast4: sampleCreditCardVal.ccNumberLast4,
-//                                                                   ccExpMonth: updatedMonth,
-//                                                                   ccExpYear: updatedYear,
-//                                                                   ccType: sampleCreditCardVal.ccType)
-//        let value = try XCTUnwrap(
-//            subject.updateDecryptedCreditCard(
-//                from: sampleCreditCardVal,
-//                with: sampleCreditCardVal.ccNumberEnc,
-//                fieldValues: newUnencryptedCreditCard
-//            )
-//        )
-//        XCTAssertEqual(value.ccName, updatedName)
-//        XCTAssertEqual(value.ccExpMonth, updatedMonth)
-//        XCTAssertEqual(value.ccExpYear, updatedYear)
-//        XCTAssertEqual(value.ccNumber, sampleCreditCardVal.ccNumberEnc)
-//    }
-//
-//    func test_didTapMainButton_withSaveState_callsAddCreditCard() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//        let autofill = try XCTUnwrap(mockAutofill)
-//
-//        subject.state = .save
-//        subject.decryptedCreditCard = samplePlainTextCard
-//        let expectation = expectation(description: "wait for credit card fields to be saved")
-//
-//        subject.didTapMainButton { error in
-//            guard error == nil else {
-//                XCTFail("Should not have received error: \(String(describing: error?.localizedDescription))")
-//                return
-//            }
-//
-//            XCTAssertEqual(autofill.addCreditCardCalledCount, 1)
-//            expectation.fulfill()
-//        }
-//
-//        waitForExpectations(timeout: 5.0)
-//    }
-//
-//    func test_didTapMainButton_withUpdateState_callsAddCreditCard() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//        let autofill = try XCTUnwrap(mockAutofill)
-//
-//        subject.state = .update
-//        subject.decryptedCreditCard = samplePlainTextCard
-//        let expectation = expectation(description: "wait for credit card fields to be updated")
-//
-//        subject.didTapMainButton { error in
-//            guard error == nil else {
-//                XCTFail("Should not have received error: \(String(describing: error?.localizedDescription))")
-//                return
-//            }
-//            XCTAssertEqual(autofill.updateCreditCardCalledCount, 1)
-//            expectation.fulfill()
-//        }
-//
-//        waitForExpectations(timeout: 5.0)
-//    }
-//
-//    func test_updateCreditCardList_callsListCreditCards() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//        let autofill = try XCTUnwrap(mockAutofill)
-//
-//        let expectation = expectation(description: "wait for credit card to be added")
-//        subject.creditCard = nil
-//        subject.decryptedCreditCard = nil
-//        subject.state = .selectSavedCard
-//
-//        subject.updateCreditCardList({ cards in
-//            XCTAssertEqual(subject.creditCards, cards)
-//            XCTAssertEqual(cards?.count, 1)
-//            XCTAssertEqual(cards?.first?.guid, "1")
-//            XCTAssertEqual(cards?.first?.ccName, "Allen Burges")
-//            XCTAssertEqual(autofill.listCreditCardsCalledCount, 1)
-//            expectation.fulfill()
-//        })
-//        waitForExpectations(timeout: 5.0)
-//    }
-//
-//    func test_updateCreditCardList_withoutSelectedSavedCardState_doesNotCallListCreditCards() throws {
-//        let subject = try XCTUnwrap(viewModel)
-//
-//        let expectation = expectation(description: "wait for credit card to be added")
-//        expectation.isInverted = true
-//        subject.creditCard = nil
-//        subject.decryptedCreditCard = nil
-//
-//        subject.updateCreditCardList({ cards in
-//            expectation.fulfill()
-//        })
-//        waitForExpectations(timeout: 1.0)
-//    }
-// }
+@testable import Client
+
+class CreditCardBottomSheetViewModelTests: XCTestCase {
+    private var autofill: MockCreditCardProvider!
+    private var dispatchQueue: MockDispatchQueue!
+    private var samplePlainTextCard = UnencryptedCreditCardFields(ccName: "Allen Burges",
+                                                                  ccNumber: "4111111111111111",
+                                                                  ccNumberLast4: "1111",
+                                                                  ccExpMonth: 3,
+                                                                  ccExpYear: 2043,
+                                                                  ccType: "VISA")
+
+    private var samplePlainTextUpdateCard = UnencryptedCreditCardFields(ccName: "Allen Burgers",
+                                                                        ccNumber: "4111111111111111",
+                                                                        ccNumberLast4: "1111",
+                                                                        ccExpMonth: 09,
+                                                                        ccExpYear: 2056,
+                                                                        ccType: "VISA")
+    private var sampleCreditCard = CreditCard(guid: "1",
+                                              ccName: "Allen Burges",
+                                              ccNumberEnc: "4111111111111111",
+                                              ccNumberLast4: "1111",
+                                              ccExpMonth: 3,
+                                              ccExpYear: 2043,
+                                              ccType: "VISA",
+                                              timeCreated: 1234678,
+                                              timeLastUsed: nil,
+                                              timeLastModified: 123123,
+                                              timesUsed: 123123)
+
+    override func setUp() {
+        super.setUp()
+        autofill = MockCreditCardProvider()
+        dispatchQueue = MockDispatchQueue()
+    }
+
+    override func tearDown() {
+        autofill = nil
+        dispatchQueue = nil
+        super.tearDown()
+    }
+
+    // MARK: - Test Cases
+    func test_saveCreditCard_callsAddCreditCard() throws {
+        let subject = createSubject()
+
+        let expectation = expectation(description: "wait for credit card fields to be saved")
+        let decryptedCreditCard = try XCTUnwrap(subject.getPlainCreditCardValues(bottomSheetState: .save))
+        // Make sure the year saved is a 4 digit year and not 2 digit
+        // 2000 because that is our current period
+        XCTAssertTrue(decryptedCreditCard.ccExpYear > 2000)
+        subject.saveCreditCard(with: decryptedCreditCard) { creditCard, error in
+            XCTAssertEqual(self.autofill.addCreditCardCalledCount, 1)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func test_saveAndUpdateCreditCard_callsProperAutofillMethods() throws {
+        let subject = createSubject()
+
+        subject.state = .save
+        let expectationSave = expectation(description: "wait for credit card fields to be saved")
+        let expectationUpdate = expectation(description: "wait for credit card fields to be updated")
+
+        subject.saveCreditCard(with: samplePlainTextCard) { creditCard, error in
+            XCTAssertEqual(self.autofill.addCreditCardCalledCount, 1)
+            expectationSave.fulfill()
+            subject.state = .update
+            subject.updateCreditCard(for: creditCard?.guid,
+                                     with: self.samplePlainTextCard
+            ) { didUpdate, error in
+                XCTAssertEqual(self.autofill.updateCreditCardCalledCount, 1)
+                expectationUpdate.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 6.0)
+    }
+
+    func testViewSetupForRememberCreditCard() throws {
+        let subject = createSubject()
+
+        subject.state = .save
+        XCTAssertTrue(subject.state.yesButtonTitle == .CreditCard.RememberCreditCard.MainButtonTitle)
+        XCTAssertTrue(subject.state.notNowButtonTitle == .CreditCard.RememberCreditCard.SecondaryButtonTitle)
+        XCTAssertTrue(subject.state.header == String(
+            format: String.CreditCard.RememberCreditCard.Header,
+            AppName.shortName.rawValue))
+        XCTAssertTrue(subject.state.title == .CreditCard.RememberCreditCard.MainTitle)
+    }
+
+    func testViewSetupForUpdateCreditCard() throws {
+        let subject = createSubject()
+
+        subject.state = .update
+        XCTAssertTrue(subject.state.yesButtonTitle == .CreditCard.UpdateCreditCard.MainButtonTitle)
+        XCTAssertTrue(subject.state.notNowButtonTitle == .CreditCard.UpdateCreditCard.SecondaryButtonTitle)
+        XCTAssertTrue(subject.state.title == .CreditCard.UpdateCreditCard.MainTitle)
+    }
+
+    // Update the test to also account for save and selected card flow
+    // Ticket: FXIOS-6719
+    func test_save_getPlainCreditCardValues() throws {
+        let subject = createSubject()
+
+        subject.state = .save
+        let value = try XCTUnwrap(subject.getPlainCreditCardValues(bottomSheetState: .save))
+        XCTAssertEqual(value.ccName, samplePlainTextCard.ccName)
+        XCTAssertEqual(value.ccExpMonth, samplePlainTextCard.ccExpMonth)
+        XCTAssertEqual(value.ccNumberLast4, samplePlainTextCard.ccNumberLast4)
+        XCTAssertEqual(value.ccType, samplePlainTextCard.ccType)
+        // Make sure the year saved is a 4 digit year and not 2 digit
+        // 2000 because that is our current period
+        XCTAssertTrue(value.ccExpYear > 2000)
+    }
+
+    func test_getPlainCreditCardValues_NilDecryptedCard() throws {
+        let subject = createSubject()
+
+        subject.state = .save
+        subject.decryptedCreditCard = nil
+        let value = subject.getPlainCreditCardValues(bottomSheetState: .save)
+        XCTAssertNil(value)
+    }
+
+    func test_getConvertedCreditCardValues_MasterCard() throws {
+        let subject = createSubject()
+
+        subject.state = .save
+        let masterCard = UnencryptedCreditCardFields(ccName: "John Doe",
+                                                     ccNumber: "5555555555554444",
+                                                     ccNumberLast4: "4444",
+                                                     ccExpMonth: 12,
+                                                     ccExpYear: 2023,
+                                                     ccType: "MasterCard")
+        subject.decryptedCreditCard = masterCard
+        let value = subject.getConvertedCreditCardValues(
+            bottomSheetState: .save,
+            ccNumberDecrypted: masterCard.ccNumber
+        )
+        let cardValue = try XCTUnwrap(value)
+        XCTAssertEqual(cardValue.ccType, "MasterCard")
+    }
+
+    func test_getPlainCreditCardValues_InvalidMonth() throws {
+        let subject = createSubject()
+
+        subject.state = .save
+        let invalidCard = UnencryptedCreditCardFields(ccName: "Jane Smith",
+                                                      ccNumber: "4111111111111111",
+                                                      ccNumberLast4: "1111",
+                                                      ccExpMonth: 13, // Invalid month
+                                                      ccExpYear: 2023,
+                                                      ccType: "VISA")
+        subject.decryptedCreditCard = invalidCard
+        let value = subject.getPlainCreditCardValues(bottomSheetState: .save)
+        XCTAssertNotNil(value)
+    }
+
+    func test_getConvertedCreditCardValues_UpcomingExpiry() throws {
+        let subject = createSubject()
+
+        subject.state = .save
+        let currentDate = Date()
+        let calendar = Calendar.current
+        let upcomingMonth = calendar.component(.month, from: currentDate) + 1
+        let upcomingYear = calendar.component(.year, from: currentDate)
+        let upcomingExpiryCard = UnencryptedCreditCardFields(ccName: "Jane Smith",
+                                                             ccNumber: "4111111111111111",
+                                                             ccNumberLast4: "1111",
+                                                             ccExpMonth: Int64(upcomingMonth),
+                                                             ccExpYear: Int64(upcomingYear),
+                                                             ccType: "VISA")
+        subject.decryptedCreditCard = upcomingExpiryCard
+        let value = try XCTUnwrap(subject.getConvertedCreditCardValues(
+            bottomSheetState: .save,
+            ccNumberDecrypted: upcomingExpiryCard.ccNumber
+        ))
+        XCTAssertEqual(value.ccExpMonth, Int64(upcomingMonth))
+        XCTAssertEqual(value.ccExpYear, Int64(upcomingYear))
+    }
+
+    func test_getConvertedCreditCardValues_WhenStateIsSelectAndRowIsOutOfBounds() throws {
+        let subject = createSubject()
+
+        subject.state = .selectSavedCard
+        let result = subject.getConvertedCreditCardValues(bottomSheetState: .selectSavedCard,
+                                                          ccNumberDecrypted: "1234567890123456",
+                                                          row: 9999)
+        XCTAssertNil(result)
+    }
+
+    func test_select_PlainCreditCard_WithNegativeRow() throws {
+        let subject = createSubject()
+
+        subject.state = .selectSavedCard
+        subject.creditCards = [sampleCreditCard]
+        let value = subject.getPlainCreditCardValues(bottomSheetState: .selectSavedCard, row: -1)
+        XCTAssertNil(value)
+    }
+
+    func test_save_getConvertedCreditCardValues() throws {
+        let subject = createSubject()
+
+        subject.state = .save
+        let value = try XCTUnwrap(
+            subject.getConvertedCreditCardValues(
+                bottomSheetState: .save,
+                ccNumberDecrypted: ""
+            )
+        )
+
+        XCTAssertEqual(value.ccName, samplePlainTextCard.ccName)
+        XCTAssertEqual(value.ccExpMonth, samplePlainTextCard.ccExpMonth)
+        XCTAssertEqual(value.ccNumberLast4, samplePlainTextCard.ccNumberLast4)
+        XCTAssertEqual(value.ccType, samplePlainTextCard.ccType)
+    }
+
+    func test_update_getConvertedCreditCardValues() throws {
+        let subject = createSubject()
+
+        subject.creditCard = sampleCreditCard
+        subject.decryptedCreditCard = samplePlainTextCard
+
+        // convert the saved credit card and check values
+        let decryptedCCNumber = "4111111111111111"
+        let value = try XCTUnwrap(
+            subject.getConvertedCreditCardValues(
+                bottomSheetState: .update,
+                ccNumberDecrypted: decryptedCCNumber
+            )
+        )
+        XCTAssertEqual(value.ccName, self.samplePlainTextCard.ccName)
+        XCTAssertEqual(value.ccExpMonth, self.samplePlainTextCard.ccExpMonth)
+        XCTAssertEqual(value.ccNumberLast4, self.samplePlainTextCard.ccNumberLast4)
+        XCTAssertEqual(value.ccType, self.samplePlainTextCard.ccType)
+    }
+
+    func test_update_selectConvertedCreditCardValues_ForSpecificRow() throws {
+        let subject = createSubject()
+
+        subject.creditCards = [sampleCreditCard]
+
+        let value = try XCTUnwrap(
+            subject.getConvertedCreditCardValues(
+                bottomSheetState: .selectSavedCard,
+                ccNumberDecrypted: "",
+                row: 0
+            )
+        )
+        XCTAssertEqual(value.ccName, self.samplePlainTextCard.ccName)
+        XCTAssertEqual(value.ccExpMonth, self.samplePlainTextCard.ccExpMonth)
+        XCTAssertEqual(value.ccNumberLast4, self.samplePlainTextCard.ccNumberLast4)
+        XCTAssertEqual(value.ccType, self.samplePlainTextCard.ccType)
+    }
+
+    func test_update_selectConvertedCreditCardValues_ForInvalidRow() throws {
+        let subject = createSubject()
+
+        subject.creditCards = [sampleCreditCard]
+
+        let value = subject.getConvertedCreditCardValues(
+            bottomSheetState: .selectSavedCard,
+            ccNumberDecrypted: ""
+        )
+        XCTAssertNil(value)
+    }
+
+    func test_update_selectConvertedCreditCardValues_ForMinusRow() throws {
+        let subject = createSubject()
+
+        subject.creditCards = [sampleCreditCard]
+
+        let value = subject.getConvertedCreditCardValues(
+            bottomSheetState: .selectSavedCard,
+            ccNumberDecrypted: "",
+            row: -1
+        )
+        XCTAssertNil(value)
+    }
+
+    func test_update_selectConvertedCreditCardValues_ForEmptyCreditCards() throws {
+        let subject = createSubject()
+
+        subject.creditCards = []
+
+        let value = subject.getConvertedCreditCardValues(
+            bottomSheetState: .selectSavedCard,
+            ccNumberDecrypted: "",
+            row: 1
+        )
+        XCTAssertNil(value)
+    }
+
+    func test_updateDecryptedCreditCard() throws {
+        let subject = createSubject()
+
+        let sampleCreditCardVal = sampleCreditCard
+        let updatedName = "Red Dragon"
+        let updatedMonth: Int64 = 12
+        let updatedYear: Int64 = 2048
+        let newUnencryptedCreditCard = UnencryptedCreditCardFields(ccName: updatedName,
+                                                                   ccNumber: sampleCreditCardVal.ccNumberEnc,
+                                                                   ccNumberLast4: sampleCreditCardVal.ccNumberLast4,
+                                                                   ccExpMonth: updatedMonth,
+                                                                   ccExpYear: updatedYear,
+                                                                   ccType: sampleCreditCardVal.ccType)
+        let value = try XCTUnwrap(
+            subject.updateDecryptedCreditCard(
+                from: sampleCreditCardVal,
+                with: sampleCreditCardVal.ccNumberEnc,
+                fieldValues: newUnencryptedCreditCard
+            )
+        )
+        XCTAssertEqual(value.ccName, updatedName)
+        XCTAssertEqual(value.ccExpMonth, updatedMonth)
+        XCTAssertEqual(value.ccExpYear, updatedYear)
+        XCTAssertEqual(value.ccNumber, sampleCreditCardVal.ccNumberEnc)
+    }
+
+    func test_didTapMainButton_withSaveState_callsAddCreditCard() throws {
+        let subject = createSubject()
+
+        subject.state = .save
+        subject.decryptedCreditCard = samplePlainTextCard
+        let expectation = expectation(description: "wait for credit card fields to be saved")
+
+        subject.didTapMainButton(queue: dispatchQueue) { error in
+            guard error == nil else {
+                XCTFail("Should not have received error: \(String(describing: error?.localizedDescription))")
+                return
+            }
+
+            XCTAssertEqual(self.autofill.addCreditCardCalledCount, 1)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0)
+    }
+
+    func test_didTapMainButton_withUpdateState_callsAddCreditCard() throws {
+        let subject = createSubject()
+
+        subject.state = .update
+        subject.decryptedCreditCard = samplePlainTextCard
+        let expectation = expectation(description: "wait for credit card fields to be updated")
+
+        subject.didTapMainButton(queue: dispatchQueue) { error in
+            guard error == nil else {
+                XCTFail("Should not have received error: \(String(describing: error?.localizedDescription))")
+                return
+            }
+            XCTAssertEqual(self.autofill.updateCreditCardCalledCount, 1)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0)
+    }
+
+    func test_updateCreditCardList_callsListCreditCards() throws {
+        let subject = createSubject()
+
+        let expectation = expectation(description: "wait for credit card to be added")
+        subject.creditCard = nil
+        subject.decryptedCreditCard = nil
+        subject.state = .selectSavedCard
+
+        subject.updateCreditCardList(queue: dispatchQueue) { cards in
+            XCTAssertEqual(subject.creditCards, cards)
+            XCTAssertEqual(cards?.count, 1)
+            XCTAssertEqual(cards?.first?.guid, "1")
+            XCTAssertEqual(cards?.first?.ccName, "Allen Burges")
+            XCTAssertEqual(self.autofill.listCreditCardsCalledCount, 1)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5.0)
+    }
+
+    func test_updateCreditCardList_withoutSelectedSavedCardState_doesNotCallListCreditCards() throws {
+        let subject = createSubject()
+
+        let expectation = expectation(description: "wait for credit card to be added")
+        expectation.isInverted = true
+        subject.creditCard = nil
+        subject.decryptedCreditCard = nil
+
+        subject.updateCreditCardList(queue: dispatchQueue) { cards in
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    // MARK: Helper methods
+
+    private func createSubject() -> CreditCardBottomSheetViewModel {
+        let subject = CreditCardBottomSheetViewModel(
+            creditCardProvider: autofill,
+            creditCard: sampleCreditCard,
+            decryptedCreditCard: samplePlainTextCard,
+            state: CreditCardBottomSheetState.save
+        )
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/ThrottlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/ThrottlerTests.swift
@@ -12,10 +12,22 @@ class ThrottlerTests: XCTestCase {
         static let defaultTestMaxWaitTime: Double = 2
     }
 
-    private let testQueue = DispatchQueue.global()
+    private var testQueue: DispatchQueue!
     private var throttler: Throttler!
     private var expectation: XCTestExpectation!
     private var testValue = 0
+
+    override func setUp() {
+        super.setUp()
+        testQueue = DispatchQueue.global()
+    }
+
+    override func tearDown() {
+        throttler = nil
+        expectation = nil
+        testQueue = nil
+        super.tearDown()
+    }
 
     func testMultipleFastConsecutiveCallsAreThrottledAndExecutedAtMostOneTime() {
         prepareTest(timeout: Timing.veryLongDelay)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/XCTestCaseExtensions.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/XCTestCaseExtensions.swift
@@ -11,19 +11,6 @@ extension XCTestCase {
         XCTWaiter().wait(for: [expectation], timeout: timeout)
     }
 
-    func waitForCondition(timeout: TimeInterval = 10, condition: () -> Bool) {
-        let timeoutTime = Date.timeIntervalSinceReferenceDate + timeout
-
-        while !condition() {
-            if Date.timeIntervalSinceReferenceDate > timeoutTime {
-                XCTFail("Condition timed out")
-                return
-            }
-
-            wait(0.1)
-        }
-    }
-
     func trackForMemoryLeaks(_ instance: AnyObject, file: StaticString = #file, line: UInt = #line) {
         addTeardownBlock { [weak instance] in
             XCTAssertNil(
@@ -40,8 +27,10 @@ extension XCTestCase {
     /// It is a wrapper of XCTUnwrap. Since is not possible to do ```XCTUnwrap(await asyncMethod())```
     ///
     /// it has to be done always in two steps, this method make it one line for users.
-    func unwrapAsync<T>(asyncMethod: () async throws -> T?) async throws -> T {
+    func unwrapAsync<T>(asyncMethod: () async throws -> T?,
+                        file: StaticString = #file,
+                        line: UInt = #line) async throws -> T {
         let returnValue = try await asyncMethod()
-        return try XCTUnwrap(returnValue)
+        return try XCTUnwrap(returnValue, file: file, line: line)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9855)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21636)

## :bulb: Description
Couple of tests changes:
- Introduced `DispatchQueueInterface` inside `CreditCardBottomSheetViewModel` to be able to use `MockDispatchQueue` for unit tests. This makes those test synchronous, which will remove some part of the flakiness hopefully. 
- `ThrottlerTests` were failing for me locally, now using `setUp` and `tearDown` to ensure fresh state on each test run.
- `func waitForCondition(timeout:condition:)` wasn't used, so removing it
- Added `file` and `line` to `unwrapAsync` as I saw some failing tests without knowing on which line exactly it was failing.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

