### PR TITLE
Remove MTE-3997 - home page tests workarounds

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -96,11 +96,9 @@ class HomePageSettingsUITests: BaseTestCase {
         let homePageMenuItem = app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton]
         homePageMenuItem.waitAndTap()
         waitUntilPageLoad()
-        // Issue found - https://mozilla-hub.atlassian.net/browse/FXIOS-10753
-        // Workaround - the test will start to fail once the issue is fixed
         mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
         mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField],
-                                value: "Search or enter address")
+                                value: "example.com")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339258
@@ -169,12 +167,9 @@ class HomePageSettingsUITests: BaseTestCase {
         waitForTabsButton()
         navigator.nowAt(BrowserTab)
         navigator.performAction(Action.GoToHomePage)
-
-        // Issue found - https://mozilla-hub.atlassian.net/browse/FXIOS-10753
-        // Workaround - the test will start to fail once the issue is fixed
         mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
         mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField],
-                                value: "Search or enter address")
+                                value: "mozilla.org")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339489

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -309,6 +309,8 @@ class TopTabsTest: BaseTestCase {
             mozWaitForElementToExist(app.buttons["Show Tabs"])
             app.buttons["Show Tabs"].press(forDuration: 1)
             app.tables.cells.otherElements["New Private Tab"].waitAndTap()
+            let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
+            mozWaitForElementToExist(tabsButton)
             navigator.nowAt(NewTabScreen)
             app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-3997

## :bulb: Description
https://mozilla-hub.atlassian.net/browse/FXIOS-10753 has been fixed.
Removed workarounds for testTyping and testSetCustomURLAsHome tests.
Also attempted to fix testLongTapTabCounter smoke test that started to be flaky.
