### PR TITLE
Refactor FXIOS-7301 [Swiftlint] Remove 1 closure_body_length violation from MainMenuState.swift and decrease threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -102,8 +102,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 71
-  error: 71
+  warning: 68
+  error: 68
 
 file_header:
   required_string: |

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -208,4 +208,14 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon
         )
     }
+
+    private static func handleUpdateAccountHeaderAction(state: MainMenuState, action: MainMenuAction) -> MainMenuState {
+        return MainMenuState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuElements,
+            currentTabInfo: state.currentTabInfo,
+            accountData: action.accountData,
+            accountIcon: action.accountIcon
+        )
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -212,4 +212,19 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: action.accountIcon
         )
     }
+
+    private static func handleUpdateCurrentTabInfoAction(state: MainMenuState,
+                                                         currentTabInfo: MainMenuTabInfo) -> MainMenuState {
+        return MainMenuState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuConfigurator.generateMenuElements(
+                with: currentTabInfo,
+                for: state.currentSubmenuView,
+                and: state.windowUUID
+            ),
+            currentTabInfo: currentTabInfo,
+            accountData: state.accountData,
+            accountIcon: state.accountIcon
+        )
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -217,4 +217,15 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon
         )
     }
+
+    private static func handleTapShowDetailsViewAction(state: MainMenuState, action: MainMenuAction) -> MainMenuState {
+        return MainMenuState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuElements,
+            currentTabInfo: state.currentTabInfo,
+            submenuDestination: action.detailsViewToShow,
+            accountData: state.accountData,
+            accountIcon: state.accountIcon
+        )
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -225,4 +225,15 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon
         )
     }
+
+    private static func handleTapToggleUserAgentAndCloseMenuAction(state: MainMenuState) -> MainMenuState {
+        return MainMenuState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuElements,
+            currentTabInfo: state.currentTabInfo,
+            shouldDismiss: true,
+            accountData: state.accountData,
+            accountIcon: state.accountIcon
+        )
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -175,8 +175,7 @@ struct MainMenuState: ScreenState, Equatable {
         )
     }
 
-    private static func handleUpdateCurrentTabInfoAction(state: MainMenuState,
-                                                         action: Action) -> MainMenuState {
+    private static func handleUpdateCurrentTabInfoAction(state: MainMenuState, action: Action) -> MainMenuState {
         guard let action = action as? MainMenuAction,
               let currentTabInfo = action.currentTabInfo
         else { return defaultState(from: state) }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -130,11 +130,7 @@ struct MainMenuState: ScreenState, Equatable {
         case MainMenuMiddlewareActionType.updateAccountHeader:
             return handleUpdateAccountHeaderAction(state: state, action: action)
         case MainMenuActionType.updateCurrentTabInfo:
-            guard let action = action as? MainMenuAction,
-                  let currentTabInfo = action.currentTabInfo
-            else { return defaultState(from: state) }
-
-            return handleUpdateCurrentTabInfoAction(state: state, currentTabInfo: currentTabInfo)
+            return handleUpdateCurrentTabInfoAction(state: state, action: action)
         case MainMenuActionType.tapShowDetailsView:
             guard let action = action as? MainMenuAction else { return defaultState(from: state) }
             return handleTapShowDetailsViewAction(state: state, action: action)
@@ -183,7 +179,11 @@ struct MainMenuState: ScreenState, Equatable {
     }
 
     private static func handleUpdateCurrentTabInfoAction(state: MainMenuState,
-                                                         currentTabInfo: MainMenuTabInfo) -> MainMenuState {
+                                                         action: Action) -> MainMenuState {
+        guard let action = action as? MainMenuAction,
+              let currentTabInfo = action.currentTabInfo
+        else { return defaultState(from: state) }
+
         return MainMenuState(
             windowUUID: state.windowUUID,
             menuElements: state.menuConfigurator.generateMenuElements(

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -137,17 +137,7 @@ struct MainMenuState: ScreenState, Equatable {
                   let currentTabInfo = action.currentTabInfo
             else { return defaultState(from: state) }
 
-            return MainMenuState(
-                windowUUID: state.windowUUID,
-                menuElements: state.menuConfigurator.generateMenuElements(
-                    with: currentTabInfo,
-                    for: state.currentSubmenuView,
-                    and: state.windowUUID
-                ),
-                currentTabInfo: currentTabInfo,
-                accountData: state.accountData,
-                accountIcon: state.accountIcon
-            )
+            return handleUpdateCurrentTabInfoAction(state: state, currentTabInfo: currentTabInfo)
         case MainMenuActionType.tapShowDetailsView:
             guard let action = action as? MainMenuAction else { return defaultState(from: state) }
             return MainMenuState(

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -165,8 +165,7 @@ struct MainMenuState: ScreenState, Equatable {
     }
 
     private static func handleUpdateAccountHeaderAction(state: MainMenuState, action: Action) -> MainMenuState {
-        guard let action = action as? MainMenuAction
-        else { return defaultState(from: state) }
+        guard let action = action as? MainMenuAction else { return defaultState(from: state) }
 
         return MainMenuState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -126,13 +126,7 @@ struct MainMenuState: ScreenState, Equatable {
 
         switch action.actionType {
         case MainMenuActionType.viewDidLoad:
-            return MainMenuState(
-                windowUUID: state.windowUUID,
-                menuElements: state.menuElements,
-                currentTabInfo: state.currentTabInfo,
-                accountData: state.accountData,
-                accountIcon: state.accountIcon
-            )
+            return handleViewDidLoadAction(state: state)
         case MainMenuMiddlewareActionType.updateAccountHeader:
             guard let action = action as? MainMenuAction
             else { return defaultState(from: state) }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -143,14 +143,7 @@ struct MainMenuState: ScreenState, Equatable {
             return handleTapShowDetailsViewAction(state: state, action: action)
         case MainMenuActionType.tapNavigateToDestination:
             guard let action = action as? MainMenuAction else { return defaultState(from: state) }
-            return MainMenuState(
-                windowUUID: state.windowUUID,
-                menuElements: state.menuElements,
-                currentTabInfo: state.currentTabInfo,
-                navigationDestination: action.navigationDestination,
-                accountData: state.accountData,
-                accountIcon: state.accountIcon
-            )
+            return handleTapNavigateToDestinationAction(state: state, action: action)
         case MainMenuActionType.tapToggleUserAgent,
             MainMenuActionType.tapCloseMenu:
             return MainMenuState(

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -140,14 +140,7 @@ struct MainMenuState: ScreenState, Equatable {
             return handleUpdateCurrentTabInfoAction(state: state, currentTabInfo: currentTabInfo)
         case MainMenuActionType.tapShowDetailsView:
             guard let action = action as? MainMenuAction else { return defaultState(from: state) }
-            return MainMenuState(
-                windowUUID: state.windowUUID,
-                menuElements: state.menuElements,
-                currentTabInfo: state.currentTabInfo,
-                submenuDestination: action.detailsViewToShow,
-                accountData: state.accountData,
-                accountIcon: state.accountIcon
-            )
+            return handleTapShowDetailsViewAction(state: state, action: action)
         case MainMenuActionType.tapNavigateToDestination:
             guard let action = action as? MainMenuAction else { return defaultState(from: state) }
             return MainMenuState(

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -221,4 +221,15 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon
         )
     }
+
+    private static func handleTapNavigateToDestinationAction(state: MainMenuState, action: MainMenuAction) -> MainMenuState {
+        return MainMenuState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuElements,
+            currentTabInfo: state.currentTabInfo,
+            navigationDestination: action.navigationDestination,
+            accountData: state.accountData,
+            accountIcon: state.accountIcon
+        )
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -134,7 +134,6 @@ struct MainMenuState: ScreenState, Equatable {
         case MainMenuActionType.tapShowDetailsView:
             return handleTapShowDetailsViewAction(state: state, action: action)
         case MainMenuActionType.tapNavigateToDestination:
-            guard let action = action as? MainMenuAction else { return defaultState(from: state) }
             return handleTapNavigateToDestinationAction(state: state, action: action)
         case MainMenuActionType.tapToggleUserAgent,
             MainMenuActionType.tapCloseMenu:
@@ -208,7 +207,9 @@ struct MainMenuState: ScreenState, Equatable {
         )
     }
 
-    private static func handleTapNavigateToDestinationAction(state: MainMenuState, action: MainMenuAction) -> MainMenuState {
+    private static func handleTapNavigateToDestinationAction(state: MainMenuState, action: Action) -> MainMenuState {
+        guard let action = action as? MainMenuAction else { return defaultState(from: state) }
+
         return MainMenuState(
             windowUUID: state.windowUUID,
             menuElements: state.menuElements,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -131,13 +131,7 @@ struct MainMenuState: ScreenState, Equatable {
             guard let action = action as? MainMenuAction
             else { return defaultState(from: state) }
 
-            return MainMenuState(
-                windowUUID: state.windowUUID,
-                menuElements: state.menuElements,
-                currentTabInfo: state.currentTabInfo,
-                accountData: action.accountData,
-                accountIcon: action.accountIcon
-            )
+            return handleUpdateAccountHeaderAction(state: state, action: action)
         case MainMenuActionType.updateCurrentTabInfo:
             guard let action = action as? MainMenuAction,
                   let currentTabInfo = action.currentTabInfo

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -146,7 +146,7 @@ struct MainMenuState: ScreenState, Equatable {
             return handleTapNavigateToDestinationAction(state: state, action: action)
         case MainMenuActionType.tapToggleUserAgent,
             MainMenuActionType.tapCloseMenu:
-            return handleTapToggleUserAgentAndCloseMenuAction(state: state)
+            return handleTapToggleUserAgentAndTapCloseMenuAction(state: state)
         default:
             return defaultState(from: state)
         }
@@ -219,7 +219,7 @@ struct MainMenuState: ScreenState, Equatable {
         )
     }
 
-    private static func handleTapToggleUserAgentAndCloseMenuAction(state: MainMenuState) -> MainMenuState {
+    private static func handleTapToggleUserAgentAndTapCloseMenuAction(state: MainMenuState) -> MainMenuState {
         return MainMenuState(
             windowUUID: state.windowUUID,
             menuElements: state.menuElements,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -204,4 +204,14 @@ struct MainMenuState: ScreenState, Equatable {
             accountIcon: state.accountIcon
         )
     }
+
+    private static func handleViewDidLoadAction(state: MainMenuState) -> MainMenuState {
+        return MainMenuState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuElements,
+            currentTabInfo: state.currentTabInfo,
+            accountData: state.accountData,
+            accountIcon: state.accountIcon
+        )
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -128,9 +128,6 @@ struct MainMenuState: ScreenState, Equatable {
         case MainMenuActionType.viewDidLoad:
             return handleViewDidLoadAction(state: state)
         case MainMenuMiddlewareActionType.updateAccountHeader:
-            guard let action = action as? MainMenuAction
-            else { return defaultState(from: state) }
-
             return handleUpdateAccountHeaderAction(state: state, action: action)
         case MainMenuActionType.updateCurrentTabInfo:
             guard let action = action as? MainMenuAction,
@@ -172,7 +169,10 @@ struct MainMenuState: ScreenState, Equatable {
         )
     }
 
-    private static func handleUpdateAccountHeaderAction(state: MainMenuState, action: MainMenuAction) -> MainMenuState {
+    private static func handleUpdateAccountHeaderAction(state: MainMenuState, action: Action) -> MainMenuState {
+        guard let action = action as? MainMenuAction
+        else { return defaultState(from: state) }
+
         return MainMenuState(
             windowUUID: state.windowUUID,
             menuElements: state.menuElements,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -146,14 +146,7 @@ struct MainMenuState: ScreenState, Equatable {
             return handleTapNavigateToDestinationAction(state: state, action: action)
         case MainMenuActionType.tapToggleUserAgent,
             MainMenuActionType.tapCloseMenu:
-            return MainMenuState(
-                windowUUID: state.windowUUID,
-                menuElements: state.menuElements,
-                currentTabInfo: state.currentTabInfo,
-                shouldDismiss: true,
-                accountData: state.accountData,
-                accountIcon: state.accountIcon
-            )
+            return handleTapToggleUserAgentAndCloseMenuAction(state: state)
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuState.swift
@@ -132,7 +132,6 @@ struct MainMenuState: ScreenState, Equatable {
         case MainMenuActionType.updateCurrentTabInfo:
             return handleUpdateCurrentTabInfoAction(state: state, action: action)
         case MainMenuActionType.tapShowDetailsView:
-            guard let action = action as? MainMenuAction else { return defaultState(from: state) }
             return handleTapShowDetailsViewAction(state: state, action: action)
         case MainMenuActionType.tapNavigateToDestination:
             guard let action = action as? MainMenuAction else { return defaultState(from: state) }
@@ -197,7 +196,9 @@ struct MainMenuState: ScreenState, Equatable {
         )
     }
 
-    private static func handleTapShowDetailsViewAction(state: MainMenuState, action: MainMenuAction) -> MainMenuState {
+    private static func handleTapShowDetailsViewAction(state: MainMenuState, action: Action) -> MainMenuState {
+        guard let action = action as? MainMenuAction else { return defaultState(from: state) }
+
         return MainMenuState(
             windowUUID: state.windowUUID,
             menuElements: state.menuElements,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `MainMenuState.swift ` file. Also, this PR decrease the warning and error threshold to 68. 

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

