### PR TITLE
Refactor FXIOS-10669 [Sent from Firefox] Remove dead toolbar redesign share code

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -45,10 +45,6 @@ extension BrowserViewController: URLBarDelegate {
         tabManager.selectedTab?.reload()
     }
 
-    func urlBarDidPressShare(_ urlBar: URLBarView, shareView: UIView) {
-        didTapOnShare(from: shareView)
-    }
-
     internal func dismissFakespotIfNeeded(animated: Bool = true) {
         guard !contentStackView.isSidebarVisible else {
             // hide sidebar as user tapped on shopping icon for a second time

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2097,8 +2097,9 @@ class BrowserViewController: UIViewController,
         case .tabTray:
             focusOnTabSegment()
         case .share:
+            // User tapped the Share button in the toolbar
             guard let button = state.buttonTapped else { return }
-            didTapOnShare(from: button)
+            shareSelectedTab(fromShareButton: button)
         case .readerMode:
             toggleReaderMode()
         case .readerModeLongPressAction:
@@ -2334,7 +2335,9 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    func didTapOnShare(from view: UIView) {
+    /// Shares the currently selected tab via the share sheet.
+    /// - Parameter sourceView: The button to which the share sheet popover will point (iPad).
+    func shareSelectedTab(fromShareButton sourceView: UIView) {
         if !isToolbarRefactorEnabled {
             TelemetryWrapper.recordEvent(category: .action,
                                          method: .tap,
@@ -2343,15 +2346,19 @@ class BrowserViewController: UIViewController,
                                          extras: nil)
         }
 
-        if let selectedTab = tabManager.selectedTab, let tabUrl = selectedTab.canonicalURL?.displayURL {
-            navigationHandler?.showShareSheet(
-                url: tabUrl,
-                title: nil,
-                sourceView: view,
-                sourceRect: nil,
-                toastContainer: contentContainer,
-                popoverArrowDirection: isBottomSearchBar ? .down : .up)
+        guard let selectedTab = tabManager.selectedTab, let tabUrl = selectedTab.canonicalURL?.displayURL else {
+            assertionFailure("Tried to share with no selected tab or URL")
+            return
         }
+
+        navigationHandler?.showShareSheet(
+            url: tabUrl,
+            title: nil,
+            sourceView: sourceView,
+            sourceRect: nil,
+            toastContainer: contentContainer,
+            popoverArrowDirection: isBottomSearchBar ? .down : .up
+        )
     }
 
     func presentTabsLongPressAction(from view: UIView) {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -55,7 +55,6 @@ protocol URLBarDelegate: AnyObject {
     // Returns either (search query, true) or (url, false).
     func urlBarDisplayTextForURL(_ url: URL?) -> (String?, Bool)
     func urlBarDidBeginDragInteraction(_ urlBar: URLBarView)
-    func urlBarDidPressShare(_ urlBar: URLBarView, shareView: UIView)
     func urlBarPresentCFR(at sourceView: UIView)
 }
 
@@ -834,10 +833,6 @@ extension URLBarView: TabLocationViewDelegate {
 
     func tabLocationViewDidTapReaderMode(_ tabLocationView: TabLocationView) {
         delegate?.urlBarDidPressReaderMode(self)
-    }
-
-    func tabLocationViewDidTapShare(_ tabLocationView: TabLocationView, button: UIButton) {
-        delegate?.urlBarDidPressShare(self, shareView: button)
     }
 
     func tabLocationViewPresentCFR(at sourceView: UIView) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/TabLocationViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Legacy/TabLocationViewTests.swift
@@ -34,7 +34,6 @@ class MockTabLocationViewDelegate: TabLocationViewDelegate {
     func tabLocationViewDidTapReload(_ tabLocationView: TabLocationView) {}
     func tabLocationViewDidTapShield(_ tabLocationView: TabLocationView) {}
     func tabLocationViewDidBeginDragInteraction(_ tabLocationView: TabLocationView) {}
-    func tabLocationViewDidTapShare(_ tabLocationView: TabLocationView, button: UIButton) {}
     func tabLocationViewDidLongPressReaderMode(_ tabLocationView: TabLocationView) -> Bool {
         return false
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10669)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR is part of the share refactor for the Sent from Firefox experiment.

It seemed like these old share code paths were no longer needed. Naming was updated as well as there are many different ways to share content, and we need to differentiate between sharing the current selected tab and sharing a website.

This is one of several refactor PRs that are broken down into more manageable pieces.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

