### PR TITLE
Bugfix FXIOS-10921 [Bookmarks Evolution] Exit and re-enter bookmarks edit mode on edit press

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -784,6 +784,8 @@ extension BookmarksViewController {
 
         switch subState {
         case .mainView, .inFolder:
+            // Set editing false first to hide any swipe actions that may already be showing
+            tableView.setEditing(false, animated: true)
             enableEditMode()
         case .inFolderEditMode:
             disableEditMode()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10921)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23865)

## :bulb: Description
- Fix table not entering "edit mode" when edit toolbar button is pressed

### 📝 Discussion
- Revealing swipe actions on a cell in a table view causes the table view to enter a variation of "edit mode", so when the actual "Edit" button is pressed while a swipe action is already displayed, the table thinks it is already in edit mode, and therefore does nothing. Exiting edit mode before entering again resolves the issue

### 📹 Videos

### Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/a601fdb9-44ce-4a92-a840-aaa02fc2d127

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/93fedb65-05fb-44d6-a58a-c3f4afa7a730

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

