### PR TITLE
Bugfix FXIOS-10911 withCheckedThrowingContinuation crash in DefaultHTMLDataRequest.fetchDataForURL

### DIFF
--- a/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/HTMLDataRequest.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconURLProcessing/URLFetcher/HTMLDataRequest.swift
@@ -30,16 +30,11 @@ struct DefaultHTMLDataRequest: HTMLDataRequest {
 
         let urlSession = URLSession(configuration: configuration)
 
-        return try await withCheckedThrowingContinuation { continuation in
-            urlSession.dataTask(with: url) { data, _, error in
-                guard let data = data,
-                      error == nil
-                else {
-                    continuation.resume(throwing: SiteImageError.invalidHTML)
-                    return
-                }
-                continuation.resume(returning: data)
-            }.resume()
+        do {
+            let (data, _) = try await urlSession.data(from: url)
+            return data
+        } catch {
+            throw SiteImageError.invalidHTML
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10911)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23829)

## :bulb: Description
This PR fixes a crash in sentry for iOS 18 devices from `withCheckedThrowingContinuation`. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

