### PR TITLE
Refactor FXIOS-10669 [Sent from Firefox] Cleanup dead code and tidy activity providers

### DIFF
--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -82,12 +82,6 @@ class ShareSheetCoordinator: BaseCoordinator,
         switch activityType {
         case CustomActivityAction.sendToDevice.actionType:
             showSendToDevice(url: url)
-        case CustomActivityAction.copyLink.actionType:
-            SimpleToast().showAlertWithText(
-                .LegacyAppMenu.AppMenuCopyURLConfirmMessage,
-                bottomContainer: alertContainer,
-                theme: themeManager.getCurrentTheme(for: windowUUID))
-            dequeueNotShownJSAlert()
         default:
             dequeueNotShownJSAlert()
         }

--- a/firefox-ios/Client/Frontend/Share/CustomAppActivity.swift
+++ b/firefox-ios/Client/Frontend/Share/CustomAppActivity.swift
@@ -9,14 +9,11 @@ import Shared
 // App-specific share sheet actions
 enum CustomActivityAction {
     case sendToDevice
-    case copyLink
 
     var title: String {
         switch self {
         case .sendToDevice:
             return .ShareSheet.SendToDeviceButtonTitle
-        case .copyLink:
-            return .ShareSheet.CopyButtonTitle
         }
     }
 
@@ -24,8 +21,6 @@ enum CustomActivityAction {
         switch self {
         case .sendToDevice:
             return UIImage(named: StandardImageIdentifiers.Large.deviceDesktopSend)
-        case .copyLink:
-            return UIImage(named: StandardImageIdentifiers.Large.link)
         }
     }
 
@@ -34,8 +29,6 @@ enum CustomActivityAction {
         switch self {
         case .sendToDevice:
             activityType = ".sendToDevice"
-        case .copyLink:
-            activityType = ".copyLink"
         }
 
         return UIActivity.ActivityType(rawValue: "\(AppInfo.bundleIdentifier)\(activityType)")

--- a/firefox-ios/Client/Frontend/Share/SendToDeviceActivity.swift
+++ b/firefox-ios/Client/Frontend/Share/SendToDeviceActivity.swift
@@ -5,8 +5,9 @@
 import UIKit
 import Shared
 
+/// Adds an option to share a tab to another synced device.
 class SendToDeviceActivity: CustomAppActivity {
-    // Send to device is only available for URL that are files
+    // Send to Device is only available for URLs that are not files
     override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
         return !url.isFileURL
     }

--- a/firefox-ios/Client/Frontend/Share/TitleActivityItemProvider.swift
+++ b/firefox-ios/Client/Frontend/Share/TitleActivityItemProvider.swift
@@ -16,44 +16,35 @@ import Foundation
 /// Note that not all applications use the Subject. For example OmniFocus ignores it, so we need to do both.
 
 class TitleActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
-    private let logger: Logger
+    private let title: String
 
+    /// We do not want to append titles to website URL shares to the pasteboard, Messages, and Mail body.
+    /// However, this provider will append the title to the Mail subject line.
     static let activityTypesToIgnore = [
         UIActivity.ActivityType.copyToPasteboard,
         UIActivity.ActivityType.message,
-        UIActivity.ActivityType.mail]
+        UIActivity.ActivityType.mail
+    ]
 
-    init(title: String, logger: Logger = DefaultLogger.shared) {
-        self.logger = logger
+    init(title: String) {
+        self.title = title
+
         super.init(placeholderItem: title)
     }
 
     override var item: Any {
-        if let activityType = activityType {
-            if TitleActivityItemProvider.activityTypesToIgnore.contains(activityType) {
-                return NSNull()
-            }
-        }
-        if let item = placeholderItem as? AnyObject {
-            return item
-        } else {
-            logger.log("placeholderItem is not of expected type AnyObject",
-                       level: .fatal,
-                       category: .library)
+        // For excluded activites, we don't want to provide any content
+        if let activityType = activityType, TitleActivityItemProvider.activityTypesToIgnore.contains(activityType) {
             return NSNull()
         }
+
+        return title
     }
 
     override func activityViewController(
         _ activityViewController: UIActivityViewController,
         subjectForActivityType activityType: UIActivity.ActivityType?
     ) -> String {
-        guard let placeholderString = placeholderItem as? String else {
-            logger.log("Failed to cast placeholderItem to String",
-                       level: .fatal,
-                       category: .library)
-            return ""
-        }
-        return placeholderString
+        return title
     }
 }

--- a/firefox-ios/Client/Frontend/Share/URLActivityItemProvider.swift
+++ b/firefox-ios/Client/Frontend/Share/URLActivityItemProvider.swift
@@ -8,6 +8,7 @@ import UniformTypeIdentifiers
 class URLActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
     private let url: URL
 
+    // We don't want to add this URL to Safari's Reading List
     static let excludedActivities = [
         UIActivity.ActivityType.addToReadingList,
     ]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR is part of the share refactor for the Sent from Firefox experiment.

This is one of several refactor PRs that are broken down into more manageable pieces.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

