### PR TITLE
Refactor FXIOS-10669, Bugfix FXIOS-10826, FXIOS-10749, FXIOS-10825, FXIOS-10827, FXIOS-10830 [Sent from Firefox] Refactor the ShareManager to use an explicit interface for sharing different types of content

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -48,6 +48,9 @@ public enum LoggerCategory: String {
     /// Related to the setup of services on app launch.
     case setup
 
+    /// Related to showing the share sheet from multiple places in the app.
+    case shareSheet
+
     /// Related to storage (keychain, SQL database, store of different types, etc).
     case storage
 

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1883,6 +1883,7 @@
 		ED45893E2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893D2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift */; };
 		ED4589402CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */; };
 		ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */; };
+		ED575BD32D00F9D00056BCDA /* MockTemporaryDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED575BD22D00F9D00056BCDA /* MockTemporaryDocument.swift */; };
 		ED6C8DAC2CE6A4BB00D7F7F3 /* Sentry-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = ED6C8DAB2CE6A4BB00D7F7F3 /* Sentry-Dynamic */; };
 		ED70CD812CE3BD2C0018761B /* MockStoreForMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */; };
 		ED7A08DB2CF674730035EC8F /* ShareMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A08DA2CF674730035EC8F /* ShareMessage.swift */; };
@@ -9467,6 +9468,7 @@
 		ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSearchEngineSelectionCoordinator.swift; sourceTree = "<group>"; };
 		ED5144A0BE3A8C7B15047C3F /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinatorTests.swift; sourceTree = "<group>"; };
+		ED575BD22D00F9D00056BCDA /* MockTemporaryDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTemporaryDocument.swift; sourceTree = "<group>"; };
 		ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreForMiddleware.swift; sourceTree = "<group>"; };
 		ED7A08DA2CF674730035EC8F /* ShareMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareMessage.swift; sourceTree = "<group>"; };
 		ED7A08DC2CF6749B0035EC8F /* ShareType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareType.swift; sourceTree = "<group>"; };
@@ -12843,6 +12845,7 @@
 				8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */,
 				281B2BE91ADF4D90002917DC /* MockProfile.swift */,
 				ED7A08E02CF679CE0035EC8F /* MockShareTab.swift */,
+				ED575BD22D00F9D00056BCDA /* MockTemporaryDocument.swift */,
 				8A7A26E029D4785900EA76F1 /* MockRouter.swift */,
 				C8C3FE9C29F907B30038E3BA /* MockSearchHandlerRouteCoordinator.swift */,
 				21D884402A79628E00AF144C /* MockSettingsDelegate.swift */,
@@ -17219,6 +17222,7 @@
 				8AA7347B28AEDB3100443D24 /* PocketViewModelTests.swift in Sources */,
 				C2446B312A856D13000C527D /* MockLibraryCoordinatorDelegate.swift in Sources */,
 				C869915728917809007ACC5C /* NetworkingMock.swift in Sources */,
+				ED575BD32D00F9D00056BCDA /* MockTemporaryDocument.swift in Sources */,
 				8A4190D22A6B0848001E8401 /* StatusBarOverlayTests.swift in Sources */,
 				C8EDDBF029DD83FC003A4C07 /* RouteTests.swift in Sources */,
 				0A7693612C7DD19600103A6D /* CertificatesViewModelTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1879,6 +1879,7 @@
 		ED371A682CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */; };
 		ED390D202CF4DE2E00A775F9 /* URLActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED390D1F2CF4DE2E00A775F9 /* URLActivityItemProvider.swift */; };
 		ED390D222CF4DEDB00A775F9 /* TitleSubtitleActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED390D212CF4DEDB00A775F9 /* TitleSubtitleActivityItemProvider.swift */; };
+		ED4294852CF1286E0077D7CB /* ShareManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4294842CF1286E0077D7CB /* ShareManagerTests.swift */; };
 		ED45893E2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893D2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift */; };
 		ED4589402CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */; };
 		ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */; };
@@ -9461,6 +9462,7 @@
 		ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinator.swift; sourceTree = "<group>"; };
 		ED390D1F2CF4DE2E00A775F9 /* URLActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLActivityItemProvider.swift; sourceTree = "<group>"; };
 		ED390D212CF4DEDB00A775F9 /* TitleSubtitleActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleSubtitleActivityItemProvider.swift; sourceTree = "<group>"; };
+		ED4294842CF1286E0077D7CB /* ShareManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareManagerTests.swift; sourceTree = "<group>"; };
 		ED45893D2CC800D9006F2C0B /* SearchEngineSelectionViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionViewControllerTests.swift; sourceTree = "<group>"; };
 		ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSearchEngineSelectionCoordinator.swift; sourceTree = "<group>"; };
 		ED5144A0BE3A8C7B15047C3F /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
@@ -14268,6 +14270,7 @@
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
 				8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */,
 				0ECB6B672CCFE663006A7C82 /* DateGroupedTableDataTests.swift */,
+				ED4294842CF1286E0077D7CB /* ShareManagerTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -17315,6 +17318,7 @@
 				5A9A09D428B01D8700B6F51E /* MockTelemetryWrapper.swift in Sources */,
 				C80C11F028B3C9150062922A /* MockUserDefaults.swift in Sources */,
 				D8BA1790206D47830023AC00 /* DeferredTestUtils.swift in Sources */,
+				ED4294852CF1286E0077D7CB /* ShareManagerTests.swift in Sources */,
 				5AA75A652A46274A00533F8D /* MockThemeManager.swift in Sources */,
 				8A5038142A5DFCE000A1B02A /* MockBrowserProfile.swift in Sources */,
 				C23889E52A50329200429673 /* MockParentCoordinator.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1100,23 +1100,22 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - Private helpers
 
-    private func tryDownloadingTabFileToShare(shareType: ShareType) async -> ShareType  {
+    private func tryDownloadingTabFileToShare(shareType: ShareType) async -> ShareType {
         return await withCheckedContinuation({(continuation: CheckedContinuation<ShareType, Never>) in
-            // FIXME: BUT!! A tab might be displaying a downloaded PDF! Then it's file:// url. Where is this handled?
+            // We can only try to download files for `.tab` type shares that have a TemporaryDocument
             guard case let ShareType.tab(_, tab) = shareType,
                   let temporaryDocument = tab.temporaryDocument else {
-                // We can only try to download files for tab type shares that have a TemporaryDocument
                 continuation.resume(returning: shareType)
                 return
             }
 
             temporaryDocument.getURL { tempDocURL in
                 DispatchQueue.main.async {
-                    // If we successfully got a temp file URL, share it like a downloaded file, otherwise present the
-                    // ordinary share menu for the tab.
                     if let tempDocURL = tempDocURL, tempDocURL.isFileURL {
-                        continuation.resume(returning: ShareType.file(url: tempDocURL))
+                        // If we successfully got a temp file URL, share it like a downloaded file
+                        continuation.resume(returning: .file(url: tempDocURL))
                     } else {
+                        // If no file was downloaded, simply share the tab as usual
                         continuation.resume(returning: shareType)
                     }
                 }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -559,21 +559,16 @@ class BrowserCoordinator: BaseCoordinator,
         browserViewController.updateZoomPageBarVisibility(visible: true)
     }
 
-    func showShareSheet(with url: URL?) {
-        // Note: From New Menu > Share   MainMenuCoordinatorDelegate
-        guard let url else { return }
-
-        let shareType: ShareType
-        if let selectedTab = tabManager.selectedTab {
-            shareType = .tab(url: url, tab: selectedTab)
-        } else {
-            shareType = .site(url: url)
+    /// Share the currently selected tab using the share sheet.
+    /// Note: MainMenuCoordinatorDelegate implementation, called from the New Menu > Tools > Share.
+    func showShareSheetForCurrentlySelectedTab() {
+        guard let selectedTab = tabManager.selectedTab,
+              let url = selectedTab.canonicalURL else { // TODO check reader mode URLs... add .displayURL here?
+            return
         }
 
-        // TODO handle temp document?
-
         startShareSheetCoordinator(
-            shareType: shareType,
+            shareType: .tab(url: url, tab: selectedTab),
             shareMessage: nil,
             sourceView: self.browserViewController.addressToolbarContainer,
             sourceRect: nil,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -663,6 +663,7 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     // MARK: - BrowserNavigationHandler
+
     func showShareSheet(
         shareType: ShareType,
         shareMessage: ShareMessage?,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -775,7 +775,13 @@ class BrowserCoordinator: BaseCoordinator,
     ) {
         if let coordinator = childCoordinators.first(where: { $0 is ShareSheetCoordinator }) as? ShareSheetCoordinator {
             // The share sheet extension coordinator wasn't correctly removed in the last share session. Attempt to recover.
-            // FIXME: Log this...
+            logger.log(
+                "ShareSheetCoordinator already exists when it shouldn't. Removing and recreating it to access share sheet",
+                level: .info,
+                category: .shareSheet,
+                extra: ["existing ShareSheetCoordinator UUID": "\(coordinator.windowUUID)",
+                        "BrowserCoordinator windowUUID": "\(windowUUID)"]
+            )
 
             coordinator.dismiss()
         }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -809,9 +809,8 @@ class BrowserCoordinator: BaseCoordinator,
         }
 
         Task {
-            // FIXME: Can we replicate Safari share behaviour here instead, grabbing the file from the Tab if it's available,
-            // otherwise just sharing the URL so we don't have this buggy latency???? It's strange if the user has to wait
-            // a long time to download files.
+            // FXIOS-10824 It's strange if the user has to wait a long time to download files that are literally already
+            // being shown in the webview.
             var overrideShareType = shareType
             if case ShareType.tab = shareType {
                 overrideShareType = await tryDownloadingTabFileToShare(shareType: shareType)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -764,8 +764,8 @@ class BrowserCoordinator: BaseCoordinator,
         )
         add(child: shareSheetCoordinator)
         shareSheetCoordinator.start(
-            url: url,
-            title: title,
+            shareType: .site(url: url), // FIXME Need correct shareType, shareMessage passed in
+            shareMessage: nil,
             sourceView: sourceView,
             sourceRect: sourceRect,
             popoverArrowDirection: popoverArrowDirection

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -398,9 +398,9 @@ class BrowserCoordinator: BaseCoordinator,
         startShareSheetCoordinator(
             shareType: shareType,
             shareMessage: shareMessage,
-            sourceView: self.browserViewController.addressToolbarContainer,
+            sourceView: browserViewController.addressToolbarContainer,
             sourceRect: nil,
-            toastContainer: self.browserViewController.contentContainer,
+            toastContainer: browserViewController.contentContainer,
             popoverArrowDirection: .any
         )
     }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -772,11 +772,11 @@ class BrowserCoordinator: BaseCoordinator,
         toastContainer: UIView,
         popoverArrowDirection: UIPopoverArrowDirection
     ) {
-        guard childCoordinators.first(where: { $0 is ShareSheetCoordinator }) as? ShareSheetCoordinator == nil else {
-            // If this case is hitted it means the share extension coordinator wasn't removed
-            // correctly in the previous session.
+        if let coordinator = childCoordinators.first(where: { $0 is ShareSheetCoordinator }) as? ShareSheetCoordinator {
+            // The share sheet extension coordinator wasn't correctly removed in the last share session. Attempt to recover.
             // FIXME: Log this...
-            return
+
+            coordinator.dismiss()
         }
 
         Task {

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -389,8 +389,12 @@ class BrowserCoordinator: BaseCoordinator,
         browserViewController.presentSignInViewController(fxaParams)
     }
 
+    /// Starts the share sheet coordinator for the deep link `.sharesheet` route (share content via Nimbus Messaging).
+    /// - Parameters:
+    ///   - shareType: The content to share.
+    ///   - shareMessage: An optional textual message to accompany the shared content. May contain a Mail subject line.
     private func handleShareRoute(shareType: ShareType, shareMessage: ShareMessage?) {
-        // FIXME What should the sourceView be for deep links? Can we make it optional?
+        // FIXME: FXIOS-10829 Deep link shares should set a reasonable sourceView for iPad... or sourceView could be optional
         startShareSheetCoordinator(
             shareType: shareType,
             shareMessage: shareMessage,
@@ -768,9 +772,11 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     /// Starts the ShareSheetCoordinator, which initiates opening the iOS share sheet using an `UIActivityViewController`.
+    ///
     /// For shared tabs where the user is currently on a non-HTML page (e.g. viewing a PDF), this method will initiate a
-    /// file download, and then share the file instead. This currently blocks without any save indication, which is less
-    /// than ideal but has been the existing behaviour for a long time (task to address this: FXIOS-10823)
+    /// file download, and then share the file instead. This currently blocks without any UI indication, which is less
+    /// than ideal but has been the existing behaviour for a long time (task to address this: FXIOS-10823).
+    ///
     /// - Parameters:
     ///   - shareType: The type of content to share.
     ///   - shareMessage: An optional accompanying message to share (with optional email subject line).
@@ -780,13 +786,14 @@ class BrowserCoordinator: BaseCoordinator,
     ///   - toastContainer: The container for displaying toast information.
     ///   - popoverArrowDirection: The arrow direction for iPad share sheet popovers.
     ///
-    /// There are many ways to share many types of content from various areas of the app. A few code paths that go through
-    /// this method include:
+    /// There are many ways to share many types of content from various areas of the app. Code paths that go through this
+    /// method include:
     /// * Sharing content from a long press on Home screen tiles (e.g. long press Jump Back In context menu)
     /// * From the old Menu > Share and the new Menu > Tools > Share
     /// * From the new toolbar share button beside the address bar
     /// * From long pressing a link in the WKWebView and sharing from the context menu (via ActionProviderBuilder > addShare)
     /// * Via the sharesheet deeplink path in `RouteBuilder` (e.g. tapping home cards that initiate sharing content)
+    ///     * Currently this is the only path that is using the ShareMessage param (Info Card Referral experiment FXE-1090)
     func startShareSheetCoordinator(
         shareType: ShareType,
         shareMessage: ShareMessage?,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -27,13 +27,14 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 
     /// Shows the share sheet.
     ///
-    /// - Parameter url: The url to be shared.
+    /// - Parameter shareType: The content to be shared.
+    /// - Parameter shareMessage: An optional plain text message to be shared.
     /// - Parameter sourceView: The reference view to show the popoverViewController.
     /// - Parameter sourceRect: An optional rect to use for ipad popover presentation.
     /// - Parameter toastContainer: The view in which is displayed the toast results from actions in the share extension.
     /// - Parameter popoverArrowDirection: The arrow direction for the view controller presented as popover.
-    func showShareSheet(url: URL,
-                        title: String?,
+    func showShareSheet(shareType: ShareType,
+                        shareMessage: ShareMessage?,
                         sourceView: UIView,
                         sourceRect: CGRect?,
                         toastContainer: UIView,

--- a/firefox-ios/Client/Coordinators/Library/DownloadsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/DownloadsCoordinator.swift
@@ -49,7 +49,19 @@ class DownloadsCoordinator: BaseCoordinator,
     }
 
     private func startShare(file: DownloadedFile, sourceView: UIView) {
-        guard !childCoordinators.contains(where: { $0 is ShareSheetCoordinator }) else { return }
+        if let coordinator = childCoordinators.first(where: { $0 is ShareSheetCoordinator }) as? ShareSheetCoordinator {
+            // The share sheet extension coordinator wasn't correctly removed in the last share session. Attempt to recover.
+            logger.log(
+                "ShareSheetCoordinator already exists when it shouldn't. Removing and recreating it to access share sheet",
+                level: .info,
+                category: .shareSheet,
+                extra: ["existing ShareSheetCoordinator UUID": "\(coordinator.windowUUID)",
+                        "DownloadsCoordinator windowUUID": "N/A"]
+            )
+
+            coordinator.dismiss()
+        }
+
         let coordinator = ShareSheetCoordinator(
             alertContainer: UIView(),
             router: router,

--- a/firefox-ios/Client/Coordinators/Library/DownloadsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/DownloadsCoordinator.swift
@@ -50,11 +50,6 @@ class DownloadsCoordinator: BaseCoordinator,
 
     private func startShare(file: DownloadedFile, sourceView: UIView) {
         guard !childCoordinators.contains(where: { $0 is ShareSheetCoordinator }) else { return }
-        let coordinator = makeShareSheetCoordinator()
-        coordinator.start(url: file.path, sourceView: sourceView)
-    }
-
-    private func makeShareSheetCoordinator() -> ShareSheetCoordinator {
         let coordinator = ShareSheetCoordinator(
             alertContainer: UIView(),
             router: router,
@@ -63,7 +58,13 @@ class DownloadsCoordinator: BaseCoordinator,
             tabManager: tabManager
         )
         add(child: coordinator)
-        return coordinator
+        coordinator.start(
+            shareType: .file(url: file.path),
+            shareMessage: nil,
+            sourceView: sourceView,
+            sourceRect: nil,
+            popoverArrowDirection: .any
+        )
     }
 
     func showDocument(file: DownloadedFile) {

--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -93,8 +93,17 @@ class LibraryCoordinator: BaseCoordinator,
 
     func shareLibraryItem(url: URL, sourceView: UIView) {
         guard !childCoordinators.contains(where: { $0 is ShareSheetCoordinator }) else { return }
-        let coordinator = makeShareSheetCoordinator()
-        coordinator.start(url: url, sourceView: sourceView)
+        let coordinator = ShareSheetCoordinator(
+            alertContainer: UIView(),
+            router: router,
+            profile: profile,
+            parentCoordinator: self,
+            tabManager: tabManager
+        )
+        add(child: coordinator)
+
+        // Note: Called from history, bookmarks, reading list long presses
+        coordinator.start(shareType: .site(url: url), shareMessage: nil, sourceView: sourceView)
     }
 
     private func makeBookmarksCoordinator(navigationController: UINavigationController) {
@@ -164,18 +173,6 @@ class LibraryCoordinator: BaseCoordinator,
 
     func didFinish(from childCoordinator: any Coordinator) {
         remove(child: childCoordinator)
-    }
-
-    private func makeShareSheetCoordinator() -> ShareSheetCoordinator {
-        let coordinator = ShareSheetCoordinator(
-            alertContainer: UIView(),
-            router: router,
-            profile: profile,
-            parentCoordinator: self,
-            tabManager: tabManager
-        )
-        add(child: coordinator)
-        return coordinator
     }
 
     // MARK: - LibraryPanelDelegate

--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -132,6 +132,7 @@ final class RouteBuilder {
                 // Pass optional share message and subtitle here
                 var shareMessage: ShareMessage?
                 if let titleText = urlScanner.value(query: "title") {
+                    // TODO: FXIOS-10629 Get the optional subtitle parameter 
                     shareMessage = ShareMessage(message: titleText, subtitle: nil)
                 }
 

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -85,9 +85,16 @@ class ShareSheetCoordinator: BaseCoordinator,
         relatedTab: Tab?
     ) {
         // NOTE: didFinish will be called on each of these code paths to properly dismiss the share sheet.
+        // FIXME: FXIOS-10334 It's mysterious that we are calling dequeueNotShownJSAlert in the share coordinator. It may not
+        // be necessary, but this JS alert code is fragile right now so let's not touch it until FXIOS-10334 is underway.
         switch activityType {
         case CustomActivityAction.sendToDevice.actionType:
-            // Can only reach here for non-file shares
+            // Cannot send file:// URLs to another synced device
+            guard !shareType.wrappedURL.isFileURL else {
+                dequeueNotShownJSAlert()
+                return
+            }
+
             switch shareType {
             case let .tab(_, tab):
                 showSendToDevice(url: shareType.wrappedURL, relatedTab: tab)
@@ -96,8 +103,6 @@ class ShareSheetCoordinator: BaseCoordinator,
             }
 
         default:
-            // FIXME: FXIOS-10334 It's mysterious that we are calling this in the share coordinator. It may not be necessary,
-            // but this JS alert code is very brittle right now so let's not touch it until FXIOS-10334 is underway.
             dequeueNotShownJSAlert()
         }
     }

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -106,6 +106,11 @@ class ShareSheetCoordinator: BaseCoordinator,
         parentCoordinator?.didFinish(from: self)
     }
 
+    /// Shows the view controller that allows users to send this URL to one of their synced devices running Firefox.
+    /// - Parameters:
+    ///   - url: The URL to send.
+    ///   - relatedTab: The tab associated with this URL. Will be used to provide the displayURL and displayTitle if set.
+    ///                 Should be nil if the url to be sent is NOT related to a specific tab (e.g. a bookmark URL).
     private func showSendToDevice(url: URL, relatedTab: (any ShareTab)?) {
         let shareItem: ShareItem
         if let relatedTab, let url = relatedTab.canonicalURL?.displayURL {

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -88,7 +88,12 @@ class ShareSheetCoordinator: BaseCoordinator,
         switch activityType {
         case CustomActivityAction.sendToDevice.actionType:
             // Can only reach here for non-file shares
-            showSendToDevice(url: shareType.wrappedURL, relatedTab: relatedTab)
+            switch shareType {
+            case let .tab(_, tab):
+                showSendToDevice(url: shareType.wrappedURL, relatedTab: tab)
+            default:
+                showSendToDevice(url: shareType.wrappedURL, relatedTab: nil)
+            }
 
         default:
             // FIXME: FXIOS-10334 It's mysterious that we are calling this in the share coordinator. It may not be necessary,
@@ -101,10 +106,10 @@ class ShareSheetCoordinator: BaseCoordinator,
         parentCoordinator?.didFinish(from: self)
     }
 
-    private func showSendToDevice(url: URL, relatedTab: Tab?) {
+    private func showSendToDevice(url: URL, relatedTab: (any ShareTab)?) {
         let shareItem: ShareItem
         if let relatedTab, let url = relatedTab.canonicalURL?.displayURL {
-            shareItem = ShareItem(url: url.absoluteString, title: relatedTab.title)
+            shareItem = ShareItem(url: url.absoluteString, title: relatedTab.displayTitle)
         } else {
             shareItem = ShareItem(url: url.absoluteString, title: nil)
         }

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -117,6 +117,7 @@ class ShareSheetCoordinator: BaseCoordinator,
     ///   - relatedTab: The tab associated with this URL. Will be used to provide the displayURL and displayTitle if set.
     ///                 Should be nil if the url to be sent is NOT related to a specific tab (e.g. a bookmark URL).
     private func showSendToDevice(url: URL, relatedTab: (any ShareTab)?) {
+        // TODO: FXIOS-10831 harden this code path to ensure we don't ever share a reader mode localhost URL
         let shareItem: ShareItem
         if let relatedTab, let url = relatedTab.canonicalURL?.displayURL {
             shareItem = ShareItem(url: url.absoluteString, title: relatedTab.displayTitle)

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -18,7 +18,7 @@ class ShareSheetCoordinator: BaseCoordinator,
     private let profile: Profile
     private let alertContainer: UIView
     private weak var parentCoordinator: ParentCoordinatorDelegate?
-    private var windowUUID: WindowUUID { return tabManager.windowUUID }
+    var windowUUID: WindowUUID { return tabManager.windowUUID }
 
     // MARK: - Initializers
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
@@ -114,11 +114,12 @@ class ActionProviderBuilder {
                   let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper
             else { return }
 
+            // Shares from long-pressing a URL in the webview
             // This is only used on ipad for positioning the popover. On iPhone it is an action sheet.
             let point = webView.convert(helper.touchPoint, to: view)
             navigationHandler?.showShareSheet(
-                url: url,
-                title: nil,
+                shareType: .site(url: url), // FIXME: Not a tab since the link could be external to the current tab right?
+                shareMessage: nil,
                 sourceView: view,
                 sourceRect: CGRect(origin: point, size: CGSize(width: 10.0, height: 10.0)),
                 toastContainer: contentContainer,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
@@ -114,11 +114,12 @@ class ActionProviderBuilder {
                   let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper
             else { return }
 
-            // Shares from long-pressing a URL in the webview
-            // This is only used on ipad for positioning the popover. On iPhone it is an action sheet.
+            // The `point` is only used on ipad for positioning the popover. On iPhone it is an bottom sheet.
             let point = webView.convert(helper.touchPoint, to: view)
+
+            // Shares from long-pressing a link in the webview and tapping Share in the context menu
             navigationHandler?.showShareSheet(
-                shareType: .site(url: url), // FIXME: Not a tab since the link could be external to the current tab right?
+                shareType: .site(url: url), // NOT a `.tab` share, as the link might be to a different domain from the tab
                 shareMessage: nil,
                 sourceView: view,
                 sourceRect: CGRect(origin: point, size: CGSize(width: 10.0, height: 10.0)),

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
@@ -119,7 +119,7 @@ class ActionProviderBuilder {
 
             // Shares from long-pressing a link in the webview and tapping Share in the context menu
             navigationHandler?.showShareSheet(
-                shareType: .site(url: url), // NOT a `.tab` share, as the link might be to a different domain from the tab
+                shareType: .site(url: url), // NOT `.tab` share; the link might be to a different domain from the current tab
                 shareMessage: nil,
                 sourceView: view,
                 sourceRect: CGRect(origin: point, size: CGSize(width: 10.0, height: 10.0)),

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -636,7 +636,7 @@ extension BrowserViewController: WKNavigationDelegate {
             let group = DispatchGroup()
             var url: URL?
             group.enter()
-            let temporaryDocument = TemporaryDocument(preflightResponse: response, request: request)
+            let temporaryDocument = DefaultTemporaryDocument(preflightResponse: response, request: request)
             temporaryDocument.getURL(completionHandler: { docURL in
                 url = docURL
                 group.leave()
@@ -711,7 +711,7 @@ extension BrowserViewController: WKNavigationDelegate {
         // representative of the contents of the web view.
         if navigationResponse.isForMainFrame, let tab = tabManager[webView] {
             if response.mimeType != MIMEType.HTML, let request = request {
-                tab.temporaryDocument = TemporaryDocument(preflightResponse: response, request: request)
+                tab.temporaryDocument = DefaultTemporaryDocument(preflightResponse: response, request: request)
             } else {
                 tab.temporaryDocument = nil
             }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2354,7 +2354,7 @@ class BrowserViewController: UIViewController,
         navigationHandler?.showShareSheet(
             shareType: .tab(url: tabUrl, tab: selectedTab),
             shareMessage: nil,
-            sourceView: view,
+            sourceView: sourceView,
             sourceRect: nil,
             toastContainer: contentContainer,
             popoverArrowDirection: isBottomSearchBar ? .down : .up)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2352,13 +2352,12 @@ class BrowserViewController: UIViewController,
         }
 
         navigationHandler?.showShareSheet(
-            url: tabUrl,
-            title: nil,
-            sourceView: sourceView,
+            shareType: .tab(url: tabUrl, tab: selectedTab),
+            shareMessage: nil,
+            sourceView: view,
             sourceRect: nil,
             toastContainer: contentContainer,
-            popoverArrowDirection: isBottomSearchBar ? .down : .up
-        )
+            popoverArrowDirection: isBottomSearchBar ? .down : .up)
     }
 
     func presentTabsLongPressAction(from view: UIView) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2346,7 +2346,9 @@ class BrowserViewController: UIViewController,
                                          extras: nil)
         }
 
-        guard let selectedTab = tabManager.selectedTab, let tabUrl = selectedTab.canonicalURL?.displayURL else {
+        // We share the tab's displayURL to make sure we don't share reader mode localhost URLs
+        guard let selectedTab = tabManager.selectedTab,
+              let tabUrl = selectedTab.canonicalURL?.displayURL else {
             assertionFailure("Tried to share with no selected tab or URL")
             return
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2353,6 +2353,8 @@ class BrowserViewController: UIViewController,
             return
         }
 
+        /// Note: If the user is viewing a _downloaded_ (not online) PDF in the browser, then the current tab's URL will
+        /// have a `file://` scheme.
         navigationHandler?.showShareSheet(
             shareType: .tab(url: tabUrl, tab: selectedTab),
             shareMessage: nil,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -16,7 +16,9 @@ protocol MainMenuCoordinatorDelegate: AnyObject {
     func showFindInPage()
     func showSignInView(fxaParameters: FxASignInViewParameters?)
     func updateZoomPageBarVisibility()
-    func showShareSheet(with url: URL?)
+
+    /// Open the share sheet to share the currently selected `Tab` and its URL.
+    func showShareSheetForCurrentlySelectedTab()
 }
 
 class MainMenuCoordinator: BaseCoordinator, FeatureFlaggable {
@@ -131,7 +133,7 @@ class MainMenuCoordinator: BaseCoordinator, FeatureFlaggable {
                 )
                 self.navigationHandler?.showSignInView(fxaParameters: fxaParameters)
             case .shareSheet:
-                self.navigationHandler?.showShareSheet(with: destination.url)
+                self.navigationHandler?.showShareSheetForCurrentlySelectedTab()
             case .zoom:
                 self.navigationHandler?.updateZoomPageBarVisibility()
             }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -17,7 +17,7 @@ protocol MainMenuCoordinatorDelegate: AnyObject {
     func showSignInView(fxaParameters: FxASignInViewParameters?)
     func updateZoomPageBarVisibility()
 
-    /// Open the share sheet to share the currently selected `Tab` and its URL.
+    /// Open the share sheet to share the currently selected `Tab`.
     func showShareSheetForCurrentlySelectedTab()
 }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -588,7 +588,10 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func getShareAction() -> PhotonRowActions {
         return SingleActionViewModel(title: .LegacyAppMenu.Share,
                                      iconString: StandardImageIdentifiers.Large.share) { _ in
-            guard let tab = self.selectedTab, let url = tab.canonicalURL?.displayURL else { return }
+            // We share the tab's displayURL to make sure we don't share reader mode localhost URLs
+            guard let tab = self.selectedTab,
+                  let url = tab.canonicalURL?.displayURL
+            else { return }
 
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
             self.navigationHandler?.showShareSheet(

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -591,36 +591,14 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             guard let tab = self.selectedTab, let url = tab.canonicalURL?.displayURL else { return }
 
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
-
-            guard let temporaryDocument = tab.temporaryDocument else {
-                self.navigationHandler?.showShareSheet(
-                    url: url,
-                    title: nil,
-                    sourceView: self.buttonView,
-                    sourceRect: nil,
-                    toastContainer: self.toastContainer,
-                    popoverArrowDirection: .any)
-                return
-            }
-
-            temporaryDocument.getURL { tempDocURL in
-                DispatchQueue.main.async {
-                    // If we successfully got a temp file URL, share it like a downloaded file,
-                    // otherwise present the ordinary share menu for the web URL.
-                    if let tempDocURL = tempDocURL,
-                       tempDocURL.isFileURL {
-                        self.share(fileURL: tempDocURL, buttonView: self.buttonView)
-                    } else {
-                        self.navigationHandler?.showShareSheet(
-                            url: url,
-                            title: nil,
-                            sourceView: self.buttonView,
-                            sourceRect: nil,
-                            toastContainer: self.toastContainer,
-                            popoverArrowDirection: .any)
-                    }
-                }
-            }
+            self.navigationHandler?.showShareSheet(
+                shareType: .tab(url: url, tab: tab),
+                shareMessage: nil,
+                sourceView: self.buttonView,
+                sourceRect: nil,
+                toastContainer: self.toastContainer,
+                popoverArrowDirection: .any
+            )
         }.items
     }
 
@@ -642,8 +620,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     private func share(fileURL: URL, buttonView: UIView) {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
         navigationHandler?.showShareSheet(
-            url: fileURL,
-            title: nil,
+            shareType: .file(url: fileURL),
+            shareMessage: nil,
             sourceView: buttonView,
             sourceRect: nil,
             toastContainer: toastContainer,

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -620,6 +620,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
     /// Share the URL of a downloaded file (e.g. either a user-downloaded file being viewed in the webView, or a link with a
     /// non-HTML MIME type currently opened in the webView, such as a PDF).
+    /// NOTE: Called from getShareFileAction (files in the browser) and getShareAction (websites)
     private func share(fileURL: URL, buttonView: UIView) {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .sharePageWith)
         navigationHandler?.showShareSheet(

--- a/firefox-ios/Client/Frontend/Browser/TemporaryDocument.swift
+++ b/firefox-ios/Client/Frontend/Browser/TemporaryDocument.swift
@@ -7,7 +7,11 @@ import Shared
 
 private let temporaryDocumentOperationQueue = OperationQueue()
 
-class TemporaryDocument: NSObject {
+protocol TemporaryDocument {
+    func getURL(completionHandler: @escaping ((URL?) -> Void))
+}
+
+class DefaultTemporaryDocument: NSObject, TemporaryDocument {
     fileprivate let request: URLRequest
     fileprivate let filename: String
 

--- a/firefox-ios/Client/Frontend/Browser/TemporaryDocument.swift
+++ b/firefox-ios/Client/Frontend/Browser/TemporaryDocument.swift
@@ -40,6 +40,8 @@ class DefaultTemporaryDocument: NSObject, TemporaryDocument {
         }
     }
 
+    // FIXME: FXIOS-10830 If we call this inside a continuation (as in BrowserCoordinator), is it possible we may have a
+    // crash similar to the one fixed in https://github.com/mozilla-mobile/firefox-ios/pull/23596
     func getURL(completionHandler: @escaping ((URL?) -> Void)) {
         if let url = localFileURL {
             completionHandler(url)

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -249,8 +249,8 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
             guard let url = URL(string: site.url, invalidCharacters: false) else { return }
 
             self.browserNavigationHandler?.showShareSheet(
-                url: url,
-                title: nil,
+                shareType: .site(url: url),
+                shareMessage: nil,
                 sourceView: sourceView ?? UIView(),
                 sourceRect: nil,
                 toastContainer: self.toastContainer,

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -156,13 +156,13 @@ class DownloadsPanel: UIViewController,
     }
 
     private func shareDownloadedFile(_ downloadedFile: DownloadedFile, indexPath: IndexPath) {
-        let shareActivityViewcontroller = ShareManager.createActivityViewController(
+        let shareActivityViewController = ShareManager.createActivityViewController(
             shareType: .file(url: downloadedFile.path),
             shareMessage: nil,
             completionHandler: { _, _ in }
         )
 
-        if let popoverPresentationController = shareActivityViewcontroller.popoverPresentationController {
+        if let popoverPresentationController = shareActivityViewController.popoverPresentationController {
             guard let tableViewCell = tableView.cellForRow(at: indexPath) else { return }
 
             popoverPresentationController.sourceView = tableViewCell
@@ -170,7 +170,7 @@ class DownloadsPanel: UIViewController,
             popoverPresentationController.permittedArrowDirections = .any
         }
 
-        present(shareActivityViewcontroller, animated: true, completion: nil)
+        present(shareActivityViewController, animated: true, completion: nil)
     }
 
     private func iconForFileExtension(_ fileExtension: String) -> UIImage? {

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -156,10 +156,13 @@ class DownloadsPanel: UIViewController,
     }
 
     private func shareDownloadedFile(_ downloadedFile: DownloadedFile, indexPath: IndexPath) {
-        let helper = ShareManager(url: downloadedFile.path, tab: nil)
-        let controller = helper.createActivityViewController { _, _ in }
+        let shareActivityViewcontroller = ShareManager.createActivityViewController(
+            shareType: .file(url: downloadedFile.path),
+            shareMessage: nil,
+            completionHandler: { _, _ in }
+        )
 
-        if let popoverPresentationController = controller.popoverPresentationController {
+        if let popoverPresentationController = shareActivityViewcontroller.popoverPresentationController {
             guard let tableViewCell = tableView.cellForRow(at: indexPath) else { return }
 
             popoverPresentationController.sourceView = tableViewCell
@@ -167,7 +170,7 @@ class DownloadsPanel: UIViewController,
             popoverPresentationController.permittedArrowDirections = .any
         }
 
-        present(controller, animated: true, completion: nil)
+        present(shareActivityViewcontroller, animated: true, completion: nil)
     }
 
     private func iconForFileExtension(_ fileExtension: String) -> UIImage? {

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -96,11 +96,6 @@ class ShareManager: NSObject, FeatureFlaggable {
             // webpage or adding a website to the iOS home screen
             activityItems.append(URLActivityItemProvider(url: siteURL))
 
-            // FIXME: Check for reader mode URLs?
-            //            // Return the URL for the selected tab. If we are in reader view then decode
-            //            // it so that we copy the original and not the internal localhost one.
-            //            return url.isReaderModeURL ? url.decodeReaderModeURL : url
-
             // Only show the print activity if the tab's webview is loaded
             if tab.webView != nil {
                 activityItems.append(

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -106,8 +106,8 @@ class ShareManager: NSObject, FeatureFlaggable {
 
             // Add the webview for an option to add a website to the iOS home screen
             if #available(iOS 16.4, *), let webView = tab.webView {
-                // NOTE: You will not see "Add to Home Screen" option on debug builds. Possibility this is because of how the
-                // com.apple.developer.web-browser entitelement is applied...
+                // NOTE: You will not see "Add to Home Screen" option on debug builds. Possibly this is because of how the
+                // com.apple.developer.web-browser entitlement is applied...
                 activityItems.append(webView)
             }
 

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -9,39 +9,34 @@ import WebKit
 import UniformTypeIdentifiers
 
 class ShareManager: NSObject, FeatureFlaggable {
-    private weak var selectedTab: Tab?
+    // TODO: FXIOS-10582 not the real URL we want to use, those are still being finalized
+    static let downloadFirefoxAppStoreURL = URL(string: "https://mzl.la/3NDxAIS")!
 
-    private let url: URL
-    private let title: String?
-    private var onePasswordExtensionItem: NSExtensionItem!
-    private let browserFillIdentifier = "org.appextension.fill-browser-action"
-    private let pocketIconExtension = "com.ideashower.ReadItLaterPro.AddToPocketExtension"
-    private let pocketActionExtension = "com.ideashower.ReadItLaterPro.Action-Extension"
-
-    private var excludingActivities: [UIActivity.ActivityType] {
-        return [UIActivity.ActivityType.addToReadingList]
+    private struct ActivityIdentifiers {
+        static let browserFill = "org.appextension.fill-browser-action"
+        static let pocketIconExtension = "com.ideashower.ReadItLaterPro.AddToPocketExtension"
+        static let pocketActionExtension = "com.ideashower.ReadItLaterPro.Action-Extension"
+        // FIXME: Should this be com.apple.UIKit.activity.RemoteOpenInApplication-ByCopy ?
+        static let isOpenByCopy = "remoteopeninapplication-bycopy"
+        static let whatsApp = "net.whatsapp.WhatsApp.ShareExtension"
     }
 
-    // Can be a file:// or http(s):// url
-    init(url: URL, title: String? = nil, tab: Tab?) {
-        self.url = url
-        self.title = title
-        self.selectedTab = tab
-    }
+    // Black list for activities to which we don't want to share
+    private static let excludingActivities: [UIActivity.ActivityType] = [
+        UIActivity.ActivityType.addToReadingList
+    ]
 
-    func createActivityViewController(
-        _ webView: WKWebView? = nil,
+    static func createActivityViewController(
+        shareType: ShareType,
+        shareMessage: ShareMessage?,
         completionHandler: @escaping (
             _ completed: Bool,
             _ activityType: UIActivity.ActivityType?
         ) -> Void
     ) -> UIActivityViewController {
-        var activityItems = getActivityItems(url: url)
-        // Note: webview is required for adding websites to the iOS home screen
-        if #available(iOS 16.4, *), let webView = webView {
-            activityItems.append(webView)
-        }
-        let appActivities = getApplicationActivities()
+        let activityItems = getActivityItems(forShareType: shareType, withExplicitShareMessage: shareMessage)
+        let appActivities = getApplicationActivities(forShareType: shareType)
+
         let activityViewController = UIActivityViewController(
             activityItems: activityItems,
             applicationActivities: appActivities
@@ -56,13 +51,13 @@ class ShareManager: NSObject, FeatureFlaggable {
             }
 
             // Add telemetry for Pocket activityType
-            if activityType?.rawValue == self.pocketIconExtension {
+            if activityType?.rawValue == ActivityIdentifiers.pocketIconExtension {
                 TelemetryWrapper.recordEvent(category: .action,
                                              method: .tap,
                                              object: .shareSheet,
                                              value: .sharePocketIcon,
                                              extras: nil)
-            } else if activityType?.rawValue == self.pocketActionExtension {
+            } else if activityType?.rawValue == ActivityIdentifiers.pocketActionExtension {
                 TelemetryWrapper.recordEvent(category: .action,
                                              method: .tap,
                                              object: .shareSheet,
@@ -76,104 +71,75 @@ class ShareManager: NSObject, FeatureFlaggable {
         return activityViewController
     }
 
-    /// Get the data to be shared if the URL is a file we will share just the url if not we prepare
-    /// UIPrintInfo to get the option to print the page and tab URL and title
-    /// - Parameter url: url from the selected tab
-    /// - Returns: An array of elements to be shared
-    private func getActivityItems(url: URL) -> [Any] {
-        // If url is file return only url to be shared
-        guard !url.isFileURL else { return [url] }
+    static func getActivityItems(
+        forShareType shareType: ShareType,
+        withExplicitShareMessage explicitShareMessage: ShareMessage?
+    ) -> [Any] {
+        var activityItems: [Any] = []
 
-        var activityItems = [Any]()
+        switch shareType {
+        case .file(let fileURL):
+            activityItems.append(URLActivityItemProvider(url: fileURL))
 
-        // Add the title (if it exists)
-        if let title = self.title {
-            activityItems.append(title)
-        }
+            if let explicitShareMessage {
+                activityItems.append(TitleSubtitleActivityItemProvider(shareMessage: explicitShareMessage))
+            }
 
-        let printInfo = UIPrintInfo(dictionary: nil)
-        printInfo.jobName = (url.absoluteString as NSString).lastPathComponent
-        printInfo.outputType = .general
-        activityItems.append(printInfo)
+        case .site(let siteURL):
+            activityItems.append(URLActivityItemProvider(url: siteURL))
 
-        // when tab is not loaded (webView != nil) don't show print activity
-        if let tab = selectedTab, tab.webView != nil {
-            activityItems.append(
-                TabPrintPageRenderer(
-                    tabDisplayTitle: tab.displayTitle,
-                    tabURL: tab.url,
-                    webView: tab.webView
+            // For websites shared from a place without a webview (e.g. bookmarks), we don't actually have webview to offer
+            // any advanced information (like title, printing, sent to the iOS home screen, etc.)
+            if let explicitShareMessage {
+                activityItems.append(TitleSubtitleActivityItemProvider(shareMessage: explicitShareMessage))
+            }
+
+        case .tab(let siteURL, let tab):
+            // For websites, we also want to offer a few additional activity items besides the URL, like printing the
+            // webpage or adding a website to the iOS home screen
+            activityItems.append(URLActivityItemProvider(url: siteURL))
+
+            // FIXME: Check for reader mode URLs?
+            //            // Return the URL for the selected tab. If we are in reader view then decode
+            //            // it so that we copy the original and not the internal localhost one.
+            //            return url.isReaderModeURL ? url.decodeReaderModeURL : url
+
+            // Only show the print activity if the tab's webview is loaded
+            if tab.webView != nil {
+                activityItems.append(
+                    TabPrintPageRenderer(
+                        tabDisplayTitle: tab.displayTitle,
+                        tabURL: tab.url,
+                        webView: tab.webView
+                    )
                 )
-            )
-        }
+            }
 
-        if let title = selectedTab?.title {
-            activityItems.append(TitleActivityItemProvider(title: title))
+            // Add the webview for an option to add a website to the iOS home screen
+            if #available(iOS 16.4, *), let webView = tab.webView {
+                activityItems.append(webView)
+            }
+
+            if let explicitShareMessage {
+                activityItems.append(TitleSubtitleActivityItemProvider(shareMessage: explicitShareMessage))
+            } else {
+                // For feature parity with Safari, we use this provider to decide to which apps we should (or should not)
+                // share a display title and/or subject line
+                activityItems.append(TitleActivityItemProvider(title: tab.displayTitle))
+            }
         }
-        activityItems.append(self)
 
         return activityItems
     }
 
-    private func getApplicationActivities() -> [UIActivity] {
+    private static func getApplicationActivities(forShareType shareType: ShareType) -> [UIActivity] {
         var appActivities = [UIActivity]()
 
-        let sendToDeviceActivity = SendToDeviceActivity(activityType: .sendToDevice, url: url)
-        appActivities.append(sendToDeviceActivity)
+        if case .file(let url) = shareType {
+            // Send to device is only available for files
+            appActivities.append(SendToDeviceActivity(activityType: .sendToDevice, url: url))
+        }
 
         return appActivities
-    }
-}
-
-extension ShareManager: UIActivityItemSource {
-    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
-        return url
-    }
-
-    func activityViewController(
-        _ activityViewController: UIActivityViewController,
-        itemForActivityType activityType: UIActivity.ActivityType?
-    ) -> Any? {
-        if isPasswordManager(activityType: activityType) {
-            return onePasswordExtensionItem
-        } else if isOpenByCopy(activityType: activityType) {
-            return url
-        }
-
-        // Return the URL for the selected tab. If we are in reader view then decode
-        // it so that we copy the original and not the internal localhost one.
-        return url.isReaderModeURL ? url.decodeReaderModeURL : url
-    }
-
-    func activityViewController(
-        _ activityViewController: UIActivityViewController,
-        dataTypeIdentifierForActivityType activityType: UIActivity.ActivityType?
-    ) -> String {
-        if isPasswordManager(activityType: activityType) {
-            return browserFillIdentifier
-        } else if isOpenByCopy(activityType: activityType) {
-            return url.isFileURL ? UTType.fileURL.identifier : UTType.url.identifier
-        }
-
-        return activityType == nil ? browserFillIdentifier : UTType.url.identifier
-    }
-
-    private func isPasswordManager(activityType: UIActivity.ActivityType?) -> Bool {
-        guard let activityType = activityType?.rawValue else { return false }
-        // A 'password' substring covers the most cases, such as pwsafe and 1Password.
-        // com.agilebits.onepassword-ios.extension
-        // com.app77.ios.pwsafe2.find-login-action-password-actionExtension
-        // If your extension's bundle identifier does not contain "password", simply submit a pull request
-        // by adding your bundle identifier.
-        return (activityType.contains("password"))
-            || (activityType == "com.lastpass.ilastpass.LastPassExt")
-            || (activityType == "in.sinew.Walletx.WalletxExt")
-            || (activityType == "com.8bit.bitwarden.find-login-action-extension")
-            || (activityType == "me.mssun.passforios.find-login-action-extension")
-    }
-
-    private func isOpenByCopy(activityType: UIActivity.ActivityType?) -> Bool {
-        guard let activityType = activityType?.rawValue else { return false }
-        return activityType.lowercased().contains("remoteopeninapplication-bycopy")
     }
 }

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -9,9 +9,6 @@ import WebKit
 import UniformTypeIdentifiers
 
 class ShareManager: NSObject, FeatureFlaggable {
-    // TODO: FXIOS-10582 not the real URL we want to use, those are still being finalized
-    static let downloadFirefoxAppStoreURL = URL(string: "https://mzl.la/3NDxAIS")!
-
     private struct ActivityIdentifiers {
         static let pocketIconExtension = "com.ideashower.ReadItLaterPro.AddToPocketExtension"
         static let pocketActionExtension = "com.ideashower.ReadItLaterPro.Action-Extension"
@@ -47,7 +44,7 @@ class ShareManager: NSObject, FeatureFlaggable {
                 return
             }
 
-            // Add telemetry for Pocket activityType
+            // Add telemetry for Pocket extension activityTypes
             if activityType?.rawValue == ActivityIdentifiers.pocketIconExtension {
                 TelemetryWrapper.recordEvent(category: .action,
                                              method: .tap,

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -114,6 +114,8 @@ class ShareManager: NSObject, FeatureFlaggable {
 
             // Add the webview for an option to add a website to the iOS home screen
             if #available(iOS 16.4, *), let webView = tab.webView {
+                // NOTE: You will not see "Add to Home Screen" option on debug builds. Possibility this is because of how the
+                // com.apple.developer.web-browser entitelement is applied...
                 activityItems.append(webView)
             }
 
@@ -132,10 +134,8 @@ class ShareManager: NSObject, FeatureFlaggable {
     private static func getApplicationActivities(forShareType shareType: ShareType) -> [UIActivity] {
         var appActivities = [UIActivity]()
 
-        if case .file(let url) = shareType {
-            // Send to device is only available for files
-            appActivities.append(SendToDeviceActivity(activityType: .sendToDevice, url: url))
-        }
+        // Only acts on non-file URLs to send links to synced devices. Will ignore file URLs it can't handle.
+        appActivities.append(SendToDeviceActivity(activityType: .sendToDevice, url: shareType.wrappedURL))
 
         return appActivities
     }

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -13,11 +13,8 @@ class ShareManager: NSObject, FeatureFlaggable {
     static let downloadFirefoxAppStoreURL = URL(string: "https://mzl.la/3NDxAIS")!
 
     private struct ActivityIdentifiers {
-        static let browserFill = "org.appextension.fill-browser-action"
         static let pocketIconExtension = "com.ideashower.ReadItLaterPro.AddToPocketExtension"
         static let pocketActionExtension = "com.ideashower.ReadItLaterPro.Action-Extension"
-        // FIXME: Should this be com.apple.UIKit.activity.RemoteOpenInApplication-ByCopy ?
-        static let isOpenByCopy = "remoteopeninapplication-bycopy"
         static let whatsApp = "net.whatsapp.WhatsApp.ShareExtension"
     }
 

--- a/firefox-ios/Client/Frontend/Share/ShareMessage.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareMessage.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// Additional text to share alongside a `ShareType`. Some apps, like Mail, support an additional subject line (called a
-/// subtitle).
+/// `subtitle` with respect to `UIActivityItemProvider`s).
 struct ShareMessage: Equatable {
     let message: String
     let subtitle: String?

--- a/firefox-ios/Client/Frontend/Share/ShareTab.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTab.swift
@@ -7,6 +7,7 @@ import Foundation
 protocol ShareTab: Equatable {
     var displayTitle: String { get }
     var url: URL? { get }
+    var canonicalURL: URL? { get }
     var webView: TabWebView? { get }
 
     // Tabs displaying content other than HTML mime type can optionally be downloaded and treated as files when shared

--- a/firefox-ios/Client/Frontend/Share/ShareTab.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTab.swift
@@ -8,4 +8,7 @@ protocol ShareTab: Equatable {
     var displayTitle: String { get }
     var url: URL? { get }
     var webView: TabWebView? { get }
+
+    // Tabs displaying content other than HTML mime type can optionally be downloaded and treated as files when shared
+    var temporaryDocument: TemporaryDocument? { get }
 }

--- a/firefox-ios/Client/Frontend/Share/ShareType.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareType.swift
@@ -27,6 +27,17 @@ enum ShareType: Equatable {
             return false
         }
     }
+
+    var wrappedURL: URL {
+        switch self {
+        case let .file(url):
+            return url
+        case let .site(url):
+            return url
+        case let .tab(url, _):
+            return url
+        }
+    }
 }
 
 extension ShareTab {

--- a/firefox-ios/Client/Frontend/Share/ShareType.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareType.swift
@@ -5,11 +5,14 @@
 import Foundation
 
 /// Preconfigured sharing schemes which the share manager knows how to handle.
-///     file: Include a file URL (file://). Best used for sharing downloaded files.
-///     site: Include a website URL (http(s)://). Best used for sharing library/bookmarks, etc. without an active tab.
+///     file: Include a file URL (`file://`). Best used for sharing downloaded files.
+///     site: Include a website URL (`http(s)://`). Best used for sharing library/bookmarks, etc. without an active tab.
 ///           Shares configured using .site will not append a title to Messages but will have a subtitle in Mail.
-///     tab:  Include a website URL and a tab to share. If sharing a tab with an active webView, then additional sharing
-///           options will be configured, including printing the page and adding the webpage to your iOS home screen.
+///     tab:  Include a URL and a tab to share. If sharing a tab with an active webView, then additional sharing
+///           options can be configured, including printing the page and adding the webpage to your iOS home screen.
+///           __SPECIAL NOTE__: If you download a PDF, you can view that in a tab. In that case, the URL may have a `file://`
+///            scheme instead of `http(s)://`, so certain options, like Send to Device / Add to Home Screen, may not be
+///            available.
 enum ShareType: Equatable {
     case file(url: URL)
     case site(url: URL)

--- a/firefox-ios/Client/Frontend/Share/URLActivityItemProvider.swift
+++ b/firefox-ios/Client/Frontend/Share/URLActivityItemProvider.swift
@@ -14,9 +14,13 @@ class URLActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
     ]
 
     init(url: URL) {
-        self.url = url
+        // If the user is sharing a reader mode URL, we must decode it so we don't share internal localhost URLs
+        let parsedURL = url.isReaderModeURL
+                        ? url.decodeReaderModeURL ?? url
+                        : url
 
-        super.init(placeholderItem: url)
+        self.url = parsedURL
+        super.init(placeholderItem: parsedURL)
     }
 
     override var placeholderItem: Any? {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -307,7 +307,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(mockRouter.presentedViewController is UIActivityViewController)
         // Right now we have no interface to check the ShareType passed in to ShareSheetCoordinator's start() call, but this
         // can tell us that there was an attempt to download a TemporaryDocument for a tab type share, which is sufficient.
-        XCTAssertEqual(mockTemporaryDocument.getURLCalled, 1)
+        XCTAssertEqual(mockTemporaryDocument.getDownloadedURLCalled, 1)
     }
 
     func testShowCreditCardAutofill_addsCredentialAutofillCoordinator() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -7,6 +7,7 @@ import ComponentLibrary
 import MozillaAppServices
 import WebKit
 import XCTest
+import GCDWebServers
 
 @testable import Client
 
@@ -263,6 +264,49 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(subject.childCoordinators.first is ShareSheetCoordinator)
         XCTAssertEqual(self.mockRouter.presentCalled, 1)
         XCTAssertTrue(self.mockRouter.presentedViewController is UIActivityViewController)
+    }
+
+    func testStartShareSheetCoordinator_isSharingTabWithTemporaryDocument_upgradesTabShareToFileShare() throws {
+        let testWebURL = URL(string: "https://mozilla.org")!
+        let testFileURL = URL(string: "file://some/file/url")!
+        let testWebpageDisplayTitle = "Mozilla"
+        let testShareMessage = ShareMessage(message: "Test Message", subtitle: "Test Subtitle")
+        let mockTemporaryDocument = MockTemporaryDocument(withFileURL: testFileURL)
+        let testTab = MockShareTab(
+            title: testWebpageDisplayTitle,
+            url: testWebURL,
+            withTemporaryDocument: mockTemporaryDocument
+        )
+
+        let mockServerURL = try startMockServer()
+
+        let subject = createSubject()
+
+        subject.startShareSheetCoordinator(
+            shareType: .tab(url: mockServerURL, tab: testTab),
+            shareMessage: testShareMessage,
+            sourceView: UIView(),
+            sourceRect: CGRect(),
+            toastContainer: UIView(),
+            popoverArrowDirection: .up
+        )
+
+        // NOTE: We are waiting for an async call to complete. Hopefully the temporary document download will be improved
+        // in the future to make this call synchronous.
+        let predicate = NSPredicate { _, _ in
+            return self.mockRouter.presentCalled == 1
+        }
+        let exp = XCTNSPredicateExpectation(predicate: predicate, object: .none)
+
+        wait(for: [exp], timeout: 3.0)
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertTrue(subject.childCoordinators.first is ShareSheetCoordinator)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertTrue(mockRouter.presentedViewController is UIActivityViewController)
+        // Right now we have no interface to check the ShareType passed in to ShareSheetCoordinator's .start call, but this
+        //  can tell us that there was an attempt to download a TemporaryDocument for a tab type share, which is sufficient.
+        XCTAssertEqual(mockTemporaryDocument.getURLCalled, 1)
     }
 
     func testShowCreditCardAutofill_addsCredentialAutofillCoordinator() {
@@ -1160,5 +1204,23 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         let result = subject.canHandle(route: route)
         subject.handle(route: route)
         return result
+    }
+
+    // MARK: - Mock Server
+
+    func startMockServer() throws -> URL {
+        let webServer = GCDWebServer()
+
+        webServer.addHandler(forMethod: "GET",
+                             path: "/",
+                             request: GCDWebServerRequest.self) { (request) -> GCDWebServerResponse? in
+            return GCDWebServerDataResponse()
+        }
+
+        if !webServer.start(withPort: 0, bonjourName: nil) {
+            XCTFail("Can't start the GCDWebServer")
+        }
+
+        return URL(string: "http://localhost:\(webServer.port)")!
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -251,8 +251,8 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
             popoverArrowDirection: .up
         )
 
-        // NOTE: We are waiting for an async call to complete. Hopefully the temporary document download will be improved
-        // in the future to make this call synchronous.
+        // NOTE: FXIOS-10824 We are waiting for an async call to complete. Hopefully the temporary document download will be
+        // improved in the future to make this call synchronous.
         let predicate = NSPredicate { _, _ in
             return self.mockRouter.presentCalled == 1
         }
@@ -275,6 +275,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         let testTab = MockShareTab(
             title: testWebpageDisplayTitle,
             url: testWebURL,
+            canonicalURL: testWebURL,
             withTemporaryDocument: mockTemporaryDocument
         )
 
@@ -291,8 +292,8 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
             popoverArrowDirection: .up
         )
 
-        // NOTE: We are waiting for an async call to complete. Hopefully the temporary document download will be improved
-        // in the future to make this call synchronous.
+        // NOTE: FXIOS-10824 We are waiting for an async call to complete. Hopefully the temporary document download will be
+        // improved in the future to make this call synchronous.
         let predicate = NSPredicate { _, _ in
             return self.mockRouter.presentCalled == 1
         }
@@ -304,8 +305,8 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(subject.childCoordinators.first is ShareSheetCoordinator)
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertTrue(mockRouter.presentedViewController is UIActivityViewController)
-        // Right now we have no interface to check the ShareType passed in to ShareSheetCoordinator's .start call, but this
-        //  can tell us that there was an attempt to download a TemporaryDocument for a tab type share, which is sufficient.
+        // Right now we have no interface to check the ShareType passed in to ShareSheetCoordinator's start() call, but this
+        // can tell us that there was an attempt to download a TemporaryDocument for a tab type share, which is sufficient.
         XCTAssertEqual(mockTemporaryDocument.getURLCalled, 1)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -238,44 +238,31 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         }
     }
 
-    func testShowShareSheet_addsShareSheetCoordinator() {
+    func testStartShareSheetCoordinator_addsShareSheetCoordinator() {
         let subject = createSubject()
 
-        subject.showShareSheet(
-            url: URL(
-                string: "https://www.google.com"
-            )!,
-            title: nil,
+        subject.startShareSheetCoordinator(
+            shareType: .site(url: URL(string: "https://www.google.com")!),
+            shareMessage: ShareMessage(message: "Test Message", subtitle: "Test Subtitle"),
             sourceView: UIView(),
             sourceRect: CGRect(),
             toastContainer: UIView(),
             popoverArrowDirection: .up
         )
 
-        XCTAssertEqual(subject.childCoordinators.count, 1)
-        XCTAssertTrue(subject.childCoordinators.first is ShareSheetCoordinator)
-        XCTAssertEqual(mockRouter.presentCalled, 1)
-        XCTAssertTrue(mockRouter.presentedViewController is UIActivityViewController)
-    }
+        // NOTE: We are waiting for an async call to complete. Hopefully the temporary document download will be improved
+        // in the future to make this call synchronous.
+        let predicate = NSPredicate { _, _ in
+            return self.mockRouter.presentCalled == 1
+        }
+        let exp = XCTNSPredicateExpectation(predicate: predicate, object: .none)
 
-    func testShowShareSheet_addsShareSheetCoordinatorWithTitle() {
-        let subject = createSubject()
-
-        subject.showShareSheet(
-            url: URL(
-                string: "https://www.google.com"
-            )!,
-            title: "TEST TITLE",
-            sourceView: UIView(),
-            sourceRect: CGRect(),
-            toastContainer: UIView(),
-            popoverArrowDirection: .up
-        )
+        wait(for: [exp], timeout: 3.0)
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertTrue(subject.childCoordinators.first is ShareSheetCoordinator)
-        XCTAssertEqual(mockRouter.presentCalled, 1)
-        XCTAssertTrue(mockRouter.presentedViewController is UIActivityViewController)
+        XCTAssertEqual(self.mockRouter.presentCalled, 1)
+        XCTAssertTrue(self.mockRouter.presentedViewController is UIActivityViewController)
     }
 
     func testShowCreditCardAutofill_addsCredentialAutofillCoordinator() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -65,14 +65,12 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
         showCreditCardAutofillCalled += 1
     }
 
-    func showShareSheet(
-        url: URL,
-        title: String?,
-        sourceView: UIView,
-        sourceRect: CGRect?,
-        toastContainer: UIView,
-        popoverArrowDirection: UIPopoverArrowDirection
-    ) {
+    func showShareSheet(shareType: ShareType,
+                        shareMessage: ShareMessage?,
+                        sourceView: UIView,
+                        sourceRect: CGRect?,
+                        toastContainer: UIView,
+                        popoverArrowDirection: UIPopoverArrowDirection) {
         showShareSheetCalled += 1
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShareSheetCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/ShareSheetCoordinatorTests.swift
@@ -24,9 +24,10 @@ final class ShareSheetCoordinatorTests: XCTestCase {
     }
 
     func testStart_presentUIActivityViewController() {
+        let testURL = URL(string: "https://www.google.com")!
         let subject = createSubject()
 
-        subject.start(url: URL(string: "https://www.google.com")!, sourceView: UIView())
+        subject.start(shareType: .site(url: testURL), shareMessage: nil, sourceView: UIView())
 
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertTrue(mockRouter.presentedViewController is UIActivityViewController)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
@@ -7,14 +7,16 @@ import Foundation
 @testable import Client
 
 class MockShareTab: ShareTab {
+    var canonicalURL: URL?
     var displayTitle: String
     var url: URL?
     var webView: TabWebView?
     var temporaryDocument: TemporaryDocument?
 
-    init(title: String, url: URL?, withActiveWebView: Bool = true, withTemporaryDocument: TemporaryDocument? = nil) {
+    init(title: String, url: URL?, canonicalURL: URL?, withActiveWebView: Bool = true, withTemporaryDocument: TemporaryDocument? = nil) {
         self.displayTitle = title
         self.url = url
+        self.canonicalURL = canonicalURL
         self.webView = TabWebView(frame: CGRect.zero, configuration: .init(), windowUUID: .XCTestDefaultUUID)
         self.temporaryDocument = withTemporaryDocument
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
@@ -13,7 +13,13 @@ class MockShareTab: ShareTab {
     var webView: TabWebView?
     var temporaryDocument: TemporaryDocument?
 
-    init(title: String, url: URL?, canonicalURL: URL?, withActiveWebView: Bool = true, withTemporaryDocument: TemporaryDocument? = nil) {
+    init(
+        title: String,
+        url: URL?,
+        canonicalURL: URL?,
+        withActiveWebView: Bool = true,
+        withTemporaryDocument: TemporaryDocument? = nil
+    ) {
         self.displayTitle = title
         self.url = url
         self.canonicalURL = canonicalURL

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
@@ -10,16 +10,19 @@ class MockShareTab: ShareTab {
     var displayTitle: String
     var url: URL?
     var webView: TabWebView?
+    var temporaryDocument: TemporaryDocument?
 
-    init(title: String, url: URL?, withActiveWebView: Bool = true) {
+    init(title: String, url: URL?, withActiveWebView: Bool = true, withTemporaryDocument: TemporaryDocument? = nil) {
         self.displayTitle = title
         self.url = url
         self.webView = TabWebView(frame: CGRect.zero, configuration: .init(), windowUUID: .XCTestDefaultUUID)
+        self.temporaryDocument = withTemporaryDocument
     }
 
     static func == (lhs: MockShareTab, rhs: MockShareTab) -> Bool {
         return lhs.displayTitle == rhs.displayTitle
         && lhs.url == rhs.url
         && lhs.webView === rhs.webView
+        && lhs.temporaryDocument === rhs.temporaryDocument
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
@@ -20,9 +20,14 @@ class MockShareTab: ShareTab {
     }
 
     static func == (lhs: MockShareTab, rhs: MockShareTab) -> Bool {
+        guard let lhsTempDoc = lhs.temporaryDocument as? MockTemporaryDocument,
+              let rhsTempDoc = rhs.temporaryDocument as? MockTemporaryDocument else {
+            return false
+        }
+
         return lhs.displayTitle == rhs.displayTitle
         && lhs.url == rhs.url
         && lhs.webView === rhs.webView
-        && lhs.temporaryDocument === rhs.temporaryDocument
+        && lhsTempDoc === rhsTempDoc
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTemporaryDocument.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTemporaryDocument.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@testable import Client
+
+class MockTemporaryDocument: TemporaryDocument {
+    var fileURL: URL
+    var getURLCalled = 0
+
+    init(withFileURL fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    func getURL(completionHandler: @escaping ((URL?) -> Void)) {
+        getURLCalled += 1
+        completionHandler(fileURL)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTemporaryDocument.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTemporaryDocument.swift
@@ -9,6 +9,7 @@ import Foundation
 class MockTemporaryDocument: TemporaryDocument {
     var fileURL: URL
     var getURLCalled = 0
+    var getDownloadedURLCalled = 0
 
     init(withFileURL fileURL: URL) {
         self.fileURL = fileURL
@@ -17,5 +18,10 @@ class MockTemporaryDocument: TemporaryDocument {
     func getURL(completionHandler: @escaping ((URL?) -> Void)) {
         getURLCalled += 1
         completionHandler(fileURL)
+    }
+
+    func getDownloadedURL() async -> URL? {
+        getDownloadedURLCalled += 1
+        return fileURL
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
@@ -16,7 +16,7 @@ final class ShareManagerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        testTab = MockShareTab(title: testWebpageDisplayTitle, url: testWebURL)
+        testTab = MockShareTab(title: testWebpageDisplayTitle, url: testWebURL, canonicalURL: testWebURL)
     }
 
     override func tearDown() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
@@ -1,0 +1,205 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UniformTypeIdentifiers
+import XCTest
+@testable import Client
+
+final class ShareManagerTests: XCTestCase {
+    let testMessage = "Test message"
+    let testSubtitle = "Test subtitle" // FIXME: naming
+    let testFileURL = URL(string: "file://some/file/url")!
+    let testWebURL = URL(string: "https://mozilla.org")!
+    let testWebpageDisplayTitle = "Mozilla"
+    var testTab: (any ShareTab)!
+
+    override func setUp() {
+        super.setUp()
+        testTab = MockShareTab(title: testWebpageDisplayTitle, url: testWebURL)
+    }
+
+    override func tearDown() {
+        testTab = nil
+        super.tearDown()
+    }
+
+    // MARK: - Test sharing a file
+
+    func testGetActivityItems_forFileURL_withNoShareText() throws {
+        let activityItems = ShareManager.getActivityItems(
+            forShareType: .file(url: testFileURL),
+            withExplicitShareMessage: nil
+        )
+
+        XCTAssertEqual(activityItems.count, 1)
+
+        let urlActivityItemProvider = try XCTUnwrap(activityItems.first as? URLActivityItemProvider)
+        XCTAssertEqual(urlActivityItemProvider.item as? URL, testFileURL)
+    }
+
+    func testGetActivityItems_forFileURL_withShareText() throws {
+        let testMessage = "Test message"
+        let testSubtitle = "Test subtitle" // FIXME: naming
+        let stubActivityViewController = UIActivityViewController(
+            activityItems: [],
+            applicationActivities: []
+        )
+        let activityItems = ShareManager.getActivityItems(
+            forShareType: .file(url: testFileURL),
+            withExplicitShareMessage: ShareMessage(message: testMessage, subtitle: testSubtitle)
+        )
+
+        // Test that we get back a URL provider and a title and subject provider with the correct content:
+        XCTAssertEqual(activityItems.count, 2)
+
+        let urlActivityItemProvider = try XCTUnwrap(activityItems[safe: 0] as? URLActivityItemProvider)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            stubActivityViewController,
+            dataTypeIdentifierForActivityType: .mail
+        )
+
+        XCTAssertEqual(urlActivityItemProvider.item as? URL, testFileURL)
+        XCTAssertEqual(urlDataIdentifier, UTType.fileURL.identifier)
+
+        let titleSubjectActivityItemProvider = try XCTUnwrap(
+            activityItems[safe: 1] as? TitleSubtitleActivityItemProvider
+        )
+        let titleSubjectSubject = titleSubjectActivityItemProvider.activityViewController(
+            stubActivityViewController,
+            subjectForActivityType: .mail
+        )
+        let titleSubjectDataIdentifier = titleSubjectActivityItemProvider.activityViewController(
+            stubActivityViewController,
+            dataTypeIdentifierForActivityType: .mail
+        )
+
+        XCTAssertEqual(titleSubjectActivityItemProvider.item as? String, testMessage)
+        XCTAssertEqual(titleSubjectSubject, testSubtitle)
+        XCTAssertEqual(titleSubjectDataIdentifier, UTType.text.identifier)
+    }
+
+    // MARK: - Test sharing a website
+
+    func testGetActivityItems_forWebsiteURL_withNoShareText() throws {
+        let activityItems = ShareManager.getActivityItems(
+            forShareType: .file(url: testWebURL),
+            withExplicitShareMessage: nil
+        )
+
+        XCTAssertEqual(activityItems.count, 1)
+
+        let urlActivityItemProvider = try XCTUnwrap(activityItems.first as? URLActivityItemProvider)
+        XCTAssertEqual(urlActivityItemProvider.item as? URL, testWebURL)
+    }
+
+    func testGetActivityItems_forWebsiteURL_withShareText() throws {
+        let testMessage = "Test message"
+        let testSubtitle = "Test subtitle" // FIXME: naming
+        let stubActivityViewController = UIActivityViewController(
+            activityItems: [],
+            applicationActivities: []
+        )
+        let activityItems = ShareManager.getActivityItems(
+            forShareType: .file(url: testWebURL),
+            withExplicitShareMessage: ShareMessage(message: testMessage, subtitle: testSubtitle)
+        )
+
+        // Test that we get back a URL provider and a title and subject provider with the correct content:
+        XCTAssertEqual(activityItems.count, 2)
+
+        let urlActivityItemProvider = try XCTUnwrap(activityItems[safe: 0] as? URLActivityItemProvider)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            stubActivityViewController,
+            dataTypeIdentifierForActivityType: .mail
+        )
+
+        XCTAssertEqual(urlActivityItemProvider.item as? URL, testWebURL)
+        XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
+
+        let titleSubjectActivityItemProvider = try XCTUnwrap(
+            activityItems[safe: 1] as? TitleSubtitleActivityItemProvider
+        )
+        let titleSubjectSubject = titleSubjectActivityItemProvider.activityViewController(
+            stubActivityViewController,
+            subjectForActivityType: .mail
+        )
+        let titleSubjectDataIdentifier = titleSubjectActivityItemProvider.activityViewController(
+            stubActivityViewController,
+            dataTypeIdentifierForActivityType: .mail
+        )
+
+        XCTAssertEqual(titleSubjectActivityItemProvider.item as? String, testMessage)
+        XCTAssertEqual(titleSubjectSubject, testSubtitle)
+        XCTAssertEqual(titleSubjectDataIdentifier, UTType.text.identifier)
+    }
+
+    // MARK: - Test sharing a website with a related Tab and webview
+
+    func testGetActivityItems_forTab_withNoShareText() throws {
+        let stubActivityViewController = UIActivityViewController(
+            activityItems: [],
+            applicationActivities: []
+        )
+
+        let activityItems = ShareManager.getActivityItems(
+            forShareType: .tab(url: testWebURL, tab: testTab),
+            withExplicitShareMessage: nil
+        )
+
+        // Check we get all 4 types of share items for tabs below
+        XCTAssertEqual(activityItems.count, 4)
+
+        let urlActivityItemProvider = try XCTUnwrap(activityItems[safe: 0] as? URLActivityItemProvider)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            stubActivityViewController,
+            dataTypeIdentifierForActivityType: .mail
+        )
+        XCTAssertEqual(urlActivityItemProvider.item as? URL, testWebURL)
+        XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
+
+        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        XCTAssertEqual(
+            titleActivityItemProvider.item as? String,
+            testWebpageDisplayTitle,
+            "When no explicit share message is set, we expect to see the webpage's title."
+        )
+    }
+
+    func testGetActivityItems_forTab_withShareText() throws {
+        let stubActivityViewController = UIActivityViewController(
+            activityItems: [],
+            applicationActivities: []
+        )
+
+        let activityItems = ShareManager.getActivityItems(
+            forShareType: .tab(url: testWebURL, tab: testTab),
+            withExplicitShareMessage: ShareMessage(message: testMessage, subtitle: testSubtitle)
+        )
+
+        // Check we get all 4 types of share items for tabs below
+        XCTAssertEqual(activityItems.count, 4)
+
+        let urlActivityItemProvider = try XCTUnwrap(activityItems[safe: 0] as? URLActivityItemProvider)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            stubActivityViewController,
+            dataTypeIdentifierForActivityType: .mail
+        )
+        XCTAssertEqual(urlActivityItemProvider.item as? URL, testWebURL)
+        XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
+        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleSubtitleActivityItemProvider)
+        XCTAssertEqual(
+            titleActivityItemProvider.item as? String,
+            testMessage,
+            "When an explicit share message is set, we expect to see that message, not the webpage's title."
+        )
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 final class ShareManagerTests: XCTestCase {
     let testMessage = "Test message"
-    let testSubtitle = "Test subtitle" // FIXME: naming
+    let testSubtitle = "Test subtitle"
     let testFileURL = URL(string: "file://some/file/url")!
     let testWebURL = URL(string: "https://mozilla.org")!
     let testWebpageDisplayTitle = "Mozilla"
@@ -40,7 +40,7 @@ final class ShareManagerTests: XCTestCase {
 
     func testGetActivityItems_forFileURL_withShareText() throws {
         let testMessage = "Test message"
-        let testSubtitle = "Test subtitle" // FIXME: naming
+        let testSubtitle = "Test subtitle"
         let stubActivityViewController = UIActivityViewController(
             activityItems: [],
             applicationActivities: []
@@ -95,7 +95,7 @@ final class ShareManagerTests: XCTestCase {
 
     func testGetActivityItems_forWebsiteURL_withShareText() throws {
         let testMessage = "Test message"
-        let testSubtitle = "Test subtitle" // FIXME: naming
+        let testSubtitle = "Test subtitle"
         let stubActivityViewController = UIActivityViewController(
             activityItems: [],
             applicationActivities: []


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-10669 Jira Refactor ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10669)
[Related Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23340)

Our preexisting share sheet implementation had many bugs. This refactor addresses several bugs, including:
- FXIOS-10825: Sharing URLs from context menus should not offer blank Print and Markup options
- FXIOS-10826: Sharing URLs from Home, Bookmarks, or History context menus should not share the unrelated selected tab's title in Mail's subject line
- FXIOS-10827: Sharing URLs from long press > Share on a website should not incorrectly share the selected tab's title in the subject line
- FXIOS-10749: Non-HTML pages (e.g. PDFs) shared from the new toolbar share button do not share files, only web URLs
- FXIOS-10830: Do not use URLSession callback calls within continuations for the TemporaryDocument

## :bulb: Description
### Background
This is probably the last in a series of PRs targeted at refactoring our decade-old share sheet code. There were a bunch of bugs, many which are fixed in this PR. Things worked by magic and coincidence, rather than explicit intention.

This refactoring is prerequisite work for the two share-related experiments, Sent from Firefox and Info Card Referral.

### History

**My apologies that this PR ran long...** There are a LOT of places where sharing needed to be updated, as lots of places are using the `ShareSheetCoordinator` and the `ShareManager`. 😔  

The good news though — at least 1/3 of this PR is under the UnitTests target!

FYI I already broke up my refactor work into a number of previous PRs:
- https://github.com/mozilla-mobile/firefox-ios/pull/23592
- https://github.com/mozilla-mobile/firefox-ios/pull/23591
- https://github.com/mozilla-mobile/firefox-ios/pull/23542
- https://github.com/mozilla-mobile/firefox-ios/pull/23428
- https://github.com/mozilla-mobile/firefox-ios/pull/23427
- https://github.com/mozilla-mobile/firefox-ios/pull/23341

### Main Changes in This PR

- The `ShareType` and `ShareMessage` types are now being used to make sharing content more explicit via the `ShareSheetCoordinator` and `ShareManager`
- Refactored the `ShareManager` (formerly `ShareExtensionHelper`). The `ShareManager` is no longer appending itself as an activity item (that's bad architecture). It instead appends a `URLActivityItemProvider`, which contains that additional extension logic that used to be in the `ShareManager`.
- Function naming has been improved so all share paths are extremely explicit in where they are coming from and what they are sharing
- Increased testability (e.g. `TemporaryDocument` protocol so we can use mocks)
- Increased test coverage with `ShareManager` unit tests
- Added new test mocks
- Added documentation to make sharing even clearer

### Test Cases

Please see [the first comment in the refactor ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10669?focusedCommentId=974140) for all the possible test cases of where you can share content in the app... 

Testing is best on a real device so you get the right options. Simulators don't offer as many options.

This PR also adds unit tests to support the ShareManager and ShareSheetCoordinator.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

