### PR TITLE
Bugfix FXIOS-10334 #22650 JS alerts refactor

### DIFF
--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -25,6 +25,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case homepageRebuild
     case inactiveTabs
     case isToolbarCFREnabled
+    case jsAlertRefactor
     case jumpBackIn
     case loginAutofill
     case menuRefactor
@@ -115,6 +116,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .fakespotProductAds,
                 .homepageRebuild,
                 .isToolbarCFREnabled,
+                .jsAlertRefactor,
                 .loginAutofill,
                 .microsurvey,
                 .menuRefactor,

--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import WebKit
 import Shared
@@ -174,6 +175,7 @@ struct NewMessageAlert: NewJSAlertInfo {
     let message: String
     let frame: WKFrameInfo
     let completionHandler: () -> Void
+    var logger: Logger = DefaultLogger.shared
 
     func alertController() -> NewJSPromptAlertController {
         let alertController = NewJSPromptAlertController(
@@ -192,6 +194,7 @@ struct NewMessageAlert: NewJSAlertInfo {
     }
 
     func cancel() {
+        logger.log("Message alert completion handler called through cancel", level: .info, category: .webview)
         completionHandler()
     }
 }
@@ -200,6 +203,7 @@ struct NewConfirmPanelAlert: NewJSAlertInfo {
     let message: String
     let frame: WKFrameInfo
     let completionHandler: (Bool) -> Void
+    var logger: Logger = DefaultLogger.shared
 
     func alertController() -> NewJSPromptAlertController {
         let alertController = NewJSPromptAlertController(
@@ -220,6 +224,7 @@ struct NewConfirmPanelAlert: NewJSAlertInfo {
     }
 
     func cancel() {
+        logger.log("Confirm panel alert completion handler called through cancel", level: .info, category: .webview)
         completionHandler(false)
     }
 }
@@ -229,6 +234,7 @@ struct NewTextInputAlert: NewJSAlertInfo {
     let frame: WKFrameInfo
     let defaultText: String?
     let completionHandler: (String?) -> Void
+    var logger: Logger = DefaultLogger.shared
 
     func alertController() -> NewJSPromptAlertController {
         let alertController = NewJSPromptAlertController(
@@ -257,6 +263,7 @@ struct NewTextInputAlert: NewJSAlertInfo {
     }
 
     func cancel() {
+        logger.log("Text input alert completion handler called through cancel", level: .info, category: .webview)
         completionHandler(nil)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -118,37 +118,6 @@ private func titleForJavaScriptPanelInitiatedByFrame(_ frame: WKFrameInfo) -> St
 /// This code duplicates existing alerts for a short moment in time to enable having a rollout of JS changes in production
 /// This code is brittle, and if there's any problems this will enable reverting easily
 
-protocol NewJSAlertInfo {
-    func alertController() -> NewJSPromptAlertController
-    func cancel()
-}
-
-struct NewMessageAlert: NewJSAlertInfo {
-    let message: String
-    let frame: WKFrameInfo
-    let completionHandler: () -> Void
-
-    func alertController() -> NewJSPromptAlertController {
-        let alertController = NewJSPromptAlertController(
-            title: titleForJavaScriptPanelInitiatedByFrame(frame),
-            message: message,
-            alertInfo: self
-        )
-        alertController.addAction(
-            UIAlertAction(title: .OKString, style: .default) { [weak alertController] _ in
-                alertController?.setDismissalResult(nil)
-                self.completionHandler()
-            }
-        )
-        alertController.alertInfo = self
-        return alertController
-    }
-
-    func cancel() {
-        completionHandler()
-    }
-}
-
 @objc
 protocol NewJSPromptAlertControllerDelegate: AnyObject {
     func promptAlertControllerDidDismiss(_ alertController: NewJSPromptAlertController, withResult result: Any?)
@@ -193,6 +162,37 @@ class NewJSPromptAlertController: UIAlertController {
             // Notify the delegate about dismissal and pass the result
             delegate?.promptAlertControllerDidDismiss(self, withResult: dismissalResult)
         }
+    }
+}
+
+protocol NewJSAlertInfo {
+    func alertController() -> NewJSPromptAlertController
+    func cancel()
+}
+
+struct NewMessageAlert: NewJSAlertInfo {
+    let message: String
+    let frame: WKFrameInfo
+    let completionHandler: () -> Void
+
+    func alertController() -> NewJSPromptAlertController {
+        let alertController = NewJSPromptAlertController(
+            title: titleForJavaScriptPanelInitiatedByFrame(frame),
+            message: message,
+            alertInfo: self
+        )
+        alertController.addAction(
+            UIAlertAction(title: .OKString, style: .default) { [weak alertController] _ in
+                alertController?.setDismissalResult(nil)
+                self.completionHandler()
+            }
+        )
+        alertController.alertInfo = self
+        return alertController
+    }
+
+    func cancel() {
+        completionHandler()
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -121,7 +121,7 @@ private func titleForJavaScriptPanelInitiatedByFrame(_ frame: WKFrameInfo) -> St
 
 @objc
 protocol NewJSPromptAlertControllerDelegate: AnyObject {
-    func promptAlertControllerDidDismiss(_ alertController: NewJSPromptAlertController, withResult result: Any?)
+    func newPromptAlertControllerDidDismiss(_ alertController: NewJSPromptAlertController)
 }
 
 /// A simple version of UIAlertController that attaches a delegate to the viewDidDisappear method
@@ -161,7 +161,9 @@ class NewJSPromptAlertController: UIAlertController {
             }
 
             // Notify the delegate about dismissal and pass the result
-            delegate?.promptAlertControllerDidDismiss(self, withResult: dismissalResult)
+            delegate?.newPromptAlertControllerDidDismiss(self)
+
+            alertInfo?.handleAlertDismissal(dismissalResult)
         }
     }
 }
@@ -169,6 +171,7 @@ class NewJSPromptAlertController: UIAlertController {
 protocol NewJSAlertInfo {
     func alertController() -> NewJSPromptAlertController
     func cancel()
+    func handleAlertDismissal(_ result: Any?)
 }
 
 struct NewMessageAlert: NewJSAlertInfo {
@@ -196,6 +199,10 @@ struct NewMessageAlert: NewJSAlertInfo {
     func cancel() {
         logger.log("Message alert completion handler called through cancel", level: .info, category: .webview)
         completionHandler()
+    }
+
+    func handleAlertDismissal(_ result: Any?) {
+        logger.log("Message alert dismissed with no result.", level: .info, category: .webview)
     }
 }
 
@@ -226,6 +233,14 @@ struct NewConfirmPanelAlert: NewJSAlertInfo {
     func cancel() {
         logger.log("Confirm panel alert completion handler called through cancel", level: .info, category: .webview)
         completionHandler(false)
+    }
+
+    func handleAlertDismissal(_ result: Any?) {
+        if (result as? Bool) != nil {
+            logger.log("Confirm alert dismissed with result.", level: .info, category: .webview)
+        } else {
+            logger.log("Confirm alert dismissed with no result.", level: .info, category: .webview)
+        }
     }
 }
 
@@ -265,5 +280,13 @@ struct NewTextInputAlert: NewJSAlertInfo {
     func cancel() {
         logger.log("Text input alert completion handler called through cancel", level: .info, category: .webview)
         completionHandler(nil)
+    }
+
+    func handleAlertDismissal(_ result: Any?) {
+        if (result as? String) != nil {
+            logger.log("Text input alert dismissed with input.", level: .info, category: .webview)
+        } else {
+            logger.log("Text input alert dismissed with no input.", level: .info, category: .webview)
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1060,6 +1060,7 @@ class BrowserViewController: UIViewController,
         ])
 
         if isJSAlertRefactorEnabled {
+            // This will be documented with FXIOS-10952
             checkForJSAlerts()
         } else {
             showQueuedAlertIfAvailable()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4164,11 +4164,9 @@ extension BrowserViewController: NewJSPromptAlertControllerDelegate {
 
     func newShowQueuedAlertIfAvailable() {
         if let nextAlert = tabManager.selectedTab?.newDequeueJavascriptAlertPrompt() {
-            DispatchQueue.main.async {
-                let alertController = nextAlert.alertController()
-                alertController.delegate = self
-                self.present(alertController, animated: true, completion: nil)
-            }
+            let alertController = nextAlert.alertController()
+            alertController.delegate = self
+            presentWithModalDismissIfNeeded(alertController, animated: true)
         }
     }
 }

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -55,6 +55,9 @@ final class NimbusFeatureFlagLayer {
         case .inactiveTabs:
             return checkTabTrayFeature(for: featureID, from: nimbus)
 
+        case .jsAlertRefactor:
+            return checkJSAlertRefactor(from: nimbus)
+
         case .loginAutofill:
             return checkNimbusForLoginAutofill(for: featureID, from: nimbus)
 
@@ -308,6 +311,12 @@ final class NimbusFeatureFlagLayer {
         guard let status = config.sectionsEnabled[nimbusID] else { return false }
 
         return status
+    }
+
+    private func checkJSAlertRefactor(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.jsAlertRefactor.value()
+
+        return config.enabled
     }
 
     private func checkFakespotFeature(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -898,6 +898,10 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         return newAlertQueue.removeFirst()
     }
 
+    func hasJavascriptAlertPrompt() -> Bool {
+        return !newAlertQueue.isEmpty
+    }
+
     override func observeValue(
         forKeyPath keyPath: String?,
         of object: Any?,

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -421,6 +421,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     /// Any time a tab tries to make requests to display a Javascript Alert and we are not the active
     /// tab instance, queue it for later until we become foregrounded.
     private var alertQueue = [JSAlertInfo]()
+    private var newAlertQueue = [NewJSAlertInfo]()
 
     var onLoading: VoidReturnCallback?
     private var webViewLoadingObserver: NSKeyValueObservation?
@@ -878,6 +879,23 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     func dequeueJavascriptAlertPrompt() -> JSAlertInfo? {
         guard !alertQueue.isEmpty else { return nil }
         return alertQueue.removeFirst()
+    }
+
+    func cancelQueuedAlerts() {
+        newAlertQueue.forEach { alert in
+            alert.cancel()
+        }
+    }
+
+    /// Queues a JS Alert for later display
+    /// Do not call completionHandler until the alert is displayed and dismissed
+    func newQueueJavascriptAlertPrompt(_ alert: NewJSAlertInfo) {
+        newAlertQueue.append(alert)
+    }
+
+    func newDequeueJavascriptAlertPrompt() -> NewJSAlertInfo? {
+        guard !newAlertQueue.isEmpty else { return nil }
+        return newAlertQueue.removeFirst()
     }
 
     override func observeValue(

--- a/firefox-ios/nimbus-features/jsAlertRefactor.yaml
+++ b/firefox-ios/nimbus-features/jsAlertRefactor.yaml
@@ -12,7 +12,7 @@ features:
     defaults:
       - channel: beta
         value:
-          enabled: false
+          enabled: true
       - channel: developer
         value:
           enabled: true

--- a/firefox-ios/nimbus-features/jsAlertRefactor.yaml
+++ b/firefox-ios/nimbus-features/jsAlertRefactor.yaml
@@ -1,0 +1,18 @@
+# The configuration for the jsAlertRefactor feature
+features:
+  js-alert-refactor:
+    description: >
+      This feature is for the JavaScript Webview refactor
+    variables:
+      enabled:
+        description: >
+          When true this enables the new JS alerts system to be used
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -25,6 +25,7 @@ include:
   - nimbus-features/gleanServerKnobs.yaml
   - nimbus-features/homepageRebuildFeature.yaml
   - nimbus-features/homescreenFeature.yaml
+  - nimbus-features/jsAlertRefactor.yaml
   - nimbus-features/menuRefactorFeature.yaml
   - nimbus-features/messagingFeature.yaml
   - nimbus-features/microsurveyFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10334)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22650)

## :bulb: Description

### Summary of changes
- `BrowserPrompts` are basically duplicated to easily use feature flag to enable the refactor and revert easily if there's any issues in production.
- The browser prompts are called `New`blablabla classes and function for now, but if this goes in I would do a follow up so we rename old function to `legacy` to avoid name conflicts.
- `NewMessageAlert` will call the completion handler when it's "OK"button is pressed (it wasn't before since it was called when the alert was created). This means it also now keeps a reference to the completion handler.
- `NewTextInputAlert` and `NewConfirmPanelAlert` are pretty much the same apart from changes in how alerts are handled through `NewJSPromptAlertController`.
- `NewJSPromptAlertController` now has new functionalities. 
    - It now has a `handledAction` used in case the action was not handled by a button click and the alert is dismissed. This will ensure the `cancel()` function is called on the `JSAlertInfo`.
    - `NewJSPromptAlertController` also has a `dismissalResult` to help debug JS alert (see `func handleAlertDismissalResult`).
- I cross referenced how Brave handles [their JS alerts](https://github.com/brave/brave-core/blob/master/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserPrompts.swift) since they are based on our codebase, even if their JS alerts have added functionnalities it enabled me to find some issues such as a `DispatchQueue` needed under the `viewDidDisappear` of our `NewJSPromptAlertController`.

### Why I think this will solve the issues we have
- Completion handler was called beforehand when the alert was queued in some cases.
- Completion handler is called either when the user clicks on the JS alert actions (like "Ok" or "Cancel").
- If it's not called from the JS Alert actions, and the JS view controller is dismissed for some reasons, then we still ensure the completion alert is called.
- If the webview `willDeleteWebView` is called, we make sure to clean up any remaining queue JS alerts and their respective completion handlers will be called.

### Ticket action items
#### 1. Fix incorrect MessageAlert completion handler
>  Completion handler should be called after the alert is dismissed (not presented or enqueued)

The completion handler are called after the alert is dismissed. We also ensure the alert are dequeued properly if the webview is killed. 

#### 2. Fix crashes in known test cases (listed below)
Seems good!

#### 3. Identify the cause of the crash increase in 131.3
Not sure, but the `completionHandler` under the queued message alert panel was removed without further logic change to ensure it is indeed called in all cases, as I listed above in "Why I think this will solve the issues we have".

#### 3. Remove JS alert dequeue called from BVC viewDidLayoutSubviews 
> This UI func is not a good place to be performing an alert dequeue. Unclear why it was added there; needs additional investigation

It was added in https://github.com/mozilla-mobile/firefox-ios/pull/13340. I think it was added since alerts were not getting dequeued when we were changing tab. I am changing in this PR (protected by feature flag

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

