### PR TITLE
Bugfix FXIOS-9942 [Fundamental Bugs] Fix orientation layout for Jump back in section

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -244,7 +244,8 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
             $0.refreshData(for: traitCollection,
                            size: size,
                            isPortrait: UIWindow.isPortrait,
-                           device: UIDevice.current.userInterfaceIdiom)
+                           device: UIDevice.current.userInterfaceIdiom,
+                           orientation: UIDevice.current.orientation)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModelProtocol.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModelProtocol.swift
@@ -31,7 +31,8 @@ protocol HomepageViewModelProtocol {
     func refreshData(for traitCollection: UITraitCollection,
                      size: CGSize,
                      isPortrait: Bool,
-                     device: UIUserInterfaceIdiom)
+                     device: UIUserInterfaceIdiom,
+                     orientation: UIDeviceOrientation)
 
     // Update section that are privacy sensitive, only implement when needed
     func updatePrivacyConcernedSection(isPrivate: Bool)
@@ -56,7 +57,8 @@ extension HomepageViewModelProtocol {
     func refreshData(for traitCollection: UITraitCollection,
                      size: CGSize,
                      isPortrait: Bool,
-                     device: UIUserInterfaceIdiom) {}
+                     device: UIUserInterfaceIdiom,
+                     orientation: UIDeviceOrientation) {}
 
     func screenWasShown() {}
 }

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -99,8 +99,9 @@ class JumpBackInViewModel: FeatureFlaggable {
     }
 
     private func updateSectionLayout(for traitCollection: UITraitCollection,
-                                     isPortrait: Bool = UIWindow.isPortrait,
-                                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+                                     isPortrait: Bool,
+                                     device: UIUserInterfaceIdiom,
+                                     orientation: UIDeviceOrientation) {
         let isPhoneInLandscape = device == .phone && !isPortrait
         let isPadInPortrait = device == .pad && isPortrait
         let isPadInLandscapeTwoThirdSplit = isPadInLandscapeSplit(split: 2/3, isPortrait: isPortrait, device: device)
@@ -138,7 +139,7 @@ class JumpBackInViewModel: FeatureFlaggable {
     }
 
     private func isPadInLandscapeSplit(split: CGFloat,
-                                       isPortrait: Bool = UIWindow.isPortrait,
+                                       isPortrait: Bool,
                                        device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) -> Bool {
         guard device == .pad,
               !isPortrait,
@@ -349,10 +350,14 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
     func refreshData(for traitCollection: UITraitCollection,
                      size: CGSize,
                      isPortrait: Bool = UIWindow.isPortrait,
-                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
+                     orientation: UIDeviceOrientation = UIDevice.current.orientation) {
+        // UIDevice is not always returning the correct orientation so we check against the window orientation as well
+        let isPortrait = orientation.isPortrait || isPortrait
         updateSectionLayout(for: traitCollection,
                             isPortrait: isPortrait,
-                            device: device)
+                            device: device,
+                            orientation: orientation)
         let maxItemsToDisplay = sectionLayout.maxItemsToDisplay(
             hasAccount: isSyncTabFeatureEnabled,
             device: device

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -194,7 +194,8 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     func refreshData(for traitCollection: UITraitCollection,
                      size: CGSize,
                      isPortrait: Bool = UIWindow.isPortrait,
-                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+                     device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
+                     orientation: UIDeviceOrientation = UIDevice.current.orientation) {
         let interface = TopSitesUIInterface(trait: traitCollection,
                                             availableWidth: size.width)
         numberOfRows = topSitesDataAdaptor.numberOfRows


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9942)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21827)

## :bulb: Description
The default value we use to get the phone orientation with `UIWindow.isPortrait` isn't always proper on app startup. It sometimes returns false when it should be true. That then triggers the layout of the Jump back in section to be faulty until some events happens that trigger the section to be properly layout. I noticed the same issue was happening in `Fakespot` code [here](https://github.com/mozilla-mobile/firefox-ios/blob/3d02ea63aec57caa9d332c9e5e6992963ac6e3b1/firefox-ios/Client/Frontend/Fakespot/FakespotUtils.swift#L105-L106), so just using the same solution for the legacy homepage. I'll write a comment on the new homepage jump back in [ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10169) just in case the same layout stuff will be used over there. Maybe another solution can be used in the Redux codebase.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

