### PR TITLE
Revert "Bugfix Disable testSSL for smoketest4 (temporary)"

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
@@ -106,7 +106,6 @@
         "NavigationTest\/testOpenExternalLink()",
         "NavigationTest\/testOpenInNewPrivateTab()",
         "NavigationTest\/testOpenInNewTab()",
-        "NavigationTest\/testSSL()",
         "NavigationTest\/testScrollsToTopWithMultipleTabs()",
         "NavigationTest\/testShareLink()",
         "NavigationTest\/testShareLinkPrivateMode()",


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#24022

badssl site should be up now.