### PR TITLE
Refactor FXIOS-10924 - Remove Deferred from FolderHierarchyFetcher

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
@@ -39,10 +39,11 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
             profile.places.getBookmarksTree(rootGUID: rootFolderGUID,
                                             recursive: true).uponQueue(.main) { data in
                 var folders = [Folder]()
-                defer {
+
+                guard let rootFolder = data.successValue as? BookmarkFolderData else {
                     continuation.resume(returning: folders)
+                    return
                 }
-                guard let rootFolder = data.successValue as? BookmarkFolderData else { return }
                 let hasDesktopBookmarks = (numDesktopBookmarks ?? 0) > 0
 
                 let childrenFolders = rootFolder.children?.compactMap {
@@ -52,6 +53,8 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
                 for folder in childrenFolders ?? [] {
                     recursiveAddSubFolders(folder, folders: &folders, hasDesktopBookmarks: hasDesktopBookmarks)
                 }
+
+                continuation.resume(returning: folders)
             }
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10924)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23869)

## :bulb: Description
- Refactored `FolderHierarchyFetcher` to remove the `defer` block and use a guard statement for handling invalid rootFolder data
- The continuation is now explicitly resumed after processing, ensuring the correct flow
- The `DefaultFolderHierarchyFetcherTests` passed successfully

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

