### PR TITLE
Bugfix FXIOS-10863 Homepage telemetry fix

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -94,6 +94,7 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
     weak var delegate: HomepageViewModelDelegate?
     private var wallpaperManager: WallpaperManager
     private var logger: Logger
+    private let viewWillAppearEventThrottler = Throttler(seconds: 0.5)
 
     // Child View models
     private var childViewModels: [HomepageViewModelProtocol]
@@ -198,7 +199,10 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
         guard !viewAppeared else { return }
 
         viewAppeared = true
-        Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
+        // TODO: FXIOS-9428 - Need to fix issue where viewWillAppear is called twice so we can remove the throttle workaround
+        viewWillAppearEventThrottler.throttle {
+            Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
+        }
         nimbus.features.homescreenFeature.recordExposure()
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .view,

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -94,7 +94,6 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
     weak var delegate: HomepageViewModelDelegate?
     private var wallpaperManager: WallpaperManager
     private var logger: Logger
-    private let viewWillAppearEventThrottler = Throttler(seconds: 0.5)
 
     // Child View models
     private var childViewModels: [HomepageViewModelProtocol]
@@ -199,10 +198,7 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
         guard !viewAppeared else { return }
 
         viewAppeared = true
-        // TODO: FXIOS-9428 - Need to fix issue where viewWillAppear is called twice so we can remove the throttle workaround
-        viewWillAppearEventThrottler.throttle {
-            Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
-        }
+        Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
         nimbus.features.homescreenFeature.recordExposure()
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .view,

--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -94,7 +94,6 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
     weak var delegate: HomepageViewModelDelegate?
     private var wallpaperManager: WallpaperManager
     private var logger: Logger
-    private let viewWillAppearEventThrottler = Throttler(seconds: 0.5)
 
     // Child View models
     private var childViewModels: [HomepageViewModelProtocol]
@@ -199,10 +198,6 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
         guard !viewAppeared else { return }
 
         viewAppeared = true
-        // TODO: FXIOS-9428 - Need to fix issue where viewWillAppear is called twice so we can remove the throttle workaround
-        viewWillAppearEventThrottler.throttle {
-            Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
-        }
         nimbus.features.homescreenFeature.recordExposure()
         TelemetryWrapper.recordEvent(category: .action,
                                      method: .view,

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -151,7 +151,6 @@ class LegacyHomepageViewController:
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        viewModel.recordViewAppeared()
 
         notificationCenter.post(name: .ShowHomepage, withUserInfo: windowUUID.userInfo)
         notificationCenter.post(name: .HistoryUpdated)
@@ -162,6 +161,8 @@ class LegacyHomepageViewController:
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        // FXIOS-9428 - Record telemetry in viewDidAppear since viewWillAppear is sometimes triggered twice
+        viewModel.recordViewAppeared()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
             self?.displayWallpaperSelector()

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -46,6 +46,8 @@ class LegacyHomepageViewController:
     private var collectionView: UICollectionView! = nil
     private var lastContentOffsetY: CGFloat = 0
     private var logger: Logger
+    private let viewWillAppearEventThrottler = Throttler(seconds: 0.5)
+
     var windowUUID: WindowUUID { return tabManager.windowUUID }
     var currentWindowUUID: UUID? { return windowUUID }
 
@@ -151,6 +153,12 @@ class LegacyHomepageViewController:
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        // TODO: FXIOS-9428 - Need to fix issue where viewWillAppear is called twice so we can remove the throttle workaround
+        // This can then be moved back inside the `viewModel.recordViewAppeared()`
+        viewWillAppearEventThrottler.throttle {
+            Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
+        }
 
         notificationCenter.post(name: .ShowHomepage, withUserInfo: windowUUID.userInfo)
         notificationCenter.post(name: .HistoryUpdated)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/LegacyHomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/LegacyHomepageViewControllerTests.swift
@@ -60,7 +60,7 @@ class LegacyHomepageViewControllerTests: XCTestCase {
                 expression: "'homepage_viewed'|eventSum('Days', 1, 0) > 0"
             )
         )
-        subject.viewDidAppear(false)
+        subject.viewWillAppear(false)
         let expectation = self.expectation(description: "Record event called")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             expectation.fulfill()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/LegacyHomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/LegacyHomepageViewControllerTests.swift
@@ -60,7 +60,7 @@ class LegacyHomepageViewControllerTests: XCTestCase {
                 expression: "'homepage_viewed'|eventSum('Days', 1, 0) > 0"
             )
         )
-        subject.viewWillAppear(false)
+        subject.viewDidAppear(false)
         let expectation = self.expectation(description: "Record event called")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             expectation.fulfill()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10863)

## :bulb: Description
As a temporary fix until this issue is fixed in [FXIOS-9428](https://mozilla-hub.atlassian.net/browse/FXIOS-9428) I propose we move `viewModel.recordViewAppeared()` to `viewDidAppear` and remove the throttler that was added previously in [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/20874). `viewDidAppear` is only called once from what I’ve seen during my tests. The add-remove-add homepage cycle happens too fast for the first homepage `viewDidAppear` to actually be called.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)



[FXIOS-9428]: https://mozilla-hub.atlassian.net/browse/FXIOS-9428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ