### PR TITLE
Add FXIOS-10928 [Bookmarks Evolution] Last Viewed Bookmarks Folder Persists Across App Sessions

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -202,6 +202,11 @@ public struct PrefsKeys {
     // The guid of the bookmark folder that was most recently created or saved to by the user.
     // Used to indicate where we should save the next bookmark by default.
     public static let RecentBookmarkFolder = "RecentBookmarkFolder"
+
+    // The guid of the bookmark folder that was last viewed.
+    // Used to indicate which folder should be opened across app sessions.
+    public static let LastViewedBookmarkFolder = "LastViewedBookmarkFolder"
+
     // Represents whether or not the bookmark refactor feature flag is enabled
     // Used in the share extension
     public static let IsBookmarksRefactorEnabled = "IsBookmarksRefactorEnabled"

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -7,7 +7,7 @@ import Common
 import MozillaAppServices
 
 protocol BookmarksCoordinatorDelegate: AnyObject, LibraryPanelCoordinatorDelegate {
-    func start(from folder: FxBookmarkNode)
+    func start(fromGUID folderGUID: String, animated: Bool)
 
     /// Shows the bookmark detail to modify a bookmark folder
     func showBookmarkDetail(for node: FxBookmarkNode, folder: FxBookmarkNode, completion: (() -> Void)?)
@@ -75,10 +75,10 @@ class BookmarksCoordinator: BaseCoordinator,
 
     // MARK: - BookmarksCoordinatorDelegate
 
-    func start(from folder: FxBookmarkNode) {
+    func start(fromGUID folderGUID: String, animated: Bool = true) {
         let viewModel = BookmarksPanelViewModel(profile: profile,
                                                 bookmarksHandler: profile.places,
-                                                bookmarkFolderGUID: folder.guid)
+                                                bookmarkFolderGUID: folderGUID)
         if isBookmarkRefactorEnabled {
             let controller = BookmarksViewController(viewModel: viewModel, windowUUID: windowUUID)
             controller.bookmarkCoordinatorDelegate = self

--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -131,7 +131,7 @@ protocol NewJSPromptAlertControllerDelegate: AnyObject {
 class NewJSPromptAlertController: UIAlertController {
     var alertInfo: NewJSAlertInfo?
     weak var delegate: NewJSPromptAlertControllerDelegate?
-    private var handledAction: Bool = false
+    private var handledAction = false
     private var dismissalResult: Any?
 
     convenience init(

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -137,6 +137,11 @@ class BookmarksViewController: SiteTableViewController,
         setupEmptyStateView()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        profile.prefs.setString(viewModel.bookmarkFolderGUID, forKey: PrefsKeys.LastViewedBookmarkFolder)
+    }
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
@@ -453,7 +458,7 @@ class BookmarksViewController: SiteTableViewController,
             libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .bookmark)
         } else {
             guard let folder = bookmarkCell as? FxBookmarkNode else { return }
-            bookmarkCoordinatorDelegate?.start(from: folder)
+            bookmarkCoordinatorDelegate?.start(fromGUID: folder.guid, animated: true)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
@@ -396,7 +396,7 @@ class LegacyBookmarksPanel: SiteTableViewController,
             libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .bookmark)
         } else {
             guard let folder = bookmarkCell as? FxBookmarkNode else { return }
-            bookmarkCoordinatorDelegate?.start(from: folder)
+            bookmarkCoordinatorDelegate?.start(fromGUID: folder.guid, animated: true)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
@@ -37,7 +37,7 @@ final class BookmarksCoordinatorTests: XCTestCase {
         let subject = createSubject()
         let folder = LocalDesktopFolder()
 
-        subject.start(from: folder)
+        subject.start(fromGUID: folder.guid, animated: true)
 
         XCTAssertTrue(router.pushedViewController is LegacyBookmarksPanel)
         XCTAssertEqual(router.pushCalled, 1)
@@ -77,7 +77,7 @@ final class BookmarksCoordinatorTests: XCTestCase {
         let subject = createSubject(isBookmarkRefactorEnabled: true)
         let folder = LocalDesktopFolder()
 
-        subject.start(from: folder)
+        subject.start(fromGUID: folder.guid, animated: true)
 
         XCTAssertTrue(router.pushedViewController is BookmarksViewController)
         XCTAssertEqual(router.pushCalled, 1)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10928)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23874)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
After entering a bookmarks folder in the as you view the bookmarks panel, you can now close the app and will be shown the same folder upon re-entering the bookmarks panel

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

