### PR TITLE
Add FXIOS-10816 [Sent from Firefox] Add more URLActivityItemProvider unit tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ShareManagerTests.swift
@@ -291,8 +291,12 @@ final class ShareManagerTests: XCTestCase {
         _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        let itemForTitleActivity = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: whatsAppActivity
+        )
         XCTAssertEqual(
-            titleActivityItemProvider.item as? String,
+            itemForTitleActivity as? String,
             testWebpageDisplayTitle,
             "When no explicit share message is set, we expect to see the webpage's title."
         )
@@ -332,8 +336,12 @@ final class ShareManagerTests: XCTestCase {
         _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        let itemForTitleActivity = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: whatsAppActivity
+        )
         XCTAssertEqual(
-            titleActivityItemProvider.item as? String,
+            itemForTitleActivity as? String,
             testWebpageDisplayTitle,
             "When no explicit share message is set, we expect to see the webpage's title."
         )
@@ -371,10 +379,13 @@ final class ShareManagerTests: XCTestCase {
         _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
-        XCTAssertEqual(
-            titleActivityItemProvider.item as? String,
-            testWebpageDisplayTitle,
-            "When no explicit share message is set, we expect to see the webpage's title."
+        let itemForTitleActivity = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: mailActivity
+        )
+        XCTAssertTrue(
+            itemForTitleActivity is NSNull,
+            "When no explicit share message, TitleActivityItemProvider item should not be shared to excluded activity Mail."
         )
     }
 
@@ -411,8 +422,12 @@ final class ShareManagerTests: XCTestCase {
         _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
 
         let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        let itemForTitleActivity = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: whatsAppActivity
+        )
         XCTAssertEqual(
-            titleActivityItemProvider.item as? String,
+            itemForTitleActivity as? String,
             testWebpageDisplayTitle,
             "When no explicit share message is set, we expect to see the webpage's title."
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/URLActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/URLActivityItemProviderTests.swift
@@ -16,7 +16,7 @@ final class URLActivityItemProviderTests: XCTestCase {
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
     }
 
-    func testWebURL_forMailActivity() throws {
+    func testWebURL_forMailActivity() {
         let testActivityType = UIActivity.ActivityType.mail
 
         let urlActivityItemProvider = URLActivityItemProvider(url: testWebURL, allowSentFromFirefoxTreatment: false)
@@ -33,7 +33,7 @@ final class URLActivityItemProviderTests: XCTestCase {
         XCTAssertEqual(itemForActivity as? URL, testWebURL)
     }
 
-    func testWebURL_forMessagesActivity() throws {
+    func testWebURL_forMessagesActivity() {
         let testActivityType = UIActivity.ActivityType.message
 
         let urlActivityItemProvider = URLActivityItemProvider(url: testWebURL, allowSentFromFirefoxTreatment: false)
@@ -50,7 +50,7 @@ final class URLActivityItemProviderTests: XCTestCase {
         XCTAssertEqual(itemForActivity as? URL, testWebURL)
     }
 
-    func testFileURL_forMailActivity() throws {
+    func testFileURL_forMailActivity() {
         let testActivityType = UIActivity.ActivityType.mail
 
         let urlActivityItemProvider = URLActivityItemProvider(url: testFileURL, allowSentFromFirefoxTreatment: false)
@@ -67,7 +67,7 @@ final class URLActivityItemProviderTests: XCTestCase {
         XCTAssertEqual(itemForActivity as? URL, testFileURL)
     }
 
-    func testFileURL_forMessagesActivity() throws {
+    func testFileURL_forMessagesActivity() {
         let testActivityType = UIActivity.ActivityType.message
 
         let urlActivityItemProvider = URLActivityItemProvider(url: testFileURL, allowSentFromFirefoxTreatment: false)
@@ -84,7 +84,7 @@ final class URLActivityItemProviderTests: XCTestCase {
         XCTAssertEqual(itemForActivity as? URL, testFileURL)
     }
 
-    func testWebURL_forExcludedActivity() throws {
+    func testWebURL_forExcludedActivity() {
         let testActivityType = UIActivity.ActivityType.addToReadingList
 
         let urlActivityItemProvider = URLActivityItemProvider(url: testWebURL, allowSentFromFirefoxTreatment: false)
@@ -101,7 +101,7 @@ final class URLActivityItemProviderTests: XCTestCase {
         XCTAssertTrue(itemForActivity is NSNull)
     }
 
-    func testFileURL_forExcludedActivity() throws {
+    func testFileURL_forExcludedActivity() {
         let testActivityType = UIActivity.ActivityType.addToReadingList
 
         let urlActivityItemProvider = URLActivityItemProvider(url: testFileURL, allowSentFromFirefoxTreatment: false)
@@ -120,7 +120,7 @@ final class URLActivityItemProviderTests: XCTestCase {
 
     // MARK: - Sent from Firefox experiment WhatsApp tab share override
 
-    func testOveridesWhatsAppShareItem_forTreatmentA() throws {
+    func testOveridesWhatsAppShareItem_forTreatmentA() {
         setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: true)
 
         let expectedShareContentA = "https://mozilla.org Sent from Firefox 🦊 Try the mobile browser: https://mzl.la/4fOWPpd"
@@ -135,7 +135,7 @@ final class URLActivityItemProviderTests: XCTestCase {
         XCTAssertEqual(itemForActivity as? String, expectedShareContentA)
     }
 
-    func testOveridesWhatsAppShareItem_forTreatmentB() throws {
+    func testOveridesWhatsAppShareItem_forTreatmentB() {
         setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: false)
 
         let expectedShareContentB = "https://mozilla.org Sent from Firefox 🦊 https://mzl.la/3YSUOl8"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/URLActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/URLActivityItemProviderTests.swift
@@ -6,14 +6,116 @@ import UniformTypeIdentifiers
 import XCTest
 @testable import Client
 
-// TODO: FXIOS-10816 Flesh out these unit tests
 final class URLActivityItemProviderTests: XCTestCase {
+    let testFileURL = URL(string: "file://some/file/url")!
     let testWebURL = URL(string: "https://mozilla.org")!
 
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
+    }
+
+    func testWebURL_forMailActivity() throws {
+        let testActivityType = UIActivity.ActivityType.mail
+
+        let urlActivityItemProvider = URLActivityItemProvider(url: testWebURL, allowSentFromFirefoxTreatment: false)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: testActivityType
+        )
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+
+        XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
+        XCTAssertEqual(itemForActivity as? URL, testWebURL)
+    }
+
+    func testWebURL_forMessagesActivity() throws {
+        let testActivityType = UIActivity.ActivityType.message
+
+        let urlActivityItemProvider = URLActivityItemProvider(url: testWebURL, allowSentFromFirefoxTreatment: false)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: testActivityType
+        )
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+
+        XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
+        XCTAssertEqual(itemForActivity as? URL, testWebURL)
+    }
+
+    func testFileURL_forMailActivity() throws {
+        let testActivityType = UIActivity.ActivityType.mail
+
+        let urlActivityItemProvider = URLActivityItemProvider(url: testFileURL, allowSentFromFirefoxTreatment: false)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: testActivityType
+        )
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+
+        XCTAssertEqual(urlDataIdentifier, UTType.fileURL.identifier)
+        XCTAssertEqual(itemForActivity as? URL, testFileURL)
+    }
+
+    func testFileURL_forMessagesActivity() throws {
+        let testActivityType = UIActivity.ActivityType.message
+
+        let urlActivityItemProvider = URLActivityItemProvider(url: testFileURL, allowSentFromFirefoxTreatment: false)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: testActivityType
+        )
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+
+        XCTAssertEqual(urlDataIdentifier, UTType.fileURL.identifier)
+        XCTAssertEqual(itemForActivity as? URL, testFileURL)
+    }
+
+    func testWebURL_forExcludedActivity() throws {
+        let testActivityType = UIActivity.ActivityType.addToReadingList
+
+        let urlActivityItemProvider = URLActivityItemProvider(url: testWebURL, allowSentFromFirefoxTreatment: false)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: testActivityType
+        )
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+
+        XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
+        XCTAssertTrue(itemForActivity is NSNull)
+    }
+
+    func testFileURL_forExcludedActivity() throws {
+        let testActivityType = UIActivity.ActivityType.addToReadingList
+
+        let urlActivityItemProvider = URLActivityItemProvider(url: testFileURL, allowSentFromFirefoxTreatment: false)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: testActivityType
+        )
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+
+        XCTAssertEqual(urlDataIdentifier, UTType.fileURL.identifier)
+        XCTAssertTrue(itemForActivity is NSNull)
     }
 
     // MARK: - Sent from Firefox experiment WhatsApp tab share override


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10816)

## :bulb: Description
Round out our URLActivityItemProvider unit tests.

The `URLActivityItemProvider` is used by the `ShareManager` to append a `URL` `ActivityItem` to the content we share out of the app. It gets used whether we're sharing file URLs, website URLs, and tabs with a web or file URL.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

