### PR TITLE
Refactor FXIOS-10325 - Add closure_body_length to .swiftlint.yml, create custom config and solve 1 violation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -101,6 +101,10 @@ line_length:
   ignores_urls: true
   ignores_interpolated_strings: true
 
+closure_body_length:
+  warning: 90
+  error: 90
+
 file_header:
   required_string: |
                     // This Source Code Form is subject to the terms of the Mozilla Public

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -85,6 +85,7 @@ only_rules: # Only enforce these rules, ignore all others
   - accessibility_label_for_image
   - accessibility_trait_for_button
   - force_cast
+  - closure_body_length
 
 # These rules were originally opted into. Disabling for now to get
 # Swiftlint up and running.

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -136,6 +136,19 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         }
     }
 
+    private static func navigateToSettingsState(from state: TrackingProtectionState) -> TrackingProtectionState {
+        return TrackingProtectionState(
+            windowUUID: state.windowUUID,
+            trackingProtectionEnabled: state.trackingProtectionEnabled,
+            connectionSecure: state.connectionSecure,
+            shouldClearCookies: false,
+            shouldUpdateBlockedTrackerStats: false,
+            shouldUpdateConnectionStatus: false,
+            navigateTo: .settings,
+            displayView: nil
+        )
+    }
+
     private static func showTrackingProtectionDetailsState(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -172,6 +172,19 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         }
     }
 
+    private static func updateBlockedTrackerStatsState(from state: TrackingProtectionState) -> TrackingProtectionState {
+        return TrackingProtectionState(
+            windowUUID: state.windowUUID,
+            trackingProtectionEnabled: state.trackingProtectionEnabled,
+            connectionSecure: state.connectionSecure,
+            shouldClearCookies: state.shouldClearCookies,
+            shouldUpdateBlockedTrackerStats: true,
+            shouldUpdateConnectionStatus: false,
+            navigateTo: nil,
+            displayView: nil
+        )
+    }
+
     private static func updateConnectionStatusState(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -108,7 +108,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         case TrackingProtectionActionType.updateConnectionStatus:
             return handleUpdateConnectionStatusAction(from: state)
         case TrackingProtectionMiddlewareActionType.showAlert:
-            return showAlertState(from: state)
+            return handleShowAlertAction(from: state)
         case TrackingProtectionActionType.toggleTrackingProtectionStatus:
             return toggleTrackingProtectionStatusState(from: state)
         case TrackingProtectionMiddlewareActionType.dismissTrackingProtection:
@@ -209,7 +209,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func showAlertState(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleShowAlertAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -181,6 +181,19 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         }
     }
 
+    private static func updateConnectionStatusState(from state: TrackingProtectionState) -> TrackingProtectionState {
+        return TrackingProtectionState(
+            windowUUID: state.windowUUID,
+            trackingProtectionEnabled: state.trackingProtectionEnabled,
+            connectionSecure: state.connectionSecure,
+            shouldClearCookies: false,
+            shouldUpdateBlockedTrackerStats: false,
+            shouldUpdateConnectionStatus: true,
+            navigateTo: nil,
+            displayView: nil
+        )
+    }
+
     private static func showAlertState(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -163,6 +163,19 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         }
     }
 
+    private static func goBackState(from state: TrackingProtectionState) -> TrackingProtectionState {
+        return TrackingProtectionState(
+            windowUUID: state.windowUUID,
+            trackingProtectionEnabled: state.trackingProtectionEnabled,
+            connectionSecure: state.connectionSecure,
+            shouldClearCookies: false,
+            shouldUpdateBlockedTrackerStats: false,
+            shouldUpdateConnectionStatus: false,
+            navigateTo: .back,
+            displayView: nil
+        )
+    }
+
     private static func updateBlockedTrackerStatsState(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -98,7 +98,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         case TrackingProtectionMiddlewareActionType.navigateToSettings:
             return handleNavigateToSettingsAction(from: state)
         case TrackingProtectionMiddlewareActionType.showTrackingProtectionDetails:
-            return showTrackingProtectionDetailsState(from: state)
+            return handleShowTrackingProtectionDetailsAction(from: state)
         case TrackingProtectionMiddlewareActionType.showBlockedTrackersDetails:
             return showBlockedTrackersDetailsState(from: state)
         case TrackingProtectionActionType.goBack:
@@ -144,7 +144,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func showTrackingProtectionDetailsState(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleShowTrackingProtectionDetailsAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -208,6 +208,19 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         }
     }
 
+    private static func dismissTrackingProtectionState(from state: TrackingProtectionState) -> TrackingProtectionState {
+        return TrackingProtectionState(
+            windowUUID: state.windowUUID,
+            trackingProtectionEnabled: state.trackingProtectionEnabled,
+            connectionSecure: state.connectionSecure,
+            shouldClearCookies: false,
+            shouldUpdateBlockedTrackerStats: false,
+            shouldUpdateConnectionStatus: false,
+            navigateTo: .close,
+            displayView: nil
+        )
+    }
+
     static func defaultState(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -138,16 +138,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
                 displayView: .blockedTrackersDetails
             )
         case TrackingProtectionActionType.goBack:
-            return TrackingProtectionState(
-                windowUUID: state.windowUUID,
-                trackingProtectionEnabled: state.trackingProtectionEnabled,
-                connectionSecure: state.connectionSecure,
-                shouldClearCookies: false,
-                shouldUpdateBlockedTrackerStats: false,
-                shouldUpdateConnectionStatus: false,
-                navigateTo: .back,
-                displayView: nil
-            )
+            return goBackState(from: state)
         case TrackingProtectionActionType.updateBlockedTrackerStats:
             return updateBlockedTrackerStatsState(from: state)
         case TrackingProtectionActionType.updateConnectionStatus:

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -112,7 +112,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         case TrackingProtectionActionType.toggleTrackingProtectionStatus:
             return handleToggleTrackingProtectionStatusAction(from: state)
         case TrackingProtectionMiddlewareActionType.dismissTrackingProtection:
-            return dismissTrackingProtectionState(from: state)
+            return handleDismissTrackingProtectionAction(from: state)
         default:
             return defaultState(from: state)
         }
@@ -235,7 +235,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func dismissTrackingProtectionState(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleDismissTrackingProtectionAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -243,7 +243,9 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func handleDismissTrackingProtectionAction(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleDismissTrackingProtectionAction(
+        from state: TrackingProtectionState
+    ) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -190,6 +190,19 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         }
     }
 
+    private static func showAlertState(from state: TrackingProtectionState) -> TrackingProtectionState {
+        return TrackingProtectionState(
+            windowUUID: state.windowUUID,
+            trackingProtectionEnabled: state.trackingProtectionEnabled,
+            connectionSecure: state.connectionSecure,
+            shouldClearCookies: false,
+            shouldUpdateBlockedTrackerStats: false,
+            shouldUpdateConnectionStatus: false,
+            navigateTo: nil,
+            displayView: .clearCookiesAlert
+        )
+    }
+
     private static func toggleTrackingProtectionStatusState(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -110,7 +110,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         case TrackingProtectionMiddlewareActionType.showAlert:
             return handleShowAlertAction(from: state)
         case TrackingProtectionActionType.toggleTrackingProtectionStatus:
-            return toggleTrackingProtectionStatusState(from: state)
+            return handleToggleTrackingProtectionStatusAction(from: state)
         case TrackingProtectionMiddlewareActionType.dismissTrackingProtection:
             return dismissTrackingProtectionState(from: state)
         default:
@@ -222,7 +222,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func toggleTrackingProtectionStatusState(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleToggleTrackingProtectionStatusAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: !state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -144,7 +144,9 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func handleShowTrackingProtectionDetailsAction(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleShowTrackingProtectionDetailsAction(
+        from state: TrackingProtectionState
+    ) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -94,7 +94,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
 
         switch action.actionType {
         case TrackingProtectionMiddlewareActionType.clearCookies:
-            return clearCookiesState(from: state)
+            return handleClearCookiesAction(from: state)
         case TrackingProtectionMiddlewareActionType.navigateToSettings:
             return navigateToSettingsState(from: state)
         case TrackingProtectionMiddlewareActionType.showTrackingProtectionDetails:
@@ -118,7 +118,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         }
     }
 
-    private static func clearCookiesState(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleClearCookiesAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: !state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -94,16 +94,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
 
         switch action.actionType {
         case TrackingProtectionMiddlewareActionType.clearCookies:
-            return TrackingProtectionState(
-                windowUUID: state.windowUUID,
-                trackingProtectionEnabled: !state.trackingProtectionEnabled,
-                connectionSecure: state.connectionSecure,
-                shouldClearCookies: true,
-                shouldUpdateBlockedTrackerStats: false,
-                shouldUpdateConnectionStatus: false,
-                navigateTo: .home,
-                displayView: nil
-            )
+            return clearCookiesState(from: state)
         case TrackingProtectionMiddlewareActionType.navigateToSettings:
             return navigateToSettingsState(from: state)
         case TrackingProtectionMiddlewareActionType.showTrackingProtectionDetails:

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -149,16 +149,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
                 displayView: nil
             )
         case TrackingProtectionActionType.updateBlockedTrackerStats:
-            return TrackingProtectionState(
-                windowUUID: state.windowUUID,
-                trackingProtectionEnabled: state.trackingProtectionEnabled,
-                connectionSecure: state.connectionSecure,
-                shouldClearCookies: state.shouldClearCookies,
-                shouldUpdateBlockedTrackerStats: true,
-                shouldUpdateConnectionStatus: false,
-                navigateTo: nil,
-                displayView: nil
-            )
+            return updateBlockedTrackerStatsState(from: state)
         case TrackingProtectionActionType.updateConnectionStatus:
             return updateConnectionStatusState(from: state)
         case TrackingProtectionMiddlewareActionType.showAlert:

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -127,16 +127,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
                 displayView: .trackingProtectionDetails
             )
         case TrackingProtectionMiddlewareActionType.showBlockedTrackersDetails:
-            return TrackingProtectionState(
-                windowUUID: state.windowUUID,
-                trackingProtectionEnabled: state.trackingProtectionEnabled,
-                connectionSecure: state.connectionSecure,
-                shouldClearCookies: false,
-                shouldUpdateBlockedTrackerStats: false,
-                shouldUpdateConnectionStatus: false,
-                navigateTo: nil,
-                displayView: .blockedTrackersDetails
-            )
+            return showBlockedTrackersDetailsState(from: state)
         case TrackingProtectionActionType.goBack:
             return goBackState(from: state)
         case TrackingProtectionActionType.updateBlockedTrackerStats:

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -199,6 +199,19 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         }
     }
 
+    private static func toggleTrackingProtectionStatusState(from state: TrackingProtectionState) -> TrackingProtectionState {
+        return TrackingProtectionState(
+            windowUUID: state.windowUUID,
+            trackingProtectionEnabled: !state.trackingProtectionEnabled,
+            connectionSecure: state.connectionSecure,
+            shouldClearCookies: false,
+            shouldUpdateBlockedTrackerStats: false,
+            shouldUpdateConnectionStatus: false,
+            navigateTo: nil,
+            displayView: nil
+        )
+    }
+
     private static func dismissTrackingProtectionState(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -102,7 +102,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         case TrackingProtectionMiddlewareActionType.showBlockedTrackersDetails:
             return handleShowBlockedTrackersDetailsAction(from: state)
         case TrackingProtectionActionType.goBack:
-            return goBackState(from: state)
+            return handleGoBackAction(from: state)
         case TrackingProtectionActionType.updateBlockedTrackerStats:
             return updateBlockedTrackerStatsState(from: state)
         case TrackingProtectionActionType.updateConnectionStatus:
@@ -170,7 +170,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func goBackState(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleGoBackAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -160,16 +160,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
                 displayView: nil
             )
         case TrackingProtectionActionType.updateConnectionStatus:
-            return TrackingProtectionState(
-                windowUUID: state.windowUUID,
-                trackingProtectionEnabled: state.trackingProtectionEnabled,
-                connectionSecure: state.connectionSecure,
-                shouldClearCookies: false,
-                shouldUpdateBlockedTrackerStats: false,
-                shouldUpdateConnectionStatus: true,
-                navigateTo: nil,
-                displayView: nil
-            )
+            return updateConnectionStatusState(from: state)
         case TrackingProtectionMiddlewareActionType.showAlert:
             return showAlertState(from: state)
         case TrackingProtectionActionType.toggleTrackingProtectionStatus:

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -193,16 +193,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
                 displayView: nil
             )
         case TrackingProtectionMiddlewareActionType.dismissTrackingProtection:
-            return TrackingProtectionState(
-                windowUUID: state.windowUUID,
-                trackingProtectionEnabled: state.trackingProtectionEnabled,
-                connectionSecure: state.connectionSecure,
-                shouldClearCookies: false,
-                shouldUpdateBlockedTrackerStats: false,
-                shouldUpdateConnectionStatus: false,
-                navigateTo: .close,
-                displayView: nil
-            )
+            return dismissTrackingProtectionState(from: state)
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -116,16 +116,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
                 displayView: nil
             )
         case TrackingProtectionMiddlewareActionType.showTrackingProtectionDetails:
-            return TrackingProtectionState(
-                windowUUID: state.windowUUID,
-                trackingProtectionEnabled: state.trackingProtectionEnabled,
-                connectionSecure: state.connectionSecure,
-                shouldClearCookies: false,
-                shouldUpdateBlockedTrackerStats: false,
-                shouldUpdateConnectionStatus: false,
-                navigateTo: nil,
-                displayView: .trackingProtectionDetails
-            )
+            return showTrackingProtectionDetailsState(from: state)
         case TrackingProtectionMiddlewareActionType.showBlockedTrackersDetails:
             return showBlockedTrackersDetailsState(from: state)
         case TrackingProtectionActionType.goBack:

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -159,7 +159,9 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func handleShowBlockedTrackersDetailsAction(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleShowBlockedTrackersDetailsAction(
+        from state: TrackingProtectionState
+    ) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -100,7 +100,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         case TrackingProtectionMiddlewareActionType.showTrackingProtectionDetails:
             return handleShowTrackingProtectionDetailsAction(from: state)
         case TrackingProtectionMiddlewareActionType.showBlockedTrackersDetails:
-            return showBlockedTrackersDetailsState(from: state)
+            return handleShowBlockedTrackersDetailsAction(from: state)
         case TrackingProtectionActionType.goBack:
             return goBackState(from: state)
         case TrackingProtectionActionType.updateBlockedTrackerStats:
@@ -157,7 +157,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func showBlockedTrackersDetailsState(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleShowBlockedTrackersDetailsAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -127,6 +127,19 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         }
     }
 
+    private static func clearCookiesState(from state: TrackingProtectionState) -> TrackingProtectionState {
+        return TrackingProtectionState(
+            windowUUID: state.windowUUID,
+            trackingProtectionEnabled: !state.trackingProtectionEnabled,
+            connectionSecure: state.connectionSecure,
+            shouldClearCookies: true,
+            shouldUpdateBlockedTrackerStats: false,
+            shouldUpdateConnectionStatus: false,
+            navigateTo: .home,
+            displayView: nil
+        )
+    }
+
     private static func navigateToSettingsState(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -104,7 +104,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         case TrackingProtectionActionType.goBack:
             return handleGoBackAction(from: state)
         case TrackingProtectionActionType.updateBlockedTrackerStats:
-            return updateBlockedTrackerStatsState(from: state)
+            return handleUpdateBlockedTrackerStatsAction(from: state)
         case TrackingProtectionActionType.updateConnectionStatus:
             return updateConnectionStatusState(from: state)
         case TrackingProtectionMiddlewareActionType.showAlert:
@@ -183,7 +183,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func updateBlockedTrackerStatsState(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleUpdateBlockedTrackerStatsAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -96,7 +96,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         case TrackingProtectionMiddlewareActionType.clearCookies:
             return handleClearCookiesAction(from: state)
         case TrackingProtectionMiddlewareActionType.navigateToSettings:
-            return navigateToSettingsState(from: state)
+            return handleNavigateToSettingsAction(from: state)
         case TrackingProtectionMiddlewareActionType.showTrackingProtectionDetails:
             return showTrackingProtectionDetailsState(from: state)
         case TrackingProtectionMiddlewareActionType.showBlockedTrackersDetails:
@@ -131,7 +131,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func navigateToSettingsState(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleNavigateToSettingsAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -145,6 +145,19 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         }
     }
 
+    private static func showTrackingProtectionDetailsState(from state: TrackingProtectionState) -> TrackingProtectionState {
+        return TrackingProtectionState(
+            windowUUID: state.windowUUID,
+            trackingProtectionEnabled: state.trackingProtectionEnabled,
+            connectionSecure: state.connectionSecure,
+            shouldClearCookies: false,
+            shouldUpdateBlockedTrackerStats: false,
+            shouldUpdateConnectionStatus: false,
+            navigateTo: nil,
+            displayView: .trackingProtectionDetails
+        )
+    }
+
     private static func showBlockedTrackersDetailsState(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -171,16 +171,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
                 displayView: nil
             )
         case TrackingProtectionMiddlewareActionType.showAlert:
-            return TrackingProtectionState(
-                windowUUID: state.windowUUID,
-                trackingProtectionEnabled: state.trackingProtectionEnabled,
-                connectionSecure: state.connectionSecure,
-                shouldClearCookies: false,
-                shouldUpdateBlockedTrackerStats: false,
-                shouldUpdateConnectionStatus: false,
-                navigateTo: nil,
-                displayView: .clearCookiesAlert
-            )
+            return showAlertState(from: state)
         case TrackingProtectionActionType.toggleTrackingProtectionStatus:
             return toggleTrackingProtectionStatusState(from: state)
         case TrackingProtectionMiddlewareActionType.dismissTrackingProtection:

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -106,7 +106,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         case TrackingProtectionActionType.updateBlockedTrackerStats:
             return handleUpdateBlockedTrackerStatsAction(from: state)
         case TrackingProtectionActionType.updateConnectionStatus:
-            return updateConnectionStatusState(from: state)
+            return handleUpdateConnectionStatusAction(from: state)
         case TrackingProtectionMiddlewareActionType.showAlert:
             return showAlertState(from: state)
         case TrackingProtectionActionType.toggleTrackingProtectionStatus:
@@ -196,7 +196,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func updateConnectionStatusState(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleUpdateConnectionStatusAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -154,6 +154,19 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         }
     }
 
+    private static func showBlockedTrackersDetailsState(from state: TrackingProtectionState) -> TrackingProtectionState {
+        return TrackingProtectionState(
+            windowUUID: state.windowUUID,
+            trackingProtectionEnabled: state.trackingProtectionEnabled,
+            connectionSecure: state.connectionSecure,
+            shouldClearCookies: false,
+            shouldUpdateBlockedTrackerStats: false,
+            shouldUpdateConnectionStatus: false,
+            navigateTo: nil,
+            displayView: .blockedTrackersDetails
+        )
+    }
+
     private static func goBackState(from state: TrackingProtectionState) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -182,16 +182,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
                 displayView: .clearCookiesAlert
             )
         case TrackingProtectionActionType.toggleTrackingProtectionStatus:
-            return TrackingProtectionState(
-                windowUUID: state.windowUUID,
-                trackingProtectionEnabled: !state.trackingProtectionEnabled,
-                connectionSecure: state.connectionSecure,
-                shouldClearCookies: false,
-                shouldUpdateBlockedTrackerStats: false,
-                shouldUpdateConnectionStatus: false,
-                navigateTo: nil,
-                displayView: nil
-            )
+            return toggleTrackingProtectionStatusState(from: state)
         case TrackingProtectionMiddlewareActionType.dismissTrackingProtection:
             return dismissTrackingProtectionState(from: state)
         default:

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -105,16 +105,7 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
                 displayView: nil
             )
         case TrackingProtectionMiddlewareActionType.navigateToSettings:
-            return TrackingProtectionState(
-                windowUUID: state.windowUUID,
-                trackingProtectionEnabled: state.trackingProtectionEnabled,
-                connectionSecure: state.connectionSecure,
-                shouldClearCookies: false,
-                shouldUpdateBlockedTrackerStats: false,
-                shouldUpdateConnectionStatus: false,
-                navigateTo: .settings,
-                displayView: nil
-            )
+            return navigateToSettingsState(from: state)
         case TrackingProtectionMiddlewareActionType.showTrackingProtectionDetails:
             return showTrackingProtectionDetailsState(from: state)
         case TrackingProtectionMiddlewareActionType.showBlockedTrackersDetails:

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -187,7 +187,9 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func handleUpdateBlockedTrackerStatsAction(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleUpdateBlockedTrackerStatsAction(
+        from state: TrackingProtectionState
+    ) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: state.trackingProtectionEnabled,

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -228,7 +228,9 @@ struct TrackingProtectionState: StateType, Equatable, ScreenState {
         )
     }
 
-    private static func handleToggleTrackingProtectionStatusAction(from state: TrackingProtectionState) -> TrackingProtectionState {
+    private static func handleToggleTrackingProtectionStatusAction(
+        from state: TrackingProtectionState
+    ) -> TrackingProtectionState {
         return TrackingProtectionState(
             windowUUID: state.windowUUID,
             trackingProtectionEnabled: !state.trackingProtectionEnabled,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10325)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22618)

## :bulb: Description
This PR introduces the `closure_body_length` rule to the `.swiftlint.yml` file. 

Due to the current number of violations, we're implementing this rule incrementally. This PR sets a custom warning and error threshold of 90, agreed upon with @FilippoZazzeroni. Subsequent PRs will gradually reduce this threshold. I'll continue to reduce this in the following plan described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804. The objective with this PR is to prevent new cases of closure body length violations, according to the threshold.

As a first step, this PR addresses a violation in `TrackingProtectionState.swift`, which contained the longest closure (115 lines).

Also, it is important to mention that SwiftLint runs in strict mode when we make push commits to the repository, so all warnings are treated as errors. Therefore, the initial 90 threshold applies to both warnings and errors.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

