### PR TITLE
Bugfix FXIOS-10976 [Menu] Fix URL field focus on new tab

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -519,7 +519,10 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     func openNewTab(inPrivateMode isPrivate: Bool) {
-        handle(homepanelSection: isPrivate ? .newPrivateTab : .newTab)
+        browserViewController.openNewTabFromMenu(
+            focusLocationField: true,
+            isPrivate: isPrivate
+        )
     }
 
     func showLibraryPanel(_ panel: Route.HomepanelSection) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10976)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23552)

## :bulb: Description
The url bar, when opening a new tab from the new menu, didn't focus. Now it does.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

