### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in CreditCardSettingsViewModel

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsViewModel.swift
@@ -25,8 +25,8 @@ class CreditCardSettingsViewModel {
     var appAuthenticator: AppAuthenticationProtocol?
 
     lazy var cardInputViewModel = CreditCardInputViewModel(profile: profile)
+    lazy var toggleModel = ToggleModel(isEnabled: isAutofillEnabled, delegate: self)
     var tableViewModel = CreditCardTableViewModel()
-    var toggleModel: ToggleModel!
 
     public init(profile: Profile,
                 windowUUID: WindowUUID,
@@ -37,7 +37,7 @@ class CreditCardSettingsViewModel {
         guard let profile = profile as? BrowserProfile else { return }
         self.autofill = profile.autofill
         self.appAuthenticator = appAuthenticator
-        self.toggleModel = ToggleModel(isEnabled: isAutofillEnabled, delegate: self)
+
         tableViewModel.toggleModel = toggleModel
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

The simplest approach here was to use a lazy property instead of implicitly unwrapped to avoid the compile error due to accessing self before initializing all properties in the init block. Let me know if this approach suits you fine 🙂 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

