### PR TITLE
Add FXIOS-10925 [Sent from Firefox] Add experiment enrolment telemetry to shared_to

### DIFF
--- a/firefox-ios/Client/Frontend/Share/ShareTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTelemetry.swift
@@ -6,14 +6,28 @@ import Foundation
 import Glean
 
 protocol ShareTelemetry {
-    func sharedTo(activityType: UIActivity.ActivityType?, shareType: ShareType, hasShareMessage: Bool)
+    func sharedTo(
+        activityType: UIActivity.ActivityType?,
+        shareType: ShareType,
+        hasShareMessage: Bool,
+        isEnrolledInSentFromFirefox: Bool,
+        isOptedInSentFromFirefox: Bool
+    )
 }
 
 struct DefaultShareTelemetry: ShareTelemetry {
-    func sharedTo(activityType: UIActivity.ActivityType?, shareType: ShareType, hasShareMessage: Bool) {
+    func sharedTo(
+        activityType: UIActivity.ActivityType?,
+        shareType: ShareType,
+        hasShareMessage: Bool,
+        isEnrolledInSentFromFirefox: Bool,
+        isOptedInSentFromFirefox: Bool
+    ) {
         let extra = GleanMetrics.ShareSheet.SharedToExtra(
             activityIdentifier: activityType?.rawValue ?? "unknown",
             hasShareMessage: hasShareMessage,
+            isEnrolledInSentFromFirefox: isEnrolledInSentFromFirefox,
+            isOptedInSentFromFirefox: isOptedInSentFromFirefox,
             shareType: shareType.typeName
         )
         GleanMetrics.ShareSheet.sharedTo.record(extra)

--- a/firefox-ios/Client/Frontend/Share/ShareTelemetryActivityItemProvider.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTelemetryActivityItemProvider.swift
@@ -7,10 +7,20 @@ import UniformTypeIdentifiers
 
 /// A special `UIActivityItemProvider` which never shares additional content, but instead records telemetry based on the
 /// share activity chosen.
-class ShareTelemetryActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
+class ShareTelemetryActivityItemProvider: UIActivityItemProvider, @unchecked Sendable, FeatureFlaggable {
     private let shareType: ShareType
     private let shareMessage: ShareMessage?
     private let telemetry: ShareTelemetry
+
+    // FXIOS-9879 For the Sent from Firefox experiment
+    private var isEnrolledInSentFromFirefox: Bool {
+        return featureFlags.isFeatureEnabled(.sentFromFirefox, checking: .buildOnly)
+    }
+
+    // FXIOS-9879 For the Sent from Firefox experiment
+    private var isOptedInSentFromFirefox: Bool {
+        return featureFlags.isFeatureEnabled(.sentFromFirefox, checking: .userOnly)
+    }
 
     init(
         shareType: ShareType,
@@ -31,7 +41,9 @@ class ShareTelemetryActivityItemProvider: UIActivityItemProvider, @unchecked Sen
         telemetry.sharedTo(
             activityType: activityType,
             shareType: shareType,
-            hasShareMessage: shareMessage != nil
+            hasShareMessage: shareMessage != nil,
+            isEnrolledInSentFromFirefox: isEnrolledInSentFromFirefox,
+            isOptedInSentFromFirefox: isOptedInSentFromFirefox
         )
 
         return NSNull() // Never actually share content; we only want to record the activity type for shares

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -5163,6 +5163,15 @@ share_sheet:
         description: |
           Whether an explicit share message (and optional subject line) was 
           appended to the shared content.
+      is_enrolled_in_sent_from_firefox:
+        type: boolean
+        description: |
+          Whether the user is enrolled in the Sent from Firefox experiment.
+      is_opted_in_sent_from_firefox:
+        type: boolean
+        description: |
+          Whether the user is opted in to the Sent from Firefox experiment.
+          Only returns true if the user is both enrolled and opted in.
 
 # Device specific metrics
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/Mocks/MockShareTelemetry.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/Mocks/MockShareTelemetry.swift
@@ -7,6 +7,12 @@ import Foundation
 @testable import Client
 
 class MockShareTelemetry: ShareTelemetry {
+    var activityType: UIActivity.ActivityType?
+    var shareType: ShareType?
+    var hasShareMessage: Bool?
+    var isEnrolledInSentFromFirefox: Bool?
+    var isOptedInSentFromFirefox: Bool?
+
     var sharedToCalled = 0
 
     func sharedTo(
@@ -16,6 +22,12 @@ class MockShareTelemetry: ShareTelemetry {
         isEnrolledInSentFromFirefox: Bool,
         isOptedInSentFromFirefox: Bool
     ) {
+        self.activityType = activityType
+        self.shareType = shareType
+        self.hasShareMessage = hasShareMessage
+        self.isEnrolledInSentFromFirefox = isEnrolledInSentFromFirefox
+        self.isOptedInSentFromFirefox = isOptedInSentFromFirefox
+
         sharedToCalled += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/Mocks/MockShareTelemetry.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/Mocks/MockShareTelemetry.swift
@@ -9,7 +9,13 @@ import Foundation
 class MockShareTelemetry: ShareTelemetry {
     var sharedToCalled = 0
 
-    func sharedTo(activityType: UIActivity.ActivityType?, shareType: ShareType, hasShareMessage: Bool) {
+    func sharedTo(
+        activityType: UIActivity.ActivityType?,
+        shareType: ShareType,
+        hasShareMessage: Bool,
+        isEnrolledInSentFromFirefox: Bool,
+        isOptedInSentFromFirefox: Bool
+    ) {
         sharedToCalled += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryActivityItemProviderTests.swift
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import UniformTypeIdentifiers
 import XCTest
+import Shared
+import UniformTypeIdentifiers
+
 @testable import Client
 
 final class ShareTelemetryActivityItemProviderTests: XCTestCase {
@@ -12,6 +14,16 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
     private let testFileURL = URL(string: "file://some/file/url")!
     private let testWebURL = URL(string: "https://mozilla.org")!
 
+    override func setUp() {
+        super.setUp()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: PrefsKeys.NimbusUserEnabledFeatureTestsOverride)
+        super.tearDown()
+    }
+    
     func testWithShareType_noShareMessage_callTelemetryOnly() throws {
         let testActivityType = UIActivity.ActivityType.mail
         let testShareType: ShareType = .site(url: testWebURL)
@@ -52,9 +64,140 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
         XCTAssertEqual(mockShareTelemetry.sharedToCalled, 1)
     }
 
+    // MARK: - Sent from Firefox experiment
+
+    func testShare_forSentFromFirefox_passesNimbusEnrolment_passesUserOptOutPreference() throws {
+        let testActivityType = UIActivity.ActivityType.mail
+        let testShareType: ShareType = .site(url: testWebURL)
+        let testShareMessage = ShareMessage(message: testMessage, subtitle: testSubtitle)
+        let mockShareTelemetry = MockShareTelemetry()
+        let testNimbusEnrollment = true
+        let testUserOptIn = false
+
+        // Enroll the user via Nimbus
+        setupNimbusSentFromFirefoxTesting(isEnabled: testNimbusEnrollment, isTreatmentA: true)
+
+        // Opt in the user preference
+        UserDefaults.standard.set(testUserOptIn, forKey: PrefsKeys.NimbusUserEnabledFeatureTestsOverride)
+
+        let shareTelemetryActivityItemProvider = ShareTelemetryActivityItemProvider(
+            shareType: testShareType,
+            shareMessage: testShareMessage,
+            telemetry: mockShareTelemetry
+        )
+        let itemForActivity = shareTelemetryActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+
+        XCTAssertTrue(itemForActivity is NSNull, "Should never share content")
+        XCTAssertEqual(mockShareTelemetry.sharedToCalled, 1)
+        XCTAssertEqual(mockShareTelemetry.isEnrolledInSentFromFirefox, testNimbusEnrollment)
+        XCTAssertEqual(mockShareTelemetry.isOptedInSentFromFirefox, testUserOptIn)
+    }
+
+    func testShare_forSentFromFirefox_passesNimbusEnrolment_passesUserOptInPreference() throws {
+        let testActivityType = UIActivity.ActivityType.mail
+        let testShareType: ShareType = .site(url: testWebURL)
+        let testShareMessage = ShareMessage(message: testMessage, subtitle: testSubtitle)
+        let mockShareTelemetry = MockShareTelemetry()
+        let testNimbusEnrollment = true
+        let testUserOptIn = true
+
+        // Enroll the user via Nimbus
+        setupNimbusSentFromFirefoxTesting(isEnabled: testNimbusEnrollment, isTreatmentA: true)
+
+        // Opt in the user preference
+        UserDefaults.standard.set(testUserOptIn, forKey: PrefsKeys.NimbusUserEnabledFeatureTestsOverride)
+
+        let shareTelemetryActivityItemProvider = ShareTelemetryActivityItemProvider(
+            shareType: testShareType,
+            shareMessage: testShareMessage,
+            telemetry: mockShareTelemetry
+        )
+        let itemForActivity = shareTelemetryActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+
+        XCTAssertTrue(itemForActivity is NSNull, "Should never share content")
+        XCTAssertEqual(mockShareTelemetry.sharedToCalled, 1)
+        XCTAssertEqual(mockShareTelemetry.isEnrolledInSentFromFirefox, testNimbusEnrollment)
+        XCTAssertEqual(mockShareTelemetry.isOptedInSentFromFirefox, testUserOptIn)
+    }
+
+    func testShare_forSentFromFirefox_passesNimbusNotEnrolled_passesUserOptOutPreference() throws {
+        let testActivityType = UIActivity.ActivityType.mail
+        let testShareType: ShareType = .site(url: testWebURL)
+        let testShareMessage = ShareMessage(message: testMessage, subtitle: testSubtitle)
+        let mockShareTelemetry = MockShareTelemetry()
+        let testNimbusEnrollment = false
+        let testUserOptIn = false
+
+        // Enroll the user via Nimbus
+        setupNimbusSentFromFirefoxTesting(isEnabled: testNimbusEnrollment, isTreatmentA: true)
+
+        // Opt in the user preference
+        UserDefaults.standard.set(testUserOptIn, forKey: PrefsKeys.NimbusUserEnabledFeatureTestsOverride)
+
+        let shareTelemetryActivityItemProvider = ShareTelemetryActivityItemProvider(
+            shareType: testShareType,
+            shareMessage: testShareMessage,
+            telemetry: mockShareTelemetry
+        )
+        let itemForActivity = shareTelemetryActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+
+        XCTAssertTrue(itemForActivity is NSNull, "Should never share content")
+        XCTAssertEqual(mockShareTelemetry.sharedToCalled, 1)
+        XCTAssertEqual(mockShareTelemetry.isEnrolledInSentFromFirefox, testNimbusEnrollment)
+        XCTAssertEqual(mockShareTelemetry.isOptedInSentFromFirefox, testUserOptIn)
+    }
+
+    func testShare_forSentFromFirefox_passesNimbusNotEnrolled_passesUserOptInPreference() throws {
+        let testActivityType = UIActivity.ActivityType.mail
+        let testShareType: ShareType = .site(url: testWebURL)
+        let testShareMessage = ShareMessage(message: testMessage, subtitle: testSubtitle)
+        let mockShareTelemetry = MockShareTelemetry()
+        let testNimbusEnrollment = false
+        let testUserOptIn = true
+
+        // Enroll the user via Nimbus
+        setupNimbusSentFromFirefoxTesting(isEnabled: testNimbusEnrollment, isTreatmentA: true)
+
+        // Opt in the user preference
+        UserDefaults.standard.set(testUserOptIn, forKey: PrefsKeys.NimbusUserEnabledFeatureTestsOverride)
+
+        let shareTelemetryActivityItemProvider = ShareTelemetryActivityItemProvider(
+            shareType: testShareType,
+            shareMessage: testShareMessage,
+            telemetry: mockShareTelemetry
+        )
+        let itemForActivity = shareTelemetryActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+
+        XCTAssertTrue(itemForActivity is NSNull, "Should never share content")
+        XCTAssertEqual(mockShareTelemetry.sharedToCalled, 1)
+        XCTAssertEqual(mockShareTelemetry.isEnrolledInSentFromFirefox, testNimbusEnrollment)
+        XCTAssertEqual(mockShareTelemetry.isOptedInSentFromFirefox, testUserOptIn)
+    }
+
     // MARK: - Helpers
 
     private func createStubActivityViewController() -> UIActivityViewController {
         return UIActivityViewController(activityItems: [], applicationActivities: [])
+    }
+
+    private func setupNimbusSentFromFirefoxTesting(isEnabled: Bool, isTreatmentA: Bool) {
+        FxNimbus.shared.features.sentFromFirefoxFeature.with { _, _ in
+            return SentFromFirefoxFeature(
+                enabled: isEnabled,
+                isTreatmentA: isTreatmentA
+            )
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryActivityItemProviderTests.swift
@@ -23,7 +23,7 @@ final class ShareTelemetryActivityItemProviderTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: PrefsKeys.NimbusUserEnabledFeatureTestsOverride)
         super.tearDown()
     }
-    
+
     func testWithShareType_noShareMessage_callTelemetryOnly() throws {
         let testActivityType = UIActivity.ActivityType.mail
         let testShareType: ShareType = .site(url: testWebURL)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
@@ -14,6 +14,8 @@ final class ShareTelemetryTests: XCTestCase {
     let activityIdentifierKey = "activity_identifier"
     let shareTypeKey = "share_type"
     let hasShareMessageKey = "has_share_message"
+    let hasIsEnrolledInSentFromFirefoxKey = "is_enrolled_in_sent_from_firefox"
+    let hasIsOptedInSentFromFirefoxKey = "is_opted_in_sent_from_firefox"
 
     override func setUp() {
         super.setUp()
@@ -29,14 +31,25 @@ final class ShareTelemetryTests: XCTestCase {
         let testActivityType: UIActivity.ActivityType? = nil
         let testShareType: ShareType = .site(url: testWebURL)
         let testHasShareMessage = true
+        let testIsEnrolledInSentFromFirefox = false
+        let testIsOptedInSentFromFirefox = false
 
-        subject.sharedTo(activityType: testActivityType, shareType: testShareType, hasShareMessage: testHasShareMessage)
+        subject.sharedTo(
+            activityType: testActivityType,
+            shareType: testShareType,
+            hasShareMessage: testHasShareMessage,
+            isEnrolledInSentFromFirefox: testIsEnrolledInSentFromFirefox,
+            isOptedInSentFromFirefox: testIsOptedInSentFromFirefox
+        )
+
         testEventMetricRecordingSuccess(metric: GleanMetrics.ShareSheet.sharedTo)
 
         let resultValue = try XCTUnwrap(GleanMetrics.ShareSheet.sharedTo.testGetValue())
         XCTAssertEqual(resultValue[0].extra?[activityIdentifierKey], "unknown")
         XCTAssertEqual(resultValue[0].extra?[shareTypeKey], testShareType.typeName)
         XCTAssertEqual(resultValue[0].extra?[hasShareMessageKey], String(testHasShareMessage))
+        XCTAssertEqual(resultValue[0].extra?[hasIsEnrolledInSentFromFirefoxKey], String(testIsEnrolledInSentFromFirefox))
+        XCTAssertEqual(resultValue[0].extra?[hasIsOptedInSentFromFirefoxKey], String(testIsOptedInSentFromFirefox))
     }
 
     func testSharedTo_withActivityType() throws {
@@ -44,14 +57,51 @@ final class ShareTelemetryTests: XCTestCase {
         let testActivityType = UIActivity.ActivityType("com.some.activity.identifier")
         let testShareType: ShareType = .site(url: testWebURL)
         let testHasShareMessage = true
+        let testIsEnrolledInSentFromFirefox = false
+        let testIsOptedInSentFromFirefox = false
 
-        subject.sharedTo(activityType: testActivityType, shareType: testShareType, hasShareMessage: testHasShareMessage)
+        subject.sharedTo(
+            activityType: testActivityType,
+            shareType: testShareType,
+            hasShareMessage: testHasShareMessage,
+            isEnrolledInSentFromFirefox: testIsEnrolledInSentFromFirefox,
+            isOptedInSentFromFirefox: testIsOptedInSentFromFirefox
+        )
+
         testEventMetricRecordingSuccess(metric: GleanMetrics.ShareSheet.sharedTo)
 
         let resultValue = try XCTUnwrap(GleanMetrics.ShareSheet.sharedTo.testGetValue())
         XCTAssertEqual(resultValue[0].extra?[activityIdentifierKey], testActivityType.rawValue)
         XCTAssertEqual(resultValue[0].extra?[shareTypeKey], testShareType.typeName)
         XCTAssertEqual(resultValue[0].extra?[hasShareMessageKey], String(testHasShareMessage))
+        XCTAssertEqual(resultValue[0].extra?[hasIsEnrolledInSentFromFirefoxKey], String(testIsEnrolledInSentFromFirefox))
+        XCTAssertEqual(resultValue[0].extra?[hasIsOptedInSentFromFirefoxKey], String(testIsOptedInSentFromFirefox))
+    }
+
+    func testSharedTo_enrolledAndOptedInSentFromFirefox() throws {
+        let subject = createSubject()
+        let testActivityType = UIActivity.ActivityType("com.some.activity.identifier")
+        let testShareType: ShareType = .site(url: testWebURL)
+        let testHasShareMessage = true
+        let testIsEnrolledInSentFromFirefox = true
+        let testIsOptedInSentFromFirefox = true
+
+        subject.sharedTo(
+            activityType: testActivityType,
+            shareType: testShareType,
+            hasShareMessage: testHasShareMessage,
+            isEnrolledInSentFromFirefox: testIsEnrolledInSentFromFirefox,
+            isOptedInSentFromFirefox: testIsOptedInSentFromFirefox
+        )
+
+        testEventMetricRecordingSuccess(metric: GleanMetrics.ShareSheet.sharedTo)
+
+        let resultValue = try XCTUnwrap(GleanMetrics.ShareSheet.sharedTo.testGetValue())
+        XCTAssertEqual(resultValue[0].extra?[activityIdentifierKey], testActivityType.rawValue)
+        XCTAssertEqual(resultValue[0].extra?[shareTypeKey], testShareType.typeName)
+        XCTAssertEqual(resultValue[0].extra?[hasShareMessageKey], String(testHasShareMessage))
+        XCTAssertEqual(resultValue[0].extra?[hasIsEnrolledInSentFromFirefoxKey], String(testIsEnrolledInSentFromFirefox))
+        XCTAssertEqual(resultValue[0].extra?[hasIsOptedInSentFromFirefoxKey], String(testIsOptedInSentFromFirefox))
     }
 
     func createSubject() -> ShareTelemetry {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10925)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23870)

## :bulb: Description
Adds the user's enrollment and opt-in status to the Sent from Firefox experiment to the shared_to telemetry collection.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

