### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in TopTabsViewController

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -36,7 +36,15 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
     // MARK: - Properties
     let tabManager: TabManager
     weak var delegate: TopTabsDelegate?
-    private var topTabDisplayManager: TopTabDisplayManager!
+
+    private lazy var topTabDisplayManager = TopTabDisplayManager(
+        collectionView: collectionView,
+        tabManager: tabManager,
+        tabDisplayer: self,
+        reuseID: TopTabCell.cellIdentifier,
+        profile: profile
+    )
+
     var tabCellIdentifier: TabDisplayerDelegate.TabCellIdentifier = TopTabCell.cellIdentifier
     var profile: Profile
     var themeManager: ThemeManager
@@ -122,11 +130,6 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
         super.init(nibName: nil, bundle: nil)
-        topTabDisplayManager = TopTabDisplayManager(collectionView: self.collectionView,
-                                                    tabManager: self.tabManager,
-                                                    tabDisplayer: self,
-                                                    reuseID: TopTabCell.cellIdentifier,
-                                                    profile: profile)
         collectionView.dataSource = topTabDisplayManager
         collectionView.delegate = tabLayoutDelegate
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

I used a lazy var here so it can be initialized with instance variables after calling `super.init(nibName:,bundle:)` instead of using an implicitly unwrapped optional

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

