### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 2 implicitly_unwrapped_optional violations in WKEngineWebView

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -132,7 +132,7 @@ class WKEngineSession: NSObject,
     }
 
     func scrollToTop() {
-        webView.engineScrollView.setContentOffset(CGPoint.zero, animated: true)
+        webView.engineScrollView?.setContentOffset(CGPoint.zero, animated: true)
     }
 
     func findInPage(text: String, function: FindInPageFunction) {

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -24,7 +24,7 @@ protocol WKEngineWebView: UIView {
     var interactionState: Any? { get set }
     var url: URL? { get }
     var title: String? { get }
-    var engineScrollView: WKScrollView! { get }
+    var engineScrollView: WKScrollView? { get }
     var engineConfiguration: WKEngineConfiguration { get }
     var hasOnlySecureContent: Bool { get }
 
@@ -132,7 +132,7 @@ extension WKEngineWebView {
 // TODO: FXIOS-7896 #17641 Handle WKEngineWebView ThemeApplicable
 // TODO: FXIOS-7897 #17642 Handle WKEngineWebView AccessoryViewProvider
 class DefaultWKEngineWebView: WKWebView, WKEngineWebView, MenuHelperWebViewInterface {
-    var engineScrollView: WKScrollView!
+    var engineScrollView: WKScrollView?
     var engineConfiguration: WKEngineConfiguration
     weak var delegate: WKEngineWebViewDelegate?
 

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -13,7 +13,7 @@ class MockWKEngineWebView: UIView, WKEngineWebView {
 
     var engineConfiguration: WKEngineConfiguration
     var interactionState: Any?
-    var engineScrollView: WKScrollView! = MockEngineScrollView()
+    var engineScrollView: WKScrollView? = MockEngineScrollView()
     var url: URL?
     var title: String?
     var hasOnlySecureContent = false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

