### PR TITLE
Bugfix FXIOS-10832 Possible workaround for FXIOS-10832 withCheckedContinuation crash in JumpBackInDataAdaptor

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2777,22 +2777,21 @@ class BrowserViewController: UIViewController,
         )
 
         // Credit card sync telemetry
-        self.profile.hasSyncAccount { [unowned self] hasSync in
-            logger.log("User has sync account setup \(hasSync)",
-                       level: .debug,
-                       category: .setup)
+        let hasSync = self.profile.hasAccount()
+        logger.log("User has sync account setup \(hasSync)",
+                   level: .debug,
+                   category: .setup)
 
-            guard hasSync else { return }
-            let syncStatus = self.profile.syncManager.checkCreditCardEngineEnablement()
-            TelemetryWrapper.recordEvent(
-                category: .information,
-                method: .settings,
-                object: .creditCardSyncEnabled,
-                extras: [
-                    TelemetryWrapper.ExtraKey.isCreditCardSyncEnabled.rawValue: syncStatus
-                ]
-            )
-        }
+        guard hasSync else { return }
+        let syncStatus = self.profile.syncManager.checkCreditCardEngineEnablement()
+        TelemetryWrapper.recordEvent(
+            category: .information,
+            method: .settings,
+            object: .creditCardSyncEnabled,
+            extras: [
+                TelemetryWrapper.ExtraKey.isCreditCardSyncEnabled.rawValue: syncStatus
+            ]
+        )
     }
 
     private func autofillCreditCardNimbusFeatureFlag() -> Bool {

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/Data/JumpBackInDataAdaptor.swift
@@ -89,7 +89,7 @@ actor JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
     // MARK: Jump back in data
 
     private func updateTabsAndAccountData() async {
-        hasSyncAccount = await getHasSyncAccount()
+        hasSyncAccount = getHasSyncAccount()
         await updateTabsData()
     }
 
@@ -124,12 +124,8 @@ actor JumpBackInDataAdaptorImplementation: JumpBackInDataAdaptor, FeatureFlaggab
 
     // MARK: Synced tab data
 
-    private func getHasSyncAccount() async -> Bool {
-        return await withCheckedContinuation { continuation in
-            profile.hasSyncAccount { hasSync in
-                continuation.resume(returning: hasSync)
-            }
-        }
+    private func getHasSyncAccount() -> Bool {
+        return profile.hasAccount()
     }
 
     private func updateRemoteTabs() async -> [ClientAndTabs]? {

--- a/firefox-ios/Client/Frontend/Onboarding/Models/UpdateViewModel.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/UpdateViewModel.swift
@@ -74,21 +74,16 @@ class UpdateViewModel: OnboardingViewModelProtocol,
     // Function added to wait for AccountManager initialization to get
     // if the user is Sign in with Sync Account to decide which cards to show
     func hasSyncableAccount(completion: @escaping () -> Void) {
-        profile.hasSyncAccount { result in
-            self.hasSyncableAccount = result
-            ensureMainThread {
-                completion()
-            }
+        hasSyncableAccount = profile.hasAccount()
+        ensureMainThread {
+            completion()
         }
     }
 
     func hasSyncableAccount() async -> Bool {
-        return await withCheckedContinuation { continuation in
-            profile.hasSyncAccount { hasSync in
-                self.hasSyncableAccount = hasSync
-                continuation.resume(returning: hasSync)
-            }
-        }
+        let hasSync = profile.hasAccount()
+        hasSyncableAccount = hasSync
+        return hasSync
     }
 
     func setupViewControllerDelegates(with delegate: OnboardingCardDelegate, for window: WindowUUID) {

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -116,9 +116,6 @@ protocol Profile: AnyObject {
     // <http://stackoverflow.com/questions/26029317/exc-bad-access-when-indirectly-accessing-inherited-member-in-swift>
     func localName() -> String
 
-    // Async call to wait for result
-    func hasSyncAccount(completion: @escaping (Bool) -> Void)
-
     // Do we have an account at all?
     func hasAccount() -> Bool
 
@@ -695,12 +692,6 @@ open class BrowserProfile: Profile {
             return nil
         }
     }()
-
-    func hasSyncAccount(completion: @escaping (Bool) -> Void) {
-        rustFxA.hasAccount { hasAccount in
-            completion(hasAccount)
-        }
-    }
 
     func hasAccount() -> Bool {
         return rustFxA.hasAccount()

--- a/firefox-ios/RustFxA/RustFirefoxAccounts.swift
+++ b/firefox-ios/RustFxA/RustFirefoxAccounts.swift
@@ -259,12 +259,6 @@ open class RustFirefoxAccounts {
         cachedUserProfile = nil
     }
 
-    public func hasAccount(completion: @escaping (Bool) -> Void) {
-        if let manager = RustFirefoxAccounts.shared.accountManager {
-            completion(manager.hasAccount())
-        }
-    }
-
     public func hasAccount() -> Bool {
         guard let accountManager = RustFirefoxAccounts.shared.accountManager else { return false }
         return accountManager.hasAccount()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10832)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23621)

## :bulb: Description

This is to fix the Sentry crash linked in the bug description related to JumpBackInDataAdaptor.

You'll notice that the Rust code is very... weird. It's strangely making a synchronous call asynchronous (completely unnecessary), and there's also a synchronous version already right underneath it...

By cleaning that up we can remove the `withCheckedContinuation` on line 128 of `JumpBackInDataAdaptor` where we were crashing, so this will hopefully fix that issue. 🤞 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

