### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in HomePanelType

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomePanelType.swift
+++ b/firefox-ios/Client/Frontend/Home/HomePanelType.swift
@@ -9,7 +9,7 @@ enum HomePanelType: Int {
     case topSites = 0
 
     var internalUrl: URL {
-        let aboutUrl: URL! = URL(string: "\(InternalURL.baseUrl)/\(AboutHomeHandler.path)", invalidCharacters: false)
+        let aboutUrl = URL(string: "\(InternalURL.baseUrl)/\(AboutHomeHandler.path)", invalidCharacters: false)!
         return URL(string: "#panel=\(self.rawValue)", relativeTo: aboutUrl)!
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

Here I force unwrap the created `aboutUrl` but since it was implicitly unwrapped right after to create `internalUrl` it's not  an extra liability.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

