### PR TITLE
Bugfix MTE-3933 BrowserTabMenu and ScreenGraphTest

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -118,7 +118,6 @@
         "ReadingListTests\/testAddToReadingList()",
         "ReadingListTests\/testLoadReaderContent()",
         "ReadingListTests\/testReadingList()",
-        "ScreenGraphTest\/testUserStateChanges()",
         "SearchTests\/testBottomVIewURLBar()",
         "SearchTests\/testDismissPromptPresence()",
         "SearchTests\/testOpenTabsInSearchSuggestions()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
@@ -11,6 +11,25 @@ class ScreenGraphTest: XCTestCase {
     var navigator: MMNavigator<TestUserState>!
     var app: XCUIApplication!
 
+    func mozWaitForElementToNotExist(_ element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
+        let startTime = Date()
+
+        while element.exists {
+            if let timeout = timeout, Date().timeIntervalSince(startTime) > timeout {
+                XCTFail("Timed out waiting for element \(element) to not exist")
+                break
+            }
+            usleep(10000)
+        }
+    }
+
+    func waitUntilPageLoad() {
+        let app = XCUIApplication()
+        let progressIndicator = app.progressIndicators.element(boundBy: 0)
+
+        mozWaitForElementToNotExist(progressIndicator, timeout: 90.0)
+    }
+
     override func setUp() {
         super.setUp()
         app = XCUIApplication()
@@ -51,6 +70,7 @@ extension ScreenGraphTest {
     func testSimpleToggleAction() {
         navigator.userState.url = "https://mozilla.org"
         navigator.performAction(TestActions.LoadURLByTyping)
+        waitUntilPageLoad()
         // Switch night mode on, by toggling.
         navigator.performAction(TestActions.ToggleNightMode)
         XCTAssertTrue(navigator.userState.nightMode)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
@@ -55,16 +55,17 @@ extension XCTestCase {
 }
 
 extension ScreenGraphTest {
-    // Temporary disable since it is failing intermittently on BB
     func testUserStateChanges() {
         XCTAssertNil(navigator.userState.url, "Current url is empty")
 
         navigator.userState.url = "https://mozilla.org"
         navigator.performAction(TestActions.LoadURLByTyping)
+        waitUntilPageLoad()
         // The UserState is mutated in BrowserTab.
         navigator.goto(BrowserTab)
         navigator.nowAt(BrowserTab)
-        XCTAssertTrue(navigator.userState.url?.starts(with: "www.mozilla.org") ?? false, "Current url recorded by from the url bar is \(navigator.userState.url ?? "nil")")
+        let currentURL = navigator.userState.url as String?
+        XCTAssertTrue(currentURL?.starts(with: "mozilla.org") ?? false, "Current url recorded by from the url bar is \(currentURL ?? "nil")")
     }
 
     func testSimpleToggleAction() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3933)

## :bulb: Description
`testSimpleToggleAction()` fails intermittently because the `ToolsBrowserTabMenu` from the `BrowserTabMenu` may not appear right after the URL is typed in the URL bar. The `ToolsBrowserTabMenu` appears for sure after the page is loaded.

To harden the test, let's wait until the page is loaded before opening the `BrowserTabMenu.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

