### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in OnboardingInstructionsPopupViewController

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingInstructionPopupViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/OnboardingInstructionPopupViewController.swift
@@ -68,7 +68,6 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
     var notificationCenter: NotificationProtocol
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
-    private var contentViewHeightConstraint: NSLayoutConstraint!
     var didTapButton = false
     var buttonTappedFinishFlow: (() -> Void)?
     var dismissDelegate: BottomSheetDismissProtocol?
@@ -116,9 +115,6 @@ class OnboardingInstructionPopupViewController: UIViewController, Themeable {
 
     func setupView() {
         addViewsToView()
-
-        contentViewHeightConstraint = contentContainerView.heightAnchor.constraint(equalToConstant: 300)
-        contentViewHeightConstraint.priority = UILayoutPriority(999)
 
         var topPadding = UX.topPaddingPhone
         var leadingPadding = UX.leadingPaddingPhone


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description

I've noticed here that the implicitly unwrapped constraint that was triggering the warning was actually not activated so I removed it, should I have activated anyway instead? Or just make it optional and leave it unused as it currently is? Let me know!

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

