### PR TITLE
Add NO_TICKET - Owners for `RemoteSettingsData/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 # those specific persons will be asked for review and not the global owners.
 /firefox-ios/Client/Experiments/initial_experiments.json @afurlan-firefox
 /firefox-ios/Client/Assets/CC_Script @nbhasin2 @issammani
+/firefox-ios/Client/Assets/RemoteSettingsData/ @nbhasin2 @issammani @mattreaganmozilla
 
 # When someone opens a pull request that only modifies those folders / files, 
 # only @mozilla-mobile/fxios-automation and not the global


### PR DESCRIPTION
## :scroll: Tickets
No tickets

## :bulb: Description
This PR adds @nbhasin2 @mattreaganmozilla  and myself as reviewers for anything under `RemoteSettingsData/`. We need this because files under that dir are updated periodically using a github action ( like this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/23107) )

## :pencil: Checklist
You have to check all boxes before merging
- [] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

