### PR TITLE
Refactor FXIOS-10927 [Bookmarks Evolution] Correct bookmarks disclosure indicator

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -37,7 +37,7 @@ extension BookmarkFolderData: BookmarksFolderCell {
         } else {
             return OneLineTableViewCellViewModel(title: title,
                                                  leftImageView: leftImageView,
-                                                 accessoryView: nil,
+                                                 accessoryView: UIImageView(image: chevronImage),
                                                  accessoryType: .disclosureIndicator,
                                                  editingAccessoryView: nil)
         }
@@ -80,7 +80,7 @@ extension BookmarkItemData: BookmarksFolderCell {
         } else {
             return OneLineTableViewCellViewModel(title: title,
                                                  leftImageView: nil,
-                                                 accessoryView: nil,
+                                                 accessoryView: UIImageView(image: chevronImage),
                                                  accessoryType: .disclosureIndicator,
                                                  editingAccessoryView: nil)
         }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -37,7 +37,7 @@ extension BookmarkFolderData: BookmarksFolderCell {
         } else {
             return OneLineTableViewCellViewModel(title: title,
                                                  leftImageView: leftImageView,
-                                                 accessoryView: UIImageView(image: chevronImage),
+                                                 accessoryView: nil,
                                                  accessoryType: .disclosureIndicator,
                                                  editingAccessoryView: nil)
         }
@@ -80,7 +80,7 @@ extension BookmarkItemData: BookmarksFolderCell {
         } else {
             return OneLineTableViewCellViewModel(title: title,
                                                  leftImageView: nil,
-                                                 accessoryView: UIImageView(image: chevronImage),
+                                                 accessoryView: nil,
                                                  accessoryType: .disclosureIndicator,
                                                  editingAccessoryView: nil)
         }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LocalDesktopFolder.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LocalDesktopFolder.swift
@@ -12,7 +12,8 @@ import struct MozillaAppServices.Guid
 /// - Have the menu, unfiled and toolbar folders all under a desktop folder that doesn't exists in the backend
 /// - Present the menu, unfiled and toolbar folders to the users without making a backend call.
 /// Desktop folder content is fetched when folder is selected.
-class LocalDesktopFolder: FxBookmarkNode {
+class LocalDesktopFolder: FxBookmarkNode,
+                            BookmarksRefactorFeatureFlagProvider {
     // Guid used locally, but never synced to Firefox Sync accounts
     static let localDesktopFolderGuid = "localDesktopFolder"
 
@@ -53,7 +54,7 @@ class LocalDesktopFolder: FxBookmarkNode {
 extension LocalDesktopFolder: BookmarksFolderCell {
     func getViewModel() -> OneLineTableViewCellViewModel {
         let image = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
-        let accessoryView = UIImageView(image: image)
+        let accessoryView = isBookmarkRefactorEnabled ? UIImageView(image: image) : nil
 
         return OneLineTableViewCellViewModel(title: LegacyLocalizedRootBookmarkFolderStrings[guid],
                                              leftImageView: leftImageView,

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LocalDesktopFolder.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LocalDesktopFolder.swift
@@ -52,9 +52,12 @@ class LocalDesktopFolder: FxBookmarkNode {
 
 extension LocalDesktopFolder: BookmarksFolderCell {
     func getViewModel() -> OneLineTableViewCellViewModel {
+        let image = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
+        let accessoryView = UIImageView(image: image)
+
         return OneLineTableViewCellViewModel(title: LegacyLocalizedRootBookmarkFolderStrings[guid],
                                              leftImageView: leftImageView,
-                                             accessoryView: nil,
+                                             accessoryView: accessoryView,
                                              accessoryType: .disclosureIndicator,
                                              editingAccessoryView: nil)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10927)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23873)

## :bulb: Description
- Update the disclosure indicator image for the "Desktop Bookmarks" folder and it's local subfolders to match the other cells

### 📝 Notes:
- Updating the disclosure indicators for regular folder and bookmark cells was done in #23926

### 📷 Screenshots
| Before | After |
| ------------- | ------------- |
| <img width="559" alt="Screenshot 2025-01-02 at 5 06 29 PM" src="https://github.com/user-attachments/assets/e996b34d-378e-4c1e-bde8-835bb871a1cd" /> | <img width="559" alt="Screenshot 2025-01-02 at 5 05 55 PM" src="https://github.com/user-attachments/assets/382c5114-0bff-4f71-82d8-3f2a406fd067" /> |

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [X] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

