### PR TITLE
Refactor FXIOS-10149 Remove unneccessary Kingfisher 8 continuation for retrieving cache images

### DIFF
--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageCache/DefaultImageCache.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageCache/DefaultImageCache.swift
@@ -19,16 +19,7 @@ protocol DefaultImageCache {
 
 extension ImageCache: DefaultImageCache {
     func retrieve(forKey key: String) async throws -> UIImage? {
-        return try await withCheckedThrowingContinuation { continuation in
-            retrieveImage(forKey: key) { result in
-                switch result {
-                case .success(let imageResult):
-                    continuation.resume(returning: imageResult.image)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+        return try await Kingfisher.ImageCache.default.retrieveImage(forKey: key).image
     }
 
     func store(image: UIImage, forKey key: String) {

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
@@ -28,8 +28,6 @@ struct DefaultFaviconFetcher: FaviconFetcher {
         do {
             let result = try await imageDownloader.downloadImage(with: imageURL)
             return result.image
-        } catch let error as KingfisherError {
-            throw SiteImageError.unableToDownloadImage(error.errorDescription ?? "No description")
         } catch let error as SiteImageError {
             throw error
         } catch {

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/FaviconFetcher.swift
@@ -28,6 +28,8 @@ struct DefaultFaviconFetcher: FaviconFetcher {
         do {
             let result = try await imageDownloader.downloadImage(with: imageURL)
             return result.image
+        } catch let error as KingfisherError {
+            throw SiteImageError.unableToDownloadImage(error.errorDescription ?? "No description")
         } catch let error as SiteImageError {
             throw error
         } catch {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10149)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22241)

## :bulb: Description
Kingfisher is still using a continuation under the hood for this call, but there's no reason for us to double it up.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

