### PR TITLE
Add FXIOS-10944 [Homepage] showing / hiding sections for Phase I

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -67,25 +67,7 @@ final class HomepageSectionLayoutProvider {
         self.dimensionImplementation = TopSitesDimensionImplementation(windowUUID: windowUUID)
     }
 
-    func createCompositionalLayout() -> UICollectionViewCompositionalLayout {
-        return UICollectionViewCompositionalLayout { (sectionIndex, environment) -> NSCollectionLayoutSection? in
-            guard let section = HomepageSection(rawValue: sectionIndex) else {
-                self.logger.log(
-                    "Section should not have been nil, something went wrong",
-                    level: .fatal,
-                    category: .homepage
-                )
-                return nil
-            }
-            return self.createLayoutSection(
-                    for: section,
-                    with: environment.traitCollection,
-                    size: environment.container.effectiveContentSize
-                )
-        }
-    }
-
-    private func createLayoutSection(
+    func createLayoutSection(
         for section: HomepageSection,
         with traitCollection: UITraitCollection,
         size: CGSize

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -276,9 +276,11 @@ final class HomepageViewController: UIViewController,
     }
 
     private func createLayout() -> UICollectionViewCompositionalLayout {
-        let layout = UICollectionViewCompositionalLayout { (sectionIndex, environment) -> NSCollectionLayoutSection? in
-            guard let section = self.dataSource?.snapshot().sectionIdentifiers[safe: sectionIndex] else {
-                self.logger.log(
+        let sectionProvider = HomepageSectionLayoutProvider(windowUUID: self.windowUUID)
+        let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex, environment)
+            -> NSCollectionLayoutSection? in
+            guard let section = self?.dataSource?.snapshot().sectionIdentifiers[safe: sectionIndex] else {
+                self?.logger.log(
                     "Section should not have been nil, something went wrong for \(sectionIndex)",
                     level: .fatal,
                     category: .homepage
@@ -286,9 +288,7 @@ final class HomepageViewController: UIViewController,
                 return nil
             }
 
-            return HomepageSectionLayoutProvider(
-                windowUUID: self.windowUUID
-            ).createLayoutSection(
+            return sectionProvider.createLayoutSection(
                 for: section,
                 with: environment.traitCollection,
                 size: environment.container.effectiveContentSize

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -55,7 +55,6 @@ final class HomepageViewController: UIViewController,
     private let overlayManager: OverlayModeManager
     private let logger: Logger
     private let toastContainer: UIView
-    private let collectionLayout: UICollectionViewLayout?
 
     // MARK: - Initializers
     init(windowUUID: WindowUUID,
@@ -74,7 +73,6 @@ final class HomepageViewController: UIViewController,
         self.statusBarScrollDelegate = statusBarScrollDelegate
         self.toastContainer = toastContainer
         self.logger = logger
-        self.collectionLayout = collectionLayout
         homepageState = HomepageState(windowUUID: windowUUID)
         super.init(nibName: nil, bundle: nil)
 
@@ -247,7 +245,7 @@ final class HomepageViewController: UIViewController,
     }
 
     private func configureCollectionView() {
-        let collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: collectionLayout ?? createLayout())
+        let collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: createLayout())
 
         HomepageItem.cellTypes.forEach {
             collectionView.register($0, forCellWithReuseIdentifier: $0.cellIdentifier)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -63,8 +63,7 @@ final class HomepageViewController: UIViewController,
          statusBarScrollDelegate: StatusBarScrollDelegate? = nil,
          toastContainer: UIView,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
-         logger: Logger = DefaultLogger.shared,
-         collectionLayout: UICollectionViewLayout? = nil
+         logger: Logger = DefaultLogger.shared
     ) {
         self.windowUUID = windowUUID
         self.themeManager = themeManager

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketAction.swift
@@ -8,19 +8,23 @@ import Redux
 
 final class PocketAction: Action {
     var pocketStories: [PocketStoryState]?
+    var isEnabled: Bool?
 
     init(
         pocketStories: [PocketStoryState]? = nil,
+        isEnabled: Bool? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
         self.pocketStories = pocketStories
+        self.isEnabled = isEnabled
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 
 enum PocketActionType: ActionType {
     case enteredForeground
+    case toggleShowSectionSetting
 }
 
 enum PocketMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketState.swift
@@ -33,28 +33,36 @@ struct PocketDiscoverState: Equatable, Hashable {
 /// State for the pocket section that is used in the homepage
 struct PocketState: StateType, Equatable {
     var windowUUID: WindowUUID
-    var pocketData: [PocketStoryState]
+    let pocketData: [PocketStoryState]
+    let shouldShowSection: Bool
+
     let sectionHeaderState = SectionHeaderState()
     let pocketDiscoverItem = PocketDiscoverState(
         title: .FirefoxHomepage.Pocket.DiscoverMore,
         url: PocketProvider.MoreStoriesURL
     )
-
     let footerURL = SupportUtils.URLForPocketLearnMore
 
-    init(windowUUID: WindowUUID) {
+    init(profile: Profile = AppContainer.shared.resolve(), windowUUID: WindowUUID) {
+        let userPrefs = profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.ASPocketStories) ?? true
+        let isLocaleSupported = PocketProvider.islocaleSupported(Locale.current.identifier)
+        let shouldShowSection = userPrefs && isLocaleSupported
+
         self.init(
             windowUUID: windowUUID,
-            pocketData: []
+            pocketData: [],
+            shouldShowSection: shouldShowSection
         )
     }
 
     private init(
         windowUUID: WindowUUID,
-        pocketData: [PocketStoryState]
+        pocketData: [PocketStoryState],
+        shouldShowSection: Bool
     ) {
         self.windowUUID = windowUUID
         self.pocketData = pocketData
+        self.shouldShowSection = shouldShowSection
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -65,13 +73,15 @@ struct PocketState: StateType, Equatable {
 
         switch action.actionType {
         case PocketMiddlewareActionType.retrievedUpdatedStories:
-            return handlePocketAction(action, state: state)
+            return handlePocketStoriesAction(action, state: state)
+        case PocketActionType.toggleShowSectionSetting:
+            return handleSettingsToggleAction(action, state: state)
         default:
             return defaultState(from: state)
         }
     }
 
-    private static func handlePocketAction(_ action: Action, state: PocketState) -> PocketState {
+    private static func handlePocketStoriesAction(_ action: Action, state: PocketState) -> PocketState {
         guard let pocketAction = action as? PocketAction,
               let pocketStories = pocketAction.pocketStories
         else {
@@ -80,14 +90,30 @@ struct PocketState: StateType, Equatable {
 
         return PocketState(
             windowUUID: state.windowUUID,
-            pocketData: pocketStories
+            pocketData: pocketStories,
+            shouldShowSection: !pocketStories.isEmpty && state.shouldShowSection
+        )
+    }
+
+    private static func handleSettingsToggleAction(_ action: Action, state: PocketState) -> PocketState {
+        guard let pocketAction = action as? PocketAction,
+              let isEnabled = pocketAction.isEnabled
+        else {
+            return defaultState(from: state)
+        }
+
+        return PocketState(
+            windowUUID: state.windowUUID,
+            pocketData: state.pocketData,
+            shouldShowSection: isEnabled
         )
     }
 
     static func defaultState(from state: PocketState) -> PocketState {
         return PocketState(
             windowUUID: state.windowUUID,
-            pocketData: state.pocketData
+            pocketData: state.pocketData,
+            shouldShowSection: state.shouldShowSection
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesAction.swift
@@ -9,14 +9,17 @@ final class TopSitesAction: Action {
     var topSites: [TopSiteState]?
     var numberOfRows: Int?
     var numberOfTilesPerRow: Int?
+    var isEnabled: Bool?
 
     init(
         topSites: [TopSiteState]? = nil,
         numberOfRows: Int? = nil,
         numberOfTilesPerRow: Int? = nil,
+        isEnabled: Bool? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.isEnabled = isEnabled
         self.topSites = topSites
         self.numberOfRows = numberOfRows
         self.numberOfTilesPerRow = numberOfTilesPerRow
@@ -28,6 +31,7 @@ enum TopSitesActionType: ActionType {
     case fetchTopSites
     case updatedNumberOfRows
     case updatedNumberOfTilesPerRow
+    case toggleShowSectionSetting
 }
 
 enum TopSitesMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
@@ -5,21 +5,6 @@
 import Common
 
 class TopSitesDimensionImplementation {
-    /// The update count of number of tiles per row based on device layout
-    /// After updating the value, the top sites state should be updated respectively
-    private var numberOfTilesPerRow: Int? {
-        willSet {
-            guard newValue != numberOfTilesPerRow else { return }
-            store.dispatch(
-                TopSitesAction(
-                    numberOfTilesPerRow: newValue,
-                    windowUUID: self.windowUUID,
-                    actionType: TopSitesActionType.updatedNumberOfTilesPerRow
-                )
-            )
-        }
-    }
-
     private let windowUUID: WindowUUID
     private let queue: DispatchQueueInterface
     init(windowUUID: WindowUUID, queue: DispatchQueueInterface = DispatchQueue.main) {
@@ -44,9 +29,23 @@ class TopSitesDimensionImplementation {
 
         // TODO: FXIOS-10972 - Investigate a better way to solve the crash issue that is resolved by adding this
         queue.async {
-            self.numberOfTilesPerRow = tilesPerRowCount
+            self.dispatchTopSiteAction(with: tilesPerRowCount)
         }
 
         return tilesPerRowCount
+    }
+
+    /// After updating the value, the top sites state should be updated respectively
+    /// - Parameter count: the update count of number of tiles per row based on device layout
+    private func dispatchTopSiteAction(with count: Int) {
+        let topSitesState = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID)?.topSitesState
+        guard topSitesState?.numberOfTilesPerRow != count else { return }
+        store.dispatch(
+            TopSitesAction(
+                numberOfTilesPerRow: count,
+                windowUUID: self.windowUUID,
+                actionType: TopSitesActionType.updatedNumberOfTilesPerRow
+            )
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
@@ -5,6 +5,21 @@
 import Common
 
 class TopSitesDimensionImplementation {
+    /// The update count of number of tiles per row based on device layout
+    /// After updating the value, the top sites state should be updated respectively
+    private var numberOfTilesPerRow: Int = 0 {
+        willSet {
+            guard newValue != numberOfTilesPerRow else { return }
+            store.dispatch(
+                TopSitesAction(
+                    numberOfTilesPerRow: newValue,
+                    windowUUID: self.windowUUID,
+                    actionType: TopSitesActionType.updatedNumberOfTilesPerRow
+                )
+            )
+        }
+    }
+
     private let windowUUID: WindowUUID
     private let queue: DispatchQueueInterface
     init(windowUUID: WindowUUID, queue: DispatchQueueInterface = DispatchQueue.main) {
@@ -29,23 +44,9 @@ class TopSitesDimensionImplementation {
 
         // TODO: FXIOS-10972 - Investigate a better way to solve the crash issue that is resolved by adding this
         queue.async {
-            self.dispatchTopSiteAction(with: tilesPerRowCount)
+            self.numberOfTilesPerRow = tilesPerRowCount
         }
 
         return tilesPerRowCount
-    }
-
-    /// After updating the value, the top sites state should be updated respectively
-    /// - Parameter count: the update count of number of tiles per row based on device layout
-    private func dispatchTopSiteAction(with count: Int) {
-        let topSitesState = store.state.screenState(HomepageState.self, for: .homepage, window: windowUUID)?.topSitesState
-        guard topSitesState?.numberOfTilesPerRow != count else { return }
-        store.dispatch(
-            TopSitesAction(
-                numberOfTilesPerRow: count,
-                windowUUID: self.windowUUID,
-                actionType: TopSitesActionType.updatedNumberOfTilesPerRow
-            )
-        )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -22,13 +22,12 @@ struct TopSitesSectionState: StateType, Equatable {
         let defaultNumberOfRows = TopSitesRowCountSettingsController.defaultNumberOfRows
         let numberOfRows = Int(preferredNumberOfRows ?? defaultNumberOfRows)
         let shouldShowSection = profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.TopSiteSection) ?? true
-        let initialNumberOfTilesPerRow = HomepageSectionLayoutProvider.UX.TopSitesConstants.minCards
 
         self.init(
             windowUUID: windowUUID,
             topSitesData: [],
             numberOfRows: numberOfRows,
-            numberOfTilesPerRow: initialNumberOfTilesPerRow,
+            numberOfTilesPerRow: 0,
             shouldShowSection: shouldShowSection
         )
     }

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -172,7 +172,15 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
                 defaultValue: true,
                 titleText: .Settings.Homepage.CustomizeFirefoxHome.ThoughtProvokingStories,
                 statusText: pocketStatusText
-            )
+            ) { value in
+                store.dispatch(
+                    PocketAction(
+                        isEnabled: value,
+                        windowUUID: self.windowUUID,
+                        actionType: PocketActionType.toggleShowSectionSetting
+                    )
+                )
+            }
             sectionItems.append(pocketSetting)
         }
 
@@ -272,6 +280,13 @@ extension HomePageSettingViewController {
             let areShortcutsOn = profile.prefs.boolForKey(PrefsKeys.UserFeatureFlagPrefs.TopSiteSection) ?? true
             typealias Shortcuts = String.Settings.Homepage.Shortcuts
             let status: String = areShortcutsOn ? Shortcuts.ToggleOn : Shortcuts.ToggleOff
+            store.dispatch(
+                TopSitesAction(
+                    isEnabled: areShortcutsOn,
+                    windowUUID: self.windowUUID,
+                    actionType: TopSitesActionType.toggleShowSectionSetting
+                )
+            )
             return NSAttributedString(string: String(format: status))
         }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -38,11 +38,10 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.updateSnapshot(state: HomepageState(windowUUID: .XCTestDefaultUUID))
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfSections, 4)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites, .pocket(nil), .customizeHomepage])
+        XCTAssertEqual(snapshot.numberOfSections, 2)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .customizeHomepage])
 
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
-        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .pocket(nil)).count, 1)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .customizeHomepage).count, 1)
     }
 
@@ -58,6 +57,15 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let state = HomepageState.reducer(
             HomepageState(windowUUID: .XCTestDefaultUUID),
+            PocketAction(
+                pocketStories: createStories(),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: PocketMiddlewareActionType.retrievedUpdatedStories
+            )
+        )
+
+        let updatedState = HomepageState.reducer(
+            state,
             WallpaperAction(
                 wallpaperConfiguration: wallpaperConfig,
                 windowUUID: .XCTestDefaultUUID,
@@ -65,10 +73,10 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             )
         )
 
-        dataSource.updateSnapshot(state: state)
+        dataSource.updateSnapshot(state: updatedState)
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(.systemCyan)), 1)
+        XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(.systemCyan)), 21)
     }
 
     func test_updateSnapshot_withValidState_returnTopSites() throws {
@@ -105,6 +113,26 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .topSites), 16)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites, .customizeHomepage])
+    }
+
+    func test_updateSnapshot_withValidState_returnPocketStories() throws {
+        let dataSource = try XCTUnwrap(diffableDataSource)
+
+        let state = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            PocketAction(
+                pocketStories: createStories(),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: PocketMiddlewareActionType.retrievedUpdatedStories
+            )
+        )
+
+        dataSource.updateSnapshot(state: state)
+
+        let snapshot = dataSource.snapshot()
+        XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil)), 21)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .pocket(nil), .customizeHomepage])
     }
 
     private func createSites(count: Int = 30) -> [TopSiteState] {
@@ -115,5 +143,18 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             sites.append(TopSiteState(site: site))
         }
         return sites
+    }
+
+    private func createStories(count: Int = 20) -> [PocketStoryState] {
+        var feedStories = [PocketFeedStory]()
+        (0..<count).forEach {
+            let story: PocketFeedStory = .make(title: "feed \($0)")
+            feedStories.append(story)
+        }
+
+        let stories = feedStories.compactMap {
+            PocketStoryState(story: PocketStory(pocketFeedStory: $0))
+        }
+        return stories
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -174,8 +174,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
             overlayManager: mockOverlayManager,
             statusBarScrollDelegate: statusBarScrollDelegate,
             toastContainer: UIView(),
-            notificationCenter: notificationCenter,
-            collectionLayout: UICollectionViewFlowLayout()
+            notificationCenter: notificationCenter
         )
         trackForMemoryLeaks(homepageViewController)
         return homepageViewController

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -174,7 +174,8 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
             overlayManager: mockOverlayManager,
             statusBarScrollDelegate: statusBarScrollDelegate,
             toastContainer: UIView(),
-            notificationCenter: notificationCenter
+            notificationCenter: notificationCenter,
+            collectionLayout: UICollectionViewFlowLayout()
         )
         trackForMemoryLeaks(homepageViewController)
         return homepageViewController

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/PocketStateTests.swift
@@ -8,6 +8,16 @@ import XCTest
 @testable import Client
 
 final class PocketStateTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        DependencyHelperMock().reset()
+        super.tearDown()
+    }
+
     func tests_initialState_returnsExpectedState() {
         let initialState = createSubject()
 
@@ -45,6 +55,40 @@ final class PocketStateTests: XCTestCase {
         XCTAssertEqual(newState.pocketData.compactMap { $0.title }, ["feed1", "feed2", "feed3"])
         XCTAssertEqual(initialState.pocketDiscoverItem.title, .FirefoxHomepage.Pocket.DiscoverMore)
         XCTAssertEqual(initialState.pocketDiscoverItem.url, PocketProvider.MoreStoriesURL)
+    }
+
+    func test_toggleShowSectionSetting_withToggleOn_returnsExpectedState() throws {
+        let initialState = createSubject()
+        let reducer = pocketReducer()
+
+        let newState = reducer(
+            initialState,
+            PocketAction(
+                isEnabled: true,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: PocketActionType.toggleShowSectionSetting
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertTrue(newState.shouldShowSection)
+    }
+
+    func test_toggleShowSectionSetting_withToggleOff_returnsExpectedState() throws {
+        let initialState = createSubject()
+        let reducer = pocketReducer()
+
+        let newState = reducer(
+            initialState,
+            PocketAction(
+                isEnabled: false,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: PocketActionType.toggleShowSectionSetting
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(newState.shouldShowSection)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
@@ -100,6 +100,40 @@ final class TopsSitesSectionStateTests: XCTestCase {
         XCTAssertEqual(newState.numberOfTilesPerRow, 8)
     }
 
+    func test_toggleShowSectionSetting_withToggleOn_returnsExpectedState() throws {
+        let initialState = createSubject()
+        let reducer = topSiteReducer()
+
+        let newState = reducer(
+            initialState,
+            TopSitesAction(
+                isEnabled: true,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: TopSitesActionType.toggleShowSectionSetting
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertTrue(newState.shouldShowSection)
+    }
+
+    func test_toggleShowSectionSetting_withToggleOff_returnsExpectedState() throws {
+        let initialState = createSubject()
+        let reducer = topSiteReducer()
+
+        let newState = reducer(
+            initialState,
+            TopSitesAction(
+                isEnabled: false,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: TopSitesActionType.toggleShowSectionSetting
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(newState.shouldShowSection)
+    }
+
     // MARK: - Private
     private func createSubject() -> TopSitesSectionState {
         return TopSitesSectionState(windowUUID: .XCTestDefaultUUID)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10944)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Add showing and hiding sections for pocket and top site section (user prefs and data).

- Update both section state with new property `shouldShowSection` that gets initial value and then updated based on user action in settings
- Section is showed depending on settings configuration as well as if there exists data (i.e. empty top sites or stories)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots

https://github.com/user-attachments/assets/2e316609-67cb-48a4-a24e-6f56b9267386

https://github.com/user-attachments/assets/2739904d-2a3a-41f0-94b9-c3e2194fc01e
