### PR TITLE
Add FXIOS-9766 [Bookmarks Evolution] Update Bookmarks Panel View Edit Mode Part 1

### DIFF
--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -57,11 +57,10 @@ class LibraryCoordinator: BaseCoordinator,
     private func makeChildPanels() -> [UINavigationController] {
         let bookmarksPanel: UIViewController
         if isBookmarkRefactorEnabled {
-            let bookmarksPanelTemp = BookmarksViewController(viewModel:
+            bookmarksPanel = BookmarksViewController(viewModel:
                                                                 BookmarksPanelViewModel(profile: profile,
                                                                                         bookmarksHandler: profile.places),
                                                      windowUUID: windowUUID)
-            bookmarksPanel = bookmarksPanelTemp
         } else {
             bookmarksPanel = LegacyBookmarksPanel(viewModel: BookmarksPanelViewModel(profile: profile,
                                                                                      bookmarksHandler: profile.places),

--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -57,9 +57,11 @@ class LibraryCoordinator: BaseCoordinator,
     private func makeChildPanels() -> [UINavigationController] {
         let bookmarksPanel: UIViewController
         if isBookmarkRefactorEnabled {
-            bookmarksPanel = BookmarksViewController(viewModel: BookmarksPanelViewModel(profile: profile,
+            let bookmarksPanelTemp = BookmarksViewController(viewModel:
+                                                                BookmarksPanelViewModel(profile: profile,
                                                                                         bookmarksHandler: profile.places),
                                                      windowUUID: windowUUID)
+            bookmarksPanel = bookmarksPanelTemp
         } else {
             bookmarksPanel = LegacyBookmarksPanel(viewModel: BookmarksPanelViewModel(profile: profile,
                                                                                      bookmarksHandler: profile.places),

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -61,7 +61,7 @@ class BookmarksViewController: SiteTableViewController,
 
     private lazy var bottomLeftButton: UIBarButtonItem = {
         let button = UIBarButtonItem(
-            image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus),
+            title: .BookmarksNewFolder,
             style: .plain,
             target: self,
             action: #selector(bottomLeftButtonAction)
@@ -151,58 +151,6 @@ class BookmarksViewController: SiteTableViewController,
                 self?.updateEmptyState()
             }
         }
-    }
-
-    // MARK: - Actions
-
-    func presentInFolderActions() {
-        let viewModel = PhotonActionSheetViewModel(actions: [[getNewFolderAction(),
-                                                              getNewSeparatorAction()]],
-                                                   modalStyle: .overFullScreen)
-        let sheet = PhotonActionSheet(viewModel: viewModel, windowUUID: windowUUID)
-        sheet.modalTransitionStyle = .crossDissolve
-        present(sheet, animated: true)
-    }
-
-    private func getNewFolderAction() -> PhotonRowActions {
-        return SingleActionViewModel(
-            title: .BookmarksNewFolder,
-            iconString: StandardImageIdentifiers.Large.folder,
-            tapHandler: { _ in
-                guard let bookmarkFolder = self.viewModel.bookmarkFolder else { return }
-
-                self.bookmarkCoordinatorDelegate?.showBookmarkDetail(
-                    bookmarkType: .folder,
-                    parentBookmarkFolder: bookmarkFolder
-                )
-            }).items
-    }
-
-    private func getNewSeparatorAction() -> PhotonRowActions {
-        return SingleActionViewModel(title: .BookmarksNewSeparator,
-                                     iconString: StandardImageIdentifiers.Large.appMenu,
-                                     tapHandler: { _ in
-            let centerVisibleRow = self.centerVisibleRow()
-
-            self.profile.places.createSeparator(parentGUID: self.viewModel.bookmarkFolderGUID,
-                                                position: UInt32(centerVisibleRow)) >>== { guid in
-                self.profile.places.getBookmark(guid: guid).uponQueue(.main) { result in
-                    guard let bookmarkNode = result.successValue,
-                          let bookmarkSeparator = bookmarkNode as? BookmarkSeparatorData
-                    else { return }
-
-                    let indexPath = IndexPath(row: centerVisibleRow,
-                                              section: BookmarksPanelViewModel.BookmarksSection.bookmarks.rawValue)
-                    self.tableView.beginUpdates()
-                    self.viewModel.bookmarkNodes.insert(bookmarkSeparator, at: centerVisibleRow)
-                    self.tableView.insertRows(at: [indexPath], with: .automatic)
-                    self.tableView.endUpdates()
-
-                    self.updateEmptyState()
-                    self.flashRow(at: indexPath)
-                }
-            }
-        }).items
     }
 
     private func centerVisibleRow() -> Int {
@@ -647,7 +595,12 @@ extension BookmarksViewController: Notifiable {
 extension BookmarksViewController {
     func bottomLeftButtonAction() {
         if state == .bookmarks(state: .inFolderEditMode) {
-            presentInFolderActions()
+            guard let bookmarkFolder = self.viewModel.bookmarkFolder else { return }
+
+            self.bookmarkCoordinatorDelegate?.showBookmarkDetail(
+                bookmarkType: .folder,
+                parentBookmarkFolder: bookmarkFolder
+            )
         }
     }
 

--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -133,6 +133,7 @@ class LibraryViewController: UIViewController, Themeable {
 
     func updateViewWithState() {
         setupButtons()
+        updateSegmentControl()
     }
 
     fileprivate func updateTitle() {
@@ -325,6 +326,17 @@ class LibraryViewController: UIViewController, Themeable {
         navigationController?.toolbar.tintColor = theme.colors.actionPrimary
     }
 
+    private func updateSegmentControl() {
+        let panelState = getCurrentPanelState()
+
+        switch panelState {
+        case .bookmarks(state: .inFolderEditMode):
+            (1...3).forEach { index in self.librarySegmentControl.setEnabled(false, forSegmentAt: index) }
+        default:
+            (0...3).forEach { index in self.librarySegmentControl.setEnabled(true, forSegmentAt: index) }
+        }
+    }
+
     func applyTheme() {
         // There is an ANNOYING bar in the nav bar above the segment control. These are the
         // UIBarBackgroundShadowViews. We must set them to be clear images in order to
@@ -362,6 +374,7 @@ extension LibraryViewController: Notifiable {
         switch notification.name {
         case .LibraryPanelStateDidChange:
             setupButtons()
+            updateSegmentControl()
         default: break
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9766)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21443)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Same as ticket description "
1. Replace the + button with a New Folder button - Doing this also removes the New Bookmark and New Separator sub-items. We’ll continue to display separators but you’ll no longer be able to create them in Firefox for iOS.
2. Remove functionality to create separators in iOS, but still display ones that were created before
3. Deactivate/disable the segmented control when in edit mode. You’ll no longer be able to switch to other tabs in the segment control while in edit mode.
"

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

