### PR TITLE
Refactor FXIOS-10633 [Wallpapers] [Homepage Rebuild] Rename default wallpaper so it is slightly more clear

### DIFF
--- a/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
@@ -63,7 +63,7 @@ class StatusBarOverlay: UIView,
     func resetState(isHomepage: Bool) {
         savedIsHomepage = isHomepage
         // We only need no status bar for one edge case
-        let needsNoStatusBar = isHomepage && wallpaperManager.currentWallpaper.type != .defaultWallpaper && isBottomSearchBar
+        let needsNoStatusBar = isHomepage && wallpaperManager.currentWallpaper.hasImage && isBottomSearchBar
         scrollOffset = needsNoStatusBar ? 0 : 1
         backgroundColor = savedBackgroundColor?.withAlphaComponent(scrollOffset)
     }

--- a/firefox-ios/Client/Frontend/Home/Blurrable.swift
+++ b/firefox-ios/Client/Frontend/Home/Blurrable.swift
@@ -17,6 +17,6 @@ extension Blurrable {
     var shouldApplyWallpaperBlur: Bool {
         guard !UIAccessibility.isReduceTransparencyEnabled else { return false }
 
-        return WallpaperManager().currentWallpaper.type != .defaultWallpaper
+        return WallpaperManager().currentWallpaper.hasImage
     }
 }

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -451,7 +451,7 @@ class LegacyHomepageViewController:
 
     private func handleScroll(_ scrollView: UIScrollView, isUserInteraction: Bool) {
         // We only handle status bar overlay alpha if there's a wallpaper applied on the homepage
-        if WallpaperManager().currentWallpaper.type != .defaultWallpaper {
+        if WallpaperManager().currentWallpaper.hasImage {
             let theme = themeManager.getCurrentTheme(for: windowUUID)
             statusBarScrollDelegate?.scrollViewDidScroll(scrollView,
                                                          statusBarFrame: statusBarFrame,

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
@@ -214,18 +214,18 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
     }
 
     private func addDefaultWallpaper(to availableCollections: [WallpaperCollection]) -> [WallpaperCollection] {
-        let defaultWallpaper = [Wallpaper.defaultWallpaper]
+        let baseWallpaper = [Wallpaper.baseWallpaper]
 
         if availableCollections.isEmpty {
             return [WallpaperCollection(id: "classic-firefox",
                                         learnMoreURL: nil,
                                         availableLocales: nil,
                                         availability: nil,
-                                        wallpapers: defaultWallpaper,
+                                        wallpapers: baseWallpaper,
                                         description: nil,
                                         heading: nil)]
         } else if let classicCollection = availableCollections.first(where: { $0.type == .classic }) {
-            let newWallpapers = defaultWallpaper + classicCollection.wallpapers
+            let newWallpapers = baseWallpaper + classicCollection.wallpapers
             let newClassic = WallpaperCollection(id: classicCollection.id,
                                                  learnMoreURL: classicCollection.learnMoreUrl?.absoluteString,
                                                  availableLocales: classicCollection.availableLocales,

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Models/Wallpaper.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 enum WallpaperType: String {
-    case defaultWallpaper
+    case none
     case other
 }
 
@@ -50,10 +50,11 @@ struct Wallpaper: Equatable {
     var portraitID: String { return "\(id)\(deviceVersionID)\(fileId.portrait)" }
     var landscapeID: String { return "\(id)\(deviceVersionID)\(fileId.landscape)" }
 
-    // TODO: This is actually just a nil wallpaper. Make this clearer in FXIOS-10633
-    static var defaultWallpaper: Wallpaper {
+    /// "Default" wallpaper object. This basically acts as a wrapper to our `noAssetID` so that
+    /// we can identify that no wallpaper is selected.
+    static var baseWallpaper: Wallpaper {
         return Wallpaper(
-            id: Wallpaper.defaultWallpaperName,
+            id: Wallpaper.noAssetID,
             textColor: nil,
             cardColor: nil,
             logoTextColor: nil
@@ -61,11 +62,15 @@ struct Wallpaper: Equatable {
     }
 
     var type: WallpaperType {
-        return id == Wallpaper.defaultWallpaperName ? .defaultWallpaper : .other
+        return id == Wallpaper.noAssetID ? .none : .other
+    }
+
+    var hasImage: Bool {
+        type != .none
     }
 
     var needsToFetchResources: Bool {
-        guard type != .defaultWallpaper else { return false }
+        guard hasImage else { return false }
         return portrait == nil || landscape == nil
     }
 
@@ -81,7 +86,9 @@ struct Wallpaper: Equatable {
         return fetchResourceFor(imageType: .landscape)
     }
 
-    private static var defaultWallpaperName = "fxDefault"
+    /// ID for the "default" wallpaper object. This is not actually an image file name, this just helps us
+    /// identify that no image is selected.
+    private static var noAssetID = "fxDefault"
     private var deviceVersionID: String {
         return UIDevice.current.userInterfaceIdiom == .pad ? fileId.iPad : fileId.iPhone
     }

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewModel.swift
@@ -213,7 +213,7 @@ private extension WallpaperSelectorViewModel {
 
         let wallpaperTypeKey = TelemetryWrapper.EventExtraKey.wallpaperType.rawValue
         switch item.wallpaper.type {
-        case .defaultWallpaper:
+        case .none:
             metadata[wallpaperTypeKey] = "default"
         case .other:
             switch item.collection.type {

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperMigrationUtility.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperMigrationUtility.swift
@@ -30,7 +30,7 @@ struct WallpaperMigrationUtility {
 
         do {
             let currentWallpaper = storageUtility.fetchCurrentWallpaper()
-            guard currentWallpaper.type != .defaultWallpaper,
+            guard currentWallpaper.type != .none,
                   let landscape = currentWallpaper.landscape,
                   let portrait = currentWallpaper.portrait,
                   let matchingID = getMatchingIdBasedOn(legacyId: currentWallpaper.id),

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperStorageUtility.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperStorageUtility.swift
@@ -97,7 +97,7 @@ struct WallpaperStorageUtility: WallpaperMetadataCodableProtocol {
             }
         }
 
-        return Wallpaper.defaultWallpaper
+        return Wallpaper.baseWallpaper
     }
 
     public func fetchImageNamed(_ name: String) throws -> UIImage? {

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperThumbnailUtility.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Utilities/WallpaperThumbnailUtility.swift
@@ -39,7 +39,7 @@ class WallpaperThumbnailUtility {
 
         collections.forEach { collection in
             collection.wallpapers.forEach { wallpaper in
-                if wallpaper.type != .defaultWallpaper && wallpaper.thumbnail == nil {
+                if wallpaper.hasImage && wallpaper.thumbnail == nil {
                     missingThumbnails[wallpaper.id] = wallpaper.thumbnailID
                 }
             }
@@ -82,7 +82,7 @@ class WallpaperThumbnailUtility {
 
         collections.forEach { collection in
             collection.wallpapers.forEach { wallpaper in
-                if wallpaper.type == .defaultWallpaper || wallpaper.thumbnail != nil {
+                if wallpaper.type == .none || wallpaper.thumbnail != nil {
                     numberOfAvailableThumbs += 1
                 }
             }

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
@@ -226,7 +226,7 @@ private extension WallpaperSettingsViewModel {
 
         let wallpaperTypeKey = TelemetryWrapper.EventExtraKey.wallpaperType.rawValue
         switch (wallpaper.type, collection.type) {
-        case (.defaultWallpaper, _):
+        case (.none, _):
             metadata[wallpaperTypeKey] = "default"
         case (.other, .classic):
             metadata[wallpaperTypeKey] = collection.type.rawValue

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -759,7 +759,7 @@ class TelemetryWrapperTests: XCTestCase {
                                          logoTextColor: nil)
 
         WallpaperManager().setCurrentWallpaper(to: defaultWallpaper) { _ in }
-        XCTAssertEqual(WallpaperManager().currentWallpaper.type, .defaultWallpaper)
+        XCTAssertEqual(WallpaperManager().currentWallpaper.type, .none)
 
         let fakeNotif = NSNotification(name: UIApplication.didEnterBackgroundNotification, object: nil)
         TelemetryWrapper.shared.recordEnteredBackgroundPreferenceMetrics(notification: fakeNotif)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10633)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23280)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
As a new person to the team it was not super clear to me that the default wallpaper was not actually a wallpaper, just a placeholder entity for no wallpaper. This is my _sad_ attempt to make the naming more clear. Any and all feedback welcome.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

