### PR TITLE
Add FXIOS-10975 [Homepage] [Context Menu] Bookmark actions to Pocket items

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -173,7 +173,12 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     func showContextMenu(for configuration: ContextMenuConfiguration) {
-        let coordinator = ContextMenuCoordinator(configuration: configuration, router: router, windowUUID: windowUUID)
+        let coordinator = ContextMenuCoordinator(
+            configuration: configuration,
+            router: router,
+            windowUUID: windowUUID,
+            bookmarksHandlerDelegate: browserViewController
+        )
         coordinator.parentCoordinator = self
         add(child: coordinator)
         coordinator.start()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
@@ -6,6 +6,7 @@ import Common
 import WebKit
 import Photos
 import Shared
+import Storage
 
 class ActionProviderBuilder {
     private var actions = [UIAction]()
@@ -37,14 +38,14 @@ class ActionProviderBuilder {
             })
     }
 
-    func addBookmarkLink(url: URL, title: String?, addBookmark: @escaping (String, String?) -> Void) {
+    func addBookmarkLink(url: URL, title: String?, addBookmark: @escaping (String, String?, Site?) -> Void) {
         actions.append(
             UIAction(
                 title: .ContextMenuBookmarkLink,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
                 identifier: UIAction.Identifier("linkContextMenu.bookmarkLink")
             ) { _ in
-                addBookmark(url.absoluteString, title)
+                addBookmark(url.absoluteString, title, nil)
                 TelemetryWrapper.recordEvent(category: .action,
                                              method: .add,
                                              object: .bookmark,
@@ -53,14 +54,14 @@ class ActionProviderBuilder {
         )
     }
 
-    func addRemoveBookmarkLink(url: URL, title: String?, removeBookmark: @escaping (URL, String?) -> Void) {
+    func addRemoveBookmarkLink(url: URL, title: String?, removeBookmark: @escaping (URL, String?, Site?) -> Void) {
         actions.append(
             UIAction(
                 title: .RemoveBookmarkContextMenuTitle,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
                 identifier: UIAction.Identifier("linkContextMenu.removeBookmarkLink")
             ) { _ in
-                removeBookmark(url, title)
+                removeBookmark(url, title, nil)
                 TelemetryWrapper.recordEvent(category: .action,
                                              method: .delete,
                                              object: .bookmark,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -33,6 +33,7 @@ class BrowserViewController: UIViewController,
                              NavigationToolbarContainerDelegate,
                              AddressToolbarContainerDelegate,
                              BookmarksRefactorFeatureFlagProvider,
+                             BookmarksHandlerDelegate,
                              FeatureFlaggable {
     private enum UX {
         static let ShowHeaderTapAreaHeight: CGFloat = 32
@@ -1646,7 +1647,7 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    func addBookmark(url: String, title: String? = nil) {
+    func addBookmark(url: String, title: String? = nil, site: Site? = nil) {
         var title = (title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         if title.isEmpty {
             title = url
@@ -1665,14 +1666,15 @@ class BrowserViewController: UIViewController,
         QuickActionsImplementation().addDynamicApplicationShortcutItemOfType(.openLastBookmark,
                                                                              withUserData: userData,
                                                                              toApplication: .shared)
-
+        site?.setBookmarked(true)
         showBookmarkToast(action: .add)
     }
 
-    func removeBookmark(url: URL, title: String?) {
+    func removeBookmark(url: URL, title: String?, site: Site? = nil) {
         profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
             guard result.isSuccess else { return }
             self.showBookmarkToast(bookmarkURL: url, title: title, action: .remove)
+            site?.setBookmarked(false)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -12,7 +12,7 @@ import Common
 
 protocol ToolBarActionMenuDelegate: AnyObject {
     func updateToolbarState()
-    func addBookmark(url: String, title: String?)
+    func addBookmark(url: String, title: String?, site: Site?)
 
     @discardableResult
     func openURLInNewTab(_ url: URL?, isPrivate: Bool) -> Tab
@@ -734,7 +734,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             else { return }
 
             // The method in BVC also handles the toast for this use case
-            self.delegate?.addBookmark(url: url.absoluteString, title: tab.title)
+            self.delegate?.addBookmark(url: url.absoluteString, title: tab.title, site: nil)
             TelemetryWrapper.recordEvent(
                 category: .action,
                 method: .add,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuCoordinator.swift
@@ -11,21 +11,30 @@ protocol ContextMenuCoordinatorDelegate: AnyObject {
 
 final class ContextMenuCoordinator: BaseCoordinator, ContextMenuCoordinatorDelegate {
     weak var parentCoordinator: ParentCoordinatorDelegate?
+
     private let windowUUID: WindowUUID
     private let configuration: ContextMenuConfiguration
+    /// Used to call bookmark methods in BVC
+    private let bookmarksHandlerDelegate: BookmarksHandlerDelegate
 
     init(
         configuration: ContextMenuConfiguration,
         router: Router,
-        windowUUID: WindowUUID
+        windowUUID: WindowUUID,
+        bookmarksHandlerDelegate: BookmarksHandlerDelegate
     ) {
         self.configuration = configuration
         self.windowUUID = windowUUID
+        self.bookmarksHandlerDelegate = bookmarksHandlerDelegate
         super.init(router: router)
     }
 
     func start() {
-        let state = ContextMenuState(configuration: configuration, windowUUID: windowUUID)
+        let state = ContextMenuState(
+            bookmarkDelegate: bookmarksHandlerDelegate,
+            configuration: configuration,
+            windowUUID: windowUUID
+        )
         let viewModel = PhotonActionSheetViewModel(
             actions: state.actions,
             site: state.site,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/ContextMenu/ContextMenuCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/ContextMenu/ContextMenuCoordinatorTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Storage
 import XCTest
 
 @testable import Client
@@ -50,14 +51,19 @@ final class ContextMenuCoordinatorTests: XCTestCase {
     private func createSubject(file: StaticString = #file,
                                line: UInt = #line) -> ContextMenuCoordinator {
         let configuration = ContextMenuConfiguration(homepageSection: .header, toastContainer: UIView())
-
         let subject = ContextMenuCoordinator(
             configuration: configuration,
             router: mockRouter,
-            windowUUID: .XCTestDefaultUUID
+            windowUUID: .XCTestDefaultUUID,
+            bookmarksHandlerDelegate: MockBookmarksHandlerDelegate()
         )
 
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
     }
+}
+
+class MockBookmarksHandlerDelegate: BookmarksHandlerDelegate {
+    func addBookmark(url: String, title: String?, site: Site?) { }
+    func removeBookmark(url: URL, title: String?, site: Site?) { }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10975)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23963)

## :bulb: Description
Add bookmark actions for pocket items. Since the legacy code is very similar to the code we have in BVC for `addBookmark` and `removeBookmark`. I decided to use the existing methods + modify it to update the site's bookmark value. 

UI tests are more appropriate for testing this flow, which will be addressed in another ticket.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots

https://github.com/user-attachments/assets/95c28abd-558e-41b6-9929-6093e90c7afc
