### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 12 implicitly_unwrapped_optional violations in Frontend/Settings

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -13,7 +13,7 @@ class CustomSearchError: MaybeErrorType {
         case DuplicateEngine, FormInput
     }
 
-    var reason: Reason!
+    var reason: Reason
 
     internal var description: String {
         return "Search Engine Not Added"

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -10,8 +10,8 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
     // MARK: - Variables
     /* variables for checkmark settings */
     let prefs: Prefs
-    var currentNewTabChoice: NewTabPage!
-    var currentStartAtHomeSetting: StartAtHomeSetting!
+    var currentNewTabChoice: NewTabPage?
+    var currentStartAtHomeSetting: StartAtHomeSetting?
     var hasHomePage = false
     var wallpaperManager: WallpaperManagerInterface
 
@@ -88,7 +88,8 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         self.hasHomePage = HomeButtonHomePageAccessors.getHomePage(self.prefs) != nil
 
         let onFinished = {
-            self.prefs.setString(self.currentNewTabChoice.rawValue, forKey: NewTabAccessors.HomePrefKey)
+            guard let currentNewTabChoice = self.currentNewTabChoice else { return }
+            self.prefs.setString(currentNewTabChoice.rawValue, forKey: NewTabAccessors.HomePrefKey)
             self.tableView.reloadData()
         }
 
@@ -111,8 +112,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             isChecked: { return !showTopSites.isChecked() },
             settingDidChange: { (string) in
                 self.currentNewTabChoice = NewTabPage.homePage
-                self.prefs.setString(self.currentNewTabChoice.rawValue, forKey: NewTabAccessors.HomePrefKey)
-                self.tableView.reloadData()
+                onFinished()
             })
 
         showWebPage.alignTextFieldToNatural()

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/ClearPrivateDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/ClearPrivateDataSetting.swift
@@ -6,7 +6,7 @@ import Foundation
 
 class ClearPrivateDataSetting: Setting {
     private let profile: Profile
-    private var tabManager: TabManager!
+    private var tabManager: TabManager?
     private weak var settingsDelegate: PrivacySettingsDelegate?
 
     override var accessoryView: UIImageView? {

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/ContentBlockerSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/ContentBlockerSetting.swift
@@ -7,7 +7,7 @@ import Foundation
 class ContentBlockerSetting: Setting {
     private weak var settingsDelegate: PrivacySettingsDelegate?
     private let profile: Profile
-    private var tabManager: TabManager!
+    private var tabManager: TabManager?
 
     override var accessoryView: UIImageView? {
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)

--- a/firefox-ios/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/NewTabContentSettingsViewController.swift
@@ -9,7 +9,7 @@ import Common
 class NewTabContentSettingsViewController: SettingsTableViewController {
     /* variables for checkmark settings */
     let prefs: Prefs
-    var currentChoice: NewTabPage!
+    var currentChoice: NewTabPage?
     var hasHomePage = false
     init(prefs: Prefs, windowUUID: WindowUUID) {
         self.prefs = prefs
@@ -27,7 +27,8 @@ class NewTabContentSettingsViewController: SettingsTableViewController {
         self.hasHomePage = NewTabHomePageAccessors.getHomePage(self.prefs) != nil
 
         let onFinished = {
-            self.prefs.setString(self.currentChoice.rawValue, forKey: NewTabAccessors.NewTabPrefKey)
+            guard let currentChoice = self.currentChoice else { return }
+            self.prefs.setString(currentChoice.rawValue, forKey: NewTabAccessors.NewTabPrefKey)
             self.tableView.reloadData()
         }
 
@@ -62,8 +63,7 @@ class NewTabContentSettingsViewController: SettingsTableViewController {
             isChecked: { return !showTopSites.isChecked() && !showBlankPage.isChecked() },
             settingDidChange: { (string) in
                 self.currentChoice = NewTabPage.homePage
-                self.prefs.setString(self.currentChoice.rawValue, forKey: NewTabAccessors.NewTabPrefKey)
-                self.tableView.reloadData()
+                onFinished()
             }
         )
 

--- a/firefox-ios/Client/Frontend/Settings/SearchEnginePicker.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchEnginePicker.swift
@@ -6,7 +6,7 @@ import UIKit
 
 class SearchEnginePicker: ThemedTableViewController {
     weak var delegate: SearchEnginePickerDelegate?
-    var engines: [OpenSearchEngine]!
+    var engines: [OpenSearchEngine] = []
     var selectedSearchEngineName: String?
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -154,26 +154,25 @@ final class SearchSettingsTableViewController: ThemedTableViewController, Featur
             return UITableViewCell()
         }
 
-        var engine: OpenSearchEngine!
         let section = Section(rawValue: sectionsToDisplay[indexPath.section].rawValue) ?? .defaultEngine
 
         switch section {
         case .defaultEngine:
-                engine = model.defaultEngine
-                cell.editingAccessoryType = .disclosureIndicator
-                cell.accessibilityLabel = .Settings.Search.AccessibilityLabels.DefaultSearchEngine
-                cell.accessibilityValue = engine.shortName
-                cell.textLabel?.text = engine.shortName
-                cell.imageView?.image = engine.image.createScaled(IconSize)
-                cell.imageView?.layer.cornerRadius = 4
-                cell.imageView?.layer.masksToBounds = true
-                cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+            guard let engine = model.defaultEngine else { break }
+            cell.editingAccessoryType = .disclosureIndicator
+            cell.accessibilityLabel = .Settings.Search.AccessibilityLabels.DefaultSearchEngine
+            cell.accessibilityValue = engine.shortName
+            cell.textLabel?.text = engine.shortName
+            cell.imageView?.image = engine.image.createScaled(IconSize)
+            cell.imageView?.layer.cornerRadius = 4
+            cell.imageView?.layer.masksToBounds = true
+            cell.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
 
         case .alternateEngines:
             // The default engine is not an alternate search engine.
             let index = indexPath.item + 1
             if index < model.orderedEngines.count {
-                engine = model.orderedEngines[index]
+                let engine = model.orderedEngines[index]
                 cell.showsReorderControl = true
 
                 let toggle = ThemedSwitch()

--- a/firefox-ios/Client/Frontend/Settings/SettingsContentViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsContentViewController.swift
@@ -26,7 +26,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate, The
     var currentWindowUUID: UUID? { windowUUID }
 
     var settingsTitle: NSAttributedString?
-    var url: URL!
+    var url: URL?
     var timer: Timer?
 
     var isLoaded = false {
@@ -73,7 +73,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate, The
     private lazy var settingsWebView: WKWebView = .build()
 
     private func startLoading(_ timeout: Double = DefaultTimeoutTimeInterval) {
-        if self.isLoaded {
+        guard !self.isLoaded, let url else {
             return
         }
         if timeout > 0 {
@@ -200,15 +200,15 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate, The
         self.isError = true
     }
 
-    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation?, withError error: Error) {
         didTimeOut()
     }
 
-    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation?, withError error: Error) {
         didTimeOut()
     }
 
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
         self.timer?.invalidate()
         self.timer = nil
         self.isLoaded = true

--- a/firefox-ios/Client/Frontend/Settings/SettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsViewController.swift
@@ -13,8 +13,8 @@ class SettingsViewController: UIViewController, Themeable {
 
     weak var settingsDelegate: SettingsDelegate?
 
-    var profile: Profile!
-    var tabManager: TabManager!
+    var profile: Profile?
+    var tabManager: TabManager?
     let windowUUID: WindowUUID
 
     var currentWindowUUID: UUID? { return windowUUID }

--- a/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -45,7 +45,7 @@ class WebsiteDataManagementViewController: UIViewController,
 
     private let viewModel = WebsiteDataManagementViewModel()
 
-    var tableView: UITableView!
+    var tableView: UITableView?
     var searchController: UISearchController?
 
     private lazy var searchResultsViewController = WebsiteDataSearchResultsViewController(viewModel: viewModel,
@@ -60,7 +60,7 @@ class WebsiteDataManagementViewController: UIViewController,
         title = .SettingsWebsiteDataTitle
         navigationController?.setToolbarHidden(true, animated: false)
 
-        tableView = UITableView()
+        let tableView = UITableView()
         tableView.dataSource = self
         tableView.delegate = self
         tableView.separatorColor = currentTheme().colors.borderPrimary
@@ -110,7 +110,7 @@ class WebsiteDataManagementViewController: UIViewController,
             guard let self = self else { return }
             self.loadingView.isHidden = self.viewModel.state != .loading
             self.searchResultsViewController.reloadData()
-            self.tableView.reloadData()
+            self.tableView?.reloadData()
         }
 
         viewModel.loadAllWebsiteData()
@@ -128,6 +128,7 @@ class WebsiteDataManagementViewController: UIViewController,
 
         navigationItem.searchController = searchController
         self.searchController = searchController
+        self.tableView = tableView
 
         definesPresentationContext = true
 
@@ -194,7 +195,7 @@ class WebsiteDataManagementViewController: UIViewController,
         }
         switch section {
         case .sites:
-            guard let cell = tableView.dequeueReusableCell(
+            guard let cell = tableView?.dequeueReusableCell(
                 withIdentifier: ThemedTableViewCell.cellIdentifier,
                 for: indexPath
             ) as? ThemedTableViewCell
@@ -203,7 +204,7 @@ class WebsiteDataManagementViewController: UIViewController,
             }
             return cell
         case .showMore:
-            guard let cell = tableView.dequeueReusableCell(
+            guard let cell = tableView?.dequeueReusableCell(
                 withIdentifier: WebsiteDataManagementViewController.showMoreCellReuseIdentifier,
                 for: indexPath
             ) as? ThemedTableViewCell
@@ -212,7 +213,7 @@ class WebsiteDataManagementViewController: UIViewController,
             }
             return cell
         case .clearButton:
-            guard let cell = tableView.dequeueReusableCell(
+            guard let cell = tableView?.dequeueReusableCell(
                 withIdentifier: ThemedCenteredTableViewCell.cellIdentifier,
                 for: indexPath
             ) as? ThemedCenteredTableViewCell
@@ -340,13 +341,14 @@ class WebsiteDataManagementViewController: UIViewController,
     }
 
     private func unfoldSearchbar() {
-        guard let searchBarHeight = navigationItem.searchController?.searchBar.intrinsicContentSize.height else { return }
+        guard let searchBarHeight = navigationItem.searchController?.searchBar.intrinsicContentSize.height,
+              let tableView else { return }
         tableView.setContentOffset(CGPoint(x: 0, y: -searchBarHeight + tableView.contentOffset.y), animated: true)
     }
 
     func applyTheme() {
         loadingView.applyTheme(theme: currentTheme())
-        tableView.separatorColor = currentTheme().colors.borderPrimary
-        tableView.backgroundColor = currentTheme().colors.layer1
+        tableView?.separatorColor = currentTheme().colors.borderPrimary
+        tableView?.backgroundColor = currentTheme().colors.layer1
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

I've started grouping changes that are closely related to limit the number of PRs while trying to keep them small, see commit history for details. Let me know if that's too much at once in which case I'll go back to creating one PR per file with violations.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

