### PR TITLE
Bugfix FXIOS-10898 [Bookmarks Evolution] Inconsistent bookmarks ordering

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
@@ -23,6 +23,7 @@ class BookmarksPanelViewModel: BookmarksRefactorFeatureFlagProvider {
     let bookmarkFolderGUID: GUID
     var bookmarkFolder: FxBookmarkNode?
     var bookmarkNodes = [FxBookmarkNode]()
+    private var hasDesktopFolders = false
     private var bookmarksHandler: BookmarksHandler
     private var flashLastRowOnNextReload = false
     private var logger: Logger
@@ -90,7 +91,7 @@ class BookmarksPanelViewModel: BookmarksRefactorFeatureFlagProvider {
     /// we need to account for this when saving bookmark index in A-S. This is done by subtracting
     /// the Local Desktop Folder number of rows it takes to the actual index.
     func getNewIndex(from index: Int) -> Int {
-        guard bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID else {
+        guard bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID, hasDesktopFolders else {
             return index
         }
 
@@ -120,8 +121,11 @@ class BookmarksPanelViewModel: BookmarksRefactorFeatureFlagProvider {
                     switch result {
                     case .success(let bookmarkCount):
                             if bookmarkCount > 0 || !self.isBookmarkRefactorEnabled {
+                                self.hasDesktopFolders = true
                                 let desktopFolder = LocalDesktopFolder()
                                 self.bookmarkNodes.insert(desktopFolder, at: 0)
+                            } else {
+                                self.hasDesktopFolders = false
                             }
                     case .failure(let error):
                             self.logger.log("Error counting bookmarks: \(error)", level: .debug, category: .library)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
@@ -91,8 +91,9 @@ class BookmarksPanelViewModel: BookmarksRefactorFeatureFlagProvider {
     /// we need to account for this when saving bookmark index in A-S. This is done by subtracting
     /// the Local Desktop Folder number of rows it takes to the actual index.
     func getNewIndex(from index: Int) -> Int {
-        guard bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID, hasDesktopFolders else {
-            return index
+        guard bookmarkFolderGUID == BookmarkRoots.MobileFolderGUID, isBookmarkRefactorEnabled ?
+                                                                    hasDesktopFolders : true else {
+            return max(index, 0)
         }
 
         // Ensure we don't return lower than 0

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
@@ -87,31 +87,10 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
         featureFlags.set(feature: .bookmarksRefactor, to: true)
         let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
 
-        let expectation = expectation(description: "Subject reloaded")
-
-        profile.places.createBookmark(
-            parentGUID: BookmarkRoots.MenuFolderGUID,
-            url: "https://www.firefox.com",
-            title: "Firefox",
-            position: 0
-        ).uponQueue(.main) { _ in
-            self.profile.places.countBookmarksInTrees(folderGuids: [BookmarkRoots.MenuFolderGUID]) { result in
-                switch result {
-                case .success(let bookmarkCount):
-                        XCTAssertEqual(bookmarkCount, 1, "Menu folder contains one bookmark")
-
-                        subject.reloadData {
-                            XCTAssertNotNil(subject.bookmarkFolder)
-                            XCTAssertEqual(subject.bookmarkNodes.count, 1, "Mobile folder contains the local desktop folder")
-                            expectation.fulfill()
-                        }
-                case .failure(let error):
-                        XCTFail("Failed to count bookmarks: \(error)")
-                        expectation.fulfill()
-                }
-            }
+        createDesktopBookmark(subject: subject) {
+            XCTAssertNotNil(subject.bookmarkFolder)
+            XCTAssertEqual(subject.bookmarkNodes.count, 1, "Mobile folder contains the local desktop folder")
         }
-        waitForExpectations(timeout: 5)
     }
 
     func testShouldReload_whenLocalDesktopFolder() {
@@ -152,7 +131,7 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
 
     func testMoveRowAtGetNewIndex_NotMobileGuid_minusIndex() {
         let subject = createSubject(guid: BookmarkRoots.MenuFolderGUID)
-        let expectedIndex = -1
+        let expectedIndex = 0
         let index = subject.getNewIndex(from: expectedIndex)
         XCTAssertEqual(index, expectedIndex)
     }
@@ -181,6 +160,60 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
         let index = subject.getNewIndex(from: 5)
         XCTAssertEqual(index, 4)
     }
+
+    func testMoveRowAtGetNewIndex_MobileGuid_showingDesktopFolder_zeroIndex_bookmarksRefactor() {
+        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
+        featureFlags.set(feature: .bookmarksRefactor, to: true)
+
+        createDesktopBookmark(subject: subject) {
+            let index = subject.getNewIndex(from: 0)
+            XCTAssertEqual(index, 0)
+        }
+    }
+
+    func testMoveRowAtGetNewIndex_MobileGuid_showingDesktopFolder_minusIndex_bookmarksRefactor() {
+        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
+        featureFlags.set(feature: .bookmarksRefactor, to: true)
+
+        createDesktopBookmark(subject: subject) {
+            let index = subject.getNewIndex(from: -1)
+            XCTAssertEqual(index, 0)
+        }
+    }
+
+    func testMoveRowAtGetNewIndex_MobileGuid_showingDesktopFolder_atFive_bookmarksRefactor() {
+        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
+        featureFlags.set(feature: .bookmarksRefactor, to: true)
+
+        createDesktopBookmark(subject: subject) {
+            let index = subject.getNewIndex(from: 5)
+            XCTAssertEqual(index, 4)
+        }
+    }
+
+    func testMoveRowAtGetNewIndex_MobileGuid_hidingDesktopFolder_zeroIndex_bookmarksRefactor() {
+        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
+        featureFlags.set(feature: .bookmarksRefactor, to: true)
+
+        let index = subject.getNewIndex(from: 0)
+        XCTAssertEqual(index, 0)
+    }
+
+    func testMoveRowAtGetNewIndex_MobileGuid_hidingDesktopFolder_minusIndex_bookmarksRefactor() {
+        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
+        featureFlags.set(feature: .bookmarksRefactor, to: true)
+
+        let index = subject.getNewIndex(from: -1)
+        XCTAssertEqual(index, 0)
+    }
+
+    func testMoveRowAtGetNewIndex_MobileGuid_hidingDesktopFolder_atFive_bookmarksRefactor() {
+        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
+        featureFlags.set(feature: .bookmarksRefactor, to: true)
+
+        let index = subject.getNewIndex(from: 5)
+        XCTAssertEqual(index, 4)
+    }
 }
 
 extension BookmarksPanelViewModelTests {
@@ -199,6 +232,32 @@ extension BookmarksPanelViewModelTests {
             nodes.append(node)
         }
         return nodes
+    }
+
+    private func createDesktopBookmark(subject: BookmarksPanelViewModel, completion: @escaping () -> Void) {
+        let expectation = expectation(description: "Subject reloaded")
+
+        profile.places.createBookmark(
+            parentGUID: BookmarkRoots.MenuFolderGUID,
+            url: "https://www.firefox.com",
+            title: "Firefox",
+            position: 0
+        ).uponQueue(.main) { _ in
+            self.profile.places.countBookmarksInTrees(folderGuids: [BookmarkRoots.MenuFolderGUID]) { result in
+                switch result {
+                case .success:
+                    subject.reloadData {
+                        completion()
+                        expectation.fulfill()
+                    }
+                case .failure(let error):
+                    XCTFail("Failed to count bookmarks: \(error)")
+                    expectation.fulfill()
+                }
+            }
+        }
+
+        waitForExpectations(timeout: 5)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10898)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23789)

## :bulb: Description
- Fixes an issue where bookmarks and folders would appear out of order after being rearranged via drag+drop

### 📝 Discussion
- When reordering bookmarks/folders via drag+drop, we were accounting for the local desktop bookmarks folder being present, even when it was hidden.

### 📹 Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/3cac602f-38ec-4cad-988a-88c9105d47a3

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/e1f158ed-bf47-4618-801e-563020ecc33b

</details>
*Note: In the video, I am slightly swiping the modal down and back up to trigger a refresh of the table after each drag+drop

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

