### PR TITLE
Add FXIOS-10675 [ToS] Firefox iOS: Manage Technical Data during Onboarding and Settings

### DIFF
--- a/BrowserKit/Sources/Shared/AppConstants.swift
+++ b/BrowserKit/Sources/Shared/AppConstants.swift
@@ -81,7 +81,6 @@ public class AppConstants {
     }()
 
     public static let prefSendUsageData = "settings.sendUsageData"
-    public static let prefSendTechnicalData = "settings.sendTechnicalData"
     public static let prefSendCrashReports = "settings.sendCrashReports"
     public static let prefSendDailyUsagePing = "settings.sendDailyUsagePing"
     public static let prefStudiesToggle = "settings.studiesToggle"

--- a/BrowserKit/Sources/Shared/Strings.swift
+++ b/BrowserKit/Sources/Shared/Strings.swift
@@ -5333,21 +5333,6 @@ extension String {
 
 // MARK: - Settings Home
 extension String {
-    public static let SendUsageSettingTitle = MZLocalizedString(
-        key: "Settings.SendUsage.Title",
-        tableName: nil,
-        value: "Send Usage Data",
-        comment: "The title for the setting to send usage data.")
-    public static let SendUsageSettingLink = MZLocalizedString(
-        key: "Settings.SendUsage.Link",
-        tableName: nil,
-        value: "Learn More.",
-        comment: "title for a link that explains how mozilla collects telemetry")
-    public static let SendUsageSettingMessage = MZLocalizedString(
-        key: "Settings.SendUsage.Message",
-        tableName: nil,
-        value: "Mozilla strives to only collect what we need to provide and improve Firefox for everyone.",
-        comment: "A short description that explains why mozilla collects usage data.")
     public static let SendCrashReportsSettingTitle = MZLocalizedString(
         key: "Settings.CrashReports.Title.v135",
         tableName: "Settings",
@@ -7582,6 +7567,21 @@ extension String {
                 tableName: nil,
                 value: nil,
                 comment: "Used as a button label for crash dialog prompt")
+            public static let SendUsageSettingTitle = MZLocalizedString(
+                key: "Settings.SendUsage.Title",
+                tableName: nil,
+                value: "Send Usage Data",
+                comment: "The title for the setting to send usage data.")
+            public static let SendUsageSettingLink = MZLocalizedString(
+                key: "Settings.SendUsage.Link",
+                tableName: nil,
+                value: "Learn More.",
+                comment: "title for a link that explains how mozilla collects telemetry")
+            public static let SendUsageSettingMessage = MZLocalizedString(
+                key: "Settings.SendUsage.Message",
+                tableName: nil,
+                value: "Mozilla strives to only collect what we need to provide and improve Firefox for everyone.",
+                comment: "A short description that explains why mozilla collects usage data.")
         }
     }
 }

--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -54,9 +54,18 @@ class LaunchCoordinator: BaseCoordinator,
         viewController.didFinishFlow = { [weak self] in
             manager.setAccepted()
             guard let self = self else { return }
+
+            let sendTechnicalData = profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
+            manager.shouldSendTechnicalData(value: sendTechnicalData)
+            self.profile.prefs.setBool(sendTechnicalData, forKey: AppConstants.prefSendUsageData)
+
             let sendCrashReports = profile.prefs.boolForKey(AppConstants.prefSendCrashReports) ?? true
             self.profile.prefs.setBool(sendCrashReports, forKey: AppConstants.prefSendCrashReports)
             self.logger.setup(sendCrashReports: sendCrashReports)
+
+            TelemetryWrapper.shared.setup(profile: profile)
+            TelemetryWrapper.shared.recordStartUpTelemetry()
+
             self.parentCoordinator?.didFinishTermsOfService(from: self)
         }
         viewController.modalPresentationStyle = .fullScreen

--- a/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPreferencesViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPreferencesViewController.swift
@@ -51,7 +51,9 @@ final class PrivacyPreferencesViewController: UIViewController,
         view.setSwitchValue(isOn: self?.profile.prefs.boolForKey(AppConstants.prefSendCrashReports) ?? true)
     }
 
-    private lazy var technicalDataSwitch: SwitchDetailedView = .build()
+    private lazy var technicalDataSwitch: SwitchDetailedView = .build { [weak self] view in
+        view.setSwitchValue(isOn: self?.profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true)
+    }
 
     // MARK: - Initializers
     init(
@@ -163,8 +165,9 @@ final class PrivacyPreferencesViewController: UIViewController,
             self?.profile.prefs.setBool(value, forKey: AppConstants.prefSendCrashReports)
         }
 
-        // TODO: FXIOS-10675 Firefox iOS: Manage Technical Data during Onboarding and Settings
-        technicalDataSwitch.switchCallback = { _ in }
+        technicalDataSwitch.switchCallback = { [weak self] value in
+            self?.profile.prefs.setBool(value, forKey: AppConstants.prefSendUsageData)
+        }
 
         // TODO: FXIOS-10739 Firefox iOS: Use the correct links for Learn more buttons, in Manage Privacy Preferences screen
         crashReportsSwitch.learnMoreCallBack = { [weak self] in

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SendDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SendDataSetting.swift
@@ -7,16 +7,10 @@ import Foundation
 import Glean
 import Shared
 
-enum SendDataType {
-    case usageData
-    case technicalData
-    case crashReports
-    case dailyUsagePing
-}
-
 class SendDataSetting: BoolSetting {
     private weak var settingsDelegate: SupportSettingsDelegate?
-    private let sendDataType: SendDataType
+    private var a11yId: String
+    private var learnMoreURL: URL?
 
     var shouldSendData: ((Bool) -> Void)?
 
@@ -24,37 +18,12 @@ class SendDataSetting: BoolSetting {
          delegate: SettingsDelegate?,
          theme: Theme,
          settingsDelegate: SupportSettingsDelegate?,
-         sendDataType: SendDataType) {
-        var title: String
-        var message: String
-        var linkedText: String
-        var prefKey: String
-
-        switch sendDataType {
-        case .usageData:
-            title = .SendUsageSettingTitle
-            message = .SendUsageSettingMessage
-            linkedText = .SendUsageSettingLink
-            prefKey = AppConstants.prefSendUsageData
-        case .technicalData:
-            title = .SendTechnicalDataSettingTitle
-            message = String(format: .SendTechnicalDataSettingMessage,
-                             MozillaName.shortName.rawValue,
-                             AppName.shortName.rawValue)
-            linkedText = .SendTechnicalDataSettingLink
-            prefKey = AppConstants.prefSendTechnicalData
-        case .crashReports:
-            title = .SendCrashReportsSettingTitle
-            message = String(format: .SendCrashReportsSettingMessage, MozillaName.shortName.rawValue)
-            linkedText = .SendCrashReportsSettingLink
-            prefKey = AppConstants.prefSendCrashReports
-        case .dailyUsagePing:
-            title = .SendDailyUsagePingSettingTitle
-            message = String(format: .SendDailyUsagePingSettingMessage, MozillaName.shortName.rawValue)
-            linkedText = .SendDailyUsagePingSettingLink
-            prefKey = AppConstants.prefSendDailyUsagePing
-        }
-
+         title: String,
+         message: String,
+         linkedText: String,
+         prefKey: String,
+         a11yId: String,
+         learnMoreURL: URL?) {
         let statusText = NSMutableAttributedString()
         statusText.append(
             NSAttributedString(
@@ -74,7 +43,8 @@ class SendDataSetting: BoolSetting {
             )
         )
 
-        self.sendDataType = sendDataType
+        self.a11yId = a11yId
+        self.learnMoreURL = learnMoreURL
         self.settingsDelegate = settingsDelegate
         super.init(
             prefs: prefs,
@@ -84,59 +54,26 @@ class SendDataSetting: BoolSetting {
             attributedStatusText: statusText
         )
 
-        setupSettingDidChange(for: sendDataType)
+        setupSettingDidChange()
 
         // We make sure to set this on initialization, in case the setting is turned off
         // in which case, we would to make sure that users are opted out of experiments
         Experiments.setTelemetrySetting(prefs.boolForKey(prefKey) ?? true)
     }
 
-    private func setupSettingDidChange(for sendDataType: SendDataType) {
+    private func setupSettingDidChange() {
         self.settingDidChange = { [weak self] value in
-            if sendDataType != .crashReports {
-                // AdjustHelper.setEnabled($0)
-                DefaultGleanWrapper.shared.setUpload(isEnabled: value)
-
-                if !value {
-                    self?.prefs?.removeObjectForKey(PrefsKeys.Usage.profileId)
-
-                    // set dummy uuid to make sure the previous one is deleted
-                    if let uuid = UUID(uuidString: "beefbeef-beef-beef-beef-beeefbeefbee") {
-                        GleanMetrics.Usage.profileId.set(uuid)
-                    }
-                }
-
-                Experiments.setTelemetrySetting(value)
-                self?.shouldSendData?(value)
-            }
+            self?.shouldSendData?(value)
         }
     }
 
     override var accessibilityIdentifier: String? {
-        switch sendDataType {
-        case .usageData:
-            return AccessibilityIdentifiers.Settings.SendData.sendAnonymousUsageDataTitle
-        case .technicalData:
-            return AccessibilityIdentifiers.Settings.SendData.sendTechnicalDataTitle
-        case .crashReports:
-            return AccessibilityIdentifiers.Settings.SendData.sendCrashReportsTitle
-        case .dailyUsagePing:
-            return AccessibilityIdentifiers.Settings.SendData.sendDailyUsagePingTitle
-        }
+        return a11yId
     }
 
     // TODO: FXIOS-10739 Firefox iOS: Use the correct links for Learn more buttons, in Manage Privacy Preferences screen
     override var url: URL? {
-        switch sendDataType {
-        case .usageData:
-            return SupportUtils.URLForTopic("adjust")
-        case .technicalData:
-            return nil
-        case .crashReports:
-            return nil
-        case .dailyUsagePing:
-            return SupportUtils.URLForTopic("dau-ping-settings-mobile")
-        }
+        return learnMoreURL
     }
 
     override func onClick(_ navigationController: UINavigationController?) {

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -159,15 +159,15 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         let isEnabled: Bool = (profile?.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.SponsoredShortcuts) ?? true) &&
                                (profile?.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.TopSiteSection) ?? true)
         recordEvent(category: .information,
-                                     method: .view,
-                                     object: .sponsoredShortcuts,
-                                     extras: [EventExtraKey.preference.rawValue: isEnabled])
+                    method: .view,
+                    object: .sponsoredShortcuts,
+                    extras: [EventExtraKey.preference.rawValue: isEnabled])
 
         if logger.crashedLastLaunch {
-        recordEvent(category: .information,
-                                         method: .error,
-                                         object: .app,
-                                         value: .crashedLastLaunch)
+            recordEvent(category: .information,
+                        method: .error,
+                        object: .app,
+                        value: .crashedLastLaunch)
         }
     }
 

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -155,6 +155,22 @@ class TelemetryWrapper: TelemetryWrapperProtocol, FeatureFlaggable {
         )
     }
 
+    func recordStartUpTelemetry() {
+        let isEnabled: Bool = (profile?.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.SponsoredShortcuts) ?? true) &&
+                               (profile?.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.TopSiteSection) ?? true)
+        recordEvent(category: .information,
+                                     method: .view,
+                                     object: .sponsoredShortcuts,
+                                     extras: [EventExtraKey.preference.rawValue: isEnabled])
+
+        if logger.crashedLastLaunch {
+        recordEvent(category: .information,
+                                         method: .error,
+                                         object: .app,
+                                         value: .crashedLastLaunch)
+        }
+    }
+
     @objc
     func recordFinishedLaunchingPreferenceMetrics(notification: NSNotification) {
         guard let profile = self.profile else { return }

--- a/firefox-ios/Client/TermsOfServiceManager.swift
+++ b/firefox-ios/Client/TermsOfServiceManager.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import Glean
 
 struct TermsOfServiceManager: FeatureFlaggable {
     var prefs: Prefs
@@ -24,5 +25,21 @@ struct TermsOfServiceManager: FeatureFlaggable {
 
     func setAccepted() {
         prefs.setInt(1, forKey: PrefsKeys.TermsOfServiceAccepted)
+    }
+
+    func shouldSendTechnicalData(value: Bool) {
+        // AdjustHelper.setEnabled($0)
+        DefaultGleanWrapper.shared.setUpload(isEnabled: value)
+
+        if !value {
+            prefs.removeObjectForKey(PrefsKeys.Usage.profileId)
+
+            // set dummy uuid to make sure the previous one is deleted
+            if let uuid = UUID(uuidString: "beefbeef-beef-beef-beef-beeefbeefbee") {
+                GleanMetrics.Usage.profileId.set(uuid)
+            }
+        }
+
+        Experiments.setTelemetrySetting(value)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10675)

## :bulb: Description
Changed the Send Usage Data option to Technical and Interaction Data.
Did a refactor for SendDataSetting class

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

