### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in LegacyLabelButtonHeaderView

### DIFF
--- a/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
@@ -79,13 +79,12 @@ class LegacyLabelButtonHeaderView: UICollectionReusableView, ReusableCell {
         stackView.addArrangedSubview(moreButton)
         addSubview(stackView)
 
-        let stackViewLeadingConstraint = stackView.leadingAnchor.constraint(equalTo: leadingAnchor,
-                                                                            constant: UX.leadingInset)
-        self.stackViewLeadingConstraint = stackViewLeadingConstraint
+        stackViewLeadingConstraint = stackView.leadingAnchor.constraint(equalTo: leadingAnchor,
+                                                                        constant: UX.leadingInset)
+        stackViewLeadingConstraint?.isActive = true
 
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackViewLeadingConstraint,
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor,
                                                 constant: -UX.trailingInset),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.bottomSpace),

--- a/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
@@ -60,7 +60,7 @@ class LegacyLabelButtonHeaderView: UICollectionReusableView, ReusableCell {
 
     private var viewModel: LabelButtonHeaderViewModel?
     var notificationCenter: NotificationProtocol = NotificationCenter.default
-    private var stackViewLeadingConstraint: NSLayoutConstraint!
+    private var stackViewLeadingConstraint: NSLayoutConstraint?
 
     // MARK: - Initializers
     override init(frame: CGRect) {
@@ -79,8 +79,10 @@ class LegacyLabelButtonHeaderView: UICollectionReusableView, ReusableCell {
         stackView.addArrangedSubview(moreButton)
         addSubview(stackView)
 
-        stackViewLeadingConstraint = stackView.leadingAnchor.constraint(equalTo: leadingAnchor,
+        let stackViewLeadingConstraint = stackView.leadingAnchor.constraint(equalTo: leadingAnchor,
                                                                         constant: UX.leadingInset)
+        self.stackViewLeadingConstraint = stackViewLeadingConstraint
+
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor),
             stackViewLeadingConstraint,

--- a/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Components/LegacyLabelButtonHeaderView.swift
@@ -80,7 +80,7 @@ class LegacyLabelButtonHeaderView: UICollectionReusableView, ReusableCell {
         addSubview(stackView)
 
         let stackViewLeadingConstraint = stackView.leadingAnchor.constraint(equalTo: leadingAnchor,
-                                                                        constant: UX.leadingInset)
+                                                                            constant: UX.leadingInset)
         self.stackViewLeadingConstraint = stackViewLeadingConstraint
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

