### PR TITLE
Bugfix FXIOS-10801 Fix webpages not loading for Basic auth

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -876,9 +876,6 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
-        // The challenge may come from a background tab, so ensure it's the one visible.
-        tabManager.selectTab(tab)
-
         let loginsHelper = tab.getContentScript(name: LoginsHelper.name()) as? LoginsHelper
         Authenticator.handleAuthRequest(
             self,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10801)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23565)

## :bulb: Description

This fixes a bug that could prevent a website from loading correctly if it presented a Basic authentication challenge ([RFC 7617](https://datatracker.ietf.org/doc/html/rfc7617)). Some notes below.

### Rationale

- The code that has been modified is only ever run for websites using Basic or NTLM auth, which should be relatively rare. So this fix should be low-risk.
- The line that was removed (to always select the tab) is from 2017; that was, frankly, a simpler time when our tab management code did not have nearly as many side effects.
- While the `selectTab` call makes sense, I can't actually see why it is necessary; it might provide some convenience in edge-case scenarios where somehow the Basic auth website is loaded in a background tab, however scenarios in which that occurs should be uncommon.

### Testing

I tested current `main` on an iPhone 13 using https://jigsaw.w3.org/HTTP/Basic/ and could replicate the problem consistently on a fresh install, and with this line removed the problem was resolved. I also wasn't able to see any issues with the auth persisting as noted in the Jira.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

