### PR TITLE
Bugfix FXIOS-9941 Incorrect behavior when (re)opening the screen

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -44,16 +44,17 @@ class StartAtHomeHelper: FeatureFlaggable {
     /// the user's last activity and whether, based on their settings, Start at Home feature
     /// should perform its function.
     public func shouldStartAtHome() -> Bool {
+        let lastActiveTimestamp = UserDefaults.standard.object(forKey: "LastActiveTimestamp") as? Date ?? Date()
+        let dateComponents = Calendar.current.dateComponents([.hour, .second],
+                                                             from: lastActiveTimestamp,
+                                                             to: Date())
         switch startAtHomeSetting {
         case .afterFourHours:
-            let lastActiveTimestamp = UserDefaults.standard.object(forKey: "LastActiveTimestamp") as? Date ?? Date()
-            let dateComponents = Calendar.current.dateComponents([.hour],
-                                                                 from: lastActiveTimestamp,
-                                                                 to: Date())
             let hoursSinceLastActive = dateComponents.hour ?? 0
             return hoursSinceLastActive >= 4
         case .always:
-            return true
+            let secondsSinceLastActive = dateComponents.second ?? 0
+            return secondsSinceLastActive >= 5
         case .disabled:
             return false
         }

--- a/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -53,7 +53,7 @@ class StartAtHomeHelper: FeatureFlaggable {
 
         switch setting {
         case .afterFourHours:
-            return dateComponents.hour ?? 9 >= 4
+            return dateComponents.hour ?? 0 >= 4
         case .always:
             return true
         case .disabled:

--- a/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -44,16 +44,14 @@ class StartAtHomeHelper: FeatureFlaggable {
     /// the user's last activity and whether, based on their settings, Start at Home feature
     /// should perform its function.
     public func shouldStartAtHome() -> Bool {
-        let setting = startAtHomeSetting
-
-        let lastActiveTimestamp = UserDefaults.standard.object(forKey: "LastActiveTimestamp") as? Date ?? Date()
-        let dateComponents = Calendar.current.dateComponents([.hour, .second],
-                                                             from: lastActiveTimestamp,
-                                                             to: Date())
-
-        switch setting {
+        switch startAtHomeSetting {
         case .afterFourHours:
-            return dateComponents.hour ?? 0 >= 4
+            let lastActiveTimestamp = UserDefaults.standard.object(forKey: "LastActiveTimestamp") as? Date ?? Date()
+            let dateComponents = Calendar.current.dateComponents([.hour],
+                                                                 from: lastActiveTimestamp,
+                                                                 to: Date())
+            let hoursSinceLastActive = dateComponents.hour ?? 0
+            return hoursSinceLastActive >= 4
         case .always:
             return true
         case .disabled:

--- a/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -45,24 +45,20 @@ class StartAtHomeHelper: FeatureFlaggable {
     /// should perform its function.
     public func shouldStartAtHome() -> Bool {
         let setting = startAtHomeSetting
-        guard setting != .disabled else { return false }
 
         let lastActiveTimestamp = UserDefaults.standard.object(forKey: "LastActiveTimestamp") as? Date ?? Date()
         let dateComponents = Calendar.current.dateComponents([.hour, .second],
                                                              from: lastActiveTimestamp,
                                                              to: Date())
-        var timeSinceLastActivity = 0
-        var timeToOpenNewHome = 0
 
-        if setting == .afterFourHours {
-            timeSinceLastActivity = dateComponents.hour ?? 0
-            timeToOpenNewHome = 4
-        } else if setting == .always {
-            timeSinceLastActivity = dateComponents.second ?? 0
-            timeToOpenNewHome = 5
+        switch setting {
+        case .afterFourHours:
+            return dateComponents.hour ?? 9 >= 4
+        case .always:
+            return true
+        case .disabled:
+            return false
         }
-
-        return timeSinceLastActivity >= timeToOpenNewHome
     }
 
     /// Looks to see if the user already has a homepage tab open (as per their preferences)

--- a/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -6,6 +6,11 @@ import Shared
 import Common
 
 class StartAtHomeHelper: FeatureFlaggable {
+    private struct Constants {
+        static let hoursToTriggerStartAtHome = 4
+        static let secondsToTriggerStartAtHome = 5
+    }
+
     private var isRestoringTabs: Bool
     // Override only for UI tests to test `shouldSkipStartHome` logic
     private var isRunningUITest: Bool
@@ -51,10 +56,10 @@ class StartAtHomeHelper: FeatureFlaggable {
         switch startAtHomeSetting {
         case .afterFourHours:
             let hoursSinceLastActive = dateComponents.hour ?? 0
-            return hoursSinceLastActive >= 4
+            return hoursSinceLastActive >= Constants.hoursToTriggerStartAtHome
         case .always:
             let secondsSinceLastActive = dateComponents.second ?? 0
-            return secondsSinceLastActive >= 5
+            return secondsSinceLastActive >= Constants.secondsToTriggerStartAtHome
         case .disabled:
             return false
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
@@ -59,12 +59,14 @@ class StartAtHomeHelperTests: XCTestCase {
 
     func testNotShouldStartAtHome_AfterFourHours() {
         setupHelper()
+        helper.startAtHomeSetting = .afterFourHours
         setupLastActiveTimeStamp(value: -3)
         XCTAssertFalse(helper.shouldStartAtHome(), "Expected to fail for less than 4 hours")
     }
 
     func testShouldStartAtHome_AfterFourHours() {
         setupHelper()
+        helper.startAtHomeSetting = .afterFourHours
         setupLastActiveTimeStamp(value: -5)
         XCTAssertTrue(helper.shouldStartAtHome(), "Expected to pass for more than 4 hours")
     }
@@ -73,7 +75,7 @@ class StartAtHomeHelperTests: XCTestCase {
         setupHelper()
         helper.startAtHomeSetting = .always
         setupLastActiveTimeStamp(value: -3, dateComponents: .second)
-        XCTAssertFalse(helper.shouldStartAtHome(), "Expected to fail for more than 5 seconds")
+        XCTAssertTrue(helper.shouldStartAtHome(), "Expected to fail for more than 5 seconds")
     }
 
     func testShouldStartAtHome_Always() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHomeHelperTests.swift
@@ -75,7 +75,7 @@ class StartAtHomeHelperTests: XCTestCase {
         setupHelper()
         helper.startAtHomeSetting = .always
         setupLastActiveTimeStamp(value: -3, dateComponents: .second)
-        XCTAssertTrue(helper.shouldStartAtHome(), "Expected to fail for more than 5 seconds")
+        XCTAssertFalse(helper.shouldStartAtHome(), "Expected to fail for more than 5 seconds")
     }
 
     func testShouldStartAtHome_Always() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9941)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21826)

## :bulb: Description
- To address this issue, the solution is to return `true` immediately to ensure proper redirection to the homepage, as described in the bug report
- Additionally, both `PocketViewModelTests` and `StartAtHomeHelperTests`have passed successfully


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)