### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 2 implicitly_unwrapped_optional violations in SwipeAnimator

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SwipeAnimator.swift
+++ b/firefox-ios/Client/Frontend/Browser/SwipeAnimator.swift
@@ -34,7 +34,7 @@ class SwipeAnimator: NSObject {
     private var prevOffset: CGPoint?
     private let params: SwipeAnimationParameters
 
-    private var panGestureRecogniser: UIPanGestureRecognizer!
+    private var panGestureRecogniser: UIPanGestureRecognizer?
 
     var containerCenter: CGPoint {
         guard let animatingView = self.animatingView else {
@@ -49,9 +49,10 @@ class SwipeAnimator: NSObject {
 
         super.init()
 
-        self.panGestureRecogniser = UIPanGestureRecognizer(target: self, action: #selector(didPan))
-        animatingView.addGestureRecognizer(self.panGestureRecogniser)
-        self.panGestureRecogniser.delegate = self
+        let panGestureRecogniser = UIPanGestureRecognizer(target: self, action: #selector(didPan))
+        panGestureRecogniser.delegate = self
+        animatingView.addGestureRecognizer(panGestureRecogniser)
+        self.panGestureRecogniser = panGestureRecogniser
     }
 }
 
@@ -113,7 +114,7 @@ extension SwipeAnimator {
 // MARK: Selectors
 extension SwipeAnimator {
     @objc
-    func didPan(_ recognizer: UIPanGestureRecognizer!) {
+    func didPan(_ recognizer: UIPanGestureRecognizer) {
         let translation = recognizer.translation(in: animatingView)
 
         switch recognizer.state {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

