### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 3 implicitly_unwrapped_optional violations in AddCredentialViewController

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
@@ -40,9 +40,9 @@ class AddCredentialViewController: UIViewController, Themeable {
         tableView.tableFooterView = UIView()
         tableView.separatorInset = .zero
     }
-    fileprivate weak var websiteField: UITextField!
-    fileprivate weak var usernameField: UITextField!
-    fileprivate weak var passwordField: UITextField!
+    fileprivate weak var websiteField: UITextField?
+    fileprivate weak var usernameField: UITextField?
+    fileprivate weak var passwordField: UITextField?
 
     fileprivate let didSaveAction: (LoginEntry) -> Void
 
@@ -107,9 +107,9 @@ class AddCredentialViewController: UIViewController, Themeable {
 
     @objc
     func addCredential() {
-        guard let hostname = websiteField.text,
-              let username = usernameField.text,
-              let password = passwordField.text else {
+        guard let hostname = websiteField?.text,
+              let username = usernameField?.text,
+              let password = passwordField?.text else {
             return
         }
 
@@ -165,7 +165,7 @@ extension AddCredentialViewController: UITableViewDataSource {
             loginCell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             usernameField = loginCell.descriptionLabel
             if isRTLLanguage {
-                usernameField.textAlignment = .right
+                usernameField?.textAlignment = .right
             }
             return loginCell
 
@@ -191,7 +191,7 @@ extension AddCredentialViewController: UITableViewDataSource {
             loginCell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             websiteField = loginCell.descriptionLabel
             if isRTLLanguage {
-                websiteField.textAlignment = .right
+                websiteField?.textAlignment = .right
             }
             return loginCell
         }
@@ -245,15 +245,15 @@ extension AddCredentialViewController: KeyboardHelperDelegate {
 extension AddCredentialViewController: LoginDetailTableViewCellDelegate {
     func textFieldDidEndEditing(_ cell: LoginDetailTableViewCell) {
         guard cell.descriptionLabel == websiteField, let website = websiteField?.text else { return }
-        websiteField.text = normalize(website: website)
+        websiteField?.text = normalize(website: website)
     }
 
     func textFieldDidChange(_ cell: LoginDetailTableViewCell) {
         // TODO: Add validation if necessary
         let enableSave =
-            !(websiteField.text?.isEmpty ?? true) &&
-            !(usernameField.text?.isEmpty ?? true) &&
-            !(passwordField.text?.isEmpty ?? true)
+            !(websiteField?.text?.isEmpty ?? true) &&
+            !(usernameField?.text?.isEmpty ?? true) &&
+            !(passwordField?.text?.isEmpty ?? true)
 
         saveButton.isEnabled = enableSave
     }
@@ -293,9 +293,9 @@ extension AddCredentialViewController: LoginDetailTableViewCellDelegate {
     func shouldReturnAfterEditingDescription(_ cell: LoginDetailTableViewCell) -> Bool {
         switch cell.descriptionLabel {
         case websiteField:
-            usernameField.becomeFirstResponder()
+            usernameField?.becomeFirstResponder()
         case usernameField:
-            passwordField.becomeFirstResponder()
+            passwordField?.becomeFirstResponder()
         case passwordField:
             return false
         default:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

