### PR TITLE
Refactor FXIOS-10797 #23557 [Sponsored tiles] Enable unified ads API in developer and beta

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDataAdaptorTests.swift
@@ -430,7 +430,7 @@ class TopSitesDataAdaptorTests: XCTestCase, FeatureFlaggable {
 }
 
 // MARK: - ContileProviderMock
-class ContileProviderMock: ContileProviderInterface {
+class ContileProviderMock: ContileProviderInterface, UnifiedAdsProviderInterface {
     typealias Mock = ContileProviderMock
     private var result: ContileResult
 
@@ -467,6 +467,27 @@ class ContileProviderMock: ContileProviderInterface {
 
     func fetchContiles(timestamp: Timestamp = Date.now(), completion: @escaping (ContileResult) -> Void) {
         completion(result)
+    }
+
+    func fetchTiles(timestamp: Timestamp, completion: @escaping (UnifiedTileResult) -> Void) {
+        switch result {
+        case .success(let contiles):
+            let unifiedTiles = self.convert(contiles: contiles)
+            completion(.success(unifiedTiles))
+        case .failure(let error):
+            completion(.failure(error))
+        }
+    }
+
+    func convert(contiles: [Contile]) -> [UnifiedTile] {
+        return contiles.enumerated().map { (index, contile) in
+            UnifiedTile(format: "tile",
+                        url: contile.url,
+                        callbacks: UnifiedTileCallback(click: contile.clickUrl, impression: contile.impressionUrl),
+                        imageUrl: contile.imageUrl,
+                        name: contile.name,
+                        blockKey: "Block_key_\(index)")
+        }
     }
 }
 
@@ -534,6 +555,7 @@ extension TopSitesDataAdaptorTests {
                                                         topSiteHistoryManager: historyStub,
                                                         googleTopSiteManager: googleManager,
                                                         contileProvider: contileProviderMock,
+                                                        unifiedAdsProvider: contileProviderMock,
                                                         notificationCenter: notificationCenter,
                                                         dispatchGroup: dispatchGroup)
 

--- a/firefox-ios/nimbus-features/unifiedAds.yaml
+++ b/firefox-ios/nimbus-features/unifiedAds.yaml
@@ -12,7 +12,7 @@ features:
     defaults:
       - channel: beta
         value:
-          enabled: false
+          enabled: true
       - channel: developer
         value:
-          enabled: false
+          enabled: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10797)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23557)

## :bulb: Description
Attempt number 2 cause I made a mistake in my previous PR [here](https://github.com/mozilla-mobile/firefox-ios/pull/23558). It enable unified ads API in developer and beta

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

