### PR TITLE
Add FXIOS-10886 [Bookmarks Evolution] Desktop bookmarks header

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -187,7 +187,11 @@ class EditBookmarkViewController: UIViewController,
             else {
                 return UITableViewCell()
             }
-            configureParentFolderCell(cell, folder: folder)
+            if folder.guid == Folder.dummyFolderGuid {
+                configureDesktopBookmarksHeaderCell(cell)
+            } else {
+                configureParentFolderCell(cell, folder: folder)
+            }
             return cell
         case .newFolder:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: OneLineTableViewCell.cellIdentifier,
@@ -222,6 +226,15 @@ class EditBookmarkViewController: UIViewController,
         cell.accessoryType = canShowAccessoryView ? .checkmark : .none
         cell.selectionStyle = .default
         cell.customization = .regular
+        cell.applyTheme(theme: theme)
+    }
+
+    private func configureDesktopBookmarksHeaderCell(_ cell: OneLineTableViewCell) {
+        cell.titleLabel.text = String.Bookmarks.Menu.EditBookmarkDesktopBookmarksLabel
+        cell.customization = .desktopBookmarksLabel
+        cell.indentationLevel = 1
+        cell.accessoryType = .none
+        cell.selectionStyle = .none
         cell.applyTheme(theme: theme)
     }
 
@@ -274,6 +287,13 @@ class EditBookmarkViewController: UIViewController,
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
         guard let section = Section(rawValue: section), section == .folder else { return 0 }
         return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        if viewModel.folderStructures[safe: indexPath.row]?.guid == "DUMMY" {
+            return nil
+        }
+        return indexPath
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -290,7 +290,7 @@ class EditBookmarkViewController: UIViewController,
     }
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        if viewModel.folderStructures[safe: indexPath.row]?.guid == "DUMMY" {
+        if viewModel.folderStructures[safe: indexPath.row]?.guid == Folder.dummyFolderGuid {
             return nil
         }
         return indexPath

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -187,7 +187,7 @@ class EditBookmarkViewController: UIViewController,
             else {
                 return UITableViewCell()
             }
-            if folder.guid == Folder.dummyFolderGuid {
+            if folder.guid == Folder.DesktopFolderHeaderPlaceholderGuid {
                 configureDesktopBookmarksHeaderCell(cell)
             } else {
                 configureParentFolderCell(cell, folder: folder)
@@ -290,7 +290,7 @@ class EditBookmarkViewController: UIViewController,
     }
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        if viewModel.folderStructures[safe: indexPath.row]?.guid == Folder.dummyFolderGuid {
+        if viewModel.folderStructures[safe: indexPath.row]?.guid == Folder.DesktopFolderHeaderPlaceholderGuid {
             return nil
         }
         return indexPath

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -180,7 +180,11 @@ class EditFolderViewController: UIViewController,
                                                            for: indexPath) as? OneLineTableViewCell,
                   let folder = viewModel.folderStructures[safe: indexPath.row]
             else { return UITableViewCell() }
-            configureParentFolderCell(cell, folder: folder)
+            if folder.guid == Folder.dummyFolderGuid {
+                configureDesktopBookmarksHeaderCell(cell)
+            } else {
+                configureParentFolderCell(cell, folder: folder)
+            }
             return cell
         }
     }
@@ -202,7 +206,24 @@ class EditFolderViewController: UIViewController,
         let canShowAccessoryView = viewModel.shouldShowDisclosureIndicator(isFolderSelected: isFolderSelected)
         cell.accessoryType = canShowAccessoryView ? .checkmark : .none
         cell.selectionStyle = .default
+        cell.customization = .regular
         cell.applyTheme(theme: theme)
+    }
+
+    private func configureDesktopBookmarksHeaderCell(_ cell: OneLineTableViewCell) {
+        cell.titleLabel.text = String.Bookmarks.Menu.EditBookmarkDesktopBookmarksLabel
+        cell.customization = .desktopBookmarksLabel
+        cell.indentationLevel = 1
+        cell.accessoryType = .none
+        cell.selectionStyle = .none
+        cell.applyTheme(theme: theme)
+    }
+
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        if viewModel.folderStructures[safe: indexPath.row]?.guid == "DUMMY" {
+            return nil
+        }
+        return indexPath
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -180,7 +180,7 @@ class EditFolderViewController: UIViewController,
                                                            for: indexPath) as? OneLineTableViewCell,
                   let folder = viewModel.folderStructures[safe: indexPath.row]
             else { return UITableViewCell() }
-            if folder.guid == Folder.dummyFolderGuid {
+            if folder.guid == Folder.DesktopFolderHeaderPlaceholderGuid {
                 configureDesktopBookmarksHeaderCell(cell)
             } else {
                 configureParentFolderCell(cell, folder: folder)
@@ -220,7 +220,7 @@ class EditFolderViewController: UIViewController,
     }
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        if viewModel.folderStructures[safe: indexPath.row]?.guid == Folder.dummyFolderGuid {
+        if viewModel.folderStructures[safe: indexPath.row]?.guid == Folder.DesktopFolderHeaderPlaceholderGuid {
             return nil
         }
         return indexPath

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -220,7 +220,7 @@ class EditFolderViewController: UIViewController,
     }
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        if viewModel.folderStructures[safe: indexPath.row]?.guid == "DUMMY" {
+        if viewModel.folderStructures[safe: indexPath.row]?.guid == Folder.dummyFolderGuid {
             return nil
         }
         return indexPath

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
@@ -123,9 +123,9 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
     }
 
     private func prependDesktopFolders(_ folder: BookmarkFolderData,
-                                        folders: inout [Folder],
-                                        indent: Int = 0,
-                                        prefixFolders: [BookmarkFolderData] = []) {
+                                       folders: inout [Folder],
+                                       indent: Int = 0,
+                                       prefixFolders: [BookmarkFolderData] = []) {
         prefixFolders.forEach {
             folders.append(Folder(title: $0.title, guid: $0.guid, indentation: indent + 2))
         }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
@@ -20,7 +20,7 @@ struct Folder: Equatable {
     let guid: String
     let indentation: Int
 
-    static let dummyFolderGuid = "DUMMY"
+    static let DesktopFolderHeaderPlaceholderGuid = "DUMMY"
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.guid == rhs.guid
@@ -131,7 +131,7 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
         }
         // Find the first desktop folder and prepend a dummy folder object to use for the "DESKTOP BOOKMARKS" header
         if let firstDesktopFolderIndex = folders.firstIndex(where: { BookmarkRoots.DesktopRoots.contains($0.guid) }) {
-            let dummyFolder = Folder(title: "", guid: Folder.dummyFolderGuid, indentation: indent + 2)
+            let dummyFolder = Folder(title: "", guid: Folder.DesktopFolderHeaderPlaceholderGuid, indentation: indent + 2)
             folders.insert(dummyFolder, at: firstDesktopFolderIndex)
         }
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
@@ -20,6 +20,8 @@ struct Folder: Equatable {
     let guid: String
     let indentation: Int
 
+    static let dummyFolderGuid = "DUMMY"
+
     static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.guid == rhs.guid
     }
@@ -44,11 +46,30 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
                     guard let rootFolder = data as? BookmarkFolderData else { return }
                     let hasDesktopBookmarks = (numDesktopBookmarks ?? 0) > 0
 
-                    let childrenFolders = rootFolder.children?.compactMap {
+                    var childrenFolders = rootFolder.children?.compactMap {
                         return $0 as? BookmarkFolderData
                     }
+
+                    // Since desktop folders always exist in the backend, we should only display them if at least one of
+                    // them contains a bookmark
+                    var desktopFolders: [BookmarkFolderData] = []
+                    if hasDesktopBookmarks {
+                        desktopFolders = childrenFolders?.filter {
+                            BookmarkRoots.DesktopRoots.contains($0.guid)
+                        } ?? []
+
+                        // Remove desktop folders from the root folder hierarchy so they aren't added when recursing
+                        // the root folder
+                        childrenFolders?.removeAll {
+                            BookmarkRoots.DesktopRoots.contains($0.guid)
+                        }
+                    }
+
                     for folder in childrenFolders ?? [] {
-                        recursiveAddSubFolders(folder, folders: &folders, hasDesktopBookmarks: hasDesktopBookmarks)
+                        recursiveAddSubFolders(folder,
+                                               folders: &folders,
+                                               hasDesktopBookmarks: hasDesktopBookmarks,
+                                               prefixFolders: desktopFolders)
                     }
                 case .failure: return
                 }
@@ -56,12 +77,26 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
         }
     }
 
+    /// Recursively adds folder objects to the inout "folders" parameter
+    /// - Parameters:
+    ///   - folder: folder to recurse
+    ///   - folders: Array containing all appended folders
+    ///   - hasDesktopBookmarks: Whether or not the folder contains desktop bookmarks in its subfolder hierarchy
+    ///   - indent: Folder indentation
+    ///   - prefixFolders: Optional folders to be prepended to the top of the "folder" subfolder hierarchy.
+    ///                    Namely used to prepend the desktop folders to the top of the mobile bookmarks subfolder hierarchy
     private func recursiveAddSubFolders(_ folder: BookmarkFolderData,
                                         folders: inout [Folder],
                                         hasDesktopBookmarks: Bool,
-                                        indent: Int = 0) {
-        if !BookmarkRoots.DesktopRoots.contains(folder.guid) || hasDesktopBookmarks || !isBookmarkRefactorEnabled {
+                                        indent: Int = 0,
+                                        prefixFolders: [BookmarkFolderData] = []) {
+        if !BookmarkRoots.DesktopRoots.contains(folder.guid) || hasDesktopBookmarks {
             folders.append(Folder(title: folder.title, guid: folder.guid, indentation: indent))
+
+            // Prepend desktop folders to the top of the mobile bookmarks folder hierarchy
+            if folder.guid == BookmarkRoots.MobileFolderGUID {
+                prependDesktopFolders(folder, folders: &folders, indent: indent, prefixFolders: prefixFolders)
+            }
         } else { return }
         for case let subFolder as BookmarkFolderData in folder.children ?? [] {
             let indentation = subFolder.isRoot ? 0 : indent + 1
@@ -84,6 +119,20 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
                     continuation.resume(returning: nil)
                 }
             }
+        }
+    }
+
+    private func prependDesktopFolders(_ folder: BookmarkFolderData,
+                                        folders: inout [Folder],
+                                        indent: Int = 0,
+                                        prefixFolders: [BookmarkFolderData] = []) {
+        prefixFolders.forEach {
+            folders.append(Folder(title: $0.title, guid: $0.guid, indentation: indent + 2))
+        }
+        // Find the first desktop folder and prepend a dummy folder object to use for the "DESKTOP BOOKMARKS" header
+        if let firstDesktopFolderIndex = folders.firstIndex(where: { BookmarkRoots.DesktopRoots.contains($0.guid) }) {
+            let dummyFolder = Folder(title: "", guid: Folder.dummyFolderGuid, indentation: indent + 2)
+            folders.insert(dummyFolder, at: firstDesktopFolderIndex)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -9,6 +9,7 @@ import SiteImageView
 enum OneLineTableViewCustomization {
     case regular
     case newFolder
+    case desktopBookmarksLabel
 }
 
 struct OneLineTableViewCellViewModel {
@@ -159,6 +160,8 @@ class OneLineTableViewCell: UITableViewCell,
         selectionStyle = .default
         separatorInset = defaultSeparatorInset
         titleLabel.text = nil
+        titleLabel.font = FXFontStyles.Regular.body.scaledFont()
+        leftImageView.isHidden = false
     }
 
     // To simplify setup, OneLineTableViewCell now has a viewModel
@@ -192,6 +195,10 @@ class OneLineTableViewCell: UITableViewCell,
             accessoryView?.tintColor = theme.colors.iconSecondary
             leftImageView.tintColor = theme.colors.textAccent
             titleLabel.textColor = theme.colors.textAccent
+        case .desktopBookmarksLabel:
+            titleLabel.font = FXFontStyles.Regular.caption1.scaledFont()
+            titleLabel.textColor = theme.colors.textSecondary
+            leftImageView.isHidden = true
         }
     }
 }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -172,6 +172,11 @@ extension String {
                 tableName: "Bookmarks",
                 value: "Edit Bookmark",
                 comment: "Label on the top of the `Edit Bookmarks` screen.")
+            public static let EditBookmarkDesktopBookmarksLabel = MZLocalizedString(
+                key: "Bookmarks.Menu.EditBookmarkDesktopBookmarksLabel.v135",
+                tableName: "Bookmarks",
+                value: "DESKTOP BOOKMARKS",
+                comment: "Header denoting that the proceeding folders in the parent folder selector table of the Edit Bookmarks Screen are folders shared with desktop.")
             public static let DeletedBookmark = MZLocalizedString(
                 key: "Bookmarks.Menu.DeletedBookmark.v131",
                 tableName: "Bookmarks",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -173,7 +173,7 @@ extension String {
                 value: "Edit Bookmark",
                 comment: "Label on the top of the `Edit Bookmarks` screen.")
             public static let EditBookmarkDesktopBookmarksLabel = MZLocalizedString(
-                key: "Bookmarks.Menu.EditBookmarkDesktopBookmarksLabel.v135",
+                key: "Bookmarks.Menu.EditBookmarkDesktopBookmarksLabel.v136",
                 tableName: "Bookmarks",
                 value: "DESKTOP BOOKMARKS",
                 comment: "Header denoting that the proceeding folders in the parent folder selector table of the Edit Bookmarks Screen are folders shared with desktop.")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10886)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23761)

## :bulb: Description
- Add "desktop bookmarks" header inline within the folder hierarchy parent folder folder selector
- Move desktop bookmark folders to be the first folders inside the "Bookmarks" folder hierarchy within the parent folder selector
- Give the desktop bookmarks an extra indentation from other children in the "Bookmarks" folder hierarchy within the parent folder selector

*Note:  These changes were made to both the "Edit bookmark" and "Edit folder" screens

### 📷 Screenshots

| Before  | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 16 - 2024-12-27 at 16 48 19](https://github.com/user-attachments/assets/dbfadc7c-977a-4479-9014-730bbe4caae0) | ![Simulator Screenshot - iPhone 16 - 2024-12-27 at 16 46 32](https://github.com/user-attachments/assets/d0a6eb84-71c8-451f-a562-68c9b1d0009a) |
| ![Simulator Screenshot - iPhone 16 - 2024-12-27 at 16 48 22](https://github.com/user-attachments/assets/f32bbf00-76e4-4b83-b77f-1a48a9eaa081) | ![Simulator Screenshot - iPhone 16 - 2024-12-27 at 16 46 37](https://github.com/user-attachments/assets/51ae86c9-4aeb-4f82-91ef-302d4b8d43ff) |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

