### PR TITLE
Fix FXIOS-10299 [Universal Links] Update applinks entitlement to use wildcard

### DIFF
--- a/firefox-ios/Client/Entitlements/FirefoxApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FirefoxApplication.entitlements
@@ -10,7 +10,7 @@
 	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:blog.mozilla.org</string>
+		<string>applinks:*.mozilla.org</string>
 	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>

--- a/firefox-ios/Client/Entitlements/FirefoxApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FirefoxApplication.entitlements
@@ -11,6 +11,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:*.mozilla.org</string>
+		<string>applinks:blog.mozilla.org</string>
+		<string>applinks:mozilla.org</string>
 	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>

--- a/firefox-ios/Client/Entitlements/FirefoxBetaApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FirefoxBetaApplication.entitlements
@@ -7,6 +7,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:*.mozilla.org</string>
+		<string>applinks:blog.mozilla.org</string>
+		<string>applinks:mozilla.org</string>
 	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>

--- a/firefox-ios/Client/Entitlements/FirefoxBetaApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FirefoxBetaApplication.entitlements
@@ -6,7 +6,7 @@
 	<string>production</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:blog.mozilla.org</string>
+		<string>applinks:*.mozilla.org</string>
 	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10299)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Update the `applinks` in `Firefox` and `FirefoxBeta` to use the wildcard for mozilla.org instead of blog.mozilla.org based on this documentation:
>This will only work with the root domain of applinks:example.com and subdomains that are matched with the wildcard applinks:*.example.com. This will not work with specific subdomains like applinks:www.example.com or applinks:foo.example.com.

https://developer.apple.com/documentation/technotes/tn3155-debugging-universal-links

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

