### PR TITLE
Bugfix MTE-4007 Catch errors from fastlane

### DIFF
--- a/firefox-ios/l10n-screenshots.sh
+++ b/firefox-ios/l10n-screenshots.sh
@@ -46,6 +46,9 @@ for lang in $LOCALES; do
     if [ "$?" != "0" ]; then
         echo "Fastlane exited with code: $?"
         exit $?
+    elif grep -q "** TEST FAILED **"; then
+        echo "Test/compilation failed"
+        exit 1
     elif grep -q "Caught error" "output.txt"; then
         echo "Fastlane caught error"
         exit 1

--- a/firefox-ios/l10n-screenshots.sh
+++ b/firefox-ios/l10n-screenshots.sh
@@ -42,6 +42,15 @@ for lang in $LOCALES; do
         --erase_simulator --localize_simulator \
         --devices "iPhone 15" --languages "$lang" \
         --output_directory "l10n-screenshots/$lang" \
-        $EXTRA_FAST_LANE_ARGS
-    echo "Fastlane exited with code: $?"
+        $EXTRA_FAST_LANE_ARGS | tee output.txt
+    if [ "$?" != "0" ]; then
+        echo "Fastlane exited with code: $?"
+        exit $?
+    elif grep -q "Caught error" "output.txt"; then
+        echo "Fastlane caught error"
+        exit 1
+    elif grep -q "❌" "output.txt"; then
+        exit 1
+    fi
+    rm output.txt
 done


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4007)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
`fastlane` returns `0` even if the command fails (https://github.com/fastlane/fastlane/issues/20419), so we didn't know the compilation failed by looking at the L10nBuild status on Bitrise.

This PR added some known parts of the logs that are known to indicate failures.

Here is a sample failed workflow demonstrating how the error was caught: https://app.bitrise.io/build/b53416ce-86e2-4379-9f2d-10c2abf11036?tab=log

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

