### PR TITLE
Refactor FXIOS-10781 [Bookmarks Evolution] Auto-select the folder that was just created

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -940,6 +940,12 @@
 		8A9AC46B276D11280047F5B0 /* PocketViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9AC46A276D11280047F5B0 /* PocketViewModel.swift */; };
 		8A9B87AD2C1B39100042B894 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9B87AC2C1B39100042B894 /* SearchViewModel.swift */; };
 		8A9B87AF2C1B39EA0042B894 /* SearchListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9B87AE2C1B39EA0042B894 /* SearchListSection.swift */; };
+		8A9D31602D13506400171502 /* MockParentFolderSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D315F2D13506100171502 /* MockParentFolderSelector.swift */; };
+		8A9D31622D13545A00171502 /* EditFolderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31612D13545100171502 /* EditFolderViewModelTests.swift */; };
+		8A9D31642D1355EE00171502 /* MockFxBookmarkNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31632D1355E900171502 /* MockFxBookmarkNode.swift */; };
+		8A9D31662D13586500171502 /* MockFolderHierarchyFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31652D13586100171502 /* MockFolderHierarchyFetcher.swift */; };
+		8A9D31682D135A1300171502 /* MockBookmarksSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31672D135A1300171502 /* MockBookmarksSaver.swift */; };
+		8A9D316A2D135EB000171502 /* EditBookmarkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31692D135EB000171502 /* EditBookmarkViewModelTests.swift */; };
 		8A9E46BD2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9E46BC2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift */; };
 		8A9F0B5627C595F300FE09AE /* ImageIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */; };
 		8A9F0B5727C59E1700FE09AE /* ImageIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */; };
@@ -7536,6 +7542,12 @@
 		8A9AC46A276D11280047F5B0 /* PocketViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketViewModel.swift; sourceTree = "<group>"; };
 		8A9B87AC2C1B39100042B894 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		8A9B87AE2C1B39EA0042B894 /* SearchListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListSection.swift; sourceTree = "<group>"; };
+		8A9D315F2D13506100171502 /* MockParentFolderSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockParentFolderSelector.swift; sourceTree = "<group>"; };
+		8A9D31612D13545100171502 /* EditFolderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditFolderViewModelTests.swift; sourceTree = "<group>"; };
+		8A9D31632D1355E900171502 /* MockFxBookmarkNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFxBookmarkNode.swift; sourceTree = "<group>"; };
+		8A9D31652D13586100171502 /* MockFolderHierarchyFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFolderHierarchyFetcher.swift; sourceTree = "<group>"; };
+		8A9D31672D135A1300171502 /* MockBookmarksSaver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBookmarksSaver.swift; sourceTree = "<group>"; };
+		8A9D31692D135EB000171502 /* EditBookmarkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditBookmarkViewModelTests.swift; sourceTree = "<group>"; };
 		8A9E46BC2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStatusBarScrollDelegate.swift; sourceTree = "<group>"; };
 		8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageIdentifiers.swift; sourceTree = "<group>"; };
 		8AA020EE2B9A37E500771DE0 /* NimbusSplashScreenFeatureLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusSplashScreenFeatureLayer.swift; sourceTree = "<group>"; };
@@ -9881,20 +9893,14 @@
 		0B7CF8852CAC1BFB00DC02F8 /* Bookmarks */ = {
 			isa = PBXGroup;
 			children = (
-				0B7FC3D42CAE82AE005C5CCE /* Mocks */,
+				8A9D31612D13545100171502 /* EditFolderViewModelTests.swift */,
+				8A9D31692D135EB000171502 /* EditBookmarkViewModelTests.swift */,
 				0B7CF8862CAC1C4E00DC02F8 /* DefaultFolderHierarchyFetcherTests.swift */,
 				0B7FC3D12CAE811B005C5CCE /* DefaultBookmarksSaverTests.swift */,
 				8AED868228CA3B3400351A50 /* BookmarkPanelViewModelTests.swift */,
 				0B7CF8842CAC1B7000DC02F8 /* Legacy */,
 			);
 			path = Bookmarks;
-			sourceTree = "<group>";
-		};
-		0B7FC3D42CAE82AE005C5CCE /* Mocks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Mocks;
 			sourceTree = "<group>";
 		};
 		0B8BF3732CA2EB3300E9812D /* Edit Bookmark */ = {
@@ -12761,21 +12767,24 @@
 		C889D7D22858C85200121E1D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				8A9D31672D135A1300171502 /* MockBookmarksSaver.swift */,
+				8A9D31652D13586100171502 /* MockFolderHierarchyFetcher.swift */,
 				45D5EDBF292D619000311934 /* MockablePinnedSites.swift */,
 				2165B2C32860CB34004C0786 /* MockAdjustTelemetryData.swift */,
 				8A359EF52A1FE840004A5BB7 /* MockAdjustWrapper.swift */,
 				434CD57729F6FC4500A0D04B /* MockAppAuthenticator.swift */,
 				8AABBD022A001CBC0089941E /* MockApplicationHelper.swift */,
 				965C3C9729343445006499ED /* MockAppSessionManager.swift */,
-				0AFF7F632C7784D600265214 /* MockDataCleaner.swift */,
 				8A5D1C9F2A30C9D7005AD35C /* MockAppSettingsDelegate.swift */,
 				8A5038132A5DFCE000A1B02A /* MockBrowserProfile.swift */,
 				C8C3FEA029F973C40038E3BA /* MockBrowserViewController.swift */,
 				8AF6D4DE2A856A9000B0474B /* MockContileNetworking.swift */,
 				8AABBD042A0041380089941E /* MockCoordinator.swift */,
-				ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */,
+				0AFF7F632C7784D600265214 /* MockDataCleaner.swift */,
 				8AE80BB42891AE6700BC12EA /* MockDispatchGroup.swift */,
 				8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */,
+				0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */,
+				8A9D31632D1355E900171502 /* MockFxBookmarkNode.swift */,
 				8AABBCFD2A0017560089941E /* MockGleanWrapper.swift */,
 				21B548962B1E6AC300DC1DF8 /* MockInactiveTabsManager.swift */,
 				8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */,
@@ -12788,17 +12797,19 @@
 				5AB4237B28A1947A003BC40C /* MockNotificationCenter.swift */,
 				E18259E229B2A51B00E6BE76 /* MockNotificationManager.swift */,
 				21B41A1B298B1876008BC0A2 /* MockOverlayModeManager.swift */,
+				8A9D315F2D13506100171502 /* MockParentFolderSelector.swift */,
 				8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */,
 				281B2BE91ADF4D90002917DC /* MockProfile.swift */,
-				ED7A08E02CF679CE0035EC8F /* MockShareTab.swift */,
-				ED575BD22D00F9D00056BCDA /* MockTemporaryDocument.swift */,
 				8A7A26E029D4785900EA76F1 /* MockRouter.swift */,
+				ED45893F2CC8220A006F2C0B /* MockSearchEngineSelectionCoordinator.swift */,
 				C8C3FE9C29F907B30038E3BA /* MockSearchHandlerRouteCoordinator.swift */,
 				21D884402A79628E00AF144C /* MockSettingsDelegate.swift */,
 				8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */,
+				ED7A08E02CF679CE0035EC8F /* MockShareTab.swift */,
 				8A9E46BC2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift */,
 				8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */,
 				5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */,
+				ED575BD22D00F9D00056BCDA /* MockTemporaryDocument.swift */,
 				C80C11F228B3CD3E0062922A /* MockTests */,
 				5AA75A622A46272000533F8D /* MockThemeManager.swift */,
 				8AE80BAE2891960300BC12EA /* MockTraitCollection.swift */,
@@ -12806,10 +12817,9 @@
 				5A9A09D528B01FD500B6F51E /* MockURLBarView.swift */,
 				C80C11EF28B3C9150062922A /* MockUserDefaults.swift */,
 				E1463D0529830E4F0074E16E /* MockUserNotificationCenter.swift */,
-				2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */,
 				BA1C68BB2B7ED153000D9397 /* MockWebKit.swift */,
 				1D558A562BED7ECB001EF527 /* MockWindowManager.swift */,
-				0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */,
+				2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -17077,6 +17087,7 @@
 				C2D1A1112A67E73D00205DCC /* BookmarksCoordinatorTests.swift in Sources */,
 				C2200A6A2B7D148C00DC062A /* ContentBlockerTests.swift in Sources */,
 				C869916328918C36007ACC5C /* WallpaperNetworkingModuleTests.swift in Sources */,
+				8A9D31662D13586500171502 /* MockFolderHierarchyFetcher.swift in Sources */,
 				B640467E29B9B58200C5C7B6 /* TabLocationViewTests.swift in Sources */,
 				8ABA9C8D28931223002C0077 /* MockDispatchQueue.swift in Sources */,
 				8CCD74732B90A945008F919B /* LoginListViewModelTests.swift in Sources */,
@@ -17096,6 +17107,7 @@
 				C2446B312A856D13000C527D /* MockLibraryCoordinatorDelegate.swift in Sources */,
 				C869915728917809007ACC5C /* NetworkingMock.swift in Sources */,
 				ED575BD32D00F9D00056BCDA /* MockTemporaryDocument.swift in Sources */,
+				8A9D31682D135A1300171502 /* MockBookmarksSaver.swift in Sources */,
 				8A4190D22A6B0848001E8401 /* StatusBarOverlayTests.swift in Sources */,
 				C8EDDBF029DD83FC003A4C07 /* RouteTests.swift in Sources */,
 				0A7693612C7DD19600103A6D /* CertificatesViewModelTests.swift in Sources */,
@@ -17230,7 +17242,9 @@
 				8A827E322C20C8AE008D5E3C /* MockMicrosurveySurfaceManager.swift in Sources */,
 				39D0DA7629D767DE000760B8 /* NimbusMessagingTriggerTests.swift in Sources */,
 				21B41A1D298B187A008BC0A2 /* MockOverlayModeManager.swift in Sources */,
+				8A9D31642D1355EE00171502 /* MockFxBookmarkNode.swift in Sources */,
 				8A827E302C20C7F5008D5E3C /* MicrosurveyMiddlewareTests.swift in Sources */,
+				8A9D31622D13545A00171502 /* EditFolderViewModelTests.swift in Sources */,
 				21B548992B1E7FDF00DC1DF8 /* InactiveTabsManagerTests.swift in Sources */,
 				8AF6D4DF2A856A9000B0474B /* MockContileNetworking.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
@@ -17312,6 +17326,7 @@
 				5A475E8E29DB89C7009C13FD /* TabManagerTests.swift in Sources */,
 				C88012232A40E38D00F4D1D6 /* IntroViewControllerTests.swift in Sources */,
 				E16E1C9628BFB2E600EE2EF5 /* WallpaperSettingsViewModelTests.swift in Sources */,
+				8A9D31602D13506400171502 /* MockParentFolderSelector.swift in Sources */,
 				E1463D042982D0240074E16E /* NotificationManagerTests.swift in Sources */,
 				8AA0A6682CAC747500AC7EB3 /* HomepageDiffableDataSourceTests.swift in Sources */,
 				3B61CD591F2A750800D38DE1 /* PocketFeedTests.swift in Sources */,
@@ -17323,6 +17338,7 @@
 				8A93F86829D373B0004159D9 /* MockNavigationController.swift in Sources */,
 				8AE1E1D927B1BD380024C45E /* UIStackViewExtensionsTests.swift in Sources */,
 				8A0727492B4898D20071BB9F /* WebviewTelemetryTests.swift in Sources */,
+				8A9D316A2D135EB000171502 /* EditBookmarkViewModelTests.swift in Sources */,
 				3B6F40181DC7849C00656CC6 /* TopSitesViewModelTests.swift in Sources */,
 				8A00BD882CAB401700680AF9 /* HomepageViewControllerTests.swift in Sources */,
 				C869915528917803007ACC5C /* WallpaperMetadataTestProvider.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -196,7 +196,7 @@ class BookmarksCoordinator: BaseCoordinator,
             self?.reloadLastBookmarksController()
         }
         viewModel.bookmarkCoordinatorDelegate = self
-        setBackBarButtonItemTitle(viewModel.backNavigationButtonTitle())
+        setBackBarButtonItemTitle(viewModel.getBackNavigationButtonTitle)
         let controller = EditBookmarkViewController(viewModel: viewModel,
                                                     windowUUID: windowUUID)
         controller.onViewWillAppear = { [weak self] in

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -42,7 +42,6 @@ extension BookmarksCoordinatorDelegate {
 class BookmarksCoordinator: BaseCoordinator,
                             BookmarksCoordinatorDelegate,
                             QRCodeNavigationHandler,
-                            BookmarksRefactorFeatureFlagProvider,
                             ParentCoordinatorDelegate {
     // MARK: - Properties
 
@@ -51,6 +50,7 @@ class BookmarksCoordinator: BaseCoordinator,
     private weak var navigationHandler: LibraryNavigationHandler?
     private var fxAccountViewController: FirefoxAccountSignInViewController?
     private let windowUUID: WindowUUID
+    private let isBookmarkRefactorEnabled: Bool
 
     // MARK: - Initializers
 
@@ -59,12 +59,14 @@ class BookmarksCoordinator: BaseCoordinator,
         profile: Profile,
         windowUUID: WindowUUID,
         parentCoordinator: LibraryCoordinatorDelegate?,
-        navigationHandler: LibraryNavigationHandler?
+        navigationHandler: LibraryNavigationHandler?,
+        isBookmarkRefactorEnabled: Bool
     ) {
         self.profile = profile
         self.windowUUID = windowUUID
         self.parentCoordinator = parentCoordinator
         self.navigationHandler = navigationHandler
+        self.isBookmarkRefactorEnabled = isBookmarkRefactorEnabled
         super.init(router: router)
     }
 

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -219,7 +219,7 @@ class BookmarksCoordinator: BaseCoordinator,
         viewModel.onBookmarkSaved = { [weak self] in
             self?.reloadLastBookmarksController()
         }
-        viewModel.onFolderCreated = parentFolderSelector
+        viewModel.parentFolderSelector = parentFolderSelector
         setBackBarButtonItemTitle("")
         let controller = EditFolderViewController(viewModel: viewModel,
                                                   windowUUID: windowUUID)

--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -128,7 +128,8 @@ class LibraryCoordinator: BaseCoordinator,
             profile: profile,
             windowUUID: windowUUID,
             parentCoordinator: parentCoordinator,
-            navigationHandler: self
+            navigationHandler: self,
+            isBookmarkRefactorEnabled: isBookmarkRefactorEnabled
         )
         add(child: bookmarksCoordinator)
         if isBookmarkRefactorEnabled {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -76,7 +76,7 @@ class EditBookmarkViewController: UIViewController,
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setTheme(theme)
-        _ = viewModel.backNavigationButtonTitle()
+        _ = viewModel.getBackNavigationButtonTitle
         navigationController?.setNavigationBarHidden(false, animated: true)
         navigationController?.interactivePopGestureRecognizer?.isEnabled = false
         onViewWillAppear?()

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -10,7 +10,7 @@ import Shared
 typealias VoidReturnCallback = () -> Void
 
 protocol ParentFolderSelector: AnyObject {
-    /// Enables a child `EditFolderViewController` to pass information to the parent `EditBookmarkViewController`
+    /// In some cases, a child `EditFolderViewController` needs to pass information to a parent `EditBookmarkViewController`
     /// to select the folder that was just created
     /// - Parameter folder: The folder that was created in the `EditFolderViewController`
     func selectFolderCreatedFromChild(folder: Folder)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -39,6 +39,13 @@ class EditBookmarkViewModel: ParentFolderSelector {
     var onFolderStatusUpdate: VoidReturnCallback?
     var onBookmarkSaved: VoidReturnCallback?
 
+    var getBackNavigationButtonTitle: String {
+        if parentFolder.guid == BookmarkRoots.MobileFolderGUID {
+            return .Bookmarks.Menu.AllBookmarks
+        }
+        return parentFolder.title
+    }
+
     init(parentFolder: FxBookmarkNode,
          node: FxBookmarkNode?,
          profile: Profile,
@@ -55,13 +62,6 @@ class EditBookmarkViewModel: ParentFolderSelector {
         let folder = Folder(title: parentFolder.title, guid: parentFolder.guid, indentation: 0)
         folderStructures = [folder]
         selectedFolder = folder
-    }
-
-    func backNavigationButtonTitle() -> String {
-        if parentFolder.guid == BookmarkRoots.MobileFolderGUID {
-            return .Bookmarks.Menu.AllBookmarks
-        }
-        return parentFolder.title
     }
 
     func shouldShowDisclosureIndicator(isFolderSelected: Bool) -> Bool {
@@ -104,9 +104,10 @@ class EditBookmarkViewModel: ParentFolderSelector {
         node = node?.copy(with: bookmarkTitle, url: url)
     }
 
-    func saveBookmark() {
-        guard let selectedFolder, let node else { return }
-        Task { @MainActor [weak self] in
+    @discardableResult
+    func saveBookmark() -> Task<Void, Never>? {
+        guard let selectedFolder, let node else { return nil }
+        return Task { @MainActor [weak self] in
             // There is no way to access the EditBookmarkViewController without the bookmark already existing,
             // so this call will always try to update an existing bookmark
             let result = await self?.bookmarksSaver.save(bookmark: node,

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -25,7 +25,7 @@ class EditBookmarkViewModel: ParentFolderSelector {
     private let bookmarksSaver: BookmarksSaver
     weak var bookmarkCoordinatorDelegate: BookmarksCoordinatorDelegate?
 
-    private var isFolderCollapsed = true
+    private(set) var isFolderCollapsed = true
     private(set) var folderStructures: [Folder] = []
     private(set) var selectedFolder: Folder?
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -9,7 +9,14 @@ import Shared
 
 typealias VoidReturnCallback = () -> Void
 
-class EditBookmarkViewModel {
+protocol ParentFolderSelector: AnyObject {
+    /// Enables a child `EditFolderViewController` to pass information to the parent `EditBookmarkViewController`
+    /// to select the folder that was just created
+    /// - Parameter folder: The folder that was created in the `EditFolderViewController`
+    func selectFolderCreatedFromChild(folder: Folder)
+}
+
+class EditBookmarkViewModel: ParentFolderSelector {
     private let parentFolder: FxBookmarkNode
     private var node: BookmarkItemData?
     private let profile: Profile
@@ -73,9 +80,10 @@ class EditBookmarkViewModel {
     }
 
     func createNewFolder() {
-        self.bookmarkCoordinatorDelegate?.showBookmarkDetail(
+        bookmarkCoordinatorDelegate?.showBookmarkDetail(
             bookmarkType: .folder,
-            parentBookmarkFolder: parentFolder)
+            parentBookmarkFolder: parentFolder,
+            parentFolderSelector: self)
     }
 
     private func getFolderStructure(_ selectedFolder: Folder) {
@@ -117,6 +125,15 @@ class EditBookmarkViewModel {
 
             self?.onBookmarkSaved?()
         }
+    }
+
+    // MARK: ParentFolderSelector
+
+    func selectFolderCreatedFromChild(folder: Folder) {
+        isFolderCollapsed = true
+        selectedFolder = folder
+        folderStructures = [folder]
+        onFolderStatusUpdate?()
     }
 }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -23,7 +23,7 @@ class EditFolderViewModel {
 
     var onFolderStatusUpdate: VoidReturnCallback?
     var onBookmarkSaved: VoidReturnCallback?
-    var onFolderCreated: ParentFolderSelector?
+    weak var parentFolderSelector: ParentFolderSelector?
 
     var controllerTitle: String {
         return isNewFolderView ? .BookmarksNewFolder : .BookmarksEditFolder
@@ -112,7 +112,7 @@ class EditFolderViewModel {
                 // When the folder edit view is a child of the edit bookmark view, the newly created folder
                 // should be selected
                 let folderCreated = Folder(title: folder.title, guid: guid, indentation: 0)
-                onFolderCreated?.selectFolderCreatedFromChild(folder: folderCreated)
+                parentFolderSelector?.selectFolderCreatedFromChild(folder: folderCreated)
             case .failure(let error):
                 self.logger.log("Failed to save folder: \(error)", level: .warning, category: .library)
             }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -17,12 +17,16 @@ class EditFolderViewModel {
     private(set) var selectedFolder: Folder?
     private(set) var folderStructures = [Folder]()
     private(set) var isFolderCollapsed = true
+    private var isNewFolderView: Bool {
+        return folder == nil
+    }
 
     var onFolderStatusUpdate: VoidReturnCallback?
     var onBookmarkSaved: VoidReturnCallback?
+    var onFolderCreated: ParentFolderSelector?
 
     var controllerTitle: String {
-        return folder == nil ? .BookmarksNewFolder : .BookmarksEditFolder
+        return isNewFolderView ? .BookmarksNewFolder : .BookmarksEditFolder
     }
     var editedFolderTitle: String? {
         return folder?.title
@@ -103,6 +107,11 @@ class EditFolderViewModel {
                 // A nil guid indicates a bookmark update, not creation
                 guard let guid else { return }
                 profile.prefs.setString(guid, forKey: PrefsKeys.RecentBookmarkFolder)
+
+                // When the folder edit view is a child of the edit bookmark view, the newly created folder
+                // should be selected
+                let folderCreated = Folder(title: folder.title, guid: guid, indentation: 0)
+                onFolderCreated?.selectFolderCreatedFromChild(folder: folderCreated)
             case .failure(let error):
                 self.logger.log("Failed to save folder: \(error)", level: .warning, category: .library)
             }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -93,7 +93,7 @@ class EditFolderViewModel {
     }
 
     func save() {
-        guard let folder else { return }
+        guard let folder, !folder.title.isEmpty else { return }
         let selectedFolderGUID = selectedFolder?.guid ?? parentFolder.guid
         Task { @MainActor in
             // Creates or updates the folder

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -96,10 +96,11 @@ class EditFolderViewModel {
         }
     }
 
-    func save() {
-        guard let folder, !folder.title.isEmpty else { return }
+    @discardableResult
+    func save() -> Task<Void, Never>? {
+        guard let folder, !folder.title.isEmpty else { return nil }
         let selectedFolderGUID = selectedFolder?.guid ?? parentFolder.guid
-        Task { @MainActor in
+        return Task { @MainActor in
             // Creates or updates the folder
             let result = await bookmarkSaver.save(bookmark: folder, parentFolderGUID: selectedFolderGUID)
             switch result {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
@@ -31,7 +31,9 @@ final class BookmarksCoordinatorTests: XCTestCase {
         navigationHandler = nil
     }
 
-    func testStart() {
+    // MARK: Legacy Bookmarks
+
+    func testStart_legacy() {
         let subject = createSubject()
         let folder = LocalDesktopFolder()
 
@@ -41,7 +43,7 @@ final class BookmarksCoordinatorTests: XCTestCase {
         XCTAssertEqual(router.pushCalled, 1)
     }
 
-    func testShowBookmarksDetail_forFolder() {
+    func testShowBookmarksDetail_forFolder_legacy() {
         let subject = createSubject()
         let folder = LocalDesktopFolder()
 
@@ -51,7 +53,7 @@ final class BookmarksCoordinatorTests: XCTestCase {
         XCTAssertEqual(router.pushCalled, 1)
     }
 
-    func testShowBookmarkDetail_forBookmarkCreation() {
+    func testShowBookmarkDetail_forBookmarkCreation_legacy() {
         let subject = createSubject()
 
         subject.showBookmarkDetail(bookmarkType: .bookmark, parentBookmarkFolder: LocalDesktopFolder())
@@ -60,7 +62,7 @@ final class BookmarksCoordinatorTests: XCTestCase {
         XCTAssertEqual(router.pushCalled, 1)
     }
 
-    func testShowBookmarkDetail_forFolderCreation() {
+    func testShowBookmarkDetail_forFolderCreation_legacy() {
         let subject = createSubject()
 
         subject.showBookmarkDetail(bookmarkType: .folder, parentBookmarkFolder: LocalDesktopFolder())
@@ -68,6 +70,48 @@ final class BookmarksCoordinatorTests: XCTestCase {
         XCTAssertTrue(router.pushedViewController is LegacyBookmarkDetailPanel)
         XCTAssertEqual(router.pushCalled, 1)
     }
+
+    // MARK: Bookmark refactor
+
+    func testStart() {
+        let subject = createSubject(isBookmarkRefactorEnabled: true)
+        let folder = LocalDesktopFolder()
+
+        subject.start(from: folder)
+
+        XCTAssertTrue(router.pushedViewController is BookmarksViewController)
+        XCTAssertEqual(router.pushCalled, 1)
+    }
+
+    func testShowBookmarksDetail_forFolder() {
+        let subject = createSubject(isBookmarkRefactorEnabled: true)
+        let folder = LocalDesktopFolder()
+
+        subject.showBookmarkDetail(for: folder, folder: folder)
+
+        XCTAssertTrue(router.pushedViewController is EditFolderViewController)
+        XCTAssertEqual(router.pushCalled, 1)
+    }
+
+    func testShowBookmarkDetail_forBookmarkCreation() {
+        let subject = createSubject(isBookmarkRefactorEnabled: true)
+
+        subject.showBookmarkDetail(bookmarkType: .bookmark, parentBookmarkFolder: LocalDesktopFolder())
+
+        XCTAssertTrue(router.pushedViewController is EditBookmarkViewController)
+        XCTAssertEqual(router.pushCalled, 1)
+    }
+
+    func testShowBookmarkDetail_forFolderCreation() {
+        let subject = createSubject(isBookmarkRefactorEnabled: true)
+
+        subject.showBookmarkDetail(bookmarkType: .folder, parentBookmarkFolder: LocalDesktopFolder())
+
+        XCTAssertTrue(router.pushedViewController is EditFolderViewController)
+        XCTAssertEqual(router.pushCalled, 1)
+    }
+
+    // MARK: Sign in
 
     func testShowSignInViewController() {
         let subject = createSubject()
@@ -98,6 +142,8 @@ final class BookmarksCoordinatorTests: XCTestCase {
         XCTAssertTrue(router.presentedViewController is QRCodeNavigationController)
     }
 
+    // MARK: Did finish
+
     func testDidFinishCalled() {
         let subject = createSubject()
         let delegate = MockQRCodeViewControllerDelegate()
@@ -114,6 +160,8 @@ final class BookmarksCoordinatorTests: XCTestCase {
         XCTAssertEqual(subject.childCoordinators.count, 0)
     }
 
+    // MARK: Share sheet
+
     func testShowShareSheet_callsNavigationHandlerShareFunction() {
         let subject = createSubject()
 
@@ -127,13 +175,16 @@ final class BookmarksCoordinatorTests: XCTestCase {
         XCTAssertEqual(navigationHandler.didShareLibraryItemCalled, 1)
     }
 
-    private func createSubject() -> BookmarksCoordinator {
+    // MARK: Helper methods
+
+    private func createSubject(isBookmarkRefactorEnabled: Bool = false) -> BookmarksCoordinator {
         let subject = BookmarksCoordinator(
             router: router,
             profile: profile,
             windowUUID: .XCTestDefaultUUID,
             parentCoordinator: parentCoordinator,
-            navigationHandler: navigationHandler
+            navigationHandler: navigationHandler,
+            isBookmarkRefactorEnabled: isBookmarkRefactorEnabled
         )
         trackForMemoryLeaks(subject)
         return subject

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/EditBookmarkViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/EditBookmarkViewModelTests.swift
@@ -1,0 +1,161 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MozillaRustComponents
+import Shared
+
+@testable import Client
+
+class EditBookmarkViewModelTests: XCTestCase {
+    let folder = MockFxBookmarkNode(type: .folder,
+                                    guid: "1235",
+                                    position: 1,
+                                    isRoot: false,
+                                    title: "Hello")
+    let emptyTitleFolder = MockFxBookmarkNode(type: .folder,
+                                              guid: "1235",
+                                              position: 1,
+                                              isRoot: false,
+                                              title: "Hello")
+    let parentFolder = MockFxBookmarkNode(type: .folder,
+                                          guid: "5678",
+                                          position: 0,
+                                          isRoot: false,
+                                          title: "Parent")
+    var folderFetcher: MockFolderHierarchyFetcher!
+    var bookmarksSaver: MockBookmarksSaver!
+    var profile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+        folderFetcher = MockFolderHierarchyFetcher()
+        bookmarksSaver = MockBookmarksSaver()
+        profile = MockProfile()
+    }
+
+    override func tearDown() {
+        folderFetcher = nil
+        bookmarksSaver = nil
+        profile = nil
+        super.tearDown()
+    }
+
+    func testInit() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+
+        XCTAssertTrue(subject.isFolderCollapsed)
+        XCTAssertTrue(!subject.folderStructures.isEmpty)
+        XCTAssertEqual(subject.selectedFolder?.title, parentFolder.title)
+        XCTAssertEqual(subject.selectedFolder?.guid, parentFolder.guid)
+    }
+
+    func testShouldShowDisclosureIndicator_whenIsFolderSelected() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+
+        XCTAssertTrue(subject.shouldShowDisclosureIndicator(isFolderSelected: true))
+    }
+
+    func testShouldShowDisclosureIndicator_whenIsNotFolderSelected() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+
+        XCTAssertTrue(subject.shouldShowDisclosureIndicator(isFolderSelected: false))
+    }
+
+    func testShouldShowDisclosureIndicator_whenIsNotFolderSelectedAfterSelectFolder() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        subject.selectFolder(Folder(title: "Test", guid: "", indentation: 0))
+
+        XCTAssertTrue(subject.shouldShowDisclosureIndicator(isFolderSelected: false))
+    }
+
+    func testSelectFolder_callsOnFolderStatusUpdate() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onFolderStatusUpdate should be called")
+        subject.onFolderStatusUpdate = {
+            expectation.fulfill()
+        }
+        subject.selectFolder(Folder(title: "Test", guid: "", indentation: 0))
+
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testSelectFolder_callsGetFolderStructure() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onFolderStatusUpdate should be called")
+        subject.onFolderStatusUpdate = {
+            expectation.fulfill()
+        }
+
+        subject.selectFolder(Folder(title: "Test", guid: "", indentation: 0))
+
+        waitForExpectations(timeout: 0.1)
+        XCTAssertEqual(folderFetcher.fetchFoldersCalled, 1)
+        XCTAssertEqual(folderFetcher.mockFolderStructures, subject.folderStructures)
+    }
+
+    func testSave_whenEmptyFolder_thenDoesntSave() throws {
+        let subject = createSubject(folder: emptyTitleFolder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onBookmarkSaved should be called")
+        subject.onBookmarkSaved = {
+            expectation.fulfill()
+        }
+
+        subject.saveBookmark()
+
+        waitForExpectations(timeout: 0.1)
+        let prefs = try XCTUnwrap(profile.prefs as? MockProfilePrefs)
+        let recentBookmark = try XCTUnwrap(prefs.things[PrefsKeys.RecentBookmarkFolder] as? String)
+        XCTAssertEqual(recentBookmark, "")
+        XCTAssertEqual(bookmarksSaver.saveCalled, 1)
+    }
+
+    func testSave_whenRecentFolderPrefsDoesntMatch_thenWillSetString() throws {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onBookmarkSaved should be called")
+        subject.onBookmarkSaved = {
+            expectation.fulfill()
+        }
+
+        subject.saveBookmark()
+
+        waitForExpectations(timeout: 0.1)
+        let prefs = try XCTUnwrap(profile.prefs as? MockProfilePrefs)
+        let recentBookmark = try XCTUnwrap(prefs.things[PrefsKeys.RecentBookmarkFolder] as? String)
+        XCTAssertEqual(recentBookmark, "")
+        XCTAssertEqual(bookmarksSaver.saveCalled, 1)
+    }
+
+    func testSave_whenRecentFolderPrefsMatch_thenShouldntSetString() throws {
+        profile.prefs.setString("1235", forKey: PrefsKeys.RecentBookmarkFolder)
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onBookmarkSaved should be called")
+        subject.onBookmarkSaved = {
+            expectation.fulfill()
+        }
+
+        subject.saveBookmark()
+
+        waitForExpectations(timeout: 0.1)
+        let prefs = try XCTUnwrap(profile.prefs as? MockProfilePrefs)
+        let recentBookmark = try XCTUnwrap(prefs.things[PrefsKeys.RecentBookmarkFolder] as? String)
+        XCTAssertEqual(recentBookmark, "")
+        XCTAssertEqual(bookmarksSaver.saveCalled, 1)
+    }
+
+    // MARK: Helper function
+
+    func createSubject(folder: FxBookmarkNode,
+                       parentFolder: FxBookmarkNode,
+                       file: StaticString = #file,
+                       line: UInt = #line) -> EditBookmarkViewModel {
+        let subject = EditBookmarkViewModel(parentFolder: parentFolder,
+                                            node: folder,
+                                            profile: profile,
+                                            bookmarksSaver: bookmarksSaver,
+                                            folderFetcher: folderFetcher)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/EditBookmarkViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/EditBookmarkViewModelTests.swift
@@ -157,6 +157,38 @@ class EditBookmarkViewModelTests: XCTestCase {
         XCTAssertEqual(bookmarksSaver.saveCalled, 1)
     }
 
+    func testSelectFolderCreatedFromChild_ensureFolderIsCollapsed() {
+        let subject = createSubject(folder: folderBookmarkItemData, parentFolder: parentFolder)
+        let folderToSelect = Folder(title: folder.title, guid: folder.guid, indentation: 0)
+
+        subject.selectFolder(folderToSelect)
+        subject.selectFolderCreatedFromChild(folder: folderToSelect)
+
+        XCTAssertTrue(subject.isFolderCollapsed)
+    }
+
+    func testSelectFolderCreatedFromChild_ensureFolderSelectedUpdates() {
+        let subject = createSubject(folder: folderBookmarkItemData, parentFolder: parentFolder)
+        let folderToSelect = Folder(title: folder.title, guid: folder.guid, indentation: 0)
+
+        subject.selectFolderCreatedFromChild(folder: folderToSelect)
+
+        XCTAssertEqual(subject.selectedFolder, folderToSelect)
+        XCTAssertEqual(subject.folderStructures, [folderToSelect])    }
+
+    func testSelectFolderCreatedFromChild_ensureOnFolderStatusUpdateIsCalled() {
+        let subject = createSubject(folder: folderBookmarkItemData, parentFolder: parentFolder)
+        let folderToSelect = Folder(title: folder.title, guid: folder.guid, indentation: 0)
+        let expectation = expectation(description: "onFolderStatusUpdate should be called")
+        subject.onFolderStatusUpdate = {
+            expectation.fulfill()
+        }
+
+        subject.selectFolderCreatedFromChild(folder: folderToSelect)
+
+        waitForExpectations(timeout: 0.1)
+    }
+
     // MARK: Helper function
 
     func createSubject(folder: FxBookmarkNode,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/EditFolderViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/EditFolderViewModelTests.swift
@@ -135,12 +135,12 @@ class EditFolderViewModelTests: XCTestCase {
         XCTAssertEqual(bookmarksSaver.saveCalled, 1)
     }
 
-    func testSave_whenHasGuidCallsOnFolderCreated() async throws {
+    func testSave_whenHasGuidCallsParentFolderSelector() async throws {
         let expectedGuid = "09876"
         bookmarksSaver.mockCreateGuid = expectedGuid
         profile.prefs.setString(expectedGuid, forKey: PrefsKeys.RecentBookmarkFolder)
         let subject = createSubject(folder: folder, parentFolder: parentFolder)
-        subject.onFolderCreated = parentFolderSelector
+        subject.parentFolderSelector = parentFolderSelector
 
         let task = subject.save()
         await task?.value

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/EditFolderViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/EditFolderViewModelTests.swift
@@ -1,0 +1,163 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MozillaRustComponents
+import Shared
+
+@testable import Client
+
+class EditFolderViewModelTests: XCTestCase {
+    let folder = MockFxBookmarkNode(type: .folder,
+                                    guid: "1235",
+                                    position: 1,
+                                    isRoot: false,
+                                    title: "Hello")
+    let emptyTitleFolder = MockFxBookmarkNode(type: .folder,
+                                              guid: "1235",
+                                              position: 1,
+                                              isRoot: false,
+                                              title: "")
+    let parentFolder = MockFxBookmarkNode(type: .folder,
+                                          guid: "5678",
+                                          position: 0,
+                                          isRoot: false,
+                                          title: "Parent")
+    var folderFetcher: MockFolderHierarchyFetcher!
+    var bookmarksSaver: MockBookmarksSaver!
+    var profile: MockProfile!
+    var parentFolderSelector: MockParentFolderSelector!
+
+    override func setUp() {
+        super.setUp()
+        folderFetcher = MockFolderHierarchyFetcher()
+        bookmarksSaver = MockBookmarksSaver()
+        profile = MockProfile()
+        parentFolderSelector = MockParentFolderSelector()
+    }
+
+    override func tearDown() {
+        folderFetcher = nil
+        bookmarksSaver = nil
+        profile = nil
+        parentFolderSelector = nil
+        super.tearDown()
+    }
+
+    func testInit() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+
+        XCTAssertTrue(subject.isFolderCollapsed)
+        XCTAssertTrue(!subject.folderStructures.isEmpty)
+        XCTAssertEqual(subject.selectedFolder?.title, parentFolder.title)
+        XCTAssertEqual(subject.selectedFolder?.guid, parentFolder.guid)
+    }
+
+    func testShouldShowDisclosureIndicator_whenIsFolderSelected() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+
+        XCTAssertFalse(subject.shouldShowDisclosureIndicator(isFolderSelected: true))
+    }
+
+    func testShouldShowDisclosureIndicator_whenIsNotFolderSelected() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+
+        XCTAssertFalse(subject.shouldShowDisclosureIndicator(isFolderSelected: false))
+    }
+
+    func testShouldShowDisclosureIndicator_whenIsNotFolderSelectedAfterSelectFolder() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        subject.selectFolder(Folder(title: "Test", guid: "", indentation: 0))
+
+        XCTAssertTrue(subject.shouldShowDisclosureIndicator(isFolderSelected: true))
+    }
+
+    func testSelectFolder_callsOnFolderStatusUpdate() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onFolderStatusUpdate should be called")
+        subject.onFolderStatusUpdate = {
+            expectation.fulfill()
+        }
+        subject.selectFolder(Folder(title: "Test", guid: "", indentation: 0))
+
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testSelectFolder_callsGetFolderStructure() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onFolderStatusUpdate should be called")
+        subject.onFolderStatusUpdate = {
+            expectation.fulfill()
+        }
+
+        subject.selectFolder(Folder(title: "Test", guid: "", indentation: 0))
+
+        waitForExpectations(timeout: 0.1)
+        XCTAssertEqual(folderFetcher.fetchFoldersCalled, 1)
+        XCTAssertEqual(folderFetcher.mockFolderStructures, subject.folderStructures)
+    }
+
+    func testSave_whenEmptyFolder_thenDoesntSave() throws {
+        let subject = createSubject(folder: emptyTitleFolder, parentFolder: parentFolder)
+        subject.save()
+
+        XCTAssertEqual(bookmarksSaver.saveCalled, 0)
+    }
+
+    func testSave_whenNilGuidReturned() throws {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        subject.save()
+
+        let prefs = try XCTUnwrap(profile.prefs as? MockProfilePrefs)
+        XCTAssertNil(prefs.things[PrefsKeys.RecentBookmarkFolder])
+        XCTAssertEqual(bookmarksSaver.saveCalled, 0)
+    }
+
+    func testSave_whenHasGuidSavesRecentBookmark() throws {
+        let expectedGuid = "09876"
+        bookmarksSaver.mockCreateGuid = expectedGuid
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onBookmarkSaved should be called")
+        subject.onBookmarkSaved = {
+            expectation.fulfill()
+        }
+
+        subject.save()
+
+        waitForExpectations(timeout: 0.1)
+        let prefs = try XCTUnwrap(profile.prefs as? MockProfilePrefs)
+        let recentBookmarkGuid = try XCTUnwrap(prefs.things[PrefsKeys.RecentBookmarkFolder] as? String)
+        XCTAssertEqual(recentBookmarkGuid, expectedGuid)
+        XCTAssertEqual(bookmarksSaver.saveCalled, 1)
+    }
+
+    func testSave_whenHasGuidCallsOnFolderCreated() throws {
+        let expectedGuid = "09876"
+        bookmarksSaver.mockCreateGuid = expectedGuid
+        profile.prefs.setString(expectedGuid, forKey: PrefsKeys.RecentBookmarkFolder)
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onFolderCreated should be called")
+        subject.onFolderCreated = parentFolderSelector
+
+        subject.save()
+
+        waitForExpectations(timeout: 0.1)
+        XCTAssertNotNil(parentFolderSelector.selectedFolder)
+    }
+
+    // MARK: Helper function
+
+    func createSubject(folder: FxBookmarkNode,
+                       parentFolder: FxBookmarkNode,
+                       file: StaticString = #file,
+                       line: UInt = #line) -> EditFolderViewModel {
+        let subject = EditFolderViewModel(profile: profile,
+                                          parentFolder: parentFolder,
+                                          folder: folder,
+                                          bookmarkSaver: bookmarksSaver,
+                                          folderFetcher: folderFetcher)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBookmarksSaver.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBookmarksSaver.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import Shared
+
+class MockBookmarksSaver: BookmarksSaver {
+    var saveCalled = 0
+    var createBookmarkCalled = 0
+    var mockCreateGuid: GUID?
+
+    var savedBookmarkURL: String?
+    var savedBookmarkTitle: String?
+    var savedBookmarkPosition: UInt32?
+
+    func save(bookmark: any FxBookmarkNode,
+              parentFolderGUID: String) async -> Result<GUID?, any Error> {
+        saveCalled += 1
+        return Result.success(mockCreateGuid)
+    }
+
+    func createBookmark(url: String, title: String?, position: UInt32?) async {
+        savedBookmarkURL = url
+        savedBookmarkTitle = title
+        savedBookmarkPosition = position
+        createBookmarkCalled += 1
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockFolderHierarchyFetcher.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockFolderHierarchyFetcher.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+class MockFolderHierarchyFetcher: FolderHierarchyFetcher {
+    var fetchFoldersCalled = 0
+    var mockFolderStructures = [Folder(title: "Example", guid: "123456", indentation: 0)]
+
+    func fetchFolders() async -> [Folder] {
+        fetchFoldersCalled += 1
+        return mockFolderStructures
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockFxBookmarkNode.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockFxBookmarkNode.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MozillaAppServices
+
+@testable import Client
+
+struct MockFxBookmarkNode: FxBookmarkNode {
+    var type: MozillaAppServices.BookmarkNodeType
+    var guid: String
+    var parentGUID: String?
+    var position: UInt32
+    var isRoot: Bool
+    var title: String
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockParentFolderSelector.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockParentFolderSelector.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+class MockParentFolderSelector: ParentFolderSelector {
+    var selectedFolder: Folder?
+    func selectFolderCreatedFromChild(folder: Folder) {
+        selectedFolder = folder
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10781)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23519)

## :bulb: Description
Auto-select the folder that was just created through delegate pattern, went with this approach as I felt this is a one off type of thing which only happens when there's a folder view created as a child of an edit bookmark view. 

~~There's pending questions here~~ Questions were answered:
1. Should the table be collapsed when we go back to the edit bookmark view? I currently set it to be collapsed.
> Yes it should be collapsed
2. When we move back to the main bookmarks view from the edit bookmark view, should the folder the user saved his bookmark in be selected? i.e. if I create a new folder, should this folder be selected?
> No it shouldn't be selected

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

