### PR TITLE
Bugfix FXIOS-10798 [Sponsored tiles] URLCache doesn't retrieve from cache

### DIFF
--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsProvider.swift
@@ -62,7 +62,10 @@ class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, FeatureFlagga
             return
         }
 
-        if let cachedData = findCachedData(for: request, timestamp: timestamp) {
+        // FXIOS-10798 - URLCache doesn't retrieve from cache if there's an httpBody set on the request
+        var cacheRequest = request
+        cacheRequest.httpBody = nil
+        if let cachedData = findCachedData(for: cacheRequest, timestamp: timestamp) {
             decode(data: cachedData, completion: completion)
         } else {
             fetchTiles(request: request, completion: completion)
@@ -114,7 +117,10 @@ class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, FeatureFlagga
             guard let self = self else { return }
             switch result {
             case .success(let result):
-                self.cache(response: result.response, for: request, with: result.data)
+                // FXIOS-10798 - URLCache doesn't retrieve from cache if there's an httpBody set on the request
+                var cacheRequest = request
+                cacheRequest.httpBody = nil
+                self.cache(response: result.response, for: cacheRequest, with: result.data)
                 self.decode(data: result.data, completion: completion)
             case .failure:
                 completion(.failure(Error.noDataAvailable))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10798)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23562)

## :bulb: Description
URLCache doesn't retrieve from cache if there's an httpBody set on the request. I really hope we can set this code in fire soon, cause I don't like this fix at all 😆 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

