### PR TITLE
Refactor FXIOS-10629 Sharesheet route: Accept optional subtitle parameter

### DIFF
--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -132,8 +132,9 @@ final class RouteBuilder {
                 // Pass optional share message and subtitle here
                 var shareMessage: ShareMessage?
                 if let titleText = urlScanner.value(query: "title") {
-                    // TODO: FXIOS-10629 Get the optional subtitle parameter 
-                    shareMessage = ShareMessage(message: titleText, subtitle: nil)
+                    let subtitleText: String? = urlScanner.value(query: "subtitle")
+
+                    shareMessage = ShareMessage(message: titleText, subtitle: subtitleText)
                 }
 
                 // Deeplinks cannot have an associated tab or file, so this must be a website URL `.site` share

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -357,7 +357,7 @@ class RouteTests: XCTestCase {
         XCTAssertEqual(route, .sharesheet(shareType: .site(url: testURL), shareMessage: nil))
     }
 
-    func testShareSheetRouteUrlAndTitle() {
+    func testShareSheetRouteUrlTitle() {
         let testURL = URL(string: "https://www.google.com")!
         let testTitle = "TEST TITLE"
         let shareURL = URL(string: "firefox://share-sheet?url=\(testURL.absoluteString)&title=\(testTitle)")!
@@ -368,6 +368,21 @@ class RouteTests: XCTestCase {
 
         let expectedShareType = ShareType.site(url: testURL)
         let expectedShareMessage = ShareMessage(message: testTitle, subtitle: nil)
+        XCTAssertEqual(route, .sharesheet(shareType: expectedShareType, shareMessage: expectedShareMessage))
+    }
+
+    func testShareSheetRouteUrlTitleAndSubtitle() {
+        let testURL = URL(string: "https://www.google.com")!
+        let testTitle = "TEST TITLE"
+        let testSubtitle = "TEST SUBTITLE"
+        let shareURL = URL(string: "firefox://share-sheet?url=\(testURL.absoluteString)&title=\(testTitle)&subtitle=\(testSubtitle)")!
+
+        let subject = createSubject()
+
+        let route = subject.makeRoute(url: shareURL)
+
+        let expectedShareType = ShareType.site(url: testURL)
+        let expectedShareMessage = ShareMessage(message: testTitle, subtitle: testSubtitle)
         XCTAssertEqual(route, .sharesheet(shareType: expectedShareType, shareMessage: expectedShareMessage))
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10629)

## :bulb: Description
Refactor sharesheet route to accept optional subtitle parameter. This will be used as the subject when user shares the message in Mail. Note: currently doesn't work in gmail app :( 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

