### PR TITLE
Add FXIOS-9747 [Bookmarks Evolution] Save bookmarks to most recent folder

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -202,6 +202,9 @@ public struct PrefsKeys {
     // The guid of the bookmark folder that was most recently created or saved to by the user.
     // Used to indicate where we should save the next bookmark by default.
     public static let RecentBookmarkFolder = "RecentBookmarkFolder"
+    // Represents whether or not the bookmark refactor feature flag is enabled
+    // Used in the share extension
+    public static let IsBookmarksRefactorEnabled = "IsBookmarksRefactorEnabled"
 
     public struct Usage {
         public static let profileId = "profileId"

--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -199,8 +199,9 @@ public struct PrefsKeys {
     // Represents whether or not the user has seen the photon main menu once, at least.
     public static let PhotonMainMenuShown = "PhotonMainMenuShown"
 
-    // Most recently created or saved to bookmark folder that we should save all future bookmarks to
-    public static let BookmarkSaveToFolder = "BookmarkSaveToFolder"
+    // The guid of the bookmark folder that was most recently created or saved to by the user.
+    // Used to indicate where we should save the next bookmark by default.
+    public static let RecentBookmarkFolder = "RecentBookmarkFolder"
 
     public struct Usage {
         public static let profileId = "profileId"

--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -199,6 +199,9 @@ public struct PrefsKeys {
     // Represents whether or not the user has seen the photon main menu once, at least.
     public static let PhotonMainMenuShown = "PhotonMainMenuShown"
 
+    // Most recently created or saved to bookmark folder that we should save all future bookmarks to
+    public static let BookmarkSaveToFolder = "BookmarkSaveToFolder"
+
     public struct Usage {
         public static let profileId = "profileId"
     }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -48,7 +48,7 @@
 		0B6FBAB21AC1F830007EC669 /* numberedPage.html in Resources */ = {isa = PBXBuildFile; fileRef = 0B6FBAB11AC1F830007EC669 /* numberedPage.html */; };
 		0B75AEA91AC20FB20015E5DC /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8E0FF31A932BD500161DC3 /* ImageIO.framework */; };
 		0B7C1E951F6097AD006A8869 /* TrackingProtectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7C1E941F6097AD006A8869 /* TrackingProtectionTests.swift */; };
-		0B7CF8872CAC1C4E00DC02F8 /* DefaultFolderHeirarchyFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7CF8862CAC1C4E00DC02F8 /* DefaultFolderHeirarchyFetcherTests.swift */; };
+		0B7CF8872CAC1C4E00DC02F8 /* DefaultFolderHierarchyFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7CF8862CAC1C4E00DC02F8 /* DefaultFolderHierarchyFetcherTests.swift */; };
 		0B7FC3D32CAE811F005C5CCE /* DefaultBookmarksSaverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7FC3D12CAE811B005C5CCE /* DefaultBookmarksSaverTests.swift */; };
 		0B8BF3702CA2D60B00E9812D /* BookmarksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8BF36F2CA2D60B00E9812D /* BookmarksViewController.swift */; };
 		0B8BF3722CA2DA4600E9812D /* EditBookmarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8BF3712CA2DA4600E9812D /* EditBookmarkViewController.swift */; };
@@ -2320,7 +2320,7 @@
 		0B62EFD11AD63CD100ACB9CD /* Clearables.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Clearables.swift; sourceTree = "<group>"; };
 		0B6FBAB11AC1F830007EC669 /* numberedPage.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = numberedPage.html; sourceTree = "<group>"; };
 		0B7C1E941F6097AD006A8869 /* TrackingProtectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionTests.swift; sourceTree = "<group>"; };
-		0B7CF8862CAC1C4E00DC02F8 /* DefaultFolderHeirarchyFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFolderHeirarchyFetcherTests.swift; sourceTree = "<group>"; };
+		0B7CF8862CAC1C4E00DC02F8 /* DefaultFolderHierarchyFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFolderHierarchyFetcherTests.swift; sourceTree = "<group>"; };
 		0B7FC3D12CAE811B005C5CCE /* DefaultBookmarksSaverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBookmarksSaverTests.swift; sourceTree = "<group>"; };
 		0B8749EB891EE229EA88FEF3 /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		0B8BF36F2CA2D60B00E9812D /* BookmarksViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksViewController.swift; sourceTree = "<group>"; };
@@ -9854,7 +9854,7 @@
 			isa = PBXGroup;
 			children = (
 				0B7FC3D42CAE82AE005C5CCE /* Mocks */,
-				0B7CF8862CAC1C4E00DC02F8 /* DefaultFolderHeirarchyFetcherTests.swift */,
+				0B7CF8862CAC1C4E00DC02F8 /* DefaultFolderHierarchyFetcherTests.swift */,
 				0B7FC3D12CAE811B005C5CCE /* DefaultBookmarksSaverTests.swift */,
 				8AED868228CA3B3400351A50 /* BookmarkPanelViewModelTests.swift */,
 				0B7CF8842CAC1B7000DC02F8 /* Legacy */,
@@ -17090,7 +17090,7 @@
 				8CFD56892AAF06D3003157A6 /* ShoppingProductTests.swift in Sources */,
 				8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */,
 				217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */,
-				0B7CF8872CAC1C4E00DC02F8 /* DefaultFolderHeirarchyFetcherTests.swift in Sources */,
+				0B7CF8872CAC1C4E00DC02F8 /* DefaultFolderHierarchyFetcherTests.swift in Sources */,
 				E16C76812ABDC0DB00172DB5 /* FakespotHighlightsCardViewModelTests.swift in Sources */,
 				1D8487B62AD6038100F7527C /* RemoteTabPanelStateTests.swift in Sources */,
 				2137786129802B7000D01309 /* DownloadsPanelViewModelTests.swift in Sources */,

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -66,7 +66,6 @@ class AppLaunchUtil {
                                                                                 checking: .buildOnly),
                               forKey: PrefsKeys.IsBookmarksRefactorEnabled)
 
-
         logger.setup(sendCrashReports: sendCrashReports && !termsOfServiceManager.isFeatureEnabled)
 
         // Start initializing the Nimbus SDK. This should be done after Glean

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -61,6 +61,12 @@ class AppLaunchUtil {
         // i.e. this must be run before initializing those systems.
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
 
+        // Used by share extension to determine if the bookmarks refactor feature flag is enabled
+        profile.prefs.setBool(LegacyFeatureFlagsManager.shared.isFeatureEnabled(.bookmarksRefactor,
+                                                                                checking: .buildOnly),
+                              forKey: PrefsKeys.IsBookmarksRefactorEnabled)
+
+
         logger.setup(sendCrashReports: sendCrashReports && !termsOfServiceManager.isFeatureEnabled)
 
         // Start initializing the Nimbus SDK. This should be done after Glean

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -212,7 +212,7 @@ class SettingsCoordinator: BaseCoordinator,
     }
 
     func showDebugFeatureFlags() {
-        let featureFlagsViewController = FeatureFlagsDebugViewController(windowUUID: windowUUID)
+        let featureFlagsViewController = FeatureFlagsDebugViewController(profile: profile, windowUUID: windowUUID)
         router.push(featureFlagsViewController)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1640,7 +1640,10 @@ class BrowserViewController: UIViewController,
         }
 
         let shareItem = ShareItem(url: url, title: title)
-        bookmarksSaver.createBookmark(url: shareItem.url, title: shareItem.title, position: 0)
+
+        Task { @MainActor in
+            await self.bookmarksSaver.createBookmark(url: shareItem.url, title: shareItem.title, position: 0)
+        }
 
         var userData = [QuickActionInfos.tabURLKey: shareItem.url]
         if let title = shareItem.title {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -32,6 +32,7 @@ class BrowserViewController: UIViewController,
                              BrowserFrameInfoProvider,
                              NavigationToolbarContainerDelegate,
                              AddressToolbarContainerDelegate,
+                             BookmarksRefactorFeatureFlagProvider,
                              FeatureFlaggable {
     private enum UX {
         static let ShowHeaderTapAreaHeight: CGFloat = 32
@@ -1636,8 +1637,12 @@ class BrowserViewController: UIViewController,
         }
 
         let shareItem = ShareItem(url: url, title: title)
-        // Add new mobile bookmark at the top of the list
-        profile.places.createBookmark(parentGUID: BookmarkRoots.MobileFolderGUID,
+
+        // Add new bookmark to the top of the folder
+        // If bookmarks refactor is enabled, save bookmark to recent bookmark folder, otherwise save to root folder
+        let recentBookmarkFolderGuid = profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder)
+        let parentGuid = (isBookmarkRefactorEnabled ? recentBookmarkFolderGuid : nil) ?? BookmarkRoots.MobileFolderGUID
+        profile.places.createBookmark(parentGUID: parentGuid,
                                       url: shareItem.url,
                                       title: shareItem.title,
                                       position: 0)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -229,6 +229,8 @@ class BrowserViewController: UIViewController,
 
     private var keyboardPressesHandlerValue: Any?
 
+    private let bookmarksSaver: BookmarksSaver
+
     var themeManager: ThemeManager
     var notificationCenter: NotificationProtocol
     var themeObserver: NSObjectProtocol?
@@ -270,6 +272,7 @@ class BrowserViewController: UIViewController,
         self.logger = logger
         self.appAuthenticator = appAuthenticator
         self.overlayManager = DefaultOverlayModeManager()
+        self.bookmarksSaver = DefaultBookmarksSaver(profile: profile)
         let windowUUID = tabManager.windowUUID
         let contextualViewProvider = ContextualHintViewProvider(forHintType: .toolbarLocation,
                                                                 with: profile)
@@ -1637,15 +1640,7 @@ class BrowserViewController: UIViewController,
         }
 
         let shareItem = ShareItem(url: url, title: title)
-
-        // Add new bookmark to the top of the folder
-        // If bookmarks refactor is enabled, save bookmark to recent bookmark folder, otherwise save to root folder
-        let recentBookmarkFolderGuid = profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder)
-        let parentGuid = (isBookmarkRefactorEnabled ? recentBookmarkFolderGuid : nil) ?? BookmarkRoots.MobileFolderGUID
-        profile.places.createBookmark(parentGUID: parentGuid,
-                                      url: shareItem.url,
-                                      title: shareItem.title,
-                                      position: 0)
+        bookmarksSaver.createBookmark(url: shareItem.url, title: shareItem.title, position: 0)
 
         var userData = [QuickActionInfos.tabURLKey: shareItem.url]
         if let title = shareItem.title {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1641,7 +1641,7 @@ class BrowserViewController: UIViewController,
 
         let shareItem = ShareItem(url: url, title: title)
 
-        Task { @MainActor in
+        Task {
             await self.bookmarksSaver.createBookmark(url: shareItem.url, title: shareItem.title, position: 0)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -902,7 +902,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
     private func addToBookmarks(_ shareItem: ShareItem?) {
         guard let shareItem else { return }
 
-        Task { @MainActor in
+        Task {
             await self.bookmarksSaver.createBookmark(url: shareItem.url, title: shareItem.title, position: 0)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -901,7 +901,10 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
 
     private func addToBookmarks(_ shareItem: ShareItem?) {
         guard let shareItem else { return }
-        bookmarksSaver.createBookmark(url: shareItem.url, title: shareItem.title, position: 0)
+
+        Task { @MainActor in
+            await self.bookmarksSaver.createBookmark(url: shareItem.url, title: shareItem.title, position: 0)
+        }
     }
 
     private func addToReadingList(with tabID: TabUUID?, uuid: WindowUUID) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -10,8 +10,7 @@ import Storage
 
 import enum MozillaAppServices.BookmarkRoots
 
-class TabManagerMiddleware: FeatureFlaggable,
-                            BookmarksRefactorFeatureFlagProvider {
+class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
     private let profile: Profile
     private let logger: Logger
     private let inactiveTabTelemetry = InactiveTabsTelemetry()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -10,7 +10,8 @@ import Storage
 
 import enum MozillaAppServices.BookmarkRoots
 
-class TabManagerMiddleware: FeatureFlaggable {
+class TabManagerMiddleware: FeatureFlaggable,
+                            BookmarksRefactorFeatureFlagProvider {
     private let profile: Profile
     private let logger: Logger
     private let inactiveTabTelemetry = InactiveTabsTelemetry()
@@ -899,10 +900,8 @@ class TabManagerMiddleware: FeatureFlaggable {
     private func addToBookmarks(_ shareItem: ShareItem?) {
         guard let shareItem else { return }
         // Add new mobile bookmark at the top of the list
-        let isBookmarksRefactorEnabled = featureFlags.isFeatureEnabled(.bookmarksRefactor, checking: .buildOnly)
-        let bookmarksSaveToFolderGuid = profile.prefs.stringForKey(PrefsKeys.BookmarkSaveToFolder)
-        let parentGuid = isBookmarksRefactorEnabled ?
-        bookmarksSaveToFolderGuid ?? BookmarkRoots.MobileFolderGUID : BookmarkRoots.MobileFolderGUID
+        let recentBookmarkFolderGuid = profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder)
+        let parentGuid = (isBookmarkRefactorEnabled ? recentBookmarkFolderGuid : nil) ?? BookmarkRoots.MobileFolderGUID
 
         profile.places.createBookmark(parentGUID: parentGuid,
                                       url: shareItem.url,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -10,7 +10,7 @@ import Storage
 
 import enum MozillaAppServices.BookmarkRoots
 
-class TabManagerMiddleware {
+class TabManagerMiddleware: FeatureFlaggable {
     private let profile: Profile
     private let logger: Logger
     private let inactiveTabTelemetry = InactiveTabsTelemetry()
@@ -899,7 +899,12 @@ class TabManagerMiddleware {
     private func addToBookmarks(_ shareItem: ShareItem?) {
         guard let shareItem else { return }
         // Add new mobile bookmark at the top of the list
-        profile.places.createBookmark(parentGUID: BookmarkRoots.MobileFolderGUID,
+        let isBookmarksRefactorEnabled = featureFlags.isFeatureEnabled(.bookmarksRefactor, checking: .buildOnly)
+        let bookmarksSaveToFolderGuid = profile.prefs.stringForKey(PrefsKeys.BookmarkSaveToFolder)
+        let parentGuid = isBookmarksRefactorEnabled ?
+        bookmarksSaveToFolderGuid ?? BookmarkRoots.MobileFolderGUID : BookmarkRoots.MobileFolderGUID
+
+        profile.places.createBookmark(parentGUID: parentGuid,
                                       url: shareItem.url,
                                       title: shareItem.title,
                                       position: 0)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -898,7 +898,9 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
 
     private func addToBookmarks(_ shareItem: ShareItem?) {
         guard let shareItem else { return }
-        // Add new mobile bookmark at the top of the list
+
+        // Add new bookmark to the top of the folder
+        // If bookmarks refactor is enabled, save bookmark to recent bookmark folder, otherwise save to root folder
         let recentBookmarkFolderGuid = profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder)
         let parentGuid = (isBookmarkRefactorEnabled ? recentBookmarkFolderGuid : nil) ?? BookmarkRoots.MobileFolderGUID
 

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -220,7 +220,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol,
                                      tapHandler: { _ in
             let shareItem = ShareItem(url: site.url, title: site.title)
 
-            Task { @MainActor in
+            Task {
                 await self.bookmarksSaver.createBookmark(url: shareItem.url, title: shareItem.title, position: 0)
             }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -219,7 +219,10 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol,
                                      allowIconScaling: true,
                                      tapHandler: { _ in
             let shareItem = ShareItem(url: site.url, title: site.title)
-            self.bookmarksSaver.createBookmark(url: shareItem.url, title: shareItem.title, position: 0)
+
+            Task { @MainActor in
+                await self.bookmarksSaver.createBookmark(url: shareItem.url, title: shareItem.title, position: 0)
+            }
 
             var userData = [QuickActionInfos.tabURLKey: shareItem.url]
             if let title = shareItem.title {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -247,9 +247,9 @@ class BookmarksViewController: SiteTableViewController,
     /// table view data source immediately for responsiveness.
     private func deleteBookmarkNode(_ indexPath: IndexPath, bookmarkNode: FxBookmarkNode) {
         profile.places.deleteBookmarkNode(guid: bookmarkNode.guid).uponQueue(.main) { _ in
-            let bookmarksSaveToFolderPref = PrefsKeys.RecentBookmarkFolder
-            if bookmarkNode.guid == self.profile.prefs.stringForKey(bookmarksSaveToFolderPref) {
-                self.profile.prefs.removeObjectForKey(bookmarksSaveToFolderPref)
+            let recentBookmarkFolderPref = PrefsKeys.RecentBookmarkFolder
+            if bookmarkNode.guid == self.profile.prefs.stringForKey(recentBookmarkFolderPref) {
+                self.profile.prefs.removeObjectForKey(recentBookmarkFolderPref)
             }
             self.removeBookmarkShortcut()
         }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -247,7 +247,7 @@ class BookmarksViewController: SiteTableViewController,
     /// table view data source immediately for responsiveness.
     private func deleteBookmarkNode(_ indexPath: IndexPath, bookmarkNode: FxBookmarkNode) {
         profile.places.deleteBookmarkNode(guid: bookmarkNode.guid).uponQueue(.main) { _ in
-            let bookmarksSaveToFolderPref = PrefsKeys.BookmarkSaveToFolder
+            let bookmarksSaveToFolderPref = PrefsKeys.RecentBookmarkFolder
             if bookmarkNode.guid == self.profile.prefs.stringForKey(bookmarksSaveToFolderPref) {
                 self.profile.prefs.removeObjectForKey(bookmarksSaveToFolderPref)
             }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -247,6 +247,10 @@ class BookmarksViewController: SiteTableViewController,
     /// table view data source immediately for responsiveness.
     private func deleteBookmarkNode(_ indexPath: IndexPath, bookmarkNode: FxBookmarkNode) {
         profile.places.deleteBookmarkNode(guid: bookmarkNode.guid).uponQueue(.main) { _ in
+            let bookmarksSaveToFolderPref = PrefsKeys.BookmarkSaveToFolder
+            if bookmarkNode.guid == self.profile.prefs.stringForKey(bookmarksSaveToFolderPref) {
+                self.profile.prefs.removeObjectForKey(bookmarksSaveToFolderPref)
+            }
             self.removeBookmarkShortcut()
         }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -99,7 +99,8 @@ class EditBookmarkViewModel {
     func saveBookmark() {
         guard let selectedFolder, let node else { return }
         Task { @MainActor [weak self] in
-            // Updates the bookmark
+            // There is no way to access the EditBookmarkViewController without the bookmark already existing,
+            // so this call will always try to update an existing bookmark
             let result = await self?.bookmarksSaver.save(bookmark: node,
                                                          parentFolderGUID: selectedFolder.guid)
             // Only update the recent folder pref if the bookmarks parent folder changes

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -103,8 +103,8 @@ class EditBookmarkViewModel {
             // so this call will always try to update an existing bookmark
             let result = await self?.bookmarksSaver.save(bookmark: node,
                                                          parentFolderGUID: selectedFolder.guid)
-            // Only update the recent folder pref if the bookmarks parent folder changes
-            if selectedFolder.guid != self?.parentFolder.guid {
+            // Only update the recent folder pref if it doesn't match whats saved in the pref
+            if selectedFolder.guid != self?.profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder) {
                 switch result {
                 case .success:
                     self?.profile.prefs.setString(selectedFolder.guid, forKey: PrefsKeys.RecentBookmarkFolder)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -103,11 +103,12 @@ class EditBookmarkViewModel {
                                                          parentFolderGUID: selectedFolder.guid)
             if selectedFolder.guid != self?.parentFolder.guid {
                 switch result {
-                case .success(let saveResult):
-                    guard saveResult == .void else { break }
-                    self?.profile.prefs.setString(selectedFolder.guid, forKey: PrefsKeys.BookmarkSaveToFolder)
+                case .success(let guid):
+                    if guid == nil {
+                        self?.profile.prefs.setString(selectedFolder.guid, forKey: PrefsKeys.RecentBookmarkFolder)
+                    }
                 case .failure(let error):
-                    self?.logger.log("Failed to save: \(error)", level: .warning, category: .library)
+                    self?.logger.log("Failed to save bookmark: \(error)", level: .warning, category: .library)
                 case .none:
                     break
                 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -95,8 +95,24 @@ class EditBookmarkViewModel {
     func saveBookmark() {
         guard let selectedFolder, let node else { return }
         Task { @MainActor [weak self] in
-            _ = await self?.bookmarksSaver.save(bookmark: node,
-                                                parentFolderGUID: selectedFolder.guid)
+            let result = await self?.bookmarksSaver.save(bookmark: node,
+                                                         parentFolderGUID: selectedFolder.guid)
+            if selectedFolder.guid != self?.parentFolder.guid {
+                switch result {
+                case .success(let saveResult):
+                    switch saveResult {
+                    case .void:
+                        self?.profile.prefs.setString(selectedFolder.guid, forKey: PrefsKeys.BookmarkSaveToFolder)
+                    default:
+                        break
+                    }
+                case .failure(let error):
+                    print("Failed to save: \(error)")
+                case .none:
+                    break
+                }
+            }
+
             self?.onBookmarkSaved?()
         }
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -99,14 +99,14 @@ class EditBookmarkViewModel {
     func saveBookmark() {
         guard let selectedFolder, let node else { return }
         Task { @MainActor [weak self] in
+            // Updates the bookmark
             let result = await self?.bookmarksSaver.save(bookmark: node,
                                                          parentFolderGUID: selectedFolder.guid)
+            // Only update the recent folder pref if the bookmarks parent folder changes
             if selectedFolder.guid != self?.parentFolder.guid {
                 switch result {
-                case .success(let guid):
-                    if guid == nil {
-                        self?.profile.prefs.setString(selectedFolder.guid, forKey: PrefsKeys.RecentBookmarkFolder)
-                    }
+                case .success:
+                    self?.profile.prefs.setString(selectedFolder.guid, forKey: PrefsKeys.RecentBookmarkFolder)
                 case .failure(let error):
                     self?.logger.log("Failed to save bookmark: \(error)", level: .warning, category: .library)
                 case .none:

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -2,12 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import MozillaAppServices
 import Shared
 
 class EditFolderViewModel {
     private let profile: Profile
+    private let logger: Logger
     private let parentFolder: FxBookmarkNode
     private var folder: FxBookmarkNode?
     private let bookmarkSaver: BookmarksSaver
@@ -27,11 +29,13 @@ class EditFolderViewModel {
     }
 
     init(profile: Profile,
+         logger: Logger = DefaultLogger.shared,
          parentFolder: FxBookmarkNode,
          folder: FxBookmarkNode?,
          bookmarkSaver: BookmarksSaver? = nil,
          folderFetcher: FolderHierarchyFetcher? = nil) {
         self.profile = profile
+        self.logger = logger
         self.parentFolder = parentFolder
         self.folder = folder
         self.bookmarkSaver = bookmarkSaver ?? DefaultBookmarksSaver(profile: profile)
@@ -102,7 +106,7 @@ class EditFolderViewModel {
                         break
                     }
                 case .failure(let error):
-                    print("Failed to save: \(error)")
+                    self.logger.log("Failed to save: \(error)", level: .warning, category: .library)
                 }
 
                 onBookmarkSaved?()

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -96,12 +96,12 @@ class EditFolderViewModel {
         guard let folder else { return }
         let selectedFolderGUID = selectedFolder?.guid ?? parentFolder.guid
         Task { @MainActor in
+            // Creats or updates the folder
             let result = await bookmarkSaver.save(bookmark: folder, parentFolderGUID: selectedFolderGUID)
             switch result {
             case .success(let guid):
-                if let guid = guid {
-                    profile.prefs.setString(guid, forKey: PrefsKeys.RecentBookmarkFolder)
-                }
+                guard let guid else { return }
+                profile.prefs.setString(guid, forKey: PrefsKeys.RecentBookmarkFolder)
             case .failure(let error):
                 self.logger.log("Failed to save folder: \(error)", level: .warning, category: .library)
             }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -96,20 +96,17 @@ class EditFolderViewModel {
         guard let folder else { return }
         let selectedFolderGUID = selectedFolder?.guid ?? parentFolder.guid
         Task { @MainActor in
-                let result = await bookmarkSaver.save(bookmark: folder, parentFolderGUID: selectedFolderGUID)
-                switch result {
-                case .success(let saveResult):
-                    switch saveResult {
-                    case .guid(let guid):
-                        profile.prefs.setString(guid, forKey: PrefsKeys.BookmarkSaveToFolder)
-                    default:
-                        break
-                    }
-                case .failure(let error):
-                    self.logger.log("Failed to save: \(error)", level: .warning, category: .library)
+            let result = await bookmarkSaver.save(bookmark: folder, parentFolderGUID: selectedFolderGUID)
+            switch result {
+            case .success(let guid):
+                if let guid = guid {
+                    profile.prefs.setString(guid, forKey: PrefsKeys.RecentBookmarkFolder)
                 }
+            case .failure(let error):
+                self.logger.log("Failed to save folder: \(error)", level: .warning, category: .library)
+            }
 
-                onBookmarkSaved?()
+            onBookmarkSaved?()
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -96,7 +96,7 @@ class EditFolderViewModel {
         guard let folder else { return }
         let selectedFolderGUID = selectedFolder?.guid ?? parentFolder.guid
         Task { @MainActor in
-            // Creats or updates the folder
+            // Creates or updates the folder
             let result = await bookmarkSaver.save(bookmark: folder, parentFolderGUID: selectedFolderGUID)
             switch result {
             case .success(let guid):

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -100,6 +100,7 @@ class EditFolderViewModel {
             let result = await bookmarkSaver.save(bookmark: folder, parentFolderGUID: selectedFolderGUID)
             switch result {
             case .success(let guid):
+                // A nil guid indicates a bookmark update, not creation
                 guard let guid else { return }
                 profile.prefs.setString(guid, forKey: PrefsKeys.RecentBookmarkFolder)
             case .failure(let error):

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
@@ -11,7 +11,7 @@ protocol BookmarksSaver {
     func save(bookmark: FxBookmarkNode, parentFolderGUID: String) async -> Result<SaveResult, Error>
 }
 
-enum SaveResult {
+enum SaveResult: Equatable {
     case guid(String)
     case void
 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
@@ -10,7 +10,7 @@ protocol BookmarksSaver {
     /// Saves or updates a bookmark or folder
     /// Returns a GUID when creating a bookmark or folder, or nil when updating them
     func save(bookmark: FxBookmarkNode, parentFolderGUID: String) async -> Result<GUID?, Error>
-    func createBookmark(url: String, title: String?, position: UInt32?)
+    func createBookmark(url: String, title: String?, position: UInt32?) async
 }
 
 struct DefaultBookmarksSaver: BookmarksSaver, BookmarksRefactorFeatureFlagProvider {
@@ -86,7 +86,7 @@ struct DefaultBookmarksSaver: BookmarksSaver, BookmarksRefactorFeatureFlagProvid
         }
     }
 
-    func createBookmark(url: String, title: String?, position: UInt32?) {
+    func createBookmark(url: String, title: String?, position: UInt32?) async {
         let bookmarkData = BookmarkItemData(guid: "",
                                             dateAdded: 0,
                                             lastModified: 0,
@@ -98,8 +98,6 @@ struct DefaultBookmarksSaver: BookmarksSaver, BookmarksRefactorFeatureFlagProvid
         // If bookmarks refactor is enabled, save bookmark to recent bookmark folder, otherwise save to root folder
         let recentBookmarkFolderGuid = profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder)
         let parentGuid = (isBookmarkRefactorEnabled ? recentBookmarkFolderGuid : nil) ?? BookmarkRoots.MobileFolderGUID
-        Task { @MainActor in
-            await save(bookmark: bookmarkData, parentFolderGUID: parentGuid)
-        }
+        _ = await save(bookmark: bookmarkData, parentFolderGUID: parentGuid)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -4,11 +4,13 @@
 
 import Common
 import Foundation
+import Shared
 
 /// A view controller that manages the hidden Firefox Suggest debug settings.
 final class FeatureFlagsDebugViewController: SettingsTableViewController, FeatureFlaggable {
-    init(windowUUID: WindowUUID) {
+    init(profile: Profile, windowUUID: WindowUUID) {
         super.init(style: .grouped, windowUUID: windowUUID)
+        self.profile = profile
         self.title = "Feature Flags"
     }
 
@@ -30,6 +32,9 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     statusText: format(string: "Toggle to use the new bookmarks design")
                 ) { [weak self] _ in
                     self?.reloadView()
+                    let isBookmarksRefactorEnabled = self?.featureFlags.isFeatureEnabled(.bookmarksRefactor,
+                                                                                         checking: .buildOnly) ?? false
+                    self?.profile.prefs.setBool(isBookmarksRefactorEnabled, forKey: PrefsKeys.IsBookmarksRefactorEnabled)
                 },
                 FeatureFlagsBoolSetting(
                     with: .closeRemoteTabs,

--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -469,8 +469,13 @@ extension ShareViewController {
             let profile = BrowserProfile(localName: "profile")
             profile.reopen()
             // Intentionally block thread with database call.
-            // Add new mobile bookmark at the top of the list
-            _ = profile.places.createBookmark(parentGUID: BookmarkRoots.MobileFolderGUID,
+
+            // Add new bookmark to the top of the folder
+            // If bookmarks refactor is enabled, save bookmark to recent bookmark folder, otherwise save to root folder
+            let isBookmarkRefactorEnabled = profile.prefs.boolForKey(PrefsKeys.IsBookmarksRefactorEnabled) ?? false
+            let recentBookmarkFolderGuid = profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder)
+            let parentGuid = (isBookmarkRefactorEnabled ? recentBookmarkFolderGuid : nil) ?? BookmarkRoots.MobileFolderGUID
+            _ = profile.places.createBookmark(parentGUID: parentGuid,
                                               url: item.url,
                                               title: item.title,
                                               position: 0).value

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultBookmarksSaverTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultBookmarksSaverTests.swift
@@ -6,7 +6,7 @@ import XCTest
 import MozillaAppServices
 @testable import Client
 
-final class DefaultBookmarksSaverTests: XCTestCase, FeatureFlaggable {
+final class DefaultBookmarksSaverTests: XCTestCase {
     var mockProfile: MockProfile!
     let rootFolderGUID = BookmarkRoots.MobileFolderGUID
     let testBookmark = Bookmark(title: "test", url: "https://www.test.com")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultBookmarksSaverTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultBookmarksSaverTests.swift
@@ -18,6 +18,7 @@ final class DefaultBookmarksSaverTests: XCTestCase, FeatureFlaggable {
     override func setUp() async throws {
         try await super.setUp()
         mockProfile = MockProfile()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
         testBookmarkGUID = await addBookmark(title: testBookmark.title, url: testBookmark.url)
         testFolderGUID = await addFolder(title: testFolder.title)
     }
@@ -173,8 +174,6 @@ final class DefaultBookmarksSaverTests: XCTestCase, FeatureFlaggable {
     func testCreateBookmark_createsNewBookmark() async throws {
         let bookmarkUrl = "https://www.mozilla.com/"
         let bookmarTitle =  "testTitle"
-
-        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
 
         let subject = createSubject()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultBookmarksSaverTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultBookmarksSaverTests.swift
@@ -68,11 +68,17 @@ final class DefaultBookmarksSaverTests: XCTestCase {
                                       parentFolderGUID: modifiedBookmark.parentGUID ?? rootFolderGUID)
         }
 
+        switch result {
+        case .success(let value):
+            XCTAssertNil(value, "Expected the result value to be nil for updates.")
+        case .failure(let error):
+            XCTFail("Expected success but got failure: \(error)")
+        }
+
         let readModfiedBookmark = try await unwrapAsync {
             return await readNode(guid: previouslyAddedBookmark.guid) as? BookmarkItemData
         }
 
-        XCTAssertNotNil(try? result.get())
         XCTAssertEqual(readModfiedBookmark.title, newTitle)
         XCTAssertEqual(readModfiedBookmark.url, newUrl)
     }
@@ -130,11 +136,17 @@ final class DefaultBookmarksSaverTests: XCTestCase {
                                       parentFolderGUID: modifiedFolder.parentGUID ?? rootFolderGUID)
         }
 
+        switch result {
+        case .success(let value):
+            XCTAssertNil(value, "Expected the result value to be nil for updates.")
+        case .failure(let error):
+            XCTFail("Expected success but got failure: \(error)")
+        }
+
         let readModfiedBookmark = try await unwrapAsync {
             return await readNode(guid: modifiedFolder.guid) as? BookmarkFolderData
         }
 
-        XCTAssertNotNil(try? result.get())
         XCTAssertEqual(readModfiedBookmark.title, newTitle)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultFolderHeirarchyFetcherTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultFolderHeirarchyFetcherTests.swift
@@ -14,6 +14,7 @@ final class DefaultFolderHeirarchyFetcherTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         mockProfile = MockProfile()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
         await addFolder(title: testFolderTitle)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultFolderHierarchyFetcherTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultFolderHierarchyFetcherTests.swift
@@ -6,7 +6,7 @@ import XCTest
 import MozillaAppServices
 @testable import Client
 
-final class DefaultFolderHeirarchyFetcherTests: XCTestCase {
+final class DefaultFolderHierarchyFetcherTests: XCTestCase {
     var mockProfile: MockProfile!
     let rootFolderGUID = BookmarkRoots.MobileFolderGUID
     let testFolderTitle = "testTitle"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9747)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21416)

## :bulb: Description
- Saving a bookmark via the app menu will now save it to the most recent folder instead of the root (mobile) folder

### 📝 Notes: 
- Most recent folder (aka `RecentBookmarkFolder` in `Prefs.swift`) is defined by either: 
  - a) The last saved-to folder
  - b) The last created folder 
- If the most recent folder is deleted, bookmarks will save to the root (mobile) folder until a new most recent folder is set
- Updating a folder's name *does not* make it or it's parent the most recent folder
- `BookmarksSaver::Save` updated to return a `GUID?` which contains the `GUID` of a created bookmark or folder, and `nil` when updating a bookmark or folder
- `IsBookmarksRefactorEnabled` pref added to check bookmark refactor feature flag from share extension (`ShareTo` target) when saving a bookmark via share extension
  - Pref is saved on app start when nimbus is initialized, and when the feature flag is toggled in settings > debug menu > feature flags (`FeatureFlagsDebugViewController`)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

