### PR TITLE
Bugfix FXIOS-11007 #24042 Crash during deinit of a window trying to refresh tabs

### DIFF
--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -35,7 +35,8 @@ protocol WindowManager {
     /// Convenience. Returns the TabManager for a specific window.
     func tabManager(for windowUUID: WindowUUID) -> TabManager
 
-    /// Convenience. Returns the TabManager for a specific window but in a safe way as it can be deinit for that particular window.
+    /// Convenience. Returns the TabManager for a specific window but in a safe way as it can be deinit
+    /// for that particular window.
     func safeTabManager(for windowUUID: WindowUUID) -> TabManager?
 
     /// Convenience. Returns all TabManagers for all open windows.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11007)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24042)

## :bulb: Description
This particular crash occurs during the deinit of a window. `applicationDidEnterBackground` and `SceneDelegate: scene did disconnect` are both called before the crash occurs. A Redux event to update the `tabPanelDidLoad` is fired after the deinit of the window was started, which triggers a `refreshTabs` to be called in the `TabManagerMiddleware`.

I guess the root cause is that the Redux event shouldn't be fired at that point(?). We should unsubscribe from the redux events and not be calling UI updates for that window. The `showScreen` redux action is called right before the `tabPanelDidLoad` redux action (see screenshot of breadcrumbs). We call those from the `TabDisplayPanelViewController.subscribeToRedux`, (note that `TabDisplayPanelViewController` is called `TabDisplayPanel` in previous version). I am not sure why we are showing that VC and subscribing to redux at that point since when we are in fact deinitializing the window and calling `dismissChildTabTrayPanels`. You might have some insights here!
![Screenshot 2025-01-08 at 12 21 48 PM](https://github.com/user-attachments/assets/8c6c0117-7fe6-4fbe-a578-52418bbb23be)

As a workaround for this crash, I think we could add a way to safely check that the `tabManager` is present to do the UI method to `refreshTabs`. If there's no tab manager, we shouldn't try to do UI update. The change is localized and small, so it feels safe to try, although it is a patch, so I am really looking here for feedback (and keeping this in draft for now). You might have some ideas already on how to solve this issue in a more elegant way :) ! 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

