### PR TITLE
Refactor FXIOS-10205 - Resolve 3 implicitly_unwrapped_optional violations in BrowserKitInformation

### DIFF
--- a/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
+++ b/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
@@ -10,9 +10,9 @@ import Foundation
 public class BrowserKitInformation {
     public static var shared = BrowserKitInformation()
 
-    public var buildChannel: AppBuildChannel!
-    public var nightlyAppVersion: String!
-    public var sharedContainerIdentifier: String!
+    public var buildChannel: AppBuildChannel?
+    public var nightlyAppVersion: String?
+    public var sharedContainerIdentifier: String?
 
     public func configure(buildChannel: AppBuildChannel,
                           nightlyAppVersion: String,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

This is the first PR of a long series of resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

