### PR TITLE
Refactor FXIOS-10924 - Remove 1 opening brace space violation from RustPlaces.swift

### DIFF
--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -228,14 +228,12 @@ public class RustPlaces: BookmarksHandler, HistoryMetadataObserver {
         recursive: Bool,
         completion: @escaping (Result<BookmarkNodeData?, any Error>) -> Void
     ) {
-        withReader(
-            { connection in
-                return try connection.getBookmarksTree(
-                    rootGUID: rootGUID,
-                    recursive: recursive
-                )
-            },
-            completion: completion)
+        withReader({ connection in
+            return try connection.getBookmarksTree(
+                rootGUID: rootGUID,
+                recursive: recursive
+            )
+        }, completion: completion)
     }
 
     public func getBookmark(guid: GUID) -> Deferred<Maybe<BookmarkNodeData?>> {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10924)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23787)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
As part of my ongoing efforts to address the [Swiftlint: closure body length issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442), I ran Swiftlint and noticed a single violation for an opening brace space. This issue was introduced in a [recent PR](https://github.com/mozilla-mobile/firefox-ios/pull/23900).

To ensure a clean slate for addressing the closure body length violations and to avoid any disruptions when pushing commits to the repository (because of `swiftlint --strict` in pre-push hook), this PR resolves the linter issue first. Once merged, I’ll resume work on the closure body length task.

Sorry for stepping in!

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

