### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in SyncedTabCell

### DIFF
--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
@@ -39,7 +39,7 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
     private var syncedDeviceIconFirstBaselineConstraint: NSLayoutConstraint?
     private var syncedDeviceIconCenterConstraint: NSLayoutConstraint?
     private var showAllSyncedTabsAction: (() -> Void)?
-    private var tabStackTopConstraint: NSLayoutConstraint!
+    private var tabStackTopConstraint: NSLayoutConstraint?
     private var openSyncedTabAction: (() -> Void)?
 
     // MARK: - UI Elements
@@ -207,6 +207,7 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
         tabStackTopConstraint = tabStack.topAnchor.constraint(
             equalTo: syncedTabsButton.bottomAnchor,
             constant: UX.tabStackTopAnchorConstant)
+        tabStackTopConstraint?.isActive = true
 
         NSLayoutConstraint.activate([
             cardTitle.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
@@ -217,8 +218,6 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
             syncedTabsButton.leadingAnchor.constraint(equalTo: cardTitle.leadingAnchor, constant: 0),
             syncedTabsButton.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor,
                                                        constant: -16),
-
-            tabStackTopConstraint,
             tabStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
             tabStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
             tabStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16),
@@ -294,7 +293,7 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
         if traitCollection.horizontalSizeClass == .compact, !isPhoneInLandscape {
             tabStackTopAnchorConstant = UX.tabStackTopAnchorCompactPhoneConstant
         }
-        tabStackTopConstraint.constant = tabStackTopAnchorConstant
+        tabStackTopConstraint?.constant = tabStackTopAnchorConstant
     }
 
     private func setupShadow(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/SyncedTabCell.swift
@@ -218,6 +218,7 @@ class SyncedTabCell: UICollectionViewCell, ReusableCell {
             syncedTabsButton.leadingAnchor.constraint(equalTo: cardTitle.leadingAnchor, constant: 0),
             syncedTabsButton.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor,
                                                        constant: -16),
+
             tabStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
             tabStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
             tabStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

