### PR TITLE
Bugfix FXIOS-10850 - [Toolbar Redesign] Preserve Text Alignment in Address Bar Unless Layout Updates to RTL Language

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -93,6 +93,10 @@ final class LocationView: UIView,
         urlTextField.adjustsFontForContentSizeCategory = true
         urlTextField.autocompleteDelegate = self
         urlTextField.accessibilityActionsSource = self
+        // Update the `textAlignment` property only when the entire layout direction is RTL or LTR,
+        // similar to Apple's handling in Safari, ensuring that `textAlignment` remains in sync with the layout constraints.
+        let layoutDirection = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute)
+        urlTextField.textAlignment = layoutDirection == .rightToLeft ? .right : .left
     }
 
     // MARK: - Init


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10850)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23659)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- We currently change the alignment of the text in `urlTextFIeld` even though the layout has not changed to RTL, making the layout look broken.
- This PR changes the text alignment only when the entire layout is set RTL, like apple does with Safari.
### Screenshots
- We don't change the text alignment when the keyboard has a RTL language set, as we did before.
![alignmentUnchanged](https://github.com/user-attachments/assets/da7591fb-6714-4719-8702-ff9a95ca3554)
- We change the text alignment when the entire layout is RTL.
![AlignmentUpdated](https://github.com/user-attachments/assets/e1763b33-f9ef-4031-993c-2f270c572d47)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

