### PR TITLE
Bugfix FXIOS-10880 URLBarView enterOverlay mode is slow when opening first time keyboard

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -51,7 +51,9 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
         returnKeyType = .go
         tintAdjustmentMode = .normal
 
-        // Disables OS to load AutoFill content, since for URL type is not needed.
+        // Setting the content type to a field that is not related to AutoFill functionality
+        // like email and password, should disable the Operating system to load those content,
+        // hence having a faster keyboard start up the first time
         textContentType = .URL
         delegate = self
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -50,8 +50,9 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
         autocapitalizationType = .none
         returnKeyType = .go
         tintAdjustmentMode = .normal
-        // Disables OS to load AutoFill content, this results in keyboard loaded faster.
-        textContentType = .none
+
+        // Disables OS to load AutoFill content, since for URL type is not needed.
+        textContentType = .URL
         delegate = self
 
         // Disable dragging urls on iPhones because it conflicts with editing the text

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -50,6 +50,8 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
         autocapitalizationType = .none
         returnKeyType = .go
         tintAdjustmentMode = .normal
+        // Disables OS to load AutoFill content, this results in keyboard loaded faster.
+        textContentType = .none
         delegate = self
 
         // Disable dragging urls on iPhones because it conflicts with editing the text

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1034,9 +1034,6 @@ class BrowserViewController: UIViewController,
             statusBarOverlay.heightAnchor.constraint(equalToConstant: view.safeAreaInsets.top)
         ])
 
-        // Ensure the layout is updated immediately
-        view.layoutIfNeeded()
-
         // TODO: [FXIOS-10334] Needs investigation. Dequeuing JS alerts as part of subview layout is problematic.
         showQueuedAlertIfAvailable()
         switchToolbarIfNeeded()

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
@@ -28,8 +28,8 @@ class ToolbarTextField: AutocompleteTextField {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        // Disable OS to load AutoFill, this results in keyboard loaded faster
-        textContentType = .none
+        // Disable OS to load AutoFill, since for URL type is not needed.
+        textContentType = .URL
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
@@ -28,6 +28,8 @@ class ToolbarTextField: AutocompleteTextField {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        // Disable OS to load AutoFill, this results in keyboard loaded faster
+        textContentType = .none
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/ToolbarTextField.swift
@@ -28,7 +28,9 @@ class ToolbarTextField: AutocompleteTextField {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        // Disable OS to load AutoFill, since for URL type is not needed.
+        // Setting the content type to a field that is not related to AutoFill functionality
+        // like email and password, should disable the Operating system to load those content,
+        // hence having a faster keyboard start up the first time
         textContentType = .URL
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10880)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23747)

## :bulb: Description
Bug fix `URLBarView.enterOverlay` being slow when opening first time the keyboard.
The profiling result can be seen in this [Spreadsheet](https://docs.google.com/spreadsheets/d/12aDe29FdszMCnusN0T8Jmfs4xsuObc2o5y_-utcpQRM/edit?usp=sharing)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

