### PR TITLE
Add FXIOS-10875, FXIOS-10876 [Sent from Firefox] Add unit tests for TitleActivityItemProvider and TitleSubtitleActivityItemProvider

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1846,6 +1846,7 @@
 		ED4589402CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */; };
 		ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */; };
 		ED575BD32D00F9D00056BCDA /* MockTemporaryDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED575BD22D00F9D00056BCDA /* MockTemporaryDocument.swift */; };
+		ED67B2922D0B79F000BDC599 /* TitleSubtitleActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED67B2912D0B79F000BDC599 /* TitleSubtitleActivityItemProviderTests.swift */; };
 		ED6C8DAC2CE6A4BB00D7F7F3 /* Sentry-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = ED6C8DAB2CE6A4BB00D7F7F3 /* Sentry-Dynamic */; };
 		ED70CD812CE3BD2C0018761B /* MockStoreForMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */; };
 		ED7A08DB2CF674730035EC8F /* ShareMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A08DA2CF674730035EC8F /* ShareMessage.swift */; };
@@ -9378,6 +9379,7 @@
 		ED5144A0BE3A8C7B15047C3F /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinatorTests.swift; sourceTree = "<group>"; };
 		ED575BD22D00F9D00056BCDA /* MockTemporaryDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTemporaryDocument.swift; sourceTree = "<group>"; };
+		ED67B2912D0B79F000BDC599 /* TitleSubtitleActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleSubtitleActivityItemProviderTests.swift; sourceTree = "<group>"; };
 		ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreForMiddleware.swift; sourceTree = "<group>"; };
 		ED7A08DA2CF674730035EC8F /* ShareMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareMessage.swift; sourceTree = "<group>"; };
 		ED7A08DC2CF6749B0035EC8F /* ShareType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareType.swift; sourceTree = "<group>"; };
@@ -14121,6 +14123,7 @@
 				0ECB6B672CCFE663006A7C82 /* DateGroupedTableDataTests.swift */,
 				ED4294842CF1286E0077D7CB /* ShareManagerTests.swift */,
 				ED33E3562D0A4CE9002265A7 /* URLActivityItemProviderTests.swift */,
+				ED67B2912D0B79F000BDC599 /* TitleSubtitleActivityItemProviderTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -16992,6 +16995,7 @@
 				C706CBEF2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift in Sources */,
 				E19B38B128A3E69300D8C541 /* WallpaperCollectionAvailabilityTests.swift in Sources */,
 				81DAB2F32C88F14400F4BE98 /* MainMenuCoordinatorTests.swift in Sources */,
+				ED67B2922D0B79F000BDC599 /* TitleSubtitleActivityItemProviderTests.swift in Sources */,
 				8A359EF62A1FE840004A5BB7 /* MockAdjustWrapper.swift in Sources */,
 				8AC225662B6D403200CDA7FD /* HomepageTelemetryTests.swift in Sources */,
 				1D558A582BED7ECB001EF527 /* MockWindowManager.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1847,6 +1847,7 @@
 		ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */; };
 		ED575BD32D00F9D00056BCDA /* MockTemporaryDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED575BD22D00F9D00056BCDA /* MockTemporaryDocument.swift */; };
 		ED67B2922D0B79F000BDC599 /* TitleSubtitleActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED67B2912D0B79F000BDC599 /* TitleSubtitleActivityItemProviderTests.swift */; };
+		ED67B2942D0B80E200BDC599 /* TitleActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED67B2932D0B80E200BDC599 /* TitleActivityItemProviderTests.swift */; };
 		ED6C8DAC2CE6A4BB00D7F7F3 /* Sentry-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = ED6C8DAB2CE6A4BB00D7F7F3 /* Sentry-Dynamic */; };
 		ED70CD812CE3BD2C0018761B /* MockStoreForMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */; };
 		ED7A08DB2CF674730035EC8F /* ShareMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A08DA2CF674730035EC8F /* ShareMessage.swift */; };
@@ -9380,6 +9381,7 @@
 		ED55DC8B2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinatorTests.swift; sourceTree = "<group>"; };
 		ED575BD22D00F9D00056BCDA /* MockTemporaryDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTemporaryDocument.swift; sourceTree = "<group>"; };
 		ED67B2912D0B79F000BDC599 /* TitleSubtitleActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleSubtitleActivityItemProviderTests.swift; sourceTree = "<group>"; };
+		ED67B2932D0B80E200BDC599 /* TitleActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleActivityItemProviderTests.swift; sourceTree = "<group>"; };
 		ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreForMiddleware.swift; sourceTree = "<group>"; };
 		ED7A08DA2CF674730035EC8F /* ShareMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareMessage.swift; sourceTree = "<group>"; };
 		ED7A08DC2CF6749B0035EC8F /* ShareType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareType.swift; sourceTree = "<group>"; };
@@ -14124,6 +14126,7 @@
 				ED4294842CF1286E0077D7CB /* ShareManagerTests.swift */,
 				ED33E3562D0A4CE9002265A7 /* URLActivityItemProviderTests.swift */,
 				ED67B2912D0B79F000BDC599 /* TitleSubtitleActivityItemProviderTests.swift */,
+				ED67B2932D0B80E200BDC599 /* TitleActivityItemProviderTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -17015,6 +17018,7 @@
 				C869916328918C36007ACC5C /* WallpaperNetworkingModuleTests.swift in Sources */,
 				B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */,
 				8ABA9C8D28931223002C0077 /* MockDispatchQueue.swift in Sources */,
+				ED67B2942D0B80E200BDC599 /* TitleActivityItemProviderTests.swift in Sources */,
 				8CCD74732B90A945008F919B /* LoginListViewModelTests.swift in Sources */,
 				C81C66C429F00D1000F6422F /* UserActivityRouteTests.swift in Sources */,
 				8AFCE50529DDF38300B1B253 /* LaunchScreenViewControllerTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Share/TitleActivityItemProvider.swift
+++ b/firefox-ios/Client/Frontend/Share/TitleActivityItemProvider.swift
@@ -32,7 +32,10 @@ class TitleActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
         super.init(placeholderItem: title)
     }
 
-    override var item: Any {
+    override func activityViewController(
+        _ activityViewController: UIActivityViewController,
+        itemForActivityType activityType: UIActivity.ActivityType?
+    ) -> Any? {
         // For excluded activites, we don't want to provide any content
         if let activityType = activityType, TitleActivityItemProvider.activityTypesToIgnore.contains(activityType) {
             return NSNull()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TitleActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TitleActivityItemProviderTests.swift
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UniformTypeIdentifiers
+import XCTest
+@testable import Client
+
+final class TitleActivityItemProviderTests: XCTestCase {
+    let testMessage = "Test message"
+
+    func testNoShare_forMailActivity() throws {
+        let testActivityType = UIActivity.ActivityType.mail
+
+        let titleActivityItemProvider = TitleActivityItemProvider(title: testMessage)
+        let itemForActivity = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+        let subtitle = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            subjectForActivityType: testActivityType
+        )
+
+        XCTAssertTrue(itemForActivity is NSNull, "No title should be set for Mail")
+        XCTAssertEqual(subtitle, testMessage)
+    }
+
+    func testNoShare_forMessagesActivity() throws {
+        let testActivityType = UIActivity.ActivityType.message
+
+        let titleActivityItemProvider = TitleActivityItemProvider(title: testMessage)
+        let itemForActivity = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+        let subtitle = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            subjectForActivityType: testActivityType
+        )
+
+        XCTAssertTrue(itemForActivity is NSNull, "No title should be set for Messages")
+        XCTAssertEqual(subtitle, testMessage)
+    }
+
+    func testNoShare_forCopyToPasteboardActivity() throws {
+        let testActivityType = UIActivity.ActivityType.copyToPasteboard
+
+        let titleActivityItemProvider = TitleActivityItemProvider(title: testMessage)
+        let itemForActivity = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+        let subtitle = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            subjectForActivityType: testActivityType
+        )
+
+        XCTAssertTrue(itemForActivity is NSNull, "No title should be set for Copy & Pasteboard")
+        XCTAssertEqual(subtitle, testMessage)
+    }
+
+    func testShares_forNonExcludedActivity() throws {
+        let testActivityType = UIActivity.ActivityType(rawValue: "com.random.non-excluded.activity")
+
+        let titleActivityItemProvider = TitleActivityItemProvider(title: testMessage)
+        let itemForActivity = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+        let subtitle = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            subjectForActivityType: testActivityType
+        )
+
+        XCTAssertEqual(itemForActivity as? String, testMessage, "Must set title for non-excluded activity")
+        XCTAssertEqual(subtitle, testMessage)
+    }
+
+    // MARK: - Helpers
+
+    private func createStubActivityViewController() -> UIActivityViewController {
+        return UIActivityViewController(activityItems: [], applicationActivities: [])
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TitleSubtitleActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TitleSubtitleActivityItemProviderTests.swift
@@ -47,7 +47,7 @@ final class TitleSubtitleActivityItemProviderTests: XCTestCase {
 
         XCTAssertEqual(dataIdentifier, UTType.text.identifier)
         XCTAssertEqual(titleSubtitleActivityItemProvider.item as? String, testMessage)
-        XCTAssertEqual(subtitle, testMessage, "If no subtitle set, should repeat title")
+        XCTAssertEqual(subtitle, testSubtitle)
     }
 
     func testShareMessage_forMessagesActivity_noSubtitle() throws {
@@ -85,7 +85,7 @@ final class TitleSubtitleActivityItemProviderTests: XCTestCase {
 
         XCTAssertEqual(dataIdentifier, UTType.text.identifier)
         XCTAssertEqual(titleSubtitleActivityItemProvider.item as? String, testMessage)
-        XCTAssertEqual(subtitle, testMessage, "If no subtitle set, should repeat title")
+        XCTAssertEqual(subtitle, testSubtitle)
     }
 
     // MARK: - Helpers

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TitleSubtitleActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TitleSubtitleActivityItemProviderTests.swift
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UniformTypeIdentifiers
+import XCTest
+@testable import Client
+
+final class TitleSubtitleActivityItemProviderTests: XCTestCase {
+    let testMessage = "Test message"
+    let testSubtitle = "Test subtitle"
+    let testFileURL = URL(string: "file://some/file/url")!
+    let testWebURL = URL(string: "https://mozilla.org")!
+
+    func testShareMessage_forMailActivity_noSubtitle() throws {
+        let testActivityType = UIActivity.ActivityType.mail
+        let testShareMessage = ShareMessage(message: testMessage, subtitle: nil)
+
+        let titleSubtitleActivityItemProvider = TitleSubtitleActivityItemProvider(shareMessage: testShareMessage)
+        let dataIdentifier = titleSubtitleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: testActivityType
+        )
+        let subtitle = titleSubtitleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            subjectForActivityType: testActivityType
+        )
+
+        XCTAssertEqual(dataIdentifier, UTType.text.identifier)
+        XCTAssertEqual(titleSubtitleActivityItemProvider.item as? String, testMessage)
+        XCTAssertEqual(subtitle, testMessage, "If no subtitle set, should repeat title")
+    }
+
+    func testShareMessage_forMailActivity_withSubtitle() throws {
+        let testActivityType = UIActivity.ActivityType.mail
+        let testShareMessage = ShareMessage(message: testMessage, subtitle: testSubtitle)
+
+        let titleSubtitleActivityItemProvider = TitleSubtitleActivityItemProvider(shareMessage: testShareMessage)
+        let dataIdentifier = titleSubtitleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: testActivityType
+        )
+        let subtitle = titleSubtitleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            subjectForActivityType: testActivityType
+        )
+
+        XCTAssertEqual(dataIdentifier, UTType.text.identifier)
+        XCTAssertEqual(titleSubtitleActivityItemProvider.item as? String, testMessage)
+        XCTAssertEqual(subtitle, testMessage, "If no subtitle set, should repeat title")
+    }
+
+    func testShareMessage_forMessagesActivity_noSubtitle() throws {
+        let testActivityType = UIActivity.ActivityType.message
+        let testShareMessage = ShareMessage(message: testMessage, subtitle: nil)
+
+        let titleSubtitleActivityItemProvider = TitleSubtitleActivityItemProvider(shareMessage: testShareMessage)
+        let dataIdentifier = titleSubtitleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: testActivityType
+        )
+        let subtitle = titleSubtitleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            subjectForActivityType: testActivityType
+        )
+
+        XCTAssertEqual(dataIdentifier, UTType.text.identifier)
+        XCTAssertEqual(titleSubtitleActivityItemProvider.item as? String, testMessage)
+        XCTAssertEqual(subtitle, testMessage, "If no subtitle set, should repeat title")
+    }
+
+    func testShareMessage_forMessagesActivity_withSubtitle() throws {
+        let testActivityType = UIActivity.ActivityType.message
+        let testShareMessage = ShareMessage(message: testMessage, subtitle: testSubtitle)
+
+        let titleSubtitleActivityItemProvider = TitleSubtitleActivityItemProvider(shareMessage: testShareMessage)
+        let dataIdentifier = titleSubtitleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: testActivityType
+        )
+        let subtitle = titleSubtitleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            subjectForActivityType: testActivityType
+        )
+
+        XCTAssertEqual(dataIdentifier, UTType.text.identifier)
+        XCTAssertEqual(titleSubtitleActivityItemProvider.item as? String, testMessage)
+        XCTAssertEqual(subtitle, testMessage, "If no subtitle set, should repeat title")
+    }
+
+    // MARK: - Helpers
+
+    private func createStubActivityViewController() -> UIActivityViewController {
+        return UIActivityViewController(activityItems: [], applicationActivities: [])
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket 1](https://mozilla-hub.atlassian.net/browse/FXIOS-10875)
[Jira ticket 2](https://mozilla-hub.atlassian.net/browse/FXIOS-10876)

## :bulb: Description
This PR adds unit tests for `TitleActivityItemProvider` and `TitleSubtitleActivityItemProvider`. Also makes `TitleActivityItemProvider` a bit more testable.

Add as well an example of an excluded share activity type test case using `TitleActivityItemProvider` via `ShareManager` tests (integration).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

