### PR TITLE
Bugfix FXIOS-10923 [Bookmarks Evolution] Hide new folder button when folder selector table is collapsed

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -79,6 +79,7 @@ class EditBookmarkViewController: UIViewController,
         viewModel.onFolderStatusUpdate = { [weak self] in
             guard let self = self else { return }
 
+            // TODO: FXIOS-10985 - replace batch updates with diffable data source
             self.tableView.performBatchUpdates {
                 if self.viewModel.isFolderCollapsed {
                     self.tableView.deleteSections(IndexSet(integer: Section.newFolder.rawValue), with: .none)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -76,16 +76,14 @@ class EditBookmarkViewController: UIViewController,
     override func viewDidLoad() {
         super.viewDidLoad()
         title = .Bookmarks.Menu.EditBookmarkTitle
-        viewModel.onFolderStatusUpdate = { [weak self] shouldUpdateNewFolderSection in
+        viewModel.onFolderStatusUpdate = { [weak self] in
             guard let self = self else { return }
 
             self.tableView.performBatchUpdates {
-                if shouldUpdateNewFolderSection {
-                    if self.viewModel.isFolderCollapsed {
-                        self.tableView.deleteSections(IndexSet(integer: Section.newFolder.rawValue), with: .none)
-                    } else {
-                        self.tableView.insertSections(IndexSet(integer: Section.newFolder.rawValue), with: .none)
-                    }
+                if self.viewModel.isFolderCollapsed {
+                    self.tableView.deleteSections(IndexSet(integer: Section.newFolder.rawValue), with: .none)
+                } else {
+                    self.tableView.insertSections(IndexSet(integer: Section.newFolder.rawValue), with: .none)
                 }
                 self.tableView.reloadSections(IndexSet(integer: Section.folder.rawValue), with: .automatic)
             }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -36,7 +36,7 @@ class EditBookmarkViewModel: ParentFolderSelector {
         return node?.url ?? ""
     }
 
-    var onFolderStatusUpdate: VoidReturnCallback?
+    var onFolderStatusUpdate: ((Bool) -> Void)?
     var onBookmarkSaved: VoidReturnCallback?
 
     var getBackNavigationButtonTitle: String {
@@ -73,10 +73,10 @@ class EditBookmarkViewModel: ParentFolderSelector {
         if isFolderCollapsed {
             selectedFolder = folder
             folderStructures = [folder]
-            onFolderStatusUpdate?()
         } else {
             getFolderStructure(folder)
         }
+        onFolderStatusUpdate?(true)
     }
 
     func createNewFolder() {
@@ -92,7 +92,7 @@ class EditBookmarkViewModel: ParentFolderSelector {
             guard let folders else { return }
             self?.folderStructures = folders
             self?.selectedFolder = selectedFolder
-            self?.onFolderStatusUpdate?()
+            self?.onFolderStatusUpdate?(false)
         }
     }
 
@@ -138,7 +138,7 @@ class EditBookmarkViewModel: ParentFolderSelector {
         isFolderCollapsed = true
         selectedFolder = folder
         folderStructures = [folder]
-        onFolderStatusUpdate?()
+        onFolderStatusUpdate?(true)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -36,7 +36,7 @@ class EditBookmarkViewModel: ParentFolderSelector {
         return node?.url ?? ""
     }
 
-    var onFolderStatusUpdate: ((Bool) -> Void)?
+    var onFolderStatusUpdate: VoidReturnCallback?
     var onBookmarkSaved: VoidReturnCallback?
 
     var getBackNavigationButtonTitle: String {
@@ -73,10 +73,10 @@ class EditBookmarkViewModel: ParentFolderSelector {
         if isFolderCollapsed {
             selectedFolder = folder
             folderStructures = [folder]
+            onFolderStatusUpdate?()
         } else {
             getFolderStructure(folder)
         }
-        onFolderStatusUpdate?(true)
     }
 
     func createNewFolder() {
@@ -92,7 +92,7 @@ class EditBookmarkViewModel: ParentFolderSelector {
             guard let folders else { return }
             self?.folderStructures = folders
             self?.selectedFolder = selectedFolder
-            self?.onFolderStatusUpdate?(false)
+            self?.onFolderStatusUpdate?()
         }
     }
 
@@ -138,7 +138,7 @@ class EditBookmarkViewModel: ParentFolderSelector {
         isFolderCollapsed = true
         selectedFolder = folder
         folderStructures = [folder]
-        onFolderStatusUpdate?(true)
+        onFolderStatusUpdate?()
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10923)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23866)

## :bulb: Description
- Hides the "New folder" button in the folder selector table when collapsed

| Before | After |
| ------------- | ------------- |
| <img width="559" alt="Screenshot 2024-12-30 at 12 40 29 PM" src="https://github.com/user-attachments/assets/d1d0465e-2eab-4006-af97-cbcb850a147e" /> | <img width="559" alt="Screenshot 2024-12-30 at 12 38 03 PM" src="https://github.com/user-attachments/assets/c4190387-87b7-48c7-8022-a4988dbf4c74" /> |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

