### PR TITLE
Remove additional applinks and add applink info to plist

### DIFF
--- a/firefox-ios/Client/Entitlements/FirefoxApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FirefoxApplication.entitlements
@@ -10,9 +10,7 @@
 	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:*.mozilla.org</string>
 		<string>applinks:blog.mozilla.org</string>
-		<string>applinks:mozilla.org</string>
 	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>

--- a/firefox-ios/Client/Entitlements/FirefoxBetaApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FirefoxBetaApplication.entitlements
@@ -6,9 +6,7 @@
 	<string>production</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:*.mozilla.org</string>
 		<string>applinks:blog.mozilla.org</string>
-		<string>applinks:mozilla.org</string>
 	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:blog.mozilla.org?mode=developer</string>
+		<string>applinks:blog.mozilla.org</string>
 	</array>
 	<key>AdjustAppToken</key>
 	<string>$(ADJUST_APP_TOKEN)</string>

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:blog.mozilla.org?mode=developer</string>
+	</array>
 	<key>AdjustAppToken</key>
 	<string>$(ADJUST_APP_TOKEN)</string>
 	<key>AppIdentifierPrefix</key>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10299)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Based on call with apple we want to make some updates to our entitlements:
- Remove all but blog.mozilla.org from the list of applinks. We only need the subdomain since that is where our AASA file is hosted.
- Add associated domains information to the plist file. This is redundant but will confirm we have all our bases covered

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

