### PR TITLE
Bugfix FXIOS-10933 String import failing to import new strings

### DIFF
--- a/.github/workflows/firefox-ios-import-strings.yml
+++ b/.github/workflows/firefox-ios-import-strings.yml
@@ -30,6 +30,22 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    
+    - name: Install Python dependencies
+      run: |
+        pip install -r firefoxios-l10n/.github/scripts/requirements.txt
+    
+    - name: Clone l10n iOS repository
+      uses: actions/checkout@v4
+      with:
+        repository: "mozilla-l10n/firefoxios-l10n"
+        path: "firefoxios-l10n"
+
+    - name: Clone Localization Tools
+      uses: actions/checkout@v4
+      with:
+        repository: "mozilla-mobile/LocalizationTools"
+        path: "LocalizationTools"
 
     - name: Determine PR Version Number
       id: versioning
@@ -60,10 +76,15 @@ jobs:
           echo "branch_name=string-import-$current_branch-$current_date" >> $GITHUB_ENV
           echo "pr_title=Localize [$version] String import $current_date" >> $GITHUB_ENV
           echo "pr_body=This automated PR imports string changes into branch '$current_branch'" >> $GITHUB_ENV
-        fi
-
+        fi    
+            
+    - name: Prepare Xliff files to import
+      run: |
+        # Change all the Xliff files original from en.lproj to en-US.lproj so they can be imported correctly
+        python3 "firefoxios-l10n/.github/scripts/rewrite_original_attribute.py" --path "firefoxios-l10n"
+        
     - name: Run script to import strings
-      run: sh ./bootstrap.sh --importLocales
+      run: sh ./firefox-ios/import-strings.sh
 
     - name: Update new strings
       run: |-

--- a/.github/workflows/firefox-ios-import-strings.yml
+++ b/.github/workflows/firefox-ios-import-strings.yml
@@ -30,22 +30,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    
-    - name: Clone l10n iOS repository
-      uses: actions/checkout@v4
-      with:
-        repository: "mozilla-l10n/firefoxios-l10n"
-        path: "firefoxios-l10n"
-    
-    - name: Install Python dependencies
-      run: |
-        pip install -r firefoxios-l10n/.github/scripts/requirements.txt
-
-    - name: Clone Localization Tools
-      uses: actions/checkout@v4
-      with:
-        repository: "mozilla-mobile/LocalizationTools"
-        path: "LocalizationTools"
 
     - name: Determine PR Version Number
       id: versioning
@@ -76,12 +60,7 @@ jobs:
           echo "branch_name=string-import-$current_branch-$current_date" >> $GITHUB_ENV
           echo "pr_title=Localize [$version] String import $current_date" >> $GITHUB_ENV
           echo "pr_body=This automated PR imports string changes into branch '$current_branch'" >> $GITHUB_ENV
-        fi    
-
-    - name: Prepare Xliff files to import
-      run: |
-        # Change all the Xliff files original from en.lproj to en-US.lproj so they can be imported correctly
-        python3 "firefoxios-l10n/.github/scripts/rewrite_original_attribute.py" --path "firefoxios-l10n"
+        fi
         
     - name: Run script to import strings
       run: sh ./firefox-ios/import-strings.sh

--- a/.github/workflows/firefox-ios-import-strings.yml
+++ b/.github/workflows/firefox-ios-import-strings.yml
@@ -31,15 +31,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     
-    - name: Install Python dependencies
-      run: |
-        pip install -r firefoxios-l10n/.github/scripts/requirements.txt
-    
     - name: Clone l10n iOS repository
       uses: actions/checkout@v4
       with:
         repository: "mozilla-l10n/firefoxios-l10n"
         path: "firefoxios-l10n"
+    
+    - name: Install Python dependencies
+      run: |
+        pip install -r firefoxios-l10n/.github/scripts/requirements.txt
 
     - name: Clone Localization Tools
       uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
           echo "pr_title=Localize [$version] String import $current_date" >> $GITHUB_ENV
           echo "pr_body=This automated PR imports string changes into branch '$current_branch'" >> $GITHUB_ENV
         fi    
-            
+
     - name: Prepare Xliff files to import
       run: |
         # Change all the Xliff files original from en.lproj to en-US.lproj so they can be imported correctly

--- a/.github/workflows/firefox-ios-import-strings.yml
+++ b/.github/workflows/firefox-ios-import-strings.yml
@@ -61,7 +61,7 @@ jobs:
           echo "pr_title=Localize [$version] String import $current_date" >> $GITHUB_ENV
           echo "pr_body=This automated PR imports string changes into branch '$current_branch'" >> $GITHUB_ENV
         fi
-          
+  
     - name: Run script to import strings
       run: sh ./firefox-ios/import-strings.sh
 

--- a/.github/workflows/firefox-ios-import-strings.yml
+++ b/.github/workflows/firefox-ios-import-strings.yml
@@ -61,7 +61,7 @@ jobs:
           echo "pr_title=Localize [$version] String import $current_date" >> $GITHUB_ENV
           echo "pr_body=This automated PR imports string changes into branch '$current_branch'" >> $GITHUB_ENV
         fi
-  
+
     - name: Run script to import strings
       run: sh ./firefox-ios/import-strings.sh
 

--- a/.github/workflows/firefox-ios-import-strings.yml
+++ b/.github/workflows/firefox-ios-import-strings.yml
@@ -61,7 +61,7 @@ jobs:
           echo "pr_title=Localize [$version] String import $current_date" >> $GITHUB_ENV
           echo "pr_body=This automated PR imports string changes into branch '$current_branch'" >> $GITHUB_ENV
         fi
-        
+          
     - name: Run script to import strings
       run: sh ./firefox-ios/import-strings.sh
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,35 +6,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 #
 # Use the --force option to force a re-build locales.
-# Use the --importLocales option to fetch and update locales only
-
-getLocale() {
-  echo "Getting locale..."
-  rm -rf LocalizationTools
-  git clone https://github.com/mozilla-mobile/LocalizationTools.git || exit 1
-
-  echo "Creating firefoxios-l10n Git repo"
-  rm -rf firefoxios-l10n
-  git clone --depth 1 https://github.com/mozilla-l10n/firefoxios-l10n firefoxios-l10n || exit 1
-}
 
 if [ "$1" == "--force" ]; then
-    rm -rf firefoxios-l10n
-    rm -rf LocalizationTools
     rm -rf build
-fi
-
-if [ "$1" == "--importLocales" ]; then
-  # Import locales
-  if [ -d "/firefoxios-l10n" ] && [ -d "/LocalizationTools" ]; then
-      echo "l10n directories found. Not downloading scripts."
-  else
-      echo "l10n directory not found. Downloading repo and scripts."
-      getLocale
-  fi
-
-  ./firefox-ios/import-strings.sh
-  exit 0
 fi
 
 # Download the nimbus-fml.sh script from application-services.

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -5,11 +5,12 @@
 // swiftlint:disable line_length
 import Foundation
 
-public struct Strings {
-    public static let bundle = Bundle(for: LocalizationClass.self)
-}
+// MARK: - Localization bundle setup
+class BundleClass {}
 
-class LocalizationClass {}
+public struct Strings {
+    public static let bundle = Bundle(for: BundleClass.self)
+}
 
 // MARK: - Localization helper function
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -6,10 +6,10 @@
 import Foundation
 
 public struct Strings {
-    // This is a little workaround to get localizations
-    // FXIOS-10838 will fix this by moving localizations or this struct into the appropriate place
-    public static let bundle = Bundle(identifier: "org.mozilla.ios.Localizations") ?? .main
+    public static let bundle = Bundle(for: LocalizationClass.self)
 }
+
+class LocalizationClass {}
 
 // MARK: - Localization helper function
 

--- a/firefox-ios/import-strings.sh
+++ b/firefox-ios/import-strings.sh
@@ -1,4 +1,11 @@
 
+echo "\n\n[*] Cloning required repo to import strings"
+git clone https://github.com/mozilla-mobile/LocalizationTools.git || exit 1
+git clone --depth 1 https://github.com/mozilla-l10n/firefoxios-l10n || exit 1
+
+pip install firefoxios-l10n/.github/scripts/requirements.txt
+python3 firefoxios-l10n/.github/scripts/rewrite_original_attribute.py --path firefoxios-l10n
+
 echo "\n\n[*] Building tools/Localizations"
 (cd LocalizationTools && swift build)
 

--- a/firefox-ios/import-strings.sh
+++ b/firefox-ios/import-strings.sh
@@ -6,7 +6,7 @@ git clone https://github.com/mozilla-mobile/LocalizationTools.git || exit 1
 git clone --depth 1 https://github.com/mozilla-l10n/firefoxios-l10n || exit 1
 
 pip install -r firefoxios-l10n/.github/scripts/requirements.txt
-python3 "firefoxios-l10n/.github/scripts/rewrite_original_attribute.py" --path "firefoxios-l10n"
+python3 firefoxios-l10n/.github/scripts/rewrite_original_attribute.py --path firefoxios-l10n
 
 echo "\n\n[*] Building tools/Localizations"
 (cd LocalizationTools && swift build)

--- a/firefox-ios/import-strings.sh
+++ b/firefox-ios/import-strings.sh
@@ -1,10 +1,12 @@
 
 echo "\n\n[*] Cloning required repo to import strings"
+rm -rf LocalizationTools
+rm -rf firefoxios-l10n
 git clone https://github.com/mozilla-mobile/LocalizationTools.git || exit 1
 git clone --depth 1 https://github.com/mozilla-l10n/firefoxios-l10n || exit 1
 
-pip install "firefoxios-l10n/.github/scripts/requirements.txt:
-python3 firefoxios-l10n/.github/scripts/rewrite_original_attribute.py --path firefoxios-l10n
+pip install "firefoxios-l10n/.github/scripts/requirements.txt"
+python3 "firefoxios-l10n/.github/scripts/rewrite_original_attribute.py" --path "firefoxios-l10n"
 
 echo "\n\n[*] Building tools/Localizations"
 (cd LocalizationTools && swift build)

--- a/firefox-ios/import-strings.sh
+++ b/firefox-ios/import-strings.sh
@@ -1,7 +1,11 @@
 
 echo "\n\n[*] Cloning required repo to import strings"
-rm -rf LocalizationTools
-rm -rf firefoxios-l10n
+
+if [ -d "LocalizationTools" ] || [ -d "firefoxios-l10n" ]; then
+    rm -rf LocalizationTools
+    rm -rf firefoxios-l10n
+fi
+
 git clone https://github.com/mozilla-mobile/LocalizationTools.git || exit 1
 git clone --depth 1 https://github.com/mozilla-l10n/firefoxios-l10n || exit 1
 
@@ -18,3 +22,7 @@ echo "\n\n[*] Importing Strings - takes a minute. (output in import-strings.log)
   --l10n-project-path "$PWD/../firefoxios-l10n") > import-strings.log 2>&1
 
 echo "\n\n[!] Strings have been imported. You can now create a PR."
+
+echo "\n\n[!] Clean up cloned repos"
+rm -rf LocalizationTools
+rm -rf firefoxios-l10n

--- a/firefox-ios/import-strings.sh
+++ b/firefox-ios/import-strings.sh
@@ -23,6 +23,6 @@ echo "\n\n[*] Importing Strings - takes a minute. (output in import-strings.log)
 
 echo "\n\n[!] Strings have been imported. You can now create a PR."
 
-echo "\n\n[!] Clean up cloned repos"
+echo "\n\n[*] Clean up cloned repos"
 rm -rf LocalizationTools
 rm -rf firefoxios-l10n

--- a/firefox-ios/import-strings.sh
+++ b/firefox-ios/import-strings.sh
@@ -3,7 +3,7 @@ echo "\n\n[*] Cloning required repo to import strings"
 git clone https://github.com/mozilla-mobile/LocalizationTools.git || exit 1
 git clone --depth 1 https://github.com/mozilla-l10n/firefoxios-l10n || exit 1
 
-pip install firefoxios-l10n/.github/scripts/requirements.txt
+pip install "firefoxios-l10n/.github/scripts/requirements.txt:
 python3 firefoxios-l10n/.github/scripts/rewrite_original_attribute.py --path firefoxios-l10n
 
 echo "\n\n[*] Building tools/Localizations"

--- a/firefox-ios/import-strings.sh
+++ b/firefox-ios/import-strings.sh
@@ -5,7 +5,7 @@ rm -rf firefoxios-l10n
 git clone https://github.com/mozilla-mobile/LocalizationTools.git || exit 1
 git clone --depth 1 https://github.com/mozilla-l10n/firefoxios-l10n || exit 1
 
-pip install "firefoxios-l10n/.github/scripts/requirements.txt"
+pip install -r firefoxios-l10n/.github/scripts/requirements.txt
 python3 "firefoxios-l10n/.github/scripts/rewrite_original_attribute.py" --path "firefoxios-l10n"
 
 echo "\n\n[*] Building tools/Localizations"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10933)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23878)

## :bulb: Description
Changed `firefox-ios-import-strings.yml` in order to download `firefoxios-l10n` repo and `LocalizationTools` and to prepare Xliff file for import with script from `firefoxios-l10n` repo.
The bootstrap reference has been removed from the action since the `bootstrap.sh --importLocales` was basically cloning `firefoxios-l10n` repo and `LocalizationTools` repo. 

@nbhasin2 i've cleaned `boostrap.sh` import Local functionality since it is replaced in the `import-string.sh`, let me know if this makes sense, i didn't find any other places where we are using that flag.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

