### PR TITLE
Bugfix FXIOS-10981 Focus: allow manual run of l10n import workflow

### DIFF
--- a/.github/workflows/focus-ios-import-strings.yml
+++ b/.github/workflows/focus-ios-import-strings.yml
@@ -7,6 +7,7 @@ permissions:
 on:
   schedule:
     - cron: '0 10 * * 1'
+  workflow_dispatch: {}
 
 jobs:
   build:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10981)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23981)

## :bulb: Description
Allow running the l10n import workflow manually for Focus (that's already possible for Firefox).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
