### PR TITLE
Add FXIOS-10864 [Nimbus] Add isDefaultBrowser Nimbus first run parameter

### DIFF
--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -170,7 +170,8 @@ enum Experiments {
             "isFirstRun": "\(isFirstRun)",
             "is_first_run": isFirstRun,
             "is_phone": isPhone,
-            "is_review_checker_enabled": isReviewCheckerEnabled()
+            "is_review_checker_enabled": isReviewCheckerEnabled(),
+            "is_default_browser": isDefaultBrowser(),
         ]
 
         // App settings, to allow experiments to target the app name and the
@@ -189,6 +190,10 @@ enum Experiments {
             isReviewCheckerEnabled = prefs.bool(forKey: "profile." + PrefsKeys.Shopping2023OptIn)
         }
         return isReviewCheckerEnabled
+    }
+
+    private static func isDefaultBrowser() -> Bool {
+        return UserDefaults.standard.bool(forKey: PrefsKeys.AppleConfirmedUserIsDefaultBrowser)
     }
 
     private static func buildNimbus(dbPath: String,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10864)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23699)

## :bulb: Description
Add a first run targeting parameter for Nimbus.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

