### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in WallpaperSelectorViewController

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/UI/WallpaperSelectorViewController.swift
@@ -24,7 +24,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
 
     // Views
     private lazy var contentView: UIView = .build { _ in }
-    private var collectionViewHeightConstraint: NSLayoutConstraint!
+    private var collectionViewHeightConstraint: NSLayoutConstraint?
 
     private lazy var headerLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.headline.scaledFont()
@@ -89,7 +89,7 @@ class WallpaperSelectorViewController: WallpaperBaseViewController, Themeable {
         // make collection view fixed height so the bottom sheet can size correctly
         let height = collectionView.collectionViewLayout.collectionViewContentSize.height +
             WallpaperSelectorViewController.UX.cardShadowHeight
-        collectionViewHeightConstraint.constant = height
+        collectionViewHeightConstraint?.constant = height
         view.layoutIfNeeded()
 
         collectionView.selectItem(at: viewModel.selectedIndexPath, animated: false, scrollPosition: [])
@@ -145,7 +145,8 @@ private extension WallpaperSelectorViewController {
         view.addSubview(contentView)
 
         collectionViewHeightConstraint = collectionView.heightAnchor.constraint(equalToConstant: 300)
-        collectionViewHeightConstraint.priority = UILayoutPriority(999)
+        collectionViewHeightConstraint?.priority = UILayoutPriority(999)
+        collectionViewHeightConstraint?.isActive = true
 
         NSLayoutConstraint.activate([
             contentView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -165,7 +166,6 @@ private extension WallpaperSelectorViewController {
             collectionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -43),
             collectionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            collectionViewHeightConstraint
         ])
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

