### PR TITLE
Bugfix FXIOS-10769 ⁃ [Menu design][Accessibility] Close button is labeled incorrectly

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
@@ -101,6 +101,7 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
             target: self,
             action: #selector(topLeftButtonAction)
         )
+        button.accessibilityLabel = .MainMenu.Account.AccessibilityLabels.CloseButton
         return button
     }()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10769)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23492)

## :bulb: Description
Fixed accessibility label for close button from Edit Bookmark screen

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

