### PR TITLE
Add FXIOS-10611 [Homepage] Confirm layout configuration for homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Header/HeaderState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Header/HeaderState.swift
@@ -7,27 +7,27 @@ import Foundation
 import Redux
 
 /// State for the header cell that is used in the homepage header section
-struct HeaderState: StateType, Equatable {
+struct HeaderState: StateType, Equatable, Hashable {
     var windowUUID: WindowUUID
     var isPrivate: Bool
-    var showPrivateModeToggle: Bool
+    var showiPadSetup: Bool
 
     init(windowUUID: WindowUUID) {
         self.init(
             windowUUID: windowUUID,
             isPrivate: false,
-            showPrivateModeToggle: true
+            showiPadSetup: false
         )
     }
 
     private init(
         windowUUID: WindowUUID,
         isPrivate: Bool,
-        showPrivateModeToggle: Bool
+        showiPadSetup: Bool
     ) {
         self.windowUUID = windowUUID
         self.isPrivate = isPrivate
-        self.showPrivateModeToggle = showPrivateModeToggle
+        self.showiPadSetup = showiPadSetup
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -38,23 +38,45 @@ struct HeaderState: StateType, Equatable {
 
         switch action.actionType {
         case HomepageActionType.initialize:
-            // TODO: FXIOS-10259 - Update with felt privacy feature flags 
-            // or confirm we can remove the showPrivateModeToggle check
-            return HeaderState(
-                windowUUID: state.windowUUID,
-                isPrivate: false,
-                showPrivateModeToggle: true
-            )
+            return handleInitializeAction(for: state, with: action)
+        case HomepageActionType.traitCollectionDidChange:
+            return handleTraitCollectionDidChangeAction(for: state, with: action)
         default:
             return defaultState(from: state)
         }
+    }
+
+    private static func handleInitializeAction(for state: HeaderState, with action: Action) -> HeaderState {
+        guard let homepageAction = action as? HomepageAction,
+              let showiPadSetup = homepageAction.showiPadSetup
+        else {
+            return defaultState(from: state)
+        }
+        return HeaderState(
+            windowUUID: state.windowUUID,
+            isPrivate: false,
+            showiPadSetup: showiPadSetup
+        )
+    }
+
+    private static func handleTraitCollectionDidChangeAction(for state: HeaderState, with action: Action) -> HeaderState {
+        guard let homepageAction = action as? HomepageAction,
+              let showiPadSetup = homepageAction.showiPadSetup
+        else {
+            return defaultState(from: state)
+        }
+        return HeaderState(
+            windowUUID: state.windowUUID,
+            isPrivate: state.isPrivate,
+            showiPadSetup: showiPadSetup
+        )
     }
 
     static func defaultState(from state: HeaderState) -> HeaderState {
         return HeaderState(
             windowUUID: state.windowUUID,
             isPrivate: state.isPrivate,
-            showPrivateModeToggle: state.showPrivateModeToggle
+            showiPadSetup: state.showiPadSetup
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Header/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Header/HomepageHeaderCell.swift
@@ -77,14 +77,13 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable {
 
     func configure(
         headerState: HeaderState,
-        showiPadSetup: Bool,
         action: @escaping () -> Void
     ) {
         self.headerState = headerState
         self.action = action
-        setupView(with: showiPadSetup)
-        logoHeaderCell.configure(with: showiPadSetup)
-        privateModeButton.isHidden = showiPadSetup || !headerState.showPrivateModeToggle
+        setupView(with: headerState.showiPadSetup)
+        logoHeaderCell.configure(with: headerState.showiPadSetup)
+        privateModeButton.isHidden = headerState.showiPadSetup
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -31,7 +31,7 @@ final class HomepageDiffableDataSource:
     }
 
     enum HomeItem: Hashable {
-        case header(TextColor?)
+        case header(HeaderState)
         case topSite(TopSiteState, TextColor?)
         case topSiteEmpty
         case pocket(PocketStoryState)
@@ -54,8 +54,9 @@ final class HomepageDiffableDataSource:
         var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeItem>()
 
         let textColor = state.wallpaperState.wallpaperConfiguration.textColor
+
         snapshot.appendSections([.header])
-        snapshot.appendItems([.header(textColor)], toSection: .header)
+        snapshot.appendItems([.header(state.headerState)], toSection: .header)
 
         if let topSites = getTopSites(with: state.topSitesState, and: textColor) {
             snapshot.appendSections([.topSites])

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -289,7 +289,7 @@ final class HomepageViewController: UIViewController,
             return sectionProvider.createLayoutSection(
                 for: section,
                 with: environment.traitCollection,
-                size: environment.container.effectiveContentSize
+                size: environment.container.contentSize
             )
         }
         return layout

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -103,6 +103,7 @@ final class HomepageViewController: UIViewController,
 
         store.dispatch(
             HomepageAction(
+                showiPadSetup: shouldUseiPadSetup(),
                 windowUUID: windowUUID,
                 actionType: HomepageActionType.initialize
             )
@@ -320,7 +321,7 @@ final class HomepageViewController: UIViewController,
         at indexPath: IndexPath
     ) -> UICollectionViewCell {
         switch item {
-        case .header:
+        case .header(let state):
             guard let headerCell = collectionView?.dequeueReusableCell(
                 cellType: HomepageHeaderCell.self,
                 for: indexPath
@@ -328,10 +329,7 @@ final class HomepageViewController: UIViewController,
                 return UICollectionViewCell()
             }
 
-            headerCell.configure(
-                headerState: homepageState.headerState,
-                showiPadSetup: shouldUseiPadSetup()
-            ) { [weak self] in
+            headerCell.configure(headerState: state) { [weak self] in
                 self?.toggleHomepageMode()
             }
 
@@ -451,6 +449,17 @@ final class HomepageViewController: UIViewController,
         default:
             return nil
         }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        store.dispatch(
+            HomepageAction(
+                showiPadSetup: shouldUseiPadSetup(),
+                windowUUID: windowUUID,
+                actionType: HomepageActionType.traitCollectionDidChange
+            )
+        )
     }
 
     // MARK: Tap Geasutre Recognizer

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -6,11 +6,15 @@ import Common
 import Redux
 
 final class HomepageAction: Action {
-    override init(windowUUID: WindowUUID, actionType: any ActionType) {
+    var showiPadSetup: Bool?
+
+    init(showiPadSetup: Bool? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
+        self.showiPadSetup = showiPadSetup
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 
 enum HomepageActionType: ActionType {
     case initialize
+    case traitCollectionDidChange
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -145,7 +145,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, GeneralBrowserMiddlewareActionType.websiteDidScroll)
     }
 
-    func test_scrollViewWillBeginDragging_triggersHomepageAction() throws {
+    func test_scrollViewWillBeginDragging_triggersToolbarAction() throws {
         let homepageVC = createSubject()
         let scrollView = UIScrollView()
         scrollView.contentOffset.y = 10
@@ -160,6 +160,19 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         )
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
         XCTAssertEqual(actionType, ToolbarActionType.cancelEditOnHomepage)
+    }
+
+    func test_traitCollectionDidChange_triggersHomepageAction() throws {
+        let subject = createSubject()
+        subject.traitCollectionDidChange(nil)
+
+        let actionCalled = try XCTUnwrap(
+            mockStore.dispatchedActions.first(where: { $0 is HomepageAction }) as? HomepageAction
+        )
+        let actionType = try XCTUnwrap(actionCalled.actionType as? HomepageActionType)
+        XCTAssertEqual(actionType, HomepageActionType.traitCollectionDidChange)
+        XCTAssertEqual(actionCalled.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(actionCalled.showiPadSetup ?? true)
     }
 
     private func createSubject(statusBarScrollDelegate: StatusBarScrollDelegate? = nil) -> HomepageViewController {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HeaderStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HeaderStateTests.swift
@@ -13,7 +13,7 @@ final class HeaderStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
         XCTAssertFalse(initialState.isPrivate)
-        XCTAssertTrue(initialState.showPrivateModeToggle)
+        XCTAssertFalse(initialState.showiPadSetup)
     }
 
     func test_initializeAction_returnsExpectedState() {
@@ -23,6 +23,7 @@ final class HeaderStateTests: XCTestCase {
         let newState = reducer(
             initialState,
             HomepageAction(
+                showiPadSetup: true,
                 windowUUID: .XCTestDefaultUUID,
                 actionType: HomepageActionType.initialize
             )
@@ -30,7 +31,25 @@ final class HeaderStateTests: XCTestCase {
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertFalse(newState.isPrivate)
-        XCTAssertTrue(newState.showPrivateModeToggle)
+        XCTAssertTrue(newState.showiPadSetup)
+    }
+
+    func test_initializeAction_withoutIpadSetup_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = headerReducer()
+
+        let newState = reducer(
+            initialState,
+            HomepageAction(
+                showiPadSetup: false,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.initialize
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(newState.isPrivate)
+        XCTAssertFalse(newState.showiPadSetup)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
@@ -24,7 +24,7 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
 
         XCTAssertFalse(initialState.headerState.isPrivate)
-        XCTAssertTrue(initialState.headerState.showPrivateModeToggle)
+        XCTAssertFalse(initialState.headerState.showiPadSetup)
     }
 
     func test_initializeAction_returnsExpectedState() {
@@ -34,15 +34,15 @@ final class HomepageStateTests: XCTestCase {
         let newState = reducer(
             initialState,
             HomepageAction(
+                showiPadSetup: true,
                 windowUUID: .XCTestDefaultUUID,
                 actionType: HomepageActionType.initialize
             )
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-
         XCTAssertFalse(newState.headerState.isPrivate)
-        XCTAssertTrue(newState.headerState.showPrivateModeToggle)
+        XCTAssertTrue(initialState.headerState.showiPadSetup)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
@@ -42,7 +42,7 @@ final class HomepageStateTests: XCTestCase {
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertFalse(newState.headerState.isPrivate)
-        XCTAssertTrue(initialState.headerState.showiPadSetup)
+        XCTAssertTrue(newState.headerState.showiPadSetup)
     }
 
     // MARK: - Private


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10611)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10268)
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10949)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23241)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22483)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23919)

## :bulb: Description
* Confirm homepage layout for the following: iPad (landscape, portrait), iPhone (landscape, portrait), Multi-window (split-screen)
* Move `shouldUseiPad` to HeaderState (address issue#22483) and update value on initial state and when trait Collection changes.
* Fix issue where less top sites are shown than expected (change `effectiveContentSize` to `contentSize`
* Remove `showPrivateModeToggle` since confirm that Felt Privacy feature flag is not needed, so always show toggle

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)


## Screenshots 
| Portrait | Landscape |
| --- | --- |
| ![simulator_screenshot_D3866037-9144-4D4B-8432-94ECF9C83433](https://github.com/user-attachments/assets/43ed7f51-d098-4b6c-bc81-a30481390f08) | ![simulator_screenshot_650CE9D0-E62F-4572-9CDA-B14B18D704C2](https://github.com/user-attachments/assets/c94fbe32-94f6-45a6-b26f-4422165f9964) |
| ![simulator_screenshot_6F83D6C1-91AB-4CF5-AE85-1338B51E7F50](https://github.com/user-attachments/assets/4d3e1d4b-0c99-41b0-bd94-7756e1a3dc45) | ![simulator_screenshot_9EFF53D9-3771-47B6-8A4B-AADCCA341414](https://github.com/user-attachments/assets/afacc03b-6508-4724-a083-b0a49364cfc6)|
| ![simulator_screenshot_A651DFFA-A237-4FCC-BBF2-7C00058E41C4](https://github.com/user-attachments/assets/51897ab6-4b08-41f5-ac01-a299b6684c7b) | ![simulator_screenshot_55CF3334-604B-4574-91B6-643E4B7CC410](https://github.com/user-attachments/assets/1a05cb1f-f5e9-4446-8073-eaa3aced9aa1)|