### PR TITLE
Add FXIOS-9751 [Bookmarks evolution] Update bookmarks panel title with folder title

### DIFF
--- a/BrowserKit/Sources/Shared/NotificationConstants.swift
+++ b/BrowserKit/Sources/Shared/NotificationConstants.swift
@@ -81,6 +81,8 @@ extension Notification.Name {
 
     public static let LibraryPanelStateDidChange = Notification.Name("LibraryPanelStateDidChange")
 
+    public static let LibraryPanelBookmarkTitleChanged = Notification.Name("LibraryPanelBookmarkTitleChanged")
+
     public static let SearchSettingsChanged = Notification.Name("SearchSettingsChanged")
 
     public static let SponsoredAndNonSponsoredSuggestionsChanged = Notification.Name("SponsoredAndNonSponsoredSuggestions")

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -155,7 +155,6 @@ class BookmarksViewController: SiteTableViewController,
     }
 
     private func updateParentViewControllerTitle() {
-        guard viewModel.isBookmarkRefactorEnabled else { return }
         if !viewModel.isRootNode, let folderTitle = viewModel.bookmarkFolder?.title {
             notificationCenter.post(name: .LibraryPanelBookmarkTitleChanged,
                                     withObject: nil,

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -113,7 +113,7 @@ class BookmarksViewController: SiteTableViewController,
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        notificationCenter.removeObserver(self)
     }
 
     // MARK: - Lifecycle
@@ -149,9 +149,26 @@ class BookmarksViewController: SiteTableViewController,
                     self?.flashRow()
                 }
                 self?.updateEmptyState()
+                self?.updateParentViewControllerTitle()
             }
         }
     }
+
+    private func updateParentViewControllerTitle() {
+        guard viewModel.isBookmarkRefactorEnabled else { return }
+        if !viewModel.isRootNode, let folderTitle = viewModel.bookmarkFolder?.title {
+            notificationCenter.post(name: .LibraryPanelBookmarkTitleChanged,
+                                    withObject: nil,
+                                    withUserInfo: ["title": folderTitle])
+        } else {
+            // This will set the title to the default one
+            notificationCenter.post(name: .LibraryPanelBookmarkTitleChanged,
+                                    withObject: nil,
+                                    withUserInfo: nil)
+        }
+    }
+
+    // MARK: - Actions
 
     private func centerVisibleRow() -> Int {
         let visibleCells = tableView.visibleCells


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9751)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21420)

## :bulb: Description
Update bookmarks panel title with folder title through a notification.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

