### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 2 implicitly_unwrapped_optional violations in BrowserPrompts

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -81,19 +81,19 @@ struct TextInputAlert: JSAlertInfo {
     let defaultText: String?
     let completionHandler: (String?) -> Void
 
-    var input: UITextField!
+    var input: UITextField?
 
     func alertController() -> JSPromptAlertController {
         let alertController = JSPromptAlertController(title: titleForJavaScriptPanelInitiatedByFrame(frame),
                                                       message: message,
                                                       preferredStyle: .alert)
-        var input: UITextField!
+        var input: UITextField?
         alertController.addTextField(configurationHandler: { (textField: UITextField) in
             input = textField
-            input.text = self.defaultText
+            input?.text = self.defaultText
         })
         alertController.addAction(UIAlertAction(title: .OKString, style: .default) { _ in
-            self.completionHandler(input.text)
+            self.completionHandler(input?.text)
         })
         alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel) { _ in
             self.completionHandler(nil)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

