### PR TITLE
Bugfix Disable testSSL for smoketest4 (temporary)

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
@@ -106,6 +106,7 @@
         "NavigationTest\/testOpenExternalLink()",
         "NavigationTest\/testOpenInNewPrivateTab()",
         "NavigationTest\/testOpenInNewTab()",
+        "NavigationTest\/testSSL()",
         "NavigationTest\/testScrollsToTopWithMultipleTabs()",
         "NavigationTest\/testShareLink()",
         "NavigationTest\/testShareLinkPrivateMode()",


### PR DESCRIPTION
## :scroll: Tickets

## :bulb: Description
Disable testSSL for smoketest4 due to expired.badssl.com returns 404.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

