### PR TITLE
Add FXIOS-10614 [Homepage] [Context Menu] specific action for top sites menu

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -836,6 +836,7 @@
 		8A5189C92C1B614E00CDB668 /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A87AEE02C1B4D17007428B2 /* SearchViewModelTests.swift */; };
 		8A552AC72CB43AB400564C98 /* HomepageStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */; };
 		8A552AC82CB43AB400564C98 /* HeaderStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */; };
+		8A5564022D23317100028CA7 /* ContextMenuAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5564012D23317100028CA7 /* ContextMenuAction.swift */; };
 		8A55E8042BFBA9BE006DBD85 /* MicrosurveyCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E5F3D2BFBA49400DE052B /* MicrosurveyCoordinatorTests.swift */; };
 		8A5604F629DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */; };
 		8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */; };
@@ -7628,6 +7629,7 @@
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
 		8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomepageStateTests.swift; sourceTree = "<group>"; };
 		8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderStateTests.swift; sourceTree = "<group>"; };
+		8A5564012D23317100028CA7 /* ContextMenuAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuAction.swift; sourceTree = "<group>"; };
 		8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A57519827AD80B800A84DBF /* ReaderModeStyleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleViewModel.swift; sourceTree = "<group>"; };
@@ -11767,6 +11769,7 @@
 			children = (
 				8AC0B1BF2D1D9356004237FD /* ContextMenuConfiguration.swift */,
 				8A62B15C2CED408B0045F46E /* ContextMenuState.swift */,
+				8A5564012D23317100028CA7 /* ContextMenuAction.swift */,
 				8A855C022D1EE9EF00C1A2F3 /* ContextMenuCoordinator.swift */,
 			);
 			path = ContextMenu;
@@ -16680,6 +16683,7 @@
 				8AE1E1CD27B191110024C45E /* SearchBarSettingsViewModel.swift in Sources */,
 				43D16B8529831EA5009F8279 /* Style.swift in Sources */,
 				E16258EF2A83BE0800522742 /* FakespotLoadingView.swift in Sources */,
+				8A5564022D23317100028CA7 /* ContextMenuAction.swift in Sources */,
 				8A19ACAB2A32895E001C2147 /* BrowserNavigationHandler.swift in Sources */,
 				8AE80BB82891BE0700BC12EA /* JumpBackInDataAdaptor.swift in Sources */,
 				8A01891C275E9C2A00923EFE /* ClearHistorySheetProvider.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuAction.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Redux
+import Storage
+
+final class ContextMenuAction: Action {
+    var site: Site?
+
+    init(
+        site: Site? = nil,
+        windowUUID: WindowUUID,
+        actionType: any ActionType
+    ) {
+        self.site = site
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
+
+enum ContextMenuActionType: ActionType {
+    case tappedOnRemoveTopSites
+    case tappedOnAddTopSites
+    case tappedOnRemovePinnedSites
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuAction.swift
@@ -21,7 +21,7 @@ final class ContextMenuAction: Action {
 }
 
 enum ContextMenuActionType: ActionType {
-    case tappedOnRemoveTopSites
-    case tappedOnAddTopSites
-    case tappedOnRemovePinnedSites
+    case tappedOnRemoveTopSite
+    case tappedOnPinTopSite
+    case tappedOnUnpinTopSite
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -88,7 +88,7 @@ struct ContextMenuState {
                                      iconString: StandardImageIdentifiers.Large.cross,
                                      allowIconScaling: true,
                                      tapHandler: { _ in
-            dispatchContextMenuAction(site: site, actionType: ContextMenuActionType.tappedOnRemoveTopSites)
+            dispatchContextMenuAction(site: site, actionType: ContextMenuActionType.tappedOnRemoveTopSite)
             // TODO: FXIOS-10171 - Add telemetry
         }).items
     }
@@ -98,7 +98,7 @@ struct ContextMenuState {
                                      iconString: StandardImageIdentifiers.Large.pin,
                                      allowIconScaling: true,
                                      tapHandler: { _ in
-            dispatchContextMenuAction(site: site, actionType: ContextMenuActionType.tappedOnAddTopSites)
+            dispatchContextMenuAction(site: site, actionType: ContextMenuActionType.tappedOnPinTopSite)
             // TODO: FXIOS-10171 - Add telemetry
         }).items
     }
@@ -110,7 +110,7 @@ struct ContextMenuState {
                                      iconString: StandardImageIdentifiers.Large.pinSlash,
                                      allowIconScaling: true,
                                      tapHandler: { _ in
-            dispatchContextMenuAction(site: site, actionType: ContextMenuActionType.tappedOnRemovePinnedSites)
+            dispatchContextMenuAction(site: site, actionType: ContextMenuActionType.tappedOnUnpinTopSite)
             // TODO: FXIOS-10171 - Add telemetry
         }).items
     }
@@ -182,7 +182,7 @@ struct ContextMenuState {
         if site.bookmarked ?? false {
             bookmarkAction = getRemoveBookmarkAction()
         } else {
-            bookmarkAction = getAddBookmarkAction()
+            bookmarkAction = getAddBookmarkAction(site: site)
         }
         return bookmarkAction.items
     }
@@ -196,7 +196,7 @@ struct ContextMenuState {
         })
     }
 
-    private func getAddBookmarkAction() -> SingleActionViewModel {
+    private func getAddBookmarkAction(site: Site) -> SingleActionViewModel {
         return SingleActionViewModel(title: .BookmarkContextMenuTitle,
                                      iconString: StandardImageIdentifiers.Large.bookmark,
                                      allowIconScaling: true,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteState.swift
@@ -39,8 +39,6 @@ final class TopSiteState: Hashable, Equatable {
         return site.url == GoogleTopSiteManager.Constants.usUrl || site.url == GoogleTopSiteManager.Constants.rowUrl
     }
 
-    var identifier = UUID().uuidString
-
     init(site: Site) {
         self.site = site
         if let provider = site.metadata?.providerName {
@@ -75,11 +73,21 @@ final class TopSiteState: Hashable, Equatable {
 
     // MARK: - Equatable
     static func == (lhs: TopSiteState, rhs: TopSiteState) -> Bool {
-        lhs.site == rhs.site
+        lhs.site == rhs.site &&
+        lhs.isPinned == rhs.isPinned &&
+        lhs.isSuggested == rhs.isSuggested &&
+        lhs.isSponsoredTile == rhs.isSponsoredTile &&
+        lhs.isGoogleGUID == rhs.isGoogleGUID &&
+        lhs.isGoogleURL == rhs.isGoogleURL
     }
 
     // MARK: - Hashable
     func hash(into hasher: inout Hasher) {
         hasher.combine(self.site)
+        hasher.combine(self.isPinned)
+        hasher.combine(self.isSuggested)
+        hasher.combine(self.isSponsoredTile)
+        hasher.combine(self.isGoogleGUID)
+        hasher.combine(self.isGoogleURL)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
@@ -25,12 +25,18 @@ protocol TopSitesManagerInterface {
     /// then comes the sponsored tiles, pinned sites and then frecency top sites.
     /// We only add Google or sponsored tiles if number of pinned tiles doesn't exceeds the available number shown of tiles.
     func recalculateTopSites(otherSites: [TopSiteState], sponsoredSites: [SponsoredTile]) async -> [TopSiteState]
+
+    func removeTopSite(_ site: Site)
+
+    func pinTopSite(_ site: Site)
+
+    func removePinTopSite(_ site: Site)
 }
 
 /// Manager to fetch the top sites data, the data gets updated from notifications on specific user actions
 class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
     private var logger: Logger
-    private let prefs: Prefs
+    private let profile: Profile
     private let contileProvider: ContileProviderInterface
     private let googleTopSiteManager: GoogleTopSiteManagerProvider
     private let topSiteHistoryManager: TopSiteHistoryManagerProvider
@@ -41,7 +47,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
     private let maxNumberOfSponsoredTile: Int = 2
 
     init(
-        prefs: Prefs,
+        profile: Profile,
         contileProvider: ContileProviderInterface = ContileProvider(),
         unifiedAdsProvider: UnifiedAdsProviderInterface = UnifiedAdsProvider(),
         googleTopSiteManager: GoogleTopSiteManagerProvider,
@@ -50,7 +56,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
         logger: Logger = DefaultLogger.shared,
         maxTopSites: Int = 4 * 14 // Max rows * max tiles on the largest screen plus some padding
     ) {
-        self.prefs = prefs
+        self.profile = profile
         self.contileProvider = contileProvider
         self.unifiedAdsProvider = unifiedAdsProvider
         self.googleTopSiteManager = googleTopSiteManager
@@ -76,7 +82,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
     // MARK: Google tile
     private func addGoogleTopSite(with availableSpaceCount: Int) -> [TopSiteState] {
         guard googleTopSiteManager.shouldAddGoogleTopSite(hasSpace: availableSpaceCount > 0),
-                let googleSite = googleTopSiteManager.suggestedSiteData
+              let googleSite = googleTopSiteManager.suggestedSiteData
         else {
             return []
         }
@@ -120,7 +126,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
     }
 
     private var shouldLoadSponsoredTiles: Bool {
-        return prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.SponsoredShortcuts) ?? true
+        return profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.SponsoredShortcuts) ?? true
     }
 
     private func filterSponsoredSites(
@@ -140,7 +146,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
         return filteredContiles
     }
 
-    /// Show the sponsored site only if site is not already present in the pinned sites 
+    /// Show the sponsored site only if site is not already present in the pinned sites
     /// and it's not the default search engine
     private func shouldShowSponsoredSite(with sponsoredSite: Site, and otherSites: [TopSiteState]) -> Bool {
         let siteDomain = sponsoredSite.url.asURL?.shortDomain
@@ -203,6 +209,32 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
             duplicates.insert(state)
 
             return state
+        }
+    }
+
+    // MARK: - Context actions
+    func removeTopSite(_ site: Site) {
+        removePinTopSite(site)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            self?.hideURLFromTopSites(site)
+        }
+    }
+
+    func pinTopSite(_ site: Site) {
+        _ = profile.pinnedSites.addPinnedTopSite(site)
+    }
+
+    func removePinTopSite(_ site: Site) {
+        googleTopSiteManager.removeGoogleTopSite(site: site)
+        topSiteHistoryManager.removeTopSite(site: site)
+    }
+
+    private func hideURLFromTopSites(_ site: Site) {
+        topSiteHistoryManager.removeDefaultTopSitesTile(site: site)
+        // We make sure to remove all history for URL so it doesn't show anymore in the
+        // top sites, this is the approach that Android takes too.
+        profile.places.deleteVisitsFor(url: site.url).uponQueue(.main) { _ in
+            NotificationCenter.default.post(name: .TopSitesUpdated, object: self)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -5,16 +5,22 @@
 import Common
 import Foundation
 import Redux
+import Storage
 
 final class TopSitesMiddleware {
     private let topSitesManager: TopSitesManagerInterface
+    private let logger: Logger
 
     // Raw data to build top sites with, we may want to revisit and fetch only the number of top sites we want
     // but keeping logic consistent for now
     private var otherSites: [TopSiteState] = []
     private var sponsoredTiles: [SponsoredTile] = []
 
-    init(profile: Profile = AppContainer.shared.resolve(), topSitesManager: TopSitesManagerInterface? = nil) {
+    init(
+        profile: Profile = AppContainer.shared.resolve(),
+        topSitesManager: TopSitesManagerInterface? = nil,
+        logger: Logger = DefaultLogger.shared
+    ) {
         self.topSitesManager = topSitesManager ?? TopSitesManager(
             profile: profile,
             googleTopSiteManager: GoogleTopSiteManager(
@@ -23,6 +29,7 @@ final class TopSitesMiddleware {
             topSiteHistoryManager: TopSiteHistoryManager(profile: profile),
             searchEnginesManager: profile.searchEnginesManager
         )
+        self.logger = logger
     }
 
     lazy var topSitesProvider: Middleware<AppState> = { state, action in
@@ -30,27 +37,30 @@ final class TopSitesMiddleware {
         case HomepageActionType.initialize,
             TopSitesActionType.fetchTopSites:
             self.getTopSitesDataAndUpdateState(for: action)
-        case ContextMenuActionType.tappedOnAddTopSites:
-            guard let site = (action as? ContextMenuAction)?.site else {
-                // add logger
-                return
-            }
+        case ContextMenuActionType.tappedOnPinTopSite:
+            guard let site = self.getSite(for: action) else { return }
             self.topSitesManager.pinTopSite(site)
-        case ContextMenuActionType.tappedOnRemovePinnedSites:
-            guard let site = (action as? ContextMenuAction)?.site else {
-                // add logger
-                return
-            }
-            self.topSitesManager.removePinTopSite(site)
-        case ContextMenuActionType.tappedOnRemoveTopSites:
-            guard let site = (action as? ContextMenuAction)?.site else {
-                // add logger
-                return
-            }
+        case ContextMenuActionType.tappedOnUnpinTopSite:
+            guard let site = self.getSite(for: action) else { return }
+            self.topSitesManager.unpinTopSite(site)
+        case ContextMenuActionType.tappedOnRemoveTopSite:
+            guard let site = self.getSite(for: action) else { return }
             self.topSitesManager.removeTopSite(site)
         default:
             break
         }
+    }
+
+    private func getSite(for action: Action) -> Site? {
+        guard let site = (action as? ContextMenuAction)?.site else {
+            self.logger.log(
+                "Unable to retrieve site for \(action.actionType)",
+                level: .warning,
+                category: .homepage
+            )
+            return nil
+        }
+        return site
     }
 
     private func getTopSitesDataAndUpdateState(for action: Action) {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -16,7 +16,7 @@ final class TopSitesMiddleware {
 
     init(profile: Profile = AppContainer.shared.resolve(), topSitesManager: TopSitesManagerInterface? = nil) {
         self.topSitesManager = topSitesManager ?? TopSitesManager(
-            prefs: profile.prefs,
+            profile: profile,
             googleTopSiteManager: GoogleTopSiteManager(
                 prefs: profile.prefs
             ),
@@ -30,6 +30,24 @@ final class TopSitesMiddleware {
         case HomepageActionType.initialize,
             TopSitesActionType.fetchTopSites:
             self.getTopSitesDataAndUpdateState(for: action)
+        case ContextMenuActionType.tappedOnAddTopSites:
+            guard let site = (action as? ContextMenuAction)?.site else {
+                // add logger
+                return
+            }
+            self.topSitesManager.pinTopSite(site)
+        case ContextMenuActionType.tappedOnRemovePinnedSites:
+            guard let site = (action as? ContextMenuAction)?.site else {
+                // add logger
+                return
+            }
+            self.topSitesManager.removePinTopSite(site)
+        case ContextMenuActionType.tappedOnRemoveTopSites:
+            guard let site = (action as? ContextMenuAction)?.site else {
+                // add logger
+                return
+            }
+            self.topSitesManager.removeTopSite(site)
         default:
             break
         }

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/GoogleTopSiteManager.swift
@@ -10,6 +10,7 @@ import SiteImageView
 public protocol GoogleTopSiteManagerProvider {
     var suggestedSiteData: PinnedSite? { get }
     func shouldAddGoogleTopSite(hasSpace: Bool) -> Bool
+    func removeGoogleTopSite(site: Site)
 }
 // Manage the specific Google top site case
 class GoogleTopSiteManager: GoogleTopSiteManagerProvider {

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
@@ -8,6 +8,8 @@ import Storage
 
 protocol TopSiteHistoryManagerProvider {
     func getTopSites(completion: @escaping ([Site]?) -> Void)
+    func removeDefaultTopSitesTile(site: Site)
+    func removeTopSite(site: Site)
 }
 
 // Manages the top site

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockGoogleTopSiteManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockGoogleTopSiteManager.swift
@@ -9,6 +9,7 @@ import Storage
 
 class MockGoogleTopSiteManager: GoogleTopSiteManagerProvider {
     private let mockSiteData: PinnedSite?
+    var removeGoogleTopSiteCalledCount = 0
 
     init(mockSiteData: PinnedSite? = PinnedSite(
         site: Site(url: GoogleTopSiteManager.Constants.usUrl, title: "Google Test"),
@@ -22,5 +23,9 @@ class MockGoogleTopSiteManager: GoogleTopSiteManagerProvider {
 
     func shouldAddGoogleTopSite(hasSpace: Bool) -> Bool {
         return hasSpace
+    }
+
+    func removeGoogleTopSite(site: Site) {
+        removeGoogleTopSiteCalledCount += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSiteHistoryManager.swift
@@ -9,6 +9,9 @@ import Storage
 
 class MockTopSiteHistoryManager: TopSiteHistoryManagerProvider {
     private let sites: [Site]?
+    var removeDefaultTopSitesTileCalledCount = 0
+    var removeTopSiteCalledCount = 0
+
     static var defaultSuccessData: [Site] {
         return [
             PinnedSite(
@@ -46,5 +49,13 @@ class MockTopSiteHistoryManager: TopSiteHistoryManagerProvider {
 
     func getTopSites(completion: @escaping ([Site]?) -> Void) {
         completion(sites)
+    }
+
+    func removeDefaultTopSitesTile(site: Site) {
+        removeDefaultTopSitesTileCalledCount += 1
+    }
+
+    func removeTopSite(site: Site) {
+        removeTopSiteCalledCount += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
@@ -12,6 +12,10 @@ final class MockTopSitesManager: TopSitesManagerInterface {
     var fetchSponsoredSitesCalledCount = 0
     var recalculateTopSitesCalledCount = 0
 
+    var removeTopSiteCalledCount = 0
+    var pinTopSiteCalledCount = 0
+    var unpinTopSiteCalledCount = 0
+
     func getOtherSites() async -> [TopSiteState] {
         getOtherSitesCalledCount += 1
         return createSites(count: 15, subtitle: ": otherSites")
@@ -37,5 +41,17 @@ final class MockTopSitesManager: TopSitesManagerInterface {
             sites.append(TopSiteState(site: site))
         }
         return sites
+    }
+
+    func removeTopSite(_ site: Site) {
+        removeTopSiteCalledCount += 1
+    }
+
+    func pinTopSite(_ site: Site) {
+        pinTopSiteCalledCount += 1
+    }
+
+    func unpinTopSite(_ site: Site) {
+        unpinTopSiteCalledCount += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Redux
+import Storage
 import XCTest
 
 @testable import Client
@@ -76,6 +77,78 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 3)
         XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites, .retrievedUpdatedSites])
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
+    }
+
+    func test_tappedOnPinTopSite_withSite_callsPinTopSite() {
+        let subject = createSubject(topSitesManager: mockTopSitesManager)
+        let site = Site(url: "www.example.com", title: "Pinned Top Site")
+        let action = ContextMenuAction(
+            site: site,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ContextMenuActionType.tappedOnPinTopSite
+        )
+
+        subject.topSitesProvider(appState, action)
+
+        XCTAssertEqual(mockTopSitesManager.pinTopSiteCalledCount, 1)
+    }
+
+    func test_tappedOnPinTopSite_withoutSite_doesNotCallPinTopSite() {
+        let subject = createSubject(topSitesManager: mockTopSitesManager)
+        let action = ContextMenuAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ContextMenuActionType.tappedOnPinTopSite
+        )
+
+        subject.topSitesProvider(appState, action)
+
+        XCTAssertEqual(mockTopSitesManager.pinTopSiteCalledCount, 0)
+    }
+
+    func test_tappedOnUnpinTopSite_withSite_callsUnpinTopSite() {
+        let subject = createSubject(topSitesManager: mockTopSitesManager)
+        let site = Site(url: "www.example.com", title: "Pinned Top Site")
+        let action = ContextMenuAction(
+            site: site,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ContextMenuActionType.tappedOnUnpinTopSite
+        )
+
+        subject.topSitesProvider(appState, action)
+
+        XCTAssertEqual(mockTopSitesManager.unpinTopSiteCalledCount, 1)
+    }
+
+    func test_tappedOnUnpinTopSite_withoutSite_doesNotCallUnpinTopSite() {
+        let subject = createSubject(topSitesManager: mockTopSitesManager)
+        let action = TopSitesAction(windowUUID: .XCTestDefaultUUID, actionType: ContextMenuActionType.tappedOnUnpinTopSite)
+
+        subject.topSitesProvider(appState, action)
+
+        XCTAssertEqual(mockTopSitesManager.unpinTopSiteCalledCount, 0)
+    }
+
+    func test_tappedOnRemoveTopSite_withSite_callsRemoveTopSite() {
+        let subject = createSubject(topSitesManager: mockTopSitesManager)
+        let site = Site(url: "www.example.com", title: "Pinned Top Site")
+        let action = ContextMenuAction(
+            site: site,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ContextMenuActionType.tappedOnRemoveTopSite
+        )
+
+        subject.topSitesProvider(appState, action)
+
+        XCTAssertEqual(mockTopSitesManager.removeTopSiteCalledCount, 1)
+    }
+
+    func test_tappedOnRemoveTopSite_withoutSite_doesNotCallRemoveTopSite() {
+        let subject = createSubject(topSitesManager: mockTopSitesManager)
+        let action = TopSitesAction(windowUUID: .XCTestDefaultUUID, actionType: ContextMenuActionType.tappedOnRemoveTopSite)
+
+        subject.topSitesProvider(appState, action)
+
+        XCTAssertEqual(mockTopSitesManager.removeTopSiteCalledCount, 0)
     }
 
     // MARK: - Helpers

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
@@ -2,21 +2,25 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import XCTest
+import Common
 import Shared
 import Storage
+import XCTest
 
 @testable import Client
 
 final class TopSitesManagerTests: XCTestCase {
     private var profile: MockProfile?
+    private var dispatchQueue: MockDispatchQueue?
     override func setUp() {
         super.setUp()
         profile = MockProfile()
+        dispatchQueue = MockDispatchQueue()
         LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: MockProfile())
     }
 
     override func tearDown() {
+        dispatchQueue = nil
         profile = nil
         super.tearDown()
     }
@@ -341,7 +345,53 @@ final class TopSitesManagerTests: XCTestCase {
         XCTAssertEqual(topSites.compactMap { $0.site.url }, ["https://www.google.com/webhp?client=firefox-b-1-m&channel=ts", "https://mozilla.com"])
     }
 
+    // MARK: Context menu actions
+    func test_unpinTopSite_callsProperMethods() throws {
+        let mockGoogleTopSiteManager = MockGoogleTopSiteManager()
+        let mockTopSiteHistoryManager = MockTopSiteHistoryManager()
+        let subject = try createSubject(
+            googleTopSiteManager: mockGoogleTopSiteManager,
+            topSiteHistoryManager: mockTopSiteHistoryManager
+        )
+        let site = Site(url: "www.example.com", title: "Example Pinned Site")
+        subject.unpinTopSite(site)
+
+        XCTAssertEqual(mockGoogleTopSiteManager.removeGoogleTopSiteCalledCount, 1)
+        XCTAssertEqual(mockTopSiteHistoryManager.removeTopSiteCalledCount, 1)
+    }
+
+    func test_removeTopSite_callsProperMethods() throws {
+        let mockGoogleTopSiteManager = MockGoogleTopSiteManager()
+        let mockTopSiteHistoryManager = MockTopSiteHistoryManager()
+        let subject = try createSubject(
+            googleTopSiteManager: mockGoogleTopSiteManager,
+            topSiteHistoryManager: mockTopSiteHistoryManager
+        )
+        let site = Site(url: "www.example.com", title: "Example Pinned Site")
+        subject.removeTopSite(site)
+
+        XCTAssertEqual(mockGoogleTopSiteManager.removeGoogleTopSiteCalledCount, 1)
+        XCTAssertEqual(mockTopSiteHistoryManager.removeTopSiteCalledCount, 1)
+        XCTAssertEqual(mockTopSiteHistoryManager.removeDefaultTopSitesTileCalledCount, 1)
+    }
+
+    func test_pinTopSite_callsProperMethods() throws {
+        let mockPinnedSites = MockablePinnedSites()
+        let profile = MockProfile(injectedPinnedSites: mockPinnedSites)
+        let mockTopSiteHistoryManager = MockTopSiteHistoryManager()
+        let subject = try createSubject(
+            injectedProfile: profile,
+            topSiteHistoryManager: mockTopSiteHistoryManager
+        )
+        let site = Site(url: "www.example.com", title: "Example Pinned Site")
+
+        subject.pinTopSite(site)
+
+        XCTAssertEqual(mockPinnedSites.addPinnedTopSiteCalledCount, 1)
+    }
+
     private func createSubject(
+        injectedProfile: Profile? = nil,
         googleTopSiteManager: GoogleTopSiteManagerProvider = MockGoogleTopSiteManager(mockSiteData: nil),
         contileProvider: ContileProviderInterface = MockSponsoredProvider(
             result: .success(MockSponsoredProvider.emptySuccessData)
@@ -355,14 +405,16 @@ final class TopSitesManagerTests: XCTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) throws -> TopSitesManager {
-        let mockProfile = try XCTUnwrap(profile)
+        let mockProfile = try XCTUnwrap(injectedProfile ?? profile)
+        let mockQueue = try XCTUnwrap(dispatchQueue)
         let subject = TopSitesManager(
-            prefs: mockProfile.prefs,
+            profile: mockProfile,
             contileProvider: contileProvider,
             unifiedAdsProvider: unifiedAdsProvider,
             googleTopSiteManager: googleTopSiteManager,
             topSiteHistoryManager: topSiteHistoryManager,
             searchEnginesManager: searchEngineManager,
+            dispatchQueue: mockQueue,
             maxTopSites: maxCount
         )
         trackForMemoryLeaks(subject, file: file, line: line)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockProfile.swift
@@ -118,12 +118,18 @@ open class MockProfile: Client.Profile {
 
     private let directory: String
     private let databasePrefix: String
+    private let injectedPinnedSites: MockablePinnedSites?
 
-    init(databasePrefix: String = "mock", firefoxSuggest: RustFirefoxSuggestProtocol? = nil) {
+    init(
+        databasePrefix: String = "mock",
+        firefoxSuggest: RustFirefoxSuggestProtocol? = nil,
+        injectedPinnedSites: MockablePinnedSites? = nil
+    ) {
         files = MockFiles()
         syncManager = ClientSyncManagerSpy()
         self.databasePrefix = databasePrefix
         self.firefoxSuggest = firefoxSuggest
+        self.injectedPinnedSites = injectedPinnedSites
 
         do {
             directory = try files.getAndEnsureDirectory()
@@ -242,7 +248,7 @@ open class MockProfile: Client.Profile {
     }()
 
     public lazy var pinnedSites: PinnedSites = {
-        legacyPlaces
+        injectedPinnedSites ?? legacyPlaces
     }()
 
     public func hasSyncAccount(completion: @escaping (Bool) -> Void) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockablePinnedSites.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockablePinnedSites.swift
@@ -8,8 +8,12 @@ import Shared
 
 /// A class that adheres to all the requirements for a profile's pinned sites
 class MockablePinnedSites: PinnedSites {
+    var addPinnedTopSiteCalledCount = 0
     func removeFromPinnedTopSites(_ site: Site) -> Success { fatalError() }
     func isPinnedTopSite(_ url: String) -> Deferred<Maybe<Bool>> { fatalError()}
-    func addPinnedTopSite(_ site: Site) -> Success { fatalError() }
+    func addPinnedTopSite(_ site: Site) -> Success {
+        addPinnedTopSiteCalledCount += 1
+        return Success()
+    }
     func getPinnedTopSites() -> Deferred<Maybe<Cursor<Site>>> { fatalError() }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10614)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23245)

## :bulb: Description
Add the rest of the actions for the top sites section context menu (i.e. pin, unpin, remove)
- Created new `ContextMenuAction` class
- Copied over methods that were `TopSitesViewModel`
- Added tests and made some modification to mock better

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots 
**Pin**  + **Unpin**

https://github.com/user-attachments/assets/44e45460-2c84-4cbb-8a19-f0c49dd705c9

**Remove**

https://github.com/user-attachments/assets/341b04fc-ff9c-4ce1-8746-27d46336c8b4