### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in LegacyFeatureFlagsManager

### DIFF
--- a/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
+++ b/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
@@ -35,7 +35,7 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
     static let shared = LegacyFeatureFlagsManager()
 
     // MARK: - Variables
-    private var profile: Profile!
+    private var profile: Profile?
     private var coreFeatures: [CoreFeatureFlagID: CoreFlaggableFeature] = [:]
 
     // MARK: - Public methods
@@ -51,6 +51,10 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
     public func isFeatureEnabled(_ featureID: NimbusFeatureFlagID,
                                  checking channelsToCheck: FlaggableFeatureCheckOptions
     ) -> Bool {
+        guard let profile else {
+            return false
+        }
+
         let feature = NimbusFlaggableFeature(withID: featureID, and: profile)
         let nimbusSetting = getNimbusOrDebugSetting(with: feature)
         let userSetting = feature.isUserEnabled(using: nimbusFlags)
@@ -78,6 +82,10 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
     /// binary state. Further information on return types can be found in
     /// `FlaggableFeatureOptions`
     public func getCustomState<T>(for featureID: NimbusFeatureFlagWithCustomOptionsID) -> T? {
+        guard let profile else {
+            return nil
+        }
+
         let feature = NimbusFlaggableFeature(withID: convertCustomIDToStandard(featureID),
                                              and: profile)
         guard let userSetting = feature.getUserPreference(using: nimbusFlags) else { return nil }
@@ -101,6 +109,10 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
 
     /// Set a feature that has a binary state to on or off
     public func set(feature featureID: NimbusFeatureFlagID, to desiredState: Bool, isDebug: Bool = false) {
+        guard let profile else {
+            return
+        }
+
         let feature = NimbusFlaggableFeature(withID: featureID, and: profile)
         #if MOZ_CHANNEL_BETA || MOZ_CHANNEL_FENNEC
         if isDebug {
@@ -119,6 +131,10 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
         feature featureID: NimbusFeatureFlagWithCustomOptionsID,
         to desiredState: T
     ) {
+        guard let profile else {
+            return
+        }
+
         let feature = NimbusFlaggableFeature(withID: convertCustomIDToStandard(featureID),
                                              and: profile)
         switch featureID {

--- a/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
+++ b/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
@@ -51,9 +51,7 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
     public func isFeatureEnabled(_ featureID: NimbusFeatureFlagID,
                                  checking channelsToCheck: FlaggableFeatureCheckOptions
     ) -> Bool {
-        guard let profile else {
-            return false
-        }
+        guard let profile else { return false }
 
         let feature = NimbusFlaggableFeature(withID: featureID, and: profile)
         let nimbusSetting = getNimbusOrDebugSetting(with: feature)
@@ -82,9 +80,7 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
     /// binary state. Further information on return types can be found in
     /// `FlaggableFeatureOptions`
     public func getCustomState<T>(for featureID: NimbusFeatureFlagWithCustomOptionsID) -> T? {
-        guard let profile else {
-            return nil
-        }
+        guard let profile else { return nil }
 
         let feature = NimbusFlaggableFeature(withID: convertCustomIDToStandard(featureID),
                                              and: profile)
@@ -109,9 +105,7 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
 
     /// Set a feature that has a binary state to on or off
     public func set(feature featureID: NimbusFeatureFlagID, to desiredState: Bool, isDebug: Bool = false) {
-        guard let profile else {
-            return
-        }
+        guard let profile else { return }
 
         let feature = NimbusFlaggableFeature(withID: featureID, and: profile)
         #if MOZ_CHANNEL_BETA || MOZ_CHANNEL_FENNEC
@@ -131,9 +125,7 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
         feature featureID: NimbusFeatureFlagWithCustomOptionsID,
         to desiredState: T
     ) {
-        guard let profile else {
-            return
-        }
+        guard let profile else { return }
 
         let feature = NimbusFlaggableFeature(withID: convertCustomIDToStandard(featureID),
                                              and: profile)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

