### PR TITLE
Bugfix FXIOS-10795 [Bookmarks Evolution] Legacy bookmarks panel crash

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -143,7 +143,7 @@ class BookmarksViewController: SiteTableViewController,
 
     override func reloadData() {
         viewModel.reloadData { [weak self] in
-            DispatchQueue.main.async {
+            ensureMainThread {
                 self?.tableView.reloadData()
                 if self?.viewModel.shouldFlashRow ?? false {
                     self?.flashRow()

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
@@ -150,8 +150,9 @@ class LegacyBookmarksPanel: SiteTableViewController,
 
     override func reloadData() {
         viewModel.reloadData { [weak self] in
-            self?.tableView.reloadData()
-
+            DispatchQueue.main.async {
+                self?.tableView.reloadData()
+            }
             if self?.viewModel.shouldFlashRow ?? false {
                 self?.flashRow()
             }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
@@ -150,7 +150,7 @@ class LegacyBookmarksPanel: SiteTableViewController,
 
     override func reloadData() {
         viewModel.reloadData { [weak self] in
-            DispatchQueue.main.async {
+            ensureMainThread {
                 self?.tableView.reloadData()
             }
             if self?.viewModel.shouldFlashRow ?? false {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10795)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23549)

## :bulb: Description
- Fixes a crash that would occur when opening the legacy bookmarks panel (bookmark refactor feature disabled)

### 💡 Solution
- Reload the bookmarks table on the main thread

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

