### PR TITLE
Bugfix FXIOS-10711 Fix false-positive for metric event tabLossDetected

### DIFF
--- a/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
@@ -22,37 +22,54 @@ final class TabErrorTelemetryHelper {
         self.windowManager = windowManager
     }
 
-    /// Records the scene (windows) tab count for the purposes of sanity-checking for
-    /// potential tab-loss related errors. Such bugs can significantly impact users, so
-    /// we attempt to detect any issues which could indicate potential tab loss.
+    // MARK: - Public API
+
+    /// Records the window's tab count upon the app being backgrounded.
+    /// This count is then checked again upon foregrounding in an attempt to
+    /// identify potential tab-loss errors.
     func recordTabCountForBackgroundedScene(_ window: WindowUUID) {
-        ensureMainThread {
-            guard self.tabManagerAvailable(for: window) else { return }
-            var tabCounts = self.defaults.object(forKey: self.defaultsKey) as? [String: Int] ?? [String: Int]()
-            let tabCount = self.getTabCount(window: window)
-            tabCounts[window.uuidString] = tabCount
-            self.defaults.set(tabCounts, forKey: self.defaultsKey)
-        }
+        ensureMainThread { self.recordTabCount(window) }
     }
 
-    /// Validates the tab count against the recorded tab count. If this has decreased
-    /// without any obvious cause (e.g. Close All Tabs action) then it is suggestive of
-    /// a potential bug impacting users, and a MetricKit event is logged.
+    /// Validates the tab count when the app is foregrounded to ensure the
+    /// count is consistent with the count upon backgrounding.
     func validateTabCountForForegroundedScene(_ window: WindowUUID) {
-        ensureMainThread {
-            guard self.tabManagerAvailable(for: window) else { return }
-            guard let tabCounts = self.defaults.object(forKey: self.defaultsKey) as? [String: Int],
-                  let expectedTabCount = tabCounts[window.uuidString] else { return }
-            let currentTabCount = self.getTabCount(window: window)
-
-            if expectedTabCount > 1 && (expectedTabCount - currentTabCount) > 1 {
-                // Potential tab loss bug detected. Log a MetricKit error.
-                self.sendTelemetryTabLossDetectedEvent()
-            }
-        }
+        ensureMainThread { self.validateTabCount(window) }
     }
 
     // MARK: - Internal Utility
+
+    private func recordTabCount(_ window: WindowUUID) {
+        guard self.tabManagerAvailable(for: window) else { return }
+        var tabCounts = self.defaults.object(forKey: self.defaultsKey) as? [String: Int] ?? [String: Int]()
+        let tabCount = self.getTabCount(window: window)
+        tabCounts[window.uuidString] = tabCount
+        self.defaults.set(tabCounts, forKey: self.defaultsKey)
+    }
+
+    private func validateTabCount(_ window: WindowUUID) {
+        guard self.tabManagerAvailable(for: window) else { return }
+        guard let tabCounts = self.defaults.object(forKey: self.defaultsKey) as? [String: Int],
+              let expectedTabCount = tabCounts[window.uuidString] else { return }
+        let currentTabCount = self.getTabCount(window: window)
+
+        if expectedTabCount > 1 && (expectedTabCount - currentTabCount) > 1 {
+            // Potential tab loss bug detected. Log a MetricKit error.
+            self.sendTelemetryTabLossDetectedEvent()
+        }
+
+        // After validating the tab count, we make sure to remove the count
+        // in preferences until the next time that the app is backgrounded.
+        // This is to prevent false-positives that can occur if a stale count
+        // is still in preferences and the app crashes. If the user removed
+        // any tabs during this time, it means the next launch there will be
+        // fewer tabs than recorded and we'll send the event erroneously.
+        invalidateTabCount()
+    }
+
+    func invalidateTabCount() {
+        defaults.removeObject(forKey: defaultsKey)
+    }
 
     /// It's possible for this telemetry helper to be called during onboarding flow before
     /// any tab managers have been configured.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10711)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23415)

## :bulb: Description

Fixes a false-positive that was causing the rate for this errors to be reported higher than it should have.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

