### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 2 implicitly_unwrapped_optional violations in PrivacyPolicyViewController

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPolicyViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPolicyViewController.swift
@@ -22,7 +22,7 @@ class PrivacyPolicyViewController: UIViewController, Themeable {
             }
         }
     }
-    private var webView: WKWebView!
+    private var webView: WKWebView?
     private var url: URL
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
@@ -80,9 +80,11 @@ class PrivacyPolicyViewController: UIViewController, Themeable {
                            width: view.frame.width * UX.contentScalePhone,
                            height: view.frame.height - UX.topPaddingPhone)
         }
-        webView = WKWebView(frame: frame)
+        let webView = WKWebView(frame: frame)
         webView.navigationDelegate = self
         webView.load(URLRequest(url: url))
+        self.webView = webView
+
         view.backgroundColor = .systemBackground
         view.addSubview(webView)
     }
@@ -95,7 +97,7 @@ class PrivacyPolicyViewController: UIViewController, Themeable {
 }
 
 extension PrivacyPolicyViewController: WKNavigationDelegate {
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
         let contentSize = webView.scrollView.contentSize
         let viewSize = self.view.bounds.size
         let zoom = viewSize.width / contentSize.width


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

