### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Enable implicitly_unwrapped_optional rule but keep it disabled for test files using nested Swiftlint configurations

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -86,6 +86,7 @@ only_rules: # Only enforce these rules, ignore all others
   - accessibility_trait_for_button
   - force_cast
   - closure_body_length
+  - implicitly_unwrapped_optional
 
 # These rules were originally opted into. Disabling for now to get
 # Swiftlint up and running.

--- a/BrowserKit/Tests/.swiftlint.yml
+++ b/BrowserKit/Tests/.swiftlint.yml
@@ -1,0 +1,9 @@
+# Swiftlint configuration overloads that will be applied to all files
+# in this folder and all its children recursively, unless another
+# nested configuration takes over.
+# https://github.com/realm/SwiftLint#nested-configurations.
+
+disabled_rules:
+  # Many test use implicitly unwrapped optional properties that 
+  # initialized in setUp and reset in tearDown.
+  - implicitly_unwrapped_optional

--- a/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
+++ b/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
@@ -7,15 +7,15 @@ import WebEngine
 
 struct EngineProvider {
     // We only have one session in the SampleBrowser
-    private(set) var session: EngineSession?
+    private(set) var session: EngineSession
     let view: EngineView
 
-    init(engine: Engine = WKEngine.factory(),
-         sessionDependencies: EngineSessionDependencies? = nil) {
+    init?(engine: Engine = WKEngine.factory(),
+          sessionDependencies: EngineSessionDependencies? = nil) {
         do {
             session = try engine.createSession(dependencies: sessionDependencies)
         } catch {
-            session = nil
+            return nil
         }
 
         view = engine.createView()

--- a/SampleBrowser/SampleBrowser/SceneDelegate.swift
+++ b/SampleBrowser/SampleBrowser/SceneDelegate.swift
@@ -8,7 +8,7 @@ import WebEngine
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
-    var engineProvider: EngineProvider = {
+    var engineProvider: EngineProvider? = {
         let dependencies = EngineSessionDependencies(telemetryProxy: TelemetryHandler())
         return EngineProvider(sessionDependencies: dependencies)
     }()
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,
                options connectionOptions: UIScene.ConnectionOptions) {
-        guard let windowScene = (scene as? UIWindowScene) else { return }
+        guard let windowScene = (scene as? UIWindowScene), let engineProvider else { return }
         let windowUUID = UUID()
         let baseViewController = RootViewController(engineProvider: engineProvider, windowUUID: windowUUID)
         window = UIWindow(windowScene: windowScene)

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -21,7 +21,7 @@ class BrowserViewController: UIViewController,
                              FindInPageHelperDelegate {
     weak var navigationDelegate: NavigationDelegate?
     private lazy var progressView: UIProgressView = .build { _ in }
-    private var engineSession: EngineSession!
+    private var engineSession: EngineSession
     private var engineView: EngineView
     private let urlFormatter: URLFormatter
 
@@ -203,7 +203,7 @@ class BrowserViewController: UIViewController,
         guard let url = linkURL else { return nil }
 
         let previewProvider: UIContextMenuContentPreviewProvider = {
-            let previewEngineProvider = EngineProvider()
+            guard let previewEngineProvider = EngineProvider() else { return nil }
             let previewVC = BrowserViewController(engineProvider: previewEngineProvider)
             previewVC.engineSession.load(url: url.absoluteString)
             return previewVC

--- a/SampleBrowser/SampleBrowser/UI/Suggestion/SuggestionViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Suggestion/SuggestionViewController.swift
@@ -10,7 +10,7 @@ protocol SuggestionViewControllerDelegate: AnyObject {
 
 class SuggestionViewController: UIViewController, UITableViewDelegate {
     private var tableView: UITableView
-    private var dataSource: SuggestionDataSource!
+    private var dataSource: SuggestionDataSource?
     private weak var delegate: SuggestionViewControllerDelegate?
 
     private var gradientLayer: CAGradientLayer?
@@ -87,14 +87,14 @@ class SuggestionViewController: UIViewController, UITableViewDelegate {
 
     func updateUI(for suggestions: [String]) {
         tableView.isHidden = suggestions.isEmpty
-        dataSource.suggestions = suggestions
+        dataSource?.suggestions = suggestions
         tableView.reloadData()
     }
 
     // MARK: - UITableViewDelegate
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let term = dataSource.suggestions[indexPath.row]
+        guard let term = dataSource?.suggestions[indexPath.row] else { return }
         delegate?.tapOnSuggestion(term: term)
     }
 }

--- a/SampleComponentLibraryApp/SampleComponentLibraryApp/BottomSheet/BottomSheetChildViewController.swift
+++ b/SampleComponentLibraryApp/SampleComponentLibraryApp/BottomSheet/BottomSheetChildViewController.swift
@@ -25,8 +25,6 @@ class BottomSheetChildViewController: UIViewController, BottomSheetChild, Themea
         label.numberOfLines = 0
     }
 
-    private var heightConstraint: NSLayoutConstraint!
-
     init(themeManager: ThemeManager = AppContainer.shared.resolve()) {
         self.themeManager = themeManager
         super.init(nibName: nil, bundle: nil)

--- a/firefox-ios/firefox-ios-tests/Tests/.swiftlint.yml
+++ b/firefox-ios/firefox-ios-tests/Tests/.swiftlint.yml
@@ -1,0 +1,9 @@
+# Swiftlint configuration overloads that will be applied to all files
+# in this folder and all its children recursively, unless another
+# nested configuration takes over.
+# https://github.com/realm/SwiftLint#nested-configurations.
+
+disabled_rules:
+  # Many test use implicitly unwrapped optional properties that 
+  # initialized in setUp and reset in tearDown.
+  - implicitly_unwrapped_optional

--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -14,4 +14,5 @@ disabled_rules:
   - attributes
   - trailing_whitespace
   - vertical_whitespace
+  - implicitly_unwrapped_optional
   


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10205)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22337)

## :bulb: Description

Now that all `implicitly_unwrapped_optional` violations in source files are resolved (still waiting on #23809 and #23880 to be merged), enable the rule in the Swiftlint configuration.

Since most of the test files use implicitly unwrapped optional properties that are initialized in `setUp` and reset in `tearDown`, we would like not to enable this rule for test files. An approach is to use Swiftlint [nested configurations](https://github.com/realm/SwiftLint#nested-configurations) by adding additional `.swiftlint.yml` files that can alter the global configuration for subfolders (in this case, disable `implicitly_unwrapped_optional` for `Tests` folders).

Nested configurations cannot be used together with the `--config` option to point to the Swiftlint config file, so the workaround is to navigate to the directory containing the config before running `swiftlint` in the build phase.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

