### PR TITLE
Refactor FXIOS-10246 [Homepage Rebuild] Add status bar logic to new homepage

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -137,7 +137,11 @@ class BrowserCoordinator: BaseCoordinator,
         screenshotService.screenshotableView = nil
     }
 
-    func showHomepage(overlayManager: OverlayModeManager, isZeroSearch: Bool) {
+    func showHomepage(
+        overlayManager: OverlayModeManager,
+        isZeroSearch: Bool,
+        statusBarScrollDelegate: StatusBarScrollDelegate
+    ) {
         let homepageCoordinator = childCoordinators[HomepageCoordinator.self] ?? HomepageCoordinator(
             windowUUID: windowUUID,
             profile: profile,
@@ -148,7 +152,8 @@ class BrowserCoordinator: BaseCoordinator,
         let homepageController = self.homepageViewController ?? HomepageViewController(
             windowUUID: windowUUID,
             homepageDelegate: homepageCoordinator,
-            overlayManager: overlayManager
+            overlayManager: overlayManager,
+            statusBarScrollDelegate: statusBarScrollDelegate
         )
         guard browserViewController.embedContent(homepageController) else {
             logger.log("Unable to embed new homepage", level: .debug, category: .coordinator)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -24,7 +24,11 @@ protocol BrowserDelegate: AnyObject {
     )
 
     /// Show the new homepage to the user as part of the homepage rebuild project
-    func showHomepage(overlayManager: OverlayModeManager, isZeroSearch: Bool)
+    func showHomepage(
+        overlayManager: OverlayModeManager,
+        isZeroSearch: Bool,
+        statusBarScrollDelegate: StatusBarScrollDelegate
+    )
 
     /// Show the private homepage to the user as part of felt privacy
     func showPrivateHomepage(overlayManager: OverlayModeManager)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1313,7 +1313,11 @@ class BrowserViewController: UIViewController,
 
     func frontEmbeddedContent(_ viewController: ContentContainable) {
         contentContainer.update(content: viewController)
-        statusBarOverlay.resetState(isHomepage: contentContainer.hasLegacyHomepage)
+        if featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly) {
+            statusBarOverlay.resetState(isHomepage: contentContainer.hasHomepage)
+        } else {
+            statusBarOverlay.resetState(isHomepage: contentContainer.hasLegacyHomepage)
+        }
     }
 
     /// Embed a ContentContainable inside the content container
@@ -1326,7 +1330,11 @@ class BrowserViewController: UIViewController,
         viewController.willMove(toParent: self)
         contentContainer.add(content: viewController)
         viewController.didMove(toParent: self)
-        statusBarOverlay.resetState(isHomepage: contentContainer.hasLegacyHomepage)
+        if featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly) {
+            statusBarOverlay.resetState(isHomepage: contentContainer.hasHomepage)
+        } else {
+            statusBarOverlay.resetState(isHomepage: contentContainer.hasLegacyHomepage)
+        }
 
         UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: nil)
         return true
@@ -1352,7 +1360,11 @@ class BrowserViewController: UIViewController,
         }
 
         if featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly) {
-            browserDelegate?.showHomepage(overlayManager: overlayManager, isZeroSearch: inline)
+            browserDelegate?.showHomepage(
+                overlayManager: overlayManager,
+                isZeroSearch: inline,
+                statusBarScrollDelegate: statusBarOverlay
+            )
         } else {
             browserDelegate?.showLegacyHomepage(
                 inline: inline,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -9,10 +9,10 @@ struct HomepageState: ScreenState, Equatable {
     var windowUUID: WindowUUID
 
     // Homepage sections state in the order they appear on the collection view
-    var headerState: HeaderState
-    var topSitesState: TopSitesSectionState
-    var pocketState: PocketState
-    var wallpaperState: WallpaperState
+   let headerState: HeaderState
+   let topSitesState: TopSitesSectionState
+   let pocketState: PocketState
+   let wallpaperState: WallpaperState
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let homepageState = store.state.screenState(

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
@@ -48,19 +48,22 @@ struct WallpaperConfiguration: Equatable {
     var textColor: UIColor?
     var cardColor: UIColor?
     var logoTextColor: UIColor?
+    var hasImage: Bool
 
     init(
         landscapeImage: UIImage? = nil,
         portraitImage: UIImage? = nil,
         textColor: UIColor? = nil,
         cardColor: UIColor? = nil,
-        logoTextColor: UIColor? = nil
+        logoTextColor: UIColor? = nil,
+        hasImage: Bool = false
     ) {
         self.landscapeImage = landscapeImage
         self.portraitImage = portraitImage
         self.textColor = textColor
         self.cardColor = cardColor
         self.logoTextColor = logoTextColor
+        self.hasImage = hasImage
     }
 
     init(wallpaper: Wallpaper) {
@@ -69,7 +72,8 @@ struct WallpaperConfiguration: Equatable {
             portraitImage: wallpaper.portrait,
             textColor: wallpaper.textColor,
             cardColor: wallpaper.cardColor,
-            logoTextColor: wallpaper.logoTextColor
+            logoTextColor: wallpaper.logoTextColor,
+            hasImage: wallpaper.hasImage
         )
     }
  }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -141,7 +141,11 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
     func testShowNewHomepage_setsProperViewController() {
         let subject = createSubject()
-        subject.showHomepage(overlayManager: overlayModeManager, isZeroSearch: false)
+        subject.showHomepage(
+            overlayManager: overlayModeManager,
+            isZeroSearch: false,
+            statusBarScrollDelegate: scrollDelegate
+        )
 
         XCTAssertNotNil(subject.homepageViewController)
         XCTAssertNil(subject.webviewController)
@@ -150,11 +154,19 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
     func testShowNewHomepage_hasSameInstance() {
         let subject = createSubject()
-        subject.showHomepage(overlayManager: overlayModeManager, isZeroSearch: false)
+        subject.showHomepage(
+            overlayManager: overlayModeManager,
+            isZeroSearch: false,
+            statusBarScrollDelegate: scrollDelegate
+        )
         let firstHomepage = subject.homepageViewController
         XCTAssertNotNil(subject.homepageViewController)
 
-        subject.showHomepage(overlayManager: overlayModeManager, isZeroSearch: false)
+        subject.showHomepage(
+            overlayManager: overlayModeManager,
+            isZeroSearch: false,
+            statusBarScrollDelegate: scrollDelegate
+        )
         let secondHomepage = subject.homepageViewController
         XCTAssertEqual(firstHomepage, secondHomepage)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -53,9 +53,14 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             logoTextColor: .blue
         )
 
-        let wallpaperState = WallpaperState(windowUUID: .XCTestDefaultUUID, wallpaperConfiguration: wallpaperConfig)
-        var state = HomepageState(windowUUID: .XCTestDefaultUUID)
-        state.wallpaperState = wallpaperState
+        let state = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            WallpaperAction(
+                wallpaperConfiguration: wallpaperConfig,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
+            )
+        )
 
         dataSource.updateSnapshot(state: state)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -75,6 +75,28 @@ final class HomepageViewControllerTests: XCTestCase {
         XCTAssertEqual(mockNotificationCenter?.removeObserverCallCount, 1)
     }
 
+    func test_scrollViewDidScroll_updatesStatusBarScrollDelegate() {
+        let mockStatusBarScrollDelegate = MockStatusBarScrollDelegate()
+        let homepageVC = createSubject(statusBarScrollDelegate: mockStatusBarScrollDelegate)
+        let wallpaperConfiguration = WallpaperConfiguration(hasImage: true)
+        let newState = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            WallpaperAction(
+                wallpaperConfiguration: wallpaperConfiguration,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: WallpaperMiddlewareActionType.wallpaperDidInitialize
+            )
+        )
+        homepageVC.newState(state: newState)
+        let scrollView = UIScrollView()
+
+        XCTAssertNil(mockStatusBarScrollDelegate.savedScrollView)
+
+        homepageVC.scrollViewDidScroll(scrollView)
+
+        XCTAssertEqual(mockStatusBarScrollDelegate.savedScrollView, scrollView)
+    }
+
     private func createSubject(statusBarScrollDelegate: StatusBarScrollDelegate? = nil) -> HomepageViewController {
         let notificationCenter = MockNotificationCenter()
         let themeManager = MockThemeManager()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -75,7 +75,7 @@ final class HomepageViewControllerTests: XCTestCase {
         XCTAssertEqual(mockNotificationCenter?.removeObserverCallCount, 1)
     }
 
-    private func createSubject() -> HomepageViewController {
+    private func createSubject(statusBarScrollDelegate: StatusBarScrollDelegate? = nil) -> HomepageViewController {
         let notificationCenter = MockNotificationCenter()
         let themeManager = MockThemeManager()
         let mockOverlayManager = MockOverlayModeManager()
@@ -85,6 +85,7 @@ final class HomepageViewControllerTests: XCTestCase {
             windowUUID: .XCTestDefaultUUID,
             themeManager: themeManager,
             overlayManager: mockOverlayManager,
+            statusBarScrollDelegate: statusBarScrollDelegate,
             notificationCenter: notificationCenter
         )
         trackForMemoryLeaks(homepageViewController)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10246)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22422)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Adds status bar logic to new homepage:
- If the wallpaper is set on scroll, call `statusBarDelegate.scrollViewDidScroll`
- Call `statusBarOverlay.resetState` for new homepage if homepage rebuild feature flag is enabled

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

