### PR TITLE
Refactor FXIOS-10695 [Password Generator] Update padding for iPad and iPhone

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -11,7 +11,17 @@ import WebKit
 
 class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themeable, Notifiable {
     private enum UX {
-        static let containerPadding: CGFloat = 20
+        static let containerVerticalPadding: CGFloat = 20
+        static var containerHorizontalPadding: CGFloat {
+            if ((UIDevice.current.userInterfaceIdiom == .phone) && UIDevice.current.orientation.isLandscape) ||
+                ((UIDevice.current.userInterfaceIdiom == .pad) && UIDevice.current.orientation.isPortrait) {
+                return 90
+            }
+            if (UIDevice.current.userInterfaceIdiom == .pad) && UIDevice.current.orientation.isLandscape {
+                return 270
+            }
+            return containerVerticalPadding
+        }
         static let containerElementsVerticalPadding: CGFloat = 16
         static let headerTrailingPadding: CGFloat = 45
     }
@@ -113,16 +123,16 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
         NSLayoutConstraint.activate([
             contentView.leadingAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.leadingAnchor,
-                constant: UX.containerPadding),
+                constant: UX.containerHorizontalPadding),
             contentView.trailingAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.trailingAnchor,
-                constant: -UX.containerPadding),
+                constant: -UX.containerHorizontalPadding),
             contentView.topAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.topAnchor,
-                constant: UX.containerPadding),
+                constant: UX.containerVerticalPadding),
             contentView.bottomAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-                constant: -UX.containerPadding),
+                constant: -UX.containerVerticalPadding)
         ])
 
         // Content View Elements Layout

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -12,18 +12,21 @@ import WebKit
 class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themeable, Notifiable {
     private enum UX {
         static let containerVerticalPadding: CGFloat = 20
-        static var containerHorizontalPadding: CGFloat {
-            if ((UIDevice.current.userInterfaceIdiom == .phone) && UIDevice.current.orientation.isLandscape) ||
-                ((UIDevice.current.userInterfaceIdiom == .pad) && UIDevice.current.orientation.isPortrait) {
-                return 90
-            }
-            if (UIDevice.current.userInterfaceIdiom == .pad) && UIDevice.current.orientation.isLandscape {
-                return 270
-            }
-            return containerVerticalPadding
-        }
+        static let containerHorizontalPaddingSm: CGFloat = 20
+        static let containerHorizontalPaddingMd: CGFloat = 90
+        static let containerHorizontalPaddingLg: CGFloat = 270
         static let containerElementsVerticalPadding: CGFloat = 16
         static let headerTrailingPadding: CGFloat = 45
+    }
+
+    private func getContainerHorizontalPadding() -> CGFloat {
+        if UIDevice.current.orientation.isLandscape {
+             return UIDevice.current.userInterfaceIdiom == .pad ? UX.containerHorizontalPaddingLg :
+                UX.containerHorizontalPaddingMd
+        } else {
+             return UIDevice.current.userInterfaceIdiom == .pad ? UX.containerHorizontalPaddingMd :
+                UX.containerHorizontalPaddingSm
+        }
     }
 
     // MARK: - Redux
@@ -120,13 +123,14 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
         contentView.addSubviews(header, descriptionLabel, passwordField, usePasswordButton)
 
         // Content View Constraints
+        let containerHorizontalPadding = getContainerHorizontalPadding()
         NSLayoutConstraint.activate([
             contentView.leadingAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.leadingAnchor,
-                constant: UX.containerHorizontalPadding),
+                constant: containerHorizontalPadding),
             contentView.trailingAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.trailingAnchor,
-                constant: -UX.containerHorizontalPadding),
+                constant: -containerHorizontalPadding),
             contentView.topAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.topAnchor,
                 constant: UX.containerVerticalPadding),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10695)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23378)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR updates the constraints for the padding on the Password Generator bottomsheet on iPad and landscapemode on iPhones. The new rules are as follows:
- if the user is on iPad AND portrait mode: 90px horizontal padding
- if the user is on iPad AND landscape mode: 270px horizontal padding
- if the user is on iPhone AND landscape mode: 90px horizontal padding
- otherwise, use the default padding (20px at the time of this PR, which is equivalent to the vertical padding)
- vertical padding remains unchanged (still 20px)

Note: If the bottomsheet is already opened and the orientation is changed, the new padding will not take effect until the bottomsheet has been closed and reopened again.

![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-12-30 at 22 30 41](https://github.com/user-attachments/assets/64efb00b-139f-4438-9683-71a24e7119ab)
iPad Portrait

![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-12-30 at 22 30 53](https://github.com/user-attachments/assets/3f0a8c03-e3bf-48b9-b469-ebcf91accaa7)
iPad Landscape

![Simulator Screenshot - iPhone 16 Pro - 2024-12-30 at 22 32 38](https://github.com/user-attachments/assets/69cebd32-b77a-4f77-9ad1-8ebc6edfc864)
iPhone Landscape


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

