### PR TITLE
Add FXIOS-10582 [Sent from Firefox] Add the A/B feature flags for the Sent from Firefox experiment

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -41,6 +41,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case reportSiteIssue
     case searchHighlights
     case sentFromFirefox
+    case sentFromFirefoxTreatmentA
     case splashScreen
     case unifiedAds
     case unifiedSearch
@@ -128,6 +129,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .feltPrivacySimplifiedUI,
                 .feltPrivacyFeltDeletion,
                 .searchHighlights,
+                .sentFromFirefoxTreatmentA,
                 .splashScreen,
                 .unifiedAds,
                 .unifiedSearch,

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -403,15 +403,14 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
     private func getSupportSettings() -> [SettingSection] {
         guard let sendAnonymousUsageDataSetting, let studiesToggleSetting else { return [] }
-        let isSentFromFirefoxEnabled = featureFlags.isFeatureEnabled(.sentFromFirefox, checking: .buildOnly)
 
         var supportSettings = [
             ShowIntroductionSetting(settings: self, settingsDelegate: self),
             SendFeedbackSetting(settingsDelegate: parentCoordinator),
         ]
 
-        // Only add this toggle to the Settings if Sent from Firefox feature flag is enabled
-        if isSentFromFirefoxEnabled {
+        // Only add this toggle to the Settings if Sent from Firefox feature flag is enabled from Nimbus
+        if featureFlags.isFeatureEnabled(.sentFromFirefox, checking: .buildOnly) {
             supportSettings.append(
                 SentFromFirefoxSetting(
                     prefs: profile.prefs,

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SentFromFirefoxSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SentFromFirefoxSetting.swift
@@ -34,9 +34,7 @@ final class SentFromFirefoxSetting: BoolSetting {
             defaultValue: true,
             attributedTitleText: titleAttributedString,
             attributedStatusText: subtitleAttributedString,
-            settingDidChange: { toValue in
-                // TODO: FXIOS-10582 enable/disable experimentation
-            }
+            featureFlagName: .sentFromFirefox
         )
     }
 

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -97,6 +97,9 @@ final class NimbusFeatureFlagLayer {
         case .sentFromFirefox:
             return checkSentFromFirefoxFeature(from: nimbus)
 
+        case .sentFromFirefoxTreatmentA:
+            return checkSentFromFirefoxFeatureTreatmentA(from: nimbus)
+
         case .splashScreen:
             return checkSplashScreenFeature(for: featureID, from: nimbus)
 
@@ -149,6 +152,11 @@ final class NimbusFeatureFlagLayer {
     private func checkSentFromFirefoxFeature(from nimbus: FxNimbus) -> Bool {
         let config = nimbus.features.sentFromFirefoxFeature.value()
         return config.enabled
+    }
+
+    private func checkSentFromFirefoxFeatureTreatmentA(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.sentFromFirefoxFeature.value()
+        return config.isTreatmentA
     }
 
     private func checkAwesomeBarFeature(for featureID: NimbusFeatureFlagID,

--- a/firefox-ios/nimbus-features/sentFromFirefoxFeature.yaml
+++ b/firefox-ios/nimbus-features/sentFromFirefoxFeature.yaml
@@ -9,10 +9,17 @@ features:
           Controls whether promo text is added to WhatsApp shares and an on/off toggle is added to Settings.
         type: Boolean
         default: false
+      isTreatmentA:
+        description: >
+          If true, shares the treatment A text. If false, shares the treatment B text.
+        type: Boolean
+        default: true
     defaults:
       - channel: beta
         value:
           enabled: false
+          isTreatmentA: true
       - channel: developer
         value:
-          enabled: false
+          enabled: true
+          isTreatmentA: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10582)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23170)

## :bulb: Description
This PR is for the Sent from Firefox experiment. It simply adds an extra boolean to the Nimbus config that will be used to tweak A/B treatment for the experiment.

There is a toggle in Settings which enables/disables the user's preference for this experiment.

The experiment seems pretty low impact so I've also enabled it in the developer channel.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

