### PR TITLE
Refactor MTE-3977 Use iOS 18.2 simulator in sync integration tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/xcodebuild.py
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/xcodebuild.py
@@ -10,7 +10,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 class XCodeBuild(object):
     binary = 'xcodebuild'
-    destination = 'platform=iOS Simulator,name=iPhone 16,OS=18.1'
+    destination = 'platform=iOS Simulator,name=iPhone 16,OS=18.2'
     logger = logging.getLogger()
     scheme = 'Fennec'
     testPlan = 'SyncIntegrationTestPlan'


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3977)

## :bulb: Description
Let's have the sync integration tests to use iOS 18.2 in the testing. Currently, the tests work on Xcode 16.2 RC and iOS 18.1, but let's be sure that we use the same iOS version in our testing.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

