### PR TITLE
Refactor FXIOS-10908 [Homepage Rebuild] Move logic for cancelling edit from homepage to toolbar state

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -181,6 +181,9 @@ struct AddressBarState: StateType, Equatable {
         case ToolbarActionType.didStartEditingUrl:
             return handleDidStartEditingUrlAction(state: state, action: action)
 
+        case ToolbarActionType.cancelEditOnHomepage:
+            return handleCancelEditOnHomepageAction(state: state, action: action)
+
         case ToolbarActionType.cancelEdit:
             return handleCancelEditAction(state: state, action: action)
 
@@ -521,6 +524,14 @@ struct AddressBarState: StateType, Equatable {
             showQRPageAction: showQRPageAction,
             alternativeSearchEngine: state.alternativeSearchEngine
         )
+    }
+
+    private static func handleCancelEditOnHomepageAction(state: Self, action: Action) -> Self {
+        if state.url == nil {
+            return handleCancelEditAction(state: state, action: action)
+        } else {
+            return handleHideKeyboardAction(state: state)
+        }
     }
 
     private static func handleCancelEditAction(state: Self, action: Action) -> Self {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -81,6 +81,7 @@ enum ToolbarActionType: ActionType {
     case showMenuWarningBadge
     case didPasteSearchTerm
     case didStartEditingUrl
+    case cancelEditOnHomepage
     case cancelEdit
     case hideKeyboard
     case readerModeStateChanged

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -114,6 +114,7 @@ struct ToolbarState: ScreenState, Equatable {
         case ToolbarActionType.borderPositionChanged, ToolbarActionType.urlDidChange,
             ToolbarActionType.didSetTextInLocationView, ToolbarActionType.didPasteSearchTerm,
             ToolbarActionType.didStartEditingUrl, ToolbarActionType.cancelEdit,
+            ToolbarActionType.cancelEditOnHomepage,
             ToolbarActionType.hideKeyboard, ToolbarActionType.websiteLoadingStateDidChange,
             ToolbarActionType.searchEngineDidChange, ToolbarActionType.clearSearch,
             ToolbarActionType.didDeleteSearchTerm, ToolbarActionType.didEnterSearchTerm,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -153,23 +153,10 @@ final class HomepageViewController: UIViewController,
     }
 
     private func handleToolbarStateOnScroll() {
-        // TODO: FXIOS-10877 This logic will be handled by toolbar state, the homepage will just dispatch the action
-        let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID)
-
-        // Only dispatch action when user is in edit mode to avoid having the toolbar re-displayed
-        if featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly),
-           let toolbarState,
-           toolbarState.addressToolbar.isEditing {
-            // When the user scrolls the homepage (not overlaid on a webpage when searching) we cancel edit mode
-            // On a website we just dismiss the keyboard
-            if toolbarState.addressToolbar.url == nil {
-                let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.cancelEdit)
-                store.dispatch(action)
-            } else {
-                let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.hideKeyboard)
-                store.dispatch(action)
-            }
-        }
+        guard featureFlags.isFeatureEnabled(.toolbarRefactor, checking: .buildOnly) else { return }
+        // When the user scrolls the homepage (not overlaid on a webpage when searching) we cancel edit mode
+        let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.cancelEditOnHomepage)
+        store.dispatch(action)
     }
 
     // MARK: - Redux

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -15,6 +15,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
 
     override func setUp() {
         super.setUp()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
         DependencyHelperMock().bootstrapDependencies()
         setupStore()
     }
@@ -144,6 +145,23 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, GeneralBrowserMiddlewareActionType.websiteDidScroll)
     }
 
+    func test_scrollViewWillBeginDragging_triggersHomepageAction() throws {
+        let homepageVC = createSubject()
+        let scrollView = UIScrollView()
+        scrollView.contentOffset.y = 10
+        setupNimbusToolbarRefactorTesting(isEnabled: true)
+
+        homepageVC.scrollViewWillBeginDragging(scrollView)
+
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.first(where: {
+                $0 is ToolbarAction
+            }) as? ToolbarAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
+        XCTAssertEqual(actionType, ToolbarActionType.cancelEditOnHomepage)
+    }
+
     private func createSubject(statusBarScrollDelegate: StatusBarScrollDelegate? = nil) -> HomepageViewController {
         let notificationCenter = MockNotificationCenter()
         let themeManager = MockThemeManager()
@@ -172,5 +190,13 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
 
     func resetStore() {
         StoreTestUtilityHelper.resetStore()
+    }
+
+    private func setupNimbusToolbarRefactorTesting(isEnabled: Bool) {
+        FxNimbus.shared.features.toolbarRefactorFeature.with { _, _ in
+            return ToolbarRefactorFeature(
+                enabled: isEnabled
+            )
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -428,7 +428,33 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertFalse(newState.showQRPageAction)
     }
 
-    func test_cancelEditAction_onHomepage_returnsExpectedState() {
+    func test_cancelEditOnHomepageAction_withURL_returnsExpectedState() {
+        setupStore()
+        let initialState = createSubject()
+        let reducer = addressBarReducer()
+        let didChangeURLAction = ToolbarAction(url: URL(string: "https://mozilla.com")!,
+                                               windowUUID: windowUUID,
+                                               actionType: ToolbarActionType.urlDidChange
+        )
+        let stateWithURL = reducer(
+            initialState,
+            didChangeURLAction
+        )
+
+        let newState = reducer(
+            stateWithURL,
+            ToolbarAction(
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.cancelEditOnHomepage
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, windowUUID)
+        XCTAssertFalse(newState.shouldShowKeyboard)
+        XCTAssertEqual(newState.isEditing, initialState.isEditing)
+    }
+
+    func test_cancelEditOnHomepageAction_withNoURL_returnsExpectedState() {
         setupStore()
         let initialState = createSubject()
         let reducer = addressBarReducer()
@@ -437,26 +463,13 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
             initialState,
             ToolbarAction(
                 windowUUID: windowUUID,
-                actionType: ToolbarActionType.cancelEdit
+                actionType: ToolbarActionType.cancelEditOnHomepage
             )
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.navigationActions.count, 0)
-
-        XCTAssertEqual(newState.pageActions.count, 1)
-        XCTAssertEqual(newState.pageActions[0].actionType, .qrCode)
-
-        XCTAssertEqual(newState.browserActions.count, 2)
-        XCTAssertEqual(newState.browserActions[0].actionType, .tabs)
-        XCTAssertEqual(newState.browserActions[1].actionType, .menu)
-
-        XCTAssertEqual(newState.searchTerm, nil)
         XCTAssertFalse(newState.isEditing)
         XCTAssertTrue(newState.shouldShowKeyboard)
-        XCTAssertFalse(newState.shouldSelectSearchTerm)
-        XCTAssertFalse(newState.didStartTyping)
-        XCTAssertTrue(newState.showQRPageAction)
     }
 
     func test_cancelEditAction_withWebsite_returnsExpectedState() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -436,10 +436,8 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
                                                windowUUID: windowUUID,
                                                actionType: ToolbarActionType.urlDidChange
         )
-        let stateWithURL = reducer(
-            initialState,
-            didChangeURLAction
-        )
+
+        let stateWithURL = reducer(initialState, didChangeURLAction)
 
         let newState = reducer(
             stateWithURL,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10908)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23825)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Add a new `ToolbarAction` for `cancelEditOnHomepage` that moves the logic of checking if the URL is nil into the toolbar state so that the homepage view controller doesn't need to hold on to a reference to the toolbar state or toolbar manager to handle toolbar updates. We are only changing this for the new homepage to mitigate risk.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

