### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in BottomSheetViewController

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -58,7 +58,7 @@ public class BottomSheetViewController: UIViewController,
     private lazy var sheetView: UIView = .build { _ in }
     private lazy var contentView: UIView = .build { _ in }
     private lazy var scrollContentView: UIView = .build { _ in }
-    private var contentViewBottomConstraint: NSLayoutConstraint!
+    private var contentViewBottomConstraint: NSLayoutConstraint?
     private var viewTranslation = CGPoint(x: 0, y: 0)
     private let windowUUID: WindowUUID
 
@@ -103,7 +103,7 @@ public class BottomSheetViewController: UIViewController,
         listenForThemeChange(view)
         setupView()
 
-        contentViewBottomConstraint.constant = childViewController.view.frame.height
+        contentViewBottomConstraint?.constant = childViewController.view.frame.height
         view.layoutIfNeeded()
     }
 
@@ -114,7 +114,7 @@ public class BottomSheetViewController: UIViewController,
 
     override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        contentViewBottomConstraint.constant = 0
+        contentViewBottomConstraint?.constant = 0
         UIView.animate(withDuration: viewModel.animationTransitionDuration) {
             self.view.backgroundColor = self.viewModel.backgroundColor
             self.view.layoutIfNeeded()
@@ -175,7 +175,9 @@ public class BottomSheetViewController: UIViewController,
         view.addSubviews(dimmedBackgroundView, topTapView, sheetView)
         view.accessibilityElements = [closeButton, sheetView]
 
-        contentViewBottomConstraint = sheetView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let contentViewBottomConstraint = sheetView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        self.contentViewBottomConstraint = contentViewBottomConstraint
+
         let scrollViewHeightConstraint = scrollView.heightAnchor.constraint(
             greaterThanOrEqualTo: scrollContentView.heightAnchor)
 
@@ -284,7 +286,7 @@ public class BottomSheetViewController: UIViewController,
 
     public func dismissSheetViewController(completion: (() -> Void)? = nil) {
         childViewController.willDismiss()
-        contentViewBottomConstraint.constant = childViewController.view.frame.height
+        contentViewBottomConstraint?.constant = childViewController.view.frame.height
         UIView.animate(
             withDuration: viewModel.animationTransitionDuration,
             animations: {

--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -175,8 +175,8 @@ public class BottomSheetViewController: UIViewController,
         view.addSubviews(dimmedBackgroundView, topTapView, sheetView)
         view.accessibilityElements = [closeButton, sheetView]
 
-        let contentViewBottomConstraint = sheetView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        self.contentViewBottomConstraint = contentViewBottomConstraint
+        contentViewBottomConstraint = sheetView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        contentViewBottomConstraint?.isActive = true
 
         let scrollViewHeightConstraint = scrollView.heightAnchor.constraint(
             greaterThanOrEqualTo: scrollContentView.heightAnchor)
@@ -195,7 +195,6 @@ public class BottomSheetViewController: UIViewController,
             sheetView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor,
                                            constant: BottomSheetViewController.UX.minVisibleTopSpace),
             sheetView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            contentViewBottomConstraint,
             sheetView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
 
             contentView.topAnchor.constraint(equalTo: sheetView.topAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

