### PR TITLE
Bugfix FXIOS-10775 Pull refresh theme not applied correctly when going from Private browsing to normal browsing

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -342,6 +342,7 @@ private extension TabScrollingController {
               let webView = tab?.webView,
               !scrollView.subviews.contains(where: { $0 is PullRefreshView })
         else {
+            pullToRefreshView?.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
             pullToRefreshView?.startObservingContentScroll()
             return
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10775)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23506)

## :bulb: Description
Bugfix Pull refresh theme not applied correctly when going from Private browsing to normal browsing

### Before
https://github.com/user-attachments/assets/9c99d932-71e6-4ab8-9886-f62e6f416714

### Fix
https://github.com/user-attachments/assets/ad93ef30-757f-4186-a294-3da80831208f

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

