### PR TITLE
Bugfix FXIOS-10981 Fix l10n import script for Focus, use Xcode 16.2

### DIFF
--- a/.github/workflows/firefox-ios-import-strings.yml
+++ b/.github/workflows/firefox-ios-import-strings.yml
@@ -10,12 +10,12 @@ on:
         default: 'main'
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.9]
-        xcode: ["15.0.1"]
+        xcode: ["16.2"]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/focus-ios-import-strings.yml
+++ b/.github/workflows/focus-ios-import-strings.yml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.9]
-        xcode: ["15.0.1"]
+        xcode: ["16.2"]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/focus-ios/focus-ios-tests/tools/import-strings.sh
+++ b/focus-ios/focus-ios-tests/tools/import-strings.sh
@@ -48,6 +48,9 @@ sed -i '' 's/firefox-ios.xliff/focus-ios.xliff/g' focus-ios-tests/tools/Localiza
 echo "[*] Removing es-ES locale mapping from swift import task"
 sed -i '' '/es-ES/d' focus-ios-tests/tools/Localizations/Sources/LocalizationTools/tasks/ImportTask.swift
 
+echo "[*] Use en instead of en-US as developmentRegion in swift import task"
+sed -i '' 's/"developmentRegion" : "en-US"/"developmentRegion" : "en"/' focus-ios-tests/tools/Localizations/Sources/LocalizationTools/tasks/ImportTask.swift
+
 echo "[*] Removing WidgetKit/en-US.lproj/WidgetIntents.strings from swift import task"
 # Match all text between a line containing 'ShortcutItemTitleQRCode' to ']' and delete them
 sed -ri '' '/ShortcutItemTitleQRCode/,/\]/{/ShortcutItemTitleQRCode/!{/\]/!d;};}' focus-ios-tests/tools/Localizations/Sources/LocalizationTools/tasks/ImportTask.swift


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10981)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23981)

## :bulb: Description
Import for Focus is currently broken. This is a quick patch (vs fixing LocalizationTools) to restart importing translations consistently.

Also using the PR to switch to Xcode 16.2, which is what developers are currently using.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)

