### PR TITLE
Add FXIOS-10831 Ensure reader mode URLs don't get sent to other devices.

### DIFF
--- a/firefox-ios/Client/Frontend/Share/CustomAppActivity.swift
+++ b/firefox-ios/Client/Frontend/Share/CustomAppActivity.swift
@@ -63,7 +63,9 @@ class CustomAppActivity: UIActivity, AppActivityProtocol {
 
     init(activityType: CustomActivityAction, url: URL) {
         self.appActivityType = activityType
-        self.url = url
+        self.url = url.isReaderModeURL
+                   ? (url.decodeReaderModeURL ?? url)
+                   : url
         super.init()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10831)

## :bulb: Description
Sharing reader mode URLs isn't currently possible, but this PR add an extra safety check for URLs shared in the share sheet via our custom "Send to Device" action.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

