### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 2 implicitly_unwrapped_optional violations in SettingsTableViewController and resolve susequent build errors

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -60,17 +60,21 @@ class AdvancedAccountSettingViewController: SettingsTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = .SettingsAdvancedAccountTitle
-        self.customFxAContentURI = self.profile.prefs.stringForKey(PrefsKeys.KeyCustomFxAContentServer)
-        self.customSyncTokenServerURI = self.profile.prefs.stringForKey(PrefsKeys.KeyCustomSyncTokenServerOverride)
+        customFxAContentURI = self.profile?.prefs.stringForKey(PrefsKeys.KeyCustomFxAContentServer)
+        customSyncTokenServerURI = self.profile?.prefs.stringForKey(PrefsKeys.KeyCustomSyncTokenServerOverride)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        RustFirefoxAccounts.reconfig(prefs: profile.prefs) { _ in }
+        if let profile {
+            RustFirefoxAccounts.reconfig(prefs: profile.prefs) { _ in }
+        }
     }
 
     override func generateSettings() -> [SettingSection] {
-        let prefs = profile.prefs
+        guard let prefs = profile?.prefs else {
+            return []
+        }
 
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         let attributes = [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]

--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -90,27 +90,32 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
             return setting
         }
 
-        let enabledSetting = BoolSetting(
-            prefs: profile.prefs,
-            prefKey: ContentBlockingConfig.Prefs.EnabledKey,
-            defaultValue: ContentBlockingConfig.Defaults.NormalBrowsing,
-            attributedTitleText: NSAttributedString(string: .TrackingProtectionEnableTitle)) { [weak self] enabled in
-                TabContentBlocker.prefsChanged()
-                strengthSetting.forEach { item in
-                    item.enabled = enabled
-                }
-                self?.tableView.reloadData()
-                TelemetryWrapper.recordEvent(category: .action,
-                                             method: .tap,
-                                             object: .trackingProtectionMenu,
-                                             extras: [TelemetryWrapper.EventExtraKey.etpEnabled.rawValue: enabled] )
-        }
+        var sections: [SettingSection] = []
 
-        let firstSection = SettingSection(
-            title: nil,
-            footerTitle: NSAttributedString(string: .TrackingProtectionCellFooter),
-            children: [enabledSetting]
-        )
+        if let profile {
+            let enabledSetting = BoolSetting(
+                prefs: profile.prefs,
+                prefKey: ContentBlockingConfig.Prefs.EnabledKey,
+                defaultValue: ContentBlockingConfig.Defaults.NormalBrowsing,
+                attributedTitleText: NSAttributedString(string: .TrackingProtectionEnableTitle)) { [weak self] enabled in
+                    TabContentBlocker.prefsChanged()
+                    strengthSetting.forEach { item in
+                        item.enabled = enabled
+                    }
+                    self?.tableView.reloadData()
+                    TelemetryWrapper.recordEvent(category: .action,
+                                                 method: .tap,
+                                                 object: .trackingProtectionMenu,
+                                                 extras: [TelemetryWrapper.EventExtraKey.etpEnabled.rawValue: enabled] )
+            }
+
+            let firstSection = SettingSection(
+                title: nil,
+                footerTitle: NSAttributedString(string: .TrackingProtectionCellFooter),
+                children: [enabledSetting]
+            )
+            sections.append(firstSection)
+        }
 
         let optionalFooterTitle = NSAttributedString(string: .TrackingProtectionLevelFooter)
 
@@ -122,7 +127,9 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
             footerTitle: optionalFooterTitle,
             children: strengthSetting
         )
-        return [firstSection, secondSection]
+        sections.append(secondSection)
+
+        return sections
     }
 
     private func recordEventOnChecked(option: BlockingStrength) {

--- a/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/CustomSearchViewController.swift
@@ -69,7 +69,7 @@ class CustomSearchViewController: SettingsTableViewController {
             do {
                 let engine = try await createEngine(query: trimmedQuery, name: trimmedTitle)
                 self.spinnerView.stopAnimating()
-                self.profile.searchEnginesManager.addSearchEngine(engine)
+                self.profile?.searchEnginesManager.addSearchEngine(engine)
 
                 CATransaction.begin() // Use transaction to call callback after animation has been completed
                 CATransaction.setCompletionBlock(self.successCallback)
@@ -124,6 +124,7 @@ class CustomSearchViewController: SettingsTableViewController {
     }
 
     private func engineExists(name: String, template: String) -> Bool {
+        guard let profile else { return false }
         return profile.searchEnginesManager.orderedEngines.contains { (engine) -> Bool in
             return engine.shortName == name || engine.searchTemplate == template
         }
@@ -309,6 +310,8 @@ class CustomSearchEngineTextView: Setting, UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         placeholderLabel.isHidden = !textField.text.isEmpty
         settingDidChange?(textView.text)
+
+        guard let theme else { return }
         let color = isValid(textField.text) ? theme.colors.textPrimary : theme.colors.textCritical
         textField.textColor = color
     }

--- a/firefox-ios/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/FirefoxSuggestSettingsViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 /// A view controller that manages the hidden Firefox Suggest debug settings.
 class FirefoxSuggestSettingsViewController: SettingsTableViewController, FeatureFlaggable {
-    init(profile: Profile, windowUUID: WindowUUID) {
+    init(profile: Profile?, windowUUID: WindowUUID) {
         super.init(style: .grouped, windowUUID: windowUUID)
         self.profile = profile
         self.title = "Firefox Suggest"
@@ -48,16 +48,17 @@ class FirefoxSuggestSettingsViewController: SettingsTableViewController, Feature
 /// A Firefox Suggest debug setting that downloads and stores new suggestions
 /// immediately, without waiting for the background ingestion task to run.
 class ForceFirefoxSuggestIngestSetting: Setting {
-    let profile: Profile
+    let profile: Profile?
     let logger: Logger
 
-    init(profile: Profile, logger: Logger = DefaultLogger.shared) {
+    init(profile: Profile?, logger: Logger = DefaultLogger.shared) {
         self.profile = profile
         self.logger = logger
         super.init()
     }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(string: "Ingest new suggestions now",
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
@@ -69,7 +70,7 @@ class ForceFirefoxSuggestIngestSetting: Setting {
                        level: .info,
                        category: .storage)
             do {
-                try await self.profile.firefoxSuggest?.ingest()
+                try await self.profile?.firefoxSuggest?.ingest()
                 logger.log("Successfully ingested new suggestions",
                            level: .info,
                            category: .storage)

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -132,36 +132,15 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             format: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStoriesSubtitle,
             PocketAppName.shortName.rawValue)
 
-        let pocketSetting = BoolSetting(
-            prefs: profile.prefs,
-            theme: themeManager.getCurrentTheme(for: windowUUID),
-            prefKey: PrefsKeys.UserFeatureFlagPrefs.ASPocketStories,
-            defaultValue: true,
-            titleText: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStories,
-            statusText: pocketStatusText
-        )
-
         let jumpBackInSetting = BoolSetting(
             with: .jumpBackIn,
             titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.JumpBackIn)
-        )
-
-        let bookmarksSetting = BoolSetting(
-            prefs: profile.prefs,
-            theme: themeManager.getCurrentTheme(for: windowUUID),
-            prefKey: PrefsKeys.UserFeatureFlagPrefs.BookmarksSection,
-            defaultValue: true,
-            titleText: .Settings.Homepage.CustomizeFirefoxHome.Bookmarks
         )
 
         let historyHighlightsSetting = BoolSetting(
             with: .historyHighlights,
             titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.RecentlyVisited)
         )
-        let wallpaperSetting = WallpaperSettings(settings: self,
-                                                 settingsDelegate: settingsDelegate,
-                                                 tabManager: tabManager,
-                                                 wallpaperManager: wallpaperManager)
 
         // Section ordering
         sectionItems.append(TopSitesSettings(settings: self))
@@ -170,17 +149,40 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             sectionItems.append(jumpBackInSetting)
         }
 
-        sectionItems.append(bookmarksSetting)
+        if let profile {
+            let bookmarksSetting = BoolSetting(
+                prefs: profile.prefs,
+                theme: themeManager.getCurrentTheme(for: windowUUID),
+                prefKey: PrefsKeys.UserFeatureFlagPrefs.BookmarksSection,
+                defaultValue: true,
+                titleText: .Settings.Homepage.CustomizeFirefoxHome.Bookmarks
+            )
+            sectionItems.append(bookmarksSetting)
+        }
 
         if isHistoryHighlightsSectionEnabled {
             sectionItems.append(historyHighlightsSetting)
         }
 
-        if isPocketSectionEnabled {
+        if isPocketSectionEnabled, let profile {
+            let pocketSetting = BoolSetting(
+                prefs: profile.prefs,
+                theme: themeManager.getCurrentTheme(for: windowUUID),
+                prefKey: PrefsKeys.UserFeatureFlagPrefs.ASPocketStories,
+                defaultValue: true,
+                titleText: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStories,
+                statusText: pocketStatusText
+            )
             sectionItems.append(pocketSetting)
         }
 
-        if isWallpaperSectionEnabled {
+        if isWallpaperSectionEnabled, let tabManager {
+            let wallpaperSetting = WallpaperSettings(
+                settings: self,
+                settingsDelegate: settingsDelegate,
+                tabManager: tabManager,
+                wallpaperManager: wallpaperManager
+            )
             sectionItems.append(wallpaperSetting)
         }
 
@@ -256,7 +258,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
 // MARK: - TopSitesSettings
 extension HomePageSettingViewController {
     class TopSitesSettings: Setting, FeatureFlaggable {
-        var profile: Profile
+        var profile: Profile?
         let windowUUID: WindowUUID
 
         override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
@@ -265,7 +267,8 @@ extension HomePageSettingViewController {
         }
         override var style: UITableViewCell.CellStyle { return .value1 }
 
-        override var status: NSAttributedString {
+        override var status: NSAttributedString? {
+            guard let profile else { return nil }
             let areShortcutsOn = profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.TopSiteSection) ?? true
             typealias Shortcuts = String.Settings.Homepage.Shortcuts
             let status: String = areShortcutsOn ? Shortcuts.ToggleOn : Shortcuts.ToggleOff

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -28,45 +28,47 @@ class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlagga
 
     // MARK: - Methods
     override func generateSettings() -> [SettingSection] {
-        var sections = [Setting]()
-        let topSitesSetting = BoolSetting(
-            prefs: profile.prefs,
-            theme: themeManager.getCurrentTheme(for: windowUUID),
-            prefKey: PrefsKeys.UserFeatureFlagPrefs.TopSiteSection,
-            defaultValue: true,
-            titleText: .Settings.Homepage.Shortcuts.ShortcutsToggle
-        )
-        sections.append(topSitesSetting)
+        var sections: [SettingSection] = []
 
-        let sponsoredShortcutSetting = BoolSetting(
-            prefs: profile.prefs,
-            theme: themeManager.getCurrentTheme(for: windowUUID),
-            prefKey: PrefsKeys.UserFeatureFlagPrefs.SponsoredShortcuts,
-            defaultValue: true,
-            titleText: .Settings.Homepage.Shortcuts.SponsoredShortcutsToggle
-        )
-        sections.append(sponsoredShortcutSetting)
-
-        let toggleSection = SettingSection(title: nil,
-                                           children: sections)
+        if let profile {
+            let toggleSettings = [
+                BoolSetting(
+                    prefs: profile.prefs,
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    prefKey: PrefsKeys.UserFeatureFlagPrefs.TopSiteSection,
+                    defaultValue: true,
+                    titleText: .Settings.Homepage.Shortcuts.ShortcutsToggle
+                ),
+                BoolSetting(
+                    prefs: profile.prefs,
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    prefKey: PrefsKeys.UserFeatureFlagPrefs.SponsoredShortcuts,
+                    defaultValue: true,
+                    titleText: .Settings.Homepage.Shortcuts.SponsoredShortcutsToggle
+                )
+            ]
+            let toggleSection = SettingSection(title: nil, children: toggleSettings)
+            sections.append(toggleSection)
+        }
 
         let rowSetting = RowSettings(settings: self)
         let rowSection = SettingSection(title: nil, children: [rowSetting])
+        sections.append(rowSection)
 
-        return [toggleSection, rowSection]
+        return sections
     }
 }
 
 // MARK: - TopSitesSettings
 extension TopSitesSettingsViewController {
     class RowSettings: Setting {
-        let profile: Profile
+        let profile: Profile?
         let windowUUID: WindowUUID
 
         override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
         override var status: NSAttributedString {
             let defaultValue = TopSitesRowCountSettingsController.defaultNumberOfRows
-            let numberOfRows = profile.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? defaultValue
+            let numberOfRows = profile?.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows) ?? defaultValue
 
             return NSAttributedString(string: String(format: "%d", numberOfRows))
         }
@@ -91,6 +93,7 @@ extension TopSitesSettingsViewController {
         }
 
         override func onClick(_ navigationController: UINavigationController?) {
+            guard let profile else { return }
             let viewController = TopSitesRowCountSettingsController(prefs: profile.prefs, windowUUID: windowUUID)
             viewController.profile = profile
             navigationController?.pushViewController(viewController, animated: true)

--- a/firefox-ios/Client/Frontend/Settings/Main/About/AppStoreReviewSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/About/AppStoreReviewSetting.swift
@@ -7,6 +7,7 @@ import Foundation
 /// Opens the App Store review page of this app
 class AppStoreReviewSetting: Setting {
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(string: .Settings.About.RateOnAppStore,
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/About/LicenseAndAcknowledgementsSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/About/LicenseAndAcknowledgementsSetting.swift
@@ -8,6 +8,7 @@ import Shared
 /// Opens the license page in a new tab
 class LicenseAndAcknowledgementsSetting: Setting {
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(string: .AppSettingsLicenses,
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/About/VersionSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/About/VersionSetting.swift
@@ -22,6 +22,7 @@ class VersionSetting: Setting {
     }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(string: versionString,
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/About/YourRightsSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/About/YourRightsSetting.swift
@@ -7,6 +7,7 @@ import Foundation
 /// Opens about:rights page in the content view controller
 class YourRightsSetting: Setting {
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(string: .AppSettingsYourRights,
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/AccountStatusSetting.swift
@@ -37,11 +37,12 @@ class AccountStatusSetting: WithAccountSetting {
     }
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
     override var title: NSAttributedString? {
-        guard let profile = RustFirefoxAccounts.shared.userProfile else { return nil }
+        guard let profile = RustFirefoxAccounts.shared.userProfile, let theme else { return nil }
 
         let string = profile.displayName ?? profile.email
 
@@ -54,20 +55,18 @@ class AccountStatusSetting: WithAccountSetting {
     }
 
     override var status: NSAttributedString? {
-        if RustFirefoxAccounts.shared.isActionNeeded {
-            let string: String = .FxAAccountVerifyPassword
-            let color = theme.colors.textCritical
-            let range = NSRange(location: 0, length: string.count)
-            let attrs = [NSAttributedString.Key.foregroundColor: color]
-            let res = NSMutableAttributedString(string: string)
-            res.setAttributes(attrs, range: range)
-            return res
-        }
-        return nil
+        guard RustFirefoxAccounts.shared.isActionNeeded, let theme else { return nil }
+        let string: String = .FxAAccountVerifyPassword
+        let color = theme.colors.textCritical
+        let range = NSRange(location: 0, length: string.count)
+        let attrs = [NSAttributedString.Key.foregroundColor: color]
+        let res = NSMutableAttributedString(string: string)
+        res.setAttributes(attrs, range: range)
+        return res
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        guard !profile.rustFxA.accountNeedsReauth() else {
+        guard let profile, !profile.rustFxA.accountNeedsReauth() else {
             TelemetryWrapper.recordEvent(category: .firefoxAccount, method: .view, object: .settings)
             settingsDelegate?.pressedToShowFirefoxAccount()
             return

--- a/firefox-ios/Client/Frontend/Settings/Main/Account/AdvancedAccountSettings.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/AdvancedAccountSettings.swift
@@ -7,10 +7,11 @@ import Foundation
 // Shown only when debug menu is active
 class AdvancedAccountSetting: HiddenSetting {
     private weak var settingsDelegate: AccountSettingsDelegate?
-    private let profile: Profile
+    private let profile: Profile?
     private let isHidden: Bool
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
@@ -19,6 +20,7 @@ class AdvancedAccountSetting: HiddenSetting {
     }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(
             string: .SettingsAdvancedAccountTitle,
             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]
@@ -39,6 +41,6 @@ class AdvancedAccountSetting: HiddenSetting {
     }
 
     override var hidden: Bool {
-        return !isHidden || profile.hasAccount()
+        return !isHidden || (profile?.hasAccount() ?? false)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/Account/ChinaSyncServiceSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/ChinaSyncServiceSetting.swift
@@ -13,26 +13,25 @@ class ChinaSyncServiceSetting: Setting {
     private var prefs: Prefs { return profile.prefs }
     private let prefKey = PrefsKeys.KeyEnableChinaSyncService
     private let profile: Profile
-    private let settings: UIViewController
 
     override var accessoryType: UITableViewCell.AccessoryType { return .none }
 
     override var hidden: Bool { return !AppInfo.isChinaEdition }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(string: "本地同步服务",
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 
     override var status: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(string: "禁用后使用全球服务同步数据",
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textSecondary])
     }
 
-    init(settings: SettingsTableViewController,
-         settingsDelegate: SharedSettingsDelegate?) {
-        self.profile = settings.profile
-        self.settings = settings
+    init(profile: Profile, settingsDelegate: SharedSettingsDelegate?) {
+        self.profile = profile
         self.settingsDelegate = settingsDelegate
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
@@ -11,10 +11,12 @@ class ConnectSetting: WithoutAccountSetting {
     private weak var settingsDelegate: AccountSettingsDelegate?
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(string: .Settings.Sync.ButtonTitle,
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -43,7 +43,9 @@ class SyncNowSetting: WithAccountSetting {
         return formatter
     }()
 
-    private var syncNowTitle: NSAttributedString {
+    private var syncNowTitle: NSAttributedString? {
+        guard let theme else { return nil }
+
         if !DeviceInfo.hasConnectivity() {
             return NSAttributedString(
                 string: .FxANoInternetConnection,
@@ -81,6 +83,7 @@ class SyncNowSetting: WithAccountSetting {
     override var accessoryType: UITableViewCell.AccessoryType { return .none }
 
     override var image: UIImage? {
+        guard let profile, let theme else { return nil }
         guard let syncStatus = profile.syncManager.syncDisplayState else {
             return syncIcon?.tinted(withColor: theme.colors.iconPrimary)
         }
@@ -94,7 +97,7 @@ class SyncNowSetting: WithAccountSetting {
     }
 
     override var title: NSAttributedString? {
-        guard let syncStatus = profile.syncManager.syncDisplayState else {
+        guard let profile, let theme, let syncStatus = profile.syncManager.syncDisplayState else {
             return syncNowTitle
         }
 
@@ -113,15 +116,20 @@ class SyncNowSetting: WithAccountSetting {
         case .inProgress:
             return NSAttributedString(
                 string: .SyncingMessageWithEllipsis,
-                attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary,
-                             NSAttributedString.Key.font: FXFontStyles.Regular.body.scaledFont()])
+                attributes: [
+                    NSAttributedString.Key.foregroundColor: theme.colors.textPrimary,
+                    NSAttributedString.Key.font: FXFontStyles.Regular.body.scaledFont()
+                ]
+            )
         default:
             return syncNowTitle
         }
     }
 
     override var status: NSAttributedString? {
-        guard let timestamp = profile.syncManager.lastSyncFinishTime else { return nil }
+        guard let profile, let theme, let timestamp = profile.syncManager.lastSyncFinishTime else {
+            return nil
+        }
 
         let formattedLabel = timestampFormatter.string(from: Date.fromTimestamp(timestamp))
         let attributedString = NSMutableAttributedString(string: formattedLabel)
@@ -142,7 +150,7 @@ class SyncNowSetting: WithAccountSetting {
                 return false
             }
 
-            return profile.hasSyncableAccount()
+            return profile?.hasSyncableAccount() ?? false
         }
         // swiftlint:disable unused_setter_value
         set { }
@@ -150,10 +158,10 @@ class SyncNowSetting: WithAccountSetting {
     }
 
     private lazy var troubleshootButton: UIButton = .build { [weak self] troubleshootButton in
-        guard let self = self else { return }
+        guard let self = self, let theme = self.theme else { return }
         troubleshootButton.setTitle(.FirefoxSyncTroubleshootTitle, for: .normal)
         troubleshootButton.addTarget(self, action: #selector(self.troubleshoot), for: .touchUpInside)
-        troubleshootButton.setTitleColor(self.theme.colors.textCritical, for: .normal)
+        troubleshootButton.setTitleColor(theme.colors.textCritical, for: .normal)
         troubleshootButton.titleLabel?.font = FXFontStyles.Regular.caption1.scaledFont()
     }
 
@@ -165,15 +173,15 @@ class SyncNowSetting: WithAccountSetting {
     }
 
     private lazy var warningIcon: UIImageView = {
-        let image = UIImage(named: StandardImageIdentifiers.Large.warningFill)?
-            .tinted(withColor: theme.colors.iconCritical)
-        return UIImageView(image: image)
+        let image = UIImage(named: StandardImageIdentifiers.Large.warningFill)
+        guard let theme else { return UIImageView(image: image) }
+        return UIImageView(image: image?.tinted(withColor: theme.colors.iconCritical))
     }()
 
     private lazy var errorIcon: UIImageView = {
-        let image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.warningFill)?
-            .tinted(withColor: theme.colors.iconCritical)
-        return UIImageView(image: image)
+        let image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.warningFill)
+        guard let theme else { return UIImageView(image: image) }
+        return UIImageView(image: image?.tinted(withColor: theme.colors.iconCritical))
     }()
 
     private let syncSUMOURL = SupportUtils.URLForTopic("sync-status-ios")
@@ -188,7 +196,7 @@ class SyncNowSetting: WithAccountSetting {
         cell.textLabel?.attributedText = title
         cell.textLabel?.numberOfLines = 0
         cell.textLabel?.lineBreakMode = .byWordWrapping
-        if let syncStatus = profile.syncManager.syncDisplayState {
+        if let syncStatus = profile?.syncManager.syncDisplayState {
             switch syncStatus {
             case .bad(let message):
                 if message != nil {
@@ -215,7 +223,7 @@ class SyncNowSetting: WithAccountSetting {
             cell.accessoryView = nil
         }
         cell.accessoryType = accessoryType
-        cell.isUserInteractionEnabled = !profile.syncManager.isSyncing && DeviceInfo.hasConnectivity()
+        cell.isUserInteractionEnabled = !(profile?.syncManager.isSyncing ?? false) && DeviceInfo.hasConnectivity()
 
         // Animation that loops continuously until stopped
         continuousRotateAnimation.fromValue = 0.0
@@ -234,7 +242,7 @@ class SyncNowSetting: WithAccountSetting {
         cell.imageView?.image = syncIconWrapper
         cell.imageView?.addSubview(imageView)
 
-        if let syncStatus = profile.syncManager.syncDisplayState {
+        if let syncStatus = profile?.syncManager.syncDisplayState {
             switch syncStatus {
             case .inProgress:
                 self.startRotateSyncIcon()
@@ -258,7 +266,7 @@ class SyncNowSetting: WithAccountSetting {
             return
         }
 
-        profile.syncManager.syncEverything(why: .user)
-        profile.pollCommands(forcePoll: true)
+        profile?.syncManager.syncEverything(why: .user)
+        profile?.pollCommands(forcePoll: true)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -330,9 +330,11 @@ class AppSettingsTableViewController: SettingsTableViewController,
             OpenWithSetting(settings: self, settingsDelegate: parentCoordinator),
             ThemeSetting(settings: self, settingsDelegate: parentCoordinator),
             SiriPageSetting(settings: self, settingsDelegate: parentCoordinator),
-            BlockPopupSetting(settings: self),
             NoImageModeSetting(settings: self),
         ]
+        if let prefs = profile?.prefs {
+            generalSettings.insert(BlockPopupSetting(prefs: prefs), at: 6)
+        }
 
         if isSearchBarLocationFeatureEnabled {
             generalSettings.insert(SearchBarSetting(settings: self, settingsDelegate: parentCoordinator), at: 5)

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -208,8 +208,8 @@ class AppSettingsTableViewController: SettingsTableViewController,
             )
 
             sendTechnicalDataSettings.shouldSendData = { [weak self] value in
-                guard let self else { return }
-                TermsOfServiceManager(prefs: self.profile.prefs).shouldSendTechnicalData(value: value)
+                guard let self, let profile = self.profile else { return }
+                TermsOfServiceManager(prefs: profile.prefs).shouldSendTechnicalData(value: value)
                 studiesSetting.updateSetting(for: value)
             }
             sendTechnicalDataSetting = sendTechnicalDataSettings
@@ -249,8 +249,8 @@ class AppSettingsTableViewController: SettingsTableViewController,
             )
 
             sendAnonymousUsageDataSettings.shouldSendData = { [weak self] value in
-                guard let self else { return }
-                TermsOfServiceManager(prefs: self.profile.prefs).shouldSendTechnicalData(value: value)
+                guard let self, let profile = self.profile else { return }
+                TermsOfServiceManager(prefs: profile.prefs).shouldSendTechnicalData(value: value)
                 studiesSetting.updateSetting(for: value)
             }
             sendAnonymousUsageDataSetting = sendAnonymousUsageDataSettings

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -301,29 +301,25 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getAccountSetting() -> [SettingSection] {
-        let accountChinaSyncSetting: [Setting]
-        if !AppInfo.isChinaEdition {
-            accountChinaSyncSetting = []
-        } else {
-            accountChinaSyncSetting = [
-                // Show China sync service setting:
-                ChinaSyncServiceSetting(settings: self, settingsDelegate: self)
-            ]
-        }
-
         let accountSectionTitle = NSAttributedString(string: .FxAFirefoxAccount)
 
         let attributedString = NSAttributedString(string: .Settings.Sync.ButtonDescription)
         let accountFooterText = !(profile?.hasAccount() ?? false) ? attributedString : nil
 
-        return [SettingSection(title: accountSectionTitle, footerTitle: accountFooterText, children: [
+        var settings = [
             // Without a Firefox Account:
             ConnectSetting(settings: self, settingsDelegate: parentCoordinator),
             AdvancedAccountSetting(settings: self, isHidden: showDebugSettings, settingsDelegate: parentCoordinator),
             // With a Firefox Account:
             AccountStatusSetting(settings: self, settingsDelegate: parentCoordinator),
             SyncNowSetting(settings: self, settingsDelegate: parentCoordinator)
-        ] + accountChinaSyncSetting)]
+        ]
+        if AppInfo.isChinaEdition, let profile {
+            settings.append(ChinaSyncServiceSetting(profile: profile, settingsDelegate: self))
+        }
+        return [
+            SettingSection(title: accountSectionTitle, footerTitle: accountFooterText, children: settings)
+        ]
     }
 
     private func getGeneralSettings() -> [SettingSection] {

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -330,10 +330,12 @@ class AppSettingsTableViewController: SettingsTableViewController,
             OpenWithSetting(settings: self, settingsDelegate: parentCoordinator),
             ThemeSetting(settings: self, settingsDelegate: parentCoordinator),
             SiriPageSetting(settings: self, settingsDelegate: parentCoordinator),
-            NoImageModeSetting(settings: self),
         ]
-        if let prefs = profile?.prefs {
-            generalSettings.insert(BlockPopupSetting(prefs: prefs), at: 6)
+        if let profile {
+            generalSettings += [
+                BlockPopupSetting(prefs: profile.prefs),
+                NoImageModeSetting(profile: profile)
+            ]
         }
 
         if isSearchBarLocationFeatureEnabled {

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -338,8 +338,11 @@ class AppSettingsTableViewController: SettingsTableViewController,
             ]
         }
 
-        if isSearchBarLocationFeatureEnabled {
-            generalSettings.insert(SearchBarSetting(settings: self, settingsDelegate: parentCoordinator), at: 5)
+        if isSearchBarLocationFeatureEnabled, let profile {
+            generalSettings.insert(
+                SearchBarSetting(settings: self, profile: profile, settingsDelegate: parentCoordinator),
+                at: 5
+            )
         }
 
         let inactiveTabsAreBuildActive = featureFlags.isFeatureEnabled(.inactiveTabs, checking: .buildOnly)

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/AppDataUsageReportSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/AppDataUsageReportSetting.swift
@@ -7,6 +7,7 @@ import Common
 
 class AppDataUsageReportSetting: HiddenSetting {
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         // Not localized for now.
         return NSAttributedString(string: "App Data Usage Report",
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/AppReviewPromptSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/AppReviewPromptSetting.swift
@@ -15,6 +15,7 @@ class AppReviewPromptSetting: HiddenSetting {
     }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(
             string: "Toggle App Review (needs tab switch)",
             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeToChinaSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeToChinaSetting.swift
@@ -7,6 +7,7 @@ import Foundation
 
 class ChangeToChinaSetting: HiddenSetting {
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(
             string: "Toggle China version (needs restart)",
             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/DeleteExportedDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/DeleteExportedDataSetting.swift
@@ -6,6 +6,7 @@ import Foundation
 
 class DeleteExportedDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         // Not localized for now.
         return NSAttributedString(
             string: "Delete exported databases",

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ExportBrowserDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ExportBrowserDataSetting.swift
@@ -6,6 +6,7 @@ import Foundation
 
 class ExportBrowserDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         // Not localized for now.
         return NSAttributedString(
             string: "Copy databases to app container",
@@ -16,7 +17,8 @@ class ExportBrowserDataSetting: HiddenSetting {
     override func onClick(_ navigationController: UINavigationController?) {
         let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
         do {
-            try self.settings.profile.files.copyMatching(
+            guard let profile  = self.settings.profile else { return }
+            try profile.files.copyMatching(
                 fromRelativeDirectory: "",
                 toAbsoluteDirectory: documentsPath
             ) { file in

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ExportLogDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ExportLogDataSetting.swift
@@ -7,6 +7,7 @@ import Foundation
 
 class ExportLogDataSetting: HiddenSetting {
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         // Not localized for now.
         return NSAttributedString(
             string: "Copy log files to app container",

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FasterInactiveTabs.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FasterInactiveTabs.swift
@@ -48,6 +48,7 @@ class FasterInactiveTabs: HiddenSetting {
     }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         let rawValue = UserDefaults.standard.integer(forKey: PrefsKeys.FasterInactiveTabsOverride)
         let fasterInactiveTabOption = FasterInactiveTabsOption(rawValue: rawValue) ?? .normal
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -31,10 +31,11 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     titleText: format(string: "Enable Bookmarks Redesign"),
                     statusText: format(string: "Toggle to use the new bookmarks design")
                 ) { [weak self] _ in
-                    self?.reloadView()
-                    let isBookmarksRefactorEnabled = self?.featureFlags.isFeatureEnabled(.bookmarksRefactor,
-                                                                                         checking: .buildOnly) ?? false
-                    self?.profile.prefs.setBool(isBookmarksRefactorEnabled, forKey: PrefsKeys.IsBookmarksRefactorEnabled)
+                    guard let self else { return }
+                    self.reloadView()
+                    let isBookmarksRefactorEnabled = self.featureFlags.isFeatureEnabled(.bookmarksRefactor,
+                                                                                        checking: .buildOnly)
+                    self.profile?.prefs.setBool(isBookmarksRefactorEnabled, forKey: PrefsKeys.IsBookmarksRefactorEnabled)
                 },
                 FeatureFlagsBoolSetting(
                     with: .closeRemoteTabs,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ForceCrashSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ForceCrashSetting.swift
@@ -6,6 +6,7 @@ import Foundation
 
 class ForceCrashSetting: HiddenSetting {
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(
             string: "Force Crash 💥",
             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/OpenFiftyTabsDebugOption.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/OpenFiftyTabsDebugOption.swift
@@ -15,6 +15,7 @@ class OpenFiftyTabsDebugOption: HiddenSetting {
     }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(
             string: "Open 50 `mozilla.org` tabs ⚠️",
             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ResetContextualHints.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ResetContextualHints.swift
@@ -6,11 +6,12 @@ import Foundation
 import Shared
 
 class ResetContextualHints: HiddenSetting {
-    let profile: Profile
+    let profile: Profile?
 
     override var accessibilityIdentifier: String? { return "ResetContextualHints.Setting" }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(
             string: "Reset all contextual hints",
             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
@@ -23,7 +24,7 @@ class ResetContextualHints: HiddenSetting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         PrefsKeys.ContextualHints.allCases.forEach {
-            self.profile.prefs.removeObjectForKey($0.rawValue)
+            self.profile?.prefs.removeObjectForKey($0.rawValue)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ResetWallpaperOnboardingPage.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ResetWallpaperOnboardingPage.swift
@@ -15,6 +15,7 @@ class ResetWallpaperOnboardingPage: HiddenSetting {
     }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         let seenStatus = UserDefaults.standard.bool(forKey: PrefsKeys.Wallpapers.OnboardingSeenKey) ? "seen" : "unseen"
         return NSAttributedString(string: "Reset wallpaper onboarding sheet (\(seenStatus))",
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/SentryIDSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/SentryIDSetting.swift
@@ -13,6 +13,7 @@ class SentryIDSetting: HiddenSetting {
     )?.string(forKey: "SentryDeviceAppHash")
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(
             string: "Sentry ID \(deviceAppHash ?? "(null)")",
             attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/SwitchFakespotProduction.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/SwitchFakespotProduction.swift
@@ -15,6 +15,7 @@ class SwitchFakespotProduction: HiddenSetting, FeatureFlaggable {
     }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         let toNewStatus = featureFlags.isCoreFeatureEnabled(.useStagingFakespotAPI) ? "prod" : "staging"
         return NSAttributedString(string: "Switch FakespotEndpoint to \(toNewStatus)",
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ToggleInactiveTabs.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ToggleInactiveTabs.swift
@@ -14,6 +14,7 @@ class ToggleInactiveTabs: HiddenSetting, FeatureFlaggable {
     }
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         let toNewStatus = featureFlags.isFeatureEnabled(.inactiveTabs, checking: .userOnly) ? "OFF" : "ON"
         return NSAttributedString(string: "Toggle inactive tabs \(toNewStatus)",
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])

--- a/firefox-ios/Client/Frontend/Settings/Main/General/BlockPopupSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/BlockPopupSetting.swift
@@ -6,15 +6,15 @@ import Foundation
 import Shared
 
 class BlockPopupSetting: BoolSetting {
-    init(settings: SettingsTableViewController) {
-        let currentValue = settings.profile.prefs.boolForKey(PrefsKeys.KeyBlockPopups)
+    init(prefs: Prefs) {
+        let currentValue = prefs.boolForKey(PrefsKeys.KeyBlockPopups)
         let didChange = { (isEnabled: Bool) in
             NotificationCenter.default.post(name: .BlockPopup,
                                             object: nil)
         }
 
         super.init(title: .AppSettingsBlockPopups,
-                   prefs: settings.profile.prefs,
+                   prefs: prefs,
                    prefKey: PrefsKeys.KeyBlockPopups,
                    defaultValue: currentValue ?? true) { isEnabled in
             didChange(isEnabled)

--- a/firefox-ios/Client/Frontend/Settings/Main/General/HomeSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/HomeSetting.swift
@@ -6,9 +6,10 @@ import Foundation
 
 class HomeSetting: Setting {
     private weak var settingsDelegate: GeneralSettingsDelegate?
-    private let profile: Profile
+    private let profile: Profile?
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
@@ -16,8 +17,9 @@ class HomeSetting: Setting {
         return AccessibilityIdentifiers.Settings.Homepage.homeSettings
     }
 
-    override var status: NSAttributedString {
-        return NSAttributedString(string: NewTabAccessors.getHomePage(self.profile.prefs).settingTitle)
+    override var status: NSAttributedString? {
+        guard let profile else { return nil }
+        return NSAttributedString(string: NewTabAccessors.getHomePage(profile.prefs).settingTitle)
     }
 
     override var style: UITableViewCell.CellStyle { return .value1 }

--- a/firefox-ios/Client/Frontend/Settings/Main/General/NewTabPageSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/NewTabPageSetting.swift
@@ -5,10 +5,11 @@
 import Foundation
 
 class NewTabPageSetting: Setting {
-    private let profile: Profile
+    private let profile: Profile?
     private weak var settingsDelegate: GeneralSettingsDelegate?
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
@@ -16,8 +17,9 @@ class NewTabPageSetting: Setting {
         return AccessibilityIdentifiers.Settings.NewTab.title
     }
 
-    override var status: NSAttributedString {
-        return NSAttributedString(string: NewTabAccessors.getNewTabPage(self.profile.prefs).settingTitle)
+    override var status: NSAttributedString? {
+        guard let profile else { return nil }
+        return NSAttributedString(string: NewTabAccessors.getNewTabPage(profile.prefs).settingTitle)
     }
 
     override var style: UITableViewCell.CellStyle { return .value1 }

--- a/firefox-ios/Client/Frontend/Settings/Main/General/NoImageModeSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/NoImageModeSetting.swift
@@ -5,14 +5,14 @@
 import Foundation
 
 class NoImageModeSetting: BoolSetting {
-    init(settings: SettingsTableViewController) {
-        let noImageEnabled = NoImageModeHelper.isActivated(settings.profile.prefs)
+    init(profile: Profile) {
+        let noImageEnabled = NoImageModeHelper.isActivated(profile.prefs)
         let didChange = { (isEnabled: Bool) in
-            NoImageModeHelper.toggle(isEnabled: isEnabled, profile: settings.profile)
+            NoImageModeHelper.toggle(isEnabled: isEnabled, profile: profile)
         }
 
         super.init(
-            prefs: settings.profile.prefs,
+            prefs: profile.prefs,
             prefKey: NoImageModePrefsKey.NoImageModeStatus,
             defaultValue: noImageEnabled,
             attributedTitleText: NSAttributedString(string: .Settings.Toggle.NoImageMode),

--- a/firefox-ios/Client/Frontend/Settings/Main/General/OpenWithSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/OpenWithSetting.swift
@@ -8,10 +8,11 @@ import Common
 
 class OpenWithSetting: Setting {
     private weak var settingsDelegate: GeneralSettingsDelegate?
-    private let profile: Profile
+    private let profile: Profile?
     private let windowUUID: WindowUUID
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
@@ -20,7 +21,7 @@ class OpenWithSetting: Setting {
     }
 
     override var status: NSAttributedString {
-        guard let provider = self.profile.prefs.stringForKey(PrefsKeys.KeyMailToOption) else {
+        guard let provider = self.profile?.prefs.stringForKey(PrefsKeys.KeyMailToOption) else {
             return NSAttributedString(string: "")
         }
         if let path = Bundle.main.path(forResource: "MailSchemes", ofType: "plist"),

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SearchBarSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SearchBarSetting.swift
@@ -9,6 +9,7 @@ class SearchBarSetting: Setting {
     private weak var settingsDelegate: GeneralSettingsDelegate?
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
@@ -22,9 +23,10 @@ class SearchBarSetting: Setting {
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
-    init(settings: SettingsTableViewController,
+    init?(settings: SettingsTableViewController,
          settingsDelegate: GeneralSettingsDelegate?) {
-        self.viewModel = SearchBarSettingsViewModel(prefs: settings.profile.prefs)
+        guard let profile = settings.profile else { return nil }
+        self.viewModel = SearchBarSettingsViewModel(prefs: profile.prefs)
         self.settingsDelegate = settingsDelegate
         let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SearchBarSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SearchBarSetting.swift
@@ -23,9 +23,9 @@ class SearchBarSetting: Setting {
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
-    init?(settings: SettingsTableViewController,
+    init(settings: SettingsTableViewController,
+         profile: Profile,
          settingsDelegate: GeneralSettingsDelegate?) {
-        guard let profile = settings.profile else { return nil }
         self.viewModel = SearchBarSettingsViewModel(prefs: profile.prefs)
         self.settingsDelegate = settingsDelegate
         let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SearchSetting.swift
@@ -5,16 +5,18 @@
 import Foundation
 
 class SearchSetting: Setting {
-    private let profile: Profile
+    private let profile: Profile?
     private weak var settingsDelegate: GeneralSettingsDelegate?
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
-    override var status: NSAttributedString {
+    override var status: NSAttributedString? {
+        guard let profile else { return nil }
         return NSAttributedString(
             string: profile.searchEnginesManager.defaultEngine?.shortName ?? ""
         )

--- a/firefox-ios/Client/Frontend/Settings/Main/General/SiriPageSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/SiriPageSetting.swift
@@ -6,9 +6,9 @@ import Foundation
 
 class SiriPageSetting: Setting {
     private weak var settingsDelegate: GeneralSettingsDelegate?
-    private let profile: Profile
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
@@ -18,7 +18,6 @@ class SiriPageSetting: Setting {
 
     init(settings: SettingsTableViewController,
          settingsDelegate: GeneralSettingsDelegate?) {
-        self.profile = settings.profile
         self.settingsDelegate = settingsDelegate
         let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
         super.init(

--- a/firefox-ios/Client/Frontend/Settings/Main/General/TabsSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/TabsSetting.swift
@@ -9,7 +9,10 @@ import Shared
 class TabsSetting: Setting {
     private weak var settingsDelegate: GeneralSettingsDelegate?
 
-    override var accessoryView: UIImageView? { return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme) }
+    override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
+        return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
+    }
 
     override var accessibilityIdentifier: String? {
         return AccessibilityIdentifiers.Settings.Tabs.title

--- a/firefox-ios/Client/Frontend/Settings/Main/General/ThemeSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/ThemeSetting.swift
@@ -7,10 +7,10 @@ import Common
 
 class ThemeSetting: Setting {
     private weak var settingsDelegate: GeneralSettingsDelegate?
-    private let profile: Profile
     private let themeManager: ThemeManager
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
     override var style: UITableViewCell.CellStyle { return .value1 }
@@ -35,7 +35,6 @@ class ThemeSetting: Setting {
          settingsDelegate: GeneralSettingsDelegate?,
          themeManager: ThemeManager = AppContainer.shared.resolve()
     ) {
-        self.profile = settings.profile
         self.settingsDelegate = settingsDelegate
         self.themeManager = themeManager
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/AddressAutofillSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/AddressAutofillSetting.swift
@@ -20,6 +20,7 @@ class AddressAutofillSetting: Setting {
 
     /// The accessory view for the setting, indicating it has additional details.
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/AutofillCreditCardSettings.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/AutofillCreditCardSettings.swift
@@ -6,10 +6,10 @@ import Foundation
 
 class AutofillCreditCardSettings: Setting, FeatureFlaggable {
     private weak var settingsDelegate: PrivacySettingsDelegate?
-    private let profile: Profile
     weak var settings: AppSettingsTableViewController?
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
@@ -19,7 +19,6 @@ class AutofillCreditCardSettings: Setting, FeatureFlaggable {
 
     init(settings: SettingsTableViewController,
          settingsDelegate: PrivacySettingsDelegate?) {
-        self.profile = settings.profile
         self.settings = settings as? AppSettingsTableViewController
         self.settingsDelegate = settingsDelegate
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/ClearPrivateDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/ClearPrivateDataSetting.swift
@@ -5,11 +5,11 @@
 import Foundation
 
 class ClearPrivateDataSetting: Setting {
-    private let profile: Profile
     private var tabManager: TabManager?
     private weak var settingsDelegate: PrivacySettingsDelegate?
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
@@ -17,7 +17,6 @@ class ClearPrivateDataSetting: Setting {
 
     init(settings: SettingsTableViewController,
          settingsDelegate: PrivacySettingsDelegate?) {
-        self.profile = settings.profile
         self.tabManager = settings.tabManager
         self.settingsDelegate = settingsDelegate
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/ContentBlockerSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/ContentBlockerSetting.swift
@@ -6,10 +6,11 @@ import Foundation
 
 class ContentBlockerSetting: Setting {
     private weak var settingsDelegate: PrivacySettingsDelegate?
-    private let profile: Profile
+    private let profile: Profile?
     private var tabManager: TabManager?
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 
@@ -18,6 +19,7 @@ class ContentBlockerSetting: Setting {
     }
 
     override var status: NSAttributedString? {
+        guard let profile else { return nil }
         let defaultValue = ContentBlockingConfig.Defaults.NormalBrowsing
         let isOn = profile.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? defaultValue
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/NotificationsSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/NotificationsSetting.swift
@@ -11,6 +11,7 @@ class NotificationsSetting: Setting {
     private let profile: Profile
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/PasswordManagerSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/PasswordManagerSetting.swift
@@ -8,6 +8,7 @@ class PasswordManagerSetting: Setting {
     private weak var settingsDelegate: PrivacySettingsDelegate?
 
     override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
         return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SendFeedbackSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SendFeedbackSetting.swift
@@ -9,6 +9,7 @@ class SendFeedbackSetting: Setting {
     private weak var settingsDelegate: SupportSettingsDelegate?
 
     override var title: NSAttributedString? {
+        guard let theme else { return nil }
         return NSAttributedString(string: .AppSettingsSendFeedback,
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -32,7 +32,7 @@ class Setting: NSObject {
     private var _footerTitle: NSAttributedString?
     private var _cellHeight: CGFloat?
     private var _image: UIImage?
-    var theme: Theme!
+    var theme: Theme?
 
     weak var delegate: SettingsDelegate?
 
@@ -632,7 +632,7 @@ class StringSetting: Setting, UITextFieldDelegate {
 
     @objc
     func textFieldDidChange(_ textField: UITextField) {
-        let color = isValid(textField.text) ? theme.colors.textPrimary : theme.colors.textCritical
+        let color = isValid(textField.text) ? theme?.colors.textPrimary : theme?.colors.textCritical
         textField.textColor = color
     }
 
@@ -769,7 +769,7 @@ class CheckmarkSetting: Setting {
 class AccountSetting: Setting {
     unowned var settings: SettingsTableViewController
 
-    var profile: Profile {
+    var profile: Profile? {
         return settings.profile
     }
 
@@ -782,7 +782,7 @@ class AccountSetting: Setting {
 
     override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
         super.onConfigureCell(cell, theme: theme)
-        if settings.profile.rustFxA.userProfile != nil {
+        if settings.profile?.rustFxA.userProfile != nil {
             cell.selectionStyle = .none
         }
     }
@@ -791,11 +791,17 @@ class AccountSetting: Setting {
 }
 
 class WithAccountSetting: AccountSetting {
-    override var hidden: Bool { return !profile.hasAccount() }
+    override var hidden: Bool {
+        guard let profile else { return true }
+        return !profile.hasAccount()
+    }
 }
 
 class WithoutAccountSetting: AccountSetting {
-    override var hidden: Bool { return profile.hasAccount() }
+    override var hidden: Bool {
+        guard let profile else { return false }
+        return profile.hasAccount()
+    }
 }
 
 @objc
@@ -816,8 +822,8 @@ class SettingsTableViewController: ThemedTableViewController {
 
     weak var settingsDelegate: SettingsDelegate?
 
-    var profile: Profile!
-    var tabManager: TabManager!
+    var profile: Profile?
+    var tabManager: TabManager?
 
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

This one is ended up growing bigger than others because changing `profile` and `theme` properties to optionals in `SettingsTableViewController` induced quite a lot of safe unwrapping to do in other places to get it to build. Most of it was pretty much straightforward and just involves adding optional unwrapping operators or guard let statements, but let me know if you need some additional clarification!

This shouldn't change anything behaviour wise because those properties were implicitly unwrapped so trying to access them while they are nil would have resulted in a crash, so this is mostly just syntactic changes.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

