### PR TITLE
Bugfix FXIOS-10791 Easter gif is truncated on small devices

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
@@ -229,14 +229,21 @@ class PullRefreshView: UIView,
 }
 
 struct EasterEggViewLayoutBuilder {
+    private struct UX {
+        static let sidePadding: CGFloat = 32.0
+        /// The max height that we are considering a device a small one.
+        /// This screen height refers to iPhone SE 2/3 rd gen, 6,7,8.
+        ///
+        /// https://www.appmysite.com/blog/the-complete-guide-to-iphone-screen-resolutions-and-sizes/
+        static let smallDevicesMaxScreenHeight: CGFloat = 667.0
+    }
+
     let easterEggSize: CGSize
-    let sidePadding: CGFloat = 32.0
 
     func layoutEasterEggView(_ view: UIView, superview: UIView, isPortrait: Bool, isIpad: Bool) {
         var isPortrait = isPortrait
-        // MARK: 667 is the screen height for iPhone SE 2/3 rd gen, 6,7,8.
-        // https://www.appmysite.com/blog/the-complete-guide-to-iphone-screen-resolutions-and-sizes/
-        if let screenHeight = UIWindow.keyWindow?.windowScene?.screen.bounds.height, screenHeight <= 667.0 {
+        if let screenHeight = UIWindow.keyWindow?.windowScene?.screen.bounds.height,
+           screenHeight <= UX.smallDevicesMaxScreenHeight {
             // Force landscape layout so the easter egg shows only bottom sides and doesn't render clipped for small devices
             isPortrait = false
         }
@@ -258,12 +265,12 @@ struct EasterEggViewLayoutBuilder {
             [
                 view.bottomAnchor.constraint(equalTo: superview.bottomAnchor),
                 view.leadingAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.leadingAnchor,
-                                              constant: sidePadding)
+                                              constant: UX.sidePadding)
             ]
         case .bottomTrailing:
             [
                 view.trailingAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.trailingAnchor,
-                                               constant: -sidePadding),
+                                               constant: -UX.sidePadding),
                 view.bottomAnchor.constraint(equalTo: superview.bottomAnchor)
             ]
         case .trailing:

--- a/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
@@ -249,12 +249,6 @@ struct EasterEggViewLayoutBuilder {
 
     private func layoutEasterEggView(_ view: UIView, superview: UIView, position: NSRectAlignment) {
         let constraints: [NSLayoutConstraint] = switch position {
-        case .topLeading:
-            [
-                view.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: -easterEggSize.height / 1.5),
-                view.leadingAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.leadingAnchor,
-                                              constant: sidePadding)
-            ]
         case .leading:
             [
                 view.leadingAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.leadingAnchor),
@@ -276,12 +270,6 @@ struct EasterEggViewLayoutBuilder {
             [
                 view.trailingAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.trailingAnchor),
                 view.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: -easterEggSize.height / 2.0)
-            ]
-        case .topTrailing:
-            [
-                view.trailingAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.trailingAnchor,
-                                               constant: -sidePadding),
-                view.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: -easterEggSize.height / 1.5)
             ]
         default:
             []
@@ -316,8 +304,6 @@ struct EasterEggViewLayoutBuilder {
         let allowedPositions: [NSRectAlignment] = [
             .bottomLeading,
             .bottomTrailing,
-            .topLeading,
-            .topTrailing,
             .leading,
             .trailing
         ]

--- a/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/PullRefreshView.swift
@@ -42,7 +42,7 @@ class PullRefreshView: UIView,
     }
 
     private var isIpad: Bool {
-        traitCollection.userInterfaceIdiom == .pad && traitCollection.horizontalSizeClass == .regular
+        return traitCollection.userInterfaceIdiom == .pad && traitCollection.horizontalSizeClass == .regular
     }
 
     init(parentScrollView: UIScrollView?,
@@ -233,6 +233,13 @@ struct EasterEggViewLayoutBuilder {
     let sidePadding: CGFloat = 32.0
 
     func layoutEasterEggView(_ view: UIView, superview: UIView, isPortrait: Bool, isIpad: Bool) {
+        var isPortrait = isPortrait
+        // MARK: 667 is the screen height for iPhone SE 2/3 rd gen, 6,7,8.
+        // https://www.appmysite.com/blog/the-complete-guide-to-iphone-screen-resolutions-and-sizes/
+        if let screenHeight = UIWindow.keyWindow?.windowScene?.screen.bounds.height, screenHeight <= 667.0 {
+            // Force landscape layout so the easter egg shows only bottom sides and doesn't render clipped for small devices
+            isPortrait = false
+        }
         if isPortrait || isIpad {
             layoutEasterEggView(view, superview: superview, position: randomPortraitLayoutPosition())
         } else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10791)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23540)

## :bulb: Description
Bugfix Easter egg on pull refresh showing truncated on small devices by forcing landscape layout of the easter egg.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

