### PR TITLE
Bugfix FXIOS-10832 - Made pocket provider fetchStories to be async to fix withCheckedContinuation crash

### DIFF
--- a/firefox-ios/Client/Protocols/URLSession/URLSessionProtocol.swift
+++ b/firefox-ios/Client/Protocols/URLSession/URLSessionProtocol.swift
@@ -9,6 +9,8 @@ protocol URLSessionProtocol {
 
     func data(from url: URL) async throws -> (Data, URLResponse)
 
+    func data(from urlRequest: URLRequest) async throws -> (Data, URLResponse)
+
     func dataTaskWith(_ url: URL,
                       completionHandler: @escaping DataTaskResult
     ) -> URLSessionDataTaskProtocol
@@ -22,6 +24,10 @@ protocol URLSessionProtocol {
 extension URLSession: URLSessionProtocol {
     public func data(from url: URL) async throws -> (Data, URLResponse) {
         try await data(from: url, delegate: nil)
+    }
+    
+    public func data(from urlRequest: URLRequest) async throws -> (Data, URLResponse) {
+        try await data(for: urlRequest, delegate: nil)
     }
 
     func dataTaskWith(

--- a/firefox-ios/Client/Protocols/URLSession/URLSessionProtocol.swift
+++ b/firefox-ios/Client/Protocols/URLSession/URLSessionProtocol.swift
@@ -25,7 +25,7 @@ extension URLSession: URLSessionProtocol {
     public func data(from url: URL) async throws -> (Data, URLResponse) {
         try await data(from: url, delegate: nil)
     }
-    
+
     public func data(from urlRequest: URLRequest) async throws -> (Data, URLResponse) {
         try await data(for: urlRequest, delegate: nil)
     }

--- a/firefox-ios/Providers/Pocket/PocketProvider.swift
+++ b/firefox-ios/Providers/Pocket/PocketProvider.swift
@@ -15,7 +15,7 @@ protocol PocketStoriesProviding {
 extension PocketStoriesProviding {
     func fetchStories(items: Int) async throws -> [PocketFeedStory] {
         do {
-            return try await fetchStoriesNewV2(items: items)
+            return try await fetchStories(items: items)
         } catch {
             throw error
         }

--- a/firefox-ios/Providers/Pocket/PocketProvider.swift
+++ b/firefox-ios/Providers/Pocket/PocketProvider.swift
@@ -131,9 +131,9 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
             throw error
         }
     }
-    
+
     // Fetch items from the global pocket feed
-    func fetchStoriesNEWV1(items: Int) async throws -> [PocketFeedStory]  {
+    func fetchStoriesNEWV1(items: Int) async throws -> [PocketFeedStory] {
         let isFeatureEnabled = prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.ASPocketStories) ?? true
         let isCurrentLocaleSupported = PocketProvider.islocaleSupported(Locale.current.identifier)
 
@@ -232,7 +232,7 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
 
         return completion(.success(Array(PocketFeedStory.parseJSON(list: items).prefix(count))))
     }
-    
+
     private func getMockDataFeed(count: Int = 2) async throws -> [PocketFeedStory] {
         guard let path = Bundle(for: type(of: self)).path(forResource: "pocketglobalfeed", ofType: "json"),
               let data = try? Data(contentsOf: URL(fileURLWithPath: path))

--- a/firefox-ios/Providers/Pocket/PocketProvider.swift
+++ b/firefox-ios/Providers/Pocket/PocketProvider.swift
@@ -102,7 +102,7 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
             throw Error.failure
         }
 
-        return PocketFeedStory.parseJSON(list: items) // Added missing return
+        return PocketFeedStory.parseJSON(list: items)
     }
 
     // Returns nil if the locale is not supported

--- a/firefox-ios/Providers/Pocket/PocketProvider.swift
+++ b/firefox-ios/Providers/Pocket/PocketProvider.swift
@@ -156,19 +156,6 @@ class PocketProvider: PocketStoriesProviding, FeatureFlaggable, URLCaching {
         return featureFlags.isCoreFeatureEnabled(.useMockData) && pocketKey.isEmpty
     }
 
-    private func getMockDataFeedold(count: Int = 2, completion: (StoryResult) -> Void) {
-        guard let path = Bundle(for: type(of: self)).path(forResource: "pocketglobalfeed", ofType: "json"),
-              let data = try? Data(contentsOf: URL(fileURLWithPath: path))
-        else { return }
-
-        let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
-        guard let items = json?["recommendations"] as? [[String: Any]] else {
-            return completion(.failure(Error.failure))
-        }
-
-        return completion(.success(Array(PocketFeedStory.parseJSON(list: items).prefix(count))))
-    }
-
     private func getMockDataFeed(count: Int = 2) async throws -> [PocketFeedStory] {
         guard let path = Bundle(for: type(of: self)).path(forResource: "pocketglobalfeed", ofType: "json"),
               let data = try? Data(contentsOf: URL(fileURLWithPath: path))

--- a/firefox-ios/Providers/Pocket/PocketProvider.swift
+++ b/firefox-ios/Providers/Pocket/PocketProvider.swift
@@ -14,11 +14,7 @@ protocol PocketStoriesProviding {
 
 extension PocketStoriesProviding {
     func fetchStories(items: Int) async throws -> [PocketFeedStory] {
-        do {
-            return try await fetchStories(items: items)
-        } catch {
-            throw error
-        }
+        return try await fetchStories(items: items)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockPocketAPI.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockPocketAPI.swift
@@ -12,13 +12,12 @@ class MockPocketAPI: PocketStoriesProviding {
 
     var result: Result<[PocketFeedStory], Error>
 
-    func fetchStories(items: Int, completion: @escaping (StoryResult) -> Void) {
+    func fetchStories(items: Int) async throws -> [PocketFeedStory] {
         switch result {
         case .success(let value):
-            completion(.success(Array(value.prefix(items))))
+            return Array(value.prefix(items))
         case .failure(let error):
-            completion(.failure(error))
+            throw error
         }
-        return
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/WallpaperURLSessionMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/WallpaperURLSessionMock.swift
@@ -38,6 +38,14 @@ class WallpaperURLSessionMock: URLSessionProtocol {
         return (data ?? Data(), response ?? URLResponse())
     }
 
+    func data(from urlRequest: URLRequest) async throws -> (Data, URLResponse) {
+        if let error = error {
+            throw error
+        }
+
+        return (data ?? Data(), response ?? URLResponse())
+    }
+
     func dataTaskWith(_ url: URL,
                       completionHandler completion: @escaping DataTaskResult
     ) -> URLSessionDataTaskProtocol {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/WallpaperURLSessionMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/Mocks/WallpaperURLSessionMock.swift
@@ -39,11 +39,7 @@ class WallpaperURLSessionMock: URLSessionProtocol {
     }
 
     func data(from urlRequest: URLRequest) async throws -> (Data, URLResponse) {
-        if let error = error {
-            throw error
-        }
-
-        return (data ?? Data(), response ?? URLResponse())
+        try await data(from: urlRequest.url!)
     }
 
     func dataTaskWith(_ url: URL,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10832)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23621)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Made pocket provider fetchStories to be async to fix withCheckedContinuation crash

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

