### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in CreditCardBottomSheetViewController

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -170,17 +170,17 @@ class CreditCardBottomSheetViewController: UIViewController,
             estimatedContentHeight += UX.yesButtonHeight
         }
 
-        let contentViewHeightConstraint = contentView.heightAnchor.constraint(
+        contentViewHeightConstraint = contentView.heightAnchor.constraint(
             greaterThanOrEqualToConstant: estimatedContentHeight
         )
-        contentViewHeightConstraint.priority = UILayoutPriority(999)
-        self.contentViewHeightConstraint = contentViewHeightConstraint
+        contentViewHeightConstraint?.priority = UILayoutPriority(999)
+        contentViewHeightConstraint?.isActive = true
 
         let contentWidthCheck = UX.contentViewWidth > view.frame.width
         let contentViewWidth = contentWidthCheck ? view.frame.width - UX.containerPadding : UX.contentViewWidth
-        let contentWidthConstraint = contentView.widthAnchor.constraint(equalToConstant: contentViewWidth)
-        contentWidthConstraint.priority = UILayoutPriority(999)
-        self.contentWidthConstraint = contentWidthConstraint
+        contentWidthConstraint = contentView.widthAnchor.constraint(equalToConstant: contentViewWidth)
+        contentWidthConstraint?.priority = UILayoutPriority(999)
+        contentWidthConstraint?.isActive = true
 
         NSLayoutConstraint.activate(
             [
@@ -213,8 +213,6 @@ class CreditCardBottomSheetViewController: UIViewController,
                 ),
 
                 yesButton.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.yesButtonHeight),
-                contentWidthConstraint,
-                contentViewHeightConstraint
             ]
         )
     }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -92,8 +92,8 @@ class CreditCardBottomSheetViewController: UIViewController,
         button.addTarget(self, action: #selector(self.didTapYes), for: .touchUpInside)
     }
 
-    private var contentViewHeightConstraint: NSLayoutConstraint!
-    private var contentWidthConstraint: NSLayoutConstraint!
+    private var contentViewHeightConstraint: NSLayoutConstraint?
+    private var contentWidthConstraint: NSLayoutConstraint?
 
     // MARK: - Initializers
     init(viewModel: CreditCardBottomSheetViewModel,
@@ -170,15 +170,17 @@ class CreditCardBottomSheetViewController: UIViewController,
             estimatedContentHeight += UX.yesButtonHeight
         }
 
-        contentViewHeightConstraint = contentView.heightAnchor.constraint(
+        let contentViewHeightConstraint = contentView.heightAnchor.constraint(
             greaterThanOrEqualToConstant: estimatedContentHeight
         )
         contentViewHeightConstraint.priority = UILayoutPriority(999)
+        self.contentViewHeightConstraint = contentViewHeightConstraint
 
         let contentWidthCheck = UX.contentViewWidth > view.frame.width
         let contentViewWidth = contentWidthCheck ? view.frame.width - UX.containerPadding : UX.contentViewWidth
-        contentWidthConstraint = contentView.widthAnchor.constraint(equalToConstant: contentViewWidth)
+        let contentWidthConstraint = contentView.widthAnchor.constraint(equalToConstant: contentViewWidth)
         contentWidthConstraint.priority = UILayoutPriority(999)
+        self.contentWidthConstraint = contentWidthConstraint
 
         NSLayoutConstraint.activate(
             [
@@ -222,11 +224,11 @@ class CreditCardBottomSheetViewController: UIViewController,
         let estimatedContentHeight = cardTableView.contentSize.height +
         buttonsHeight + UX.bottomSpacing + UX.distanceBetweenHeaderAndTop
         let aspectRatio = estimatedContentHeight / contentView.bounds.size.height
-        contentViewHeightConstraint.constant = contentViewHeightConstraint.constant * aspectRatio
+        contentViewHeightConstraint?.constant = (contentViewHeightConstraint?.constant ?? 0.0) * aspectRatio
 
         let contentWidthCheck = UX.contentViewWidth > view.frame.size.width
         let contentViewWidth = contentWidthCheck ? view.frame.size.width - UX.containerPadding : UX.contentViewWidth
-        contentWidthConstraint.constant = contentViewWidth
+        contentWidthConstraint?.constant = contentViewWidth
     }
 
     // MARK: View Transitions
@@ -239,7 +241,7 @@ class CreditCardBottomSheetViewController: UIViewController,
         super.viewWillTransition(to: size, with: coordinator)
         let contentWidthCheck = UX.contentViewWidth > size.width
         let contentViewWidth = contentWidthCheck ? size.width - UX.containerPadding : UX.contentViewWidth
-        contentWidthConstraint.constant = contentViewWidth
+        contentWidthConstraint?.constant = contentViewWidth
         if let header = cardTableView.headerView(forSection: 0) as? CreditCardBottomSheetHeaderView {
             header.titleLabelTrailingConstraint.constant = contentWidthCheck ? -UX.closeButtonMarginAndWidth : 0
         }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -107,8 +107,9 @@ class CreditCardBottomSheetViewController: UIViewController,
         super.init(nibName: nil, bundle: nil)
 
         self.viewModel.didUpdateCreditCard = { [weak self] in
-            self?.cardTableView.reloadData()
-            self?.cardTableView.isScrollEnabled = self?.cardTableView.contentSize.height ?? 0 > self?.view.frame.height ?? 0
+            guard let self else { return }
+            self.cardTableView.reloadData()
+            self.cardTableView.isScrollEnabled = self.cardTableView.contentSize.height > self.view.frame.height
         }
 
         // Only allow selection when we are in selectSavedCard state

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -218,11 +218,13 @@ class CreditCardBottomSheetViewController: UIViewController,
     }
 
     func updateConstraints() {
-        let buttonsHeight = buttonsContainerStackView.frame.height
-        let estimatedContentHeight = cardTableView.contentSize.height +
-        buttonsHeight + UX.bottomSpacing + UX.distanceBetweenHeaderAndTop
-        let aspectRatio = estimatedContentHeight / contentView.bounds.size.height
-        contentViewHeightConstraint?.constant = (contentViewHeightConstraint?.constant ?? 0.0) * aspectRatio
+        if let contentViewHeightConstraint {
+            let buttonsHeight = buttonsContainerStackView.frame.height
+            let estimatedContentHeight = cardTableView.contentSize.height +
+                buttonsHeight + UX.bottomSpacing + UX.distanceBetweenHeaderAndTop
+            let aspectRatio = estimatedContentHeight / contentView.bounds.size.height
+            contentViewHeightConstraint.constant = contentViewHeightConstraint.constant * aspectRatio
+        }
 
         let contentWidthCheck = UX.contentViewWidth > view.frame.size.width
         let contentViewWidth = contentWidthCheck ? view.frame.size.width - UX.containerPadding : UX.contentViewWidth


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

