### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 4 implicitly_unwrapped_optional violations in BackForwardListViewController

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BackForwardListAnimator.swift
+++ b/firefox-ios/Client/Frontend/Browser/BackForwardListAnimator.swift
@@ -83,7 +83,7 @@ extension BackForwardListAnimator {
                 options: [],
                 animations: { () in
                     backForward.view.alpha = 1
-                    backForward.tableViewHeightAnchor.constant = backForward.tableHeight
+                    backForward.tableViewHeightAnchor?.constant = backForward.tableHeight
                     backForward.view.layoutIfNeeded()
                 }, completion: { (completed) in
                     transitionContext.completeTransition(completed)
@@ -97,7 +97,7 @@ extension BackForwardListAnimator {
                 options: [],
                 animations: { () in
                     backForward.view.alpha = 0
-                    backForward.tableViewHeightAnchor.constant = 0
+                    backForward.tableViewHeightAnchor?.constant = 0
                     backForward.view.layoutIfNeeded()
                 }, completion: { (completed) in
                     backForward.view.removeFromSuperview()

--- a/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -32,9 +32,9 @@ class BackForwardListViewController: UIViewController,
     private var dismissing = false
     private var currentRow = 0
     private var verticalConstraints: [NSLayoutConstraint] = []
-    var tableViewTopAnchor: NSLayoutConstraint!
-    var tableViewBottomAnchor: NSLayoutConstraint!
-    var tableViewHeightAnchor: NSLayoutConstraint!
+    var tableViewTopAnchor: NSLayoutConstraint?
+    var tableViewBottomAnchor: NSLayoutConstraint?
+    var tableViewHeightAnchor: NSLayoutConstraint?
 
     // MARK: - Theme
     var themeManager: ThemeManager
@@ -53,7 +53,7 @@ class BackForwardListViewController: UIViewController,
 
     lazy var shadow: UIView = .build { _ in }
 
-    var tabManager: TabManager!
+    var tabManager: TabManager?
     weak var browserFrameInfoProvider: BrowserFrameInfoProvider?
     var currentItem: WKBackForwardListItem?
     var listData = [WKBackForwardListItem]()
@@ -104,7 +104,9 @@ class BackForwardListViewController: UIViewController,
         view.addSubview(tableView)
 
         snappedToBottom = isDisplayedAtBottom(for: traitCollection, isBottomSearchBar: isBottomSearchBar)
-        tableViewHeightAnchor = tableView.heightAnchor.constraint(equalToConstant: 0)
+        let tableViewHeightAnchor = tableView.heightAnchor.constraint(equalToConstant: 0)
+        self.tableViewHeightAnchor = tableViewHeightAnchor
+
         NSLayoutConstraint.activate([
             tableViewHeightAnchor,
             tableView.leftAnchor.constraint(equalTo: view.leftAnchor),
@@ -185,14 +187,14 @@ class BackForwardListViewController: UIViewController,
             snappedToBottom = isDisplayedAtBottom
             let anchor = snappedToBottom ? tableViewTopAnchor : tableViewBottomAnchor
             anchor?.constant = 0
-            tableViewHeightAnchor.constant = 0
+            tableViewHeightAnchor?.constant = 0
         }
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         let correctHeight = {
-            self.tableViewHeightAnchor.constant = min(
+            self.tableViewHeightAnchor?.constant = min(
                 BackForwardViewUX.RowHeight * CGFloat(self.listData.count),
                 size.height / 2
             )
@@ -220,7 +222,9 @@ class BackForwardListViewController: UIViewController,
             let keyboardContainerHeight = browserFrameInfo.getOverKeyboardContainerSize().height
             let toolbarContainerheight = browserFrameInfo.getBottomContainerSize().height
             let offset = keyboardContainerHeight + toolbarContainerheight
-            tableViewBottomAnchor = tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -offset)
+            let tableViewBottomAnchor = tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -offset)
+            self.tableViewBottomAnchor = tableViewBottomAnchor
+
             let constraints: [NSLayoutConstraint] = [
                 tableViewBottomAnchor,
                 shadow.bottomAnchor.constraint(equalTo: tableView.topAnchor),
@@ -230,10 +234,12 @@ class BackForwardListViewController: UIViewController,
             verticalConstraints += constraints
         } else {
             let statusBarHeight = UIWindow.keyWindow?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
-            tableViewTopAnchor = tableView.topAnchor.constraint(
+            let tableViewTopAnchor = tableView.topAnchor.constraint(
                 equalTo: view.topAnchor,
                 constant: browserFrameInfo.getHeaderSize().height + statusBarHeight
             )
+            self.tableViewTopAnchor = tableViewTopAnchor
+
             let constraints: [NSLayoutConstraint] = [
                 tableViewTopAnchor,
                 shadow.topAnchor.constraint(equalTo: tableView.bottomAnchor),
@@ -313,7 +319,7 @@ class BackForwardListViewController: UIViewController,
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tabManager.selectedTab?.goToBackForwardListItem(listData[indexPath.item])
+        tabManager?.selectedTab?.goToBackForwardListItem(listData[indexPath.item])
         dismiss(animated: true, completion: nil)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

