### PR TITLE
Bugfix FXIOS-10793 Fix bug when opening JS links via context menu

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -286,12 +286,15 @@ extension BrowserViewController: WKUIDelegate {
                        currentTab: Tab,
                        webView: WKWebView) -> [UIAction] {
         let actionBuilder = ActionProviderBuilder()
+        let isJavascriptScheme = (url.scheme?.caseInsensitiveCompare("javascript") == .orderedSame)
 
-        if !isPrivate {
+        if !isPrivate && !isJavascriptScheme {
             actionBuilder.addOpenInNewTab(url: url, currentTab: currentTab, addTab: addTab)
         }
 
-        actionBuilder.addOpenInNewPrivateTab(url: url, currentTab: currentTab, addTab: addTab)
+        if !isJavascriptScheme {
+            actionBuilder.addOpenInNewPrivateTab(url: url, currentTab: currentTab, addTab: addTab)
+        }
 
         let isBookmarkedSite = profile.places
             .isBookmarked(url: url.absoluteString)
@@ -305,7 +308,7 @@ extension BrowserViewController: WKUIDelegate {
             actionBuilder.addBookmarkLink(url: url, title: title, addBookmark: self.addBookmark)
         }
 
-        if url.scheme != "javascript" {
+        if !isJavascriptScheme {
             actionBuilder.addDownload(url: url, currentTab: currentTab, assignWebView: assignWebView)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -149,50 +149,53 @@ extension BrowserViewController: WKUIDelegate {
         completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
     ) {
         guard let url = elementInfo.linkURL else { return }
+        completionHandler(contextMenuConfiguration(for: url, webView: webView))
+    }
 
-        completionHandler(
-            UIContextMenuConfiguration(
-                identifier: nil,
-                previewProvider: {
-                    guard self.profile.prefs.boolForKey(PrefsKeys.ContextMenuShowLinkPreviews) ?? true else { return nil }
+    private func contextMenuConfiguration(for url: URL, webView: WKWebView) -> UIContextMenuConfiguration {
+        return UIContextMenuConfiguration(identifier: nil,
+                                          previewProvider: contextMenuPreviewProvider(for: url, webView: webView),
+                                          actionProvider: contextMenuActionProvider(for: url, webView: webView))
+    }
 
-                    let previewViewController = UIViewController()
-                    previewViewController.view.isUserInteractionEnabled = false
-                    let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
+    private func contextMenuActionProvider(for url: URL, webView: WKWebView) -> UIContextMenuActionProvider {
+        return { [self] (suggested) -> UIMenu? in
+            guard let currentTab = tabManager.selectedTab,
+                  let contextHelper = currentTab.getContentScript(
+                    name: ContextMenuHelper.name()
+                  ) as? ContextMenuHelper,
+                  let elements = contextHelper.elements
+            else { return nil }
 
-                    previewViewController.view.addSubview(clonedWebView)
-                    NSLayoutConstraint.activate([
-                        clonedWebView.topAnchor.constraint(equalTo: previewViewController.view.topAnchor),
-                        clonedWebView.leadingAnchor.constraint(equalTo: previewViewController.view.leadingAnchor),
-                        clonedWebView.trailingAnchor.constraint(equalTo: previewViewController.view.trailingAnchor),
-                        clonedWebView.bottomAnchor.constraint(equalTo: previewViewController.view.bottomAnchor)
-                    ])
-                    clonedWebView.translatesAutoresizingMaskIntoConstraints = false
+            let isPrivate = currentTab.isPrivate
 
-                    clonedWebView.load(URLRequest(url: url))
+            let actions = createActions(isPrivate: isPrivate,
+                                        url: url,
+                                        addTab: self.addTab,
+                                        title: elements.title,
+                                        image: elements.image,
+                                        currentTab: currentTab,
+                                        webView: webView)
+            return UIMenu(title: url.absoluteString, children: actions)
+        }
+    }
 
-                    return previewViewController
-                },
-                actionProvider: { [self] (suggested) -> UIMenu? in
-                    guard let currentTab = tabManager.selectedTab,
-                          let contextHelper = currentTab.getContentScript(
-                            name: ContextMenuHelper.name()
-                          ) as? ContextMenuHelper,
-                          let elements = contextHelper.elements
-                    else { return nil }
+    private func contextMenuPreviewProvider(for url: URL, webView: WKWebView) -> UIContextMenuContentPreviewProvider? {
+        let provider: UIContextMenuContentPreviewProvider = {
+            guard self.profile.prefs.boolForKey(PrefsKeys.ContextMenuShowLinkPreviews) ?? true else { return nil }
 
-                    let isPrivate = currentTab.isPrivate
+            let previewViewController = UIViewController()
+            previewViewController.view.isUserInteractionEnabled = false
+            let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
 
-                    let actions = createActions(isPrivate: isPrivate,
-                                                url: url,
-                                                addTab: self.addTab,
-                                                title: elements.title,
-                                                image: elements.image,
-                                                currentTab: currentTab,
-                                                webView: webView)
-                    return UIMenu(title: url.absoluteString, children: actions)
-                })
-        )
+            previewViewController.view.addSubview(clonedWebView)
+            NSLayoutConstraint.pinToSuperview(clonedWebView)
+
+            clonedWebView.load(URLRequest(url: url))
+
+            return previewViewController
+        }
+        return provider
     }
 
     func addTab(rURL: URL, isPrivate: Bool, currentTab: Tab) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -189,7 +189,7 @@ extension BrowserViewController: WKUIDelegate {
             let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
 
             previewViewController.view.addSubview(clonedWebView)
-            NSLayoutConstraint.pinToSuperview(clonedWebView)
+            clonedWebView.pinToSuperview()
 
             clonedWebView.load(URLRequest(url: url))
 

--- a/firefox-ios/Client/Utils/Layout.swift
+++ b/firefox-ios/Client/Utils/Layout.swift
@@ -13,6 +13,18 @@ extension NSLayoutConstraint {
         self.priority = priority
         return self
     }
+
+    /// Convenience utility for pinning a subview to the bounds of its superview.
+    class func pinToSuperview(_ view: UIView) {
+        guard let parentView = view.superview else { return }
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: parentView.topAnchor),
+            view.leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: parentView.bottomAnchor)
+        ])
+        view.translatesAutoresizingMaskIntoConstraints = false
+    }
 }
 
 extension NSLayoutAnchor where AnchorType == NSLayoutXAxisAnchor {

--- a/firefox-ios/Client/Utils/Layout.swift
+++ b/firefox-ios/Client/Utils/Layout.swift
@@ -4,6 +4,20 @@
 
 import UIKit
 
+extension UIView {
+    /// Convenience utility for pinning a subview to the bounds of its superview.
+    func pinToSuperview() {
+        guard let parentView = superview else { return }
+        NSLayoutConstraint.activate([
+            topAnchor.constraint(equalTo: parentView.topAnchor),
+            leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
+            trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
+            bottomAnchor.constraint(equalTo: parentView.bottomAnchor)
+        ])
+        translatesAutoresizingMaskIntoConstraints = false
+    }
+}
+
 extension NSLayoutConstraint {
     /// Builder function that return a new NSLayoutConstraints with the priority set. This is useful
     /// to inline constraint creation in a call to `NSLayoutConstraint.active()`.
@@ -12,18 +26,6 @@ extension NSLayoutConstraint {
     func priority(_ priority: UILayoutPriority) -> NSLayoutConstraint {
         self.priority = priority
         return self
-    }
-
-    /// Convenience utility for pinning a subview to the bounds of its superview.
-    class func pinToSuperview(_ view: UIView) {
-        guard let parentView = view.superview else { return }
-        NSLayoutConstraint.activate([
-            view.topAnchor.constraint(equalTo: parentView.topAnchor),
-            view.leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
-            view.trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
-            view.bottomAnchor.constraint(equalTo: parentView.bottomAnchor)
-        ])
-        view.translatesAutoresizingMaskIntoConstraints = false
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10793)
[Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1933172)

## :bulb: Description

Fix for Bugzilla ticket 1933172. Addresses an issue with opening Javascript links via the long-press contextual menu.

Note: I am investigating some potential fixes for a few overlapping/related problems, in particular how we are parsing and displaying domains for some less-common URLs and schemes. Those will likely be forthcoming as part of a separate ticket, however, as it's been decided for now to address this with the simplest approach which is to customize the contextual menu when the URL scheme is `javascript`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

