### PR TITLE
Add FXIOS-10895 [Bookmarks evolution] Add save button + fix issue with saving an update to bookmark

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -44,6 +44,16 @@ class EditFolderViewController: UIViewController,
         view.tableHeaderView = headerSpacerView
     }
 
+    private lazy var saveBarButton: UIBarButtonItem =  {
+        let button = UIBarButtonItem(
+            title: String.Bookmarks.Menu.EditBookmarkSave,
+            style: .done,
+            target: self,
+            action: #selector(saveButtonAction)
+        )
+        return button
+    }()
+
     init(viewModel: EditFolderViewModel,
          windowUUID: WindowUUID,
          themeManager: any ThemeManager = AppContainer.shared.resolve(),
@@ -64,6 +74,7 @@ class EditFolderViewController: UIViewController,
     override func viewDidLoad() {
         super.viewDidLoad()
         title = viewModel.controllerTitle
+        navigationItem.rightBarButtonItem = saveBarButton
         viewModel.onFolderStatusUpdate = { [weak self] in
             self?.tableView.reloadSections(IndexSet(integer: Section.parentFolder.rawValue), with: .automatic)
         }
@@ -103,6 +114,14 @@ class EditFolderViewController: UIViewController,
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+    }
+
+    // MARK: - Actions
+
+    @objc
+    func saveButtonAction() {
+        // Save will happen in viewWillDisappear
+        navigationController?.popViewController(animated: true)
     }
 
     // MARK: - Themeable

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -106,7 +106,7 @@ class EditFolderViewModel {
             switch result {
             case .success(let guid):
                 // A nil guid indicates a bookmark update, not creation
-                guard let guid else { return }
+                guard let guid else { break }
                 profile.prefs.setString(guid, forKey: PrefsKeys.RecentBookmarkFolder)
 
                 // When the folder edit view is a child of the edit bookmark view, the newly created folder

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/EditFolderViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/EditFolderViewModelTests.swift
@@ -105,12 +105,17 @@ class EditFolderViewModelTests: XCTestCase {
         XCTAssertEqual(bookmarksSaver.saveCalled, 0)
     }
 
-    func testSave_whenNilGuidReturned() async throws {
+    func testSave_whenNilGuidReturned_thenCallsSaveBookmarkButNoRecentBookmark() async throws {
         let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onBookmarkSaved should be called")
+        subject.onBookmarkSaved = {
+            expectation.fulfill()
+        }
 
         let task = subject.save()
         await task?.value
 
+        await fulfillment(of: [expectation])
         let prefs = try XCTUnwrap(profile.prefs as? MockProfilePrefs)
         XCTAssertNil(prefs.things[PrefsKeys.RecentBookmarkFolder])
         XCTAssertEqual(bookmarksSaver.saveCalled, 1)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10895)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23784)

## :bulb: Description
- Add the save button back on the Edit folder view.
- Fix a bug where the `onBookmarkSaved?()` completion wasn't called on an update of a Folder since the `guid` was nil. Using a `break` ensures we quit the switch case only, and not the complete function. The result of that bug was that going back to the main bookmarks folder, the changes were not visible (since the cells were not updated from the closure call). Adjusted the test to catch that issue at the same time.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

