### PR TITLE
Bugfix FXIOS-11006 #24039 KVO deinit TabScrollController crashes

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController.swift
@@ -146,7 +146,7 @@ class TabScrollingController: NSObject,
 
     deinit {
         logger.log("TabScrollController deallocating", level: .info, category: .lifecycle)
-        observedScrollViews.forEach({ stopObserving(scrollView: $0) })
+        observedScrollViews.compactMap { $0 }.forEach { stopObserving(scrollView: $0) }
         guard let themeObserver else { return }
         notificationCenter.removeObserver(themeObserver)
     }
@@ -277,9 +277,9 @@ class TabScrollingController: NSObject,
         scrollView.addObserver(self, forKeyPath: KVOConstants.contentSize.rawValue, options: .new, context: nil)
     }
 
-    func stopObserving(scrollView: UIScrollView) {
-        guard observedScrollViews.contains(scrollView) else {
-            logger.log("Duplicate KVO de-registration for scroll view", level: .warning, category: .webview)
+    func stopObserving(scrollView: UIScrollView?) {
+        guard let scrollView = scrollView, observedScrollViews.contains(scrollView) else {
+            logger.log("Duplicate KVO de-registration or nil scrollView", level: .warning, category: .webview)
             return
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11006)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24039)

## :bulb: Description
Just wanted to add some safeguard around this code since it seems to be the highest crash in Sentry. Changes are minimal, and it shouldn't hurt the code.
- Before calling `removeObserver(_:forKeyPath:)`, let's ensure the scrollView object is not nil since it's a possibility. 
- Use `compactMap` instead of `forEach` in `deinit` to access valid references

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

