### PR TITLE
Add FXIOS-9743/FXIOS-10909 [Bookmarks Evolution] Display where bookmark was saved to in toast

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -358,7 +358,11 @@ extension BrowserViewController: ToolBarActionMenuDelegate, UIDocumentPickerDele
                                     theme: currentTheme()) { isButtonTapped in
                 isButtonTapped ? self.openBookmarkEditPanel() : nil
             }
-            self.show(toast: toast)
+            if isBookmarkRefactorEnabled {
+                self.show(toast: toast, duration: DispatchTimeInterval.milliseconds(8000))
+            } else {
+                self.show(toast: toast)
+            }
         case .removeBookmark:
             let viewModel = ButtonToastViewModel(labelText: message,
                                                  buttonText: .UndoString,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1687,13 +1687,13 @@ class BrowserViewController: UIViewController,
     private func showBookmarkToast(bookmarkURL: URL? = nil, title: String? = nil, action: BookmarkAction) {
         func showAddBookmarkToast(folderName: String) {
             let message = String(format: .Bookmarks.Menu.SavedBookmarkToastLabel, folderName)
-            self.showToast(message: message, toastAction: .bookmarkPage)
+            showToast(message: message, toastAction: .bookmarkPage)
         }
 
         switch action {
         case .add:
             if !isBookmarkRefactorEnabled {
-                self.showToast(message: .LegacyAppMenu.AddBookmarkConfirmMessage, toastAction: .bookmarkPage)
+                showToast(message: .LegacyAppMenu.AddBookmarkConfirmMessage, toastAction: .bookmarkPage)
             }
             // Get the folder title using the recent bookmark folder pref
             // Special case for mobile folder since it's title is "mobile" and we want to display it as "Bookmarks"

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -182,6 +182,16 @@ extension String {
                 tableName: "Bookmarks",
                 value: "Delete Bookmark",
                 comment: "The title for the Delete Bookmark button, in the Edit Bookmark popup screen which is summoned from the main menu's Save submenu, which will delete the currently bookmarked site from the user's bookmarks.")
+            public static let SavedBookmarkToastLabel = MZLocalizedString(
+                key: "Bookmarks.Menu.SavedBookmarkToastLabel.v135",
+                tableName: "Bookmarks",
+                value: "Saved in \"%@\"",
+                comment: "The label displayed in the toast when saving a bookmark via the menu. The placeholder represents the folder where the bookmark is saved to")
+            public static let SavedBookmarkToastDefaultFolderLabel = MZLocalizedString(
+                key: "Bookmarks.Menu.SavedBookmarkToastDefaultFolderLabel.v135",
+                tableName: "Bookmarks",
+                value: "Bookmarks",
+                comment: "Label describing the name of the default folder that a bookmark is saved to when a recent folder is not set. This label is used for the saved bookmark toast. The toast would read: (Saved in \"Bookmarks\")")
         }
 
         public struct EmptyState {

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -183,12 +183,12 @@ extension String {
                 value: "Delete Bookmark",
                 comment: "The title for the Delete Bookmark button, in the Edit Bookmark popup screen which is summoned from the main menu's Save submenu, which will delete the currently bookmarked site from the user's bookmarks.")
             public static let SavedBookmarkToastLabel = MZLocalizedString(
-                key: "Bookmarks.Menu.SavedBookmarkToastLabel.v135",
+                key: "Bookmarks.Menu.SavedBookmarkToastLabel.v136",
                 tableName: "Bookmarks",
                 value: "Saved in \"%@\"",
                 comment: "The label displayed in the toast when saving a bookmark via the menu. The placeholder represents the folder where the bookmark is saved to")
             public static let SavedBookmarkToastDefaultFolderLabel = MZLocalizedString(
-                key: "Bookmarks.Menu.SavedBookmarkToastDefaultFolderLabel.v135",
+                key: "Bookmarks.Menu.SavedBookmarkToastDefaultFolderLabel.v136",
                 tableName: "Bookmarks",
                 value: "Bookmarks",
                 comment: "Label describing the name of the default folder that a bookmark is saved to when a recent folder is not set. This label is used for the saved bookmark toast. The toast would read: (Saved in \"Bookmarks\")")


### PR DESCRIPTION
## :scroll: Tickets
9743: 
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9743)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21406)

10909: 
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10909)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23827)

## :bulb: Description
- Display the name of the folder where the bookmark is being saved to on the toast message
- Restore the "Edit" toast action to the "Add bookmark" toast when saving a booking via the new menu
- Increase the duration of the "Add bookmark" toast from 4.5 seconds -> 8 seconds

### 📷 Screenshots

| Before | After |
| ------------- | ------------- |
| <img width="559" alt="Screenshot 2024-12-31 at 2 23 55 PM" src="https://github.com/user-attachments/assets/57c77bec-adae-4b29-becd-b6c7cda594d1" /> | <img width="559" alt="Screenshot 2024-12-31 at 2 22 35 PM" src="https://github.com/user-attachments/assets/a6924b9b-018d-4015-9b1a-44ffacd6ebd8" /> |

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

