### PR TITLE
Refactor FXIOS-10758 [Sponsored tiles] Reduce max cache age for unified ads

### DIFF
--- a/BrowserKit/Sources/Shared/URLCaching.swift
+++ b/BrowserKit/Sources/Shared/URLCaching.swift
@@ -7,6 +7,7 @@ import Foundation
 /// Protocol to provide a caching functionality for network calls
 public protocol URLCaching {
     var urlCache: URLCache { get }
+    var maxCacheAge: Timestamp { get }
 
     func findCachedData(for request: URLRequest, timestamp: Timestamp) -> Data?
     func findCachedResponse(for request: URLRequest) -> [String: Any]?

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsProvider.swift
@@ -27,6 +27,7 @@ extension UnifiedAdsProviderInterface {
 class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, FeatureFlaggable {
     private static let prodResourceEndpoint = "https://ads.mozilla.org/v1/ads"
     static let stagingResourceEndpoint = "https://ads.allizom.org/v1/ads"
+    var maxCacheAge: Timestamp = OneMinuteInMilliseconds * 30
 
     var urlCache: URLCache
     private var logger: Logger


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10758)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23478)

## :bulb: Description
Following [conversation in Slack](https://mozilla.slack.com/archives/C05SHUDMSMN/p1733938630701309?thread_ts=1733781822.077249&cid=C05SHUDMSMN), we should reduce TTL (time to live) to 30 minutes instead of an hour.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

