### PR TITLE
Refactor FXIOS-10845 - [Shavar Deprecation] Pull tracking lists from PROD instead of DEV

### DIFF
--- a/firefox-ios/Client/Assets/RemoteSettingsData/RemoteSettingsFetchConfig.json
+++ b/firefox-ios/Client/Assets/RemoteSettingsData/RemoteSettingsFetchConfig.json
@@ -9,8 +9,8 @@
     },
     {
       "name": "Tracking Protection Lists",
-      "url": "https://remote-settings-dev.allizom.org/v1",
-      "bucket_id": "main-preview",
+      "url": "https://firefox.settings.services.mozilla.com/v1",
+      "bucket_id": "main",
       "collection_id": "tracking-protection-lists-ios",
       "fetch_attachments": true,
       "save_records": false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10845)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23655)

## :bulb: Description
Now that we have the record in PROD ( and stage if we need it ) we can pull directly from PROD. We can use DEV as a playground later if we want to add additional lists ( e.g. easy list ).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

