### PR TITLE
Bugfix FXIOS-10969 - [Toolbar Redesign] - Can't type Chinese/Japanese in search bar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -174,7 +174,6 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
         guard !isSettingMarkedText else { return }
 
         hideCursor = markedTextRange != nil
-        removeCompletion()
 
         let isKeyboardReplacingText = lastReplacement != nil
         if isKeyboardReplacingText, markedTextRange == nil {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10969)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23955)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Remove call of `removeCompletion()` when text changes in the address bar.
- Tested and the old behavior still works + now the Japanese/Chinese keyboard input as well. I've attached a screen recording below.
- This PR also fixes the duplicate issue: https://mozilla-hub.atlassian.net/browse/FXIOS-10834.
### Screen Recording

https://github.com/user-attachments/assets/e8a7a388-dd0b-4170-9985-6832aa886efa



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

