### PR TITLE
Refactor FXIOS-7301 [Swiftlint] Remove 1 closure_body_length violation from MainMenuMiddleware.swift and decrease threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -102,8 +102,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 80
-  error: 80
+  warning: 71
+  error: 71
 
 file_header:
   required_string: |

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -102,8 +102,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 90
-  error: 90
+  warning: 80
+  error: 80
 
 file_header:
   required_string: |

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -198,6 +198,12 @@ final class MainMenuMiddleware {
         )
     }
 
+    private func handleTapToggleNightModeAction(action: MainMenuAction, isHomepage: Bool) {
+        guard let isActionOn = action.telemetryInfo?.isActionOn else { return }
+        let option = isActionOn ? TelemetryAction.nightModeTurnOn : TelemetryAction.nightModeTurnOff
+        telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: option)
+    }
+
     private func getAccountData() -> AccountData? {
         let rustAccount = RustFirefoxAccounts.shared
         let needsReAuth = rustAccount.accountNeedsReauth()

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -70,21 +70,7 @@ final class MainMenuMiddleware {
             self.handleShowReaderModeAction(action: action)
 
         case MainMenuActionType.didInstantiateView:
-            if let accountData = self.getAccountData() {
-                if let iconURL = accountData.iconURL {
-                    GeneralizedImageFetcher().getImageFor(url: iconURL) { [weak self] image in
-                        guard let self else { return }
-                        self.dispatchUpdateAccountHeader(
-                            accountData: accountData,
-                            action: action,
-                            icon: image)
-                    }
-                } else {
-                    self.dispatchUpdateAccountHeader(accountData: accountData, action: action)
-                }
-            } else {
-                self.dispatchUpdateAccountHeader(action: action)
-            }
+            self.handleDidInstantiateViewAction(action: action)
 
         case MainMenuActionType.viewDidLoad:
             store.dispatch(

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -159,6 +159,13 @@ final class MainMenuMiddleware {
         }
     }
 
+    private func handleActionTypeAction(action: MainMenuAction, isHomepage: Bool) {
+        guard let destination = action.navigationDestination?.destination else { return }
+        handleTelemetryFor(for: destination,
+                           isHomepage: isHomepage,
+                           and: action.navigationDestination?.url)
+    }
+
     private func dispatchUpdateAccountHeader(
         accountData: AccountData? = nil,
         action: MainMenuAction,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -106,12 +106,7 @@ final class MainMenuMiddleware {
             self.handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
 
         case MainMenuDetailsActionType.tapBackToMainMenu:
-            guard let submenuType = action.telemetryInfo?.submenuType else { return }
-            if submenuType == .save {
-                self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.back)
-            } else {
-                self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.back)
-            }
+            self.handleTapBackToMainMenuAction(action: action, isHomepage: isHomepage)
 
         case MainMenuDetailsActionType.tapDismissView:
             self.telemetry.closeButtonTapped(isHomepage: isHomepage)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -58,11 +58,7 @@ final class MainMenuMiddleware {
             self.handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
 
         case MainMenuActionType.tapShowDetailsView:
-            if action.detailsViewToShow == .tools {
-                self.telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.tools)
-            } else if action.detailsViewToShow == .save {
-                self.telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.save)
-            }
+            self.handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
 
         case MainMenuActionType.tapToggleUserAgent:
             guard let defaultIsDesktop = action.telemetryInfo?.isDefaultUserAgentDesktop,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -55,10 +55,7 @@ final class MainMenuMiddleware {
 
         switch action.actionType {
         case MainMenuActionType.tapNavigateToDestination:
-            guard let destination = action.navigationDestination?.destination else { return }
-            self.handleTelemetryFor(for: destination,
-                                    isHomepage: isHomepage,
-                                    and: action.navigationDestination?.url)
+            self.handleActionTypeAction(action: action, isHomepage: isHomepage)
 
         case MainMenuActionType.tapShowDetailsView:
             if action.detailsViewToShow == .tools {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -61,16 +61,7 @@ final class MainMenuMiddleware {
             self.handleTapShowDetailsViewAction(action: action, isHomepage: isHomepage)
 
         case MainMenuActionType.tapToggleUserAgent:
-            guard let defaultIsDesktop = action.telemetryInfo?.isDefaultUserAgentDesktop,
-                  let hasChangedUserAgent = action.telemetryInfo?.hasChangedUserAgent
-            else { return }
-            if defaultIsDesktop {
-                let option = hasChangedUserAgent ? TelemetryAction.switchToDesktopSite : TelemetryAction.switchToMobileSite
-                self.telemetry.mainMenuOptionTapped(with: isHomepage, and: option)
-            } else {
-                let option = hasChangedUserAgent ? TelemetryAction.switchToMobileSite : TelemetryAction.switchToDesktopSite
-                self.telemetry.mainMenuOptionTapped(with: isHomepage, and: option)
-            }
+            self.handleTapToggleUserAgentAction(action: action, isHomepage: isHomepage)
 
         case MainMenuActionType.tapCloseMenu:
             self.telemetry.closeButtonTapped(isHomepage: isHomepage)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -167,6 +167,19 @@ final class MainMenuMiddleware {
         }
     }
 
+    private func handleTapToggleUserAgentAction(action: MainMenuAction, isHomepage: Bool) {
+        guard let defaultIsDesktop = action.telemetryInfo?.isDefaultUserAgentDesktop,
+              let hasChangedUserAgent = action.telemetryInfo?.hasChangedUserAgent
+        else { return }
+        if defaultIsDesktop {
+            let option = hasChangedUserAgent ? TelemetryAction.switchToDesktopSite : TelemetryAction.switchToMobileSite
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: option)
+        } else {
+            let option = hasChangedUserAgent ? TelemetryAction.switchToMobileSite : TelemetryAction.switchToDesktopSite
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: option)
+        }
+    }
+
     private func dispatchUpdateAccountHeader(
         accountData: AccountData? = nil,
         action: MainMenuAction,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -163,6 +163,14 @@ final class MainMenuMiddleware {
                            and: action.navigationDestination?.url)
     }
 
+    private func handleTapShowDetailsViewAction(action: MainMenuAction, isHomepage: Bool) {
+        if action.detailsViewToShow == .tools {
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.tools)
+        } else if action.detailsViewToShow == .save {
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.save)
+        }
+    }
+
     private func dispatchUpdateAccountHeader(
         accountData: AccountData? = nil,
         action: MainMenuAction,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -103,9 +103,7 @@ final class MainMenuMiddleware {
             self.telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.removeFromReadingList)
 
         case MainMenuDetailsActionType.tapToggleNightMode:
-            guard let isActionOn = action.telemetryInfo?.isActionOn else { return }
-            let option = isActionOn ? TelemetryAction.nightModeTurnOn : TelemetryAction.nightModeTurnOff
-            self.telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: option)
+            self.handleTapToggleNightModeAction(action: action, isHomepage: isHomepage)
 
         case MainMenuDetailsActionType.tapBackToMainMenu:
             guard let submenuType = action.telemetryInfo?.submenuType else { return }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -175,6 +175,24 @@ final class MainMenuMiddleware {
         telemetry.toolsSubmenuOptionTapped(with: false, and: option)
     }
 
+    private func handleDidInstantiateViewAction(action: MainMenuAction) {
+        if let accountData = getAccountData() {
+            if let iconURL = accountData.iconURL {
+                GeneralizedImageFetcher().getImageFor(url: iconURL) { [weak self] image in
+                    guard let self else { return }
+                    self.dispatchUpdateAccountHeader(
+                        accountData: accountData,
+                        action: action,
+                        icon: image)
+                }
+            } else {
+                dispatchUpdateAccountHeader(accountData: accountData, action: action)
+            }
+        } else {
+            dispatchUpdateAccountHeader(action: action)
+        }
+    }
+
     private func dispatchUpdateAccountHeader(
         accountData: AccountData? = nil,
         action: MainMenuAction,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -194,6 +194,15 @@ final class MainMenuMiddleware {
         )
     }
 
+    private func handleViewDidLoadAction(action: MainMenuAction) {
+        store.dispatch(
+            MainMenuAction(
+                windowUUID: action.windowUUID,
+                actionType: MainMenuMiddlewareActionType.requestTabInfo
+            )
+        )
+    }
+
     private func getAccountData() -> AccountData? {
         let rustAccount = RustFirefoxAccounts.shared
         let needsReAuth = rustAccount.accountNeedsReauth()

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -202,6 +202,15 @@ final class MainMenuMiddleware {
         telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: option)
     }
 
+    private func handleTapBackToMainMenuAction(action: MainMenuAction, isHomepage: Bool) {
+        guard let submenuType = action.telemetryInfo?.submenuType else { return }
+        if submenuType == .save {
+            telemetry.saveSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.back)
+        } else {
+            telemetry.toolsSubmenuOptionTapped(with: isHomepage, and: TelemetryAction.back)
+        }
+    }
+
     private func getAccountData() -> AccountData? {
         let rustAccount = RustFirefoxAccounts.shared
         let needsReAuth = rustAccount.accountNeedsReauth()

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -67,9 +67,7 @@ final class MainMenuMiddleware {
             self.telemetry.closeButtonTapped(isHomepage: isHomepage)
 
         case GeneralBrowserActionType.showReaderMode:
-            guard let isActionOn = action.telemetryInfo?.isActionOn else { return }
-            let option = isActionOn ? TelemetryAction.readerViewTurnOn : TelemetryAction.readerViewTurnOff
-            self.telemetry.toolsSubmenuOptionTapped(with: false, and: option)
+            self.handleShowReaderModeAction(action: action)
 
         case MainMenuActionType.didInstantiateView:
             if let accountData = self.getAccountData() {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -73,12 +73,7 @@ final class MainMenuMiddleware {
             self.handleDidInstantiateViewAction(action: action)
 
         case MainMenuActionType.viewDidLoad:
-            store.dispatch(
-                MainMenuAction(
-                    windowUUID: action.windowUUID,
-                    actionType: MainMenuMiddlewareActionType.requestTabInfo
-                )
-            )
+            self.handleViewDidLoadAction(action: action)
 
         case MainMenuActionType.menuDismissed:
             self.telemetry.menuDismissed(isHomepage: isHomepage)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -55,7 +55,7 @@ final class MainMenuMiddleware {
 
         switch action.actionType {
         case MainMenuActionType.tapNavigateToDestination:
-            self.handleActionTypeAction(action: action, isHomepage: isHomepage)
+            self.handleTapNavigateToDestinationAction(action: action, isHomepage: isHomepage)
 
         case MainMenuActionType.tapShowDetailsView:
             if action.detailsViewToShow == .tools {
@@ -156,7 +156,7 @@ final class MainMenuMiddleware {
         }
     }
 
-    private func handleActionTypeAction(action: MainMenuAction, isHomepage: Bool) {
+    private func handleTapNavigateToDestinationAction(action: MainMenuAction, isHomepage: Bool) {
         guard let destination = action.navigationDestination?.destination else { return }
         handleTelemetryFor(for: destination,
                            isHomepage: isHomepage,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -171,6 +171,12 @@ final class MainMenuMiddleware {
         }
     }
 
+    private func handleShowReaderModeAction(action: MainMenuAction) {
+        guard let isActionOn = action.telemetryInfo?.isActionOn else { return }
+        let option = isActionOn ? TelemetryAction.readerViewTurnOn : TelemetryAction.readerViewTurnOff
+        telemetry.toolsSubmenuOptionTapped(with: false, and: option)
+    }
+
     private func dispatchUpdateAccountHeader(
         accountData: AccountData? = nil,
         action: MainMenuAction,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `MainMenuMiddleware.swift` file. Also, this PR decrease the warning and error threshold to 71. 

Before this PR, this class spans 87 lines in `mainMenuProvider` property, and now spans 43 lines. If we want to reach the default warning threshold, we need to improve this implementation.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

