### PR TITLE
Bugfix MTE-4206 macos-15 Github Actions runner and Xcode 16.2

### DIFF
--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install packages
         run: |
           pip3 install virtualenv pipenv
-          gem install xcpretty -v 0.4.0
+          gem install xcpretty -v 0.3.0
           pip install blockkit==1.9.1
       - name: Setup Xcode
         id: xcode
@@ -83,7 +83,7 @@ jobs:
             -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan FullFunctionalTests \
             -resultBundlePath ${{ env.test_results_directory }}/results-fullfunctionaltests \
-            | tee xcodebuild-fullfunctionaltests.log | xcpretty -r junit --output ./junit-fullfunctionaltests.xml && exit ${PIPESTATUS[0]}
+            | tee xcodebuild-fullfunctionaltests.log | xcpretty _0.3.0_ -r junit --output ./junit-fullfunctionaltests.xml && exit ${PIPESTATUS[0]}
         working-directory: ${{ env.browser }}
         continue-on-error: true
       - name: Determine pass/fail status

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   Focus-iOS-Tests:
     name: Focus iOS
-    runs-on: macos-15
+    runs-on: macos-15-arm64
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -52,6 +52,7 @@ jobs:
         id: setup-simulator
         run: |
           output=$(xcrun simctl list runtimes | grep "${{ matrix.ios_version }}")
+          echo $output
           if  [ -n "$output" ]; then
             echo "iOS ${{ matrix.ios_version }} simulator has already been installed"
           else

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           output=$(xcrun simctl list runtimes | grep "${{ matrix.ios_version }}")
           if  [ -n "$output" ]; then
-            echo "Pattern found."
+            echo "iOS ${{ matrix.ios_version }} simulator has already been installed"
           else
             sudo xcodes runtimes install "iOS ${{ matrix.ios_version }}"
           fi

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -20,8 +20,8 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - ios_version: 17.5
-            ios_simulator: iPhone 15
+          # - ios_version: 17.5
+          #  ios_simulator: iPhone 15
           - ios_version: 16.4
             ios_simulator: iPhone 14
           - ios_version: 15.5

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -52,8 +52,8 @@ jobs:
         id: setup-simulator
         run: |
           xcrun simctl list runtimes
-          xcrun simctl list runtimes | grep "${{ matrix.ios_version }}"
-          output=$(xcrun simctl list runtimes | grep "${{ matrix.ios_version }}")
+          xcrun simctl list runtimes | grep "iOS ${{ matrix.ios_version }}"
+          output=$(xcrun simctl list runtimes | grep "iOS ${{ matrix.ios_version }}")
           echo "output: '$output'"
           if  [ -z "$output" ]; then
             echo "iOS ${{ matrix.ios_version }} simulator has already been installed"

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -55,6 +55,7 @@ jobs:
           if  [ -n "$output" ]; then
             echo "iOS ${{ matrix.ios_version }} simulator has already been installed"
           else
+            echo "Install iOS ${{ matrix.ios_version }} runtime"
             sudo xcodes runtimes install "iOS ${{ matrix.ios_version }}"
           fi
           xcrun simctl list devices iphone

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -7,6 +7,8 @@ on:
 env:
     browser: focus-ios
     xcode_version: 16.2
+    xcodebuild_scheme: Focus
+    xcodebuild_target: XCUITest
     test_results_directory: /Users/runner/tmp
 
 jobs:
@@ -54,35 +56,39 @@ jobs:
       - name: Build Focus
         id: compile
         run: |
-          xcodebuild build-for-testing \
-            -project Blockzilla.xcodeproj -scheme Focus \
-            -configuration FocusDebug \
-            CODE_SIGNING_ALLOWED=NO -destination \
-            'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}'
+          xcodebuild \
+            build-for-testing \
+            -scheme ${{ env.xcodebuild_scheme }} \
+            -target ${{ env.xcodebuild_target }} \
+            -derivedDataPath ~/DerivedData \
+            -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
+            COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ARCH="arm64"
         working-directory:  ${{ env.browser }}
       - name: Run smoke tests
         id: run-smoketests
         run: |
-          xcodebuild test-without-building \
-            -project Blockzilla.xcodeproj -scheme Focus \
-            -configuration FocusDebug \
-            CODE_SIGNING_ALLOWED=NO \
+          xcodebuild \
+            test-without-building \
+            -scheme ${{ env.xcodebuild_scheme }} \
+            -target ${{ env.xcodebuild_target }} \
+            -derivedDataPath ~/DerivedData \
             -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan SmokeTest \
-            -resultBundlePath ${{ env.test_results_directory }}/results-smoketests \
-            | tee xcodebuild-smoketests.log | xcpretty -r junit --output ./junit-smoketests.xml && exit ${PIPESTATUS[0]}
+            -resultBundlePath ${{ env.test_results_directory }}/results \
+            | tee xcodebuild-smoketests.log | xcpretty _0.3.0_ -r junit --output ./junit-smoketests.xml && exit ${PIPESTATUS[0]}
         working-directory: ${{ env.browser }}
         continue-on-error: true
       - name: Run full functional tests
         id: run-fullfunctionaltests
         run: |
-          xcodebuild test-without-building \
-            -project Blockzilla.xcodeproj -scheme Focus \
-            -configuration FocusDebug \
-            CODE_SIGNING_ALLOWED=NO \
+          xcodebuild \
+            test-without-building \
+            -scheme ${{ env.xcodebuild_scheme }} \
+            -target ${{ env.xcodebuild_target }} \
+            -derivedDataPath ~/DerivedData \
             -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan FullFunctionalTests \
-            -resultBundlePath ${{ env.test_results_directory }}/results-fullfunctionaltests \
+            -resultBundlePath ${{ env.test_results_directory }}/results \
             | tee xcodebuild-fullfunctionaltests.log | xcpretty _0.3.0_ -r junit --output ./junit-fullfunctionaltests.xml && exit ${PIPESTATUS[0]}
         working-directory: ${{ env.browser }}
         continue-on-error: true

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -51,7 +51,12 @@ jobs:
       - name: Create iOS ${{ matrix.ios_version }} simulator
         id: setup-simulator
         run: |
-          sudo xcodes runtimes install "iOS ${{ matrix.ios_version }}"
+          output=$(xcrun simctl list runtimes | grep "${{ matrix.ios_version }}")
+          if  [ -n "$output" ]; then
+            echo "Pattern found."
+          else
+            sudo xcodes runtimes install "iOS ${{ matrix.ios_version }}"
+          fi
           xcrun simctl list devices iphone
       - name: Build Focus
         id: compile

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -20,7 +20,7 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - ios_version: 17.5
+          - ios_version: 17.4
             ios_simulator: iPhone 15
           - ios_version: 16.4
             ios_simulator: iPhone 14

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -20,7 +20,7 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - ios_version: 17.4
+          - ios_version: 17.5
             ios_simulator: iPhone 15
           - ios_version: 16.4
             ios_simulator: iPhone 14

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -6,7 +6,7 @@ on:
 
 env:
     browser: focus-ios
-    xcode_version: 16.1
+    xcode_version: 16.2
     test_results_directory: /Users/runner/tmp
 
 jobs:
@@ -34,7 +34,7 @@ jobs:
       - name: Install packages
         run: |
           pip3 install virtualenv pipenv
-          gem install xcpretty -v 0.3.0
+          gem install xcpretty -v 0.4.0
           pip install blockkit==1.9.1
       - name: Setup Xcode
         id: xcode

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   Focus-iOS-Tests:
     name: Focus iOS
-    runs-on: macos-15-arm64
+    runs-on: macos-15
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -51,9 +51,11 @@ jobs:
       - name: Create iOS ${{ matrix.ios_version }} simulator
         id: setup-simulator
         run: |
+          xcrun simctl list runtimes
+          xcrun simctl list runtimes | grep "${{ matrix.ios_version }}"
           output=$(xcrun simctl list runtimes | grep "${{ matrix.ios_version }}")
-          echo $output
-          if  [ -n "$output" ]; then
+          echo "output: '$output'"
+          if  [ -z "$output" ]; then
             echo "iOS ${{ matrix.ios_version }} simulator has already been installed"
           else
             echo "Install iOS ${{ matrix.ios_version }} runtime"

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -74,7 +74,7 @@ jobs:
             -derivedDataPath ~/DerivedData \
             -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan SmokeTest \
-            -resultBundlePath ${{ env.test_results_directory }}/results \
+            -resultBundlePath ${{ env.test_results_directory }}/results-smoketests \
             | tee xcodebuild-smoketests.log | xcpretty _0.3.0_ -r junit --output ./junit-smoketests.xml && exit ${PIPESTATUS[0]}
         working-directory: ${{ env.browser }}
         continue-on-error: true
@@ -88,7 +88,7 @@ jobs:
             -derivedDataPath ~/DerivedData \
             -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ matrix.ios_version }}' \
             -testPlan FullFunctionalTests \
-            -resultBundlePath ${{ env.test_results_directory }}/results \
+            -resultBundlePath ${{ env.test_results_directory }}/results-fullfunctionaltests \
             | tee xcodebuild-fullfunctionaltests.log | xcpretty _0.3.0_ -r junit --output ./junit-fullfunctionaltests.xml && exit ${PIPESTATUS[0]}
         working-directory: ${{ env.browser }}
         continue-on-error: true

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -52,10 +52,10 @@ jobs:
         id: setup-simulator
         run: |
           xcrun simctl list runtimes
-          xcrun simctl list runtimes | grep "iOS ${{ matrix.ios_version }}"
-          output=`xcrun simctl list runtimes | grep "iOS ${{ matrix.ios_version }}"`
+          xcrun simctl list runtimes | grep 'iOS'
+          output=$(xcrun simctl list runtimes | grep 'iOS ${{ matrix.ios_version }}')
           echo "output: '$output'"
-          if  [ -z "$output" ]; then
+          if $output then
             echo "iOS ${{ matrix.ios_version }} simulator has already been installed"
           else
             echo "Install iOS ${{ matrix.ios_version }} runtime"

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           xcrun simctl list runtimes
           xcrun simctl list runtimes | grep "iOS ${{ matrix.ios_version }}"
-          output=$(xcrun simctl list runtimes | grep "iOS ${{ matrix.ios_version }}")
+          output=`xcrun simctl list runtimes | grep "iOS ${{ matrix.ios_version }}"`
           echo "output: '$output'"
           if  [ -z "$output" ]; then
             echo "iOS ${{ matrix.ios_version }} simulator has already been installed"

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -20,8 +20,8 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          # - ios_version: 17.5
-          #  ios_simulator: iPhone 15
+          - ios_version: 17.5
+            ios_simulator: iPhone 15
           - ios_version: 16.4
             ios_simulator: iPhone 14
           - ios_version: 15.5

--- a/.github/workflows/focus-ios-ui-tests-previous-os.yml
+++ b/.github/workflows/focus-ios-ui-tests-previous-os.yml
@@ -52,10 +52,8 @@ jobs:
         id: setup-simulator
         run: |
           xcrun simctl list runtimes
-          xcrun simctl list runtimes | grep 'iOS'
-          output=$(xcrun simctl list runtimes | grep 'iOS ${{ matrix.ios_version }}')
-          echo "output: '$output'"
-          if $output then
+          output=$(xcrun simctl list runtimes | grep 'iOS ${{ matrix.ios_version }}' || true)
+          if [ -n "$output" ]; then
             echo "iOS ${{ matrix.ios_version }} simulator has already been installed"
           else
             echo "Install iOS ${{ matrix.ios_version }} runtime"

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -90,7 +90,7 @@ jobs:
                     -derivedDataPath ~/DerivedData \
                     -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
                     -testPlan ${{ matrix.xcodebuild_test_plan }} \
-                    -resultBundlePath ${{ env.test_results_directory }}/results
+                    -resultBundlePath ${{ env.test_results_directory }}/results \
                     | tee xcodebuild.log | xcpretty -r junit && exit ${PIPESTATUS[0]}
               working-directory:  ${{ env.browser }}
               continue-on-error: true

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -91,7 +91,8 @@ jobs:
                     -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
                     -testPlan ${{ matrix.xcodebuild_test_plan }} \
                     -resultBundlePath ${{ env.test_results_directory }}/results \
-                    | tee xcodebuild.log | xcpretty -r junit && exit ${PIPESTATUS[0]}
+                    | xcpretty -r junit && exit ${PIPESTATUS[0]}
+                touch xcodebuild.log
               working-directory:  ${{ env.browser }}
               continue-on-error: true
             - name: Print test report

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -55,17 +55,17 @@ jobs:
             fail-fast: false
             max-parallel: 1
             matrix:
-                xcodebuild_test_plan: ['SmokeTest', 'FullFunctionalTests']
-                ios_simulator: [ 'iPhone 16', 'iPad (10th generation)']
+                xcodebuild_test_plan: ['SmokeTest']
+                ios_simulator: ['iPhone 16']
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
             - name: Install packages
               id: packages
               run: |
-                gem install xcpretty -v 0.4.0
-                gem install erb -v 2.2.0
+                gem install xcpretty -v 0.2.8
                 pip install blockkit==1.9.1
+                xcpretty -version
             - name: Setup Xcode
               id: xcode
               run: |
@@ -91,7 +91,7 @@ jobs:
                     -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
                     -testPlan ${{ matrix.xcodebuild_test_plan }} \
                     -resultBundlePath ${{ env.test_results_directory }}/results
-                touch xcodebuild.log
+                    | tee xcodebuild.log | xcpretty -r junit && exit ${PIPESTATUS[0]}
               working-directory:  ${{ env.browser }}
               continue-on-error: true
             # - name: Print test report
@@ -115,22 +115,22 @@ jobs:
             #     name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
             #     path: ${{ env.browser }}/build/reports/junit.xml
             #     retention-days: 90
-            - name: Report to Slack
-              id: slack
-              uses: slackapi/slack-github-action@v1.26.0
-              with:
-                payload-file-path: ${{ env.browser }}/slack.json
-              env:
-                SLACK_WEBHOOK_URL: ${{ secrets.WEBHOOK_SLACK_TOKEN }}
-                SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-                ios_simulator: ${{ matrix.ios_simulator }}
-                pass_fail:  ${{ steps.run-tests.outcome == 'success' && ':white_check_mark:' || ':x:' }}
-                xcodebuild_test_plan: ${{ matrix.xcodebuild_test_plan }}
-                ref_name: ${{ github.ref_name }}
-                repository: ${{ github.repository }}
-                run_id: ${{ github.run_id }}
-                server_url: ${{ github.server_url }}
-                sha: ${{ github.sha }}
+            # - name: Report to Slack
+            #   id: slack
+            #   uses: slackapi/slack-github-action@v1.26.0
+            #   with:
+            #     payload-file-path: ${{ env.browser }}/slack.json
+            #   env:
+            #     SLACK_WEBHOOK_URL: ${{ secrets.WEBHOOK_SLACK_TOKEN }}
+            #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+            #     ios_simulator: ${{ matrix.ios_simulator }}
+            #     pass_fail:  ${{ steps.run-tests.outcome == 'success' && ':white_check_mark:' || ':x:' }}
+            #     xcodebuild_test_plan: ${{ matrix.xcodebuild_test_plan }}
+            #     ref_name: ${{ github.ref_name }}
+            #     repository: ${{ github.repository }}
+            #     run_id: ${{ github.run_id }}
+            #     server_url: ${{ github.server_url }}
+            #     sha: ${{ github.sha }}
             - name: Return fail status if a test fails
               run: |
                 exit ${{ steps.run-tests.outcome == 'success' && '0' || '1' }}

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -38,7 +38,7 @@ jobs:
                   -target ${{ env.xcodebuild_target }} \
                   -derivedDataPath ~/DerivedData \
                   -destination 'platform=iOS Simulator,name=${{ env.ios_simulator_default }},OS=${{ env.ios_version }}' \
-                  COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ARCH="arm64"
+                  COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
               working-directory: ${{ env.browser }}
             - name: Save Derived Data
               id: upload-derived-data

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -63,9 +63,10 @@ jobs:
             - name: Install packages
               id: packages
               run: |
-                gem install xcpretty -v 0.2.8
-                pip install blockkit==1.9.1
+                gem uninstall xcpretty -ax
+                gem install xcpretty -v 0.3.0
                 xcpretty -version
+                pip install blockkit==1.9.1
             - name: Setup Xcode
               id: xcode
               run: |

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -63,7 +63,7 @@ jobs:
             - name: Install packages
               id: packages
               run: |
-                gem uninstall xcpretty -ax
+                gem uninstall xcpretty -ax -v 0.4.0
                 gem install xcpretty -v 0.3.0
                 xcpretty -version
                 pip install blockkit==1.9.1

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -24,9 +24,8 @@ jobs:
             - name: Install packages
               id: packages
               run: |
-                gem uninstall xcpretty -v 0.4.0
                 gem install xcpretty -v 0.3.0
-                xcpretty -version
+                xcpretty _0.3.0_ -version
                 pip install blockkit==1.9.1
             - name: Setup Xcode
               id: xcode
@@ -70,9 +69,8 @@ jobs:
             - name: Install packages
               id: packages
               run: |
-                gem uninstall xcpretty -v 0.4.0
                 gem install xcpretty -v 0.3.0
-                xcpretty -version
+                xcpretty _0.3.0_ -version
                 pip install blockkit==1.9.1
             - name: Setup Xcode
               id: xcode
@@ -99,7 +97,7 @@ jobs:
                     -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
                     -testPlan ${{ matrix.xcodebuild_test_plan }} \
                     -resultBundlePath ${{ env.test_results_directory }}/results \
-                    | tee xcodebuild.log | xcpretty -r junit && exit ${PIPESTATUS[0]}
+                    | tee xcodebuild.log | xcpretty _0.3.0_ -r junit && exit ${PIPESTATUS[0]}
               working-directory:  ${{ env.browser }}
               continue-on-error: true
             # - name: Print test report

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -25,7 +25,6 @@ jobs:
               id: packages
               run: |
                 gem install xcpretty -v 0.3.0
-                xcpretty _0.3.0_ -version
                 pip install blockkit==1.9.1
             - name: Setup Xcode
               id: xcode

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -17,7 +17,7 @@ env:
 jobs:
     compile:
         name: Compile
-        runs-on: macos-15
+        runs-on: macos-15-arm64
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
@@ -49,7 +49,7 @@ jobs:
                 retention-days: 2          
     run-tests:
         name: Run tests
-        runs-on: macos-15
+        runs-on: macos-15-arm64
         needs: compile
         strategy:
             fail-fast: false

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -64,6 +64,7 @@ jobs:
               id: packages
               run: |
                 gem install xcpretty -v 0.4.0
+                gem install erb -v 2.2.0
                 pip install blockkit==1.9.1
             - name: Setup Xcode
               id: xcode

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -21,11 +21,6 @@ jobs:
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
-            - name: Install packages
-              id: packages
-              run: |
-                gem install xcpretty -v 0.3.0
-                pip install blockkit==1.9.1
             - name: Setup Xcode
               id: xcode
               run: |

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -21,6 +21,13 @@ jobs:
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
+            - name: Install packages
+              id: packages
+              run: |
+                gem uninstall xcpretty -v 0.4.0
+                gem install xcpretty -v 0.3.0
+                xcpretty -version
+                pip install blockkit==1.9.1
             - name: Setup Xcode
               id: xcode
               run: |
@@ -63,7 +70,7 @@ jobs:
             - name: Install packages
               id: packages
               run: |
-                gem uninstall xcpretty -ax -v 0.4.0
+                gem uninstall xcpretty -v 0.4.0
                 gem install xcpretty -v 0.3.0
                 xcpretty -version
                 pip install blockkit==1.9.1

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -63,7 +63,7 @@ jobs:
             - name: Install packages
               id: packages
               run: |
-                gem install xcpretty -v 0.3.0
+                gem install xcpretty -v 0.4.0
                 pip install blockkit==1.9.1
             - name: Setup Xcode
               id: xcode

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -17,7 +17,7 @@ env:
 jobs:
     compile:
         name: Compile
-        runs-on: macos-15-arm64
+        runs-on: macos-15
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
@@ -49,7 +49,7 @@ jobs:
                 retention-days: 2          
     run-tests:
         name: Run tests
-        runs-on: macos-15-arm64
+        runs-on: macos-15
         needs: compile
         strategy:
             fail-fast: false

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -61,8 +61,8 @@ jobs:
             fail-fast: false
             max-parallel: 1
             matrix:
-                xcodebuild_test_plan: ['SmokeTest']
-                ios_simulator: ['iPhone 16']
+              xcodebuild_test_plan: ['SmokeTest', 'FullFunctionalTests']
+              ios_simulator: [ 'iPhone 16', 'iPad (10th generation)']
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7
@@ -121,22 +121,22 @@ jobs:
                 name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
                 path: ${{ env.browser }}/build/reports/junit.xml
                 retention-days: 90
-            # - name: Report to Slack
-            #   id: slack
-            #   uses: slackapi/slack-github-action@v1.26.0
-            #   with:
-            #     payload-file-path: ${{ env.browser }}/slack.json
-            #   env:
-            #     SLACK_WEBHOOK_URL: ${{ secrets.WEBHOOK_SLACK_TOKEN }}
-            #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-            #     ios_simulator: ${{ matrix.ios_simulator }}
-            #     pass_fail:  ${{ steps.run-tests.outcome == 'success' && ':white_check_mark:' || ':x:' }}
-            #     xcodebuild_test_plan: ${{ matrix.xcodebuild_test_plan }}
-            #     ref_name: ${{ github.ref_name }}
-            #     repository: ${{ github.repository }}
-            #     run_id: ${{ github.run_id }}
-            #     server_url: ${{ github.server_url }}
-            #     sha: ${{ github.sha }}
+            - name: Report to Slack
+              id: slack
+              uses: slackapi/slack-github-action@v1.26.0
+              with:
+                payload-file-path: ${{ env.browser }}/slack.json
+              env:
+                SLACK_WEBHOOK_URL: ${{ secrets.WEBHOOK_SLACK_TOKEN }}
+                SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+                ios_simulator: ${{ matrix.ios_simulator }}
+                pass_fail:  ${{ steps.run-tests.outcome == 'success' && ':white_check_mark:' || ':x:' }}
+                xcodebuild_test_plan: ${{ matrix.xcodebuild_test_plan }}
+                ref_name: ${{ github.ref_name }}
+                repository: ${{ github.repository }}
+                run_id: ${{ github.run_id }}
+                server_url: ${{ github.server_url }}
+                sha: ${{ github.sha }}
             - name: Return fail status if a test fails
               run: |
                 exit ${{ steps.run-tests.outcome == 'success' && '0' || '1' }}

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -100,27 +100,27 @@ jobs:
                     | tee xcodebuild.log | xcpretty _0.3.0_ -r junit && exit ${PIPESTATUS[0]}
               working-directory:  ${{ env.browser }}
               continue-on-error: true
-            # - name: Print test report
-            #   id: test-report
-            #   run: |
-            #     python ../test-fixtures/ci/convert_junit_to_markdown.py ${{ matrix.xcodebuild_test_plan == 'SmokeTest' && '--smoke' || '' }} --github --${{ env.browser }} ./build/reports/junit.xml ./github.md
-            #     cat github.md >> $GITHUB_STEP_SUMMARY
-            #     python ../test-fixtures/ci/convert_junit_to_markdown.py ${{ matrix.xcodebuild_test_plan == 'SmokeTest' && '--smoke' || '' }} --slack --${{ env.browser }} ./build/reports/junit.xml ./slack.json
-            #   working-directory:  ${{ env.browser }}
-            # - name: Upload log file
-            #   id: upload-log
-            #   uses: actions/upload-artifact@v4.3.3
-            #   with:
-            #     name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-xcodebuildlog-${{ github.run_number }}
-            #     path: ${{ env.browser }}/xcodebuild.log
-            #     retention-days: 90
-            # - name: Upload junit files
-            #   id: upload-junit
-            #   uses: actions/upload-artifact@v4.3.3
-            #   with:
-            #     name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
-            #     path: ${{ env.browser }}/build/reports/junit.xml
-            #     retention-days: 90
+            - name: Print test report
+              id: test-report
+              run: |
+                python ../test-fixtures/ci/convert_junit_to_markdown.py ${{ matrix.xcodebuild_test_plan == 'SmokeTest' && '--smoke' || '' }} --github --${{ env.browser }} ./build/reports/junit.xml ./github.md
+                cat github.md >> $GITHUB_STEP_SUMMARY
+                python ../test-fixtures/ci/convert_junit_to_markdown.py ${{ matrix.xcodebuild_test_plan == 'SmokeTest' && '--smoke' || '' }} --slack --${{ env.browser }} ./build/reports/junit.xml ./slack.json
+              working-directory:  ${{ env.browser }}
+            - name: Upload log file
+              id: upload-log
+              uses: actions/upload-artifact@v4.3.3
+              with:
+                name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-xcodebuildlog-${{ github.run_number }}
+                path: ${{ env.browser }}/xcodebuild.log
+                retention-days: 90
+            - name: Upload junit files
+              id: upload-junit
+              uses: actions/upload-artifact@v4.3.3
+              with:
+                name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
+                path: ${{ env.browser }}/build/reports/junit.xml
+                retention-days: 90
             # - name: Report to Slack
             #   id: slack
             #   uses: slackapi/slack-github-action@v1.26.0

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -7,8 +7,8 @@ on:
 
 env:
     browser: focus-ios
-    xcode_version: 16.1
-    ios_version: 18.1
+    xcode_version: 16.2
+    ios_version: 18.2
     ios_simulator_default: iPhone 16
     xcodebuild_scheme: Focus
     xcodebuild_target: XCUITest

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -61,8 +61,8 @@ jobs:
             fail-fast: false
             max-parallel: 1
             matrix:
-              xcodebuild_test_plan: ['SmokeTest', 'FullFunctionalTests']
-              ios_simulator: [ 'iPhone 16', 'iPad (10th generation)']
+                xcodebuild_test_plan: ['SmokeTest', 'FullFunctionalTests']
+                ios_simulator: [ 'iPhone 16', 'iPad (10th generation)']
         steps:
             - name: Check out source code
               uses: actions/checkout@v4.1.7

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -64,7 +64,6 @@ jobs:
               id: packages
               run: |
                 gem install xcpretty -v 0.3.0
-                xcpretty _0.3.0_ -version
                 pip install blockkit==1.9.1
             - name: Setup Xcode
               id: xcode

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -90,32 +90,31 @@ jobs:
                     -derivedDataPath ~/DerivedData \
                     -destination 'platform=iOS Simulator,name=${{ matrix.ios_simulator }},OS=${{ env.ios_version }}' \
                     -testPlan ${{ matrix.xcodebuild_test_plan }} \
-                    -resultBundlePath ${{ env.test_results_directory }}/results \
-                    | xcpretty -r junit && exit ${PIPESTATUS[0]}
+                    -resultBundlePath ${{ env.test_results_directory }}/results
                 touch xcodebuild.log
               working-directory:  ${{ env.browser }}
               continue-on-error: true
-            - name: Print test report
-              id: test-report
-              run: |
-                python ../test-fixtures/ci/convert_junit_to_markdown.py ${{ matrix.xcodebuild_test_plan == 'SmokeTest' && '--smoke' || '' }} --github --${{ env.browser }} ./build/reports/junit.xml ./github.md
-                cat github.md >> $GITHUB_STEP_SUMMARY
-                python ../test-fixtures/ci/convert_junit_to_markdown.py ${{ matrix.xcodebuild_test_plan == 'SmokeTest' && '--smoke' || '' }} --slack --${{ env.browser }} ./build/reports/junit.xml ./slack.json
-              working-directory:  ${{ env.browser }}
-            - name: Upload log file
-              id: upload-log
-              uses: actions/upload-artifact@v4.3.3
-              with:
-                name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-xcodebuildlog-${{ github.run_number }}
-                path: ${{ env.browser }}/xcodebuild.log
-                retention-days: 90
-            - name: Upload junit files
-              id: upload-junit
-              uses: actions/upload-artifact@v4.3.3
-              with:
-                name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
-                path: ${{ env.browser }}/build/reports/junit.xml
-                retention-days: 90
+            # - name: Print test report
+            #   id: test-report
+            #   run: |
+            #     python ../test-fixtures/ci/convert_junit_to_markdown.py ${{ matrix.xcodebuild_test_plan == 'SmokeTest' && '--smoke' || '' }} --github --${{ env.browser }} ./build/reports/junit.xml ./github.md
+            #     cat github.md >> $GITHUB_STEP_SUMMARY
+            #     python ../test-fixtures/ci/convert_junit_to_markdown.py ${{ matrix.xcodebuild_test_plan == 'SmokeTest' && '--smoke' || '' }} --slack --${{ env.browser }} ./build/reports/junit.xml ./slack.json
+            #   working-directory:  ${{ env.browser }}
+            # - name: Upload log file
+            #   id: upload-log
+            #   uses: actions/upload-artifact@v4.3.3
+            #   with:
+            #     name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-xcodebuildlog-${{ github.run_number }}
+            #     path: ${{ env.browser }}/xcodebuild.log
+            #     retention-days: 90
+            # - name: Upload junit files
+            #   id: upload-junit
+            #   uses: actions/upload-artifact@v4.3.3
+            #   with:
+            #     name: ${{ env.browser }}-${{ matrix.xcodebuild_test_plan }}-${{ matrix.ios_simulator }}-junit-${{ github.run_number }}
+            #     path: ${{ env.browser }}/build/reports/junit.xml
+            #     retention-days: 90
             - name: Report to Slack
               id: slack
               uses: slackapi/slack-github-action@v1.26.0

--- a/.github/workflows/focus-ios-ui-tests.yml
+++ b/.github/workflows/focus-ios-ui-tests.yml
@@ -38,7 +38,7 @@ jobs:
                   -target ${{ env.xcodebuild_target }} \
                   -derivedDataPath ~/DerivedData \
                   -destination 'platform=iOS Simulator,name=${{ env.ios_simulator_default }},OS=${{ env.ios_version }}' \
-                  COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+                  COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ARCH="arm64"
               working-directory: ${{ env.browser }}
             - name: Save Derived Data
               id: upload-derived-data


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4206)

## :bulb: Description
This PR address the following caused by the Xcode 16 and the Github Actions runner upgrade:
* Bump Xcode version to 16.2
* `xcpretty` does not work if a test fails, even intermittently. We pin the version of `xcpretty` to 0.3.0 instead of using 0.4.0 from the Github Actions `macos-15` runner. (We have installed v0.3.0 previously, but we did not pin the version.)
* For previous versions of iOS, if the simulator runtime is already installed, do not attempt to reinstall the runtime.
* Use the same command to compile and test throughout *all* Focus tests.

Focus for iOS 15, 16 and 17: https://github.com/mozilla-mobile/firefox-ios/actions/runs/12422652690
Focus UI Tests: https://github.com/mozilla-mobile/firefox-ios/actions/runs/12422654698

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

