### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in SurveySurfaceViewController

### DIFF
--- a/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
+++ b/firefox-ios/Client/Frontend/SurveySurface/SurveySurfaceViewController.swift
@@ -34,7 +34,7 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     var notificationCenter: NotificationProtocol
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
-    var imageViewYConstraint: NSLayoutConstraint!
+    var imageViewYConstraint: NSLayoutConstraint?
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
 
@@ -136,13 +136,13 @@ class SurveySurfaceViewController: UIViewController, Themeable {
 
     private func constrainViews() {
         imageViewYConstraint = imageView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        imageViewYConstraint?.isActive = true
 
         NSLayoutConstraint.activate(
             [
                 imageView.heightAnchor.constraint(equalToConstant: UX.imageViewSize.height),
                 imageView.widthAnchor.constraint(equalToConstant: UX.imageViewSize.width),
                 imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                imageViewYConstraint,
 
                 titleLabel.topAnchor.constraint(
                     equalTo: imageView.bottomAnchor,
@@ -211,12 +211,12 @@ class SurveySurfaceViewController: UIViewController, Themeable {
     /// Changes the constraint of the imageView. This needs to be done separately
     /// if we want to do it in an animation.
     private func changeImageViewConstraint() {
-        NSLayoutConstraint.deactivate([imageViewYConstraint])
+        imageViewYConstraint?.isActive = false
         imageViewYConstraint = imageView.centerYAnchor.constraint(
             equalTo: view.centerYAnchor,
             constant: -(view.frame.height * UX.imageViewCenterYOffset)
         )
-        NSLayoutConstraint.activate([imageViewYConstraint])
+        imageViewYConstraint?.isActive = true
     }
 
     // MARK: - Button Actions


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

