### PR TITLE
Add FXIOS-10613 [Homepage] [ContextMenu] Navigation actions

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -725,6 +725,7 @@
 		8A093D7F2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */; };
 		8A093D812A4B58330099ABA5 /* MockSettingsFlowDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */; };
 		8A093D832A4B68940099ABA5 /* PrivacySettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A093D822A4B68940099ABA5 /* PrivacySettingsDelegate.swift */; };
+		8A09BCC32D22F1BE00CFDF60 /* ContextMenuCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A09BCC22D22F1BE00CFDF60 /* ContextMenuCoordinatorTests.swift */; };
 		8A0A1BA02B2200FD00E8706F /* PrivateHomepageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0A1B9F2B2200FD00E8706F /* PrivateHomepageViewController.swift */; };
 		8A0A1BA32B22030100E8706F /* PrivateMessageCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0A1BA22B22030100E8706F /* PrivateMessageCardCell.swift */; };
 		8A0D32842A61E1CC007D976D /* StatusBarOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */; };
@@ -906,6 +907,7 @@
 		8A83B74A2A265044002FF9AC /* SettingsCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A83B7492A265044002FF9AC /* SettingsCoordinatorTests.swift */; };
 		8A83B74C2A265061002FF9AC /* LibraryCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A83B74B2A265061002FF9AC /* LibraryCoordinatorTests.swift */; };
 		8A8482F02BE1602500F9007B /* MicrosurveyPromptStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8482EE2BE15FFE00F9007B /* MicrosurveyPromptStateTests.swift */; };
+		8A855C032D1EE9EF00C1A2F3 /* ContextMenuCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A855C022D1EE9EF00C1A2F3 /* ContextMenuCoordinator.swift */; };
 		8A8629E2288096C40096DDB1 /* BookmarksFolderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */; };
 		8A8629E72880B7330096DDB1 /* LegacyBookmarksPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8629E52880B69C0096DDB1 /* LegacyBookmarksPanelTests.swift */; };
 		8A86DAD8277298DE00D7BFFF /* ClosedTabsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */; };
@@ -7507,6 +7509,7 @@
 		8A093D7E2A4B3E7D0099ABA5 /* GeneralSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A093D802A4B58330099ABA5 /* MockSettingsFlowDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSettingsFlowDelegate.swift; sourceTree = "<group>"; };
 		8A093D822A4B68940099ABA5 /* PrivacySettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsDelegate.swift; sourceTree = "<group>"; };
+		8A09BCC22D22F1BE00CFDF60 /* ContextMenuCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A0A1B9F2B2200FD00E8706F /* PrivateHomepageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateHomepageViewController.swift; sourceTree = "<group>"; };
 		8A0A1BA22B22030100E8706F /* PrivateMessageCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateMessageCardCell.swift; sourceTree = "<group>"; };
 		8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarOverlay.swift; sourceTree = "<group>"; };
@@ -7695,6 +7698,7 @@
 		8A83B7492A265044002FF9AC /* SettingsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A83B74B2A265061002FF9AC /* LibraryCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A8482EE2BE15FFE00F9007B /* MicrosurveyPromptStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyPromptStateTests.swift; sourceTree = "<group>"; };
+		8A855C022D1EE9EF00C1A2F3 /* ContextMenuCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuCoordinator.swift; sourceTree = "<group>"; };
 		8A8629E1288096C40096DDB1 /* BookmarksFolderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksFolderCell.swift; sourceTree = "<group>"; };
 		8A8629E52880B69C0096DDB1 /* LegacyBookmarksPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyBookmarksPanelTests.swift; sourceTree = "<group>"; };
 		8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabsStoreTests.swift; sourceTree = "<group>"; };
@@ -11377,8 +11381,8 @@
 		8A00BD852CAB3FC200680AF9 /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
+				8A09BCC12D22F1A500CFDF60 /* ContextMenu */,
 				8AD3AFC42D143F0D00CFC887 /* TopSitesDimensionImplementationTests.swift */,
-				8A4B66412D1DC962008C5B64 /* ContextMenuConfigurationTests.swift */,
 				8A87B4352CC1A8FD003A9239 /* Mock */,
 				8A87B4302CC1A3BA003A9239 /* PocketManagerTests.swift */,
 				8A552AC22CB43A7000564C98 /* Redux */,
@@ -11398,6 +11402,15 @@
 				3BB50E101D6274CD004B33DF /* TopSiteItemCell.swift */,
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		8A09BCC12D22F1A500CFDF60 /* ContextMenu */ = {
+			isa = PBXGroup;
+			children = (
+				8A4B66412D1DC962008C5B64 /* ContextMenuConfigurationTests.swift */,
+				8A09BCC22D22F1BE00CFDF60 /* ContextMenuCoordinatorTests.swift */,
+			);
+			path = ContextMenu;
 			sourceTree = "<group>";
 		};
 		8A0A1BA12B22010200E8706F /* PrivateHome */ = {
@@ -11744,6 +11757,7 @@
 			children = (
 				8AC0B1BF2D1D9356004237FD /* ContextMenuConfiguration.swift */,
 				8A62B15C2CED408B0045F46E /* ContextMenuState.swift */,
+				8A855C022D1EE9EF00C1A2F3 /* ContextMenuCoordinator.swift */,
 			);
 			path = ContextMenu;
 			sourceTree = "<group>";
@@ -16282,6 +16296,7 @@
 				8AD40FCF27BADC6B00672675 /* URLTextField.swift in Sources */,
 				31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */,
 				8AD1980F27BEB3F100D64B0E /* PhotonActionSheetViewModel.swift in Sources */,
+				8A855C032D1EE9EF00C1A2F3 /* ContextMenuCoordinator.swift in Sources */,
 				EB9A179D20E69A7F00B12184 /* LegacyTheme.swift in Sources */,
 				E17BE4C42A94BA6900C5124E /* FakespotHighlightGroupView.swift in Sources */,
 				8A2DAD4B2CC02AA00067ECD0 /* LabelButtonHeaderView.swift in Sources */,
@@ -17374,6 +17389,7 @@
 				8CFD56892AAF06D3003157A6 /* ShoppingProductTests.swift in Sources */,
 				8ACA8F7629198D6400D3075D /* ThrottlerTests.swift in Sources */,
 				217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */,
+				8A09BCC32D22F1BE00CFDF60 /* ContextMenuCoordinatorTests.swift in Sources */,
 				0B7CF8872CAC1C4E00DC02F8 /* DefaultFolderHierarchyFetcherTests.swift in Sources */,
 				E16C76812ABDC0DB00172DB5 /* FakespotHighlightsCardViewModelTests.swift in Sources */,
 				1D8487B62AD6038100F7527C /* RemoteTabPanelStateTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -27,7 +27,8 @@ protocol BrowserDelegate: AnyObject {
     func showHomepage(
         overlayManager: OverlayModeManager,
         isZeroSearch: Bool,
-        statusBarScrollDelegate: StatusBarScrollDelegate
+        statusBarScrollDelegate: StatusBarScrollDelegate,
+        toastContainer: UIView
     )
 
     /// Show the private homepage to the user as part of felt privacy

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -110,6 +110,8 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 
     /// Navigates to the edit bookmark view
     func showEditBookmark(parentFolder: FxBookmarkNode, bookmark: FxBookmarkNode)
+
+    func openInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool)
 }
 
 extension BrowserNavigationHandler {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
@@ -20,9 +20,17 @@ class NavigationBrowserAction: Action {
 }
 
 enum NavigationBrowserActionType: ActionType {
-    case tapOnCustomizeHomepage
-    case tapOnCell
-    case tapOnLink
+    // Native views
     case tapOnTrackingProtection
+    case tapOnShareSheet
+    case tapOnCustomizeHomepage
+    case tapOnSettingsSection
+
+    // link related
+    case tapOnLink
+    case tapOnOpenInNewTab
+
+    // cell related
+    case tapOnCell
     case longPressOnCell
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
@@ -8,28 +8,47 @@ import Foundation
 enum BrowserNavigationDestination: Equatable {
     // Native views
     case contextMenu
-    case customizeHomepage
+    case settings(Route.SettingsSection)
     case trackingProtectionSettings
 
     // Webpage views
     case link
+    case newTab
+
+    // System views
+    case shareSheet(ShareSheetConfiguration)
+}
+
+struct ShareSheetConfiguration: Equatable {
+    let shareType: ShareType
+    let shareMessage: ShareMessage?
+    let sourceView: UIView
+    let sourceRect: CGRect?
+    let toastContainer: UIView
+    let popoverArrowDirection: UIPopoverArrowDirection
 }
 
 /// This type exists as a field on the BrowserViewControllerState
 struct NavigationDestination: Equatable {
     let destination: BrowserNavigationDestination
     let url: URL?
+    let isPrivate: Bool?
+    let selectNewTab: Bool?
     let isGoogleTopSite: Bool?
     let contextMenuConfiguration: ContextMenuConfiguration?
 
     init(
         _ destination: BrowserNavigationDestination,
         url: URL? = nil,
+        isPrivate: Bool? = nil,
+        selectNewTab: Bool? = nil,
         isGoogleTopSite: Bool? = nil,
         contextMenuConfiguration: ContextMenuConfiguration? = nil
     ) {
         self.destination = destination
         self.url = url
+        self.isPrivate = isPrivate
+        self.selectNewTab = selectNewTab
         self.isGoogleTopSite = isGoogleTopSite
         self.contextMenuConfiguration = contextMenuConfiguration
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -160,7 +160,10 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             NavigationBrowserActionType.tapOnTrackingProtection,
             NavigationBrowserActionType.tapOnCell,
             NavigationBrowserActionType.tapOnLink,
-            NavigationBrowserActionType.longPressOnCell:
+            NavigationBrowserActionType.longPressOnCell,
+            NavigationBrowserActionType.tapOnOpenInNewTab,
+            NavigationBrowserActionType.tapOnSettingsSection,
+            NavigationBrowserActionType.tapOnShareSheet:
             return BrowserViewControllerState(
                 searchScreenState: state.searchScreenState,
                 showDataClearanceFlow: state.showDataClearanceFlow,
@@ -170,7 +173,6 @@ struct BrowserViewControllerState: ScreenState, Equatable {
                 microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
                 navigationDestination: action.navigationDestination
             )
-
         default:
             return defaultState(from: state, action: action)
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1378,7 +1378,8 @@ class BrowserViewController: UIViewController,
             browserDelegate?.showHomepage(
                 overlayManager: overlayManager,
                 isZeroSearch: inline,
-                statusBarScrollDelegate: statusBarOverlay
+                statusBarScrollDelegate: statusBarOverlay,
+                toastContainer: contentContainer
             )
         } else {
             browserDelegate?.showLegacyHomepage(
@@ -2114,8 +2115,8 @@ class BrowserViewController: UIViewController,
             navigationHandler?.showContextMenu(for: configuration)
         case .trackingProtectionSettings:
             navigationHandler?.show(settings: .contentBlocker)
-        case .customizeHomepage:
-            navigationHandler?.show(settings: .homePage)
+        case .settings(let section):
+            navigationHandler?.show(settings: section)
         case .link:
             guard let url = type.url else {
                 logger.log("url should not be nil when navigating for a link type", level: .warning, category: .coordinator)
@@ -2125,6 +2126,21 @@ class BrowserViewController: UIViewController,
                 to: url,
                 visitType: .link,
                 isGoogleTopSite: type.isGoogleTopSite ?? false
+            )
+        case .newTab:
+            guard let url = type.url, let isPrivate = type.isPrivate, let selectNewTab = type.selectNewTab else {
+                logger.log("all params need to be set to properly create a new tab", level: .warning, category: .coordinator)
+                return
+            }
+            navigationHandler?.openInNewTab(url: url, isPrivate: isPrivate, selectNewTab: selectNewTab)
+        case .shareSheet(let config):
+            navigationHandler?.showShareSheet(
+                shareType: config.shareType,
+                shareMessage: config.shareMessage,
+                sourceView: config.sourceView,
+                sourceRect: config.sourceRect,
+                toastContainer: config.toastContainer,
+                popoverArrowDirection: config.popoverArrowDirection
             )
         }
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuConfiguration.swift
@@ -6,6 +6,7 @@ import Storage
 struct ContextMenuConfiguration: Equatable {
     var homepageSection: HomepageSection
     var sourceView: UIView?
+    var toastContainer: UIView
 
     var site: Site? {
         switch item {
@@ -27,10 +28,12 @@ struct ContextMenuConfiguration: Equatable {
     init(
         homepageSection: HomepageSection,
         item: HomepageItem? = nil,
-        sourceView: UIView? = nil
+        sourceView: UIView? = nil,
+        toastContainer: UIView
     ) {
         self.homepageSection = homepageSection
         self.item = item
         self.sourceView = sourceView
+        self.toastContainer = toastContainer
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuCoordinator.swift
@@ -5,7 +5,11 @@
 import Foundation
 import Common
 
-final class ContextMenuCoordinator: BaseCoordinator {
+protocol ContextMenuCoordinatorDelegate: AnyObject {
+    func dismissFlow()
+}
+
+final class ContextMenuCoordinator: BaseCoordinator, ContextMenuCoordinatorDelegate {
     weak var parentCoordinator: ParentCoordinatorDelegate?
     private let windowUUID: WindowUUID
     private let configuration: ContextMenuConfiguration
@@ -28,6 +32,7 @@ final class ContextMenuCoordinator: BaseCoordinator {
             modalStyle: .overFullScreen
         )
         let sheet = PhotonActionSheet(viewModel: viewModel, windowUUID: windowUUID)
+        sheet.coordinator = self
         sheet.modalTransitionStyle = .crossDissolve
         router.present(sheet)
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuCoordinator.swift
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+final class ContextMenuCoordinator: BaseCoordinator {
+    weak var parentCoordinator: ParentCoordinatorDelegate?
+    private let windowUUID: WindowUUID
+    private let configuration: ContextMenuConfiguration
+
+    init(
+        configuration: ContextMenuConfiguration,
+        router: Router,
+        windowUUID: WindowUUID
+    ) {
+        self.configuration = configuration
+        self.windowUUID = windowUUID
+        super.init(router: router)
+    }
+
+    func start() {
+        let state = ContextMenuState(configuration: configuration, windowUUID: windowUUID)
+        let viewModel = PhotonActionSheetViewModel(
+            actions: state.actions,
+            site: state.site,
+            modalStyle: .overFullScreen
+        )
+        let sheet = PhotonActionSheet(viewModel: viewModel, windowUUID: windowUUID)
+        sheet.modalTransitionStyle = .crossDissolve
+        router.present(sheet)
+    }
+
+    func dismissFlow() {
+        router.dismiss(animated: true, completion: nil)
+        parentCoordinator?.didFinish(from: self)
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -18,11 +18,13 @@ struct ContextMenuState {
 
     private let configuration: ContextMenuConfiguration
     private let windowUUID: WindowUUID
+    private let logger: Logger
     weak var coordinatorDelegate: ContextMenuCoordinator?
 
-    init(configuration: ContextMenuConfiguration, windowUUID: WindowUUID) {
+    init(configuration: ContextMenuConfiguration, windowUUID: WindowUUID, logger: Logger = DefaultLogger.shared) {
         self.configuration = configuration
         self.windowUUID = windowUUID
+        self.logger = logger
 
         guard let site = configuration.site else { return }
         self.site = site
@@ -123,7 +125,14 @@ struct ContextMenuState {
                                      iconString: StandardImageIdentifiers.Large.helpCircle,
                                      allowIconScaling: true,
                                      tapHandler: { _ in
-            guard let url = SupportUtils.URLForTopic("sponsor-privacy") else { return }
+            guard let url = SupportUtils.URLForTopic("sponsor-privacy") else {
+                self.logger.log(
+                    "Unable to retrieve URL for sponsor-privacy, return early",
+                    level: .warning,
+                    category: .homepage
+                )
+                return
+            }
             dispatchOpenNewTabAction(siteURL: url, isPrivate: false, selectNewTab: true)
             // TODO: FXIOS-10171 - Add telemetry
         }).items
@@ -197,7 +206,14 @@ struct ContextMenuState {
             iconString: StandardImageIdentifiers.Large.share,
             allowIconScaling: true,
             tapHandler: { _ in
-                guard let url = URL(string: siteURL, invalidCharacters: false) else { return }
+                guard let url = URL(string: siteURL, invalidCharacters: false) else {
+                    self.logger.log(
+                        "Unable to retrieve URL for \(siteURL), return early",
+                        level: .warning,
+                        category: .homepage
+                    )
+                    return
+                }
                 let shareSheetConfiguration = ShareSheetConfiguration(
                     shareType: .site(url: url),
                     shareMessage: nil,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -43,8 +43,7 @@ final class HomepageViewController: UIViewController,
     private var dataSource: HomepageDiffableDataSource?
     // TODO: FXIOS-10541 will handle scrolling for wallpaper and other scroll issues
     private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
-    private var overlayManager: OverlayModeManager
-    private var logger: Logger
+
     private var homepageState: HomepageState
     private var lastContentOffsetY: CGFloat = 0
 
@@ -52,11 +51,17 @@ final class HomepageViewController: UIViewController,
         themeManager.getCurrentTheme(for: windowUUID)
     }
 
+    // MARK: - Private constants
+    private let overlayManager: OverlayModeManager
+    private let logger: Logger
+    private let toastContainer: UIView
+
     // MARK: - Initializers
     init(windowUUID: WindowUUID,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          overlayManager: OverlayModeManager,
          statusBarScrollDelegate: StatusBarScrollDelegate? = nil,
+         toastContainer: UIView,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          logger: Logger = DefaultLogger.shared
     ) {
@@ -65,6 +70,7 @@ final class HomepageViewController: UIViewController,
         self.notificationCenter = notificationCenter
         self.overlayManager = overlayManager
         self.statusBarScrollDelegate = statusBarScrollDelegate
+        self.toastContainer = toastContainer
         self.logger = logger
         homepageState = HomepageState(windowUUID: windowUUID)
         super.init(nibName: nil, bundle: nil)
@@ -490,7 +496,7 @@ final class HomepageViewController: UIViewController,
     private func navigateToHomepageSettings() {
         store.dispatch(
             NavigationBrowserAction(
-                navigationDestination: NavigationDestination(.customizeHomepage),
+                navigationDestination: NavigationDestination(.settings(.homePage)),
                 windowUUID: self.windowUUID,
                 actionType: NavigationBrowserActionType.tapOnCustomizeHomepage
             )
@@ -508,7 +514,12 @@ final class HomepageViewController: UIViewController,
     }
 
     private func navigateToContextMenu(for section: HomepageSection, and item: HomepageItem, sourceView: UIView? = nil) {
-        let configuration = ContextMenuConfiguration(homepageSection: section, item: item, sourceView: sourceView)
+        let configuration = ContextMenuConfiguration(
+            homepageSection: section,
+            item: item,
+            sourceView: sourceView,
+            toastContainer: toastContainer
+        )
         store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(.contextMenu, contextMenuConfiguration: configuration),

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -48,6 +48,8 @@ class PhotonActionSheet: UIViewController, Themeable {
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
 
+    weak var coordinator: ContextMenuCoordinatorDelegate?
+
     private lazy var closeButton: UIButton = .build { button in
         button.setTitle(.CloseButtonTitle, for: .normal)
         button.layer.cornerRadius = UX.cornerRadius
@@ -324,7 +326,7 @@ class PhotonActionSheet: UIViewController, Themeable {
 
     @objc
     private func dismiss(_ gestureRecognizer: UIGestureRecognizer?) {
-        dismissVC()
+        dismissSheet()
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -332,7 +334,7 @@ class PhotonActionSheet: UIViewController, Themeable {
         // Need to handle click outside view for non-popover sheet styles
         guard let touch = touches.first else { return }
         if !tableView.frame.contains(touch.location(in: view)) {
-            dismissVC()
+            dismissSheet()
         }
     }
 
@@ -490,11 +492,16 @@ extension PhotonActionSheet: UITableViewDataSource, UITableViewDelegate {
         (header as? ThemeApplicable)?.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         return header
     }
+
+    private func dismissSheet(withCompletion completion: (() -> Void)? = nil) {
+        dismissVC(withCompletion: completion)
+        coordinator?.dismissFlow()
+    }
 }
 
 // MARK: - PhotonActionSheetViewDelegate
 extension PhotonActionSheet: PhotonActionSheetContainerCellDelegate {
     func didClick(item: SingleActionViewModel?, animationCompletion: @escaping () -> Void) {
-        dismissVC(withCompletion: animationCompletion)
+        dismissSheet(withCompletion: animationCompletion)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -88,16 +88,16 @@ final class BrowserViewControllerStateTests: XCTestCase {
     }
 
     // MARK: - Navigation Browser Action
-    func test_customizeHomepage_navigationBrowserAction_returnsExpectedState() {
+    func test_tapOnCustomizeHomepage_navigationBrowserAction_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = browserViewControllerReducer()
 
         XCTAssertNil(initialState.navigationDestination)
 
-        let action = getNavigationBrowserAction(for: .tapOnCustomizeHomepage, destination: .customizeHomepage)
+        let action = getNavigationBrowserAction(for: .tapOnCustomizeHomepage, destination: .settings(.homePage))
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.navigationDestination?.destination, .customizeHomepage)
+        XCTAssertEqual(newState.navigationDestination?.destination, .settings(.homePage))
         XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
@@ -127,6 +127,100 @@ final class BrowserViewControllerStateTests: XCTestCase {
 
         XCTAssertEqual(newState.navigationDestination?.destination, .link)
         XCTAssertEqual(newState.navigationDestination?.url?.absoluteString, "www.example.com")
+    }
+
+    func test_tapOnShareSheet_navigationBrowserAction_returnsExpectedState() throws {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.navigationDestination)
+
+        let url = try XCTUnwrap(URL(string: "www.example.com"))
+        let shareSheetConfiguration = ShareSheetConfiguration(
+            shareType: .site(url: url),
+            shareMessage: nil,
+            sourceView: UIView(),
+            sourceRect: nil,
+            toastContainer: UIView(),
+            popoverArrowDirection: [.up]
+        )
+        let action = getNavigationBrowserAction(
+            for: .tapOnShareSheet,
+            destination: .shareSheet(shareSheetConfiguration)
+        )
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.navigationDestination?.destination, .shareSheet(shareSheetConfiguration))
+        XCTAssertEqual(newState.navigationDestination?.url, nil)
+    }
+
+    func test_longPressOnCell_navigationBrowserAction_returnsExpectedState() throws {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.navigationDestination)
+
+        let url = try XCTUnwrap(URL(string: "www.example.com"))
+        let action = getNavigationBrowserAction(for: .longPressOnCell, destination: .link, url: url)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.navigationDestination?.destination, .link)
+        XCTAssertEqual(newState.navigationDestination?.url?.absoluteString, "www.example.com")
+    }
+
+    func test_tapOnOpenInNewTab_navigationBrowserAction_returnsExpectedState() throws {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.navigationDestination)
+
+        let url = try XCTUnwrap(URL(string: "www.example.com"))
+        let action = NavigationBrowserAction(
+            navigationDestination: NavigationDestination(.newTab, url: url, isPrivate: false, selectNewTab: false),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: NavigationBrowserActionType.tapOnOpenInNewTab
+        )
+        let newState = reducer(initialState, action)
+
+        let navigationDestination = try XCTUnwrap(newState.navigationDestination)
+        XCTAssertEqual(navigationDestination.destination, .newTab)
+        XCTAssertEqual(navigationDestination.url?.absoluteString, "www.example.com")
+        XCTAssertFalse(navigationDestination.isPrivate ?? true)
+        XCTAssertFalse(navigationDestination.selectNewTab ?? true)
+    }
+
+    func test_tapOnOpenInNewTab_forPrivateTab_navigationBrowserAction_returnsExpectedState() throws {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.navigationDestination)
+
+        let url = try XCTUnwrap(URL(string: "www.example.com"))
+        let action = NavigationBrowserAction(
+            navigationDestination: NavigationDestination(.newTab, url: url, isPrivate: true, selectNewTab: true),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: NavigationBrowserActionType.tapOnOpenInNewTab
+        )
+        let newState = reducer(initialState, action)
+
+        let navigationDestination = try XCTUnwrap(newState.navigationDestination)
+        XCTAssertEqual(navigationDestination.destination, .newTab)
+        XCTAssertEqual(navigationDestination.url?.absoluteString, "www.example.com")
+        XCTAssertTrue(navigationDestination.isPrivate ?? false)
+        XCTAssertTrue(navigationDestination.selectNewTab ?? false)
+    }
+
+    func test_tapOnSettingsSection_navigationBrowserAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.navigationDestination)
+
+        let action = getNavigationBrowserAction(for: .tapOnSettingsSection, destination: .settings(.topSites))
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.navigationDestination?.destination, .settings(.topSites))
+        XCTAssertEqual(newState.navigationDestination?.url, nil)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -144,7 +144,8 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         subject.showHomepage(
             overlayManager: overlayModeManager,
             isZeroSearch: false,
-            statusBarScrollDelegate: scrollDelegate
+            statusBarScrollDelegate: scrollDelegate,
+            toastContainer: UIView()
         )
 
         XCTAssertNotNil(subject.homepageViewController)
@@ -157,7 +158,8 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         subject.showHomepage(
             overlayManager: overlayModeManager,
             isZeroSearch: false,
-            statusBarScrollDelegate: scrollDelegate
+            statusBarScrollDelegate: scrollDelegate,
+            toastContainer: UIView()
         )
         let firstHomepage = subject.homepageViewController
         XCTAssertNotNil(subject.homepageViewController)
@@ -165,7 +167,8 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
         subject.showHomepage(
             overlayManager: overlayModeManager,
             isZeroSearch: false,
-            statusBarScrollDelegate: scrollDelegate
+            statusBarScrollDelegate: scrollDelegate,
+            toastContainer: UIView()
         )
         let secondHomepage = subject.homepageViewController
         XCTAssertEqual(firstHomepage, secondHomepage)
@@ -431,6 +434,17 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertTrue(mockRouter.presentedViewController is BottomSheetViewController)
+    }
+
+    func testShowContextMenu_addsContextMenuCoordinator() {
+        let subject = createSubject()
+        let config = ContextMenuConfiguration(homepageSection: .customizeHomepage, toastContainer: UIView())
+        subject.showContextMenu(for: config)
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertTrue(subject.childCoordinators.first is ContextMenuCoordinator)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertTrue(mockRouter.presentedViewController is PhotonActionSheet)
     }
 
     // MARK: - ParentCoordinatorDelegate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -37,6 +37,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
     var navigateFromHomePanelCalled = 0
     var showContextMenuCalled = 0
     var showEditBookmarkCalled = 0
+    var openInNewTabCalled = 0
 
     func show(settings: Client.Route.SettingsSection, onDismiss: (() -> Void)?) {
         showSettingsCalled += 1
@@ -154,5 +155,9 @@ class MockBrowserCoordinator: BrowserNavigationHandler, ParentCoordinatorDelegat
 
     func showEditBookmark(parentFolder: FxBookmarkNode, bookmark: FxBookmarkNode) {
         showEditBookmarkCalled += 1
+    }
+
+    func openInNewTab(url: URL, isPrivate: Bool, selectNewTab: Bool) {
+        openInNewTabCalled += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -47,14 +47,22 @@ final class ContentContainerTests: XCTestCase {
 
     func testCanAddNewHomepage() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
+        let homepage = HomepageViewController(
+            windowUUID: .XCTestDefaultUUID,
+            overlayManager: overlayModeManager,
+            toastContainer: UIView()
+        )
 
         XCTAssertTrue(subject.canAdd(content: homepage))
     }
 
     func testCanAddNewHomepageOnceOnly() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
+        let homepage = HomepageViewController(
+            windowUUID: .XCTestDefaultUUID,
+            overlayManager: overlayModeManager,
+            toastContainer: UIView()
+        )
 
         subject.add(content: homepage)
         XCTAssertFalse(subject.canAdd(content: homepage))
@@ -127,7 +135,11 @@ final class ContentContainerTests: XCTestCase {
 
     func testHasNewHomepage_returnsTrueWhenAdded() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
+        let homepage = HomepageViewController(
+            windowUUID: .XCTestDefaultUUID,
+            overlayManager: overlayModeManager,
+            toastContainer: UIView()
+        )
         subject.add(content: homepage)
 
         XCTAssertTrue(subject.hasHomepage)
@@ -188,7 +200,11 @@ final class ContentContainerTests: XCTestCase {
 
     func testContentView_hasContentNewHomepage_viewIsNotNil() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
+        let homepage = HomepageViewController(
+            windowUUID: .XCTestDefaultUUID,
+            overlayManager: overlayModeManager,
+            toastContainer: UIView()
+        )
         subject.add(content: homepage)
         XCTAssertNotNil(subject.contentView)
     }
@@ -217,7 +233,11 @@ final class ContentContainerTests: XCTestCase {
 
     func test_update_hasNewHomepage_returnsTrue() {
         let subject = ContentContainer(frame: .zero)
-        let homepage = HomepageViewController(windowUUID: .XCTestDefaultUUID, overlayManager: overlayModeManager)
+        let homepage = HomepageViewController(
+            windowUUID: .XCTestDefaultUUID,
+            overlayManager: overlayModeManager,
+            toastContainer: UIView()
+        )
         subject.update(content: homepage)
         XCTAssertTrue(subject.hasHomepage)
         XCTAssertFalse(subject.hasLegacyHomepage)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/ContextMenu/ContextMenuConfigurationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/ContextMenu/ContextMenuConfigurationTests.swift
@@ -31,7 +31,8 @@ final class ContextMenuConfigurationTests: XCTestCase {
         )
         let subject = ContextMenuConfiguration(
             homepageSection: .pocket(nil),
-            item: pocketItem
+            item: pocketItem,
+            toastContainer: UIView()
         )
         XCTAssertEqual(subject.site?.tileURL.absoluteString, "file:///www.example.com/1234")
         XCTAssertEqual(subject.site?.title, "Site 0")
@@ -46,7 +47,8 @@ final class ContextMenuConfigurationTests: XCTestCase {
         )
         let subject = ContextMenuConfiguration(
             homepageSection: .pocket(nil),
-            item: pocketItem
+            item: pocketItem,
+            toastContainer: UIView()
         )
         XCTAssertEqual(subject.site?.tileURL.absoluteString, "file:///www.example.com/1234")
         XCTAssertEqual(subject.site?.title, "Discover Site 0")
@@ -60,7 +62,8 @@ final class ContextMenuConfigurationTests: XCTestCase {
         )
         let subject = ContextMenuConfiguration(
             homepageSection: .topSites,
-            item: topSiteItem
+            item: topSiteItem,
+            toastContainer: UIView()
         )
         XCTAssertEqual(subject.site?.tileURL.absoluteString, "www.example.com/1234")
         XCTAssertEqual(subject.site?.title, "Site 0")
@@ -69,7 +72,8 @@ final class ContextMenuConfigurationTests: XCTestCase {
     func tests_initialState_forNoItem_returnsExpectedState() {
         let subject = ContextMenuConfiguration(
             homepageSection: .topSites,
-            item: nil
+            item: nil,
+            toastContainer: UIView()
         )
         XCTAssertNil(subject.site)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/ContextMenu/ContextMenuCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/ContextMenu/ContextMenuCoordinatorTests.swift
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+
+@testable import Client
+
+final class ContextMenuCoordinatorTests: XCTestCase {
+    private var mockRouter: MockRouter!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        mockRouter = MockRouter(navigationController: MockNavigationController())
+    }
+
+    override func tearDown() {
+        mockRouter = nil
+        DependencyHelperMock().reset()
+        super.tearDown()
+    }
+
+    func test_initialState() {
+        _ = createSubject()
+
+        XCTAssertFalse(mockRouter.presentedViewController is PhotonActionSheet)
+        XCTAssertEqual(mockRouter.presentCalled, 0)
+    }
+
+    func test_start_presentsContextMenuController() throws {
+        let subject = createSubject()
+
+        subject.start()
+
+        XCTAssertTrue(mockRouter.presentedViewController is PhotonActionSheet)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+    }
+
+    func test_dismissFlow_callsRouterDismiss() throws {
+        let subject = createSubject()
+
+        subject.start()
+        subject.dismissFlow()
+
+        XCTAssertEqual(mockRouter.dismissCalled, 1)
+    }
+
+    private func createSubject(file: StaticString = #file,
+                               line: UInt = #line) -> ContextMenuCoordinator {
+        let configuration = ContextMenuConfiguration(homepageSection: .header, toastContainer: UIView())
+
+        let subject = ContextMenuCoordinator(
+            configuration: configuration,
+            router: mockRouter,
+            windowUUID: .XCTestDefaultUUID
+        )
+
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -155,6 +155,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
             themeManager: themeManager,
             overlayManager: mockOverlayManager,
             statusBarScrollDelegate: statusBarScrollDelegate,
+            toastContainer: UIView(),
             notificationCenter: notificationCenter
         )
         trackForMemoryLeaks(homepageViewController)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10613)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23244)

## :bulb: Description
Add navigation actions to context menu for pocket and top sites:
- Show share sheet
- Show settings section 
- Open in new tab (private + normal browsing)

Also creates `ContextMenuCoordinator` to simplify the `showContextMenu` method and follow our coordinator pattern. Updated existing `PhotonActionSheet` to remove child coordinator when dismissing (to avoid memory leaks). 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots

https://github.com/user-attachments/assets/a6144526-713a-4dfd-9c36-5d1e38297ca5


