### PR TITLE
Bugfix FXIOS-XXXX #23755 "Open in Firefox" of share extension isn't working

### DIFF
--- a/firefox-ios/Extensions/ShareTo/ShareViewController.swift
+++ b/firefox-ios/Extensions/ShareTo/ShareViewController.swift
@@ -529,9 +529,15 @@ extension ShareViewController {
         var responder = self as UIResponder?
         let selectorOpenURL = sel_registerName("openURL:")
         while let current = responder {
-            if current.responds(to: selectorOpenURL) {
-                current.perform(selectorOpenURL, with: url, afterDelay: 0)
-                break
+            if #available(iOS 18.0, *) {
+                if let application = responder as? UIApplication {
+                    application.open(url, options: [:], completionHandler: nil)
+                }
+            } else {
+                if current.responds(to: selectorOpenURL) {
+                    current.perform(selectorOpenURL, with: url, afterDelay: 0)
+                    break
+                }
             }
 
             responder = current.next


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Hi - this is my first PR in the community - please let me know for any misalignments with the guidelines!

In iOS 18 openURL(:) is deprecated, instead open( :options:completionHandler:) is used. 
I added the ios18 if condition and let the previous code as a fallback for earlier ios versions for backwards compatibility.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

