### PR TITLE
Refactor FXIOS-10710 [Default Browser] Move location of relevant user default setters

### DIFF
--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -30,6 +30,8 @@ class AppLaunchUtil {
             logger.copyLogsToDocuments()
         }
 
+        DefaultBrowserUtil().processUserDefaultState(isFirstRun: introScreenManager.shouldShowIntroScreen)
+
         TelemetryWrapper.shared.setup(profile: profile)
         recordStartUpTelemetry()
 
@@ -100,8 +102,6 @@ class AppLaunchUtil {
     }
 
     func setUpPostLaunchDependencies() {
-        DefaultBrowserUtil().processUserDefaultState(isFirstRun: introScreenManager.shouldShowIntroScreen)
-
         let persistedCurrentVersion = InstallType.persistedCurrentVersion()
         // upgrade install - Intro screen shown & persisted current version does not match
         if !introScreenManager.shouldShowIntroScreen && persistedCurrentVersion != AppInfo.appVersion {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10710)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23411)

## :bulb: Description
Make setting of user defaults happen first, so we can hook into it for el Nimbus.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

