### PR TITLE
Add FXIOS-10529 [Sent from Firefox] Include Firefox Download Link on WhatsApp Shares

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1844,6 +1844,7 @@
 		ED07C0F22CCAFED1006C0627 /* SearchEngineSelectionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0F02CCAFEC2006C0627 /* SearchEngineSelectionStateTests.swift */; };
 		ED07C0F52CCB020B006C0627 /* SearchEngineSelectionMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0F32CCB0200006C0627 /* SearchEngineSelectionMiddlewareTests.swift */; };
 		ED28DAC92C45A95F00D2641C /* TabScrollBehaviorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */; };
+		ED33E3572D0A4CE9002265A7 /* URLActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED33E3562D0A4CE9002265A7 /* URLActivityItemProviderTests.swift */; };
 		ED371A682CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */; };
 		ED390D202CF4DE2E00A775F9 /* URLActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED390D1F2CF4DE2E00A775F9 /* URLActivityItemProvider.swift */; };
 		ED390D222CF4DEDB00A775F9 /* TitleSubtitleActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED390D212CF4DEDB00A775F9 /* TitleSubtitleActivityItemProvider.swift */; };
@@ -9381,6 +9382,7 @@
 		ED07C0F32CCB0200006C0627 /* SearchEngineSelectionMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionMiddlewareTests.swift; sourceTree = "<group>"; };
 		ED264785844AD63AD616A882 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollBehaviorModel.swift; sourceTree = "<group>"; };
+		ED33E3562D0A4CE9002265A7 /* URLActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLActivityItemProviderTests.swift; sourceTree = "<group>"; };
 		ED364EECB95B96AB639A82DE /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/Localizable.strings; sourceTree = "<group>"; };
 		ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinator.swift; sourceTree = "<group>"; };
 		ED390D1F2CF4DE2E00A775F9 /* URLActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLActivityItemProvider.swift; sourceTree = "<group>"; };
@@ -14150,6 +14152,7 @@
 				8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */,
 				0ECB6B672CCFE663006A7C82 /* DateGroupedTableDataTests.swift */,
 				ED4294842CF1286E0077D7CB /* ShareManagerTests.swift */,
+				ED33E3562D0A4CE9002265A7 /* URLActivityItemProviderTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -16973,6 +16976,7 @@
 				E1AEC179286E0CF500062E29 /* FirefoxHomeViewModelTests.swift in Sources */,
 				DF940A0C2A96352B00C1497D /* FakespotSettingsCardViewModelTests.swift in Sources */,
 				8ABCFEA62B45CB4C00C2988A /* PrivateBrowsingTelemetryTests.swift in Sources */,
+				ED33E3572D0A4CE9002265A7 /* URLActivityItemProviderTests.swift in Sources */,
 				281B2BEA1ADF4D90002917DC /* MockProfile.swift in Sources */,
 				96AF8C1C29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift in Sources */,
 				21FA8FB02AE856590013B815 /* RemoteTabsCoordinatorTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -90,8 +90,8 @@ class ShareManager: NSObject, FeatureFlaggable {
 
         case .tab(let siteURL, let tab):
             let isSentFromFirefoxEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(
-                .sentFromFirefoxTreatmentA,
-                checking: .buildOnly
+                .sentFromFirefox,
+                checking: .buildAndUser
             )
             activityItems.append(
                 URLActivityItemProvider(

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -89,9 +89,19 @@ class ShareManager: NSObject, FeatureFlaggable {
             }
 
         case .tab(let siteURL, let tab):
+            let isSentFromFirefoxEnabled = LegacyFeatureFlagsManager.shared.isFeatureEnabled(
+                .sentFromFirefoxTreatmentA,
+                checking: .buildOnly
+            )
+            activityItems.append(
+                URLActivityItemProvider(
+                    url: siteURL,
+                    allowSentFromFirefoxTreatment: isSentFromFirefoxEnabled
+                )
+            )
+
             // For websites, we also want to offer a few additional activity items besides the URL, like printing the
             // webpage or adding a website to the iOS home screen
-            activityItems.append(URLActivityItemProvider(url: siteURL, allowSentFromFirefoxTreatment: true))
 
             // Only show the print activity if the tab's webview is loaded
             if tab.webView != nil {

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -91,7 +91,7 @@ class ShareManager: NSObject, FeatureFlaggable {
         case .tab(let siteURL, let tab):
             // For websites, we also want to offer a few additional activity items besides the URL, like printing the
             // webpage or adding a website to the iOS home screen
-            activityItems.append(URLActivityItemProvider(url: siteURL))
+            activityItems.append(URLActivityItemProvider(url: siteURL, allowSentFromFirefoxTreatment: true))
 
             // Only show the print activity if the tab's webview is loaded
             if tab.webView != nil {

--- a/firefox-ios/Client/Frontend/Share/URLActivityItemProvider.swift
+++ b/firefox-ios/Client/Frontend/Share/URLActivityItemProvider.swift
@@ -4,22 +4,48 @@
 
 import Foundation
 import UniformTypeIdentifiers
+import Shared
 
 class URLActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
+    private struct ActivityIdentifiers {
+        static let whatsApp = "net.whatsapp.WhatsApp.ShareExtension"
+    }
+
+    private static var isSentFromFirefoxTreatmentA: Bool {
+        return LegacyFeatureFlagsManager.shared.isFeatureEnabled(.sentFromFirefoxTreatmentA, checking: .buildOnly)
+    }
+
     private let url: URL
+    private let allowSentFromFirefoxTreatment: Bool // FXIOS-9879 For the Sent from Firefox experiment
+    private let whatsAppShareText: String // FXIOS-9879 For the Sent from Firefox experiment
 
     // We don't want to add this URL to Safari's Reading List
     static let excludedActivities = [
         UIActivity.ActivityType.addToReadingList,
     ]
 
-    init(url: URL) {
+    init(url: URL, allowSentFromFirefoxTreatment: Bool = false) {
         // If the user is sharing a reader mode URL, we must decode it so we don't share internal localhost URLs
         let parsedURL = url.isReaderModeURL
                         ? url.decodeReaderModeURL ?? url
                         : url
 
         self.url = parsedURL
+
+        // FXIOS-9879 For the Sent from Firefox experiment
+        self.allowSentFromFirefoxTreatment = allowSentFromFirefoxTreatment
+        if URLActivityItemProvider.isSentFromFirefoxTreatmentA {
+            whatsAppShareText = String.localizedStringWithFormat(.SentFromFirefox.SocialShare.ShareMessageA,
+                                                                 parsedURL.absoluteString,
+                                                                 AppName.shortName.rawValue,
+                                                                 "<FXIOS-10858 marketing link here>")
+        } else {
+            whatsAppShareText = String.localizedStringWithFormat(.SentFromFirefox.SocialShare.ShareMessageB,
+                                                                 parsedURL.absoluteString,
+                                                                 AppName.shortName.rawValue,
+                                                                 "<FXIOS-10858 marketing link here>")
+        }
+
         super.init(placeholderItem: parsedURL)
     }
 
@@ -27,9 +53,15 @@ class URLActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
         return url
     }
 
-    override var item: Any {
+    override func activityViewController(
+        _ activityViewController: UIActivityViewController,
+        itemForActivityType activityType: UIActivity.ActivityType?
+    ) -> Any? {
         if let activityType = activityType, URLActivityItemProvider.excludedActivities.contains(activityType) {
             return NSNull()
+        } else if allowSentFromFirefoxTreatment, activityType?.rawValue == ActivityIdentifiers.whatsApp {
+            // FXIOS-9879 For the Sent from Firefox experiment, we override sharing the URL to instead share text to WhatsApp
+            return whatsAppShareText
         }
 
         return url
@@ -39,6 +71,11 @@ class URLActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
         _ activityViewController: UIActivityViewController,
         dataTypeIdentifierForActivityType activityType: UIActivity.ActivityType?
     ) -> String {
+        if allowSentFromFirefoxTreatment, activityType?.rawValue == ActivityIdentifiers.whatsApp {
+            // FXIOS-9879 For the Sent from Firefox experiment, we override sharing the URL to instead share text to WhatsApp
+            return UTType.plainText.identifier
+        }
+
         return url.isFileURL ? UTType.fileURL.identifier : UTType.url.identifier
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -258,7 +258,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         }
         let exp = XCTNSPredicateExpectation(predicate: predicate, object: .none)
 
-        wait(for: [exp], timeout: 3.0)
+        wait(for: [exp], timeout: 5.0)
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertTrue(subject.childCoordinators.first is ShareSheetCoordinator)
@@ -299,7 +299,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         }
         let exp = XCTNSPredicateExpectation(predicate: predicate, object: .none)
 
-        wait(for: [exp], timeout: 3.0)
+        wait(for: [exp], timeout: 5.0)
 
         XCTAssertEqual(subject.childCoordinators.count, 1)
         XCTAssertTrue(subject.childCoordinators.first is ShareSheetCoordinator)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/URLActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/URLActivityItemProviderTests.swift
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UniformTypeIdentifiers
+import XCTest
+@testable import Client
+
+// TODO: FXIOS-10816 Flesh out these unit tests
+final class URLActivityItemProviderTests: XCTestCase {
+    let testWebURL = URL(string: "https://mozilla.org")!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
+    }
+
+    // MARK: - Sent from Firefox experiment WhatsApp tab share override
+
+    func testOveridesWhatsAppShareItem() throws {
+        // TODO: FXIOS-10858 Real links to come
+        let expectedShareContent = "https://mozilla.org Sent from Firefox 🦊 Try the mobile browser: <FXIOS-10858 marketing link here>"
+        let whatsAppActivityIdentifier = "net.whatsapp.WhatsApp.ShareExtension"
+
+        let urlActivityItemProvider = URLActivityItemProvider(url: testWebURL, allowSentFromFirefoxTreatment: true)
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: UIActivity.ActivityType(rawValue: whatsAppActivityIdentifier)
+        )
+
+        XCTAssertEqual(itemForActivity as? String, expectedShareContent)
+    }
+
+    // MARK: - Helpers
+
+    private func createStubActivityViewController() -> UIActivityViewController {
+        return UIActivityViewController(activityItems: [], applicationActivities: [])
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10529)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR is for the Sent from Firefox experiment. We handle website shares to WhatsApp differently for users enrolled in the experiment.

### Testing Details

Open the `sentFromFirefoxFeature.yaml` file and change the developer channel settings for `enabled` and `isTreatmentA` to manually test your enrollment in this experiment. If isTreatmetA is true, we should one type of text, and if it is false, we show a slightly different type of text.

Users enrolled with `enabled == true` will append additional text to URLs shared via the new toolbar Share button or Menu > Share. Users can change the "Include Firefox Download Link on WhatsApp Shares" toggle in Settings if they don't want to automatically share the Firefox link to WhatsApp.

You should test on a real iPhone if you can, ideally with WhatsApp installed (you don't have to be logged in, you can put breakpoints in the code to see what text is shared from`URLActivityItemProvider`.)

If you do have a WhatsApp account when you test, I'd love to see a screenshot of what the shared content looks like! (I don't have an account to test myself).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

