### PR TITLE
Fix FXIOS-10834 - [Toolbar Redesign] Update `removeCompletion` to handle marked text properly

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -197,7 +197,10 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     @objc
     @discardableResult
     private func removeCompletion() -> Bool {
-        guard markedTextRange != nil else { return false }
+        // If markedTextRange exists, avoid clearing it prematurely.
+        if markedTextRange != nil {
+            return false
+        }
 
         text = textWithoutSuggestion()
         return true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10834)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23625)

## :bulb: Description
This PR fixes an issue where intermediate text composition (e.g., for Japanese or Chinese) was prematurely cleared in the `LocationTextField` during input. The root cause was that removeCompletion() did not properly respect markedTextRange, which is used for handling partially composed text by the system.

The updated implementation of `removeCompletion` now skips clearing the text if markedTextRange is active. This allows users to type and confirm their input without disruption. Normal autocompletion behavior is maintained.

⚠️ **NOTE1:** This will need to be backported to 133 and 134.
⚠️ **NOTE2:** I would have liked to test this but we would need a UI test probably to interact with keyboard all.

**Before ( for Chinese. Notice no input in urlbar )**

https://github.com/user-attachments/assets/a68b3e26-8ac2-44f3-83f9-aaff3f143632

**After ( for both Chinese and Japanese. Notice user can input text and autocomplete works )**

| Chinese  | Japanese |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/d1dfa139-ef1d-4204-b86a-af267795b10a"/> | <video src="https://github.com/user-attachments/assets/dff1de85-87e7-4ee9-94e0-991b3f2fa5a6" /> |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

