### PR TITLE
Focus l10n: Import strings manually

### DIFF
--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -683,6 +683,12 @@
 		A847EEFA289A4F5A002AC855 /* pa-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pa-IN"; path = "pa-IN.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		A847EEFC289A4F5A002AC855 /* pa-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pa-IN"; path = "pa-IN.lproj/Intro.strings"; sourceTree = "<group>"; };
 		A847EEFD289A4F5A002AC855 /* pa-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pa-IN"; path = "pa-IN.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		A858FC272D271326008B994A /* scn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = scn; path = scn.lproj/Intents.strings; sourceTree = "<group>"; };
+		A858FC282D271326008B994A /* scn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = scn; path = scn.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		A858FC292D271326008B994A /* scn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = scn; path = scn.lproj/Intro.strings; sourceTree = "<group>"; };
+		A858FC2A2D271326008B994A /* scn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = scn; path = scn.lproj/Localizable.strings; sourceTree = "<group>"; };
+		A858FC2B2D271326008B994A /* scn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = scn; path = scn.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		A858FC2C2D271326008B994A /* scn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = scn; path = scn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A892C8D428BBA27600A64567 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A892C8D628BBA27600A64567 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/Intro.strings; sourceTree = "<group>"; };
 		A892C8D728BBA27600A64567 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -691,6 +697,12 @@
 		A89766D51F57DCA8008183C5 /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		A89766D61F57DCA9008183C5 /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		A89766D71F57DCA9008183C5 /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		A8BDA74A2D27124B00E02B59 /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/Intents.strings"; sourceTree = "<group>"; };
+		A8BDA74B2D27124B00E02B59 /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		A8BDA74C2D27124B00E02B59 /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/Intro.strings"; sourceTree = "<group>"; };
+		A8BDA74D2D27124B00E02B59 /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		A8BDA74E2D27124B00E02B59 /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		A8BDA74F2D27124B00E02B59 /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		A8EA0CE4289A4F4100B99C37 /* et */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = et; path = et.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A8EA0CE6289A4F4100B99C37 /* et */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = et; path = et.lproj/Intro.strings; sourceTree = "<group>"; };
 		A8EA0CE7289A4F4100B99C37 /* et */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = et; path = et.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -2317,6 +2329,8 @@
 				be,
 				am,
 				gl,
+				"en-CA",
+				scn,
 			);
 			mainGroup = E4BF2DCA1BACE8CA00DA9D68;
 			packageReferences = (
@@ -2915,6 +2929,8 @@
 				4369C6E22C0493E800CA4991 /* hy-AM */,
 				43D5D1B72CB3EAD7001137A4 /* ar */,
 				4343874F2CB3EC32009962A9 /* ne-NP */,
+				A8BDA74F2D27124B00E02B59 /* en-CA */,
+				A858FC2C2D271326008B994A /* scn */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -3007,6 +3023,8 @@
 				43D535F52959011100A7C85C /* be */,
 				43D302E229B54A120040A4CC /* am */,
 				434B6DC32A2408A400EE7F9A /* gl */,
+				A8BDA74C2D27124B00E02B59 /* en-CA */,
+				A858FC292D271326008B994A /* scn */,
 			);
 			name = Intro.strings;
 			sourceTree = "<group>";
@@ -3099,6 +3117,8 @@
 				43D535F62959011100A7C85C /* be */,
 				43D302E329B54A120040A4CC /* am */,
 				434B6DC42A2408A400EE7F9A /* gl */,
+				A8BDA74D2D27124B00E02B59 /* en-CA */,
+				A858FC2A2D271326008B994A /* scn */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -3191,6 +3211,8 @@
 				43D535F32959011000A7C85C /* be */,
 				43D302E129B54A120040A4CC /* am */,
 				434B6DC22A2408A400EE7F9A /* gl */,
+				A8BDA74B2D27124B00E02B59 /* en-CA */,
+				A858FC282D271326008B994A /* scn */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -3424,6 +3446,8 @@
 				437778062A24092200BD08C5 /* pa-IN */,
 				4379F1D62A24094200FB3E77 /* si */,
 				438F047A2A24096D00960A50 /* tt */,
+				A8BDA74E2D27124B00E02B59 /* en-CA */,
+				A858FC2B2D271326008B994A /* scn */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -3517,6 +3541,8 @@
 				E521DDFA29782D3C00655202 /* cy */,
 				43D302E029B54A120040A4CC /* am */,
 				434B6DC12A2408A400EE7F9A /* gl */,
+				A8BDA74A2D27124B00E02B59 /* en-CA */,
+				A858FC272D271326008B994A /* scn */,
 			);
 			name = Intents.intentdefinition;
 			sourceTree = "<group>";

--- a/focus-ios/Blockzilla/be.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/be.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Цёмная";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Справаздачы аб збоях дазваляюць дыягнаставаць і выпраўляць праблемы з браўзерам.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ будзе адпраўляць правайдару пошуку тэкст, які вы ўводзіце ў адрасны радок.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Сацыяльныя сеткі";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Аўтаматычна адпраўляць справаздачы аб збоях";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Выкарыстоўваць Face ID для разблакіравання праграмы";

--- a/focus-ios/Blockzilla/bg.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/bg.lproj/Localizable.strings
@@ -185,7 +185,7 @@
 "NewOnboarding.Subtitle.V2" = "Бързо. Поверително. Без разсейване.";
 
 /* Text for a label that indicates the title of button from onboarding screen */
-"Onboarding.Button.Title" = "Започнете да сърфирате";
+"Onboarding.Button.Title" = "Започнете да разглеждате";
 
 /* Text for a label that indicates the title of the bottom button from the default browser onboarding screen version 2. */
 "Onboarding.DefaultBrowser.BottomButtonTitle.V2" = "Пропускане";

--- a/focus-ios/Blockzilla/bs.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/bs.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Tamna";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Izvještaji o padu omogućavaju nam da dijagnosticiramo i popravimo probleme s preglednikom.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ će poslati ono što unesete u adresnu traku vašem pretraživaču.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Društvene mreže";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Automatski šalji izvještaje o padu";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Koristite Face ID za otključavanje aplikacije";

--- a/focus-ios/Blockzilla/co.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/co.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Scuru";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "I rapporti d’accidente ci permettenu d’identificà è currege i prublemi cù u navigatore.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ manderà à u vostru mutore di ricerca ciò chì vo stampittate in a barra d’indirizzu.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Suciale";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Mandà autumaticamente i raporti d’accidente";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Impiegà Face ID per spalancà l’appiecazione";

--- a/focus-ios/Blockzilla/cs.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/cs.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Tmavý";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Hlášení o selhání nám umožňují diagnostikovat a opravit problémy s prohlížečem.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ bude odesílat text zadávaný to adresního řádku vyhledávači.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Sociální sítě";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Automaticky odesílat hlášení o pádech";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Použít Face ID pro odemčení aplikace";

--- a/focus-ios/Blockzilla/cy.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/cy.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Tywyll";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Mae adroddiadau chwalu'n ein galluogi i wneud diagnosis a thrwsio problemau gyda'r porwr.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "Bydd %@ yn anfon yr hyn rydych yn ei deipio yn y bar cyfeiriad i'ch peiriant chwilio.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Cymdeithasol";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Anfon Adroddiadau Chwalu'n Awtomatig";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Defnyddio Face ID i ddatgloi ap";

--- a/focus-ios/Blockzilla/de.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/de.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Dunkel";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Absturzberichte ermöglichen es uns, Probleme mit dem Browser zu diagnostizieren und zu beheben.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ übermittelt Ihre Eingaben in die Adressleiste an Ihre Suchmaschine.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Soziale Netzwerke";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Absturzberichte automatisch senden";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Face ID zum Entsperren der App verwenden";

--- a/focus-ios/Blockzilla/dsb.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/dsb.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Śamny";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Rozpšawy wowalenjow nam zmóžnjaju, problemy z wobglědowakom diagnosticěrowaś a rozwězaś.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ se na wašu pytnicu pósćelo, což w adresowem pólu zapódajośo.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Socialne seśi";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Rozpšawy wowalenjow awtomatiski pósłaś";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Face ID za wótwórjanje nałoženja wužywaś";

--- a/focus-ios/Blockzilla/en-CA.lproj/InfoPlist.strings
+++ b/focus-ios/Blockzilla/en-CA.lproj/InfoPlist.strings
@@ -1,0 +1,18 @@
+/* Privacy - Camera Usage Description */
+"NSCameraUsageDescription" = "This lets you take and upload photos.";
+
+/* Privacy - Face ID Usage Description */
+"NSFaceIDUsageDescription" = "This lets you unlock the app.";
+
+/* Privacy - Location When In Use Usage Description */
+"NSLocationWhenInUseUsageDescription" = "Websites you visit may request your location.";
+
+/* Privacy - Microphone Usage Description */
+"NSMicrophoneUsageDescription" = "This lets you take and upload videos.";
+
+/* Privacy - Photo Library Additions Usage Description */
+"NSPhotoLibraryAddUsageDescription" = "This lets you save and upload photos.";
+
+/* This is the menu item that appears when you long press the Focus icon on the phone home screen. */
+"UIApplicationShortcutItemTitle.EraseAndOpen" = "Erase and Open";
+

--- a/focus-ios/Blockzilla/en-CA.lproj/Intents.strings
+++ b/focus-ios/Blockzilla/en-CA.lproj/Intents.strings
@@ -1,0 +1,6 @@
+/* (No Comment) */
+"Intents.Erase.Description" = "Erase browsing session";
+
+/* (No Comment) */
+"Intents.Erase.Title" = "Erase";
+

--- a/focus-ios/Blockzilla/en-CA.lproj/Intro.strings
+++ b/focus-ios/Blockzilla/en-CA.lproj/Intro.strings
@@ -1,0 +1,24 @@
+/* Description for the 'History' panel in the First Run tour. */
+"Intro.Slides.History.Description" = "Clear your entire browsing session history, passwords, cookies anytime with a single tap.";
+
+/* Title for the third  panel 'History' in the First Run tour. */
+"Intro.Slides.History.Title" = "Your history is history";
+
+/* Button to go to the next card in Focus onboarding. */
+"Intro.Slides.Next.Button" = "Next";
+
+/* Description for the 'Favorite Search Engine' panel in the First Run tour. */
+"Intro.Slides.Search.Description" = "Searching for something different? Choose a different search engine.";
+
+/* Title for the second  panel 'Search' in the First Run tour. */
+"Intro.Slides.Search.Title" = "Your search, your way";
+
+/* Button to skip onboarding in Focus */
+"Intro.Slides.Skip.Button" = "Skip";
+
+/* Description for the 'Welcome' panel in the First Run tour. */
+"Intro.Slides.Welcome.Description" = "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.";
+
+/* Title for the first panel 'Welcome' in the First Run tour. */
+"Intro.Slides.Welcome.Title" = "Power up your privacy";
+

--- a/focus-ios/Blockzilla/en-CA.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/en-CA.lproj/Localizable.strings
@@ -1,654 +1,654 @@
 /* Button on About screen */
-"About.learnMoreButton" = "Tìm hiểu thêm";
+"About.learnMoreButton" = "Learn more";
 
 /* Label on About screen */
-"About.missionLabel" = "%@ được sáng lập bởi Mozilla. Nhiệm vụ của chúng tôi là thúc đẩy một Internet lành mạnh, cởi mở.";
+"About.missionLabel" = "%@ is produced by Mozilla. Our mission is to foster a healthy, open Internet.";
 
 /* Label on About screen */
-"About.privateBullet1" = "Tìm kiếm và duyệt ngay trong ứng dụng";
+"About.privateBullet1" = "Search and browse right in the app";
 
 /* Label on About screen */
-"About.privateBullet2" = "Chặn trình theo dõi (hoặc cập nhật cài đặt để cho phép trình theo dõi)";
+"About.privateBullet2" = "Block trackers (or update settings to allow trackers)";
 
 /* Label on About screen */
-"About.privateBullet3" = "Xóa cookie cũng như lịch sử tìm kiếm và duyệt web khi xong phiên làm việc";
+"About.privateBullet3" = "Erase to delete cookies as well as search and browsing history";
 
 /* Label on About screen */
-"About.privateBulletHeader" = "Sử dụng nó như trình duyệt riêng tư:";
+"About.privateBulletHeader" = "Use it as a private browser:";
 
 /* Label for row in About screen */
-"About.rowHelp" = "Trợ giúp";
+"About.rowHelp" = "Help";
 
 /* Link to Privacy Notice in the About screen */
-"About.rowPrivacy" = "Chính sách riêng tư";
+"About.rowPrivacy" = "Privacy Notice";
 
 /* Label for row in About screen */
-"About.rowRights" = "Quyền lợi của bạn";
+"About.rowRights" = "Your Rights";
 
 /* Label on About screen */
-"About.safariBullet1" = "Chặn trình theo dõi để cải thiện sự riêng tư";
+"About.safariBullet1" = "Block trackers for improved privacy";
 
 /* Label on About screen */
-"About.safariBullet2" = "Chặn phông chữ Web để giảm kích thước trang";
+"About.safariBullet2" = "Block web fonts to reduce page size";
 
 /* Label on About screen */
-"About.safariBulletHeader" = "Sử dụng nó như phần mở rộng của Safari:";
+"About.safariBulletHeader" = "Use it as a Safari extension:";
 
 /* %@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page. */
-"About.title" = "Giới thiệu %@";
+"About.title" = "About %@";
 
 /* Label on About screen */
-"About.topLabel" = "%@ giúp bạn kiểm soát.";
+"About.topLabel" = "%@ puts you in control.";
 
 /* Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page. */
-"actionSheet.openIn" = "Mở trong %@";
+"actionSheet.openIn" = "Open in %@";
 
 /* Button to dismiss the 'Add Pass Failed' alert. */
 "AddPass.Error.Dismiss" = "Ok";
 
 /* Message of the 'Add Pass Failed' alert. */
-"AddPass.Error.Message" = "Đã xảy ra lỗi trong khi thêm thẻ vào Wallet. Vui lòng thử lại sau.";
+"AddPass.Error.Message" = "An error occurred while adding the pass to Wallet. Please try again later.";
 
 /* Title of the 'Add Pass Failed' alert. */
-"AddPass.Error.Title" = "Thất bại khi thêm thẻ";
+"AddPass.Error.Title" = "Failed to Add Pass";
 
 /* %@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app. */
-"Authentication.reason" = "Xác thực để quay lại %@";
+"Authentication.reason" = "Authenticate to return to %@";
 
 /* Label for button to add a custom URL */
-"Autocomplete.addCustomUrl" = "Thêm URL tùy chỉnh";
+"Autocomplete.addCustomUrl" = "Add Custom URL";
 
 /* Label for error state when entering an invalid URL */
-"Autocomplete.addCustomUrlError" = "Kiểm tra lại URL mà bạn đã nhập.";
+"Autocomplete.addCustomUrlError" = "Double-check the URL you entered.";
 
 /* A label displaying an example URL */
-"Autocomplete.addCustomUrlExample" = "Ví dụ: example.com";
+"Autocomplete.addCustomUrlExample" = "Example: example.com";
 
 /* Label for the input to add a custom URL */
-"Autocomplete.addCustomUrlLabel" = "URL muốn thêm";
+"Autocomplete.addCustomUrlLabel" = "URL to add";
 
 /* Placeholder for the input field to add a custom URL */
-"Autocomplete.addCustomUrlPlaceholder" = "Dán hoặc nhập URL";
+"Autocomplete.addCustomUrlPlaceholder" = "Paste or enter URL";
 
 /* Label for button to add a custom URL with the + prefix */
-"Autocomplete.addCustomUrlWithPlus" = "+ Thêm URL tùy chỉnh";
+"Autocomplete.addCustomUrlWithPlus" = "+ Add Custom URL";
 
 /* Label for toast alerting a custom URL has been added */
-"Autocomplete.customUrlAdded" = "URL tùy chỉnh mới đã được thêm vào.";
+"Autocomplete.customUrlAdded" = "New Custom URL added.";
 
 /* Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. */
-"Autocomplete.defaultDescriptoin" = "Cho phép tự đồng điền %@ trên 450 URL phổ biến trên thanh địa chỉ.";
+"Autocomplete.defaultDescriptoin" = "Enable to have %@ autocomplete over 450 popular URLs in the address bar.";
 
 /* label describing URL Autocomplete as disabled */
-"Autocomplete.disabled" = "Đã tắt";
+"Autocomplete.disabled" = "Disabled";
 
 /* Label for toast alerting that the custom URL being added is a duplicate */
-"Autocomplete.duplicateUrl" = "URL đã tồn tại";
+"Autocomplete.duplicateUrl" = "URL already exists";
 
 /* Label for button to add a custom URL */
-"Autocomplete.emptyState" = "Không có URL tùy chỉnh nào được hiển thị";
+"Autocomplete.emptyState" = "No Custom URLs to display";
 
 /* label describing URL Autocomplete as enabled */
-"Autocomplete.enabled" = "Đã bật";
+"Autocomplete.enabled" = "Enabled";
 
 /* Label for button taking you to your custom Autocomplete URL list */
-"Autocomplete.manageSites" = "Quản lý trang web";
+"Autocomplete.manageSites" = "Manage Sites";
 
 /* Label for enabling or disabling autocomplete */
-"Autocomplete.mySites" = "Các trang web của tôi";
+"Autocomplete.mySites" = "My Sites";
 
 /* Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. */
-"Autocomplete.mySitesDesc" = "Bật để %@ tự động hoàn thành các URL yêu thích của bạn.";
+"Autocomplete.mySitesDesc" = "Enable to have %@ autocomplete your favourite URLs.";
 
 /* Label for enabling or disabling top sites */
-"Autocomplete.topSites" = "Các trang web hàng đầu";
+"Autocomplete.topSites" = "Top Sites";
 
 /* Title for the action button shown on the Splash Screen which gives the user the ability to log in with biometrics. */
-"BiometricAuthentication.UnlockButton.Title" = "Mở khóa";
+"BiometricAuthentication.UnlockButton.Title" = "Unlock";
 
 /* Create a new session after failing a biometric check */
-"BiometricPrompt.newSession" = "Phiên mới";
+"BiometricPrompt.newSession" = "New Session";
 
 /* Accessibility label for the back button */
-"Browser.backLabel" = "Quay lại";
+"Browser.backLabel" = "Back";
 
 /* Toast displayed after a URL has been copied to the clipboard */
-"browser.copyAddressToast" = "URL đã được sao chép vào clipboard";
+"browser.copyAddressToast" = "URL Copied To Clipboard";
 
 /* Copy URL button in URL long press menu */
-"Browser.copyMenuLabel" = "Sao chép";
+"Browser.copyMenuLabel" = "Copy";
 
 /* Accessibility label for the forward button */
-"Browser.forwardLabel" = "Tiếp theo";
+"Browser.forwardLabel" = "Forward";
 
 /* Accessibility label for the reload button */
-"Browser.reloadLabel" = "Tải lại";
+"Browser.reloadLabel" = "Reload";
 
 /* Accessibility label for the settings button */
-"Browser.settingsLabel" = "Thiết lập";
+"Browser.settingsLabel" = "Settings";
 
 /* Accessibility label for the stop button */
-"Browser.stopLabel" = "Dừng";
+"Browser.stopLabel" = "Stop";
 
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
-"browserShortcutDescription.selectLocationBar" = "Chọn thanh địa chỉ";
+"browserShortcutDescription.selectLocationBar" = "Select Location Bar";
 
 /* Label on button to complete edits */
-"Done" = "Xong";
+"Done" = "Done";
 
 /* Label on button to allow edits */
-"Edit" = "Chỉnh sửa";
+"Edit" = "Edit";
 
 /* Button label to reload the error page */
-"Error.tryAgainButton" = "Thử lại";
+"Error.tryAgainButton" = "Try again";
 
 /* Button label used for cancelling to open another app from Focus */
-"ExternalAppLink.cancelTitle" = "Hủy bỏ";
+"ExternalAppLink.cancelTitle" = "Cancel";
 
 /* Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar. */
-"ExternalAppLink.messageTitle" = "%@ muốn mở Ứng dụng khác";
+"ExternalAppLink.messageTitle" = "%@ wants to open another App";
 
 /* Button label for opening another app from Focus */
-"ExternalAppLink.openTitle" = "Mở";
+"ExternalAppLink.openTitle" = "Open";
 
 /* Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open. */
-"externalAppLinkWithAppName.messageTitle" = "%1$@ muốn mở %2$@";
+"externalAppLinkWithAppName.messageTitle" = "%1$@ wants to open %2$@";
 
 /* Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
-"ExternalLink.cancelButton" = "Hủy bỏ";
+"ExternalLink.cancelButton" = "Cancel";
 
 /* Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
-"ExternalLink.emailButton" = "Thư điện tử";
+"ExternalLink.emailButton" = "Email";
 
 /* Accessibility label for done button in Find in Page Toolbar. */
-"FindInPage.Done" = "Hoàn thành tìm kiếm";
+"FindInPage.Done" = "Find in page done";
 
 /* Accessibility label for next result button in Find in Page Toolbar. */
-"FindInPage.NextResult" = "Kết quả tiếp theo trong trang";
+"FindInPage.NextResult" = "Find next in page";
 
 /* Accessibility label for previous result button in Find in Page Toolbar. */
-"FindInPage.PreviousResult" = "Kết quả trước trong trang";
+"FindInPage.PreviousResult" = "Find previous in page";
 
 /* Label on button to dismiss first run UI */
-"FirstRun.lastSlide.buttonLabel" = "OK, được rồi!";
+"FirstRun.lastSlide.buttonLabel" = "OK, Got It!";
 
 /* Message label on the first run screen */
-"FirstRun.messageLabelTagline" = "Duyệt như không ai xem.";
+"FirstRun.messageLabelTagline" = "Browse like no one’s watching.";
 
 /* Button label used to close a menu that displays as a popup. */
-"Menu.Close" = "Đóng";
+"Menu.Close" = "Close";
 
 /* Text for a label that indicates the title of button from onboarding screen version 2. */
-"NewOnboarding.Button.Title.V2" = "Bắt đầu";
+"NewOnboarding.Button.Title.V2" = "Get Started";
 
 /* Text for a label that indicates the subtitle for the onboarding screen version 2. */
-"NewOnboarding.Subtitle.V2" = "Nhanh. Riêng tư. Không có phiền nhiễu.";
+"NewOnboarding.Subtitle.V2" = "Fast. Private. No Distractions.";
 
 /* Text for a label that indicates the title of button from onboarding screen */
-"Onboarding.Button.Title" = "Bắt đầu duyệt web";
+"Onboarding.Button.Title" = "Start browsing";
 
 /* Text for a label that indicates the title of the bottom button from the default browser onboarding screen version 2. */
-"Onboarding.DefaultBrowser.BottomButtonTitle.V2" = "Bỏ qua";
+"Onboarding.DefaultBrowser.BottomButtonTitle.V2" = "Skip";
 
 /* Text for a label that indicates the first subtitle for the default browser onboarding screen version 2. */
-"Onboarding.DefaultBrowser.FirstSubtitle.V2" = "Để tôn trọng quyền riêng tư của bạn, lịch sử truy cập sẽ xóa mỗi khi đóng ứng dụng.";
+"Onboarding.DefaultBrowser.FirstSubtitle.V2" = "We clear your history when you close the app for extra privacy.";
 
 /* Text for a label that indicates the second subtitle for the default browser onboarding screen version 2. %@ is the name of the app (Focus/Klar) */
-"Onboarding.DefaultBrowser.SecondSubtitle.V2" = "Đặt %@ làm mặc định giúp đảm bảo sự riêng tư của bạn trên Internet.";
+"Onboarding.DefaultBrowser.SecondSubtitle.V2" = "Make %@ your default to protect your data with every link you open.";
 
 /* Text for a label that indicates the title for the default browser onboarding screen version 2. %@ is the name of the app (Focus/Klar) */
-"Onboarding.DefaultBrowser.Title.V2" = "%@ không giống như các trình duyệt khác";
+"Onboarding.DefaultBrowser.Title.V2" = "%@ isn’t like other browsers";
 
 /* Text for a label that indicates the title of the top button from the default browser onboarding screen version 2. */
-"Onboarding.DefaultBrowser.TopButtonTitle.V2" = "Đặt làm trình duyệt mặc định";
+"Onboarding.DefaultBrowser.TopButtonTitle.V2" = "Set as Default Browser";
 
 /* Text for a label that indicates the description of history section from onboarding screen. */
-"Onboarding.History.Description" = "Xóa lịch sử duyệt web, mật khẩu, cookie và ngăn các quảng cáo không mong muốn theo dõi bạn chỉ bằng một lần nhấn đơn giản!";
+"Onboarding.History.Description" = "Erase your browsing history, passwords, cookies, and prevent unwanted ads from following you in a simple click!";
 
 /* Text for a label that indicates the title of history section from onboarding screen. */
-"Onboarding.History.Title" = "Lịch sử của bạn không theo dõi bạn";
+"Onboarding.History.Title" = "Your history doesn’t follow you";
 
 /* Text for a label that indicates the description of incognito section from onboarding screen. Placeholder can be (Focus or Klar). */
-"Onboarding.Incognito.Description" = "%@ là một trình duyệt riêng tư chuyên dụng với tính năng chống theo dõi và chặn nội dung.";
+"Onboarding.Incognito.Description" = "%@ is a dedicated privacy browser with tracking protection and content blocking.";
 
 /* Text for a label that indicates the title of incognito section from onboarding screen. */
-"Onboarding.Incognito.Title" = "Không chỉ là ẩn danh";
+"Onboarding.Incognito.Title" = "More than just incognito";
 
 /* Text for a label that indicates the description of protection section from onboarding screen. */
-"Onboarding.Protection.Description" = "Định cấu hình cài đặt để bạn có thể quyết định lượng chia sẻ nhiều hay ít.";
+"Onboarding.Protection.Description" = "Configure settings so you can decide how much or how little you share.";
 
 /* Text for a label that indicates the title of protection section from onboarding screen. */
-"Onboarding.Protection.Title" = "Bảo vệ theo quyết định của riêng bạn";
+"Onboarding.Protection.Title" = "Protection at your own discretion";
 
 /* Text for a label that indicates the subtitle for onboarding screen. */
-"Onboarding.Subtitle" = "Đưa trình duyệt riêng tư của bạn lên cấp độ cao hơn.";
+"Onboarding.Subtitle" = "Take your private browsing to the next level.";
 
 /* Text for a label that indicates the title for onboarding screen. Placeholder can be (Focus or Klar). */
-"Onboarding.Title" = "Chào mừng đến với Firefox %@!";
+"Onboarding.Title" = "Welcome to Firefox %@!";
 
 /* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
-"Safari.instructionsContentBlockers" = "Chạm Safari, rồi chọn Chặn nội dung";
+"Safari.instructionsContentBlockers" = "Tap Safari, then select Content Blockers";
 
 /* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
-"Safari.instructionsEnable" = "Bật %@";
+"Safari.instructionsEnable" = "Enable %@";
 
 /* Label for instructions to enable extensions in Safari, shown when enabling Safari Integration in Settings */
-"Safari.instructionsExtentions" = "Chọn Safari, sau đó chọn Tiện ích mở rộng";
+"Safari.instructionsExtentions" = "Select Safari, then select Extensions";
 
 /* Error label when the blocker is not enabled, shown in the intro and main app when disabled */
-"Safari.instructionsNotEnabled" = "%@ không được bật.";
+"Safari.instructionsNotEnabled" = "%@ is not enabled.";
 
 /* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
-"Safari.instructionsOpen" = "Mở Cài đặt";
+"Safari.instructionsOpen" = "Open Settings App";
 
 /* Label for instructions to enable extensions in Safari, shown when enabling Safari Integration in Settings */
-"Safari.openInstruction" = "Mở cài đặt thiết bị";
+"Safari.openInstruction" = "Open device settings";
 
 /* Save button label */
-"Save" = "Lưu";
+"Save" = "Save";
 
 /* Label for error state when entering an invalid search engine URL. %s is a search term in a URL. */
-"SearchEngine.addEngineError" = "Điều đó không hoạt động. Hãy thử thay thế cụm từ tìm kiếm bằng cái này: %s.";
+"SearchEngine.addEngineError" = "That didn’t work. Try replacing the search term with this: %s.";
 
 /* Label for disable option on search suggestions prompt */
-"SearchSuggestions.promptDisable" = "Không";
+"SearchSuggestions.promptDisable" = "No";
 
 /* Label for enable option on search suggestions prompt */
-"SearchSuggestions.promptEnable" = "Có";
+"SearchSuggestions.promptEnable" = "Yes";
 
 /* %@ is the name of the app (Focus / Klar). Label for search suggestions prompt message */
-"SearchSuggestions.promptMessage" = "Để nhận đề xuất, %@ cần gửi những gì bạn nhập vào thanh địa chỉ cho công cụ tìm kiếm.";
+"SearchSuggestions.promptMessage" = "To get suggestions, %@ needs to send what you type in the address bar to the search engine.";
 
 /* Title for search suggestions prompt */
-"SearchSuggestions.promptTitle" = "Hiển thị đề xuất tìm kiếm?";
+"SearchSuggestions.promptTitle" = "Show Search Suggestions?";
 
 /* Title for the URL Autocomplete row */
-"Settings.autocompleteSection" = "Tự động điền URL";
+"Settings.autocompleteSection" = "URL Autocomplete";
 
 /* Alert message shown when toggling the Content blocker */
-"Settings.blockOtherMessage" = "Chặn các trình theo dõi nội dung khác có thể dẫn đến việc không xem được một vài video và trang web.";
+"Settings.blockOtherMessage" = "Blocking other content trackers may break some videos and web pages.";
 
 /* Button label for declining Content blocker alert */
-"Settings.blockOtherNo2" = "Hủy bỏ";
+"Settings.blockOtherNo2" = "Cancel";
 
 /* Button label for accepting Content blocker alert */
-"Settings.blockOtherYes2" = "Chặn trình theo dõi nội dung";
+"Settings.blockOtherYes2" = "Block Content Trackers";
 
 /* Dark theme option in settings menu */
-"Settings.darkTheme" = "Tối";
+"Settings.darkTheme" = "Dark";
 
 /* Description associated with the Crash Reports toggle on settings screen */
-"Settings.detailTextCrashReports" = "Báo cáo sự cố giúp chúng tôi chẩn đoán và khắc phục sự cố của trình duyệt.";
+"Settings.detailTextCrashReports" = "Crash reports allow us diagnose and fix issues with the browser.";
 
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
-"Settings.detailTextSearchSuggestion" = "%@ sẽ gửi nội dung bạn nhập vào thanh địa chỉ đến công cụ tìm kiếm của bạn.";
+"Settings.detailTextSearchSuggestion" = "%@ will send what you type in the address bar to your search engine.";
 
 /* Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar) */
-"Settings.detailTextSendUsageData" = "Mozilla chỉ thu thập những gì chúng tôi cần cung cấp và cải tiến %@ cho tất cả mọi người.";
+"Settings.detailTextSendUsageData" = "Mozilla strives to collect only what we need to provide and improve %@ for everyone.";
 
 /* Description associated to the Studies toggle on the settings screen. %@ is the app name (Focus/Klar) */
-"Settings.detailTextStudies" = "%@ có thể cài đặt và chạy các nghiên cứu theo thời gian.";
+"Settings.detailTextStudies" = "%@ may install and run studies from time to time.";
 
 /* Title for section in settings menu */
-"Settings.general" = "Tổng quát";
+"Settings.general" = "General";
 
 /* Subtitle for Send Anonymous Usage Data toggle on main screen */
-"Settings.learnMore" = "Tìm hiểu thêm.";
+"Settings.learnMore" = "Learn more.";
 
 /* Lincese option in settings menu. Tapping the cell will take the user to a list of licences for the 3rd parties used in the app. */
-"Settings.licenses" = "Giấy phép";
+"Settings.licenses" = "Licenses";
 
 /* Light theme option in settings menu */
-"Settings.lightTheme" = "Sáng";
+"Settings.lightTheme" = "Light";
 
 /* %@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store. */
-"Settings.rate" = "Đánh giá %@";
+"Settings.rate" = "Rate %@";
 
 /* Label for Safari integration section */
 "Settings.safariTitle" = "SAFARI INTEGRATION";
 
 /* Title for settings screen */
-"Settings.screenTitle" = "Cài đặt";
+"Settings.screenTitle" = "Settings";
 
 /* Text for button to add another search engine in settings */
-"Settings.Search.AddSearchEngineButton" = "Thêm công cụ tìm kiếm khác";
+"Settings.Search.AddSearchEngineButton" = "Add Another Search Engine";
 
 /* Title on add search engine settings screen */
-"Settings.Search.AddSearchEngineTitle" = "Thêm công cụ tìm kiếm";
+"Settings.Search.AddSearchEngineTitle" = "Add Search Engine";
 
 /* Header for rows of installed search engines */
-"Settings.Search.InstalledSearchEngines" = "CÔNG CỤ TÌM KIẾM ĐÃ CÀI ĐẶT";
+"Settings.Search.InstalledSearchEngines" = "INSTALLED SEARCH ENGINES";
 
 /* Label for input field for the name of the search engine to be added */
-"Settings.Search.NameToDisplay" = "Tên hiển thị";
+"Settings.Search.NameToDisplay" = "Name to display";
 
 /* Toast displayed after adding a search engine */
-"Settings.Search.NewSearchEngineAdded" = "Đã thêm công cụ tìm kiếm mới.";
+"Settings.Search.NewSearchEngineAdded" = "New Search Engine Added.";
 
 /* Label for button to bring deleted default engines back */
-"Settings.Search.RestoreEngine" = "Phục hồi các công cụ tìm kiếm mặc định";
+"Settings.Search.RestoreEngine" = "Restore Default Search Engines";
 
 /* Placeholder text for input of new search engine name */
-"Settings.Search.SearchEngineName" = "Tên công cụ tìm kiếm";
+"Settings.Search.SearchEngineName" = "Search engine name";
 
 /* Label for input of search engine template */
-"Settings.Search.SearchTemplate" = "Chuỗi tìm kiếm sử dụng";
+"Settings.Search.SearchTemplate" = "Search string to use";
 
 /* Text displayed as an example of the template to add a search engine. */
-"settings.Search.SearchTemplateExample" = "Ví dụ: searchengineexample.com/search/?q=%s";
+"settings.Search.SearchTemplateExample" = "Example: searchengine.example.com/search/?q=%s";
 
 /* Placeholder text for input of new search engine template */
-"Settings.Search.SearchTemplatePlaceholder" = "Dán hoặc nhập chuỗi tìm kiếm. Nếu cần, hãy thay thế cụm từ tìm kiếm bằng: %s.";
+"Settings.Search.SearchTemplatePlaceholder" = "Paste or enter search string. If necessary, replace search term with: %s.";
 
 /* Label for the search engine in the search screen */
-"Settings.searchLabel" = "Công cụ tìm kiếm";
+"Settings.searchLabel" = "Search Engine";
 
 /* Label for the Search Suggestions toggle row */
-"Settings.searchSuggestions" = "Nhận đề xuất tìm kiếm";
+"Settings.searchSuggestions" = "Get Search Suggestions";
 
 /* Title for the search selection screen */
-"Settings.searchTitle2" = "TÌM KIẾM";
+"Settings.searchTitle2" = "SEARCH";
 
 /* Section label for Mozilla toggles */
 "Settings.sectionMozilla" = "MOZILLA";
 
 /* Section label for privacy toggles */
-"Settings.sectionPrivacy" = "RIÊNG TƯ";
+"Settings.sectionPrivacy" = "PRIVACY";
 
 /* Label title for set as default browser row */
-"Settings.setAsDefaultBrowser" = "Đặt làm trình duyệt mặc định";
+"Settings.setAsDefaultBrowser" = "Set as Default Browser";
 
 /* %@ is the name of the app. Description for set as default browser option */
-"Settings.setAsDefaultBrowserDescription" = "Đặt các liên kết từ trang web, email và tin nhắn để tự động mở trong %@.";
+"Settings.setAsDefaultBrowserDescription" = "Set links from websites, emails and messages to open automatically in %@.";
 
 /* System value for theme section in settings menu */
-"Settings.systemTheme" = "Chủ đề hệ thống";
+"Settings.systemTheme" = "System Theme";
 
 /* Theme section in settings menu */
-"Settings.theme" = "Chủ đề";
+"Settings.theme" = "Theme";
 
 /* Header for manual theme section in settings menu */
-"Settings.themePicker" = "Bộ chọn chủ đề";
+"Settings.themePicker" = "Theme Picker";
 
 /* Label for the checkbox to toggle Advertising trackers */
-"Settings.toggleBlockAds2" = "Quảng cáo";
+"Settings.toggleBlockAds2" = "Advertising";
 
 /* Label for the checkbox to toggle Analytics trackers */
-"Settings.toggleBlockAnalytics2" = "Phân tích";
+"Settings.toggleBlockAnalytics2" = "Analytics";
 
 /* Label for toggle on main screen */
-"Settings.toggleBlockFonts" = "Chặn phông chữ trang Web";
+"Settings.toggleBlockFonts" = "Block web fonts";
 
 /* Label for the checkbox to toggle Other trackers */
-"Settings.toggleBlockOther2" = "Nội dung";
+"Settings.toggleBlockOther2" = "Content";
 
 /* Label for the checkbox to toggle Social trackers */
-"Settings.toggleBlockSocial2" = "Xã hội";
+"Settings.toggleBlockSocial2" = "Social";
 
 /* Label for Crash Reports toggle on settings screen */
-"Settings.toggleCrashReports" = "Tự động gửi báo cáo sự cố";
+"Settings.toggleCrashReports" = "Automatically Send Crash Reports";
 
 /* Label for toggle on settings screen */
-"Settings.toggleFaceID" = "Sử dụng nhận dạng khuôn mặt để mở ứng dụng";
+"Settings.toggleFaceID" = "Use Face ID to unlock app";
 
 /* %@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu. */
-"Settings.toggleFaceIDDescription" = "Face ID có thể mở khóa %@ nếu một URL đã được mở trong ứng dụng";
+"Settings.toggleFaceIDDescription" = "Face ID can unlock %@ if a URL is already open in the app";
 
 /* Show home screen tips toggle label on settings screen */
-"Settings.toggleHomeScreenTips" = "Hiện mẹo trên màn hình chính";
+"Settings.toggleHomeScreenTips" = "Show home screen tips";
 
 /* Safari toggle label on settings screen */
 "Settings.toggleSafari" = "Safari";
 
 /* Label for Send Usage Data toggle on main screen */
-"Settings.toggleSendUsageData" = "Gửi dữ liệu sử dụng";
+"Settings.toggleSendUsageData" = "Send usage data";
 
 /* Label for Studies toggle on the settings screen */
-"Settings.toggleStudies" = "Nghiên cứu";
+"Settings.toggleStudies" = "Studies";
 
 /* Label for toggle on settings screen */
-"Settings.toggleTouchID" = "Sử dụng Touch ID để mở ứng dụng";
+"Settings.toggleTouchID" = "Use Touch ID to unlock app";
 
 /* %@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu. */
-"Settings.toggleTouchIDDescription" = "Touch ID có thể mở khóa %@ nếu một URL đã được mở trong ứng dụng";
+"Settings.toggleTouchIDDescription" = "Touch ID can unlock %@ if a URL is already open in the app";
 
 /* Status off for tracking protection in settings screen */
-"Settings.trackingProtectionOff" = "Tắt";
+"Settings.trackingProtectionOff" = "Off";
 
 /* Status on for tracking protection in settings screen */
-"Settings.trackingProtectionOn" = "Bật";
+"Settings.trackingProtectionOn" = "On";
 
 /* Value for theme toggle in settings menu */
-"Settings.useSystemTheme" = "Sử dụng chế độ sáng/tối của hệ thống";
+"Settings.useSystemTheme" = "Use System Light/Dark Mode";
 
 /* Title for settings section to enable different Siri Shortcuts. */
 "Settinsg.siriShortcutsTitle" = "SIRI SHORTCUTS";
 
 /* Text for a share button */
-"share" = "Chia sẻ";
+"share" = "Share";
 
 /* Text for the share menu option when a user wants to add the site to Shortcuts */
-"ShareMenu.AddToShortcuts" = "Thêm vào lối tắt";
+"ShareMenu.AddToShortcuts" = "Add to Shortcuts";
 
 /* Toast displayed to the user after adding the item to the Shortcuts. */
-"ShareMenu.AddToShortcuts.Confirm" = "Đã thêm vào lối tắt";
+"ShareMenu.AddToShortcuts.Confirm" = "Added to Shortcuts";
 
 /* Text for the share menu when a user wants to copy a URL. */
-"shareMenu.copyAddress" = "Sao chép địa chỉ liên kết";
+"shareMenu.copyAddress" = "Copy Address";
 
 /* Text for the share menu option when a user wants to open the find in page menu */
-"ShareMenu.FindInPage" = "Tìm trong trang";
+"ShareMenu.FindInPage" = "Find in Page";
 
 /* Text for the share menu option when a user wants to remove the site from Shortcuts */
-"ShareMenu.RemoveFromShortcuts" = "Xóa khỏi lối tắt";
+"ShareMenu.RemoveFromShortcuts" = "Remove from Shortcuts";
 
 /* Toast displayed to the user after removing the item from the Shortcuts. */
-"ShareMenu.RemoveShortcut.Confirm" = "Đã xóa lối tắt";
+"ShareMenu.RemoveShortcut.Confirm" = "Shortcut removed";
 
 /* Text for the share menu option when a user wants to reload the site as a desktop */
-"ShareMenu.RequestDesktop" = "Yêu cầu trang web cho máy tính";
+"ShareMenu.RequestDesktop" = "Request Desktop Site";
 
 /* Text for the share menu option when a user wants to reload the site as a mobile device */
-"ShareMenu.RequestMobile" = "Yêu cầu trang web di động";
+"ShareMenu.RequestMobile" = "Request Mobile Site";
 
 /* Text for the share menu option when a user wants to open the current website in the Chrome app. */
-"ShareMenu.ShareOpenChrome" = "Mở trong Chrome";
+"ShareMenu.ShareOpenChrome" = "Open in Chrome";
 
 /* Text for the share menu option when a user wants to open the current website in the default browser. */
-"ShareMenu.ShareOpenDefaultBrowser" = "Mở bằng trình duyệt mặc định";
+"ShareMenu.ShareOpenDefaultBrowser" = "Open in Default Browser";
 
 /* Text for the share menu option when a user wants to open the current website in the Firefox app. */
-"ShareMenu.ShareOpenFirefox" = "Mở trong Firefox";
+"ShareMenu.ShareOpenFirefox" = "Open in Firefox";
 
 /* Text for the share menu option when a user wants to open the current website inside the app. */
-"ShareMenu.ShareOpenLink" = "Mở liên kết";
+"ShareMenu.ShareOpenLink" = "Open Link";
 
 /* Text for the share menu option when a user wants to share the current website they are on through another app. */
-"ShareMenu.SharePage" = "Chia sẻ trang với…";
+"ShareMenu.SharePage" = "Share Page With…";
 
 /* Text for the long press on a shortcut option in context menu. */
-"ShortcutView.RemoveFromShortcuts" = "Xóa khỏi lối tắt";
+"ShortcutView.RemoveFromShortcuts" = "Remove from Shortcuts";
 
 /* Text for the long press on a shortcut rename option in context menu. */
-"ShortcutView.Rename" = "Đổi tên lối tắt";
+"ShortcutView.Rename" = "Rename Shortcut";
 
 /* Text for the placeholder textfield on rename shortcut alert. */
-"ShortcutView.RenameShortcutAlertPlaceholder" = "Tên lối tắt";
+"ShortcutView.RenameShortcutAlertPlaceholder" = "Shortcut name";
 
 /* Text for the rename shortcut alert primary action. */
-"ShortcutView.RenameShortcutAlertPrimaryAction" = "Lưu";
+"ShortcutView.RenameShortcutAlertPrimaryAction" = "Save";
 
 /* Text for the rename shortcut alert secondary action. */
-"ShortcutView.RenameShortcutAlertSecondaryAction" = "Hủy bỏ";
+"ShortcutView.RenameShortcutAlertSecondaryAction" = "Cancel";
 
 /* This is the button text that is displayed in the Show Me How Onboarding Screen */
-"ShowMeHowOnboarding.ButtonText.V2" = "Xong";
+"ShowMeHowOnboarding.ButtonText.V2" = "Done";
 
 /* This is the subtitle text for step one that is displayed in the Show Me How Onboarding Screen */
-"ShowMeHowOnboarding.SubtitleStepOne.V2" = "Nhấn và giữ biểu tượng ứng dụng đến khi nó rung rinh.";
+"ShowMeHowOnboarding.SubtitleStepOne.V2" = "Long press on the Home screen until the icons start to jiggle.";
 
 /* This is the subtitle text for step three that is displayed in the Show Me How onboarding screen. %@ is the name of the app (Focus/Klar) */
-"ShowMeHowOnboarding.SubtitleStepThree.V2" = "Tìm kiếm %@. Sau đó chọn tiện ích hiển thị.";
+"ShowMeHowOnboarding.SubtitleStepThree.V2" = "Search for %@. Then choose a widget.";
 
 /* This is the subtitle text for step two that is displayed in the Show Me How Onboarding Screen */
-"ShowMeHowOnboarding.SubtitleStepTwo.V2" = "Nhấn vào nút dấu cộng.";
+"ShowMeHowOnboarding.SubtitleStepTwo.V2" = "Tap on the plus icon.";
 
 /* This is the title text that is displayed in the Show Me How Onboarding Screen. %@ is the name of the app (Focus/Klar) */
-"ShowMeHowOnboarding.Title.V2" = "Hiển thị thêm %@";
+"ShowMeHowOnboarding.Title.V2" = "Add a %@ Widget";
 
 /* Button to add a favorite URL to Siri. */
-"Siri.add" = "Thêm";
+"Siri.add" = "Add";
 
 /* Button to add a specified shortcut option to Siri. */
-"Siri.addTo" = "Thêm vào Siri";
+"Siri.addTo" = "Add to Siri";
 
 /* Label for button to edit the Siri phrase or delete the Siri functionality. */
-"Siri.editOpenUrl" = "Ghi lại hoặc xóa phím tắt";
+"Siri.editOpenUrl" = "Re-Record or Delete Shortcut";
 
 /* Title of option in settings to set up Siri to erase */
-"Siri.erase" = "Xóa";
+"Siri.erase" = "Erase";
 
 /* Title of option in settings to set up Siri to erase and then open the app. */
-"Siri.eraseAndOpen" = "Xóa & mở";
+"Siri.eraseAndOpen" = "Erase & Open";
 
 /* Title for screen to add a favorite URL to Siri. */
-"Siri.favoriteUrl" = "Mở trang yêu thích";
+"Siri.favoriteUrl" = "Open Favourite Site";
 
 /* Title of option in settings to set up Siri to open a specified URL in Focus/Klar. */
-"Siri.openURL" = "Mở trang yêu thích";
+"Siri.openURL" = "Open Favourite Site";
 
 /* Label for input to set a favorite URL to be opened by Siri. */
-"Siri.urlToOpen" = "URL để mở";
+"Siri.urlToOpen" = "URL to open";
 
 /* Text for a label that indicates the title for biometric tip. The placeholder is replaced with the long product name (Firefox Focus or Firefox Klar). */
-"Tip.Biometric.Title" = "Khóa %@ khi một trang web đang mở:";
+"Tip.Biometric.Title" = "Lock %@ when a site is open:";
 
 /* Text for a label that indicates the description for biometric Face ID tip. */
-"Tip.BiometricFaceId.Description" = "Bật Face ID";
+"Tip.BiometricFaceId.Description" = "Turn on Face ID";
 
 /* Text for a label that indicates the description for biometric Touch ID tip. */
-"Tip.BiometricTouchId.Description" = "Bật Touch ID";
+"Tip.BiometricTouchId.Description" = "Turn on Touch ID";
 
 /* Text for a label that indicates the description for request desktop tip. */
-"Tip.RequestDesktop.Description" = "Hành động trang > Yêu cầu trang web cho máy tính";
+"Tip.RequestDesktop.Description" = "Page Actions > Request Desktop Site";
 
 /* Text for a label that indicates the title for request desktop tip. */
-"Tip.RequestDesktop.Title" = "Bạn muốn xem phiên bản cho máy tính của một trang web?";
+"Tip.RequestDesktop.Title" = "Want to see the full desktop version of a site?";
 
 /* Text for a label that indicates the description for share trackers tip. The placeholder is the number of trackers blocked. Only shown when there are more than 10 trackers blocked. For locales where we would need plural support, please feel free to translate this string as `Trackers blocked so far: %@` instead. */
-"Tip.ShareTrackers.Description" = "%@ trình theo dõi đã bị chặn cho đến nay";
+"Tip.ShareTrackers.Description" = "%@ trackers blocked so far";
 
 /* Text for a label that indicates the title for share trackers tip. The placeholder is replaced with the long product name (Firefox Focus or Firefox Klar). */
-"Tip.ShareTrackers.Title" = "Bạn duyệt. %@ chặn.";
+"Tip.ShareTrackers.Title" = "You browse. %@ blocks.";
 
 /* Text for a label that indicates the description for shortcuts tip. The placeholder is replaced with the short product name (Focus or Klar). */
-"Tip.Shortcuts.Description" = "Chọn Thêm vào lối tắt từ menu %@";
+"Tip.Shortcuts.Description" = "Select Add to Shortcuts from the %@ menu";
 
 /* Text for a label that indicates the title for shortcuts tip. */
-"Tip.Shortcuts.Title" = "Tạo lối tắt đến các trang web bạn truy cập nhiều nhất:";
+"Tip.Shortcuts.Title" = "Create shortcuts to the sites you visit most:";
 
 /* Text for a label that indicates the description for siri erase tip. The shortcut in this context is the iOS Siri Shortcut, not a Focus website shortcut. */
-"Tip.SiriErase.Description" = "Thêm lối tắt Siri";
+"Tip.SiriErase.Description" = "Add Siri shortcut";
 
 /* Text for a label that indicates the title for siri erase tip. The placeholder is replaced with the long product name (Firefox Focus or Firefox Klar). */
-"Tip.SiriErase.Title" = "“Siri, xóa phiên %@ của tôi.”";
+"Tip.SiriErase.Title" = "“Siri, erase my %@ session.”";
 
 /* Text for a label that indicates the description for siri favorite tip. The shortcut in this context is the iOS Siri Shortcut, not a Focus website shortcut. */
-"Tip.SiriFavorite.Description" = "Thêm lối tắt Siri";
+"Tip.SiriFavorite.Description" = "Add Siri shortcut";
 
 /* Text for a label that indicates the title for siri favorite tip. */
-"Tip.SiriFavorite.Title" = "“Siri, mở trang web yêu thích của tôi.”";
+"Tip.SiriFavorite.Title" = "“Siri, open my favourite site.”";
 
 /* Text for a label that indicates the description for sites not working tip. */
-"Tip.SitesNotWorking.Description" = "Thử tắt tính năng Trình chống theo dõi";
+"Tip.SitesNotWorking.Description" = "Try turning off Tracking Protection";
 
 /* Text for a label that indicates the title for sites not working tip. */
-"Tip.SitesNotWorking.Title" = "Trang web thiếu nội dung hoặc hoạt động không đúng?";
+"Tip.SitesNotWorking.Title" = "Site missing content or acting strange?";
 
 /* Text shown on quick action widget inviting the user to browse in the app. %@ is the name of the app (Focus/Klar). */
-"TodayWidget.SearchInApp.Instruction" = "Tìm kiếm trong %@";
+"TodayWidget.SearchInApp.Instruction" = "Search in %@";
 
 /* This is the body text that is displayed for the Context Menu icon tooltip */
-"TooltipBodyText.ContextMenu" = "Đi đến Cài đặt để quản lý các tùy chọn quyền riêng tư và bảo mật cụ thể.";
+"TooltipBodyText.ContextMenu" = "Go to Settings to manage specific privacy & security options.";
 
 /* This is the body text that is displayed for the Privacy tooltip */
-"TooltipBodyText.Privacy" = "Các cài đặt mặc định này cung cấp khả năng bảo vệ mạnh mẽ. Tuy nhiên, thật dễ dàng để điều chỉnh cài đặt để đáp ứng các nhu cầu cụ thể của bạn.";
+"TooltipBodyText.Privacy" = "These default settings offer strong protection. But it’s easy to tweak the settings to meet your specific needs.";
 
 /* This is the body text that is displayed for the Search Bar tooltip */
-"TooltipBodyText.SearchBar" = "Bắt đầu phiên duyệt web riêng tư của bạn và chúng tôi sẽ chặn trình theo dõi và các nội dung xấu khác khi bạn di chuyển.";
+"TooltipBodyText.SearchBar" = "Start your private browsing session, and we’ll block trackers and other bad stuff as you go.";
 
 /* This is the body text that is displayed for the Shield icon tooltip. Where placeholder can be (Focus or Klar). */
-"TooltipBodyText.ShieldIcon" = "%@ đã ngăn trang web này theo dõi bạn. Nhấn vào tấm khiên để biết thông tin về những gì chúng tôi đã chặn.";
+"TooltipBodyText.ShieldIcon" = "%@ stopped this site from spying on you. Tap the shield for info on what we blocked.";
 
 /* This is the body text that is displayed for the Shield icon tooltip when we block trackers for the first time on a website */
-"TooltipBodyText.ShieldIconTrackerBlocked.V2" = "Bắt được rồi! Chúng tôi đã ngăn trang web này theo dõi bạn. Nhấn vào tấm khiên bất kỳ lúc nào để xem những gì chúng tôi đang chặn.";
+"TooltipBodyText.ShieldIconTrackerBlocked.V2" = "Got ‘em! We stopped this site from spying on you. Tap the shield any time to see what we’re blocking.";
 
 /* This is the body text that is displayed for the Trash icon tooltip */
-"TooltipBodyText.TrashIcon" = "Nhấn vào thùng rác bất cứ lúc nào để xóa tất cả dấu vết của phiên hiện tại của bạn.";
+"TooltipBodyText.TrashIcon" = "Tap the trash anytime to remove all traces of your current session.";
 
 /* This is the body text that is displayed for the Trash icon tooltip */
-"TooltipBodyText.TrashIcon.V2" = "Nhấn vào đây để xóa tất cả — lịch sử, cookie, mọi thứ — và bắt đầu làm mới trên một thẻ mới.";
+"TooltipBodyText.TrashIcon.V2" = "Tap here to trash it all — history, cookies, everything — and start fresh on a new tab.";
 
 /* This is the title text that is displayed for the Privacy tooltip */
-"TooltipTitleText.Privacy" = "Bạn đã được bảo vệ!";
+"TooltipTitleText.Privacy" = "You’re protected! ";
 
 /* Text for tracking protection screen showing the connection is not secure */
-"trackingProtection.connectionNotSecureLabel" = "Kết nối không an toàn";
+"trackingProtection.connectionNotSecureLabel" = "Connection is not secure";
 
 /* Text for tracking protection screen showing the connection is secure */
-"trackingProtection.connectionSecureLabel" = "Kết nối an toàn";
+"trackingProtection.connectionSecureLabel" = "Connection is secure";
 
 /* Title for the tracking settings page to change what trackers are blocked. */
-"trackingProtection.label" = "Trình chống theo dõi";
+"trackingProtection.label" = "Tracking Protection";
 
 /* Text for the status off from Tracking Protection. */
-"trackingProtection.statusOff" = "Bảo vệ đã TẮT cho phiên này";
+"trackingProtection.statusOff" = "Protections are OFF for this session";
 
 /* Text for the status on from Tracking Protection. */
-"trackingProtection.statusOn" = "Bảo vệ đã BẬT cho phiên này";
+"trackingProtection.statusOn" = "Protections are ON for this session";
 
 /* Text for the toggle that enables/disables tracking protection. */
-"trackingProtection.toggleLabel2" = "Trình chống theo dõi nâng cao";
+"trackingProtection.toggleLabel2" = "Enhanced Tracking Protection";
 
 /* Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application. */
-"trackingProtection.trackersBlockedLabel" = "Trình theo dõi bị chặn kể từ %@";
+"trackingProtection.trackersBlockedLabel" = "Trackers blocked since %@";
 
 /* Text for the header of trackers section from Tracking Protection. */
-"trackingProtection.trackersHeader" = "Trình theo dõi và script để chặn";
+"trackingProtection.trackersHeader" = "Trackers and scripts to block";
 
 /* Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete. */
-"URL.addToAutocompleteLabel" = "Thêm liên kết vào tự động điền";
+"URL.addToAutocompleteLabel" = "Add link to autocomplete";
 
 /* Text for the URL context menu when a user long presses on the URL bar with clipboard contents. */
-"URL.contextMenu" = "Dán & mở";
+"URL.contextMenu" = "Paste & Go";
 
 /* Erase button in the URL bar */
-"URL.eraseButtonLabel" = "XÓA";
+"URL.eraseButtonLabel" = "ERASE";
 
 /* Message shown after pressing the Erase button */
-"URL.eraseMessageLabel2" = "Đã xóa lịch sử duyệt web";
+"URL.eraseMessageLabel2" = "Browsing history cleared";
 
 /* Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page. */
-"URL.findOnPageLabel" = "Tìm trong trang: %@";
+"URL.findOnPageLabel" = "Find in page: %@";
 
 /* Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents. */
-"URL.paste" = "Dán";
+"URL.paste" = "Paste";
 
 /* Placeholder text shown in the URL bar before the user navigates to a page */
-"URL.placeholderText" = "Tìm kiếm hoặc nhập địa chỉ";
+"URL.placeholderText" = "Search or enter address";
 
 /* Label displayed for search button when typing in the URL bar */
-"URL.searchLabel" = "Tìm kiếm cho %@";
+"URL.searchLabel" = "Search for %@";
 
 /* Text for the URL bar showing the number of trackers blocked on a webpage. */
-"URL.trackersBlockedLabel" = "Theo dõi bị chặn";
+"URL.trackersBlockedLabel" = "Trackers blocked";
 
 /* Title for the action button shown on card view that will take the user to a tutorial explaining the user how to add an widget */
-"WidgetOnboardingCard.ActionButton" = "Hướng dẫn tôi";
+"WidgetOnboardingCard.ActionButton" = "Show Me How";
 
 /* Subtitle shown on card view explaining the app has a widget option. %@ is the name of the app (Focus/Klar). */
-"WidgetOnboardingCard.Subtitle" = "Chúng tôi sẽ để bạn ở chế độ duyệt web riêng tư, nhưng hãy bắt đầu nhanh hơn vào lần sau với tiện ích %@ trên màn hình chính của bạn.";
+"WidgetOnboardingCard.Subtitle" = "We’ll leave you to your private browsing, but get a quicker start next time with the %@ widget on your Home screen.";
 
 /* Title shown on card view explaining the app has a widget option */
-"WidgetOnboardingCard.Title" = "Đã xóa lịch sử duyệt web! 🎉";
+"WidgetOnboardingCard.Title" = "Browsing history cleared! 🎉";
 

--- a/focus-ios/Blockzilla/en-GB.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/en-GB.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Dark";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Crash reports allow us diagnose and fix issues with the browser.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ will send what you type in the address bar to your search engine.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Social";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Automatically Send Crash Reports";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Use Face ID to unlock app";

--- a/focus-ios/Blockzilla/en-US.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/en-US.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Dark";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Crash reports allow us diagnose and fix issues with the browser.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ will send what you type in the address bar to your search engine.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Social";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Automatically Send Crash Reports";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Use Face ID to unlock app";

--- a/focus-ios/Blockzilla/es-AR.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/es-AR.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Oscuro";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Los informes de fallos nos permiten diagnosticar y solucionar problemas con el navegador.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ enviará lo que ingrese en la barra de direcciones a su motor de búsqueda.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Social";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Enviar informes de fallos automáticamente";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Usar Face ID para desbloquear la aplicación";

--- a/focus-ios/Blockzilla/es-CL.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/es-CL.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Oscuro";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Los reportes de fallos nos permiten diagnosticar y solucionar problemas con el navegador.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ enviará lo que escribas en la barra de direcciones a tu motor de búsqueda.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Social";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Enviar automáticamente reportes de fallos";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Usar Face ID para desbloquear la app";

--- a/focus-ios/Blockzilla/es-ES.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/es-ES.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Oscuro";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Los informes de fallos nos permiten diagnosticar y solucionar problemas con el navegador.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ enviará a tu buscador lo que escribas en la barra de direcciones.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Social";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Enviar automáticamente informes de fallos";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Usar Face ID para desbloquear la aplicación";

--- a/focus-ios/Blockzilla/es-MX.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/es-MX.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Oscuro";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Los reportes de fallos nos permiten diagnosticar y solucionar problemas con el navegador.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ enviará lo que escribes en la barra de direcciones para tu motor de búsqueda.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Social";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Enviar automáticamente informes de fallos";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Usar Face ID para desbloquear la aplicación";

--- a/focus-ios/Blockzilla/eu.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/eu.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Iluna";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Hutsegite-txostenek nabigatzailearen arazoak diagnostikatzen laguntzen digute.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "Helbide-barran idazten duzuna bilaketa-motorrera bidaliko du %@(e)k.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Sare sozialak";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Bidali automatikoki hutsegite-txostenak";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Erabili Face ID aplikazioa desblokeatzeko";

--- a/focus-ios/Blockzilla/fi.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/fi.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Tumma";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Kaatumisilmoitusten avulla voimme diagnosoida ja korjata selaimen ongelmia.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ lähettää osoiteriville kirjoittamasi tiedot hakukoneelle.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Sosiaalinen";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Lähetä kaatumisilmoitukset automaattisesti";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Käytä Face ID:tä sovelluksen lukituksen avaamiseen";

--- a/focus-ios/Blockzilla/fr.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/fr.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Sombre";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Les rapports de plantage nous permettent de diagnostiquer et de corriger des problèmes avec le navigateur.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ enverra ce que vous saisissez dans la barre d’adresse à votre moteur de recherche.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Réseaux sociaux";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Envoyer automatiquement les rapports de plantage";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Utiliser Face ID pour déverrouiller l’application";

--- a/focus-ios/Blockzilla/gl.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/gl.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Escuro";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Os informes de quebras permítennos diagnosticar e solucionar problemas co navegador.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ enviará o que escriba na barra de enderezos ao seu buscador.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Social";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Enviar informes de quebras de xeito automático";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Use Face ID para desbloquear a aplicación";

--- a/focus-ios/Blockzilla/he.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/he.lproj/Localizable.strings
@@ -379,6 +379,9 @@
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "רשתות חברתיות";
 
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "שליחת דיווחי קריסה באופן אוטומטי";
+
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "שימוש ב־Face ID כדי לשחרר את נעילת היישומון";
 

--- a/focus-ios/Blockzilla/hi-IN.lproj/Intents.strings
+++ b/focus-ios/Blockzilla/hi-IN.lproj/Intents.strings
@@ -1,3 +1,6 @@
 /* (No Comment) */
+"Intents.Erase.Description" = "ब्राउज़िंग सत्र मिटाएँ";
+
+/* (No Comment) */
 "Intents.Erase.Title" = "मिटाएँ";
 

--- a/focus-ios/Blockzilla/hi-IN.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/hi-IN.lproj/Localizable.strings
@@ -187,6 +187,9 @@
 /* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
 "Safari.instructionsOpen" = "सेटिंग अनुप्रयोग खोलें";
 
+/* Label for instructions to enable extensions in Safari, shown when enabling Safari Integration in Settings */
+"Safari.openInstruction" = "डिवाइस सेटिंग खोलें";
+
 /* Save button label */
 "Save" = "सहेजें";
 

--- a/focus-ios/Blockzilla/hsb.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/hsb.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Ćmowy";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Spadowe rozprawy nam zmóžnjeja, problemy z wobhladowakom diagnosticěrować a rozrisać.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ so na wašu pytawu pósćele, štož w adresowym polu zapodaće.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Socialne syće";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Spadowe rozprawy awtomatisce pósłać";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Face ID za wotewěranje nałoženja wužiwać";

--- a/focus-ios/Blockzilla/hu.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/hu.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Sötét";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Az összeomlás-jelentések lehetővé teszik a böngésző hibáinak diagnosztizálását és javítását.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "A %@ elküldi a címsávba írt szöveget a keresőszolgáltatásának.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Közösségi média";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Összeomlás-jelentések automatikus elküldése";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Face ID használata az alkalmazás feloldásához";

--- a/focus-ios/Blockzilla/ia.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/ia.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Obscur";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Reportos de crash permitte nos de diagnosticar e reparar problemas con le navigator.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ inviara a tu motor de recerca lo que tu scribe in le barra de adresse.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Social";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Automaticamente inviar reportos de crash";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Usar Face ID pro disblocar le application";

--- a/focus-ios/Blockzilla/is.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/is.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Dökkt";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Hrunskýrslur gera okkur kleift að greina og laga vandamál í vafranum.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ mun senda það sem þú skrifar í slóðina yfir á leitarvélina þína.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Samfélagsmiðlar";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Senda hrunskýrslur inn sjálfkrafa";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Nota andlitsauðkenningu til að aflæsa smáforriti";

--- a/focus-ios/Blockzilla/it.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/it.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Scuro";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "I rapporti sugli arresti anomali ci consentono di diagnosticare e risolvere problemi con il browser.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ invierà ciò che digiti nella barra degli indirizzi al motore di ricerca in uso.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Social";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Invia automaticamente segnalazioni di arresto anomalo";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Usa Face ID per sbloccare l’app";

--- a/focus-ios/Blockzilla/ja.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/ja.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Dark";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "クラッシュレポートによって、ブラウザーの問題を診断し、修正することができます。";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "アドレスバーに入力した内容を %@ が検索エンジンに送信します。";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "ソーシャル";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "クラッシュレポートを自動的に送信する";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "アプリのロック解除に Face ID を使用";

--- a/focus-ios/Blockzilla/ka.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/ka.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "მუქი";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "უეცარი გათიშვის შეტყობინებები გვეხმარება ბრაუზერის ხარვეზების დადგენასა და მოგვარებაში.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ გაუგზავნის საძიებო სისტემას, მისამართების ველში აკრეფილ ტექსტს";
 
@@ -382,6 +385,9 @@
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "სოცქსელების";
 
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "უეცარი გათიშვის მოხსენებების თვითგაგზავნა";
+
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "გამოიყენეთ სახის ამომცნობი, პროგრამის გასახსნელად";
 
@@ -482,13 +488,13 @@
 "ShowMeHowOnboarding.SubtitleStepOne.V2" = "ხანგრძლივად დააჭირეთ მთავარ ეკრანს, სანამ ხატულები რხევას დაიწყებს.";
 
 /* This is the subtitle text for step three that is displayed in the Show Me How onboarding screen. %@ is the name of the app (Focus/Klar) */
-"ShowMeHowOnboarding.SubtitleStepThree.V2" = "მონახეთ %@. შემდეგ აირჩიეთ ვიჯეტი.";
+"ShowMeHowOnboarding.SubtitleStepThree.V2" = "მონახეთ %@. შემდეგ აირჩიეთ ჩანამატი.";
 
 /* This is the subtitle text for step two that is displayed in the Show Me How Onboarding Screen */
 "ShowMeHowOnboarding.SubtitleStepTwo.V2" = "შეეხეთ დამატების ნიშანს.";
 
 /* This is the title text that is displayed in the Show Me How Onboarding Screen. %@ is the name of the app (Focus/Klar) */
-"ShowMeHowOnboarding.Title.V2" = "დაამატეთ ვიჯეტი %@";
+"ShowMeHowOnboarding.Title.V2" = "გამოიყენეთ %@ ჩანამატით";
 
 /* Button to add a favorite URL to Siri. */
 "Siri.add" = "დამატება";
@@ -641,7 +647,7 @@
 "WidgetOnboardingCard.ActionButton" = "იხილეთ, როგორ";
 
 /* Subtitle shown on card view explaining the app has a widget option. %@ is the name of the app (Focus/Klar). */
-"WidgetOnboardingCard.Subtitle" = "ახლა გადადით პირად ფანჯარაზე, თუმცა შემდეგ ჯერზე სწრაფად გახსნისთვის გამოიყენეთ %@-ვიჯეტი მთავარი ეკრანიდან.";
+"WidgetOnboardingCard.Subtitle" = "ახლა კი დარჩით თქვენს პირად ფანჯარაში, მაგრამ მომავალში სწრაფად რომ გაიხსნას %@, გამოიყენეთ ჩანამატი მთავარ ეკრანზე.";
 
 /* Title shown on card view explaining the app has a widget option */
 "WidgetOnboardingCard.Title" = "დათვალიერების ისტორია გასუფთავებულია! 🎉";

--- a/focus-ios/Blockzilla/kk.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/kk.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Күңгірт";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Құлау хабарламалары бізге браузердегі ақауларды анықтауға және түзетуге мүмкіндік береді.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ сіз адрестік жолақта терген нәрсені сіздің іздеу жүйеңізге жіберетін болады.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Әлеуметтік";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Құлау хабарламаларын автоматты түрде жіберу";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Қолданбаны босату үшін Face ID қолданыңыз";

--- a/focus-ios/Blockzilla/ko.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/ko.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "어두운";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "충돌 보고서를 통해 브라우저 문제를 진단하고 해결할 수 있습니다.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@가 주소창에 입력한 내용을 검색엔진에 전송합니다.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "소셜";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "자동으로 충돌 보고서 보내기";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Face ID를 사용해서 앱 잠금 해제";

--- a/focus-ios/Blockzilla/lo.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/lo.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "ມືດ";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "ບົດລາຍງານການຂັດຂ້ອງເຮັດໃຫ້ພວກເຮົາວິນິດໄສ ແລະ ແກ້ໄຂບັນຫາກັບຕົວທ່ອງເວັບ.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ ຈະສົ່ງສິ່ງທີ່ທ່ານພີມໃນແຖບທີ່ຢູ່ໄປຍັງເຄື່ອງມືຄົ້ນຫາຂອງທ່ານ";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "ສັງຄົມ";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "ສົ່ງລາຍງານການຂັດຂ້ອງໂດຍອັດຕະໂນມັດ";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "ໃຊ້ Face ID ເພື່ອປົດລັອກແອັບ";

--- a/focus-ios/Blockzilla/ne-NP.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/ne-NP.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "अँध्यारो";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "क्र्यास प्रतिवेदनहरूले हामीलाई ब्राउजरसँग निदान गर्न र समस्याहरू समाधान गर्न अनुमति दिन्छ।";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ ले तपाईले ठेगाना पट्टीमा टाइप गर्नुभएका कुराहरुलाई तपाईको खोज इन्जिनमा पठाउनेछ।";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "सामाजिक";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "स्वचालित रूपमा क्र्यास प्रतिवेदनहरू पठाउनुहोस्";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "एप अनलक गर्न फेस आईडीको प्रयोग गर्नुहोस्";

--- a/focus-ios/Blockzilla/nl.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/nl.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Donker";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Met crashrapporten kunnen we problemen met de browser analyseren en oplossen.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ zal wat u in de adresbalk intypt naar uw zoekmachine sturen.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Sociaal";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Automatisch crashrapporten verzenden";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Face ID voor ontgrendelen van app gebruiken";

--- a/focus-ios/Blockzilla/nn.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/nn.lproj/Localizable.strings
@@ -382,6 +382,9 @@
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Sosialt";
 
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Send inn krasjrapportar automatisk";
+
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Bruk «Face ID» for å låse opp appen";
 

--- a/focus-ios/Blockzilla/pa-IN.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/pa-IN.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "ਗੂੜ੍ਹਾ";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "ਕਰੈਸ਼ ਰਿਪੋਰਟਾਂ ਸਾਨੂੰ ਬਰਾਊਜ਼ਰ ਬਾਰੇ ਪੜਤਾਲ ਕਰਨ ਅਤੇ ਮਸਲੇ ਠੀਕ ਕਰਨ ਲਈ ਮਦਦ ਕਰਦੀਆਂ ਹਨ।";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "ਤੁਹਾਡੇ ਵਲੋਂ ਐਡਰੈਸ ਪੱਟੀ ਵਿੱਚ ਲਿਖੀ ਲਿਖਤ %@ ਤੁਹਾਡੇ ਖੋਜ ਇੰਜਣ ਨੂੰ ਭੇਜੇਗਾ।";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "ਸਮਾਜਿਕ";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "ਕਰੈਸ਼ ਰਿਪੋਰਟਾਂ ਨੂੰ ਆਪਣੇ-ਆਪ ਭੇਜੋ";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "ਐਪ ਅਣ-ਲਾਕ ਕਰਨ ਲਈ Face ID ਵਰਤੋਂ";

--- a/focus-ios/Blockzilla/pl.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/pl.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Ciemny";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Zgłoszenia awarii umożliwiają nam diagnozowanie i naprawianie problemów z przeglądarką.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ będzie wysyłał słowa wpisywane na pasku adresu do wyszukiwarki.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Społecznościowe";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Automatycznie wysyłaj zgłoszenia awarii";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Używaj Face ID do odblokowywania aplikacji";

--- a/focus-ios/Blockzilla/pt-BR.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/pt-BR.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Escuro";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Relatórios de falhas nos permitem diagnosticar e corrigir problemas com o navegador.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "O %@ envia o que você escreve na barra de endereços para seu mecanismo de pesquisa.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Mídias sociais";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Enviar relatórios de falhas automaticamente";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Utilizar Face ID para desbloquear o aplicativo";

--- a/focus-ios/Blockzilla/pt-PT.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/pt-PT.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Escuro";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Os relatórios de falha permitem-nos diagnosticar e corrigir problemas com o navegador.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "O %@ irá enviar o que escreve na barra de endereço para o seu motor de pesquisa.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Social";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Enviar relatórios de falha automaticamente";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Utilizar Face ID para desbloquear a aplicação";

--- a/focus-ios/Blockzilla/ru.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/ru.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Тёмная";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Сообщения о падении позволяют нам диагностировать и устранять проблемы с браузером.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ будет отправлять то, что вы вводите в адресной строке, в вашу поисковую систему.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Социальные сети";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Автоматически отправлять сообщения о падениях";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Использовать Face ID для разблокировки приложения";

--- a/focus-ios/Blockzilla/scn.lproj/InfoPlist.strings
+++ b/focus-ios/Blockzilla/scn.lproj/InfoPlist.strings
@@ -1,0 +1,18 @@
+/* Privacy - Camera Usage Description */
+"NSCameraUsageDescription" = "Chistu ti pirmetti di scattari e carricari fotu.";
+
+/* Privacy - Face ID Usage Description */
+"NSFaceIDUsageDescription" = "Chistu ti pirmetti di sbluccari l'applicazzioni.";
+
+/* Privacy - Location When In Use Usage Description */
+"NSLocationWhenInUseUsageDescription" = "I siti chi vìsiti ponnu addumannari a to pusizzioni.";
+
+/* Privacy - Microphone Usage Description */
+"NSMicrophoneUsageDescription" = "Chistu ti pirmetti di scattari e carricari vidiu.";
+
+/* Privacy - Photo Library Additions Usage Description */
+"NSPhotoLibraryAddUsageDescription" = "Chistu ti pirmetti di sarbari e carricari fotu.";
+
+/* This is the menu item that appears when you long press the Focus icon on the phone home screen. */
+"UIApplicationShortcutItemTitle.EraseAndOpen" = "Scancella e grapi";
+

--- a/focus-ios/Blockzilla/scn.lproj/Intents.strings
+++ b/focus-ios/Blockzilla/scn.lproj/Intents.strings
@@ -1,0 +1,6 @@
+/* (No Comment) */
+"Intents.Erase.Description" = "Scancella sissiuni di navigazzioni";
+
+/* (No Comment) */
+"Intents.Erase.Title" = "Scancella";
+

--- a/focus-ios/Blockzilla/scn.lproj/Intro.strings
+++ b/focus-ios/Blockzilla/scn.lproj/Intro.strings
@@ -1,0 +1,24 @@
+/* Description for the 'History' panel in the First Run tour. */
+"Intro.Slides.History.Description" = "Scancella tutta a to crunuluggìa di navigazzioni, i chiavi e i viscotta quannu voi cu n'ammaccata sula.";
+
+/* Title for the third  panel 'History' in the First Run tour. */
+"Intro.Slides.History.Title" = "A to crunuluggìa è storia passata";
+
+/* Button to go to the next card in Focus onboarding. */
+"Intro.Slides.Next.Button" = "Avanti";
+
+/* Description for the 'Favorite Search Engine' panel in the First Run tour. */
+"Intro.Slides.Search.Description" = "Stai circannu n'autra cosa? Scarta n'autru muturi di risciduta.";
+
+/* Title for the second  panel 'Search' in the First Run tour. */
+"Intro.Slides.Search.Title" = "Riscedi â to manera";
+
+/* Button to skip onboarding in Focus */
+"Intro.Slides.Skip.Button" = "Sauta";
+
+/* Description for the 'Welcome' panel in the First Run tour. */
+"Intro.Slides.Welcome.Description" = "Porta a navigazzioni privata a n'autru liveḍḍu. Ferma i pubblicità e autri cuntinuti chi ti ponnu trazzari ntra i siti e fari ammurrari u carricamentu dî pàggini.";
+
+/* Title for the first panel 'Welcome' in the First Run tour. */
+"Intro.Slides.Welcome.Title" = "Ammutta a to privatizza";
+

--- a/focus-ios/Blockzilla/scn.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/scn.lproj/Localizable.strings
@@ -1,654 +1,654 @@
 /* Button on About screen */
-"About.learnMoreButton" = "Tìm hiểu thêm";
+"About.learnMoreButton" = "Cchiù nfurmazzioni";
 
 /* Label on About screen */
-"About.missionLabel" = "%@ được sáng lập bởi Mozilla. Nhiệm vụ của chúng tôi là thúc đẩy một Internet lành mạnh, cởi mở.";
+"About.missionLabel" = "%@ è criatu di Mozilla. A nostra missiuni è di ammuttari pi na riti cchiù lìbbira e 'n saluti.";
 
 /* Label on About screen */
-"About.privateBullet1" = "Tìm kiếm và duyệt ngay trong ứng dụng";
+"About.privateBullet1" = "Fai risciduti e nàviga direttu di l'applicazzioni";
 
 /* Label on About screen */
-"About.privateBullet2" = "Chặn trình theo dõi (hoặc cập nhật cài đặt để cho phép trình theo dõi)";
+"About.privateBullet2" = "Ferma i trazzatura (o attualizza i mpustazzioni pi pirmittìrili)";
 
 /* Label on About screen */
-"About.privateBullet3" = "Xóa cookie cũng như lịch sử tìm kiếm và duyệt web khi xong phiên làm việc";
+"About.privateBullet3" = "Scancella pi livari i viscotta e macari a crunuluggìa di navigazzioni e di risciduta";
 
 /* Label on About screen */
-"About.privateBulletHeader" = "Sử dụng nó như trình duyệt riêng tư:";
+"About.privateBulletHeader" = "Ùsalu pâ navigazzioni privata:";
 
 /* Label for row in About screen */
-"About.rowHelp" = "Trợ giúp";
+"About.rowHelp" = "Ajutu";
 
 /* Link to Privacy Notice in the About screen */
-"About.rowPrivacy" = "Chính sách riêng tư";
+"About.rowPrivacy" = "Abbisu di privatizza";
 
 /* Label for row in About screen */
-"About.rowRights" = "Quyền lợi của bạn";
+"About.rowRights" = "I to diritti";
 
 /* Label on About screen */
-"About.safariBullet1" = "Chặn trình theo dõi để cải thiện sự riêng tư";
+"About.safariBullet1" = "Blocca i trazzatura pi na megghiu privatizza";
 
 /* Label on About screen */
-"About.safariBullet2" = "Chặn phông chữ Web để giảm kích thước trang";
+"About.safariBullet2" = "Blocca i caràttiri 'n linia pi fari i pàggini cchiù nichi";
 
 /* Label on About screen */
-"About.safariBulletHeader" = "Sử dụng nó như phần mở rộng của Safari:";
+"About.safariBulletHeader" = "Ùsalu comu nu stinneriu di Safari:";
 
 /* %@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, takes the user to a page with information about the product. Also displayed as a header for the About page. */
-"About.title" = "Giới thiệu %@";
+"About.title" = "Supra di %@";
 
 /* Label on About screen */
-"About.topLabel" = "%@ giúp bạn kiểm soát.";
+"About.topLabel" = "%@ ti duna u cuntrollu.";
 
 /* Title for action sheet item to open the current page in another application. Placeholder is the name of the application to open the current page. */
-"actionSheet.openIn" = "Mở trong %@";
+"actionSheet.openIn" = "Grapi cu %@";
 
 /* Button to dismiss the 'Add Pass Failed' alert. */
-"AddPass.Error.Dismiss" = "Ok";
+"AddPass.Error.Dismiss" = "Bonu";
 
 /* Message of the 'Add Pass Failed' alert. */
-"AddPass.Error.Message" = "Đã xảy ra lỗi trong khi thêm thẻ vào Wallet. Vui lòng thử lại sau.";
+"AddPass.Error.Message" = "Mmattìu nu sbagghiu mentri chi junciva a carta ô Wallet. Pi favuri torna a prova.";
 
 /* Title of the 'Add Pass Failed' alert. */
-"AddPass.Error.Title" = "Thất bại khi thêm thẻ";
+"AddPass.Error.Title" = "Nun potti jùnciri a carta";
 
 /* %@ is app name. Prompt shown to ask the user to use Touch ID, Face ID, or passcode to continue browsing after returning to the app. */
-"Authentication.reason" = "Xác thực để quay lại %@";
+"Authentication.reason" = "Autènticati pi turnari a %@";
 
 /* Label for button to add a custom URL */
-"Autocomplete.addCustomUrl" = "Thêm URL tùy chỉnh";
+"Autocomplete.addCustomUrl" = "Junci nnirizzu pirsunalizzatu";
 
 /* Label for error state when entering an invalid URL */
-"Autocomplete.addCustomUrlError" = "Kiểm tra lại URL mà bạn đã nhập.";
+"Autocomplete.addCustomUrlError" = "Cuntrolla arrè u nnirizzu chi mittisti.";
 
 /* A label displaying an example URL */
-"Autocomplete.addCustomUrlExample" = "Ví dụ: example.com";
+"Autocomplete.addCustomUrlExample" = "Scempru: example.com";
 
 /* Label for the input to add a custom URL */
-"Autocomplete.addCustomUrlLabel" = "URL muốn thêm";
+"Autocomplete.addCustomUrlLabel" = "Nnirizzu di jùnciri";
 
 /* Placeholder for the input field to add a custom URL */
-"Autocomplete.addCustomUrlPlaceholder" = "Dán hoặc nhập URL";
+"Autocomplete.addCustomUrlPlaceholder" = "Ncoḍḍa o scrivi nu nnirizzu";
 
 /* Label for button to add a custom URL with the + prefix */
-"Autocomplete.addCustomUrlWithPlus" = "+ Thêm URL tùy chỉnh";
+"Autocomplete.addCustomUrlWithPlus" = "+ Junci nnirizzu pirsunalizzatu";
 
 /* Label for toast alerting a custom URL has been added */
-"Autocomplete.customUrlAdded" = "URL tùy chỉnh mới đã được thêm vào.";
+"Autocomplete.customUrlAdded" = "Juncisti nu nnirizzu pirsunalizzatu novu.";
 
 /* Description for enabling or disabling the default list. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. */
-"Autocomplete.defaultDescriptoin" = "Cho phép tự đồng điền %@ trên 450 URL phổ biến trên thanh địa chỉ.";
+"Autocomplete.defaultDescriptoin" = "Attìvalu pi fàrici cumplitari 'n autumàticu a %@ cchiù assai di 450 siti pupulari nnâ barra dû nnirizzu.";
 
 /* label describing URL Autocomplete as disabled */
-"Autocomplete.disabled" = "Đã tắt";
+"Autocomplete.disabled" = "Sdisabbilitatu";
 
 /* Label for toast alerting that the custom URL being added is a duplicate */
-"Autocomplete.duplicateUrl" = "URL đã tồn tại";
+"Autocomplete.duplicateUrl" = "U nnirizzu cc'è già";
 
 /* Label for button to add a custom URL */
-"Autocomplete.emptyState" = "Không có URL tùy chỉnh nào được hiển thị";
+"Autocomplete.emptyState" = "Nuḍḍu nnirizzu pirsunalizzatu di mustrari";
 
 /* label describing URL Autocomplete as enabled */
-"Autocomplete.enabled" = "Đã bật";
+"Autocomplete.enabled" = "Abbilitatau";
 
 /* Label for button taking you to your custom Autocomplete URL list */
-"Autocomplete.manageSites" = "Quản lý trang web";
+"Autocomplete.manageSites" = "Manija i siti";
 
 /* Label for enabling or disabling autocomplete */
-"Autocomplete.mySites" = "Các trang web của tôi";
+"Autocomplete.mySites" = "I me siti";
 
 /* Description for adding and managing custom autocomplete URLs. The placeholder is replaced with the application name, which can be either Firefox Focus or Firefox Klar. */
-"Autocomplete.mySitesDesc" = "Bật để %@ tự động hoàn thành các URL yêu thích của bạn.";
+"Autocomplete.mySitesDesc" = "Attìvalu pi fàrici jìnchiri 'n autumàticu a %@ i to siti prifiruti.";
 
 /* Label for enabling or disabling top sites */
-"Autocomplete.topSites" = "Các trang web hàng đầu";
+"Autocomplete.topSites" = "Siti cchiù visitati";
 
 /* Title for the action button shown on the Splash Screen which gives the user the ability to log in with biometrics. */
-"BiometricAuthentication.UnlockButton.Title" = "Mở khóa";
+"BiometricAuthentication.UnlockButton.Title" = "Sblocca";
 
 /* Create a new session after failing a biometric check */
-"BiometricPrompt.newSession" = "Phiên mới";
+"BiometricPrompt.newSession" = "Nova sissioni";
 
 /* Accessibility label for the back button */
-"Browser.backLabel" = "Quay lại";
+"Browser.backLabel" = "Nn'arrè";
 
 /* Toast displayed after a URL has been copied to the clipboard */
-"browser.copyAddressToast" = "URL đã được sao chép vào clipboard";
+"browser.copyAddressToast" = "URL cupiatu nnô pitazzu";
 
 /* Copy URL button in URL long press menu */
-"Browser.copyMenuLabel" = "Sao chép";
+"Browser.copyMenuLabel" = "Copia";
 
 /* Accessibility label for the forward button */
-"Browser.forwardLabel" = "Tiếp theo";
+"Browser.forwardLabel" = "Avanti";
 
 /* Accessibility label for the reload button */
-"Browser.reloadLabel" = "Tải lại";
+"Browser.reloadLabel" = "Càrrica arrè";
 
 /* Accessibility label for the settings button */
-"Browser.settingsLabel" = "Thiết lập";
+"Browser.settingsLabel" = "Mpustazzioni";
 
 /* Accessibility label for the stop button */
-"Browser.stopLabel" = "Dừng";
+"Browser.stopLabel" = "Ferma";
 
 /* Label to display in the Discoverability overlay for keyboard shortcuts */
-"browserShortcutDescription.selectLocationBar" = "Chọn thanh địa chỉ";
+"browserShortcutDescription.selectLocationBar" = "Scarta a barra dî nnirizzi";
 
 /* Label on button to complete edits */
-"Done" = "Xong";
+"Done" = "Fattu";
 
 /* Label on button to allow edits */
-"Edit" = "Chỉnh sửa";
+"Edit" = "Cancia";
 
 /* Button label to reload the error page */
-"Error.tryAgainButton" = "Thử lại";
+"Error.tryAgainButton" = "Prova arrè";
 
 /* Button label used for cancelling to open another app from Focus */
-"ExternalAppLink.cancelTitle" = "Hủy bỏ";
+"ExternalAppLink.cancelTitle" = "Sfai";
 
 /* Dialog title used for opening an external app from Focus. The placeholder string is the app name of either Focus or Klar. */
-"ExternalAppLink.messageTitle" = "%@ muốn mở Ứng dụng khác";
+"ExternalAppLink.messageTitle" = "%@ voli gràpiri n'autra applicazzioni";
 
 /* Button label for opening another app from Focus */
-"ExternalAppLink.openTitle" = "Mở";
+"ExternalAppLink.openTitle" = "Grapi";
 
 /* Dialog title used for opening an external app from Focus. First placeholder string is the app name of either Focus or Klar and the second placeholder string specifies the app it wants to open. */
-"externalAppLinkWithAppName.messageTitle" = "%1$@ muốn mở %2$@";
+"externalAppLinkWithAppName.messageTitle" = "%1$@ voli gràpiri %2$@";
 
 /* Button label in external link dialog to cancel the dialog. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
-"ExternalLink.cancelButton" = "Hủy bỏ";
+"ExternalLink.cancelButton" = "Sfai";
 
 /* Button label in mailto: dialog to send an email. Test page: https://people-mozilla.org/~bnicholson/test/schemes.html */
-"ExternalLink.emailButton" = "Thư điện tử";
+"ExternalLink.emailButton" = "Nnirizzu di posta elittrònica";
 
 /* Accessibility label for done button in Find in Page Toolbar. */
-"FindInPage.Done" = "Hoàn thành tìm kiếm";
+"FindInPage.Done" = "Risciduta nnâ pàggina finuta";
 
 /* Accessibility label for next result button in Find in Page Toolbar. */
-"FindInPage.NextResult" = "Kết quả tiếp theo trong trang";
+"FindInPage.NextResult" = "Riscedi doppu nnâ pàggina";
 
 /* Accessibility label for previous result button in Find in Page Toolbar. */
-"FindInPage.PreviousResult" = "Kết quả trước trong trang";
+"FindInPage.PreviousResult" = "Riscedi prima nnâ pàggina";
 
 /* Label on button to dismiss first run UI */
-"FirstRun.lastSlide.buttonLabel" = "OK, được rồi!";
+"FirstRun.lastSlide.buttonLabel" = "Bonu, u capivi!";
 
 /* Message label on the first run screen */
-"FirstRun.messageLabelTagline" = "Duyệt như không ai xem.";
+"FirstRun.messageLabelTagline" = "Nàviga comu si nun ti taliassi nuḍḍu";
 
 /* Button label used to close a menu that displays as a popup. */
-"Menu.Close" = "Đóng";
+"Menu.Close" = "Chiuji";
 
 /* Text for a label that indicates the title of button from onboarding screen version 2. */
-"NewOnboarding.Button.Title.V2" = "Bắt đầu";
+"NewOnboarding.Button.Title.V2" = "Accumincia";
 
 /* Text for a label that indicates the subtitle for the onboarding screen version 2. */
-"NewOnboarding.Subtitle.V2" = "Nhanh. Riêng tư. Không có phiền nhiễu.";
+"NewOnboarding.Subtitle.V2" = "Lestu. Privatu. Nuḍḍa distrazzioni.";
 
 /* Text for a label that indicates the title of button from onboarding screen */
-"Onboarding.Button.Title" = "Bắt đầu duyệt web";
+"Onboarding.Button.Title" = "Accumincia a navigari";
 
 /* Text for a label that indicates the title of the bottom button from the default browser onboarding screen version 2. */
-"Onboarding.DefaultBrowser.BottomButtonTitle.V2" = "Bỏ qua";
+"Onboarding.DefaultBrowser.BottomButtonTitle.V2" = "Sauta";
 
 /* Text for a label that indicates the first subtitle for the default browser onboarding screen version 2. */
-"Onboarding.DefaultBrowser.FirstSubtitle.V2" = "Để tôn trọng quyền riêng tư của bạn, lịch sử truy cập sẽ xóa mỗi khi đóng ứng dụng.";
+"Onboarding.DefaultBrowser.FirstSubtitle.V2" = "Scancillamu a to crunuluggìa quannu chiuji l'applicazzioni p'aviri privatizza superchiu.";
 
 /* Text for a label that indicates the second subtitle for the default browser onboarding screen version 2. %@ is the name of the app (Focus/Klar) */
-"Onboarding.DefaultBrowser.SecondSubtitle.V2" = "Đặt %@ làm mặc định giúp đảm bảo sự riêng tư của bạn trên Internet.";
+"Onboarding.DefaultBrowser.SecondSubtitle.V2" = "Cunfijura %@ comu u to navigaturi pridifinutu pi prutèggiri i to dati ogni vota chi grapi na lijami.";
 
 /* Text for a label that indicates the title for the default browser onboarding screen version 2. %@ is the name of the app (Focus/Klar) */
-"Onboarding.DefaultBrowser.Title.V2" = "%@ không giống như các trình duyệt khác";
+"Onboarding.DefaultBrowser.Title.V2" = "%@ nun è comu l'autri navigatura";
 
 /* Text for a label that indicates the title of the top button from the default browser onboarding screen version 2. */
-"Onboarding.DefaultBrowser.TopButtonTitle.V2" = "Đặt làm trình duyệt mặc định";
+"Onboarding.DefaultBrowser.TopButtonTitle.V2" = "Cunfijura comu navigaturi pridifinutu";
 
 /* Text for a label that indicates the description of history section from onboarding screen. */
-"Onboarding.History.Description" = "Xóa lịch sử duyệt web, mật khẩu, cookie và ngăn các quảng cáo không mong muốn theo dõi bạn chỉ bằng một lần nhấn đơn giản!";
+"Onboarding.History.Description" = "Scancella a to crunuluggìa di navigazzioni, i chiavi, i viscotta e blocca i pubblicità di trazzàriti c'un toccu sulu!";
 
 /* Text for a label that indicates the title of history section from onboarding screen. */
-"Onboarding.History.Title" = "Lịch sử của bạn không theo dõi bạn";
+"Onboarding.History.Title" = "A to crunuluggìa nun ti sicuta";
 
 /* Text for a label that indicates the description of incognito section from onboarding screen. Placeholder can be (Focus or Klar). */
-"Onboarding.Incognito.Description" = "%@ là một trình duyệt riêng tư chuyên dụng với tính năng chống theo dõi và chặn nội dung.";
+"Onboarding.Incognito.Description" = "%@ è un navigaturi didicatu â privatizza câ prutizzioni dû trazzamentu e u bloccu dî cuntinuti.";
 
 /* Text for a label that indicates the title of incognito section from onboarding screen. */
-"Onboarding.Incognito.Title" = "Không chỉ là ẩn danh";
+"Onboarding.Incognito.Title" = "Cchiù assai dâ privatizza";
 
 /* Text for a label that indicates the description of protection section from onboarding screen. */
-"Onboarding.Protection.Description" = "Định cấu hình cài đặt để bạn có thể quyết định lượng chia sẻ nhiều hay ít.";
+"Onboarding.Protection.Description" = "Cunfijura i mpustazzioni pi dicìdiri quantu assai o quantu picca vo' spàrtiri.";
 
 /* Text for a label that indicates the title of protection section from onboarding screen. */
-"Onboarding.Protection.Title" = "Bảo vệ theo quyết định của riêng bạn";
+"Onboarding.Protection.Title" = "Prutizzioni comu dicidi tu";
 
 /* Text for a label that indicates the subtitle for onboarding screen. */
-"Onboarding.Subtitle" = "Đưa trình duyệt riêng tư của bạn lên cấp độ cao hơn.";
+"Onboarding.Subtitle" = "Port a navigazzioni privata ôn liveḍḍu supiriuri.";
 
 /* Text for a label that indicates the title for onboarding screen. Placeholder can be (Focus or Klar). */
-"Onboarding.Title" = "Chào mừng đến với Firefox %@!";
+"Onboarding.Title" = "Bummegna nne Firefox %@!";
 
 /* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
-"Safari.instructionsContentBlockers" = "Chạm Safari, rồi chọn Chặn nội dung";
+"Safari.instructionsContentBlockers" = "Ammacca Safari, e scarta Bloccu dî cuntinuti";
 
 /* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
-"Safari.instructionsEnable" = "Bật %@";
+"Safari.instructionsEnable" = "Abbìlita %@";
 
 /* Label for instructions to enable extensions in Safari, shown when enabling Safari Integration in Settings */
-"Safari.instructionsExtentions" = "Chọn Safari, sau đó chọn Tiện ích mở rộng";
+"Safari.instructionsExtentions" = "Ammacca Safari, e scarta Stinneri";
 
 /* Error label when the blocker is not enabled, shown in the intro and main app when disabled */
-"Safari.instructionsNotEnabled" = "%@ không được bật.";
+"Safari.instructionsNotEnabled" = "%@ nun è abbilitatu.";
 
 /* Label for instructions to enable Safari, shown when enabling Safari Integration in Settings */
-"Safari.instructionsOpen" = "Mở Cài đặt";
+"Safari.instructionsOpen" = "Grapi i mpustazzioni";
 
 /* Label for instructions to enable extensions in Safari, shown when enabling Safari Integration in Settings */
-"Safari.openInstruction" = "Mở cài đặt thiết bị";
+"Safari.openInstruction" = "Grapi i mpustazzioni dû dispusitivu";
 
 /* Save button label */
-"Save" = "Lưu";
+"Save" = "Sarba";
 
 /* Label for error state when entering an invalid search engine URL. %s is a search term in a URL. */
-"SearchEngine.addEngineError" = "Điều đó không hoạt động. Hãy thử thay thế cụm từ tìm kiếm bằng cái này: %s.";
+"SearchEngine.addEngineError" = "Nun funziunau. Prova a canciari u tèrmini di risciduta cu chistu: %s.";
 
 /* Label for disable option on search suggestions prompt */
-"SearchSuggestions.promptDisable" = "Không";
+"SearchSuggestions.promptDisable" = "No";
 
 /* Label for enable option on search suggestions prompt */
-"SearchSuggestions.promptEnable" = "Có";
+"SearchSuggestions.promptEnable" = "Se";
 
 /* %@ is the name of the app (Focus / Klar). Label for search suggestions prompt message */
-"SearchSuggestions.promptMessage" = "Để nhận đề xuất, %@ cần gửi những gì bạn nhập vào thanh địa chỉ cho công cụ tìm kiếm.";
+"SearchSuggestions.promptMessage" = "P'aviri suggirimenti, %@ manna chiḍḍu chi scrivi nnâ barra dû nnirizzu ô muturi di risciduta.";
 
 /* Title for search suggestions prompt */
-"SearchSuggestions.promptTitle" = "Hiển thị đề xuất tìm kiếm?";
+"SearchSuggestions.promptTitle" = "Mustrari i suggirimenti di risciduta?";
 
 /* Title for the URL Autocomplete row */
-"Settings.autocompleteSection" = "Tự động điền URL";
+"Settings.autocompleteSection" = "Jinchimentu autumàticu dû nnirizzu";
 
 /* Alert message shown when toggling the Content blocker */
-"Settings.blockOtherMessage" = "Chặn các trình theo dõi nội dung khác có thể dẫn đến việc không xem được một vài video và trang web.";
+"Settings.blockOtherMessage" = "Bluccari autri trazzatura dî cuntinuti po fari sfarsijari certi vidiu e certi siti.";
 
 /* Button label for declining Content blocker alert */
-"Settings.blockOtherNo2" = "Hủy bỏ";
+"Settings.blockOtherNo2" = "Sfai";
 
 /* Button label for accepting Content blocker alert */
-"Settings.blockOtherYes2" = "Chặn trình theo dõi nội dung";
+"Settings.blockOtherYes2" = "Ferma i trazzatura dî cuntinuti";
 
 /* Dark theme option in settings menu */
-"Settings.darkTheme" = "Tối";
+"Settings.darkTheme" = "Scuru";
 
 /* Description associated with the Crash Reports toggle on settings screen */
-"Settings.detailTextCrashReports" = "Báo cáo sự cố giúp chúng tôi chẩn đoán và khắc phục sự cố của trình duyệt.";
+"Settings.detailTextCrashReports" = "I signalijazzioni dî scasci ni pirmèttinu di diagnusticari e abbirsari i prubblemi dû navigaturi.";
 
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
-"Settings.detailTextSearchSuggestion" = "%@ sẽ gửi nội dung bạn nhập vào thanh địa chỉ đến công cụ tìm kiếm của bạn.";
+"Settings.detailTextSearchSuggestion" = "%@ manna chiḍḍu chi scrivi nnâ barra dû nnirizzu ô to muturi di risciduta.";
 
 /* Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar) */
-"Settings.detailTextSendUsageData" = "Mozilla chỉ thu thập những gì chúng tôi cần cung cấp và cải tiến %@ cho tất cả mọi người.";
+"Settings.detailTextSendUsageData" = "Mozilla cerca di ricògghiri sulu chiḍḍu chi ci serbi p'ammigghiurari %@ pi tutti.";
 
 /* Description associated to the Studies toggle on the settings screen. %@ is the app name (Focus/Klar) */
-"Settings.detailTextStudies" = "%@ có thể cài đặt và chạy các nghiên cứu theo thời gian.";
+"Settings.detailTextStudies" = "%@ po nzitari e abbiari studi di tempu 'n tempu.";
 
 /* Title for section in settings menu */
-"Settings.general" = "Tổng quát";
+"Settings.general" = "Ginirali";
 
 /* Subtitle for Send Anonymous Usage Data toggle on main screen */
-"Settings.learnMore" = "Tìm hiểu thêm.";
+"Settings.learnMore" = "Cchiù nfurmazzioni.";
 
 /* Lincese option in settings menu. Tapping the cell will take the user to a list of licences for the 3rd parties used in the app. */
-"Settings.licenses" = "Giấy phép";
+"Settings.licenses" = "Licenzi";
 
 /* Light theme option in settings menu */
-"Settings.lightTheme" = "Sáng";
+"Settings.lightTheme" = "Chiaru";
 
 /* %@ is the name of the app (Focus / Klar). Title displayed in the settings screen that, when tapped, allows the user to leave a review for the app on the app store. */
-"Settings.rate" = "Đánh giá %@";
+"Settings.rate" = "Vota a %@";
 
 /* Label for Safari integration section */
-"Settings.safariTitle" = "SAFARI INTEGRATION";
+"Settings.safariTitle" = "NTIGRAZZIONI CU SAFARI";
 
 /* Title for settings screen */
-"Settings.screenTitle" = "Cài đặt";
+"Settings.screenTitle" = "Mpustazzioni";
 
 /* Text for button to add another search engine in settings */
-"Settings.Search.AddSearchEngineButton" = "Thêm công cụ tìm kiếm khác";
+"Settings.Search.AddSearchEngineButton" = "Junci n'autru muturi di risciduta";
 
 /* Title on add search engine settings screen */
-"Settings.Search.AddSearchEngineTitle" = "Thêm công cụ tìm kiếm";
+"Settings.Search.AddSearchEngineTitle" = "Junci muturi di risciduta";
 
 /* Header for rows of installed search engines */
-"Settings.Search.InstalledSearchEngines" = "CÔNG CỤ TÌM KIẾM ĐÃ CÀI ĐẶT";
+"Settings.Search.InstalledSearchEngines" = "MUTURI DI RISCIDUTA NZITATI";
 
 /* Label for input field for the name of the search engine to be added */
-"Settings.Search.NameToDisplay" = "Tên hiển thị";
+"Settings.Search.NameToDisplay" = "Nomu di mustrari";
 
 /* Toast displayed after adding a search engine */
-"Settings.Search.NewSearchEngineAdded" = "Đã thêm công cụ tìm kiếm mới.";
+"Settings.Search.NewSearchEngineAdded" = "Juncisti un muturi di risciduta novu.";
 
 /* Label for button to bring deleted default engines back */
-"Settings.Search.RestoreEngine" = "Phục hồi các công cụ tìm kiếm mặc định";
+"Settings.Search.RestoreEngine" = "Riprìstina i mutura di risciduta pridifinuti";
 
 /* Placeholder text for input of new search engine name */
-"Settings.Search.SearchEngineName" = "Tên công cụ tìm kiếm";
+"Settings.Search.SearchEngineName" = "Nomu dû muturi di risciduta";
 
 /* Label for input of search engine template */
-"Settings.Search.SearchTemplate" = "Chuỗi tìm kiếm sử dụng";
+"Settings.Search.SearchTemplate" = "Stringa di risciduta d'usari";
 
 /* Text displayed as an example of the template to add a search engine. */
-"settings.Search.SearchTemplateExample" = "Ví dụ: searchengineexample.com/search/?q=%s";
+"settings.Search.SearchTemplateExample" = "Scempru: searchengine.example.com/search/?q=%s";
 
 /* Placeholder text for input of new search engine template */
-"Settings.Search.SearchTemplatePlaceholder" = "Dán hoặc nhập chuỗi tìm kiếm. Nếu cần, hãy thay thế cụm từ tìm kiếm bằng: %s.";
+"Settings.Search.SearchTemplatePlaceholder" = "Ncoḍḍa o metti a stringa di risciduta. Si serbi, scancia u tèrmini di risciduta cu: %s.";
 
 /* Label for the search engine in the search screen */
-"Settings.searchLabel" = "Công cụ tìm kiếm";
+"Settings.searchLabel" = "Muturi di risciduta";
 
 /* Label for the Search Suggestions toggle row */
-"Settings.searchSuggestions" = "Nhận đề xuất tìm kiếm";
+"Settings.searchSuggestions" = "Pigghia suggirimenti di risciduta";
 
 /* Title for the search selection screen */
-"Settings.searchTitle2" = "TÌM KIẾM";
+"Settings.searchTitle2" = "RISCEDI";
 
 /* Section label for Mozilla toggles */
 "Settings.sectionMozilla" = "MOZILLA";
 
 /* Section label for privacy toggles */
-"Settings.sectionPrivacy" = "RIÊNG TƯ";
+"Settings.sectionPrivacy" = "PRIVATIZZA";
 
 /* Label title for set as default browser row */
-"Settings.setAsDefaultBrowser" = "Đặt làm trình duyệt mặc định";
+"Settings.setAsDefaultBrowser" = "Cunfijura comu navigaturi pridifinutu";
 
 /* %@ is the name of the app. Description for set as default browser option */
-"Settings.setAsDefaultBrowserDescription" = "Đặt các liên kết từ trang web, email và tin nhắn để tự động mở trong %@.";
+"Settings.setAsDefaultBrowserDescription" = "Cunfijura pi fari gràpiri 'n autumàticu cu %@ i lijami dî siti, l'e-mail e i missaggi.";
 
 /* System value for theme section in settings menu */
-"Settings.systemTheme" = "Chủ đề hệ thống";
+"Settings.systemTheme" = "Tema dû sistema";
 
 /* Theme section in settings menu */
-"Settings.theme" = "Chủ đề";
+"Settings.theme" = "Tema";
 
 /* Header for manual theme section in settings menu */
-"Settings.themePicker" = "Bộ chọn chủ đề";
+"Settings.themePicker" = "Scartaturi dî temi";
 
 /* Label for the checkbox to toggle Advertising trackers */
-"Settings.toggleBlockAds2" = "Quảng cáo";
+"Settings.toggleBlockAds2" = "Pubblicità";
 
 /* Label for the checkbox to toggle Analytics trackers */
-"Settings.toggleBlockAnalytics2" = "Phân tích";
+"Settings.toggleBlockAnalytics2" = "Statìstichi";
 
 /* Label for toggle on main screen */
-"Settings.toggleBlockFonts" = "Chặn phông chữ trang Web";
+"Settings.toggleBlockFonts" = "Ferma i caràttari 'n linia";
 
 /* Label for the checkbox to toggle Other trackers */
-"Settings.toggleBlockOther2" = "Nội dung";
+"Settings.toggleBlockOther2" = "Cuntinutu";
 
 /* Label for the checkbox to toggle Social trackers */
-"Settings.toggleBlockSocial2" = "Xã hội";
+"Settings.toggleBlockSocial2" = "Riti suciali";
 
 /* Label for Crash Reports toggle on settings screen */
-"Settings.toggleCrashReports" = "Tự động gửi báo cáo sự cố";
+"Settings.toggleCrashReports" = "Manna 'n autumàticu i signalijazzioni di scasciu";
 
 /* Label for toggle on settings screen */
-"Settings.toggleFaceID" = "Sử dụng nhận dạng khuôn mặt để mở ứng dụng";
+"Settings.toggleFaceID" = "Usa Face ID pi sbluccari l'applicazzioni";
 
 /* %@ is the name of the app (Focus / Klar). Description for 'Enable Face ID' displayed under its respective toggle in the settings menu. */
-"Settings.toggleFaceIDDescription" = "Face ID có thể mở khóa %@ nếu một URL đã được mở trong ứng dụng";
+"Settings.toggleFaceIDDescription" = "Face ID po sbluccari %@ si cc'è già nu nnirizzu graputu nni l'applicazzioni";
 
 /* Show home screen tips toggle label on settings screen */
-"Settings.toggleHomeScreenTips" = "Hiện mẹo trên màn hình chính";
+"Settings.toggleHomeScreenTips" = "Mustra i cunzigghi nnâ schirmata mastra";
 
 /* Safari toggle label on settings screen */
 "Settings.toggleSafari" = "Safari";
 
 /* Label for Send Usage Data toggle on main screen */
-"Settings.toggleSendUsageData" = "Gửi dữ liệu sử dụng";
+"Settings.toggleSendUsageData" = "Manna i dati d'usu";
 
 /* Label for Studies toggle on the settings screen */
-"Settings.toggleStudies" = "Nghiên cứu";
+"Settings.toggleStudies" = "Studi";
 
 /* Label for toggle on settings screen */
-"Settings.toggleTouchID" = "Sử dụng Touch ID để mở ứng dụng";
+"Settings.toggleTouchID" = "Usa Touch ID pi sbluccari l'applicazzioni";
 
 /* %@ is the name of the app (Focus / Klar). Description for 'Enable Touch ID' displayed under its respective toggle in the settings menu. */
-"Settings.toggleTouchIDDescription" = "Touch ID có thể mở khóa %@ nếu một URL đã được mở trong ứng dụng";
+"Settings.toggleTouchIDDescription" = "Touch ID po sbluccari %@ si cc'è già nu nnirizzu graputu nni l'applicazzioni";
 
 /* Status off for tracking protection in settings screen */
-"Settings.trackingProtectionOff" = "Tắt";
+"Settings.trackingProtectionOff" = "Sdisattiva";
 
 /* Status on for tracking protection in settings screen */
-"Settings.trackingProtectionOn" = "Bật";
+"Settings.trackingProtectionOn" = "Attiva";
 
 /* Value for theme toggle in settings menu */
-"Settings.useSystemTheme" = "Sử dụng chế độ sáng/tối của hệ thống";
+"Settings.useSystemTheme" = "Usa a mudalità chiara/scura dû sistema";
 
 /* Title for settings section to enable different Siri Shortcuts. */
-"Settinsg.siriShortcutsTitle" = "SIRI SHORTCUTS";
+"Settinsg.siriShortcutsTitle" = "ACCURZI DI SIRI";
 
 /* Text for a share button */
-"share" = "Chia sẻ";
+"share" = "Sparti";
 
 /* Text for the share menu option when a user wants to add the site to Shortcuts */
-"ShareMenu.AddToShortcuts" = "Thêm vào lối tắt";
+"ShareMenu.AddToShortcuts" = "Junci a l'accurzi";
 
 /* Toast displayed to the user after adding the item to the Shortcuts. */
-"ShareMenu.AddToShortcuts.Confirm" = "Đã thêm vào lối tắt";
+"ShareMenu.AddToShortcuts.Confirm" = "Junciutu a l'accurzi";
 
 /* Text for the share menu when a user wants to copy a URL. */
-"shareMenu.copyAddress" = "Sao chép địa chỉ liên kết";
+"shareMenu.copyAddress" = "Copia nnirizzu";
 
 /* Text for the share menu option when a user wants to open the find in page menu */
-"ShareMenu.FindInPage" = "Tìm trong trang";
+"ShareMenu.FindInPage" = "Attrova nnâ pàggina";
 
 /* Text for the share menu option when a user wants to remove the site from Shortcuts */
-"ShareMenu.RemoveFromShortcuts" = "Xóa khỏi lối tắt";
+"ShareMenu.RemoveFromShortcuts" = "Leva di l'accurzi";
 
 /* Toast displayed to the user after removing the item from the Shortcuts. */
-"ShareMenu.RemoveShortcut.Confirm" = "Đã xóa lối tắt";
+"ShareMenu.RemoveShortcut.Confirm" = "Accurzu scancillatu";
 
 /* Text for the share menu option when a user wants to reload the site as a desktop */
-"ShareMenu.RequestDesktop" = "Yêu cầu trang web cho máy tính";
+"ShareMenu.RequestDesktop" = "Addumanna situ dû scagnu";
 
 /* Text for the share menu option when a user wants to reload the site as a mobile device */
-"ShareMenu.RequestMobile" = "Yêu cầu trang web di động";
+"ShareMenu.RequestMobile" = "Addumanna situ mòbbili";
 
 /* Text for the share menu option when a user wants to open the current website in the Chrome app. */
-"ShareMenu.ShareOpenChrome" = "Mở trong Chrome";
+"ShareMenu.ShareOpenChrome" = "Grapi cu Chrome";
 
 /* Text for the share menu option when a user wants to open the current website in the default browser. */
-"ShareMenu.ShareOpenDefaultBrowser" = "Mở bằng trình duyệt mặc định";
+"ShareMenu.ShareOpenDefaultBrowser" = "Grapi cû navigaturi pridifinutu";
 
 /* Text for the share menu option when a user wants to open the current website in the Firefox app. */
-"ShareMenu.ShareOpenFirefox" = "Mở trong Firefox";
+"ShareMenu.ShareOpenFirefox" = "Grapi cu Firefox";
 
 /* Text for the share menu option when a user wants to open the current website inside the app. */
-"ShareMenu.ShareOpenLink" = "Mở liên kết";
+"ShareMenu.ShareOpenLink" = "Grapi a lijami";
 
 /* Text for the share menu option when a user wants to share the current website they are on through another app. */
-"ShareMenu.SharePage" = "Chia sẻ trang với…";
+"ShareMenu.SharePage" = "Sparti pàggina cu…";
 
 /* Text for the long press on a shortcut option in context menu. */
-"ShortcutView.RemoveFromShortcuts" = "Xóa khỏi lối tắt";
+"ShortcutView.RemoveFromShortcuts" = "Leva di l'accurzi";
 
 /* Text for the long press on a shortcut rename option in context menu. */
-"ShortcutView.Rename" = "Đổi tên lối tắt";
+"ShortcutView.Rename" = "Cancia u nomu di l'accurzu";
 
 /* Text for the placeholder textfield on rename shortcut alert. */
-"ShortcutView.RenameShortcutAlertPlaceholder" = "Tên lối tắt";
+"ShortcutView.RenameShortcutAlertPlaceholder" = "Nomu di l'accurzu";
 
 /* Text for the rename shortcut alert primary action. */
-"ShortcutView.RenameShortcutAlertPrimaryAction" = "Lưu";
+"ShortcutView.RenameShortcutAlertPrimaryAction" = "Sarba";
 
 /* Text for the rename shortcut alert secondary action. */
-"ShortcutView.RenameShortcutAlertSecondaryAction" = "Hủy bỏ";
+"ShortcutView.RenameShortcutAlertSecondaryAction" = "Sfai";
 
 /* This is the button text that is displayed in the Show Me How Onboarding Screen */
-"ShowMeHowOnboarding.ButtonText.V2" = "Xong";
+"ShowMeHowOnboarding.ButtonText.V2" = "Fattu";
 
 /* This is the subtitle text for step one that is displayed in the Show Me How Onboarding Screen */
-"ShowMeHowOnboarding.SubtitleStepOne.V2" = "Nhấn và giữ biểu tượng ứng dụng đến khi nó rung rinh.";
+"ShowMeHowOnboarding.SubtitleStepOne.V2" = "Teni ammaccatu nnâ schirmata mastra nzinu a quannu a cona accumincia a trimulijari.";
 
 /* This is the subtitle text for step three that is displayed in the Show Me How onboarding screen. %@ is the name of the app (Focus/Klar) */
-"ShowMeHowOnboarding.SubtitleStepThree.V2" = "Tìm kiếm %@. Sau đó chọn tiện ích hiển thị.";
+"ShowMeHowOnboarding.SubtitleStepThree.V2" = "Attrova %@ e scarta nu stigghiu.";
 
 /* This is the subtitle text for step two that is displayed in the Show Me How Onboarding Screen */
-"ShowMeHowOnboarding.SubtitleStepTwo.V2" = "Nhấn vào nút dấu cộng.";
+"ShowMeHowOnboarding.SubtitleStepTwo.V2" = "Ammacca a cona cû sìmmulu dâ cruci.";
 
 /* This is the title text that is displayed in the Show Me How Onboarding Screen. %@ is the name of the app (Focus/Klar) */
-"ShowMeHowOnboarding.Title.V2" = "Hiển thị thêm %@";
+"ShowMeHowOnboarding.Title.V2" = "Junci nu stigghiu di %@";
 
 /* Button to add a favorite URL to Siri. */
-"Siri.add" = "Thêm";
+"Siri.add" = "Junci";
 
 /* Button to add a specified shortcut option to Siri. */
-"Siri.addTo" = "Thêm vào Siri";
+"Siri.addTo" = "Junci a Siri";
 
 /* Label for button to edit the Siri phrase or delete the Siri functionality. */
-"Siri.editOpenUrl" = "Ghi lại hoặc xóa phím tắt";
+"Siri.editOpenUrl" = "Riggistra arrè o scancella accurzu";
 
 /* Title of option in settings to set up Siri to erase */
-"Siri.erase" = "Xóa";
+"Siri.erase" = "Scancella";
 
 /* Title of option in settings to set up Siri to erase and then open the app. */
-"Siri.eraseAndOpen" = "Xóa & mở";
+"Siri.eraseAndOpen" = "Scancella e grapi";
 
 /* Title for screen to add a favorite URL to Siri. */
-"Siri.favoriteUrl" = "Mở trang yêu thích";
+"Siri.favoriteUrl" = "Grapi situ prifirutu";
 
 /* Title of option in settings to set up Siri to open a specified URL in Focus/Klar. */
-"Siri.openURL" = "Mở trang yêu thích";
+"Siri.openURL" = "Grapi situ prifirutu";
 
 /* Label for input to set a favorite URL to be opened by Siri. */
-"Siri.urlToOpen" = "URL để mở";
+"Siri.urlToOpen" = "Nnirizzu di gràpiri";
 
 /* Text for a label that indicates the title for biometric tip. The placeholder is replaced with the long product name (Firefox Focus or Firefox Klar). */
-"Tip.Biometric.Title" = "Khóa %@ khi một trang web đang mở:";
+"Tip.Biometric.Title" = "Blocca a %@ quannu cc'è un situ graputu:";
 
 /* Text for a label that indicates the description for biometric Face ID tip. */
-"Tip.BiometricFaceId.Description" = "Bật Face ID";
+"Tip.BiometricFaceId.Description" = "Attiva Face ID";
 
 /* Text for a label that indicates the description for biometric Touch ID tip. */
-"Tip.BiometricTouchId.Description" = "Bật Touch ID";
+"Tip.BiometricTouchId.Description" = "Attiva Touch ID";
 
 /* Text for a label that indicates the description for request desktop tip. */
-"Tip.RequestDesktop.Description" = "Hành động trang > Yêu cầu trang web cho máy tính";
+"Tip.RequestDesktop.Description" = "Azzioni dâ pàggina > Addumanna situ dû scagnu";
 
 /* Text for a label that indicates the title for request desktop tip. */
-"Tip.RequestDesktop.Title" = "Bạn muốn xem phiên bản cho máy tính của một trang web?";
+"Tip.RequestDesktop.Title" = "Vo' vìdiri a virsioni cumpleta dû scagnu d'un situ?";
 
 /* Text for a label that indicates the description for share trackers tip. The placeholder is the number of trackers blocked. Only shown when there are more than 10 trackers blocked. For locales where we would need plural support, please feel free to translate this string as `Trackers blocked so far: %@` instead. */
-"Tip.ShareTrackers.Description" = "%@ trình theo dõi đã bị chặn cho đến nay";
+"Tip.ShareTrackers.Description" = "%@ trazzatura bluccati nzinu a ora";
 
 /* Text for a label that indicates the title for share trackers tip. The placeholder is replaced with the long product name (Firefox Focus or Firefox Klar). */
-"Tip.ShareTrackers.Title" = "Bạn duyệt. %@ chặn.";
+"Tip.ShareTrackers.Title" = "Tu nàvighi. %@ blocca.";
 
 /* Text for a label that indicates the description for shortcuts tip. The placeholder is replaced with the short product name (Focus or Klar). */
-"Tip.Shortcuts.Description" = "Chọn Thêm vào lối tắt từ menu %@";
+"Tip.Shortcuts.Description" = "Scarta Junci a l'accurzi dû minù di %@";
 
 /* Text for a label that indicates the title for shortcuts tip. */
-"Tip.Shortcuts.Title" = "Tạo lối tắt đến các trang web bạn truy cập nhiều nhất:";
+"Tip.Shortcuts.Title" = "Cria accurzi ê siti chi vìsiti cchiù assai:";
 
 /* Text for a label that indicates the description for siri erase tip. The shortcut in this context is the iOS Siri Shortcut, not a Focus website shortcut. */
-"Tip.SiriErase.Description" = "Thêm lối tắt Siri";
+"Tip.SiriErase.Description" = "Junci accurzu di Siri";
 
 /* Text for a label that indicates the title for siri erase tip. The placeholder is replaced with the long product name (Firefox Focus or Firefox Klar). */
-"Tip.SiriErase.Title" = "“Siri, xóa phiên %@ của tôi.”";
+"Tip.SiriErase.Title" = "“Siri, scancella a me sissioni di %@.”";
 
 /* Text for a label that indicates the description for siri favorite tip. The shortcut in this context is the iOS Siri Shortcut, not a Focus website shortcut. */
-"Tip.SiriFavorite.Description" = "Thêm lối tắt Siri";
+"Tip.SiriFavorite.Description" = "Junci accurzu di Siri";
 
 /* Text for a label that indicates the title for siri favorite tip. */
-"Tip.SiriFavorite.Title" = "“Siri, mở trang web yêu thích của tôi.”";
+"Tip.SiriFavorite.Title" = "“Siri, grapi u me situ prifirutu.”";
 
 /* Text for a label that indicates the description for sites not working tip. */
-"Tip.SitesNotWorking.Description" = "Thử tắt tính năng Trình chống theo dõi";
+"Tip.SitesNotWorking.Description" = "Prova a sdisattivari a prutizzioni dû trazzamentu";
 
 /* Text for a label that indicates the title for sites not working tip. */
-"Tip.SitesNotWorking.Title" = "Trang web thiếu nội dung hoặc hoạt động không đúng?";
+"Tip.SitesNotWorking.Title" = "Ô situ cci manca cuntinutu o si cumporta streusu?";
 
 /* Text shown on quick action widget inviting the user to browse in the app. %@ is the name of the app (Focus/Klar). */
-"TodayWidget.SearchInApp.Instruction" = "Tìm kiếm trong %@";
+"TodayWidget.SearchInApp.Instruction" = "Riscedi cu %@";
 
 /* This is the body text that is displayed for the Context Menu icon tooltip */
-"TooltipBodyText.ContextMenu" = "Đi đến Cài đặt để quản lý các tùy chọn quyền riêng tư và bảo mật cụ thể.";
+"TooltipBodyText.ContextMenu" = "Vai nnê Mpustazzioni pi manijari l'aḍḍijuti spicìfichi di privatizza e sicurizza.";
 
 /* This is the body text that is displayed for the Privacy tooltip */
-"TooltipBodyText.Privacy" = "Các cài đặt mặc định này cung cấp khả năng bảo vệ mạnh mẽ. Tuy nhiên, thật dễ dàng để điều chỉnh cài đặt để đáp ứng các nhu cầu cụ thể của bạn.";
+"TooltipBodyText.Privacy" = "Sti mpustazzioni pridifinuti òffrinu na prutizzioni forti. Ma è fàcili cancialli pi satisfari i to nicissità spicìfichi.";
 
 /* This is the body text that is displayed for the Search Bar tooltip */
-"TooltipBodyText.SearchBar" = "Bắt đầu phiên duyệt web riêng tư của bạn và chúng tôi sẽ chặn trình theo dõi và các nội dung xấu khác khi bạn di chuyển.";
+"TooltipBodyText.SearchBar" = "Accumincia a to sissioni di navigazzioni privata, e firmamu i trazzatura e autri cosi tinti mentri chi nàvighi.";
 
 /* This is the body text that is displayed for the Shield icon tooltip. Where placeholder can be (Focus or Klar). */
-"TooltipBodyText.ShieldIcon" = "%@ đã ngăn trang web này theo dõi bạn. Nhấn vào tấm khiên để biết thông tin về những gì chúng tôi đã chặn.";
+"TooltipBodyText.ShieldIcon" = "%@ firmau stu situ di spiàriti. Ammacca a cona dû scudu pi vìdiri soccu bluccammu.";
 
 /* This is the body text that is displayed for the Shield icon tooltip when we block trackers for the first time on a website */
-"TooltipBodyText.ShieldIconTrackerBlocked.V2" = "Bắt được rồi! Chúng tôi đã ngăn trang web này theo dõi bạn. Nhấn vào tấm khiên bất kỳ lúc nào để xem những gì chúng tôi đang chặn.";
+"TooltipBodyText.ShieldIconTrackerBlocked.V2" = "U ncagghiammu! Firmammu stu situ di spiàriti. Ammacca a cona dû scudu quannu vo' pi vìdiri soccu stamu bluccannu.";
 
 /* This is the body text that is displayed for the Trash icon tooltip */
-"TooltipBodyText.TrashIcon" = "Nhấn vào thùng rác bất cứ lúc nào để xóa tất cả dấu vết của phiên hiện tại của bạn.";
+"TooltipBodyText.TrashIcon" = "Ammacca a cona dâ munnizza quannu vo' pi scancillari tutti i trazzi dâ to sissioni.";
 
 /* This is the body text that is displayed for the Trash icon tooltip */
-"TooltipBodyText.TrashIcon.V2" = "Nhấn vào đây để xóa tất cả — lịch sử, cookie, mọi thứ — và bắt đầu làm mới trên một thẻ mới.";
+"TooltipBodyText.TrashIcon.V2" = "Ammacca cca pi jittari tutti cosi — crunuluggìa, viscotta, tuttu — e parti di zeru cu na scheda nova.";
 
 /* This is the title text that is displayed for the Privacy tooltip */
-"TooltipTitleText.Privacy" = "Bạn đã được bảo vệ!";
+"TooltipTitleText.Privacy" = "Ti prutiggemu! ";
 
 /* Text for tracking protection screen showing the connection is not secure */
-"trackingProtection.connectionNotSecureLabel" = "Kết nối không an toàn";
+"trackingProtection.connectionNotSecureLabel" = "A cunnissioni nun è sicura";
 
 /* Text for tracking protection screen showing the connection is secure */
-"trackingProtection.connectionSecureLabel" = "Kết nối an toàn";
+"trackingProtection.connectionSecureLabel" = "A cunnissioni è sicura";
 
 /* Title for the tracking settings page to change what trackers are blocked. */
-"trackingProtection.label" = "Trình chống theo dõi";
+"trackingProtection.label" = "Prutizzioni dû trazzamentu";
 
 /* Text for the status off from Tracking Protection. */
-"trackingProtection.statusOff" = "Bảo vệ đã TẮT cho phiên này";
+"trackingProtection.statusOff" = "Sdisattivasti i prutizzioni pi sta sissioni";
 
 /* Text for the status on from Tracking Protection. */
-"trackingProtection.statusOn" = "Bảo vệ đã BẬT cho phiên này";
+"trackingProtection.statusOn" = "Attivasti i prutizzioni pi sta sissioni";
 
 /* Text for the toggle that enables/disables tracking protection. */
-"trackingProtection.toggleLabel2" = "Trình chống theo dõi nâng cao";
+"trackingProtection.toggleLabel2" = "Prutizzioni avanzata dû trazzamentu";
 
 /* Text for tracking protection screen showing the number of trackers blocked since the app install. The placeholder is replaced with the install date of the application. */
-"trackingProtection.trackersBlockedLabel" = "Trình theo dõi bị chặn kể từ %@";
+"trackingProtection.trackersBlockedLabel" = "Trazzatura bluccati di %@";
 
 /* Text for the header of trackers section from Tracking Protection. */
-"trackingProtection.trackersHeader" = "Trình theo dõi và script để chặn";
+"trackingProtection.trackersHeader" = "Trazzatura e script di firmari";
 
 /* Label displayed for button used as a shortcut to add a link to the list of URLs to autocomplete. */
-"URL.addToAutocompleteLabel" = "Thêm liên kết vào tự động điền";
+"URL.addToAutocompleteLabel" = "Junci lijami di jìnchiri 'n autumàticu";
 
 /* Text for the URL context menu when a user long presses on the URL bar with clipboard contents. */
-"URL.contextMenu" = "Dán & mở";
+"URL.contextMenu" = "Ncoḍḍa e vai";
 
 /* Erase button in the URL bar */
-"URL.eraseButtonLabel" = "XÓA";
+"URL.eraseButtonLabel" = "SCANCELLA";
 
 /* Message shown after pressing the Erase button */
-"URL.eraseMessageLabel2" = "Đã xóa lịch sử duyệt web";
+"URL.eraseMessageLabel2" = "Crunuluggìa di navigazzioni scancillata";
 
 /* Label displayed for find in page button when typing in the URL Bar. %@ is any text the user has typed into the URL bar that they want to find on the current page. */
-"URL.findOnPageLabel" = "Tìm trong trang: %@";
+"URL.findOnPageLabel" = "Attrova nnâ pàggina: %@";
 
 /* Text for a menu displayed from the bottom of the screen when a user long presses on the URL bar with clipboard contents. */
-"URL.paste" = "Dán";
+"URL.paste" = "Ncoḍḍa";
 
 /* Placeholder text shown in the URL bar before the user navigates to a page */
-"URL.placeholderText" = "Tìm kiếm hoặc nhập địa chỉ";
+"URL.placeholderText" = "Riscedi o metti nu nnirizzu";
 
 /* Label displayed for search button when typing in the URL bar */
-"URL.searchLabel" = "Tìm kiếm cho %@";
+"URL.searchLabel" = "Riscedi %@";
 
 /* Text for the URL bar showing the number of trackers blocked on a webpage. */
-"URL.trackersBlockedLabel" = "Theo dõi bị chặn";
+"URL.trackersBlockedLabel" = "Trazzatura bluccati";
 
 /* Title for the action button shown on card view that will take the user to a tutorial explaining the user how to add an widget */
-"WidgetOnboardingCard.ActionButton" = "Hướng dẫn tôi";
+"WidgetOnboardingCard.ActionButton" = "Mùstrami comu si fa";
 
 /* Subtitle shown on card view explaining the app has a widget option. %@ is the name of the app (Focus/Klar). */
-"WidgetOnboardingCard.Subtitle" = "Chúng tôi sẽ để bạn ở chế độ duyệt web riêng tư, nhưng hãy bắt đầu nhanh hơn vào lần sau với tiện ích %@ trên màn hình chính của bạn.";
+"WidgetOnboardingCard.Subtitle" = "Ti lassamu â to navigazzioni privata, ma a pròssima vota pàrtiti cchiù lestu cû stigghiu di %@ nnâ to schirmata mastra.";
 
 /* Title shown on card view explaining the app has a widget option */
-"WidgetOnboardingCard.Title" = "Đã xóa lịch sử duyệt web! 🎉";
+"WidgetOnboardingCard.Title" = "Crunuluggìa di navigazzioni scancillata! 🎉";
 

--- a/focus-ios/Blockzilla/sk.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/sk.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Tmavá";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Správy o zlyhaní nám umožňujú diagnostikovať a opraviť problémy s prehliadačom.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ bude odosielať vami písaný text vyhľadávaciemu modulu.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Sociálne siete";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Automaticky odosielať správy o zlyhaní";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Na odomknutie aplikácie použiť Face ID";

--- a/focus-ios/Blockzilla/sl.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/sl.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Temna";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Poročila o sesutjih nam omogočajo diagnosticiranje in odpravljanje težav z brskalnikom.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ bo natipkano v naslovno vrstico poslal iskalniku.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Družbeno";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Samodejno pošlji poročila o sesutjih";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Uporabljaj Face ID za odklepanje aplikacije";

--- a/focus-ios/Blockzilla/sq.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/sq.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "E errët";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Njoftimet e vithisjeve na lejojnë të diagnostikojmë dhe ndreqim probleme me shfletuesin.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ do të dërgojë te motori juaj i kërkimeve atë çka shtypni te shtylla e adresave.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Shoqërore";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Dërgo Vetvetiu Njoftime Vithisjesh";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Përdorni Face ID që të shkyçni aplikacionin";

--- a/focus-ios/Blockzilla/sv.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/sv.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Mörkt";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Kraschrapporter tillåter oss att diagnostisera och lösa problem med webbläsaren.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ skickar det du skriver i adressfältet till din sökmotor.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Socialt";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Skicka automatiskt kraschrapporter";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Använd Face ID för att låsa upp appen";

--- a/focus-ios/Blockzilla/te.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/te.lproj/Localizable.strings
@@ -181,8 +181,17 @@
 /* Title for settings screen */
 "Settings.screenTitle" = "అమరికలు";
 
+/* Header for rows of installed search engines */
+"Settings.Search.InstalledSearchEngines" = "స్థాపితమైన వెతుకుడు యంత్రాలు";
+
 /* Label for input field for the name of the search engine to be added */
 "Settings.Search.NameToDisplay" = "ప్రదర్శించడానికి పేరు";
+
+/* Placeholder text for input of new search engine name */
+"Settings.Search.SearchEngineName" = "వెతుకుడు యంత్రం పేరు";
+
+/* Label for input of search engine template */
+"Settings.Search.SearchTemplate" = "వెతకాల్సిన పదబంధం";
 
 /* Label for the search engine in the search screen */
 "Settings.searchLabel" = "శోధన యంత్రం";

--- a/focus-ios/Blockzilla/th.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/th.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "มืด";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "รายงานข้อขัดข้องช่วยให้เราวินิจฉัยและแก้ไขปัญหาของเบราว์เซอร์ได้";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ จะส่งสิ่งที่คุณพิมพ์ในแถบที่อยู่ไปยังเครื่องมือค้นหาของคุณ";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "กลุ่มสังคม";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "ส่งรายงานข้อขัดข้องโดยอัตโนมัติ";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "ใช้ Face ID เพื่อปลดล็อคแอป";

--- a/focus-ios/Blockzilla/tr.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/tr.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Koyu";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Çökme raporları tarayıcıyla ilgili sorunları teşhis etmemize ve düzeltmemize olanak tanır.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@, adres çubuğuna yazdıklarını arama motorunuza gönderecektir.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Sosyal";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Çökme raporlarını otomatik olarak gönder";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Uygulamanın kilidini açmak için Face ID’yi kullan";

--- a/focus-ios/Blockzilla/uk.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/uk.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "Темна";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "Звіти про збої дають нам змогу діагностувати й усувати проблеми з браузером.";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ відправлятиме пошуковій системі текст, введений в адресному рядку.";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "Соціальні мережі";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "Автоматично надсилати звіти про збої";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "Використовувати Face ID для розблокування програми";

--- a/focus-ios/Blockzilla/zh-CN.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/zh-CN.lproj/Localizable.strings
@@ -277,11 +277,14 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "深色";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "我们可借助崩溃报告来诊断和修复浏览器的问题。";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "%@ 会将您在地址栏中输入的内容发送至您的搜索引擎。";
 
 /* Description associated to the Send Usage Data toggle on main screen. %@ is the app name (Focus/Klar) */
-"Settings.detailTextSendUsageData" = "Mozilla 坚持仅收集用来为大众改进 %@ 所必需的数据。";
+"Settings.detailTextSendUsageData" = "Mozilla 力图仅收集用来为大众改进 %@ 所必需的数据。";
 
 /* Description associated to the Studies toggle on the settings screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextStudies" = "%@ 可能会不时地安装并运行一些研究项目。";
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "社交";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "自动发送崩溃报告";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "使用面容 ID 解锁应用";

--- a/focus-ios/Blockzilla/zh-TW.lproj/Localizable.strings
+++ b/focus-ios/Blockzilla/zh-TW.lproj/Localizable.strings
@@ -277,6 +277,9 @@
 /* Dark theme option in settings menu */
 "Settings.darkTheme" = "暗色";
 
+/* Description associated with the Crash Reports toggle on settings screen */
+"Settings.detailTextCrashReports" = "傳送錯誤報告，可讓我們診斷並修正瀏覽器的問題。";
+
 /* Description associated to the Search Suggestions toggle on main screen. %@ is the app name (Focus/Klar) */
 "Settings.detailTextSearchSuggestion" = "您在網址列打字時，%@ 就會將您輸入的文字傳送到搜尋引擎。";
 
@@ -381,6 +384,9 @@
 
 /* Label for the checkbox to toggle Social trackers */
 "Settings.toggleBlockSocial2" = "社交";
+
+/* Label for Crash Reports toggle on settings screen */
+"Settings.toggleCrashReports" = "自動傳送錯誤報告";
 
 /* Label for toggle on settings screen */
 "Settings.toggleFaceID" = "使用 Face ID 解鎖程式";

--- a/focus-ios/ContentBlocker/en-CA.lproj/InfoPlist.strings
+++ b/focus-ios/ContentBlocker/en-CA.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Human readable description */
+"NSHumanReadableDescription" = "Content blocking and tracking protection from Mozilla";
+

--- a/focus-ios/ContentBlocker/scn.lproj/InfoPlist.strings
+++ b/focus-ios/ContentBlocker/scn.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Human readable description */
+"NSHumanReadableDescription" = "Bloccu dî cuntinuti e prutizzioni dû trazzamentu di Mozilla";
+

--- a/focus-ios/Widgets/en-CA.lproj/Localizable.strings
+++ b/focus-ios/Widgets/en-CA.lproj/Localizable.strings
@@ -1,0 +1,12 @@
+/* Description for small size widget to add it to home screen. %@ is the name of the app(Focus/Klar). */
+"TodayWidget.QuickActionGalleryDescription" = "Add a %@ shortcut to your Home screen. After adding the widget, touch and hold to edit it and select a different shortcut.";
+
+/* Description for small size widget to add it to home screen. %@ is the name of the app(Focus/Klar). */
+"TodayWidget.QuickActionGalleryDescriptionV2" = "Start a private search in %@ with your default search engine.";
+
+/* Quick Actions title when widget enters edit mode */
+"TodayWidget.QuickActionsGalleryTitle" = "Quick Actions";
+
+/* Text shown on quick action widget inviting the user to browse in the app. %@ is the name of the app (Focus/Klar). */
+"TodayWidget.SearchInApp" = "Search in %@";
+

--- a/focus-ios/Widgets/scn.lproj/Localizable.strings
+++ b/focus-ios/Widgets/scn.lproj/Localizable.strings
@@ -1,0 +1,12 @@
+/* Description for small size widget to add it to home screen. %@ is the name of the app(Focus/Klar). */
+"TodayWidget.QuickActionGalleryDescription" = "Junci n'accurzu a %@ nnâ to schirmata mastra. Doppu chi junci u stigghiu, tocca e teni ammaccatu pi canciallu e scartari n'accurzu sparti.";
+
+/* Description for small size widget to add it to home screen. %@ is the name of the app(Focus/Klar). */
+"TodayWidget.QuickActionGalleryDescriptionV2" = "Accumincia na risciduta privata nne %@ cû to muturi di risciduta pridifinutu.";
+
+/* Quick Actions title when widget enters edit mode */
+"TodayWidget.QuickActionsGalleryTitle" = "Azzioni lesti";
+
+/* Text shown on quick action widget inviting the user to browse in the app. %@ is the name of the app (Focus/Klar). */
+"TodayWidget.SearchInApp" = "Riscedi cu %@";
+


### PR DESCRIPTION
I've manually run `sh ./focus-ios/focus-ios-tests/tools/import-strings.sh`, checking out a changeset of LocalizationTools without https://github.com/mozilla-mobile/LocalizationTools/pull/4/files

```diff
diff --git a/focus-ios/focus-ios-tests/tools/import-strings.sh b/focus-ios/focus-ios-tests/tools/import-strings.sh
index 7def0ce9b..b763893f0 100755
--- a/focus-ios/focus-ios-tests/tools/import-strings.sh
+++ b/focus-ios/focus-ios-tests/tools/import-strings.sh
@@ -38,6 +38,7 @@ git clone https://github.com/mozilla-l10n/focusios-l10n.git focusios-l10n
 echo "[*] Cloning mozilla-mobile/LocalizationTools"
 [ -d focus-ios-tests/tools/Localizations ] && rm -rf focus-ios-tests/tools/Localizations
 git clone https://github.com/mozilla-mobile/LocalizationTools.git focus-ios-tests/tools/Localizations
+(cd focus-ios-tests/tools/Localizations && git checkout 625f5f44959ef4113e8e7d99a0c2a647f9c39d45)
 
 echo "[*] Building tools/Localizations"
 (cd focus-ios-tests/tools/Localizations && swift build)
```

This should unblock us while waiting for a proper fix for #23981 