### PR TITLE
Refactor MTE-4003 Workaround for "Privacy settings" link not clickable

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -377,6 +377,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
                 app.buttons[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.closeButton].tap()
             }
         }
+
+        screenState.tap(app.buttons["Close privacy and security menu"], to: BrowserTab)
     }
 
     // URLBarOpen is dismissOnUse, which ScreenGraph interprets as "now we've done this action,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -152,6 +152,7 @@ class TrackingProtectionTests: BaseTestCase {
         XCTAssertEqual(switchValueOFF as? String, "0")
 
         // Open TP Settings menu
+        // app.buttons["Privacy settings"].tap()
         // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/23706
         navigator.goto(SettingsScreen)
         app.staticTexts["Tracking Protection"].waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -152,7 +152,9 @@ class TrackingProtectionTests: BaseTestCase {
         XCTAssertEqual(switchValueOFF as? String, "0")
 
         // Open TP Settings menu
-        app.buttons["Privacy settings"].tap()
+        // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/23706
+        navigator.goto(SettingsScreen)
+        app.staticTexts["Tracking Protection"].waitAndTap()
         mozWaitForElementToExist(app.navigationBars["Tracking Protection"], timeout: 5)
         let switchSettingsValue = app.switches["prefkey.trackingprotection.normalbrowsing"].value!
         XCTAssertEqual(switchSettingsValue as? String, "1")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4003)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23706)

## :bulb: Description
The "Privacy settings" link is not clickable. Let's implement a workaround for now to go to the Tracking Protections from the Settings.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

