### PR TITLE
Bugfix MTE-3733/MTE-3971 testPinToShortcuts() for iOS 15 and 16

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -22,15 +22,25 @@ class PhotonActionSheetTests: BaseTestCase {
         let itemCell = app.cells[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         let cell = itemCell.staticTexts["Example Domain"]
         mozWaitForElementToExist(cell)
+        if #available(iOS 17, *) {
+            mozWaitForElementToExist(app.cells["Example Domain"].images[StandardImageIdentifiers.Small.pinBadgeFill])
+        } else {
+            // No identifier is available for iOS 16 amd below
+            mozWaitForElementToExist(app.cells["Example Domain"].images.element(boundBy: 1))
+        }
 
         // Remove pin
         cell.press(forDuration: 2)
-        app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash].tap()
+        app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash].waitAndTap()
         // Check that it has been unpinned
         /* FIXME: Adding a workaround until https://github.com/mozilla-mobile/firefox-ios/issues/22323 is fixed
          * We will wait for the pinned icon on the example.com tile to disappear (max 8 seconds polling)
          */
-        waitForNoExistence(app.cells["Example Domain"].images[StandardImageIdentifiers.Small.pinBadgeFill], timeoutValue: 8)
+        if #available(iOS 17, *) {
+            mozWaitForElementToNotExist(app.cells["Example Domain"].images[StandardImageIdentifiers.Small.pinBadgeFill])
+        } else {
+            mozWaitForElementToNotExist(app.cells["Example Domain"].images.element(boundBy: 1))
+        }
 
         cell.press(forDuration: 2)
         mozWaitForElementToExist(app.tables.cells.otherElements[StandardImageIdentifiers.Large.pin])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -9,7 +9,7 @@ class PhotonActionSheetTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2306849
     // Smoketest
     func testPinToShortcuts() {
-        navigator.openURL("http://example.com")
+        navigator.openURL(path(forTestPage: "test-example.html"))
         waitUntilPageLoad()
         // Open Page Action Menu Sheet and Pin the site
         navigator.performAction(Action.PinToTopSitesPAM)
@@ -42,8 +42,7 @@ class PhotonActionSheetTests: BaseTestCase {
             mozWaitForElementToNotExist(app.cells["Example Domain"].images.element(boundBy: 1))
         }
 
-        cell.press(forDuration: 2)
-        mozWaitForElementToExist(app.tables.cells.otherElements[StandardImageIdentifiers.Large.pin])
+        mozWaitForElementToNotExist(app.cells["Example Domain"])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2322067

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -25,7 +25,7 @@ class PhotonActionSheetTests: BaseTestCase {
         if #available(iOS 17, *) {
             mozWaitForElementToExist(app.cells["Example Domain"].images[StandardImageIdentifiers.Small.pinBadgeFill])
         } else {
-            // No identifier is available for iOS 16 amd below
+            // No identifier is available for iOS 17 amd below
             mozWaitForElementToExist(app.cells["Example Domain"].images.element(boundBy: 1))
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-3733)

## :bulb: Description
`testPinToShortcuts()` fails consistently on iOS 15 and 16 only because the pushpin image 📌 does not have the identifier `StandardImageIdentifiers.Small.pinBadgeFill`.

A workaround is to test for the second image under the "Example Domain" cell.

This PR also uses `localhost` as the website instead of fetching an external one.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

