### PR TITLE
Bugfix FXIOS-10842 [Bookmark Evolution] Long Press Bookmarks Folder Theme Fix

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
@@ -51,8 +51,8 @@ class PhotonActionSheetSiteHeaderView: UITableViewHeaderFooterView, ReusableCell
     func configure(with bookmarkFolderTitle: String) {
         if let image = UIImage(named: StandardImageIdentifiers.Large.folder)?.withRenderingMode(.alwaysTemplate) {
             imageView.manuallySetImage(image)
-            titleLabel.text = bookmarkFolderTitle
         }
+        titleLabel.text = bookmarkFolderTitle
     }
 
     func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetSiteHeaderView.swift
@@ -49,12 +49,15 @@ class PhotonActionSheetSiteHeaderView: UITableViewHeaderFooterView, ReusableCell
     }
 
     func configure(with bookmarkFolderTitle: String) {
-        imageView.manuallySetImage(UIImage(resource: .folderLarge))
-        titleLabel.text = bookmarkFolderTitle
+        if let image = UIImage(named: StandardImageIdentifiers.Large.folder)?.withRenderingMode(.alwaysTemplate) {
+            imageView.manuallySetImage(image)
+            titleLabel.text = bookmarkFolderTitle
+        }
     }
 
     func applyTheme(theme: Theme) {
         imageView.layer.borderColor = theme.colors.borderPrimary.cgColor
+        imageView.tintColor = theme.colors.iconPrimary
         titleLabel.textColor = theme.colors.textPrimary
         descriptionLabel.textColor = theme.colors.textPrimary
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10842)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23643)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Forgot to add theming to the folder icon that shows up after long pressing: 
![Screenshot 2024-12-09 at 3 33 55 PM](https://github.com/user-attachments/assets/58634def-4aad-47b0-887e-266214467253)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

