### PR TITLE
Refactor FXIOS-10972 [Homepage] Top Sites Layout Update

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -82,8 +82,9 @@ final class HomepageDiffableDataSource:
         with topSitesState: TopSitesSectionState,
         and textColor: TextColor?
     ) -> [HomepageDiffableDataSource.HomeItem]? {
+        guard topSitesState.shouldShowSection else { return nil }
         let topSites: [HomeItem] = topSitesState.topSitesData.compactMap { .topSite($0, textColor) }
-        guard topSitesState.shouldShowSection, !topSites.isEmpty else { return nil }
+        guard !topSites.isEmpty else { return nil }
         return topSites
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -12,22 +12,12 @@ typealias HomepageItem = HomepageDiffableDataSource.HomeItem
 final class HomepageDiffableDataSource:
     UICollectionViewDiffableDataSource<HomepageSection, HomepageItem> {
     typealias TextColor = UIColor
-
+    typealias NumberOfTilesPerRow = Int
     enum HomeSection: Hashable {
         case header
-        case topSites
+        case topSites(NumberOfTilesPerRow)
         case pocket(TextColor?)
         case customizeHomepage
-
-        init?(rawValue: Int) {
-            switch rawValue {
-            case 0: self = .header
-            case 1: self = .topSites
-            case 2: self = .pocket(nil)
-            case 3: self = .customizeHomepage
-            default: return nil
-            }
-        }
     }
 
     enum HomeItem: Hashable {
@@ -59,8 +49,8 @@ final class HomepageDiffableDataSource:
         snapshot.appendItems([.header(state.headerState)], toSection: .header)
 
         if let topSites = getTopSites(with: state.topSitesState, and: textColor) {
-            snapshot.appendSections([.topSites])
-            snapshot.appendItems(topSites, toSection: .topSites)
+            snapshot.appendSections([.topSites(state.topSitesState.numberOfTilesPerRow)])
+            snapshot.appendItems(topSites, toSection: .topSites(state.topSitesState.numberOfTilesPerRow))
         }
 
         if let stories = getPocketStories(with: state.pocketState) {
@@ -94,7 +84,6 @@ final class HomepageDiffableDataSource:
     ) -> [HomepageDiffableDataSource.HomeItem]? {
         let topSites: [HomeItem] = topSitesState.topSitesData.compactMap { .topSite($0, textColor) }
         guard topSitesState.shouldShowSection, !topSites.isEmpty else { return nil }
-        let filterTopSites = topSites.prefix(Int(topSitesState.numberOfRows) * topSitesState.numberOfTilesPerRow)
-        return Array(filterTopSites)
+        return topSites
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -69,16 +69,15 @@ final class HomepageSectionLayoutProvider {
 
     func createLayoutSection(
         for section: HomepageSection,
-        with traitCollection: UITraitCollection,
-        size: CGSize
+        with traitCollection: UITraitCollection
     ) -> NSCollectionLayoutSection {
         switch section {
         case .header:
             return createHeaderSectionLayout(for: traitCollection)
-        case .topSites:
+        case .topSites(let numberOfTilesPerRow):
             return createTopSitesSectionLayout(
                 for: traitCollection,
-                availableWidth: size.width
+                numberOfTilesPerRow: numberOfTilesPerRow
             )
         case .pocket:
             return createPocketSectionLayout(for: traitCollection)
@@ -154,16 +153,8 @@ final class HomepageSectionLayoutProvider {
 
     private func createTopSitesSectionLayout(
         for traitCollection: UITraitCollection,
-        availableWidth: CGFloat
+        numberOfTilesPerRow: Int
     ) -> NSCollectionLayoutSection {
-        let numberOfTilesPerRow = dimensionImplementation.getNumberOfTilesPerRow(
-            availableWidth: availableWidth,
-            leadingInset: UX.leadingInset(
-                traitCollection: traitCollection
-            ),
-            cellWidth: UX.TopSitesConstants.cellEstimatedSize.width
-        )
-
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0 / CGFloat(numberOfTilesPerRow)),
             heightDimension: .estimated(UX.TopSitesConstants.cellEstimatedSize.height)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -59,12 +59,10 @@ final class HomepageSectionLayoutProvider {
 
     private var logger: Logger
     private var windowUUID: WindowUUID
-    private var dimensionImplementation: TopSitesDimensionImplementation
 
     init(windowUUID: WindowUUID, logger: Logger = DefaultLogger.shared) {
         self.windowUUID = windowUUID
         self.logger = logger
-        self.dimensionImplementation = TopSitesDimensionImplementation(windowUUID: windowUUID)
     }
 
     func createLayoutSection(

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -51,6 +51,10 @@ final class HomepageViewController: UIViewController,
         themeManager.getCurrentTheme(for: windowUUID)
     }
 
+    private var availableWidth: CGFloat {
+        return view.frame.size.width
+    }
+
     // MARK: - Private constants
     private let overlayManager: OverlayModeManager
     private let logger: Logger
@@ -107,7 +111,7 @@ final class HomepageViewController: UIViewController,
         store.dispatch(
             HomepageAction(
                 showiPadSetup: shouldUseiPadSetup(),
-                numberOfTilesPerRow: numberOfTilesPerRow(for: view.frame.size.width),
+                numberOfTilesPerRow: numberOfTilesPerRow(for: availableWidth),
                 windowUUID: windowUUID,
                 actionType: HomepageActionType.initialize
             )
@@ -184,13 +188,11 @@ final class HomepageViewController: UIViewController,
     /// - Parameter availableWidth: The total width available for displaying the tiles, determined by the view's size.
     /// - Returns: The number of tiles that can fit in a single row within the available width.
     private func numberOfTilesPerRow(for availableWidth: CGFloat) -> Int {
-        let dimensionImplementation = TopSitesDimensionImplementation(windowUUID: windowUUID)
-        return dimensionImplementation.getNumberOfTilesPerRow(
+        return TopSitesDimensionImplementation().getNumberOfTilesPerRow(
             availableWidth: availableWidth,
             leadingInset: HomepageSectionLayoutProvider.UX.leadingInset(
                 traitCollection: traitCollection
-            ),
-            cellWidth: HomepageSectionLayoutProvider.UX.TopSitesConstants.cellEstimatedSize.width
+            )
         )
     }
 
@@ -640,7 +642,7 @@ final class HomepageViewController: UIViewController,
                 guard let self else { return }
                 store.dispatch(
                     TopSitesAction(
-                        numberOfTilesPerRow: self.numberOfTilesPerRow(for: self.view.frame.size.width),
+                        numberOfTilesPerRow: self.numberOfTilesPerRow(for: availableWidth),
                         windowUUID: self.windowUUID,
                         actionType: TopSitesActionType.fetchTopSites
                     )

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -7,9 +7,11 @@ import Redux
 
 final class HomepageAction: Action {
     var showiPadSetup: Bool?
+    var numberOfTilesPerRow: Int?
 
-    init(showiPadSetup: Bool? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
+    init(showiPadSetup: Bool? = nil, numberOfTilesPerRow: Int? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
         self.showiPadSetup = showiPadSetup
+        self.numberOfTilesPerRow = numberOfTilesPerRow
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
@@ -4,17 +4,13 @@
 
 import Common
 
-class TopSitesDimensionImplementation {
-    private let windowUUID: WindowUUID
-    init(windowUUID: WindowUUID) {
-        self.windowUUID = windowUUID
-    }
-
+struct TopSitesDimensionImplementation {
     /// Updates the number of tiles (top sites) per row the user will see. This depends on the UI interface the user has.
     /// - Parameter availableWidth: available width size depending on device
     /// - Parameter leadingInset: padding for top site section
     /// - Parameter cellWidth: width of individual top site tiles
-    func getNumberOfTilesPerRow(availableWidth: CGFloat, leadingInset: CGFloat, cellWidth: CGFloat) -> Int {
+    func getNumberOfTilesPerRow(availableWidth: CGFloat, leadingInset: CGFloat) -> Int {
+        let cellWidth = HomepageSectionLayoutProvider.UX.TopSitesConstants.cellEstimatedSize.width
         var availableWidth = availableWidth - leadingInset * 2
         var numberOfTiles = 0
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
@@ -5,26 +5,9 @@
 import Common
 
 class TopSitesDimensionImplementation {
-    /// The update count of number of tiles per row based on device layout
-    /// After updating the value, the top sites state should be updated respectively
-    private var numberOfTilesPerRow: Int = 0 {
-        willSet {
-            guard newValue != numberOfTilesPerRow else { return }
-            store.dispatch(
-                TopSitesAction(
-                    numberOfTilesPerRow: newValue,
-                    windowUUID: self.windowUUID,
-                    actionType: TopSitesActionType.updatedNumberOfTilesPerRow
-                )
-            )
-        }
-    }
-
     private let windowUUID: WindowUUID
-    private let queue: DispatchQueueInterface
-    init(windowUUID: WindowUUID, queue: DispatchQueueInterface = DispatchQueue.main) {
+    init(windowUUID: WindowUUID) {
         self.windowUUID = windowUUID
-        self.queue = queue
     }
 
     /// Updates the number of tiles (top sites) per row the user will see. This depends on the UI interface the user has.
@@ -41,11 +24,6 @@ class TopSitesDimensionImplementation {
         }
         let minCardsConstant = HomepageSectionLayoutProvider.UX.TopSitesConstants.minCards
         let tilesPerRowCount = numberOfTiles < minCardsConstant ? minCardsConstant : numberOfTiles
-
-        // TODO: FXIOS-10972 - Investigate a better way to solve the crash issue that is resolved by adding this
-        queue.async {
-            self.numberOfTilesPerRow = tilesPerRowCount
-        }
 
         return tilesPerRowCount
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -27,7 +27,7 @@ struct TopSitesSectionState: StateType, Equatable {
             windowUUID: windowUUID,
             topSitesData: [],
             numberOfRows: numberOfRows,
-            numberOfTilesPerRow: 0,
+            numberOfTilesPerRow: HomepageSectionLayoutProvider.UX.TopSitesConstants.minCards,
             shouldShowSection: shouldShowSection
         )
     }
@@ -59,13 +59,14 @@ struct TopSitesSectionState: StateType, Equatable {
             else {
                 return defaultState(from: state)
             }
-
+            let numberOfTilesPerRow = topSitesAction.numberOfTilesPerRow ?? state.numberOfTilesPerRow
+            let filteredSites = filter(sites: sites, with: state.numberOfRows, and: numberOfTilesPerRow)
             return TopSitesSectionState(
                 windowUUID: state.windowUUID,
-                topSitesData: sites,
+                topSitesData: filteredSites,
                 numberOfRows: state.numberOfRows,
-                numberOfTilesPerRow: state.numberOfTilesPerRow,
-                shouldShowSection: !sites.isEmpty && state.shouldShowSection
+                numberOfTilesPerRow: numberOfTilesPerRow,
+                shouldShowSection: !filteredSites.isEmpty && state.shouldShowSection
             )
         case TopSitesActionType.updatedNumberOfRows:
             guard let topSitesAction = action as? TopSitesAction,
@@ -74,9 +75,10 @@ struct TopSitesSectionState: StateType, Equatable {
                 return defaultState(from: state)
             }
 
+            let filteredSites = filter(sites: state.topSitesData, with: numberOfRows, and: state.numberOfTilesPerRow)
             return TopSitesSectionState(
                 windowUUID: state.windowUUID,
-                topSitesData: state.topSitesData,
+                topSitesData: filteredSites,
                 numberOfRows: numberOfRows,
                 numberOfTilesPerRow: state.numberOfTilesPerRow,
                 shouldShowSection: state.shouldShowSection
@@ -88,9 +90,10 @@ struct TopSitesSectionState: StateType, Equatable {
                 return defaultState(from: state)
             }
 
+            let filteredSites = filter(sites: state.topSitesData, with: state.numberOfRows, and: numberOfTilesPerRow)
             return TopSitesSectionState(
                 windowUUID: state.windowUUID,
-                topSitesData: state.topSitesData,
+                topSitesData: filteredSites,
                 numberOfRows: state.numberOfRows,
                 numberOfTilesPerRow: numberOfTilesPerRow,
                 shouldShowSection: state.shouldShowSection
@@ -112,6 +115,20 @@ struct TopSitesSectionState: StateType, Equatable {
         default:
             return defaultState(from: state)
         }
+    }
+
+    /// Filters the top sites to be displayed in the view based on user preferences and layout configuration.
+    /// - Parameters:
+    ///   - sites: The full list of sites fetched from the top sites manager.
+    ///   - numberOfRows: The maximum number of rows to display, determined by user preferences or default value.
+    ///   - numberOfTilesPerRow: The number of tiles displayed per row, determined by the view's layout.
+    /// - Returns: A list of top sites to be displayed, limited to the specified number of rows and tiles per row.
+    private static func filter(
+        sites: [TopSiteState],
+        with numberOfRows: Int,
+        and numberOfTilesPerRow: Int
+    ) -> [TopSiteState] {
+        return Array(sites.prefix(numberOfRows * numberOfTilesPerRow))
     }
 
     static func defaultState(from state: TopSitesSectionState) -> TopSitesSectionState {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/ContextMenu/ContextMenuConfigurationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/ContextMenu/ContextMenuConfigurationTests.swift
@@ -61,7 +61,7 @@ final class ContextMenuConfigurationTests: XCTestCase {
             ), nil
         )
         let subject = ContextMenuConfiguration(
-            homepageSection: .topSites,
+            homepageSection: .topSites(4),
             item: topSiteItem,
             toastContainer: UIView()
         )
@@ -71,7 +71,7 @@ final class ContextMenuConfigurationTests: XCTestCase {
 
     func tests_initialState_forNoItem_returnsExpectedState() {
         let subject = ContextMenuConfiguration(
-            homepageSection: .topSites,
+            homepageSection: .topSites(4),
             item: nil,
             toastContainer: UIView()
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -94,7 +94,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         let updatedState = HomepageState.reducer(
             state,
             TopSitesAction(
-                numberOfRows: 4,
+                numberOfRows: 2,
                 windowUUID: .XCTestDefaultUUID,
                 actionType: TopSitesActionType.updatedNumberOfRows
             )
@@ -112,8 +112,8 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.updateSnapshot(state: finalState)
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfItems(inSection: .topSites), 16)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites, .customizeHomepage])
+        XCTAssertEqual(snapshot.numberOfItems(inSection: .topSites(4)), 8)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites(4), .customizeHomepage])
     }
 
     func test_updateSnapshot_withValidState_returnPocketStories() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -187,7 +187,8 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
             overlayManager: mockOverlayManager,
             statusBarScrollDelegate: statusBarScrollDelegate,
             toastContainer: UIView(),
-            notificationCenter: notificationCenter
+            notificationCenter: notificationCenter,
+            mainQueue: MockDispatchQueue()
         )
         trackForMemoryLeaks(homepageViewController)
         return homepageViewController

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
@@ -27,7 +27,11 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
     func test_homepageInitializeAction_returnsTopSitesSection() throws {
         let subject = createSubject(topSitesManager: mockTopSitesManager)
-        let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
+        let action = HomepageAction(
+            numberOfTilesPerRow: 4,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
 
         let expectation = XCTestExpectation(description: "All relevant top sites middleware actions are dispatched")
         expectation.expectedFulfillmentCount = 3
@@ -46,15 +50,21 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
         let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
+        let numberOfTilesPerRow = try XCTUnwrap(actionsCalled.compactMap { $0.numberOfTilesPerRow } as? [Int])
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 3)
         XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites, .retrievedUpdatedSites])
+        XCTAssertEqual(numberOfTilesPerRow, [4, 4, 4])
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 
     func test_fetchTopSitesAction_returnsTopSitesSection() throws {
         let subject = createSubject(topSitesManager: mockTopSitesManager)
-        let action = TopSitesAction(windowUUID: .XCTestDefaultUUID, actionType: TopSitesActionType.fetchTopSites)
+        let action = TopSitesAction(
+            numberOfTilesPerRow: 4,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TopSitesActionType.fetchTopSites
+        )
 
         let expectation = XCTestExpectation(description: "All top sites middleware actions are dispatched")
         expectation.expectedFulfillmentCount = 3
@@ -73,9 +83,11 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
         let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
+        let numberOfTilesPerRow = try XCTUnwrap(actionsCalled.compactMap { $0.numberOfTilesPerRow } as? [Int])
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 3)
         XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites, .retrievedUpdatedSites])
+        XCTAssertEqual(numberOfTilesPerRow, [4, 4, 4])
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
@@ -66,6 +66,27 @@ final class TopsSitesSectionStateTests: XCTestCase {
         XCTAssertEqual(newState.topSitesData.compactMap { $0.title }, [])
     }
 
+    func test_retrievedUpdatedStoriesAction_withNumberOfTilesPerRow_returnsDefaultState() throws {
+        let initialState = createSubject()
+        let reducer = topSiteReducer()
+
+        let exampleTopSites = createSites(count: 15)
+
+        let newState = reducer(
+            initialState,
+            TopSitesAction(
+                topSites: exampleTopSites,
+                numberOfTilesPerRow: 1,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: TopSitesMiddlewareActionType.retrievedUpdatedSites
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.topSitesData.count, 2)
+        XCTAssertEqual(newState.topSitesData.compactMap { $0.title }, ["Title 0", "Title 1"])
+    }
+
     func test_updatedNumberOfRows_returnsExpectedState() throws {
         let initialState = createSubject()
         let reducer = topSiteReducer()
@@ -145,5 +166,15 @@ final class TopsSitesSectionStateTests: XCTestCase {
 
     private func defaultState(with state: TopSitesSectionState) -> TopSitesSectionState {
         return TopSitesSectionState.defaultState(from: state)
+    }
+
+    private func createSites(count: Int = 30) -> [TopSiteState] {
+        var sites = [TopSiteState]()
+        (0..<count).forEach {
+            let site = Site(url: "www.url\($0).com",
+                            title: "Title \($0)")
+            sites.append(TopSiteState(site: site))
+        }
+        return sites
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesDimensionImplementationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesDimensionImplementationTests.swift
@@ -13,18 +13,6 @@ class TopSitesDimensionImplementationTests: XCTestCase {
             static let iPadAir = CGSize(width: 820, height: 1180)
             static let iPadAirCompactSplit = CGSize(width: 320, height: 375)
         }
-
-        static let cellWidth = HomepageSectionLayoutProvider.UX.TopSitesConstants.cellEstimatedSize.width
-    }
-
-    override func setUp() {
-        super.setUp()
-        DependencyHelperMock().bootstrapDependencies()
-    }
-
-    override func tearDown() {
-        DependencyHelperMock().reset()
-        super.tearDown()
     }
 
     func test_getNumberOfTilesPerRow_withPortraitIphone_showsExpectedRowNumber() {
@@ -34,8 +22,7 @@ class TopSitesDimensionImplementationTests: XCTestCase {
 
         let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPhone14.width,
-            leadingInset: leadingInset,
-            cellWidth: UX.cellWidth
+            leadingInset: leadingInset
         )
 
         XCTAssertEqual(numberOfTilesPerRow, 4)
@@ -48,8 +35,7 @@ class TopSitesDimensionImplementationTests: XCTestCase {
 
         let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPhone14.height,
-            leadingInset: leadingInset,
-            cellWidth: UX.cellWidth
+            leadingInset: leadingInset
         )
 
         XCTAssertEqual(numberOfTilesPerRow, 8)
@@ -62,8 +48,7 @@ class TopSitesDimensionImplementationTests: XCTestCase {
 
         let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPadAir.width,
-            leadingInset: leadingInset,
-            cellWidth: UX.cellWidth
+            leadingInset: leadingInset
         )
 
         XCTAssertEqual(numberOfTilesPerRow, 7)
@@ -76,8 +61,7 @@ class TopSitesDimensionImplementationTests: XCTestCase {
 
         let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPadAir.height,
-            leadingInset: leadingInset,
-            cellWidth: UX.cellWidth
+            leadingInset: leadingInset
         )
 
         XCTAssertEqual(numberOfTilesPerRow, 10)
@@ -90,8 +74,7 @@ class TopSitesDimensionImplementationTests: XCTestCase {
 
         let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPadAirCompactSplit.width,
-            leadingInset: leadingInset,
-            cellWidth: UX.cellWidth
+            leadingInset: leadingInset
         )
 
         XCTAssertEqual(numberOfTilesPerRow, 4)
@@ -104,17 +87,14 @@ class TopSitesDimensionImplementationTests: XCTestCase {
 
         let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPadAirCompactSplit.height,
-            leadingInset: leadingInset,
-            cellWidth: UX.cellWidth
+            leadingInset: leadingInset
         )
 
         XCTAssertEqual(numberOfTilesPerRow, 4)
     }
 
     func createSubject() -> TopSitesDimensionImplementation {
-        let subject = TopSitesDimensionImplementation(windowUUID: .XCTestDefaultUUID)
-        trackForMemoryLeaks(subject)
-
+        let subject = TopSitesDimensionImplementation()
         return subject
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesDimensionImplementationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesDimensionImplementationTests.swift
@@ -7,8 +7,6 @@ import XCTest
 @testable import Client
 
 class TopSitesDimensionImplementationTests: XCTestCase {
-    private var dispatchQueue: MockDispatchQueue!
-
     struct UX {
         struct DeviceSize {
             static let iPhone14 = CGSize(width: 390, height: 844)
@@ -22,11 +20,9 @@ class TopSitesDimensionImplementationTests: XCTestCase {
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
-        dispatchQueue = MockDispatchQueue()
     }
 
     override func tearDown() {
-        dispatchQueue = nil
         DependencyHelperMock().reset()
         super.tearDown()
     }
@@ -116,7 +112,7 @@ class TopSitesDimensionImplementationTests: XCTestCase {
     }
 
     func createSubject() -> TopSitesDimensionImplementation {
-        let subject = TopSitesDimensionImplementation(windowUUID: .XCTestDefaultUUID, queue: dispatchQueue)
+        let subject = TopSitesDimensionImplementation(windowUUID: .XCTestDefaultUUID)
         trackForMemoryLeaks(subject)
 
         return subject


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10972)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23958)

## :bulb: Description
An improvement to the workaround fix `queue.async` that resolved a crash that occurred when rotating the device from portrait to landscape. Now, we only dispatch an action when the `viewWillTransition`. This align more with the intended behavior and removes the need for `TopSitesDimensionImplementation` to know about this.

Also moves the calculation for filtering the topsites from diffable datasource into the state.

Adds `numberOfTilesPerRow` payload to HomepageAction so that it can be pass through the middleware as well during initial load.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
**iPhone**

https://github.com/user-attachments/assets/c3ec1f24-862c-4430-af7d-0a3e1b32f34e

**iPad**

https://github.com/user-attachments/assets/ed5080a5-62b5-409c-b953-dd1acc1b755a
