### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Resolve 1 implicitly_unwrapped_optional violations in FxAWebViewController

### DIFF
--- a/firefox-ios/RustFxA/FxAWebViewController.swift
+++ b/firefox-ios/RustFxA/FxAWebViewController.swift
@@ -171,7 +171,7 @@ extension FxAWebViewController: WKNavigationDelegate {
         }
     }
 
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
         let hideLongpress = "document.body.style.webkitTouchCallout='none';"
         webView.evaluateJavascriptInDefaultContentWorld(hideLongpress)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Continuing resolving `implicitly_unwrapped_optional` violations in order to enable the rule for further developments.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

