### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in LibraryCoordinator

### DIFF
--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -26,7 +26,7 @@ class LibraryCoordinator: BaseCoordinator,
                           BookmarksRefactorFeatureFlagProvider {
     private let profile: Profile
     private let tabManager: TabManager
-    private var libraryViewController: LibraryViewController!
+    private var libraryViewController: LibraryViewController?
     weak var parentCoordinator: LibraryCoordinatorDelegate?
     override var isDismissable: Bool { false }
     private var windowUUID: WindowUUID { return tabManager.windowUUID }
@@ -43,15 +43,17 @@ class LibraryCoordinator: BaseCoordinator,
     }
 
     private func initializeLibraryViewController() {
-        libraryViewController = LibraryViewController(profile: profile, tabManager: tabManager)
+        let libraryViewController = LibraryViewController(profile: profile, tabManager: tabManager)
         router.setRootViewController(libraryViewController)
         libraryViewController.childPanelControllers = makeChildPanels()
         libraryViewController.delegate = self
         libraryViewController.navigationHandler = self
+
+        self.libraryViewController = libraryViewController
     }
 
     func start(with homepanelSection: Route.HomepanelSection) {
-        libraryViewController.setupOpenPanel(panelType: homepanelSection.libraryPanel)
+        libraryViewController?.setupOpenPanel(panelType: homepanelSection.libraryPanel)
     }
 
     private func makeChildPanels() -> [UINavigationController] {
@@ -178,7 +180,7 @@ class LibraryCoordinator: BaseCoordinator,
     }
 
     func setNavigationBarHidden(_ value: Bool) {
-        libraryViewController.setNavigationBarHidden(value)
+        libraryViewController?.setNavigationBarHidden(value)
     }
 
     // MARK: - ParentCoordinatorDelegate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

