### PR TITLE
Add FXIOS-10858 [Sent from Firefox] Add real experiment links for A/B text treatment

### DIFF
--- a/firefox-ios/Client/Frontend/Share/URLActivityItemProvider.swift
+++ b/firefox-ios/Client/Frontend/Share/URLActivityItemProvider.swift
@@ -38,12 +38,12 @@ class URLActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
             whatsAppShareText = String.localizedStringWithFormat(.SentFromFirefox.SocialShare.ShareMessageA,
                                                                  parsedURL.absoluteString,
                                                                  AppName.shortName.rawValue,
-                                                                 "<FXIOS-10858 marketing link here>")
+                                                                 "https://mzl.la/4fOWPpd")
         } else {
             whatsAppShareText = String.localizedStringWithFormat(.SentFromFirefox.SocialShare.ShareMessageB,
                                                                  parsedURL.absoluteString,
                                                                  AppName.shortName.rawValue,
-                                                                 "<FXIOS-10858 marketing link here>")
+                                                                 "https://mzl.la/3YSUOl8")
         }
 
         super.init(placeholderItem: parsedURL)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
@@ -217,8 +217,7 @@ final class ShareManagerTests: XCTestCase {
     func testGetActivityItems_forTab_withSentFromFirefoxEnabled_OverridesURL_withTreatmentA() throws {
         setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: true)
 
-        // TODO: FXIOS-10858 Real links to come
-        let expectedShareContentA = "https://mozilla.org Sent from Firefox 🦊 Try the mobile browser: <FXIOS-10858 marketing link here>"
+        let expectedShareContentA = "https://mozilla.org Sent from Firefox 🦊 Try the mobile browser: https://mzl.la/4fOWPpd"
         let whatsAppActivityIdentifier = "net.whatsapp.WhatsApp.ShareExtension"
         let whatsAppActivity = UIActivity.ActivityType(rawValue: whatsAppActivityIdentifier)
 
@@ -259,8 +258,7 @@ final class ShareManagerTests: XCTestCase {
     func testGetActivityItems_forTab_withSentFromFirefoxEnabled_OverridesURL_withTreatmentB() throws {
         setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: false)
 
-        // TODO: FXIOS-10858 Real links to come
-        let expectedShareContentB = "https://mozilla.org Sent from Firefox 🦊 <FXIOS-10858 marketing link here>"
+        let expectedShareContentB = "https://mozilla.org Sent from Firefox 🦊 https://mzl.la/3YSUOl8"
         let whatsAppActivityIdentifier = "net.whatsapp.WhatsApp.ShareExtension"
         let whatsAppActivity = UIActivity.ActivityType(rawValue: whatsAppActivityIdentifier)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/URLActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/URLActivityItemProviderTests.swift
@@ -21,8 +21,7 @@ final class URLActivityItemProviderTests: XCTestCase {
     func testOveridesWhatsAppShareItem_forTreatmentA() throws {
         setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: true)
 
-        // TODO: FXIOS-10858 Real links to come
-        let expectedShareContentA = "https://mozilla.org Sent from Firefox 🦊 Try the mobile browser: <FXIOS-10858 marketing link here>"
+        let expectedShareContentA = "https://mozilla.org Sent from Firefox 🦊 Try the mobile browser: https://mzl.la/4fOWPpd"
         let whatsAppActivityIdentifier = "net.whatsapp.WhatsApp.ShareExtension"
 
         let urlActivityItemProvider = URLActivityItemProvider(url: testWebURL, allowSentFromFirefoxTreatment: true)
@@ -37,8 +36,7 @@ final class URLActivityItemProviderTests: XCTestCase {
     func testOveridesWhatsAppShareItem_forTreatmentB() throws {
         setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: false)
 
-        // TODO: FXIOS-10858 Real links to come
-        let expectedShareContentB = "https://mozilla.org Sent from Firefox 🦊 <FXIOS-10858 marketing link here>"
+        let expectedShareContentB = "https://mozilla.org Sent from Firefox 🦊 https://mzl.la/3YSUOl8"
         let whatsAppActivityIdentifier = "net.whatsapp.WhatsApp.ShareExtension"
 
         let urlActivityItemProvider = URLActivityItemProvider(url: testWebURL, allowSentFromFirefoxTreatment: true)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10858)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23682)

## :bulb: Description
Add in real experiment A/B links for the Sent from Firefox experiment.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

