### PR TITLE
Refactor FXIOS-10541 [Homepage Rebuild] Add keyboard dismissal logic to new homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -77,6 +77,7 @@ final class HomepageViewController: UIViewController,
                                                           .TopSitesUpdated,
                                                           .DefaultSearchEngineUpdated])
         subscribeToRedux()
+        addTapGestureRecognizerToDismissKeyboard()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -400,13 +401,27 @@ final class HomepageViewController: UIViewController,
         }
     }
 
+    // MARK: Tap Geasutre Recognizer
+    private func addTapGestureRecognizerToDismissKeyboard() {
+        // We want any interaction with the homepage to dismiss the keyboard, including taps
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc
+    private func dismissKeyboard() {
+        let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.cancelEdit)
+        store.dispatch(action)
+    }
+
     // MARK: Long Press (Photon Action Sheet)
     private lazy var longPressRecognizer: UILongPressGestureRecognizer = {
         return UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress))
     }()
 
     @objc
-    fileprivate func handleLongPress(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {
+    private func handleLongPress(_ longPressGestureRecognizer: UILongPressGestureRecognizer) {
         guard longPressGestureRecognizer.state == .began else { return }
         // TODO: FXIOS-10613 - Pass proper action data to context menu
         navigateToContextMenu()

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -77,7 +77,6 @@ final class HomepageViewController: UIViewController,
                                                           .TopSitesUpdated,
                                                           .DefaultSearchEngineUpdated])
         subscribeToRedux()
-        addTapGestureRecognizerToDismissKeyboard()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -106,6 +105,7 @@ final class HomepageViewController: UIViewController,
 
         listenForThemeChange(view)
         applyTheme()
+        addTapGestureRecognizerToDismissKeyboard()
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10543)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23099)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add tap gesture recognizer to the new homepage that cancels editing mode in the toolbar. Removed logic around checking the URL because it no longer seems necessary. Validated that [this bug ](https://mozilla-hub.atlassian.net/browse/FXIOS-9969) is not reproducible, but would definitely love a second set of eyes.

I could not think of a great way to unit test this but it is probably a candidate for a UI test?

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

