### PR TITLE
Refactor FXIOS-10613 [Homepage] Navigation Actions for BVCState

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
@@ -8,18 +8,12 @@ import Redux
 
 /// Actions that are related to navigation from the user perspective
 class NavigationBrowserAction: Action {
-    let url: URL?
-    let isGoogleTopSite: Bool?
-    let contextMenuConfiguration: ContextMenuConfiguration?
+    let navigationDestination: NavigationDestination
 
-    init(url: URL? = nil,
-         isGoogleTopSite: Bool? = nil,
-         contextMenuConfiguration: ContextMenuConfiguration? = nil,
+    init(navigationDestination: NavigationDestination,
          windowUUID: WindowUUID,
          actionType: ActionType) {
-        self.url = url
-        self.isGoogleTopSite = isGoogleTopSite
-        self.contextMenuConfiguration = contextMenuConfiguration
+        self.navigationDestination = navigationDestination
         super.init(windowUUID: windowUUID,
                    actionType: actionType)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -156,7 +156,11 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         state: BrowserViewControllerState
     ) -> BrowserViewControllerState {
         switch action.actionType {
-        case NavigationBrowserActionType.tapOnCustomizeHomepage:
+        case NavigationBrowserActionType.tapOnCustomizeHomepage,
+            NavigationBrowserActionType.tapOnTrackingProtection,
+            NavigationBrowserActionType.tapOnCell,
+            NavigationBrowserActionType.tapOnLink,
+            NavigationBrowserActionType.longPressOnCell:
             return BrowserViewControllerState(
                 searchScreenState: state.searchScreenState,
                 showDataClearanceFlow: state.showDataClearanceFlow,
@@ -164,46 +168,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 windowUUID: state.windowUUID,
                 browserViewType: state.browserViewType,
                 microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
-                navigationDestination: NavigationDestination(.customizeHomepage)
-            )
-
-        case NavigationBrowserActionType.tapOnTrackingProtection:
-            return BrowserViewControllerState(
-                searchScreenState: state.searchScreenState,
-                showDataClearanceFlow: state.showDataClearanceFlow,
-                fakespotState: FakespotState.reducer(state.fakespotState, action),
-                windowUUID: state.windowUUID,
-                browserViewType: state.browserViewType,
-                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
-                navigationDestination: NavigationDestination(.trackingProtectionSettings)
-            )
-
-        case NavigationBrowserActionType.tapOnCell,
-            NavigationBrowserActionType.tapOnLink:
-            return BrowserViewControllerState(
-                searchScreenState: state.searchScreenState,
-                showDataClearanceFlow: state.showDataClearanceFlow,
-                fakespotState: FakespotState.reducer(state.fakespotState, action),
-                windowUUID: state.windowUUID,
-                browserViewType: state.browserViewType,
-                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
-                navigationDestination: NavigationDestination(
-                    .link,
-                    url: action.url,
-                    isGoogleTopSite: action.isGoogleTopSite
-                )
-            )
-
-        case NavigationBrowserActionType.longPressOnCell:
-            return BrowserViewControllerState(
-                searchScreenState: state.searchScreenState,
-                showDataClearanceFlow: state.showDataClearanceFlow,
-                fakespotState: FakespotState.reducer(state.fakespotState, action),
-                windowUUID: state.windowUUID,
-                browserViewType: state.browserViewType,
-                microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
-                navigationDestination: NavigationDestination(.contextMenu,
-                                                             contextMenuConfiguration: action.contextMenuConfiguration)
+                navigationDestination: action.navigationDestination
             )
 
         default:

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -490,6 +490,7 @@ final class HomepageViewController: UIViewController,
     private func navigateToHomepageSettings() {
         store.dispatch(
             NavigationBrowserAction(
+                navigationDestination: NavigationDestination(.customizeHomepage),
                 windowUUID: self.windowUUID,
                 actionType: NavigationBrowserActionType.tapOnCustomizeHomepage
             )
@@ -499,7 +500,7 @@ final class HomepageViewController: UIViewController,
     private func navigateToPocketLearnMore() {
         store.dispatch(
             NavigationBrowserAction(
-                url: homepageState.pocketState.footerURL,
+                navigationDestination: NavigationDestination(.link, url: homepageState.pocketState.footerURL),
                 windowUUID: self.windowUUID,
                 actionType: NavigationBrowserActionType.tapOnLink
             )
@@ -510,7 +511,7 @@ final class HomepageViewController: UIViewController,
         let configuration = ContextMenuConfiguration(homepageSection: section, item: item, sourceView: sourceView)
         store.dispatch(
             NavigationBrowserAction(
-                contextMenuConfiguration: configuration,
+                navigationDestination: NavigationDestination(.contextMenu, contextMenuConfiguration: configuration),
                 windowUUID: windowUUID,
                 actionType: NavigationBrowserActionType.longPressOnCell
             )
@@ -531,8 +532,11 @@ final class HomepageViewController: UIViewController,
         case .topSite(let state, _):
             store.dispatch(
                 NavigationBrowserAction(
-                    url: state.site.url.asURL,
-                    isGoogleTopSite: state.isGoogleURL,
+                    navigationDestination: NavigationDestination(
+                        .link,
+                        url: state.site.url.asURL,
+                        isGoogleTopSite: state.isGoogleURL
+                    ),
                     windowUUID: self.windowUUID,
                     actionType: NavigationBrowserActionType.tapOnCell
                 )
@@ -540,7 +544,7 @@ final class HomepageViewController: UIViewController,
         case .pocket(let story):
             store.dispatch(
                 NavigationBrowserAction(
-                    url: story.url,
+                    navigationDestination: NavigationDestination(.link, url: story.url),
                     windowUUID: self.windowUUID,
                     actionType: NavigationBrowserActionType.tapOnCell
                 )
@@ -548,7 +552,10 @@ final class HomepageViewController: UIViewController,
         case .pocketDiscover(let item):
             store.dispatch(
                 NavigationBrowserAction(
-                    url: item.url,
+                    navigationDestination: NavigationDestination(
+                        .link,
+                        url: item.url
+                    ),
                     windowUUID: self.windowUUID,
                     actionType: NavigationBrowserActionType.tapOnCell
                 )

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -572,6 +572,7 @@ class TrackingProtectionViewController: UIViewController,
     private func showSettings() {
         store.dispatch(
             NavigationBrowserAction(
+                navigationDestination: NavigationDestination(.trackingProtectionSettings),
                 windowUUID: self.windowUUID,
                 actionType: NavigationBrowserActionType.tapOnTrackingProtection
             )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -94,7 +94,7 @@ final class BrowserViewControllerStateTests: XCTestCase {
 
         XCTAssertNil(initialState.navigationDestination)
 
-        let action = getNavigationBrowserAction(for: .tapOnCustomizeHomepage)
+        let action = getNavigationBrowserAction(for: .tapOnCustomizeHomepage, destination: .customizeHomepage)
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.navigationDestination?.destination, .customizeHomepage)
@@ -108,7 +108,7 @@ final class BrowserViewControllerStateTests: XCTestCase {
         XCTAssertNil(initialState.navigationDestination)
 
         let url = try XCTUnwrap(URL(string: "www.example.com"))
-        let action = getNavigationBrowserAction(for: .tapOnCell, url: url)
+        let action = getNavigationBrowserAction(for: .tapOnCell, destination: .link, url: url)
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.navigationDestination?.destination, .link)
@@ -122,7 +122,7 @@ final class BrowserViewControllerStateTests: XCTestCase {
         XCTAssertNil(initialState.navigationDestination)
 
         let url = try XCTUnwrap(URL(string: "www.example.com"))
-        let action = getNavigationBrowserAction(for: .tapOnLink, url: url)
+        let action = getNavigationBrowserAction(for: .tapOnLink, destination: .link, url: url)
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.navigationDestination?.destination, .link)
@@ -144,10 +144,11 @@ final class BrowserViewControllerStateTests: XCTestCase {
 
     private func getNavigationBrowserAction(
         for actionType: NavigationBrowserActionType,
+        destination: BrowserNavigationDestination,
         url: URL? = nil
     ) -> NavigationBrowserAction {
         return NavigationBrowserAction(
-            url: url,
+            navigationDestination: NavigationDestination(destination, url: url),
             windowUUID: .XCTestDefaultUUID,
             actionType: actionType
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10613)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23244)

## :bulb: Description
In order to support the ticket of handling navigation actions for top sites / pocket items in the context menu, I did a bit of clean up of our current navigation actions for BVC state. 

Instead of duplicating properties between `NavigationBrowserAction` and `NavigationDestination`, this PR consolidates the action's payload to take in the `navigationDestination` property instead. Therefore, the state does not need to know how to parse through the separate actions and rather this get handled in the `newState` method in BVC instead. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

