### PR TITLE
Fix MTE-3948 Fix ActivityStream XCUITests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -11,7 +11,7 @@ let newTopSite = [
     "bookmarkLabel": "Mozilla - Internet for people, not profit (US)"
 ]
 let newTopSiteiOS15 = [
-    "bookmarkLabel": "Internet for people, not profit"
+    "bookmarkLabel": "Internet for people, not profit — Mozilla (US)"
 ]
 let allDefaultTopSites = ["Facebook", "YouTube", "Amazon", "Wikipedia", "X"]
 
@@ -71,7 +71,7 @@ class ActivityStreamTest: BaseTestCase {
     }
     // https://mozilla.testrail.io/index.php?/cases/view/2272219
     func testTopSitesRemoveAllExceptDefaultClearPrivateData() {
-        waitForExistence(app.cells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
+        waitForExistence(app.cells.staticTexts[newTopSiteiOS15["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
         // A new site has been added to the top sites
         if iPad() {
             checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 12)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3948)

## :bulb: Description
This PR fixes a couple of test on ActivityStreamTests. The url title changed due to the new mozilla webpage. This PR updates the title.

## :pencil: Checklist
You have to check all boxes before merging
- [X ] Filled in the above information (tickets numbers and description of your work)
- [ X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

