### PR TITLE
Bugfix FXIOS-10832 Test workaround for withCheckedContinuation crash in NotificationManager

### DIFF
--- a/firefox-ios/Client/NotificationManager.swift
+++ b/firefox-ios/Client/NotificationManager.swift
@@ -114,7 +114,8 @@ class NotificationManager: NotificationManagerProtocol {
 
     // Determines if the user has allowed notifications
     func hasPermission() async -> Bool {
-        await withCheckedContinuation { continuation in
+        // NOTE: Testing "unsafe" variant of this method, see FXIOS-10832 for details.
+        await withUnsafeContinuation { continuation in
             hasPermission { hasPermission in
                 continuation.resume(returning: hasPermission)
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10832)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Test a workaround for FXIOS-10832 crash in Sentry in NotificationManager possibly due to "checked" `with*` global concurrency methods.

This crash is affecting a very small number of users so let's see if it goes away using a non-checked version of the continuation.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

