### PR TITLE
Add FXIOS-10872 [Sent from Firefox] Add unit tests for the Sent from Firefox feature flag and Message A/B treatment

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
@@ -298,6 +298,44 @@ final class ShareManagerTests: XCTestCase {
         )
     }
 
+    func testGetActivityItems_forTab_withSentFromFirefoxEnabled_doesNotImpactOtherShares() throws {
+        setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: true)
+
+        let mailActivity = UIActivity.ActivityType.mail
+
+        let activityItems = ShareManager.getActivityItems(
+            forShareType: .tab(url: testWebURL, tab: testTab),
+            withExplicitShareMessage: nil
+        )
+
+        // Check we get all 4 types of share items for tabs below
+        XCTAssertEqual(activityItems.count, 4)
+
+        let urlActivityItemProvider = try XCTUnwrap(activityItems[safe: 0] as? URLActivityItemProvider)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: mailActivity
+        )
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: mailActivity
+        )
+
+        XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
+        XCTAssertEqual(itemForActivity as? URL, testWebURL)
+
+        // The rest of the content should be unchanged from other tests:
+        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        XCTAssertEqual(
+            titleActivityItemProvider.item as? String,
+            testWebpageDisplayTitle,
+            "When no explicit share message is set, we expect to see the webpage's title."
+        )
+    }
 
     func testGetActivityItems_forTab_withSentFromFirefoxDisabled_DoesNotOverride() throws {
         setupNimbusSentFromFirefoxTesting(isEnabled: false, isTreatmentA: true)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
@@ -212,9 +212,145 @@ final class ShareManagerTests: XCTestCase {
         )
     }
 
+    // MARK: - Sent from Firefox experiment - test that special treatment is only enabled when feature flag is enabled
+
+    func testGetActivityItems_forTab_withSentFromFirefoxEnabled_OverridesURL_withTreatmentA() throws {
+        setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: true)
+
+        // TODO: FXIOS-10858 Real links to come
+        let expectedShareContentA = "https://mozilla.org Sent from Firefox 🦊 Try the mobile browser: <FXIOS-10858 marketing link here>"
+        let whatsAppActivityIdentifier = "net.whatsapp.WhatsApp.ShareExtension"
+        let whatsAppActivity = UIActivity.ActivityType(rawValue: whatsAppActivityIdentifier)
+
+        let activityItems = ShareManager.getActivityItems(
+            forShareType: .tab(url: testWebURL, tab: testTab),
+            withExplicitShareMessage: nil
+        )
+
+        // Check we get all 4 types of share items for tabs below
+        XCTAssertEqual(activityItems.count, 4)
+
+        let urlActivityItemProvider = try XCTUnwrap(activityItems[safe: 0] as? URLActivityItemProvider)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: whatsAppActivity
+        )
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: whatsAppActivity
+        )
+
+        XCTAssertEqual(urlDataIdentifier, UTType.plainText.identifier)
+        XCTAssertEqual(itemForActivity as? String, expectedShareContentA)
+
+        // The rest of the content should be unchanged from other tests:
+        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        XCTAssertEqual(
+            titleActivityItemProvider.item as? String,
+            testWebpageDisplayTitle,
+            "When no explicit share message is set, we expect to see the webpage's title."
+        )
+    }
+
+    func testGetActivityItems_forTab_withSentFromFirefoxEnabled_OverridesURL_withTreatmentB() throws {
+        setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: false)
+
+        // TODO: FXIOS-10858 Real links to come
+        let expectedShareContentB = "https://mozilla.org Sent from Firefox 🦊 <FXIOS-10858 marketing link here>"
+        let whatsAppActivityIdentifier = "net.whatsapp.WhatsApp.ShareExtension"
+        let whatsAppActivity = UIActivity.ActivityType(rawValue: whatsAppActivityIdentifier)
+
+        let activityItems = ShareManager.getActivityItems(
+            forShareType: .tab(url: testWebURL, tab: testTab),
+            withExplicitShareMessage: nil
+        )
+
+        // Check we get all 4 types of share items for tabs below
+        XCTAssertEqual(activityItems.count, 4)
+
+        let urlActivityItemProvider = try XCTUnwrap(activityItems[safe: 0] as? URLActivityItemProvider)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: whatsAppActivity
+        )
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: whatsAppActivity
+        )
+
+        XCTAssertEqual(urlDataIdentifier, UTType.plainText.identifier)
+        XCTAssertEqual(itemForActivity as? String, expectedShareContentB)
+
+        // The rest of the content should be unchanged from other tests:
+        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        XCTAssertEqual(
+            titleActivityItemProvider.item as? String,
+            testWebpageDisplayTitle,
+            "When no explicit share message is set, we expect to see the webpage's title."
+        )
+    }
+
+
+    func testGetActivityItems_forTab_withSentFromFirefoxDisabled_DoesNotOverride() throws {
+        setupNimbusSentFromFirefoxTesting(isEnabled: false, isTreatmentA: true)
+
+        let whatsAppActivityIdentifier = "net.whatsapp.WhatsApp.ShareExtension"
+        let whatsAppActivity = UIActivity.ActivityType(rawValue: whatsAppActivityIdentifier)
+
+        let activityItems = ShareManager.getActivityItems(
+            forShareType: .tab(url: testWebURL, tab: testTab),
+            withExplicitShareMessage: nil
+        )
+
+        // Check we get all 4 types of share items for tabs below
+        XCTAssertEqual(activityItems.count, 4)
+
+        let urlActivityItemProvider = try XCTUnwrap(activityItems[safe: 0] as? URLActivityItemProvider)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: whatsAppActivity
+        )
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: whatsAppActivity
+        )
+
+        XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
+        XCTAssertEqual(itemForActivity as? URL, testWebURL)
+
+        // The rest of the content should be unchanged from other tests:
+        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        XCTAssertEqual(
+            titleActivityItemProvider.item as? String,
+            testWebpageDisplayTitle,
+            "When no explicit share message is set, we expect to see the webpage's title."
+        )
+    }
+
     // MARK: - Helpers
 
     private func createStubActivityViewController() -> UIActivityViewController {
         return UIActivityViewController(activityItems: [], applicationActivities: [])
+    }
+
+    private func setupNimbusSentFromFirefoxTesting(isEnabled: Bool, isTreatmentA: Bool) {
+        FxNimbus.shared.features.sentFromFirefoxFeature.with { _, _ in
+            return SentFromFirefoxFeature(
+                enabled: isEnabled,
+                isTreatmentA: isTreatmentA
+            )
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/URLActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/URLActivityItemProviderTests.swift
@@ -18,9 +18,11 @@ final class URLActivityItemProviderTests: XCTestCase {
 
     // MARK: - Sent from Firefox experiment WhatsApp tab share override
 
-    func testOveridesWhatsAppShareItem() throws {
+    func testOveridesWhatsAppShareItem_forTreatmentA() throws {
+        setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: true)
+
         // TODO: FXIOS-10858 Real links to come
-        let expectedShareContent = "https://mozilla.org Sent from Firefox 🦊 Try the mobile browser: <FXIOS-10858 marketing link here>"
+        let expectedShareContentA = "https://mozilla.org Sent from Firefox 🦊 Try the mobile browser: <FXIOS-10858 marketing link here>"
         let whatsAppActivityIdentifier = "net.whatsapp.WhatsApp.ShareExtension"
 
         let urlActivityItemProvider = URLActivityItemProvider(url: testWebURL, allowSentFromFirefoxTreatment: true)
@@ -29,12 +31,37 @@ final class URLActivityItemProviderTests: XCTestCase {
             itemForActivityType: UIActivity.ActivityType(rawValue: whatsAppActivityIdentifier)
         )
 
-        XCTAssertEqual(itemForActivity as? String, expectedShareContent)
+        XCTAssertEqual(itemForActivity as? String, expectedShareContentA)
+    }
+
+    func testOveridesWhatsAppShareItem_forTreatmentB() throws {
+        setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: false)
+
+        // TODO: FXIOS-10858 Real links to come
+        let expectedShareContentB = "https://mozilla.org Sent from Firefox 🦊 <FXIOS-10858 marketing link here>"
+        let whatsAppActivityIdentifier = "net.whatsapp.WhatsApp.ShareExtension"
+
+        let urlActivityItemProvider = URLActivityItemProvider(url: testWebURL, allowSentFromFirefoxTreatment: true)
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: UIActivity.ActivityType(rawValue: whatsAppActivityIdentifier)
+        )
+
+        XCTAssertEqual(itemForActivity as? String, expectedShareContentB)
     }
 
     // MARK: - Helpers
 
     private func createStubActivityViewController() -> UIActivityViewController {
         return UIActivityViewController(activityItems: [], applicationActivities: [])
+    }
+
+    private func setupNimbusSentFromFirefoxTesting(isEnabled: Bool, isTreatmentA: Bool) {
+        FxNimbus.shared.features.sentFromFirefoxFeature.with { _, _ in
+            return SentFromFirefoxFeature(
+                enabled: isEnabled,
+                isTreatmentA: isTreatmentA
+            )
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10872)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23721)

## :bulb: Description
Adds unit tests for the Sent from Firefox WhatsApp experimentation. We share either A or B type text to WhatsApp _**only**_ and no other apps. And we only do this when the user has Sent from Firefox enabled.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

