### PR TITLE
Bugfix FXIOS-10910 [Bookmarks Evolution] Fix bookmarks theming

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -65,6 +65,7 @@ class EditBookmarkViewController: UIViewController,
         self.notificationCenter = notificationCenter
         self.currentWindowUUID = windowUUID
         super.init(nibName: nil, bundle: nil)
+        listenForThemeChange(view)
     }
 
     required init?(coder: NSCoder) {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -63,6 +63,7 @@ class EditFolderViewController: UIViewController,
         self.notificationCenter = notificationCenter
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+        listenForThemeChange(view)
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10910)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23828)

## :bulb: Description
- Fix theming for `EditBookmarkViewController` and `EditFolderViewController`

### 📹  Videos
<details>
<summary>Edit bookmarks view before</summary>

https://github.com/user-attachments/assets/4e595c6f-084f-4fab-b7fa-626be7d3fb34

</details>

<details>
<summary>Edit bookmarks view after</summary>

https://github.com/user-attachments/assets/2e5fb09a-18e2-478d-94dc-cbe0329b85e7

</details>
<details>
<summary>Edit folder view before</summary>

https://github.com/user-attachments/assets/5d426775-c35b-4dc0-a2b7-f807c1cff7db

</details>
<details>
<summary>Edit folder view after</summary>

https://github.com/user-attachments/assets/7ab3f172-b8ad-41bf-a5fb-05b7cc895bfc

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

