### PR TITLE
Bugfix FXIOS-10916 Fix race condition crash during tab restore

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -100,8 +100,11 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
     private func migrateAndRestore() {
         Task {
             await buildTabRestore(window: await tabMigration.runMigration(for: windowUUID))
-            logger.log("Tabs restore ended after migration", level: .debug, category: .tabs)
-            logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)
+            Task { @MainActor in
+                // Log on main thread, where computed `tab` properties can be accessed without risk of races
+                logger.log("Tabs restore ended after migration", level: .debug, category: .tabs)
+                logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)
+            }
         }
     }
 
@@ -111,8 +114,11 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
             // Only attempt a tab data store fetch if we know we should have tabs on disk (ignore new windows)
             let windowData: WindowData? = windowIsNew ? nil : await self.tabDataStore.fetchWindowData(uuid: windowUUID)
             await buildTabRestore(window: windowData)
-            logger.log("Tabs restore ended after fetching window data", level: .debug, category: .tabs)
-            logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)
+            Task { @MainActor in
+                // Log on main thread, where computed `tab` properties can be accessed without risk of races
+                logger.log("Tabs restore ended after fetching window data", level: .debug, category: .tabs)
+                logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)
+            }
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10916)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23856)

## :bulb: Description

Speculative fix for Sentry crash. From the stacktrace it's clear that our `restoreOnly()` code is running in the crashed background thread while on the main thread the app is handling a route for an incoming link. There are a couple related issues here: 1. our various tab properties (e.g. normalTabs or inactiveTabs, which are based on the underlying `tabs`) are not thread-safe, and even logging those from a background thread can be problematic 2. we shouldn't actually be processing an incoming link if we are in the midst of tab restoration.

There are some larger architectural concerns around some of this that I'm hoping to raise with the team soon, however in the meantime this fix should be low-risk and low-impact.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

