### PR TITLE
Refactor FXIOS-10924 - Remove Deferred from FolderHierarchyFetcher

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
@@ -35,22 +35,23 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
 
     func fetchFolders() async -> [Folder] {
         let numDesktopBookmarks = await countDesktopBookmarks()
-        return await withCheckedContinuation { continuation in
-            profile.places.getBookmarksTree(rootGUID: rootFolderGUID,
-                                            recursive: true).uponQueue(.main) { data in
-                var folders = [Folder]()
-                defer {
+        return await withUnsafeContinuation { continuation in
+            profile.places.getBookmarksTree(rootGUID: rootFolderGUID, recursive: true) { result in
+                switch result {
+                case .success(let data):
+                    guard let rootFolder = data as? BookmarkFolderData else { return }
+                    let hasDesktopBookmarks = (numDesktopBookmarks ?? 0) > 0
+
+                    let childrenFolders = rootFolder.children?.compactMap {
+                        return $0 as? BookmarkFolderData
+                    }
+                    var folders = [Folder]()
+                    for folder in childrenFolders ?? [] {
+                        recursiveAddSubFolders(folder, folders: &folders, hasDesktopBookmarks: hasDesktopBookmarks)
+                    }
                     continuation.resume(returning: folders)
-                }
-                guard let rootFolder = data.successValue as? BookmarkFolderData else { return }
-                let hasDesktopBookmarks = (numDesktopBookmarks ?? 0) > 0
-
-                let childrenFolders = rootFolder.children?.compactMap {
-                    return $0 as? BookmarkFolderData
-                }
-
-                for folder in childrenFolders ?? [] {
-                    recursiveAddSubFolders(folder, folders: &folders, hasDesktopBookmarks: hasDesktopBookmarks)
+                case .failure:
+                    continuation.resume(returning: [])
                 }
             }
         }
@@ -75,7 +76,7 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
     }
 
     private func countDesktopBookmarks() async -> Int? {
-        return await withCheckedContinuation { continuation in
+        return await withUnsafeContinuation { continuation in
             profile.places.countBookmarksInTrees(folderGuids: BookmarkRoots.DesktopRoots.map { $0 }) { result in
                 switch result {
                 case .success(let count):

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Bookmarks/BookmarksDataAdaptorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Bookmarks/BookmarksDataAdaptorTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 @testable import Client
 
-class BookmarksDataAdaptorTests: XCTestCase {
+final class BookmarksDataAdaptorTests: XCTestCase {
     var subject: BookmarksDataAdaptor!
     var mockBookmarksHandler: BookmarksHandlerMock!
     var mockNotificationCenter: MockNotificationCenter!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Bookmarks/BookmarksHandlerMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Bookmarks/BookmarksHandlerMock.swift
@@ -10,7 +10,17 @@ import class MozillaAppServices.BookmarkFolderData
 import class MozillaAppServices.BookmarkItemData
 import class MozillaAppServices.BookmarkNodeData
 
-class BookmarksHandlerMock: BookmarksHandler {
+final class BookmarksHandlerMock: BookmarksHandler {
+    private let bookmarkFolderData = BookmarkFolderData(
+        guid: "1",
+        dateAdded: Int64(Date().toTimestamp()),
+        lastModified: Int64(Date().toTimestamp()),
+        parentGUID: "123",
+        position: 0,
+        title: "bookmarkfolder",
+        childGUIDs: [],
+        children: nil)
+
     var getRecentBookmarksCallCount = 0
     var getRecentBookmarksCompletion: (([BookmarkItemData]) -> Void)?
 
@@ -23,19 +33,18 @@ class BookmarksHandlerMock: BookmarksHandler {
         getRecentBookmarksCompletion?(results)
     }
 
-    var responseForBookmarksTree: Maybe<BookmarkNodeData?> = Maybe(success: BookmarkFolderData(
-        guid: "1",
-        dateAdded: Int64(Date().toTimestamp()),
-        lastModified: Int64(Date().toTimestamp()),
-        parentGUID: "123",
-        position: 0,
-        title: "bookmarkfolder",
-        childGUIDs: [],
-        children: nil))
     func getBookmarksTree(rootGUID: Shared.GUID, recursive: Bool) -> Deferred<Maybe<BookmarkNodeData?>> {
         let deferred = Deferred<Maybe<BookmarkNodeData?>>()
-        deferred.fill(responseForBookmarksTree)
+        deferred.fill(Maybe(success: bookmarkFolderData))
         return deferred
+    }
+
+    func getBookmarksTree(
+        rootGUID: GUID,
+        recursive: Bool,
+        completion: @escaping (Result<BookmarkNodeData?, any Error>) -> Void
+    ) {
+        completion(.success(bookmarkFolderData))
     }
 
     func updateBookmarkNode(guid: Shared.GUID,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10924)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23787)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Define `RustPlacesProtocol`.
- Implement its methods.
- Call them in `DefaultFolderHierarchyFetcher`.
- Tests pass.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

