### PR TITLE
Bugfix FXIOS-10811 [Wallpaper] [Crash] Fix async/await in networking module

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -68,4 +68,7 @@ public enum LoggerCategory: String {
 
     /// Password Generator
     case passwordGenerator
+
+    /// Related to wallpaper functionality, like fetching metadata, images, etc
+    case wallpaper
 }

--- a/firefox-ios/Client/Protocols/URLSession/URLSessionProtocol.swift
+++ b/firefox-ios/Client/Protocols/URLSession/URLSessionProtocol.swift
@@ -7,6 +7,8 @@ import Foundation
 protocol URLSessionProtocol {
     typealias DataTaskResult = (Data?, URLResponse?, Error?) -> Void
 
+    func data(from url: URL) async throws -> (Data, URLResponse)
+
     func dataTaskWith(_ url: URL,
                       completionHandler: @escaping DataTaskResult
     ) -> URLSessionDataTaskProtocol
@@ -18,6 +20,10 @@ protocol URLSessionProtocol {
 }
 
 extension URLSession: URLSessionProtocol {
+    public func data(from url: URL) async throws -> (Data, URLResponse) {
+        try await data(from: url, delegate: nil)
+    }
+
     func dataTaskWith(
         request: URLRequest,
         completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/WallpaperURLSessionMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/WallpaperURLSessionMock.swift
@@ -30,6 +30,14 @@ class WallpaperURLSessionMock: URLSessionProtocol {
         self.error = error
     }
 
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        if let error = error {
+            throw error
+        }
+
+        return (data ?? Data(), response ?? URLResponse())
+    }
+
     func dataTaskWith(_ url: URL,
                       completionHandler completion: @escaping DataTaskResult
     ) -> URLSessionDataTaskProtocol {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperNetworkingModuleTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperNetworkingModuleTests.swift
@@ -10,28 +10,41 @@ import XCTest
 class WallpaperNetworkingModuleTests: XCTestCase, WallpaperTestDataProvider {
     let url = URL(string: "my.testurl.com")!
 
-    func testResumeWasCalled() async {
-        let dataTask = WallpaperURLSessionDataTaskMock()
-        let session = WallpaperURLSessionMock(with: nil, response: nil, and: nil)
-        session.dataTask = dataTask
+    func testAsyncDataCall() async {
+        let expectedData = "Test data".data(using: .utf8)!
+        let expectedResponse = HTTPURLResponse(url: URL(string: "https://example.com")!,
+                                               statusCode: 200,
+                                               httpVersion: nil,
+                                               headerFields: nil)!
+
+        let session = WallpaperURLSessionMock(
+            with: expectedData,
+            response: expectedResponse,
+            and: nil
+        )
         let subject = WallpaperNetworkingModule(with: session)
 
-        _ = try? await subject.data(from: url)
-        XCTAssertTrue(dataTask.resumeWasCalled)
+        do {
+            let (responseData, response) = try await subject.data(from: url)
+            XCTAssertEqual(responseData, expectedData)
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        } catch {
+            XCTFail("This test should not throw an error, but it did.")
+        }
     }
 
     func testServerReturnsError() async {
+        let expectedError = URLError(.cannotConnectToHost)
         let session = WallpaperURLSessionMock(with: nil,
                                               response: nil,
-                                              and: URLError(.cannotConnectToHost))
+                                              and: expectedError)
         let subject = WallpaperNetworkingModule(with: session)
 
         do {
             _ = try await subject.data(from: url)
             XCTFail("This test should throw an error, but it did not.")
         } catch {
-            XCTAssertEqual(error as? URLError,
-                           URLError(.cannotConnectToHost))
+            XCTAssertEqual(error as? URLError, expectedError)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10811)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23594)

## :bulb: Description
Updating to xcode 16.1 may have cause an async/await issues with continuations, as per the ticket? THis attempts a fix by using a more modern approach.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

