### PR TITLE
Remove FXIOS-10865 [Dead code] Clean up dead code

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -44,7 +44,6 @@ struct AccessibilityIdentifiers {
             static let scanQRCodeButton = "urlBar-scanQRCode"
             static let cancelButton = "urlBar-cancel"
             static let searchTextField = "address"
-            static let url = "url"
         }
 
         struct KeyboardAccessory {
@@ -53,11 +52,9 @@ struct AccessibilityIdentifiers {
             static let previousButton = "KeyboardAccessory.previousButton"
             static let addressAutofillButton = "KeyboardAccessory.addressAutofillButton"
             static let creditCardAutofillButton = "KeyboardAccessory.creditCardAutofillButton"
-            static let loginAutofillButton = "KeyboardAccessory.loginAutofillButton"
         }
 
         struct AddressToolbar {
-            static let clear = "AddressToolbar.clear"
             static let lockIcon = "AddressToolbar.lockIcon"
             static let searchTextField = "AddressToolbar.address"
             static let searchEngine = "AddressToolbar.searchEngine"
@@ -99,13 +96,10 @@ struct AccessibilityIdentifiers {
         static let settings = "MainMenu.Settings"
         static let whatsNew = "MainMenu.WhatsNew"
         static let customizeHomepage = "MainMenu.CustomizeHomepage"
-        static let saveAsPDF = "MainMenu.SaveAsPDF"
         static let saveToReadingList = "MainMenu.SaveToReadingList"
-        static let addToHomeScreen = "MainMenu.AddToHomeScreen"
         static let addToShortcuts = "MainMenu.AddToShortcuts"
         static let bookmarkThisPage = "MainMenu.BookmarkThisPage"
         static let share = "MainMenu.Share"
-        static let print = "MainMenu.Print"
         static let reportBrokenSite = "MainMenu.ReportBrokenSite"
         static let readerView = "MainMenu.ReaderViewOn"
         static let nightMode = "MainMenu.NightModeOn"
@@ -151,13 +145,6 @@ struct AccessibilityIdentifiers {
             static let headerView = "BlockedTrackers.HeaderView"
             static let mainView = "BlockedTrackers.MainView"
             static let containerView = "BlockedTrackers.BaseView"
-            static let crossSiteTrackersView = "BlockedTrackers.CrossSiteTrackersView"
-            static let socialMediaTrackersView = "BlockedTrackers.SocialMediaTrackersView"
-            static let fingerprintersView = "BlockedTrackers.FingerprintersView"
-            static let crossSiteTrackersImage = "BlockedTrackers.CrossSiteTrackersImage"
-            static let socialMediaTrackersImage = "BlockedTrackers.SocialMediaTrackersImage"
-            static let fingerprintersImage = "BlockedTrackers.FingerprintersImage"
-            static let blockedTrackersLabel = "BlockedTrackers.BlockedTrackersLabel"
         }
 
         struct CertificatesScreen {
@@ -225,10 +212,8 @@ struct AccessibilityIdentifiers {
             static let itemCell = "SyncedTabCell"
             static let cardTitle = "SyncedTabCardTitle"
             static let showAllButton = "SyncedTabShowAllButton"
-            static let heroImage = "SyncedTabHeroImage"
             static let itemTitle = "SyncedTabItemTitle"
             static let favIconImage = "SyncedTabFavIconImage"
-            static let fallbackFavIconImage = "SyncedTabFallbackFavIconImage"
             static let descriptionLabel = "SyncedTabDescriptionLabel"
         }
     }
@@ -296,7 +281,6 @@ struct AccessibilityIdentifiers {
         struct AnalysisProgressInfoCard {
             static let card = "Shopping.AnalysisProgressInfoCard.Card"
             static let title = "Shopping.AnalysisProgressInfoCard.Title"
-            static let description = "Shopping.AnalysisProgressInfoCard.Description"
         }
 
         struct NeedsAnalysisInfoCard {
@@ -432,7 +416,6 @@ struct AccessibilityIdentifiers {
     }
 
     struct TabTray {
-        static let filteredTabs = "filteredTabs"
         static let deleteCloseAllButton = "TabTrayController.deleteButton.closeAll"
         static let deleteCancelButton = "TabTrayController.deleteButton.cancel"
         static let syncedTabs = "Synced Tabs"
@@ -481,9 +464,7 @@ struct AccessibilityIdentifiers {
 
         struct HistoryPanel {
             static let tableView = "History List"
-            static let clearHistoryCell = "HistoryPanel.clearHistory"
             static let recentlyClosedCell = "HistoryPanel.recentlyClosedCell"
-            static let syncedHistoryCell = "HistoryPanel.syncedHistoryCell"
         }
 
         struct GroupedList {
@@ -594,7 +575,6 @@ struct AccessibilityIdentifiers {
 
         struct FirefoxAccount {
             static let continueButton = "Sign up or sign in"
-            static let emailTextFieldChinaFxA = "Email"
             static let emailTextField = "Enter your email"
             static let fxaNavigationBar = "Sync and Save Data"
             static let fxaSettingsButton = "Sync and Save Data"

--- a/firefox-ios/Client/Application/ImageIdentifiers.swift
+++ b/firefox-ios/Client/Application/ImageIdentifiers.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Please see `StandardImageIdentifiers` for th standard ones.
 /// When adding new identifiers, please respect alphabetical order.
 /// Sing the song if you must.
-public struct ImageIdentifiers {
+struct ImageIdentifiers {
     public static let badgeMask = "badge-mask"
     public static let firefoxFavicon = "faviconFox"
     public static let foxConfirmation = "foxConfirmation"

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -488,10 +488,6 @@ class BrowserCoordinator: BaseCoordinator,
 
     // MARK: - LibraryCoordinatorDelegate
 
-    func openRecentlyClosedSiteInSameTab(_ url: URL) {
-        browserViewController.openRecentlyClosedSiteInSameTab(url)
-    }
-
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
         browserViewController.openRecentlyClosedSiteInNewTab(url, isPrivate: isPrivate)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3145,11 +3145,6 @@ class BrowserViewController: UIViewController,
 
     // MARK: - RecentlyClosedPanelDelegate
 
-    func openRecentlyClosedSiteInSameTab(_ url: URL) {
-        guard let tab = self.tabManager.selectedTab else { return }
-        self.finishEditingAndSubmit(url, visitType: .link, forTab: tab)
-    }
-
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {
         tabManager.selectTab(tabManager.addTab(URLRequest(url: url)))
     }

--- a/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/RecentlyClosedTabsPanel.swift
@@ -17,7 +17,6 @@ private struct RecentlyClosedPanelUX {
 
 protocol RecentlyClosedPanelDelegate: AnyObject {
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool)
-    func openRecentlyClosedSiteInSameTab(_ url: URL)
 }
 
 class RecentlyClosedTabsPanel: UIViewController, LibraryPanel, Themeable {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -986,16 +986,6 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         XCTAssertTrue(mbvc.isPrivate)
     }
 
-    func testOpenRecentlyClosedTabInSameTab_callsReletedMethodInBrowserViewController() {
-        let subject = createSubject()
-        let mbvc = MockBrowserViewController(profile: profile, tabManager: tabManager)
-        subject.browserViewController = mbvc
-
-        subject.openRecentlyClosedSiteInSameTab(URL(string: "https://www.google.com")!)
-
-        XCTAssertEqual(mbvc.didOpenRecentlyClosedSiteInSameTab, 1)
-    }
-
     func testOpenRecentlyClosedSiteInNewTab_addsOneTabToTabManager() {
         let subject = createSubject()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockLibraryCoordinatorDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockLibraryCoordinatorDelegate.swift
@@ -15,7 +15,6 @@ class MockLibraryCoordinatorDelegate: LibraryCoordinatorDelegate, LibraryPanelDe
     var didFinishSettingsCalled = 0
     var didRequestToOpenInNewTabCalled = false
     var didSelectURLCalled = false
-    var didOpenRecentlyClosedSiteInSameTab = 0
     var didOpenRecentlyClosedSiteInNewTab = 0
     var lastOpenedURL: URL?
     var lastVisitType: VisitType?
@@ -35,10 +34,6 @@ class MockLibraryCoordinatorDelegate: LibraryCoordinatorDelegate, LibraryPanelDe
         didSelectURLCalled = true
         lastOpenedURL = url
         lastVisitType = visitType
-    }
-
-    func openRecentlyClosedSiteInSameTab(_ url: URL) {
-        didOpenRecentlyClosedSiteInSameTab += 1
     }
 
     func openRecentlyClosedSiteInNewTab(_ url: URL, isPrivate: Bool) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -51,7 +51,6 @@ class MockBrowserViewController: BrowserViewController {
 
     var didRequestToOpenInNewTabCalled = false
     var didSelectURLCalled = false
-    var didOpenRecentlyClosedSiteInSameTab = 0
     var lastOpenedURL: URL?
     var lastVisitType: VisitType?
     var isPrivate = false
@@ -138,9 +137,5 @@ class MockBrowserViewController: BrowserViewController {
         didSelectURLCalled = true
         lastOpenedURL = url
         lastVisitType = visitType
-    }
-
-    override func openRecentlyClosedSiteInSameTab(_ url: URL) {
-        didOpenRecentlyClosedSiteInSameTab += 1
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10865)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23702)

## :bulb: Description
Cleaned up some unused accessibility identifiers. Remove unneeded public definition and remove `openRecentlyClosedSiteInSameTab` since it was never called in `BrowserCoordinator`.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

