### PR TITLE
Refactor MTE-4206 Bump Xcode version to 16.2

### DIFF
--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -6,7 +6,7 @@ on:
 
 env:
     browser: focus-ios
-    xcode_version: 16.1
+    xcode_version: 16.2
     test_results_directory: /Users/runner/tmp
 
 jobs:

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -7,8 +7,8 @@ on:
 
 env:
     browser: focus-ios
-    xcode_version: 16.1
-    ios_version: 18.1
+    xcode_version: 16.2
+    ios_version: 18.2
     ios_simulator_default: iPhone 16
     xcodebuild_scheme: Focus
     xcodebuild_target: XCUITest


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4206)

## :bulb: Description
Let me bump the Xcode and iOS versions before remediating the errors from `xcpretty`.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

