### PR TITLE
Bugfix FXIOS-10149, FXIOS-10940 Migrate to Kingfisher 8 and fix iOS 18 crash on launch (continuations again?)

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
             branch: "master"),
         .package(
             url: "https://github.com/onevcat/Kingfisher.git",
-            exact: "7.12.0"),
+            exact: "8.1.3"),
         .package(
             url: "https://github.com/AliSoftware/Dip.git",
             exact: "7.1.1"),

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/DefaultSiteImageDownloader.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/DefaultSiteImageDownloader.swift
@@ -6,28 +6,12 @@ import Foundation
 import Kingfisher
 import Common
 
-class DefaultSiteImageDownloader: ImageDownloader, SiteImageDownloader {
-    var continuation: CheckedContinuation<SiteImageLoadingResult, Error>?
-    var timeoutDelay: UInt64 { return 10 }
+class DefaultSiteImageDownloader: ImageDownloader, @unchecked Sendable, SiteImageDownloader {
+    var timeoutDelay: Double { return 10 }
     var logger: Logger
 
     init(name: String = "default", logger: Logger = DefaultLogger.shared) {
         self.logger = logger
         super.init(name: name)
-    }
-
-    func downloadImage(with url: URL,
-                       completionHandler: ((Result<SiteImageLoadingResult, Error>) -> Void)?
-    ) -> DownloadTask? {
-        return downloadImage(with: url,
-                             options: [.processor(SVGImageProcessor())],
-                             completionHandler: { result in
-            switch result {
-            case .success(let value):
-                completionHandler?(.success(value))
-            case .failure(let error):
-                completionHandler?(.failure(error))
-            }
-        })
     }
 }

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
@@ -28,8 +28,6 @@ struct DefaultFaviconFetcher: FaviconFetcher {
         do {
             let result = try await imageDownloader.downloadImage(with: imageURL)
             return result.image
-        } catch let error as KingfisherError {
-            throw SiteImageError.unableToDownloadImage(error.errorDescription ?? "No description")
         } catch let error as SiteImageError {
             throw error
         } catch {

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
@@ -28,6 +28,8 @@ struct DefaultFaviconFetcher: FaviconFetcher {
         do {
             let result = try await imageDownloader.downloadImage(with: imageURL)
             return result.image
+        } catch let error as KingfisherError {
+            throw SiteImageError.unableToDownloadImage(error.errorDescription ?? "No description")
         } catch let error as SiteImageError {
             throw error
         } catch {

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
@@ -11,72 +11,47 @@ import Common
 /// Image downloader wrapper around Kingfisher image downloader
 /// Used in FaviconFetcher
 protocol SiteImageDownloader: AnyObject {
-    /// Provides the KingFisher ImageDownloader with a Timeout in case the completion isn't called
-    var timeoutDelay: UInt64 { get }
-    var continuation: CheckedContinuation<any SiteImageLoadingResult, any Error>? { get set }
+    /// Specifies the timeout on image downloads
+    var timeoutDelay: Double { get }
     var logger: Logger { get }
-
-    @discardableResult
-    func downloadImage(
-        with url: URL,
-        completionHandler: ((Result<SiteImageLoadingResult, Error>) -> Void)?
-    ) -> DownloadTask?
 
     func downloadImage(with url: URL) async throws -> SiteImageLoadingResult
 }
 
 extension SiteImageDownloader {
+    /// Downloads an image at the given URL. Throws `SiteImageError` errors.
     func downloadImage(with url: URL) async throws -> SiteImageLoadingResult {
-        return try await withThrowingTaskGroup(of: SiteImageLoadingResult.self) { group in
-            // Use task groups to have a timeout when downloading an image from Kingfisher
-            // due to https://sentry.io/share/issue/951b878416374dd98eccb6fd88fd8427
-            group.addTask {
-                return try await self.handleImageDownload(url: url)
-            }
+        // Override Kingfisher's default timeout (which is 15s)
+        let modifier = AnyModifier { request in
+            var r = request
+            r.timeoutInterval = self.timeoutDelay
+            return r
+        }
 
-            group.addTask {
-                try await self.handleTimeout()
-            }
-
-            // wait for the first task and cancel the other one
-            let result = try await group.next()
-            group.cancelAll()
-            guard let result = result else {
-                throw SiteImageError.unableToDownloadImage("Result not present")
-            }
+        do {
+            let result = try await ImageDownloader.default.downloadImage(
+                with: url,
+                options: [
+                    .processor(SVGImageProcessor()),
+                    .requestModifier(modifier)
+                ]
+            )
             return result
-        }
-    }
-
-    private func handleImageDownload(url: URL) async throws -> any SiteImageLoadingResult {
-        return try await withCheckedThrowingContinuation { continuation in
-            // Store a copy of the continuation to act on in the case the sleep finishes first
-            self.continuation = continuation
-
-            _ = self.downloadImage(with: url) { result in
-                guard let continuation = self.continuation else { return }
-                switch result {
-                case .success(let imageResult):
-                    continuation.resume(returning: imageResult)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-                self.continuation = nil
+        } catch let error as KingfisherError {
+            // Log telemetry for Kingfisher timeout errors
+            if case .responseError(let reason) = error,
+               case .URLSessionError(let sessionError) = reason,
+               let error = sessionError as? URLError,
+               error.code == .timedOut {
+                self.logger.log("Timeout when downloading image reached",
+                                level: .warning,
+                                category: .images)
             }
+
+            throw SiteImageError.unableToDownloadImage(error.errorDescription ?? "No description")
+        } catch {
+            throw SiteImageError.unableToDownloadImage(error.localizedDescription)
         }
-    }
-
-    private func handleTimeout() async throws -> any SiteImageLoadingResult {
-        try await Task.sleep(nanoseconds: self.timeoutDelay * NSEC_PER_SEC)
-        try Task.checkCancellation()
-        let error = SiteImageError.unableToDownloadImage("Timeout reached")
-        self.continuation?.resume(throwing: error)
-        self.continuation = nil
-
-        self.logger.log("Timeout when downloading image reached",
-                        level: .warning,
-                        category: .images)
-        throw error
     }
 }
 

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SiteImageDownloader.swift
@@ -22,10 +22,10 @@ extension SiteImageDownloader {
     /// Downloads an image at the given URL. Throws `SiteImageError` errors.
     func downloadImage(with url: URL) async throws -> SiteImageLoadingResult {
         // Override Kingfisher's default timeout (which is 15s)
-        let modifier = AnyModifier { request in
-            var r = request
-            r.timeoutInterval = self.timeoutDelay
-            return r
+        let modifier = AnyModifier { [weak self] request in
+            var modifiedRequest = request
+            modifiedRequest.timeoutInterval = self?.timeoutDelay ?? 15
+            return modifiedRequest
         }
 
         do {

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -26014,7 +26014,7 @@
 			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
 			requirement = {
 				kind = exactVersion;
-				version = 7.12.0;
+				version = 8.1.3;
 			};
 		};
 		8AB30EC62B6C038600BD9A9B /* XCRemoteSwiftPackageReference "lottie-ios" */ = {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "2ef543ee21d63734e1c004ad6c870255e8716c50",
-        "version" : "7.12.0"
+        "revision" : "e6749919f9761d573d37a7d7e78b1b854c191d7f",
+        "version" : "8.1.3"
       }
     },
     {


### PR DESCRIPTION
## :scroll: Tickets
[Jira Kingfisher Upgrade](https://mozilla-hub.atlassian.net/browse/FXIOS-10149)
[Github Kingfisher Upgrade](https://github.com/mozilla-mobile/firefox-ios/issues/22241)

FXIOS-10940 Crash
[Github](https://github.com/mozilla-mobile/firefox-ios/issues/23903) Crash

## :bulb: Description
This PR upgrades Kingfisher to version 8 and removes continuations related to downloadImage for favicons in favor of leveraging the async/await versions.

Kingfisher has a built in timeout so I deleted timeout-related code and ensured we were setting the timeout modifier on our kingfisher downloadImage request.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

