### PR TITLE
Add FXIOS-10913 [Homepage] [Top Sites] layout configuration for number of tiles per row

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1009,6 +1009,8 @@
 		8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */; };
 		8AD248F12C0F735200500AB7 /* BehavioralTargetingEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD248F02C0F735200500AB7 /* BehavioralTargetingEvent.swift */; };
 		8AD3271527E3B45D00EAF033 /* SponsoredTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD3271427E3B45D00EAF033 /* SponsoredTile.swift */; };
+		8AD3AFC32D143EF600CFC887 /* TopSitesDimensionImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD3AFC22D143EF000CFC887 /* TopSitesDimensionImplementation.swift */; };
+		8AD3AFC52D143F1200CFC887 /* TopSitesDimensionImplementationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD3AFC42D143F0D00CFC887 /* TopSitesDimensionImplementationTests.swift */; };
 		8AD40FC527BADC1F00672675 /* TabToolbarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */; };
 		8AD40FC727BADC3400672675 /* ToolbarTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC627BADC3400672675 /* ToolbarTextField.swift */; };
 		8AD40FCA27BADC4B00672675 /* ReaderModeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD40FC827BADC4B00672675 /* ReaderModeButton.swift */; };
@@ -7594,6 +7596,8 @@
 		8AD1980E27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonActionSheetViewModel.swift; sourceTree = "<group>"; };
 		8AD248F02C0F735200500AB7 /* BehavioralTargetingEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralTargetingEvent.swift; sourceTree = "<group>"; };
 		8AD3271427E3B45D00EAF033 /* SponsoredTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredTile.swift; sourceTree = "<group>"; };
+		8AD3AFC22D143EF000CFC887 /* TopSitesDimensionImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesDimensionImplementation.swift; sourceTree = "<group>"; };
+		8AD3AFC42D143F0D00CFC887 /* TopSitesDimensionImplementationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesDimensionImplementationTests.swift; sourceTree = "<group>"; };
 		8AD40FC427BADC1E00672675 /* TabToolbarHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabToolbarHelper.swift; sourceTree = "<group>"; };
 		8AD40FC627BADC3400672675 /* ToolbarTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTextField.swift; sourceTree = "<group>"; };
 		8AD40FC827BADC4B00672675 /* ReaderModeButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeButton.swift; sourceTree = "<group>"; };
@@ -11168,6 +11172,7 @@
 		8A00BD852CAB3FC200680AF9 /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
+				8AD3AFC42D143F0D00CFC887 /* TopSitesDimensionImplementationTests.swift */,
 				8A87B4352CC1A8FD003A9239 /* Mock */,
 				8A87B4302CC1A3BA003A9239 /* PocketManagerTests.swift */,
 				8A552AC22CB43A7000564C98 /* Redux */,
@@ -11394,6 +11399,7 @@
 		8A454D3D2CB9B896009436D9 /* TopSites */ = {
 			isa = PBXGroup;
 			children = (
+				8AD3AFC22D143EF000CFC887 /* TopSitesDimensionImplementation.swift */,
 				8A454D3E2CB9B8A0009436D9 /* TopSitesSectionState.swift */,
 				8A454D422CB9B8F5009436D9 /* TopSitesManager.swift */,
 				8A454D402CB9B8AA009436D9 /* TopSitesAction.swift */,
@@ -16172,6 +16178,7 @@
 				21BFEEF52A040EF40033048D /* TabMigrationUtility.swift in Sources */,
 				8AEAD9F52C3D7BA9001A2C5A /* FeatureFlagsDebugViewController.swift in Sources */,
 				810CD9C12BB346D800E290C2 /* OnboardingCardViewController.swift in Sources */,
+				8AD3AFC32D143EF600CFC887 /* TopSitesDimensionImplementation.swift in Sources */,
 				C8A012F126AB07D70096A7A7 /* JumpBackInViewModel.swift in Sources */,
 				8AAAB05F2C1B72C9008830B3 /* SearchHighlightItem.swift in Sources */,
 				8A3EF8172A2FD2B900796E3A /* AdvancedAccountSettings.swift in Sources */,
@@ -17162,6 +17169,7 @@
 				AB4FB4E12C90491F005EF0CC /* BlockedTrackersTableViewControllerTests.swift in Sources */,
 				8A6B79A02CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift in Sources */,
 				39C137972655798A003DC662 /* NimbusIntegrationTests.swift in Sources */,
+				8AD3AFC52D143F1200CFC887 /* TopSitesDimensionImplementationTests.swift in Sources */,
 				215B458427DA87FC00E5E800 /* TabMetadataManagerTests.swift in Sources */,
 				215349062886007900FADB4D /* GleanPlumbMessageStoreTests.swift in Sources */,
 				2173326A29CCF901007F20C7 /* UIPanGestureRecognizerMock.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+struct TopSitesDimensionImplementation {
+    /// Get the number of tiles (top sites) per row the user will see. This depends on the UI interface the user has.
+    /// - Parameter availableWidth: available width size depending on device
+    /// - Parameter leadingInset: padding for top site section
+    /// - Parameter cellWidth: width of individual top site tiles
+    /// - Returns: The number of tiles per row the user will see, which is based on layout.
+    func getNumberOfTilesPerRow(availableWidth: CGFloat, leadingInset: CGFloat, cellWidth: CGFloat) -> Int {
+        var availableWidth = availableWidth - leadingInset * 2
+        var numberOfTiles = 0
+
+        while availableWidth > cellWidth {
+            numberOfTiles += 1
+            availableWidth = availableWidth - cellWidth - HomepageSectionLayoutProvider.UX.standardSpacing
+        }
+        let minCardsConstant = HomepageSectionLayoutProvider.UX.TopSitesConstants.minCards
+        return numberOfTiles < minCardsConstant ? minCardsConstant : numberOfTiles
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesDimension.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesDimension.swift
@@ -33,7 +33,7 @@ protocol TopSitesDimension {
     ) -> TopSitesSectionDimension
 }
 
-class TopSitesDimensionImplementation: TopSitesDimension {
+class LegacyTopSitesDimensionImplementation: TopSitesDimension {
     func getSectionDimension(for sites: [TopSite],
                              numberOfRows: Int,
                              interface: TopSitesUIInterface

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -42,7 +42,7 @@ class TopSitesViewModel {
         self.profile = profile
         self.isZeroSearch = isZeroSearch
         self.theme = theme
-        self.dimensionManager = TopSitesDimensionImplementation()
+        self.dimensionManager = LegacyTopSitesDimensionImplementation()
 
         self.topSiteHistoryManager = TopSiteHistoryManager(profile: profile)
         self.googleTopSiteManager = GoogleTopSiteManager(prefs: profile.prefs)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDimensionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDimensionTests.swift
@@ -7,7 +7,7 @@ import Storage
 
 @testable import Client
 
-class TopSitesDimensionTests: XCTestCase {
+class LegacyTopSitesDimensionTests: XCTestCase {
     struct DeviceSize {
         static let iPhone14 = CGSize(width: 390, height: 844)
         static let iPadAir = CGSize(width: 820, height: 1180)
@@ -173,9 +173,9 @@ class TopSitesDimensionTests: XCTestCase {
     }
 }
 
-extension TopSitesDimensionTests {
+extension LegacyTopSitesDimensionTests {
     func createSubject() -> TopSitesDimension {
-        let subject = TopSitesDimensionImplementation()
+        let subject = LegacyTopSitesDimensionImplementation()
         trackForMemoryLeaks(subject)
 
         return subject

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesDimensionImplementationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesDimensionImplementationTests.swift
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+class TopSitesDimensionImplementationTests: XCTestCase {
+    struct UX {
+        struct DeviceSize {
+            static let iPhone14 = CGSize(width: 390, height: 844)
+            static let iPadAir = CGSize(width: 820, height: 1180)
+            static let iPadAirCompactSplit = CGSize(width: 320, height: 375)
+        }
+
+        static let cellWidth = HomepageSectionLayoutProvider.UX.TopSitesConstants.cellEstimatedSize.width
+    }
+
+    func test_getNumberOfTilesPerRow_withPortraitIphone_showsExpectedRowNumber() {
+        let subject = createSubject()
+        let trait = MockTraitCollection().getTraitCollection()
+        let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .phone)
+
+        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+            availableWidth: UX.DeviceSize.iPhone14.width,
+            leadingInset: leadingInset,
+            cellWidth: UX.cellWidth
+        )
+
+        XCTAssertEqual(numberOfTilesPerRow, 4)
+    }
+
+    func test_getNumberOfTilesPerRow_withLandscapeIphone_showsExpectedRowNumber() {
+        let subject = createSubject()
+        let trait = MockTraitCollection().getTraitCollection()
+        let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .phone)
+
+        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+            availableWidth: UX.DeviceSize.iPhone14.height,
+            leadingInset: leadingInset,
+            cellWidth: UX.cellWidth
+        )
+
+        XCTAssertEqual(numberOfTilesPerRow, 8)
+    }
+
+    func test_getNumberOfTilesPerRow_withPortraitIpadRegular_showsExpectedRowNumber() {
+        let subject = createSubject()
+        let trait = MockTraitCollection().getTraitCollection()
+        let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
+
+        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+            availableWidth: UX.DeviceSize.iPadAir.width,
+            leadingInset: leadingInset,
+            cellWidth: UX.cellWidth
+        )
+
+        XCTAssertEqual(numberOfTilesPerRow, 7)
+    }
+
+    func test_getNumberOfTilesPerRow_withLandscapeIpadRegular_showsDefaultRowNumber() {
+        let subject = createSubject()
+        let trait = MockTraitCollection().getTraitCollection()
+        let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
+
+        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+            availableWidth: UX.DeviceSize.iPadAir.height,
+            leadingInset: leadingInset,
+            cellWidth: UX.cellWidth
+        )
+
+        XCTAssertEqual(numberOfTilesPerRow, 10)
+    }
+
+    func test_getNumberOfTilesPerRow_withPortraitIpadCompact_showsDefaultRowNumber() {
+        let subject = createSubject()
+        let trait = MockTraitCollection().getTraitCollection()
+        let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
+
+        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+            availableWidth: UX.DeviceSize.iPadAirCompactSplit.width,
+            leadingInset: leadingInset,
+            cellWidth: UX.cellWidth
+        )
+
+        XCTAssertEqual(numberOfTilesPerRow, 4)
+    }
+
+    func test_getNumberOfTilesPerRow_withLandscapeIpadCompact_showsDefaultRowNumber() {
+        let subject = createSubject()
+        let trait = MockTraitCollection().getTraitCollection()
+        let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
+
+        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+            availableWidth: UX.DeviceSize.iPadAirCompactSplit.height,
+            leadingInset: leadingInset,
+            cellWidth: UX.cellWidth
+        )
+
+        XCTAssertEqual(numberOfTilesPerRow, 4)
+    }
+
+    func createSubject() -> TopSitesDimensionImplementation {
+        return TopSitesDimensionImplementation()
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10913)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23842)

## :bulb: Description
Part I of updating logic for top sites layout per [wiki](https://github.com/mozilla-mobile/firefox-ios/wiki/How-do-Top-Sites-(Shortcuts)-work%3F#top-sites-layout) to keep PRs small.

This includes adjusting the number of tiles to be shown depending on the width of the device. 

> The device's screen width. Each tile space has a fixed width, and so we calculate the number of tiles that can fit inside a certain screen width to know how many tiles can show.

Renamed previous `TopSitesDimensionImplementation` class to `LegacyTopSitesDimensionImplementation` and created a new struct called `TopSitesDimensionImplementation` to simplify how the previous implementation was being used without disrupting the code from legacy homepage.

Part II will include considering the user's preference on the number of rows, which can be set from the Settings menu.

## Screenshots 

**iPhone**

https://github.com/user-attachments/assets/32a164fc-31c0-4400-83f5-6b8dcdba3a5a

**iPad**

https://github.com/user-attachments/assets/a42083ec-4d79-42cf-b429-c3d411a44b3e

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

