### PR TITLE
Bugfix FXIOS-10906 [Default Browser] Beta detect build and don't run API

### DIFF
--- a/firefox-ios/Client/Application/DefaultBrowserUtil.swift
+++ b/firefox-ios/Client/Application/DefaultBrowserUtil.swift
@@ -25,8 +25,8 @@ struct DefaultBrowserUtil {
 
     func processUserDefaultState(isFirstRun: Bool) {
         guard #available(iOS 18.2, *),
-              let isDefault = try? application.isDefault(.webBrowser)
-        else { return }
+              isRunningOnBlockListBetaOS(),
+              let isDefault = try? application.isDefault(.webBrowser) else { return }
 
         trackIfUserIsDefault(isDefault)
 
@@ -39,6 +39,13 @@ struct DefaultBrowserUtil {
                 userDefault.set(true, forKey: PrefsKeys.DidDismissDefaultBrowserMessage)
             }
         }
+    }
+
+    private func isRunningOnBlockListBetaOS() -> Bool {
+        let systemVersion = ProcessInfo.processInfo.operatingSystemVersionString
+        let betaBlockLists: [String] = ["22C5109p", "22C5125e", "22C5131e", "22C5142a"]
+
+        return betaBlockLists.contains { systemVersion.contains($0) }
     }
 
     private func trackIfUserIsDefault(_ isDefault: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10906)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23819)

## :bulb: Description
Detect beta build and don't run that API that is not available on certain builds

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

