### PR TITLE
Refactor MTE-3733 Use waitAndTap() throughout XCUITest and SyncIntegrationTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -94,7 +94,7 @@ class ActivityStreamTest: BaseTestCase {
     func testTopSitesRemoveAllExceptPinnedClearPrivateData() {
         waitForExistence(TopSiteCellgroup)
         if iPad() {
-            app.textFields.element(boundBy: 0).tap()
+            app.textFields.element(boundBy: 0).waitAndTap()
             app.typeText("mozilla.org\n")
         } else {
             navigator.openURL("mozilla.org")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
@@ -213,11 +213,11 @@ class AddressesTests: BaseTestCase {
         navigator.goto(AddressesSettings)
         let addresses = AccessibilityIdentifiers.Settings.Address.Addresses.self
         mozWaitForElementToExist(app.navigationBars[addresses.title])
-        app.buttons[addresses.addAddress].tap()
+        app.buttons[addresses.addAddress].waitAndTap()
         mozWaitForElementToExist(app.navigationBars[addresses.addAddress])
         if !app.staticTexts["Name"].exists {
-            app.buttons["Close"].tap()
-            app.buttons[addresses.addAddress].tap()
+            app.buttons["Close"].waitAndTap()
+            app.buttons[addresses.addAddress].waitAndTap()
         }
         mozWaitForElementToExist(app.staticTexts["Name"])
     }
@@ -246,7 +246,7 @@ class AddressesTests: BaseTestCase {
     }
 
     private func typeName(name: String, updateText: Bool = false) {
-        app.staticTexts["Name"].tap()
+        app.staticTexts["Name"].waitAndTap()
         if updateText {
             clearText()
         }
@@ -254,7 +254,7 @@ class AddressesTests: BaseTestCase {
     }
 
     private func typeOrganization(organization: String, updateText: Bool = false) {
-        app.staticTexts["Organization"].tap()
+        app.staticTexts["Organization"].waitAndTap()
         if updateText {
             clearText()
         }
@@ -262,7 +262,7 @@ class AddressesTests: BaseTestCase {
     }
 
     private func typeStreetAddress(street: String, updateText: Bool = false) {
-        app.staticTexts["Street Address"].tap()
+        app.staticTexts["Street Address"].waitAndTap()
         if updateText {
             clearText()
         }
@@ -270,7 +270,7 @@ class AddressesTests: BaseTestCase {
     }
 
     private func typeCity(city: String, updateText: Bool = false) {
-        app.staticTexts["City"].tap()
+        app.staticTexts["City"].waitAndTap()
         if updateText {
             clearText()
         }
@@ -278,18 +278,18 @@ class AddressesTests: BaseTestCase {
     }
 
     private func selectCountry(country: String) {
-        app.staticTexts["Country or Region"].tap()
+        app.staticTexts["Country or Region"].waitAndTap()
         mozWaitForElementToExist(app.buttons[country])
-        app.buttons[country].tap()
+        app.buttons[country].waitAndTap()
     }
 
     private func typeZIP(zip: String, updateText: Bool = false, isPostalCode: Bool = false) {
         if isPostalCode {
             scrollToElement(app.staticTexts["Postal Code"])
-            app.staticTexts["Postal Code"].tap()
+            app.staticTexts["Postal Code"].waitAndTap()
         } else {
             scrollToElement(app.staticTexts["ZIP Code"])
-            app.staticTexts["ZIP Code"].tap()
+            app.staticTexts["ZIP Code"].waitAndTap()
         }
         if updateText {
             clearText()
@@ -299,7 +299,7 @@ class AddressesTests: BaseTestCase {
 
     private func typePhone(phone: String, updateText: Bool = false) {
         if app.buttons["Done"].isHittable {
-            app.buttons["Done"].tap()
+            app.buttons["Done"].waitAndTap()
         }
         app.staticTexts["Phone"].tapOnApp()
         if updateText {
@@ -310,7 +310,7 @@ class AddressesTests: BaseTestCase {
 
     private func typeEmail(email: String, updateText: Bool = false) {
         scrollToElement(app.staticTexts["Email"])
-        app.staticTexts["Email"].tap()
+        app.staticTexts["Email"].waitAndTap()
         if updateText {
             clearText()
         }
@@ -321,7 +321,7 @@ class AddressesTests: BaseTestCase {
         if withRetry {
             app.buttons["Save"].tapWithRetry()
         } else {
-            app.buttons["Save"].tap()
+            app.buttons["Save"].waitAndTap()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
@@ -279,7 +279,6 @@ class AddressesTests: BaseTestCase {
 
     private func selectCountry(country: String) {
         app.staticTexts["Country or Region"].waitAndTap()
-        mozWaitForElementToExist(app.buttons[country])
         app.buttons[country].waitAndTap()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AuthenticationTest.swift
@@ -23,7 +23,7 @@ class AuthenticationTest: BaseTestCase {
 
         if result != .completed {
             // User already logged, tap on reload button
-            app.buttons["TabLocationView.reloadButton"].tap()
+            app.buttons["TabLocationView.reloadButton"].waitAndTap()
         }
         mozWaitForElementToExist(app.staticTexts[
             "A username and password are being requested by jigsaw.w3.org. The site says: test"
@@ -41,7 +41,7 @@ class AuthenticationTest: BaseTestCase {
         app.alerts.textFields["Username"].typeText("guest")
         app.alerts.secureTextFields["Password"].tapAndTypeText("guest")
         mozWaitElementHittable(element: app.alerts.buttons["Log in"], timeout: TIMEOUT)
-        app.alerts.buttons["Log in"].tap()
+        app.alerts.buttons["Log in"].waitAndTap()
         /* There is no other way to verify basic auth is successful as the webview is
          inaccessible after sign in to verify the success text. */
         waitForNoExistence(app.alerts.buttons["Cancel"], timeoutValue: 5)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -69,11 +69,8 @@ class BaseTestCase: XCTestCase {
         let icon = springboard.icons.containingText("Fennec").element(boundBy: 0)
         if icon.exists {
             icon.press(forDuration: 1.5)
-            mozWaitForElementToExist(springboard.buttons["Remove App"])
             springboard.buttons["Remove App"].waitAndTap()
-            mozWaitForElementToExist(springboard.alerts.buttons["Delete App"])
             springboard.alerts.buttons["Delete App"].waitAndTap()
-            mozWaitForElementToExist(springboard.alerts.buttons["Delete"])
             springboard.alerts.buttons["Delete"].waitAndTap()
         }
     }
@@ -294,10 +291,8 @@ class BaseTestCase: XCTestCase {
         userState.url = path(forTestPage: "test-mozilla-book.html")
         navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
         waitUntilPageLoad()
-        mozWaitForElementToExist(app.buttons["Reader View"])
         app.buttons["Reader View"].waitAndTap()
         waitUntilPageLoad()
-        mozWaitForElementToExist(app.buttons["Add to Reading List"])
         app.buttons["Add to Reading List"].waitAndTap()
     }
 
@@ -314,7 +309,6 @@ class BaseTestCase: XCTestCase {
     }
 
      func selectOptionFromContextMenu(option: String) {
-        mozWaitForElementToExist(app.tables["Context Menu"].cells.otherElements[option])
         app.tables["Context Menu"].cells.otherElements[option].waitAndTap()
         mozWaitForElementToNotExist(app.tables["Context Menu"])
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -70,11 +70,11 @@ class BaseTestCase: XCTestCase {
         if icon.exists {
             icon.press(forDuration: 1.5)
             mozWaitForElementToExist(springboard.buttons["Remove App"])
-            springboard.buttons["Remove App"].tap()
+            springboard.buttons["Remove App"].waitAndTap()
             mozWaitForElementToExist(springboard.alerts.buttons["Delete App"])
-            springboard.alerts.buttons["Delete App"].tap()
+            springboard.alerts.buttons["Delete App"].waitAndTap()
             mozWaitForElementToExist(springboard.alerts.buttons["Delete"])
-            springboard.alerts.buttons["Delete"].tap()
+            springboard.alerts.buttons["Delete"].waitAndTap()
         }
     }
 
@@ -138,7 +138,7 @@ class BaseTestCase: XCTestCase {
 
         if firstRunUI.exists {
             firstRunUI.swipeLeft()
-            XCUIApplication().buttons["Start Browsing"].tap()
+            XCUIApplication().buttons["Start Browsing"].waitAndTap()
         }
     }
 
@@ -295,10 +295,10 @@ class BaseTestCase: XCTestCase {
         navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
         waitUntilPageLoad()
         mozWaitForElementToExist(app.buttons["Reader View"])
-        app.buttons["Reader View"].tap()
+        app.buttons["Reader View"].waitAndTap()
         waitUntilPageLoad()
         mozWaitForElementToExist(app.buttons["Add to Reading List"])
-        app.buttons["Add to Reading List"].tap()
+        app.buttons["Add to Reading List"].waitAndTap()
     }
 
     func removeContentFromReaderView() {
@@ -310,12 +310,12 @@ class BaseTestCase: XCTestCase {
         // Remove the item from reading list
         savedToReadingList.swipeLeft()
         mozWaitForElementToExist(app.buttons["Remove"])
-        app.buttons["Remove"].tap()
+        app.buttons["Remove"].waitAndTap()
     }
 
      func selectOptionFromContextMenu(option: String) {
         mozWaitForElementToExist(app.tables["Context Menu"].cells.otherElements[option])
-        app.tables["Context Menu"].cells.otherElements[option].tap()
+        app.tables["Context Menu"].cells.otherElements[option].waitAndTap()
         mozWaitForElementToNotExist(app.tables["Context Menu"])
     }
 
@@ -323,7 +323,7 @@ class BaseTestCase: XCTestCase {
         let app = XCUIApplication()
         UIPasteboard.general.string = url
         app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].press(forDuration: 2.0)
-        app.tables["Context Menu"].cells[AccessibilityIdentifiers.Photon.pasteAndGoAction].firstMatch.tap()
+        app.tables["Context Menu"].cells[AccessibilityIdentifiers.Photon.pasteAndGoAction].firstMatch.waitAndTap()
 
         if waitForLoadToFinish {
             let finishLoadingTimeout: TimeInterval = 30
@@ -358,7 +358,7 @@ class BaseTestCase: XCTestCase {
     func unlockLoginsView() {
         // Press continue button on the password onboarding if it's shown
         if app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].exists {
-            app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].tap()
+            app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].waitAndTap()
         }
 
         let passcodeInput = springboard.otherElements.secureTextFields.firstMatch
@@ -398,7 +398,7 @@ class BaseTestCase: XCTestCase {
 
     func dismissSurveyPrompt() {
         if app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists {
-            app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].tap()
+            app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].waitAndTap()
         }
     }
 
@@ -420,11 +420,11 @@ class BaseTestCase: XCTestCase {
         }
         mozWaitForElementToExist(app.cells.staticTexts["Dark"])
         if theme == "Dark" {
-            app.cells.staticTexts["Dark"].tap()
+            app.cells.staticTexts["Dark"].waitAndTap()
         } else {
-            app.cells.staticTexts["Light"].tap()
+            app.cells.staticTexts["Light"].waitAndTap()
         }
-        app.buttons["Settings"].tap()
+        app.buttons["Settings"].waitAndTap()
         navigator.nowAt(SettingsScreen)
         app.buttons["Done"].waitAndTap()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -64,9 +64,9 @@ class BookmarksTests: BaseTestCase {
             app.collectionViews
                 .cells["Example Domain"].children(matching: .other)
                 .element.children(matching: .other)
-                .element.tap()
+                .element.waitAndTap()
         } else {
-            app.cells.staticTexts["Example Domain"].tap()
+            app.cells.staticTexts["Example Domain"].waitAndTap()
         }
         navigator.nowAt(BrowserTab)
         waitForTabsButton()
@@ -175,7 +175,7 @@ class BookmarksTests: BaseTestCase {
     func testAddBookmark() {
         addNewBookmark()
         // Verify that clicking on bookmark opens the website
-        app.tables["Bookmarks List"].cells.element(boundBy: 1).tap()
+        app.tables["Bookmarks List"].cells.element(boundBy: 1).waitAndTap()
         mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
     }
 
@@ -187,8 +187,8 @@ class BookmarksTests: BaseTestCase {
         mozWaitForElementToExist(app.navigationBars["Bookmarks"])
         // XCTAssertFalse(app.buttons["Save"].isEnabled), is this a bug allowing empty folder name?
         app.tables.cells.textFields.element(boundBy: 0).tapAndTypeText("Test Folder")
-        app.buttons["Save"].tap()
-        app.buttons["Done"].tap()
+        app.buttons["Save"].waitAndTap()
+        app.buttons["Done"].waitAndTap()
         checkItemsInBookmarksList(items: 2)
         navigator.nowAt(MobileBookmarks)
         // Now remove the folder
@@ -208,7 +208,7 @@ class BookmarksTests: BaseTestCase {
         navigator.goto(LibraryPanel_Bookmarks)
         navigator.nowAt(MobileBookmarks)
         navigator.performAction(Action.AddNewSeparator)
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
         // There is one item plus the default Desktop Bookmarks folder
         checkItemsInBookmarksList(items: 2)
 
@@ -237,7 +237,7 @@ class BookmarksTests: BaseTestCase {
         // Remove by long press and select option from context menu
         app.tables.staticTexts.element(boundBy: 1).press(forDuration: 1)
         mozWaitForElementToExist(app.tables["Context Menu"])
-        app.tables.otherElements["Remove Bookmark"].tap()
+        app.tables.otherElements["Remove Bookmark"].waitAndTap()
         // Verify that there are only 1 cell (desktop bookmark folder)
         checkItemsInBookmarksList(items: 1)
     }
@@ -307,7 +307,7 @@ class BookmarksTests: BaseTestCase {
 
         // Delete the Bookmark added, check it is removed
         app.tables["Bookmarks List"].cells.staticTexts["Example Domain"].swipeLeft()
-        app.buttons["Delete"].tap()
+        app.buttons["Delete"].waitAndTap()
         mozWaitForElementToNotExist(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"])
     }
 
@@ -323,7 +323,7 @@ class BookmarksTests: BaseTestCase {
         XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 1)
 
         // There is only three folders inside the desktop bookmarks
-        app.tables["Bookmarks List"].cells.firstMatch.tap()
+        app.tables["Bookmarks List"].cells.firstMatch.waitAndTap()
         mozWaitForElementToExist(app.tables["Bookmarks List"])
         XCTAssertEqual(app.tables["Bookmarks List"].cells.count, 3)
     }
@@ -349,12 +349,12 @@ class BookmarksTests: BaseTestCase {
         navigator.openURL(path(forTestPage: url_2["url"]!))
         waitForTabsButton()
         bookmarkPageAndTapEdit()
-        app.buttons["Close"].tap()
+        app.buttons["Close"].waitAndTap()
         waitForTabsButton()
         navigator.nowAt(BrowserTab)
         unbookmark()
         bookmarkPageAndTapEdit()
-        app.buttons["Save"].tap()
+        app.buttons["Save"].waitAndTap()
         navigator.nowAt(BrowserTab)
         navigator.goto(LibraryPanel_Bookmarks)
         checkItemInBookmarkList(oneItemBookmarked: true)
@@ -399,7 +399,7 @@ class BookmarksTests: BaseTestCase {
             ]
         )
         // Tap to "Open in New Tab"
-        contextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.plus].tap()
+        contextMenuTable.cells.otherElements[StandardImageIdentifiers.Large.plus].waitAndTap()
         // The webpage opens in a new tab
         switchToTabAndValidate(nrOfTabs: "3")
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -42,14 +42,14 @@ class BrowsingPDFTests: BaseTestCase {
         waitUntilPageLoad()
         let checkboxValidation = app.webViews["Web content"].staticTexts["Verify you are human"]
         if checkboxValidation.exists {
-            checkboxValidation.tap()
+            checkboxValidation.waitAndTap()
         }
         mozWaitForValueContains(url, value: PDF_website["urlValue"]!)
         // Let's comment the next line until that fails intermittently due to the page re-direction
         // mozWaitForElementToExist(app.staticTexts["Education and schools"])
 
         // Go back to pdf view
-        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].waitAndTap()
         mozWaitForValueContains(url, value: PDF_website["pdfValue"]!)
     }
 
@@ -93,7 +93,7 @@ class BrowsingPDFTests: BaseTestCase {
         }
 
         mozWaitForElementToExist(app.staticTexts[PDF_website["longUrlValue"]!])
-        app.buttons["Add to Reading List"].tap()
+        app.buttons["Add to Reading List"].waitAndTap()
         navigator.nowAt(BrowserTab)
 
         // Go to reading list and check that the item is there
@@ -124,7 +124,7 @@ class BrowsingPDFTests: BaseTestCase {
             .element
             .children(matching: .other)
             .element(boundBy: 0)
-        pdfTopSite.tap()
+        pdfTopSite.waitAndTap()
         waitUntilPageLoad()
         mozWaitForValueContains(url, value: PDF_website["pdfValue"]!)
 
@@ -133,7 +133,7 @@ class BrowsingPDFTests: BaseTestCase {
         mozWaitForElementToExist(app.collectionViews.cells.staticTexts[PDF_website["bookmarkLabel"]!])
         pdfTopSite.press(forDuration: 1)
         mozWaitForElementToExist(app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash])
-        app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash].tap()
+        app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash].waitAndTap()
         waitForElementsToExist(
             [
             app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell],

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -132,7 +132,6 @@ class BrowsingPDFTests: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         mozWaitForElementToExist(app.collectionViews.cells.staticTexts[PDF_website["bookmarkLabel"]!])
         pdfTopSite.press(forDuration: 1)
-        mozWaitForElementToExist(app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash])
         app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash].waitAndTap()
         waitForElementsToExist(
             [

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
@@ -18,7 +18,7 @@ class ClipBoardTests: BaseTestCase {
         navigator.goto(URLBarOpen)
         urlBarAddress.waitAndTap()
         if iPad() {
-            app.menuItems["Select All"].tap()
+            app.menuItems["Select All"].waitAndTap()
         }
         app.menuItems["Copy"].waitAndTap()
         app.typeText("\r")
@@ -32,7 +32,7 @@ class ClipBoardTests: BaseTestCase {
                 let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
                 let allowBtn = springboard.buttons["Allow Paste"]
                 if allowBtn.waitForExistence(timeout: TIMEOUT) {
-                    allowBtn.tap()
+                    allowBtn.waitAndTap()
                 }
 
                 guard var value = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].value
@@ -85,7 +85,7 @@ class ClipBoardTests: BaseTestCase {
         let urlBar = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
         mozWaitForElementToExist(urlBar)
         urlBar.press(forDuration: 1.5)
-        app.otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction].tap()
+        app.otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction].waitAndTap()
         // The URL is pasted and the page is correctly loaded
         mozWaitForElementToExist(urlBar)
         waitForValueContains(urlBar, value: "localhost")
@@ -101,9 +101,9 @@ class ClipBoardTests: BaseTestCase {
 //        waitUntilPageLoad()
 //        mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])
 //        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
-//        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
+//        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
 //        mozWaitForElementToExist(app.cells["Copy"], timeout: 15)
-//        app.cells["Copy"].tap()
+//        app.cells["Copy"].waitAndTap()
 //
 //        checkCopiedUrl()
 //        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
@@ -114,7 +114,7 @@ class ClipBoardTests: BaseTestCase {
 //        mozWaitForElementToExist(
 //            app.tables["Context Menu"].otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction]
 //        )
-//        app.tables["Context Menu"].otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction].tap()
+//        app.tables["Context Menu"].otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction].waitAndTap()
 //        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
 //        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField], value: "www.example.com")
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
@@ -101,9 +101,9 @@ class ClipBoardTests: BaseTestCase {
 //        waitUntilPageLoad()
 //        mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])
 //        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
-//        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
+//        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
 //        mozWaitForElementToExist(app.cells["Copy"], timeout: 15)
-//        app.cells["Copy"].waitAndTap()
+//        app.cells["Copy"].tap()
 //
 //        checkCopiedUrl()
 //        mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -73,7 +73,7 @@ class CreditCardsTests: BaseTestCase {
     func testDeleteButtonFromEditCard() {
         addCardAndReachViewCardPage()
         // Tap on the "Remove card" button
-        app.buttons[creditCardsStaticTexts.ViewCreditCard.edit].tap()
+        app.buttons[creditCardsStaticTexts.ViewCreditCard.edit].waitAndTap()
         app.buttons[creditCardsStaticTexts.EditCreditCard.removeCard].waitAndTap()
         // Validate the pop up displayed
         let removeThisCardAlert = app.alerts[creditCardsStaticTexts.EditCreditCard.removeThisCard]
@@ -91,12 +91,12 @@ class CreditCardsTests: BaseTestCase {
             ]
         )
         // Tap on "CANCEL"
-        cancelButton.tap()
+        cancelButton.waitAndTap()
         // The prompt is dismissed, the "Edit card" page is displayed
         mozWaitForElementToNotExist(removeThisCardAlert)
         mozWaitForElementToExist(app.navigationBars[creditCardsStaticTexts.EditCreditCard.editCreditCard])
         // Tap again on the "Remove card" button
-        app.buttons[creditCardsStaticTexts.EditCreditCard.removeCard].tap()
+        app.buttons[creditCardsStaticTexts.EditCreditCard.removeCard].waitAndTap()
         // The prompt is displayed again
         // Tap "Remove" on the prompt
         removeButton.waitAndTap()
@@ -112,7 +112,7 @@ class CreditCardsTests: BaseTestCase {
         addCardAndReachViewCardPage()
 
         // Go back to saved cards section
-        app.navigationBars.buttons[creditCardsStaticTexts.ViewCreditCard.close].tap()
+        app.navigationBars.buttons[creditCardsStaticTexts.ViewCreditCard.close].waitAndTap()
         waitForElementsToExist(
             [
                 app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards],
@@ -129,12 +129,12 @@ class CreditCardsTests: BaseTestCase {
         }
         addCreditCardAndReachAutofillWebsite()
         // Tap on the "Manage credit cards" option
-        app.buttons[manageCards].tap()
+        app.buttons[manageCards].waitAndTap()
         unlockLoginsView()
         // The user is redirected to the "Credit cards" section in Settings
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
         // Tap the back button on the Credit cards page
-        app.buttons["Settings"].tap()
+        app.buttons["Settings"].waitAndTap()
         navigator.nowAt(SettingsScreen)
         app.buttons["Done"].waitAndTap()
         // The user is returned to the webpage
@@ -153,10 +153,10 @@ class CreditCardsTests: BaseTestCase {
         let saveAndFillPaymentMethodsSwitch =
             app.switches[creditCardsStaticTexts.AutoFillCreditCard.saveAutofillCards].switches.firstMatch
         if saveAndFillPaymentMethodsSwitch.value! as? String == "1" {
-            saveAndFillPaymentMethodsSwitch.tap()
+            saveAndFillPaymentMethodsSwitch.waitAndTap()
         }
         XCTAssertEqual(saveAndFillPaymentMethodsSwitch.value! as? String, "0")
-        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].tap()
+        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].waitAndTap()
         let dateFiveYearsFromNow = Calendar.current.date(byAdding: .year, value: 5, to: Date())
         let formatter = DateFormatter()
         formatter.dateFormat = "MMyy"
@@ -177,7 +177,7 @@ class CreditCardsTests: BaseTestCase {
         let timeout: TimeInterval = 5.0 // Set the timeout duration
 
         if keyboard.waitForExistence(timeout: timeout) {
-            app.buttons["KeyboardAccessory.doneButton"].tap()
+            app.buttons["KeyboardAccessory.doneButton"].waitAndTap()
         } else {
             XCTFail("Keyboard did not appear within \(timeout) seconds")
         }
@@ -186,15 +186,15 @@ class CreditCardsTests: BaseTestCase {
         unlockLoginsView()
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
         // Enable the "Save and Fill Payment Methods" toggle
-        app.switches.element(boundBy: 1).tap()
+        app.switches.element(boundBy: 1).waitAndTap()
         XCTAssertEqual(saveAndFillPaymentMethodsSwitch.value! as? String, "1")
-        app.buttons["Settings"].tap()
+        app.buttons["Settings"].waitAndTap()
         navigator.nowAt(SettingsScreen)
         app.buttons["Done"].waitAndTap()
         cardNumber.waitAndTap()
         // The autofill option (Use saved card prompt) is displayed
         if !app.buttons[useSavedCard].waitForExistence(timeout: 3) {
-            app.webViews["Web content"].staticTexts["Card Number:"].tap()
+            app.webViews["Web content"].staticTexts["Card Number:"].waitAndTap()
         }
         mozWaitForElementToExist(app.buttons[useSavedCard])
     }
@@ -230,23 +230,23 @@ class CreditCardsTests: BaseTestCase {
         tapCardName()
         nameOnCard.clearText()
         typeCardName(name: updatedName)
-        app.buttons["Save"].tap()
+        app.buttons["Save"].waitAndTap()
         // The name of the card is saved without issues
         mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons[updatedName])
         // Go to an saved credit card and change the credit card number
-        app.tables.cells.element(boundBy: 1).tap()
-        app.buttons[creditCardsStaticTexts.ViewCreditCard.edit].tap()
+        app.tables.cells.element(boundBy: 1).waitAndTap()
+        app.buttons[creditCardsStaticTexts.ViewCreditCard.edit].waitAndTap()
         tapCardNr()
         cardNr.clearText()
         typeCardNr(cardNo: cards[1])
-        app.buttons["Save"].tap()
+        app.buttons["Save"].waitAndTap()
         // The credit card number is saved without issues
         mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons.elementContainingText("1111"))
         // Reach autofill website
         // reachAutofillWebsite() does not work on iOS 15
         if #available(iOS 16, *) {
             reachAutofillWebsite()
-            app.scrollViews.otherElements.tables.cells.firstMatch.tap()
+            app.scrollViews.otherElements.tables.cells.firstMatch.waitAndTap()
             // The credit card's number and name are imported correctly on the designated fields
             validateAutofillCardInfo(cardNr: "4111 1111 1111 1111", expirationNr: "05 / 40", name: updatedName)
         }
@@ -261,13 +261,13 @@ class CreditCardsTests: BaseTestCase {
         navigator.goto(CreditCardsSettings)
         unlockLoginsView()
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
-        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].tap()
+        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].waitAndTap()
         addCreditCard(name: "Test", cardNumber: cards[0], expirationDate: "0540")
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
-        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].tap()
+        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].waitAndTap()
         addCreditCard(name: "Test2", cardNumber: cards[1], expirationDate: "0640")
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
-        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].tap()
+        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].waitAndTap()
         addCreditCard(name: "Test3", cardNumber: cards[2], expirationDate: "0740")
         // The cards are saved and displayed in Saved cards
         XCTAssertEqual(app.tables.cells.count - 1, expectedCards)
@@ -289,7 +289,7 @@ class CreditCardsTests: BaseTestCase {
             // Reach used saved cards autofill website
             reachAutofillWebsite()
             // Any saved card can be selected/used from the autofill menu
-            app.scrollViews.otherElements.tables.cells.firstMatch.tap()
+            app.scrollViews.otherElements.tables.cells.firstMatch.waitAndTap()
             validateAutofillCardInfo(cardNr: "2720 9943 2658 1252", expirationNr: "05 / 40", name: "Test")
             dismissSavedCardsPrompt()
             swipeUp(nrOfSwipes: 2)
@@ -303,7 +303,7 @@ class CreditCardsTests: BaseTestCase {
             app.buttons[useSavedCard].waitAndTap()
             unlockLoginsView()
             mozWaitForElementToExist(app.staticTexts["Use saved card"])
-            app.scrollViews.otherElements.tables.cells["creditCardCell_1"].tap()
+            app.scrollViews.otherElements.tables.cells["creditCardCell_1"].waitAndTap()
             validateAutofillCardInfo(cardNr: "4111 1111 1111 1111", expirationNr: "06 / 40", name: "Test2")
             if #available(iOS 17, *) {
                 app.webViews["Web content"].textFields["Email"].tapOnApp()
@@ -316,7 +316,7 @@ class CreditCardsTests: BaseTestCase {
                 mozWaitForElementToExist(app.staticTexts["Use saved card"])
                 app.scrollViews.element.swipeUp()
                 mozWaitForElementToExist(app.scrollViews.otherElements.tables.cells["creditCardCell_2"])
-                app.scrollViews.otherElements.tables.cells["creditCardCell_2"].tap()
+                app.scrollViews.otherElements.tables.cells["creditCardCell_2"].waitAndTap()
                 validateAutofillCardInfo(cardNr: "5346 7556 0029 9631", expirationNr: "07 / 40", name: "Test3")
             }
         }
@@ -326,7 +326,7 @@ class CreditCardsTests: BaseTestCase {
     func testErrorStatesCreditCards() {
         // Go to a saved credit card and delete the name
         addCardAndReachViewCardPage()
-        app.buttons[creditCardsStaticTexts.ViewCreditCard.edit].tap()
+        app.buttons[creditCardsStaticTexts.ViewCreditCard.edit].waitAndTap()
         let saveButton = app.buttons[creditCardsStaticTexts.AddCreditCard.save]
         tapCardName()
         nameOnCard.clearText()
@@ -376,7 +376,7 @@ class CreditCardsTests: BaseTestCase {
         mozWaitForElementToNotExist(app.otherElements.staticTexts["Enter a valid expiration date"])
         mozWaitForElementToExist(saveButton)
         XCTAssertTrue(saveButton.isEnabled)
-        saveButton.tap()
+        saveButton.waitAndTap()
         // The credit card is saved
         let cardsInfo = ["Test", "5/40"]
         mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons.elementContainingText("1252"))
@@ -411,7 +411,7 @@ class CreditCardsTests: BaseTestCase {
             ]
         )
         // Tapping 'x' will dismiss the prompt
-        app.buttons[AccessibilityIdentifiers.SaveCardPrompt.Prompt.closeButton].tap()
+        app.buttons[AccessibilityIdentifiers.SaveCardPrompt.Prompt.closeButton].waitAndTap()
         mozWaitForElementToNotExist(app.staticTexts["Securely save this card?"])
         // Go to the Settings --> Payment methods
         swipeDown(nrOfSwipes: 2)
@@ -436,7 +436,7 @@ class CreditCardsTests: BaseTestCase {
         // Fill in the form with the card details of a new (unsaved) credit card.
         fillCardDetailsOnWebsite(cardNr: cards[1], expirationDate: "0540", nameOnCard: "Test")
         payButton.tapOnApp()
-        app.buttons["Save"].tap()
+        app.buttons["Save"].waitAndTap()
         // The prompt is dismissed. And a toast message is displayed: "New card saved"
         mozWaitForElementToExist(app.staticTexts["New Card Saved"])
         mozWaitForElementToNotExist(app.staticTexts["Securely save this card?"])
@@ -530,7 +530,7 @@ class CreditCardsTests: BaseTestCase {
         // The prompt contains two buttons: "Save" and "x".
         mozWaitForElementToExist(app.staticTexts["Update card?"])
         // Tapping 'x' will dismiss the prompt
-        app.buttons["Save"].tap()
+        app.buttons["Save"].waitAndTap()
         mozWaitForElementToNotExist(app.staticTexts["Update card?"])
         // Go to the Settings --> Payment methods
         swipeDown(nrOfSwipes: 2)
@@ -607,7 +607,7 @@ class CreditCardsTests: BaseTestCase {
         }
         sleep(1)
         if app.keyboards.firstMatch.exists {
-            app.buttons["KeyboardAccessory.doneButton"].tap()
+            app.buttons["KeyboardAccessory.doneButton"].waitAndTap()
         }
         cvc.tapOnApp()
         cvc.typeText("123")
@@ -621,7 +621,7 @@ class CreditCardsTests: BaseTestCase {
             nrOfRetries -= 1
         }
         zip.typeText("12345")
-        app.buttons["KeyboardAccessory.doneButton"].tap()
+        app.buttons["KeyboardAccessory.doneButton"].waitAndTap()
 
         if app.webViews["Web content"].switches.element(boundBy: 0).value as? String == "1" {
             app.webViews["Web content"].switches.element(boundBy: 0).tapOnApp()
@@ -647,7 +647,7 @@ class CreditCardsTests: BaseTestCase {
     private func dismissSavedCardsPrompt() {
         if app.buttons.elementContainingText("Decline").isVisible() &&
             app.buttons.elementContainingText("Decline").isHittable {
-            app.staticTexts["TEST CARDS"].tap()
+            app.staticTexts["TEST CARDS"].waitAndTap()
         }
     }
 
@@ -669,13 +669,13 @@ class CreditCardsTests: BaseTestCase {
 
     func tapCardNr() {
         initCardFields()
-        cardNr.tap()
+        cardNr.waitAndTap()
         mozWaitForElementToExist(cardNr)
     }
 
     func tapExpiration() {
         initCardFields()
-        expiration.tap()
+        expiration.waitAndTap()
         mozWaitForElementToExist(expiration)
     }
 
@@ -732,9 +732,9 @@ class CreditCardsTests: BaseTestCase {
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
         let saveAndFillPaymentMethodsSwitch = app.switches[creditCardsStaticTexts.AutoFillCreditCard.saveAutofillCards]
         if saveAndFillPaymentMethodsSwitch.value! as? String == "0" {
-            saveAndFillPaymentMethodsSwitch.tap()
+            saveAndFillPaymentMethodsSwitch.waitAndTap()
         }
-        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].tap()
+        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].waitAndTap()
         addCreditCard(name: "Test", cardNumber: cards[0], expirationDate: "0540")
         navigator.goto(NewTabScreen)
         navigator.openURL("https://checkout.stripe.dev/preview")
@@ -764,11 +764,11 @@ class CreditCardsTests: BaseTestCase {
         navigator.goto(CreditCardsSettings)
         unlockLoginsView()
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
-        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].tap()
+        app.buttons[creditCardsStaticTexts.AutoFillCreditCard.addCard].waitAndTap()
         addCreditCard(name: "Test", cardNumber: cards[0], expirationDate: "0540")
         // Tap on a saved card
         mozWaitForElementToExist(app.staticTexts[creditCardsStaticTexts.AutoFillCreditCard.autoFillCreditCards])
-        app.tables.cells.element(boundBy: 1).tap()
+        app.tables.cells.element(boundBy: 1).waitAndTap()
         // The "View card" page is displayed with all the details of the card
         waitForElementsToExist(
             [

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
@@ -16,7 +16,7 @@ class DataManagementTests: BaseTestCase {
         XCTAssertEqual(app.cells.buttons.images.count, 0, "The Website data has not cleared correctly")
         // Navigate back to the browser
         mozWaitElementHittable(element: app.buttons["Data Management"], timeout: TIMEOUT)
-        app.buttons["Data Management"].tap()
+        app.buttons["Data Management"].waitAndTap()
         app.buttons["Settings"].waitAndTap()
         app.buttons["Done"].waitAndTap()
     }
@@ -36,10 +36,10 @@ class DataManagementTests: BaseTestCase {
         var beforeDelete = 0
         if #available(iOS 17, *) {
             beforeDelete = app.cells.images.count
-            app.cells.images["circle"].firstMatch.tap()
+            app.cells.images["circle"].firstMatch.waitAndTap()
         } else {
             beforeDelete = app.cells.staticTexts.count
-            app.cells.staticTexts.firstMatch.tap()
+            app.cells.staticTexts.firstMatch.waitAndTap()
         }
 
         app.otherElements.staticTexts["Clear Items: 1"].waitAndTap()
@@ -70,7 +70,7 @@ class DataManagementTests: BaseTestCase {
             mozWaitForElementToExist(app.tables.buttons.firstMatch)
         }
         if app.cells["ShowMoreWebsiteData"].exists {
-            app.cells["ShowMoreWebsiteData"].tap()
+            app.cells["ShowMoreWebsiteData"].waitAndTap()
         }
         mozWaitForElementToExist(app.staticTexts["example.com"])
         if #available(iOS 17, *) {
@@ -96,7 +96,7 @@ class DataManagementTests: BaseTestCase {
         mozWaitForElementToExist(app.tables["Search results"])
         let expectedSearchResults = app.tables["Search results"].cells.count
         XCTAssertEqual(expectedSearchResults-1, 1)
-        app.buttons["Cancel"].tap()
+        app.buttons["Cancel"].waitAndTap()
         mozWaitForElementToExist(app.tables.otherElements["Website Data"])
         if #available(iOS 17, *) {
             XCTAssertGreaterThan(app.cells.images.count, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
@@ -169,7 +169,7 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         waitUntilPageLoad()
         // Workaround
-        app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].waitAndTap()
         navigator.goto(BrowserTabMenu)
         navigator.goto(RequestDesktopSite)
         waitUntilPageLoad()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
@@ -64,7 +64,7 @@ class DomainAutocompleteTests: BaseTestCase {
         XCTAssertEqual(value as? String, website["value"]!, "Wrong autocompletion")
 
         // Enter the complete website and check that there is not more text added, just what user typed
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         urlBarAddress.typeText(website["value"]!)
         mozWaitForValueContains(urlBarAddress, value: website["value"]!)
         let value2 = urlBarAddress.value
@@ -141,36 +141,36 @@ class DomainAutocompleteTests: BaseTestCase {
         XCTAssertEqual(value as? String, "baz", "Wrong autocompletion")
 
         // Ensure we don't match against TLDs.
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         urlBarAddress.typeText(".com")
         let value2 = urlBarAddress.value
         // Check there is not more text added, just what user typed
         XCTAssertEqual(value2 as? String, ".com", "Wrong autocompletion")
 
         // Ensure we don't match other characters ie: ., :, /
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         urlBarAddress.typeText(".")
         let value3 = urlBarAddress.value
         XCTAssertEqual(value3 as? String, ".", "Wrong autocompletion")
 
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         urlBarAddress.typeText(":")
         let value4 = urlBarAddress.value
         XCTAssertEqual(value4 as? String, ":", "Wrong autocompletion")
 
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         urlBarAddress.typeText("/")
         let value5 = urlBarAddress.value
         XCTAssertEqual(value5 as? String, "/", "Wrong autocompletion")
 
         // Ensure we don't match strings that don't start a word.
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         urlBarAddress.typeText("tter")
         let value6 = urlBarAddress.value
         XCTAssertEqual(value6 as? String, "tter", "Wrong autocompletion")
 
         // Ensure we don't match words outside of the domain
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         urlBarAddress.typeText("login")
         let value7 = urlBarAddress.value
         XCTAssertEqual(value7 as? String, "login", "Wrong autocompletion")
@@ -185,13 +185,13 @@ class DomainAutocompleteTests: BaseTestCase {
         let value = urlBarAddress.value
         XCTAssertEqual(value as? String, "amazon.com", "Wrong autocompletion")
 
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         urlBarAddress.typeText("an")
         mozWaitForValueContains(urlBarAddress, value: ".com")
         let value2 = urlBarAddress.value
         XCTAssertEqual(value2 as? String, "answers.com", "Wrong autocompletion")
 
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         urlBarAddress.typeText("anc")
         mozWaitForValueContains(urlBarAddress, value: ".com")
         let value3 = urlBarAddress.value
@@ -208,14 +208,14 @@ class DomainAutocompleteTests: BaseTestCase {
         XCTAssertEqual(value as? String, "MoZilla.org", "Wrong autocompletion")
 
         // Test that leading spaces still show suggestions.
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         urlBarAddress.typeText("    moz")
         mozWaitForValueContains(urlBarAddress, value: ".org")
         let value2 = urlBarAddress.value
         XCTAssertEqual(value2 as? String, "    mozilla.org", "Wrong autocompletion")
 
         // Test that trailing spaces do *not* show suggestions.
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         urlBarAddress.typeText("    moz ")
         mozWaitForValueContains(urlBarAddress, value: "moz")
         let value3 = urlBarAddress.value

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
@@ -56,7 +56,7 @@ class DownloadsTests: BaseTestCase {
             app.webViews.links.firstMatch.swipeLeft(velocity: 1000)
             app.webViews.links.firstMatch.swipeLeft(velocity: 1000)
         }
-        app.webViews.links[testFileName].firstMatch.tap()
+        app.webViews.links[testFileName].firstMatch.waitAndTap()
 
         waitForElementsToExist(
             [
@@ -65,7 +65,7 @@ class DownloadsTests: BaseTestCase {
                 app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download]
             ]
         )
-        app.buttons["Cancel"].tap()
+        app.buttons["Cancel"].waitAndTap()
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
         checkTheNumberOfDownloadedItems(items: 0)
@@ -149,7 +149,7 @@ class DownloadsTests: BaseTestCase {
             mozWaitForElementToExist(app.collectionViews.buttons["Copy"])
         }
         if !iPad() {
-            app.navigationBars["UIActivityContentView"].buttons["Close"].tap()
+            app.navigationBars["UIActivityContentView"].buttons["Close"].waitAndTap()
         } else {
             // Workaround to close the context menu.
             // XCUITest does not allow me to click the greyed out portion of the app without the force option.
@@ -186,7 +186,7 @@ class DownloadsTests: BaseTestCase {
             mozWaitForElementToExist(app.collectionViews.buttons["Copy"])
         }
         if !iPad() {
-            app.navigationBars["UIActivityContentView"].buttons["Close"].tap()
+            app.navigationBars["UIActivityContentView"].buttons["Close"].waitAndTap()
         } else {
             // Workaround to close the context menu.
             // XCUITest does not allow me to click the greyed out portion of the app without the force option.
@@ -201,12 +201,12 @@ class DownloadsTests: BaseTestCase {
         for _ in 0..<numberOfDownloads {
             mozWaitForElementToExist(app.webViews.links[testFileName])
 
-            app.webViews.links[testFileName].firstMatch.tap()
+            app.webViews.links[testFileName].firstMatch.waitAndTap()
 
             mozWaitForElementToExist(
                 app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download]
             )
-            app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].tap()
+            app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].waitAndTap()
         }
         waitForTabsButton()
     }
@@ -216,7 +216,7 @@ class DownloadsTests: BaseTestCase {
         waitUntilPageLoad()
         mozWaitForElementToExist(app.webViews.links["Download Text"])
         app.webViews.links["Download Text"].press(forDuration: 1)
-        app.buttons["Download Link"].tap()
+        app.buttons["Download Link"].waitAndTap()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306903
@@ -253,7 +253,7 @@ class DownloadsTests: BaseTestCase {
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(ClearPrivateDataSettings)
-        app.cells.switches["Downloaded Files"].tap()
+        app.cells.switches["Downloaded Files"].waitAndTap()
         navigator.performAction(Action.AcceptClearPrivateData)
 
         navigator.goto(HomePanelsScreen)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
@@ -199,8 +199,6 @@ class DownloadsTests: BaseTestCase {
         waitUntilPageLoad()
         app.webViews.firstMatch.swipeLeft()
         for _ in 0..<numberOfDownloads {
-            mozWaitForElementToExist(app.webViews.links[testFileName])
-
             app.webViews.links[testFileName].firstMatch.waitAndTap()
 
             mozWaitForElementToExist(

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -313,7 +313,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
 
         // Leave Tab Tray and check order in Top Tabs
-        app.cells.staticTexts[secondWebsiteUnselected.tabName].firstMatch.tap()
+        app.cells.staticTexts[secondWebsiteUnselected.tabName].firstMatch.waitAndTap()
         checkTabsOrder(dragAndDropTab: true, firstTab: secondWebsite.tabName, secondTab: firstWebsite.tabName)
     }
 
@@ -333,7 +333,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
         app.textFields[searchTextField].press(forDuration: 1, thenDragTo: searchField)
 
         // Verify that the text in the search field is the same as the text in the url text field
-        searchField.tap()
+        searchField.waitAndTap()
         guard let textValue = app.textFields[searchTextField].value as? String, textValue == websiteWithSearchField
         else {
             XCTFail("The url text field value is not equal to \(websiteWithSearchField)")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/EngagementNotificationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/EngagementNotificationTests.swift
@@ -28,13 +28,13 @@ class EngagementNotificationTests: BaseTestCase {
         navigator.goto(NotificationsSettings)
         let tipsSwitch = app.switches["TipsAndFeaturesNotificationsUserPrefsKey"]
         mozWaitForElementToExist(tipsSwitch)
-        app.switches["TipsAndFeaturesNotificationsUserPrefsKey"].tap()
+        app.switches["TipsAndFeaturesNotificationsUserPrefsKey"].waitAndTap()
         let springBoard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let popUpTitle = "Would Like to Send You Notifications"
         // Validate pop-up
         mozWaitForElementToExist(springBoard.alerts.elementContainingText(popUpTitle))
         // Choose "Don't allow"
-        springBoard.buttons["Don’t Allow"].tap()
+        springBoard.buttons["Don’t Allow"].waitAndTap()
         // Toggle moves back to the "Off" position
         mozWaitForValueContains(tipsSwitch, value: "0")
         // Validate You turned off all Firefox notifications message

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ExperimentIntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ExperimentIntegrationTests.swift
@@ -12,7 +12,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
         app.activate()
         let closeButton = app.buttons["CloseButton"]
         if closeButton.waitForExistence(timeout: TIMEOUT) {
-            closeButton.tap()
+            closeButton.waitAndTap()
         }
         super.setUpScreenGraph()
         UIView.setAnimationsEnabled(false) // IMPORTANT
@@ -23,7 +23,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
             NSPredicate(format: "identifier CONTAINS 'FxVersion'")
         )
         for _ in 0...5 {
-            element.element.tap()
+            element.element.waitAndTap()
         }
         secretMenu = true
     }
@@ -35,12 +35,12 @@ final class ExperimentIntegrationTests: BaseTestCase {
             enableSecretMenu()
         }
         let experiments = app.tables.cells.containing(NSPredicate(format: "label CONTAINS 'Experiments'"))
-        experiments.element.tap()
+        experiments.element.waitAndTap()
 
         let experiment = app.tables.cells.containing(NSPredicate(format: "label CONTAINS '\(experimentName)'"))
         XCTAssertNotNil(experiment)
 
-        experiment.element.tap()
+        experiment.element.waitAndTap()
 
         let checkmark = app.buttons.matching(
             NSPredicate(format: "label CONTAINS 'checkmark'")
@@ -67,7 +67,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
         )
 
         wait(forElement: surveyLink.element, timeout: TIMEOUT_LONG)
-        surveyLink.element.tap()
+        surveyLink.element.waitAndTap()
         mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField],
                                 value: "survey")
     }
@@ -78,7 +78,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
         )
 
         wait(forElement: dismissLink.element, timeout: TIMEOUT_LONG)
-        dismissLink.element.tap()
+        dismissLink.element.waitAndTap()
 
         navigator.goto(NewTabScreen)
         waitForTabsButton()
@@ -98,7 +98,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
         )
 
         wait(forElement: surveyLink.element, timeout: TIMEOUT_LONG)
-        surveyLink.element.tap()
+        surveyLink.element.waitAndTap()
         mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField],
                                 value: "survey")
     }
@@ -109,7 +109,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
         )
 
         wait(forElement: surveyLink.element, timeout: TIMEOUT_LONG)
-        surveyLink.element.tap()
+        surveyLink.element.waitAndTap()
         mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField],
                                 value: "survey")
     }
@@ -120,7 +120,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
         )
 
         wait(forElement: surveyLink.element, timeout: TIMEOUT_LONG)
-        surveyLink.element.tap()
+        surveyLink.element.waitAndTap()
 
         navigator.goto(NewTabScreen)
         waitForTabsButton()
@@ -136,7 +136,7 @@ final class ExperimentIntegrationTests: BaseTestCase {
         )
         wait(forElement: studiesToggle.element, timeout: TIMEOUT)
         XCTAssertEqual(studiesToggle.element.value as? String, "1")
-        studiesToggle.element.tap()
+        studiesToggle.element.waitAndTap()
         XCTAssertEqual(studiesToggle.element.value as? String, "0")
         XCTAssertFalse(checkExperimentEnrollment(experimentName: experimentName))
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -230,7 +230,6 @@ class FindInPageTests: BaseTestCase {
                 mozWaitForElementToExist(app.menuItems["show.next.items.menu.button"])
             }
         }
-        mozWaitForElementToExist(app.menuItems["Find in Page"])
         app.menuItems["Find in Page"].waitAndTap()
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.searchFields[textToFind])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -69,27 +69,27 @@ class FindInPageTests: BaseTestCase {
         }
 
         let nextInPageResultButton = app.buttons[AccessibilityIdentifiers.FindInPage.findNextButton]
-        nextInPageResultButton.tap()
+        nextInPageResultButton.waitAndTap()
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.staticTexts["2 of 6"])
             XCTAssertTrue(app.staticTexts["2 of 6"].exists)
         }
 
-        nextInPageResultButton.tap()
+        nextInPageResultButton.waitAndTap()
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.staticTexts["3 of 6"])
             XCTAssertTrue(app.staticTexts["3 of 6"].exists)
         }
 
         let previousInPageResultButton = app.buttons[AccessibilityIdentifiers.FindInPage.findPreviousButton]
-        previousInPageResultButton.tap()
+        previousInPageResultButton.waitAndTap()
 
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.staticTexts["2 of 6"])
             XCTAssertTrue(app.staticTexts["2 of 6"].exists)
         }
 
-        previousInPageResultButton.tap()
+        previousInPageResultButton.waitAndTap()
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.staticTexts["1 of 6"])
             XCTAssertTrue(app.staticTexts["1 of 6"].exists)
@@ -172,7 +172,7 @@ class FindInPageTests: BaseTestCase {
         openFindInPageFromMenu(openSite: userState.url!)
 
         // Before reloading, it is necessary to hide the keyboard
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
         urlBarAddress.typeText("\n")
 
         // Once the page is reloaded the search bar should not appear
@@ -191,7 +191,7 @@ class FindInPageTests: BaseTestCase {
         openFindInPageFromMenu(openSite: userState.url!)
 
         // Dismiss keyboard
-        app.buttons[AccessibilityIdentifiers.FindInPage.findInPageCloseButton].tap()
+        app.buttons[AccessibilityIdentifiers.FindInPage.findInPageCloseButton].waitAndTap()
         navigator.nowAt(BrowserTab)
 
         // Going to tab tray and back to the website hides the search field.
@@ -219,9 +219,9 @@ class FindInPageTests: BaseTestCase {
         // the buttons to find next and previous
         while !app.menuItems["Find in Page"].exists {
             if #available(iOS 16, *) {
-                app.buttons["Forward"].firstMatch.tap()
+                app.buttons["Forward"].firstMatch.waitAndTap()
             } else {
-                app.menuItems["show.next.items.menu.button"].tap()
+                app.menuItems["show.next.items.menu.button"].waitAndTap()
             }
             mozWaitForElementToExist(app.menuItems.firstMatch)
             if #available(iOS 16, *) {
@@ -231,7 +231,7 @@ class FindInPageTests: BaseTestCase {
             }
         }
         mozWaitForElementToExist(app.menuItems["Find in Page"])
-        app.menuItems["Find in Page"].tap()
+        app.menuItems["Find in Page"].waitAndTap()
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.searchFields[textToFind])
         } else {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -269,11 +269,11 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     let map = MMScreenGraph(for: test, with: FxUserState.self)
 
     let navigationControllerBackAction = {
-        app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap()
+        app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).waitAndTap()
     }
 
     let cancelBackAction = {
-        app.otherElements["PopoverDismissRegion"].tap()
+        app.otherElements["PopoverDismissRegion"].waitAndTap()
     }
 
     let dismissContextMenuAction = {
@@ -336,21 +336,21 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         if #unavailable(iOS 16) {
             screenState.gesture(forAction: Action.LoadURLByPasting, Action.LoadURL) { userState in
                 UIPasteboard.general.string = userState.url ?? defaultURL
-                                menu.otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction].firstMatch.tap()
+                                menu.otherElements[AccessibilityIdentifiers.Photon.pasteAndGoAction].firstMatch.waitAndTap()
             }
         }
 
         screenState.gesture(forAction: Action.SetURLByPasting) { userState in
             UIPasteboard.general.string = userState.url ?? defaultURL
-            menu.cells[AccessibilityIdentifiers.Photon.pasteAction].firstMatch.tap()
+            menu.cells[AccessibilityIdentifiers.Photon.pasteAction].firstMatch.waitAndTap()
         }
 
         screenState.backAction = {
             if isTablet {
                 // There is no Cancel option in iPad.
-                app.otherElements["PopoverDismissRegion"].tap()
+                app.otherElements["PopoverDismissRegion"].waitAndTap()
             } else {
-                app.buttons["PhotonMenu.close"].tap()
+                app.buttons["PhotonMenu.close"].waitAndTap()
             }
         }
         screenState.dismissOnUse = true
@@ -358,7 +358,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(TrackingProtectionContextMenuDetails) { screenState in
         screenState.gesture(forAction: Action.TrackingProtectionperSiteToggle) { userState in
-            app.tables.cells["tp.add-to-safelist"].tap()
+            app.tables.cells["tp.add-to-safelist"].waitAndTap()
             userState.trackingProtectionPerTabEnabled = !userState.trackingProtectionPerTabEnabled
         }
 
@@ -366,15 +366,15 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             forAction: Action.OpenSettingsFromTPMenu,
             transitionTo: TrackingProtectionSettings
         ) { userState in
-            app.cells["settings"].tap()
+            app.cells["settings"].waitAndTap()
         }
 
         screenState.gesture(forAction: Action.CloseTPContextMenu) { userState in
             if isTablet {
                 // There is no Cancel option in iPad.
-                app.otherElements["PopoverDismissRegion"].tap()
+                app.otherElements["PopoverDismissRegion"].waitAndTap()
             } else {
-                app.buttons[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.closeButton].tap()
+                app.buttons[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.closeButton].waitAndTap()
             }
         }
 
@@ -392,8 +392,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.gesture(forAction: Action.LoadURLByTyping) { userState in
             let url = userState.url ?? defaultURL
             // Workaround BB iOS13 be sure tap happens on url bar
-            app.textFields.firstMatch.tap()
-            app.textFields.firstMatch.tap()
+            app.textFields.firstMatch.waitAndTap()
+            app.textFields.firstMatch.waitAndTap()
             app.textFields.firstMatch.typeText(url)
             app.textFields.firstMatch.typeText("\r")
         }
@@ -402,8 +402,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             let url = userState.url ?? defaultURL
             // Workaround BB iOS13 be sure tap happens on url bar
             sleep(1)
-            app.textFields.firstMatch.tap()
-            app.textFields.firstMatch.tap()
+            app.textFields.firstMatch.waitAndTap()
+            app.textFields.firstMatch.waitAndTap()
             app.textFields.firstMatch.typeText("\(url)")
         }
 
@@ -411,7 +411,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.noop(to: HomePanel_TopSites)
 
         screenState.backAction = {
-            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
+            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
         }
         screenState.dismissOnUse = true
     }
@@ -446,7 +446,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(BasicAuthDialog) { screenState in
         screenState.onEnterWaitFor(element: app.alerts.element(boundBy: 0))
         screenState.backAction = {
-            app.alerts.element(boundBy: 0).buttons.element(boundBy: 0).tap()
+            app.alerts.element(boundBy: 0).buttons.element(boundBy: 0).waitAndTap()
         }
         screenState.dismissOnUse = true
     }
@@ -478,7 +478,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(LibraryPanel_Bookmarks) { screenState in
         screenState.tap(app.cells.staticTexts["Mobile Bookmarks"], to: MobileBookmarks)
         screenState.gesture(forAction: Action.CloseBookmarkPanel, transitionTo: HomePanelsScreen) { userState in
-                app.buttons["Done"].tap()
+                app.buttons["Done"].waitAndTap()
         }
 
         screenState.press(app.tables["Bookmarks List"].cells.element(boundBy: 4), to: BookmarksPanelContextMenu)
@@ -491,7 +491,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             forAction: Action.ExitMobileBookmarksFolder,
             transitionTo: LibraryPanel_Bookmarks
         ) { userState in
-                bookmarksButton.tap()
+                bookmarksButton.waitAndTap()
         }
         screenState.tap(app.buttons["Edit"], to: MobileBookmarksEdit)
     }
@@ -499,22 +499,22 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(MobileBookmarksEdit) { screenState in
         screenState.tap(app.buttons["libraryPanelBottomLeftButton"], to: MobileBookmarksAdd)
         screenState.gesture(forAction: Action.RemoveItemMobileBookmarks) { userState in
-            app.tables["Bookmarks List"].buttons.element(boundBy: 0).tap()
+            app.tables["Bookmarks List"].buttons.element(boundBy: 0).waitAndTap()
         }
         screenState.gesture(forAction: Action.ConfirmRemoveItemMobileBookmarks) { userState in
             if #available(iOS 17, *) {
                 if app.buttons["Remove Test Folder"].exists {
-                    app.buttons["Remove Test Folder"].tap()
-                    app.buttons["Delete"].tap()
+                    app.buttons["Remove Test Folder"].waitAndTap()
+                    app.buttons["Delete"].waitAndTap()
                 } else {
-                    app.buttons["Delete"].tap()
+                    app.buttons["Delete"].waitAndTap()
                 }
             } else {
                 if app.buttons["Delete Test Folder"].exists {
-                    app.buttons["Delete Test Folder"].tap()
-                    app.buttons["Delete"].tap()
+                    app.buttons["Delete Test Folder"].waitAndTap()
+                    app.buttons["Delete"].waitAndTap()
                 } else {
-                    app.buttons["Delete"].tap()
+                    app.buttons["Delete"].waitAndTap()
                 }
             }
         }
@@ -522,19 +522,19 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(MobileBookmarksAdd) { screenState in
         screenState.gesture(forAction: Action.AddNewBookmark, transitionTo: EnterNewBookmarkTitleAndUrl) { userState in
-            app.otherElements["New Bookmark"].tap()
+            app.otherElements["New Bookmark"].waitAndTap()
         }
         screenState.gesture(forAction: Action.AddNewFolder) { userState in
-            app.otherElements["New Folder"].tap()
+            app.otherElements["New Folder"].waitAndTap()
         }
         screenState.gesture(forAction: Action.AddNewSeparator) { userState in
-            app.otherElements["New Separator"].tap()
+            app.otherElements["New Separator"].waitAndTap()
         }
     }
 
     map.addScreenState(EnterNewBookmarkTitleAndUrl) { screenState in
         screenState.gesture(forAction: Action.SaveCreatedBookmark) { userState in
-            app.buttons["Save"].tap()
+            app.buttons["Save"].waitAndTap()
         }
     }
 
@@ -558,24 +558,24 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             to: HistoryRecentlyClosed
         )
         screenState.gesture(forAction: Action.ClearRecentHistory) { userState in
-            app.toolbars.matching(identifier: "Toolbar").buttons["historyBottomDeleteButton"].tap()
+            app.toolbars.matching(identifier: "Toolbar").buttons["historyBottomDeleteButton"].waitAndTap()
         }
         screenState.gesture(forAction: Action.CloseHistoryListPanel, transitionTo: HomePanelsScreen) { userState in
-                app.buttons["Done"].tap()
+                app.buttons["Done"].waitAndTap()
         }
     }
 
     map.addScreenState(LibraryPanel_ReadingList) { screenState in
         screenState.dismissOnUse = true
         screenState.gesture(forAction: Action.CloseReadingListPanel, transitionTo: HomePanelsScreen) { userState in
-                app.buttons["Done"].tap()
+                app.buttons["Done"].waitAndTap()
         }
     }
 
     map.addScreenState(LibraryPanel_Downloads) { screenState in
         screenState.dismissOnUse = true
         screenState.gesture(forAction: Action.CloseDownloadsPanel, transitionTo: HomePanelsScreen) { userState in
-            app.buttons["Done"].tap()
+            app.buttons["Done"].waitAndTap()
         }
         screenState.tap(app.buttons["readingListLarge"], to: LibraryPanel_ReadingList)
     }
@@ -621,7 +621,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.tap(table.cells[AccessibilityIdentifiers.Settings.ShowIntroduction.title], to: ShowTourInSettings)
         screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Notifications.title], to: NotificationsSettings)
         screenState.gesture(forAction: Action.ToggleNoImageMode) { userState in
-            app.otherElements.tables.cells.switches[AccessibilityIdentifiers.Settings.BlockImages.title].tap()
+            app.otherElements.tables.cells.switches[AccessibilityIdentifiers.Settings.BlockImages.title].waitAndTap()
         }
 
         screenState.backAction = navigationControllerBackAction
@@ -629,13 +629,13 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(DisplaySettings) { screenState in
         screenState.gesture(forAction: Action.SelectAutomatically) { userState in
-            app.cells.staticTexts["Automatically"].tap()
+            app.cells.staticTexts["Automatically"].waitAndTap()
         }
         screenState.gesture(forAction: Action.SelectManually) { userState in
-            app.cells.staticTexts["Manually"].tap()
+            app.cells.staticTexts["Manually"].waitAndTap()
         }
         screenState.gesture(forAction: Action.SystemThemeSwitch) { userState in
-            app.switches["SystemThemeSwitchValue"].tap()
+            app.switches["SystemThemeSwitchValue"].waitAndTap()
         }
         screenState.backAction = navigationControllerBackAction
     }
@@ -649,20 +649,20 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.backAction = navigationControllerBackAction
         screenState.gesture(forAction: Action.RemoveCustomSearchEngine) {userSTate in
             // Screengraph will go back to main Settings screen. Manually tap on settings
-            app.navigationBars[AccessibilityIdentifiers.Settings.Search.searchNavigationBar].buttons["Edit"].tap()
+            app.navigationBars[AccessibilityIdentifiers.Settings.Search.searchNavigationBar].buttons["Edit"].waitAndTap()
             if #unavailable(iOS 17) {
-                app.tables.buttons["Delete Mozilla Engine"].tap()
+                app.tables.buttons["Delete Mozilla Engine"].waitAndTap()
             } else {
-                app.tables.buttons[AccessibilityIdentifiers.Settings.Search.deleteMozillaEngine].tap()
+                app.tables.buttons[AccessibilityIdentifiers.Settings.Search.deleteMozillaEngine].waitAndTap()
             }
-            app.tables.buttons[AccessibilityIdentifiers.Settings.Search.deleteButton].tap()
+            app.tables.buttons[AccessibilityIdentifiers.Settings.Search.deleteButton].waitAndTap()
         }
     }
 
     map.addScreenState(SiriSettings) { screenState in
         screenState.gesture(forAction: Action.OpenSiriFromSettings) { userState in
             // Tap on Open New Tab to open Siri
-            app.cells["SiriSettings"].staticTexts.element(boundBy: 0).tap()
+            app.cells["SiriSettings"].staticTexts.element(boundBy: 0).waitAndTap()
         }
         screenState.backAction = navigationControllerBackAction
     }
@@ -689,10 +689,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             app.secureTextFields.element(boundBy: 0).tapAndTypeText(userState.fxaPassword!)
         }
         screenState.gesture(forAction: Action.FxATapOnContinueButton) { userState in
-            app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton].tap()
+            app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.continueButton].waitAndTap()
         }
         screenState.gesture(forAction: Action.FxATapOnSignInButton) { userState in
-            app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.signInButton].tap()
+            app.webViews.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.signInButton].waitAndTap()
         }
         screenState.tap(app.webViews.links["Create an account"].firstMatch, to: FxCreateAccount)
     }
@@ -703,9 +703,9 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(AddCustomSearchSettings) { screenState in
         screenState.gesture(forAction: Action.AddCustomSearchEngine) { userState in
-            app.tables.textViews["customEngineTitle"].staticTexts["Search Engine"].tap()
+            app.tables.textViews["customEngineTitle"].staticTexts["Search Engine"].waitAndTap()
             app.typeText("Mozilla Engine")
-            app.tables.textViews["customEngineUrl"].tap()
+            app.tables.textViews["customEngineUrl"].waitAndTap()
 
             let searchEngineUrl = "https://developer.mozilla.org/search?q=%s"
             let tablesQuery = app.tables
@@ -713,22 +713,22 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             sleep(1)
             UIPasteboard.general.string = searchEngineUrl
             customengineurlTextView.press(forDuration: 1.0)
-            app.staticTexts["Paste"].tap()
+            app.staticTexts["Paste"].waitAndTap()
         }
         screenState.backAction = navigationControllerBackAction
     }
 
     map.addScreenState(WebsiteDataSettings) { screenState in
         screenState.gesture(forAction: Action.AcceptClearAllWebsiteData) { userState in
-            app.tables.cells["ClearAllWebsiteData"].staticTexts["Clear All Website Data"].tap()
-            app.alerts.buttons["OK"].tap()
+            app.tables.cells["ClearAllWebsiteData"].staticTexts["Clear All Website Data"].waitAndTap()
+            app.alerts.buttons["OK"].waitAndTap()
         }
         // The swipeDown() is a workaround for an intermittent issue that the search filed is not always in view.
         screenState.gesture(forAction: Action.TapOnFilterWebsites) { userState in
-            app.searchFields["Filter Sites"].tap()
+            app.searchFields["Filter Sites"].waitAndTap()
         }
         screenState.gesture(forAction: Action.ShowMoreWebsiteDataEntries) { userState in
-            app.tables.cells["ShowMoreWebsiteData"].tap()
+            app.tables.cells["ShowMoreWebsiteData"].waitAndTap()
         }
         screenState.backAction = navigationControllerBackAction
     }
@@ -737,13 +737,13 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         let table = app.tables.element(boundBy: 0)
 
         screenState.gesture(forAction: Action.SelectNewTabAsBlankPage) { UserState in
-            table.cells["NewTabAsBlankPage"].tap()
+            table.cells["NewTabAsBlankPage"].waitAndTap()
         }
         screenState.gesture(forAction: Action.SelectNewTabAsFirefoxHomePage) { UserState in
-            table.cells["NewTabAsFirefoxHome"].tap()
+            table.cells["NewTabAsFirefoxHome"].waitAndTap()
         }
         screenState.gesture(forAction: Action.SelectNewTabAsCustomURL) { UserState in
-            table.cells["NewTabAsCustomURL"].tap()
+            table.cells["NewTabAsCustomURL"].waitAndTap()
         }
 
         screenState.backAction = navigationControllerBackAction
@@ -751,30 +751,30 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(HomeSettings) { screenState in
         screenState.gesture(forAction: Action.SelectHomeAsFirefoxHomePage) { UserState in
-            app.cells["HomeAsFirefoxHome"].tap()
+            app.cells["HomeAsFirefoxHome"].waitAndTap()
         }
 
         screenState.gesture(forAction: Action.SelectHomeAsCustomURL) { UserState in
-            app.cells["HomeAsCustomURL"].tap()
+            app.cells["HomeAsCustomURL"].waitAndTap()
         }
 
         screenState.gesture(forAction: Action.TogglePocketInNewTab) { userState in
             userState.pocketInNewTab = !userState.pocketInNewTab
-            app.tables.cells.switches["Thought-Provoking Stories, Articles powered by Pocket"].tap()
+            app.tables.cells.switches["Thought-Provoking Stories, Articles powered by Pocket"].waitAndTap()
         }
 
         screenState.gesture(forAction: Action.SelectTopSitesRows) { userState in
-            app.tables.cells["TopSitesRows"].tap()
+            app.tables.cells["TopSitesRows"].waitAndTap()
             select(rows: userState.numTopSitesRows)
-            app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap()
+            app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).waitAndTap()
         }
 
         screenState.gesture(forAction: Action.ToggleRecentlyVisited) { userState in
-            app.tables.cells.switches["Recently Visited"].tap()
+            app.tables.cells.switches["Recently Visited"].waitAndTap()
         }
 
         screenState.gesture(forAction: Action.ToggleRecentlySaved) { userState in
-            app.tables.cells.switches["Bookmarks"].tap()
+            app.tables.cells.switches["Bookmarks"].waitAndTap()
         }
 
         screenState.backAction = navigationControllerBackAction
@@ -782,23 +782,23 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     map.addScreenState(ToolbarSettings) { screenState in
         screenState.gesture(forAction: Action.SelectToolbarBottom) { UserState in
-            app.cells[AccessibilityIdentifiers.Settings.SearchBar.bottomSetting].tap()
+            app.cells[AccessibilityIdentifiers.Settings.SearchBar.bottomSetting].waitAndTap()
         }
 
         screenState.gesture(forAction: Action.SelectToolbarTop) { UserState in
-            app.cells[AccessibilityIdentifiers.Settings.SearchBar.topSetting].tap()
+            app.cells[AccessibilityIdentifiers.Settings.SearchBar.topSetting].waitAndTap()
         }
 
         screenState.backAction = navigationControllerBackAction
     }
 
     func select(rows: Int) {
-        app.staticTexts[String(rows)].firstMatch.tap()
+        app.staticTexts[String(rows)].firstMatch.waitAndTap()
     }
 
     func type(text: String) {
         text.forEach { char in
-            app.keys[String(char)].tap()
+            app.keys[String(char)].waitAndTap()
         }
     }
 
@@ -808,8 +808,8 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             to: WebsiteDataSettings
         )
         screenState.gesture(forAction: Action.AcceptClearPrivateData) { userState in
-            app.tables.cells["ClearPrivateData"].tap()
-            app.alerts.buttons["OK"].tap()
+            app.tables.cells["ClearPrivateData"].waitAndTap()
+            app.alerts.buttons["OK"].waitAndTap()
         }
         screenState.backAction = navigationControllerBackAction
     }
@@ -821,7 +821,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(ShowTourInSettings) { screenState in
         screenState.gesture(to: Intro_FxASignin) {
             let turnOnSyncButton = app.buttons["signInOnboardingButton"]
-            turnOnSyncButton.tap()
+            turnOnSyncButton.waitAndTap()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -420,7 +420,6 @@ class HistoryTests: BaseTestCase {
         navigator.performAction(Action.OpenNewTabFromTabTray)
         openBookOfMozilla()
         urlBarBackButton.press(forDuration: 1)
-        mozWaitForElementToExist(app.tables.staticTexts["The Book of Mozilla"])
         app.tables.staticTexts["The Book of Mozilla"].waitAndTap()
         urlBarBackButton.waitAndTap()
         XCTAssertFalse(urlBarBackButton.isEnabled)
@@ -477,7 +476,7 @@ class HistoryTests: BaseTestCase {
                 .waitAndTap()
         } else {
             app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
-            // app.otherElements.cells.element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
+            // app.otherElements.cells.element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].tap()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -103,8 +103,8 @@ class HistoryTests: BaseTestCase {
             navigator.goto(HomePanelsScreen)
             navigator.nowAt(NewTabScreen)
             navigator.goto(ClearPrivateDataSettings)
-            app.tables.cells["ClearPrivateData"].tap()
-            app.alerts.buttons["OK"].tap()
+            app.tables.cells["ClearPrivateData"].waitAndTap()
+            app.alerts.buttons["OK"].waitAndTap()
 
             // Back on History panel view check that there is not any item
             navigator.goto(LibraryPanel_History)
@@ -127,15 +127,15 @@ class HistoryTests: BaseTestCase {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         // Clear private data from settings and confirm
         navigator.goto(ClearPrivateDataSettings)
-        app.tables.cells["ClearPrivateData"].tap()
+        app.tables.cells["ClearPrivateData"].waitAndTap()
         mozWaitForElementToExist(app.tables.cells["ClearPrivateData"])
-        app.alerts.buttons["OK"].tap()
+        app.alerts.buttons["OK"].waitAndTap()
 
         // Wait for OK pop-up to disappear after confirming
         mozWaitForElementToNotExist(app.alerts.buttons["OK"])
 
         // Try to tap on the disabled Clear Private Data button
-        app.tables.cells["ClearPrivateData"].tap()
+        app.tables.cells["ClearPrivateData"].waitAndTap()
 
         // If the button is disabled, the confirmation pop-up should not exist
         // Disabling assertion due to https://mozilla-hub.atlassian.net/browse/FXIOS-7494 issue
@@ -253,8 +253,8 @@ class HistoryTests: BaseTestCase {
         navigator.goto(HomePanelsScreen)
         navigator.nowAt(NewTabScreen)
         navigator.goto(ClearPrivateDataSettings)
-        app.tables.cells["ClearPrivateData"].tap()
-        app.alerts.buttons["OK"].tap()
+        app.tables.cells["ClearPrivateData"].waitAndTap()
+        app.alerts.buttons["OK"].waitAndTap()
 
         // The closed tab is *not* listed in "Recently Closed Tabs List"
         navigator.goto(LibraryPanel_History)
@@ -310,7 +310,7 @@ class HistoryTests: BaseTestCase {
         XCTAssertEqual(userState.numTabs, 1)
         app.tables.cells.staticTexts[bookOfMozilla["label"]!].press(forDuration: 1)
         mozWaitForElementToExist(app.tables["Context Menu"])
-        app.tables.otherElements[StandardImageIdentifiers.Large.plus].tap()
+        app.tables.otherElements[StandardImageIdentifiers.Large.plus].waitAndTap()
 
         // The page is opened on the new tab
         navigator.nowAt(NewTabScreen)
@@ -344,7 +344,7 @@ class HistoryTests: BaseTestCase {
         )
         app.tables.cells.staticTexts[bookOfMozilla["label"]!].press(forDuration: 1)
         mozWaitForElementToExist(app.tables["Context Menu"])
-        app.tables.otherElements[StandardImageIdentifiers.Large.privateMode].tap()
+        app.tables.otherElements[StandardImageIdentifiers.Large.privateMode].waitAndTap()
 
         // The page is opened only on the new private tab
         navigator.nowAt(NewTabScreen)
@@ -381,7 +381,7 @@ class HistoryTests: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
         mozWaitForElementToExist(app.cells.staticTexts[webpage["label"]!])
-        app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.tap()
+        app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
 
         // On private mode, the "Recently Closed Tabs List" is empty
         navigator.performAction(Action.OpenNewTabFromTabTray)
@@ -421,8 +421,8 @@ class HistoryTests: BaseTestCase {
         openBookOfMozilla()
         urlBarBackButton.press(forDuration: 1)
         mozWaitForElementToExist(app.tables.staticTexts["The Book of Mozilla"])
-        app.tables.staticTexts["The Book of Mozilla"].tap()
-        urlBarBackButton.tap()
+        app.tables.staticTexts["The Book of Mozilla"].waitAndTap()
+        urlBarBackButton.waitAndTap()
         XCTAssertFalse(urlBarBackButton.isEnabled)
         urlBarForwardButton.press(forDuration: 1)
         app.tables.staticTexts["The Book of Mozilla"].waitAndTap()
@@ -434,7 +434,7 @@ class HistoryTests: BaseTestCase {
     // We used this approach to avoid code duplication
 
     private func tapOnClearRecentHistoryOption(optionSelected: String) {
-        app.buttons[optionSelected].tap()
+        app.buttons[optionSelected].waitAndTap()
     }
 
     private func navigateToPage() {
@@ -474,10 +474,10 @@ class HistoryTests: BaseTestCase {
                 .cells
                 .element(boundBy: 0)
                 .buttons[StandardImageIdentifiers.Large.cross]
-                .tap()
+                .waitAndTap()
         } else {
-            app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.tap()
-            // app.otherElements.cells.element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].tap()
+            app.cells.buttons[StandardImageIdentifiers.Large.cross].firstMatch.waitAndTap()
+            // app.otherElements.cells.element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
@@ -24,7 +24,7 @@ class HomeButtonTests: BaseTestCase {
 
         XCUIDevice.shared.orientation = .landscapeRight
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
-        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
         navigator.nowAt(NewTabScreen)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
@@ -23,7 +23,6 @@ class HomeButtonTests: BaseTestCase {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
 
         XCUIDevice.shared.orientation = .landscapeRight
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
         app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
         navigator.nowAt(NewTabScreen)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -107,7 +107,7 @@ class HomePageSettingsUITests: BaseTestCase {
         // Check that what's in clipboard is copied
         UIPasteboard.general.string = websiteUrl1
         navigator.goto(HomeSettings)
-        app.textFields["HomeAsCustomURLTextField"].tap()
+        app.textFields["HomeAsCustomURLTextField"].waitAndTap()
         if #unavailable(iOS 16) {
             sleep(2)
         }
@@ -181,12 +181,12 @@ class HomePageSettingsUITests: BaseTestCase {
         )
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
-        app.staticTexts["Shortcuts"].tap()
+        app.staticTexts["Shortcuts"].waitAndTap()
         XCTAssertTrue(app.switches["Shortcuts"].exists)
-        app.switches["Shortcuts"].tap()
+        app.switches["Shortcuts"].waitAndTap()
 
         navigator.goto(NewTabScreen)
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
 
         mozWaitForElementToNotExist(app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
         mozWaitForElementToNotExist(app.collectionViews.cells.staticTexts["YouTube"])
@@ -251,12 +251,12 @@ class HomePageSettingsUITests: BaseTestCase {
         } else {
             mozWaitForElementToExist(app.otherElements.cells[urlExampleLabel])
         }
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
         // Validation for when Jump In section is not displayed
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
-        app.tables.cells.switches["Jump Back In"].tap()
-        app.buttons["Done"].tap()
+        app.tables.cells.switches["Jump Back In"].waitAndTap()
+        app.buttons["Done"].waitAndTap()
         navigator.nowAt(NewTabScreen)
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn])
     }
@@ -273,7 +273,7 @@ class HomePageSettingsUITests: BaseTestCase {
             navigator.performAction(Action.GoToHomePage)
         }
         mozWaitForElementToExist(app.staticTexts["Bookmarks"])
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
         navigator.performAction(Action.ToggleRecentlySaved)
         if !iPad() {
             navigator.performAction(Action.ClickSearchButton)
@@ -297,7 +297,7 @@ class HomePageSettingsUITests: BaseTestCase {
         checkBookmarks()
         app.scrollViews
             .cells[AccessibilityIdentifiers.FirefoxHomepage.Bookmarks.itemCell]
-            .staticTexts[urlExampleLabel].tap()
+            .staticTexts[urlExampleLabel].waitAndTap()
         navigator.nowAt(BrowserTab)
         waitForTabsButton()
         unbookmark()
@@ -378,7 +378,7 @@ class HomePageSettingsUITests: BaseTestCase {
                 app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage]
             )
         }
-        app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage].tap()
+        app.cells.otherElements.buttons[AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.customizeHomePage].waitAndTap()
         // Verify default settings
         waitForElementsToExist(
             [
@@ -434,16 +434,16 @@ class HomePageSettingsUITests: BaseTestCase {
 
     private func validateNumberOfTopSitesDisplayed(row: Int, minBoundary: Int, maxBoundary: Int) {
         navigator.goto(HomeSettings)
-        app.staticTexts["Shortcuts"].tap()
+        app.staticTexts["Shortcuts"].waitAndTap()
         app.staticTexts["Rows"].waitAndTap()
         let expectedRowValues = ["1", "2", "3", "4"]
         for i in 0...3 {
             XCTAssertEqual(app.tables.cells.element(boundBy: i).label, expectedRowValues[i])
         }
-        app.tables.cells.element(boundBy: row).tap()
-        app.buttons["Shortcuts"].tap()
+        app.tables.cells.element(boundBy: row).waitAndTap()
+        app.buttons["Shortcuts"].waitAndTap()
         navigator.goto(NewTabScreen)
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
         mozWaitForElementToExist(app.links["TopSitesCell"])
         let totalTopSites = app.links.matching(identifier: "TopSitesCell").count
         XCTAssertTrue(totalTopSites > minBoundary)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
@@ -48,7 +48,7 @@ final class InactiveTabsTest: BaseTestCase {
         )
 
         // Tap on the ">" button.
-        app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView].tap()
+        app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView].waitAndTap()
         waitForElementsToExist(
             [
                 app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerButton],
@@ -58,20 +58,20 @@ final class InactiveTabsTest: BaseTestCase {
                 app.otherElements["Tabs Tray"].staticTexts["Amazon.com. Spend less. Smile more."]
             ]
         )
-        app.buttons[AccessibilityIdentifiers.TabTray.doneButton].tap()
+        app.buttons[AccessibilityIdentifiers.TabTray.doneButton].waitAndTap()
 
         // Go to Settings -> Tabs and disable "Inactive tabs"
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.Settings.Tabs.title])
-        app.cells[AccessibilityIdentifiers.Settings.Tabs.title].tap()
+        app.cells[AccessibilityIdentifiers.Settings.Tabs.title].waitAndTap()
         mozWaitForElementToExist(app.tables.otherElements[AccessibilityIdentifiers.Settings.Tabs.Customize.title])
         XCTAssertEqual(
             app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].value as? String, "1")
-        app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].tap()
+        app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].waitAndTap()
         XCTAssertEqual(
             app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].value as? String, "0")
-        app.navigationBars.buttons["Settings"].tap() // Note: No AccessibilityIdentifiers
+        app.navigationBars.buttons["Settings"].waitAndTap() // Note: No AccessibilityIdentifiers
         navigator.nowAt(SettingsScreen)
 
         // Return to tabs tray
@@ -88,18 +88,18 @@ final class InactiveTabsTest: BaseTestCase {
             ]
         )
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerButton])
-        app.buttons[AccessibilityIdentifiers.TabTray.doneButton].tap()
+        app.buttons[AccessibilityIdentifiers.TabTray.doneButton].waitAndTap()
         navigator.nowAt(NewTabScreen)
 
         // Go to Settings -> Tabs and enable "Inactive tabs"
         navigator.goto(SettingsScreen)
         mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.Settings.Tabs.title])
-        app.cells[AccessibilityIdentifiers.Settings.Tabs.title].tap()
+        app.cells[AccessibilityIdentifiers.Settings.Tabs.title].waitAndTap()
         mozWaitForElementToExist(app.tables.otherElements[AccessibilityIdentifiers.Settings.Tabs.Customize.title])
-        app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].tap()
+        app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].waitAndTap()
         XCTAssertEqual(
             app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].value as? String, "1")
-        app.navigationBars.buttons["Settings"].tap()
+        app.navigationBars.buttons["Settings"].waitAndTap()
         navigator.nowAt(SettingsScreen)
 
         // Return to tabs tray
@@ -107,14 +107,14 @@ final class InactiveTabsTest: BaseTestCase {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView])
 
         // Tap on a tab from the inactive list
-        app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView].tap()
+        app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView].waitAndTap()
         waitForElementsToExist(
             [
                 app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerButton],
                 app.otherElements["Tabs Tray"].staticTexts["Homepage"]
             ]
         )
-        app.otherElements["Tabs Tray"].staticTexts["Homepage"].tap()
+        app.otherElements["Tabs Tray"].staticTexts["Homepage"].waitAndTap()
         mozWaitForElementToNotExist(app.otherElements["Tabs Tray"])
 
         navigator.nowAt(NewTabScreen)
@@ -127,7 +127,7 @@ final class InactiveTabsTest: BaseTestCase {
         )
 
         // Expand inactive list
-        app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView].tap()
+        app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView].waitAndTap()
         waitForElementsToExist(
             [
                 app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerButton],
@@ -143,7 +143,7 @@ final class InactiveTabsTest: BaseTestCase {
         // Swipe on a tab from the list to delete
         app.otherElements["Tabs Tray"].staticTexts["Google"].swipeLeft()
         mozWaitForElementToExist(app.otherElements["Tabs Tray"].buttons["Close"])
-        app.otherElements["Tabs Tray"].buttons["Close"].tap() // Note: No AccessibilityIdentifier
+        app.otherElements["Tabs Tray"].buttons["Close"].waitAndTap() // Note: No AccessibilityIdentifier
         mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Google"])
         waitForElementsToExist(
             [
@@ -155,7 +155,7 @@ final class InactiveTabsTest: BaseTestCase {
         // Tap "Close All Inactive Tabs"
         app.swipeUp()
         mozWaitForElementToExist(app.buttons["InactiveTabs.deleteButton"])
-        app.buttons["InactiveTabs.deleteButton"].tap()
+        app.buttons["InactiveTabs.deleteButton"].waitAndTap()
         mozWaitForElementToExist(app.staticTexts["Tabs Closed: 17"])
 
         // All inactive tabs are deleted

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/InactiveTabsTest.swift
@@ -63,7 +63,6 @@ final class InactiveTabsTest: BaseTestCase {
         // Go to Settings -> Tabs and disable "Inactive tabs"
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
-        mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.Settings.Tabs.title])
         app.cells[AccessibilityIdentifiers.Settings.Tabs.title].waitAndTap()
         mozWaitForElementToExist(app.tables.otherElements[AccessibilityIdentifiers.Settings.Tabs.Customize.title])
         XCTAssertEqual(
@@ -93,9 +92,7 @@ final class InactiveTabsTest: BaseTestCase {
 
         // Go to Settings -> Tabs and enable "Inactive tabs"
         navigator.goto(SettingsScreen)
-        mozWaitForElementToExist(app.cells[AccessibilityIdentifiers.Settings.Tabs.title])
         app.cells[AccessibilityIdentifiers.Settings.Tabs.title].waitAndTap()
-        mozWaitForElementToExist(app.tables.otherElements[AccessibilityIdentifiers.Settings.Tabs.Customize.title])
         app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].waitAndTap()
         XCTAssertEqual(
             app.switches[AccessibilityIdentifiers.Settings.Tabs.Customize.inactiveTabsSwitch].value as? String, "1")
@@ -104,7 +101,6 @@ final class InactiveTabsTest: BaseTestCase {
 
         // Return to tabs tray
         navigator.goto(TabTray)
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView])
 
         // Tap on a tab from the inactive list
         app.buttons[AccessibilityIdentifiers.TabTray.InactiveTabs.headerView].waitAndTap()
@@ -142,7 +138,6 @@ final class InactiveTabsTest: BaseTestCase {
 
         // Swipe on a tab from the list to delete
         app.otherElements["Tabs Tray"].staticTexts["Google"].swipeLeft()
-        mozWaitForElementToExist(app.otherElements["Tabs Tray"].buttons["Close"])
         app.otherElements["Tabs Tray"].buttons["Close"].waitAndTap() // Note: No AccessibilityIdentifier
         mozWaitForElementToNotExist(app.otherElements["Tabs Tray"].staticTexts["Google"])
         waitForElementsToExist(

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -45,7 +45,7 @@ class IntegrationTests: BaseTestCase {
 
     func allowNotifications () {
         addUIInterruptionMonitor(withDescription: "notifications") { (alert) -> Bool in
-            alert.buttons["Allow"].tap()
+            alert.buttons["Allow"].waitAndTap()
             return true
         }
         app.swipeDown()
@@ -80,10 +80,10 @@ class IntegrationTests: BaseTestCase {
         mozWaitForElementToNotExist(app.staticTexts["Sync and Save Data"])
         sleep(5)
         if app.tables.staticTexts["Sync is offline"].exists {
-            app.tables.staticTexts["Sync is offline"].tap()
+            app.tables.staticTexts["Sync is offline"].waitAndTap()
         }
         if app.tables.staticTexts["Sync Now"].exists {
-            app.tables.staticTexts["Sync Now"].tap()
+            app.tables.staticTexts["Sync Now"].waitAndTap()
         }
         mozWaitForElementToNotExist(app.tables.staticTexts["Syncing…"])
         mozWaitForElementToExist(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
@@ -154,9 +154,9 @@ class IntegrationTests: BaseTestCase {
         )
 
         // Sync again just to make sure to sync after new name is shown
-        app.buttons["Settings"].tap()
+        app.buttons["Settings"].waitAndTap()
         mozWaitForElementToExist(app.staticTexts["ACCOUNT"])
-        app.tables.cells.element(boundBy: 2).tap()
+        app.tables.cells.element(boundBy: 2).waitAndTap()
         mozWaitForElementToExist(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
     }
 
@@ -166,10 +166,10 @@ class IntegrationTests: BaseTestCase {
 
         // Log in in order to save it
         app.webViews.textFields["Email or phone"].tapAndTypeText(userName)
-        app.webViews.buttons["Next"].tap()
+        app.webViews.buttons["Next"].waitAndTap()
         app.webViews.secureTextFields["Password"].tapAndTypeText(userPassword)
 
-        app.webViews.buttons["Sign in"].tap()
+        app.webViews.buttons["Sign in"].waitAndTap()
 
         // Save the login
         app.buttons["SaveLoginPrompt.saveLoginButton"].waitAndTap()
@@ -203,7 +203,7 @@ class IntegrationTests: BaseTestCase {
         navigator.nowAt(SettingsScreen)
         navigator.goto(LoginsSettings)
         mozWaitForElementToExist(app.buttons.firstMatch)
-        app.scrollViews.buttons["Continue"].tap()
+        app.scrollViews.buttons["Continue"].waitAndTap()
 
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let passcodeInput = springboard.secureTextFields["Passcode field"]
@@ -222,7 +222,7 @@ class IntegrationTests: BaseTestCase {
         waitForInitialSyncComplete()
 
         // Check synced Tabs
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(TabTray)
         navigator.performAction(Action.ToggleSyncMode)
@@ -258,7 +258,7 @@ class IntegrationTests: BaseTestCase {
         navigator.nowAt(SettingsScreen)
         navigator.goto(LoginsSettings)
         mozWaitForElementToExist(app.buttons.firstMatch)
-        app.scrollViews.buttons["Continue"].tap()
+        app.scrollViews.buttons["Continue"].waitAndTap()
 
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let passcodeInput = springboard.secureTextFields["Passcode field"]
@@ -270,18 +270,18 @@ class IntegrationTests: BaseTestCase {
 
         // Disconnect account
         navigator.goto(SettingsScreen)
-        app.tables.cells.element(boundBy: 1).tap()
+        app.tables.cells.element(boundBy: 1).waitAndTap()
         mozWaitForElementToExist(app.cells["DeviceNameSetting"].textFields["DeviceNameSettingTextField"])
 
-        app.cells["SignOut"].tap()
+        app.cells["SignOut"].waitAndTap()
 
         app.buttons["Disconnect"].waitAndTap()
         sleep(3)
 
         // Connect same account again
         navigator.nowAt(SettingsScreen)
-        app.tables.cells["SignInToSync"].tap()
-        app.buttons["EmailSignIn.button"].tap()
+        app.tables.cells["SignInToSync"].waitAndTap()
+        app.buttons["EmailSignIn.button"].waitAndTap()
 
         navigator.nowAt(FxASigninScreen)
         mozWaitForElementToExist(app.staticTexts["Enter your password"], timeout: TIMEOUT_LONG)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -104,7 +104,7 @@ class JumpBackInTests: BaseTestCase {
         mozWaitForElementToNotExist(app.cells["JumpBackInCell"].staticTexts["YouTube"])
 
         // Tap on Twitter from "Jump Back In"
-        app.cells["JumpBackInCell"].staticTexts["Wikipedia"].firstMatch.tap()
+        app.cells["JumpBackInCell"].staticTexts["Wikipedia"].firstMatch.waitAndTap()
 
         // The view is switched to the twitter tab
         if let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].value as? String {
@@ -134,7 +134,7 @@ class JumpBackInTests: BaseTestCase {
         } else {
             mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
         }
-        app.cells["Example Domain"].buttons[StandardImageIdentifiers.Large.cross].tap()
+        app.cells["Example Domain"].buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
 
         // Revisit the "Jump Back In" section
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LibraryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LibraryTests.swift
@@ -14,7 +14,7 @@ class LibraryTestsIpad: IpadOnlyTestCase {
         // The Bookmark panel is displayed
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.bookmarksButton])
         let libraryShorcutButton = app.buttons[AccessibilityIdentifiers.Toolbar.bookmarksButton]
-        libraryShorcutButton.tap()
+        libraryShorcutButton.waitAndTap()
         navigator.nowAt(HomePanel_Library)
         mozWaitForElementToExist(app.tables[AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.tableView])
         // Go to a different panel

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -30,7 +30,7 @@ class LoginTest: BaseTestCase {
         waitUntilPageLoad()
         app.buttons["submit"].waitAndTap()
         mozWaitForElementToExist(app.buttons["SaveLoginPrompt.saveLoginButton"])
-        app.buttons["SaveLoginPrompt.saveLoginButton"].tap()
+        app.buttons["SaveLoginPrompt.saveLoginButton"].waitAndTap()
     }
 
     private func openLoginsSettings() {
@@ -95,10 +95,10 @@ class LoginTest: BaseTestCase {
         openLoginsSettingsFromBrowserTab()
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList)
         // Save a login and check that it appears on the list from BrowserTabMenu
-        app.buttons["Settings"].tap()
+        app.buttons["Settings"].waitAndTap()
         navigator.nowAt(SettingsScreen)
         waitForExistence(app.buttons["Done"])
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
         navigator.nowAt(HomePanelsScreen)
 
         saveLogin(givenUrl: testLoginPage)
@@ -112,10 +112,10 @@ class LoginTest: BaseTestCase {
         // I can't reproduce the issue manually. The issue occurs only during test automation.
         if #available(iOS 16, *) {
             // Check to see how it works with multiple entries in the list- in this case, two for now
-            app.buttons["Settings"].tap()
+            app.buttons["Settings"].waitAndTap()
             navigator.nowAt(SettingsScreen)
             waitForExistence(app.buttons["Done"])
-            app.buttons["Done"].tap()
+            app.buttons["Done"].waitAndTap()
 
             navigator.nowAt(HomePanelsScreen)
             saveLogin(givenUrl: testSecondLoginPage)
@@ -139,8 +139,8 @@ class LoginTest: BaseTestCase {
     func testDoNotSaveLogin() {
         navigator.openURL(testLoginPage)
         waitUntilPageLoad()
-        app.buttons["submit"].tap()
-        app.buttons["SaveLoginPrompt.dontSaveButton"].tap()
+        app.buttons["submit"].waitAndTap()
+        app.buttons["SaveLoginPrompt.dontSaveButton"].waitAndTap()
         // There should not be any login saved
         openLoginsSettings()
         mozWaitForElementToNotExist(app.staticTexts[domain])
@@ -156,7 +156,7 @@ class LoginTest: BaseTestCase {
         mozWaitForElementToExist(app.staticTexts[domain])
         mozWaitForElementToExist(app.staticTexts[domainLogin])
         XCTAssertTrue(app.buttons["Edit"].isHittable)
-        app.buttons["Edit"].tap()
+        app.buttons["Edit"].waitAndTap()
 
         mozWaitForElementToExist(app.buttons["Select All"])
         mozWaitForElementToExist(app.staticTexts[domainLogin])
@@ -172,9 +172,9 @@ class LoginTest: BaseTestCase {
         openLoginsSettings()
         mozWaitForElementToExist(app.staticTexts[domainLogin])
         app.staticTexts[domain].waitAndTap()
-        app.cells.staticTexts["Delete"].tap()
+        app.cells.staticTexts["Delete"].waitAndTap()
         mozWaitForElementToExist(app.alerts["Remove Password?"])
-        app.alerts.buttons["Remove"].tap()
+        app.alerts.buttons["Remove"].waitAndTap()
         mozWaitForElementToExist(app.tables["Login List"])
         mozWaitForElementToNotExist(app.staticTexts[domain])
         mozWaitForElementToNotExist(app.staticTexts[domainLogin])
@@ -189,7 +189,7 @@ class LoginTest: BaseTestCase {
         openLoginsSettingsFromBrowserTab()
         XCTAssertTrue(app.staticTexts[domain].exists)
         XCTAssertTrue(app.staticTexts[domainLogin].exists)
-        app.staticTexts[domain].tap()
+        app.staticTexts[domain].waitAndTap()
         // The login details are available
         waitForExistence(app.tables["Login Detail List"])
         mozWaitForElementToExist(app.tables.cells[loginsListURLLabel])
@@ -197,11 +197,11 @@ class LoginTest: BaseTestCase {
         mozWaitForElementToExist(app.tables.cells[loginsListPasswordLabel])
         mozWaitForElementToExist(app.tables.cells.staticTexts["Delete"])
         // Change the username
-        app.buttons["Edit"].tap()
+        app.buttons["Edit"].waitAndTap()
         mozWaitForElementToExist(app.tables["Login Detail List"])
-        app.tables["Login Detail List"].cells.elementContainingText("Username").tap()
+        app.tables["Login Detail List"].cells.elementContainingText("Username").waitAndTap()
         mozWaitForElementToExist(app.menuItems["Select All"])
-        app.menuItems["Select All"].tap()
+        app.menuItems["Select All"].waitAndTap()
         app.menuItems["Cut"].waitAndTap()
         enterTextInField(typedText: "foo")
         app.buttons["Done"].waitAndTap()
@@ -230,7 +230,7 @@ class LoginTest: BaseTestCase {
         // mozWaitForElementToExist(app.tables["No logins found"])
 
         // Clear Text
-        app.buttons["Clear text"].tap()
+        app.buttons["Clear text"].waitAndTap()
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList + 1)
     }
 
@@ -248,7 +248,7 @@ class LoginTest: BaseTestCase {
         app.webViews.secureTextFields.element(boundBy: 0).tapAndTypeText("test15mz")
 
         // Submit form and choose to save the logins
-        app.buttons["submit"].tap()
+        app.buttons["submit"].waitAndTap()
         app.buttons["SaveLoginPrompt.saveLoginButton"].waitAndTap()
 
         // Clear Data and go to test page, fields should be filled in
@@ -303,7 +303,7 @@ class LoginTest: BaseTestCase {
     }
 
     private func createLoginManually() {
-        app.buttons["Add"].tap()
+        app.buttons["Add"].waitAndTap()
         waitForElementsToExist(
             [
                 app.tables["Add Credential"],
@@ -313,16 +313,16 @@ class LoginTest: BaseTestCase {
             ]
         )
 
-        app.tables["Add Credential"].cells["Website, "].tap()
+        app.tables["Add Credential"].cells["Website, "].waitAndTap()
         enterTextInField(typedText: "testweb")
 
-        app.tables["Add Credential"].cells["Username, "].tap()
+        app.tables["Add Credential"].cells["Username, "].waitAndTap()
         enterTextInField(typedText: "foo")
 
-        app.tables["Add Credential"].cells["Password"].tap()
+        app.tables["Add Credential"].cells["Password"].waitAndTap()
         enterTextInField(typedText: "bar")
 
-        app.buttons["Save"].tap()
+        app.buttons["Save"].waitAndTap()
         mozWaitForElementToExist(app.tables["Login List"].otherElements["SAVED PASSWORDS"])
     }
 
@@ -331,7 +331,7 @@ class LoginTest: BaseTestCase {
         if #unavailable(iOS 16) {
             mozWaitForElementToExist(app.keyboards.firstMatch)
             if app.keyboards.buttons["Continue"].exists {
-                app.keyboards.buttons["Continue"].tap()
+                app.keyboards.buttons["Continue"].waitAndTap()
                 mozWaitForElementToNotExist(app.keyboards.buttons["Continue"])
             }
             // The keyboard may need extra time to respond.
@@ -339,7 +339,7 @@ class LoginTest: BaseTestCase {
         }
         for letter in typedText {
             print("\(letter)")
-            app.keyboards.keys["\(letter)"].tap()
+            app.keyboards.keys["\(letter)"].waitAndTap()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -29,7 +29,6 @@ class LoginTest: BaseTestCase {
         navigator.openURL(givenUrl)
         waitUntilPageLoad()
         app.buttons["submit"].waitAndTap()
-        mozWaitForElementToExist(app.buttons["SaveLoginPrompt.saveLoginButton"])
         app.buttons["SaveLoginPrompt.saveLoginButton"].waitAndTap()
     }
 
@@ -200,7 +199,6 @@ class LoginTest: BaseTestCase {
         app.buttons["Edit"].waitAndTap()
         mozWaitForElementToExist(app.tables["Login Detail List"])
         app.tables["Login Detail List"].cells.elementContainingText("Username").waitAndTap()
-        mozWaitForElementToExist(app.menuItems["Select All"])
         app.menuItems["Select All"].waitAndTap()
         app.menuItems["Cut"].waitAndTap()
         enterTextInField(typedText: "foo")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MicrosurveyTests.swift
@@ -28,7 +28,7 @@ final class MicrosurveyTests: BaseTestCase {
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton].exists)
         XCTAssertTrue(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.firefoxLogo].exists)
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists)
-        app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].tap()
+        app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].waitAndTap()
         XCTAssertFalse(app.images[AccessibilityIdentifiers.Microsurvey.Prompt.closeButton].exists)
     }
 
@@ -52,7 +52,7 @@ final class MicrosurveyTests: BaseTestCase {
     func testShowMicrosurvey() {
         generateTriggerForMicrosurvey()
         let continueButton = app.buttons[AccessibilityIdentifiers.Microsurvey.Prompt.takeSurveyButton]
-        continueButton.tap()
+        continueButton.waitAndTap()
 
         waitForElementsToExist(
             [
@@ -62,7 +62,7 @@ final class MicrosurveyTests: BaseTestCase {
         )
         let tablesQuery = app.scrollViews.otherElements.tables
         let firstOption = tablesQuery.cells.firstMatch
-        firstOption.tap()
+        firstOption.waitAndTap()
         mozWaitForElementToExist(firstOption)
         XCTAssertEqual(firstOption.label, "Very satisfied")
         mozWaitForValueContains(firstOption, value: "1 out of 6")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
@@ -43,14 +43,14 @@ class MultiWindowTests: IpadOnlyTestCase {
         let homeButtom = AccessibilityIdentifiers.Toolbar.addNewTabButton
         // A new tab is opened in the same window
         app.collectionViews.cells.matching(identifier: topSites).firstMatch.waitAndTap()
-        app.buttons[homeButtom].firstMatch.tap()
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].firstMatch.tap()
+        app.buttons[homeButtom].firstMatch.waitAndTap()
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].firstMatch.waitAndTap()
         let tabButtonSecondWindow = app.buttons.matching(identifier: tabsButtonIdentifier).element(boundBy: 0)
         XCTAssertEqual(tabButtonSecondWindow.value as? String, "2", "Number of tabs opened should be equal to 2")
         // A new tab is opened in the same window
         app.collectionViews.cells.matching(identifier: topSites).element(boundBy: 6).waitAndTap()
-        app.buttons[homeButtom].firstMatch.tap()
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].firstMatch.tap()
+        app.buttons[homeButtom].firstMatch.waitAndTap()
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].firstMatch.waitAndTap()
         let tabButtonFirstWindow = app.buttons.matching(identifier: tabsButtonIdentifier).element(boundBy: 1)
         XCTAssertEqual(tabButtonFirstWindow.value as? String, "2", "Number of tabs opened should be equal to 2")
     }
@@ -64,7 +64,7 @@ class MultiWindowTests: IpadOnlyTestCase {
     private func splitViewFromHomeScreen() {
         dotMenu.waitAndTap()
         splitView.waitAndTap()
-        springboard.icons.elementContainingText("split view with Fennec").tap()
+        springboard.icons.elementContainingText("split view with Fennec").waitAndTap()
     }
 
     // Param windowsNumber - number of tab windows to open from switcher
@@ -72,7 +72,7 @@ class MultiWindowTests: IpadOnlyTestCase {
         for  _ in 1...windowsNumber {
             dotMenu.waitAndTap()
             let cardOrgMozillaIosFennecButton = springboard.buttons["card:org.mozilla.ios.Fennec:"]
-            cardOrgMozillaIosFennecButton.tap()
+            cardOrgMozillaIosFennecButton.waitAndTap()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -34,7 +34,7 @@ class NavigationTest: BaseTestCase {
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
         if iPad() {
-            app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+            app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
             // Once an url has been open, the back button is enabled but not the forward button
             navigator.performAction(Action.CloseURLBarOpen)
             navigator.nowAt(NewTabScreen)
@@ -53,13 +53,13 @@ class NavigationTest: BaseTestCase {
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
         // Go back to previous visited web site
-        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].waitAndTap()
 
         waitUntilPageLoad()
         mozWaitForValueContains(url, value: "localhost")
 
         if iPad() {
-            app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].tap()
+            app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].waitAndTap()
         } else {
             // Go forward to next visited web site
             app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].waitAndTap()
@@ -106,7 +106,7 @@ class NavigationTest: BaseTestCase {
             app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar],
             timeout: TIMEOUT_LONG
         )
-        app.buttons["EmailSignIn.button"].tap()
+        app.buttons["EmailSignIn.button"].waitAndTap()
         mozWaitForElementToExist(app.webViews.textFields.element(boundBy: 0), timeout: TIMEOUT_LONG)
 
         let email = app.webViews.textFields.element(boundBy: 0)
@@ -124,7 +124,7 @@ class NavigationTest: BaseTestCase {
         navigator.goto(TabTray)
         navigator.performAction(Action.ToggleSyncMode)
 
-        app.tables.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaSettingsButton].tap()
+        app.tables.buttons[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaSettingsButton].waitAndTap()
         waitForElementsToExist(
             [
                 app.navigationBars["Sync and Save Data"],
@@ -174,8 +174,8 @@ class NavigationTest: BaseTestCase {
         app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].press(forDuration: 2)
 
         mozWaitForElementToExist(app.tables["Context Menu"])
-        app.tables.otherElements[AccessibilityIdentifiers.Photon.pasteAction].tap()
-        app.buttons["Go"].tap()
+        app.tables.otherElements[AccessibilityIdentifiers.Photon.pasteAction].waitAndTap()
+        app.buttons["Go"].waitAndTap()
         waitUntilPageLoad()
         let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
         mozWaitForValueContains(url, value: website_2["moreLinkLongPressInfo"]!)
@@ -190,7 +190,7 @@ class NavigationTest: BaseTestCase {
         mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
         app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].press(forDuration: 2)
 
-        app.tables.otherElements[AccessibilityIdentifiers.Photon.pasteAction].tap()
+        app.tables.otherElements[AccessibilityIdentifiers.Photon.pasteAction].waitAndTap()
         app.buttons["Go"].waitAndTap()
         waitUntilPageLoad()
         let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
@@ -205,15 +205,15 @@ class NavigationTest: BaseTestCase {
             // This test is for populated clipboard only so we need to make sure there's something in Pasteboard
             urlBarAddress.typeText("www.google.com")
             // Tapping two times when the text is not selected will reveal the menu
-            urlBarAddress.tap()
+            urlBarAddress.waitAndTap()
             mozWaitForElementToExist(urlBarAddress)
-            urlBarAddress.tap()
+            urlBarAddress.waitAndTap()
             mozWaitForElementToExist(app.menuItems["Select All"])
             XCTAssertTrue(app.menuItems["Select All"].exists)
             XCTAssertTrue(app.menuItems["Select"].exists)
 
             // Tap on Select All option and make sure Copy, Cut, Paste, and Look Up are shown
-            app.menuItems["Select All"].tap()
+            app.menuItems["Select All"].waitAndTap()
             mozWaitForElementToExist(app.menuItems["Copy"])
             if iPad() {
                 XCTAssertTrue(app.menuItems["Copy"].exists)
@@ -235,14 +235,14 @@ class NavigationTest: BaseTestCase {
             mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
 
             app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].press(forDuration: 3)
-            app.tables.otherElements[StandardImageIdentifiers.Large.link].tap()
+            app.tables.otherElements[StandardImageIdentifiers.Large.link].waitAndTap()
 
             sleep(2)
-            app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+            app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
             // Since the textField value appears all selected first time is clicked
             // this workaround is necessary
             mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
-            urlBarAddress.tap()
+            urlBarAddress.waitAndTap()
             mozWaitForElementToExist(app.menuItems["Copy"])
             if iPad() {
                 XCTAssertTrue(app.menuItems["Cut"].exists)
@@ -262,17 +262,17 @@ class NavigationTest: BaseTestCase {
     private func longPressLinkOptions(optionSelected: String) {
         navigator.nowAt(NewTabScreen)
         if app.buttons["Done"].exists {
-            app.buttons["Done"].tap()
+            app.buttons["Done"].waitAndTap()
         }
         navigator.goto(ClearPrivateDataSettings)
-        app.cells.switches["Downloaded Files"].tap()
+        app.cells.switches["Downloaded Files"].waitAndTap()
         navigator.performAction(Action.AcceptClearPrivateData)
 
         navigator.goto(HomePanelsScreen)
         navigator.openURL(path(forTestPage: "test-example.html"))
         waitUntilPageLoad()
         app.webViews.links[website_2["link"]!].press(forDuration: 2)
-        app.buttons[optionSelected].tap()
+        app.buttons[optionSelected].waitAndTap()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441498
@@ -280,7 +280,7 @@ class NavigationTest: BaseTestCase {
         longPressLinkOptions(optionSelected: "Download Link")
         mozWaitForElementToExist(app.tables["Context Menu"])
         XCTAssertTrue(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].exists)
-        app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].tap()
+        app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].waitAndTap()
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
         mozWaitForElementToExist(app.tables["DownloadsTable"])
@@ -290,7 +290,7 @@ class NavigationTest: BaseTestCase {
         mozWaitForElementToExist(app.tables.cells.staticTexts["example-domains.html"])
 
         // Tap on the just downloaded link to check that the web page is loaded
-        app.tables.cells.staticTexts["example-domains.html"].tap()
+        app.tables.cells.staticTexts["example-domains.html"].waitAndTap()
         waitUntilPageLoad()
         let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
         mozWaitForValueContains(url, value: "example-domains.html")
@@ -363,7 +363,7 @@ class NavigationTest: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         navigator.goto(SettingsScreen)
         mozWaitForElementToExist(switchBlockPopUps, timeout: TIMEOUT)
-        switchBlockPopUps.tap()
+        switchBlockPopUps.waitAndTap()
         let switchValueAfter = switchBlockPopUps.value!
         XCTAssertEqual(switchValueAfter as? String, "0")
 
@@ -386,7 +386,7 @@ class NavigationTest: BaseTestCase {
         navigator.openURL("https://expired.badssl.com/")
         mozWaitForElementToExist(app.webViews.otherElements["This Connection is Untrusted"])
         XCTAssertTrue(app.webViews.otherElements["This Connection is Untrusted"].exists)
-        app.buttons["Go Back"].tap()
+        app.buttons["Go Back"].waitAndTap()
         navigator.nowAt(NewTabScreen)
         navigator.openURL("https://expired.badssl.com/")
         mozWaitForElementToExist(app.webViews.otherElements["This Connection is Untrusted"])
@@ -404,7 +404,7 @@ class NavigationTest: BaseTestCase {
         navigator.goto(SettingsScreen)
         mozWaitForElementToExist(app.tables[AccessibilityIdentifiers.Settings.tableViewController])
         let switchBlockPopUps = app.tables.cells.switches["blockPopups"]
-        switchBlockPopUps.tap()
+        switchBlockPopUps.waitAndTap()
         let switchValueAfter = switchBlockPopUps.value!
         XCTAssertEqual(switchValueAfter as? String, "0")
         navigator.goto(HomePanelsScreen)
@@ -479,9 +479,9 @@ class NavigationTest: BaseTestCase {
         XCTAssertEqual(numTabs, 1, "Total number of regulat opened tabs should be 1")
         mozWaitForElementToExist(app.otherElements["Tabs Tray"].cells.elementContainingText("Example Domain."))
         if iPad() {
-            app.buttons["Private"].tap()
+            app.buttons["Private"].waitAndTap()
         } else {
-            app.buttons["privateModeLarge"].tap()
+            app.buttons["privateModeLarge"].waitAndTap()
         }
         numTabs = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(numTabs, 1, "Total number of private opened tabs should be 1")
@@ -493,7 +493,7 @@ class NavigationTest: BaseTestCase {
         // Long-tap on an article link. Choose "Bookmark Link".
         openContextMenuForArticleLink()
         mozWaitForElementToExist(app.buttons["Bookmark Link"])
-        app.buttons["Bookmark Link"].tap()
+        app.buttons["Bookmark Link"].waitAndTap()
         // The link has been added to the Bookmarks panel in Library
         navigator.goto(LibraryPanel_Bookmarks)
         waitForElementsToExist(
@@ -517,14 +517,14 @@ class NavigationTest: BaseTestCase {
         mozWaitForElementToExist(backButton)
         mozWaitElementHittable(element: backButton, timeout: TIMEOUT)
         XCTAssertTrue(backButton.isEnabled, "Back button is disabled")
-        backButton.tap()
+        backButton.waitAndTap()
         waitUntilPageLoad()
         if #available(iOS 16, *) {
             let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
             mozWaitForValueContains(url, value: "localhost")
             XCTAssertTrue(backButton.isHittable, "Back button is not hittable")
             XCTAssertTrue(backButton.isEnabled, "Back button is disabled")
-            backButton.tap()
+            backButton.waitAndTap()
             waitUntilPageLoad()
             mozWaitForElementToExist(app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
         }
@@ -538,7 +538,7 @@ class NavigationTest: BaseTestCase {
         let switchBlockLinks = app.tables.cells.switches["blockOpeningExternalApps"]
         scrollToElement(switchBlockLinks)
         if let switchValue = switchBlockLinks.value as? String, switchValue == "1" {
-            switchBlockLinks.tap()
+            switchBlockLinks.waitAndTap()
         }
         // Open website and tap on one of the external article links
         validateExternalLink()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -205,15 +205,15 @@ class NavigationTest: BaseTestCase {
             // This test is for populated clipboard only so we need to make sure there's something in Pasteboard
             urlBarAddress.typeText("www.google.com")
             // Tapping two times when the text is not selected will reveal the menu
-            urlBarAddress.waitAndTap()
+            urlBarAddress.tap()
             mozWaitForElementToExist(urlBarAddress)
-            urlBarAddress.waitAndTap()
+            urlBarAddress.tap()
             mozWaitForElementToExist(app.menuItems["Select All"])
             XCTAssertTrue(app.menuItems["Select All"].exists)
             XCTAssertTrue(app.menuItems["Select"].exists)
 
             // Tap on Select All option and make sure Copy, Cut, Paste, and Look Up are shown
-            app.menuItems["Select All"].waitAndTap()
+            app.menuItems["Select All"].tap()
             mozWaitForElementToExist(app.menuItems["Copy"])
             if iPad() {
                 XCTAssertTrue(app.menuItems["Copy"].exists)
@@ -235,10 +235,10 @@ class NavigationTest: BaseTestCase {
             mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
 
             app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].press(forDuration: 3)
-            app.tables.otherElements[StandardImageIdentifiers.Large.link].waitAndTap()
+            app.tables.otherElements[StandardImageIdentifiers.Large.link].tap()
 
             sleep(2)
-            app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
+            app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
             // Since the textField value appears all selected first time is clicked
             // this workaround is necessary
             mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
@@ -279,7 +279,6 @@ class NavigationTest: BaseTestCase {
     func testDownloadLink() {
         longPressLinkOptions(optionSelected: "Download Link")
         mozWaitForElementToExist(app.tables["Context Menu"])
-        XCTAssertTrue(app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].exists)
         app.tables["Context Menu"].otherElements[StandardImageIdentifiers.Large.download].waitAndTap()
         navigator.goto(BrowserTabMenu)
         navigator.goto(LibraryPanel_Downloads)
@@ -362,7 +361,6 @@ class NavigationTest: BaseTestCase {
         // Now disable the Block PopUps option
         navigator.goto(BrowserTabMenu)
         navigator.goto(SettingsScreen)
-        mozWaitForElementToExist(switchBlockPopUps, timeout: TIMEOUT)
         switchBlockPopUps.waitAndTap()
         let switchValueAfter = switchBlockPopUps.value!
         XCTAssertEqual(switchValueAfter as? String, "0")
@@ -492,7 +490,6 @@ class NavigationTest: BaseTestCase {
     func testBookmarkLink() {
         // Long-tap on an article link. Choose "Bookmark Link".
         openContextMenuForArticleLink()
-        mozWaitForElementToExist(app.buttons["Bookmark Link"])
         app.buttons["Bookmark Link"].waitAndTap()
         // The link has been added to the Bookmarks panel in Library
         navigator.goto(LibraryPanel_Bookmarks)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
@@ -153,7 +153,7 @@ class NewTabSettingsTest: BaseTestCase {
         mozWaitForValueContains(url, value: "mozilla")
         XCTAssertFalse(url.isSelected, "The URL has the focus")
         XCTAssertFalse(app.keyboards.element.isVisible(), "The keyboard is shown")
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
 
         validateKeyboardIsRaisedAndDismissed()
 
@@ -164,7 +164,7 @@ class NewTabSettingsTest: BaseTestCase {
         mozWaitForValueContains(url, value: "mozilla")
         XCTAssertFalse(url.isSelected, "The URL has the focus")
         XCTAssertFalse(app.keyboards.element.isVisible(), "The keyboard is shown")
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
 
         validateKeyboardIsRaisedAndDismissed()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NightModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NightModeTests.swift
@@ -11,7 +11,7 @@ class NightModeTests: BaseTestCase {
         mozWaitForElementToExist(app.tables.cells["MainMenu.NightModeOn"])
         XCTAssertTrue(app.tables.cells["MainMenu.NightModeOn"].label == "Turn off Night Mode")
         // Turn off night mode
-        app.tables.cells["MainMenu.NightModeOn"].tap()
+        app.tables.cells["MainMenu.NightModeOn"].waitAndTap()
     }
 
     private func checkNightModeOff() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OnboardingTests.swift
@@ -48,7 +48,7 @@ class OnboardingTests: BaseTestCase {
         try app.performAccessibilityAudit()
 
         // Swipe to the second screen
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         waitForElementsToExist(
             [
@@ -72,7 +72,7 @@ class OnboardingTests: BaseTestCase {
         try app.performAccessibilityAudit()
 
         // Swipe to the fourth screen
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
         XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
@@ -83,7 +83,7 @@ class OnboardingTests: BaseTestCase {
         try app.performAccessibilityAudit()
 
         // Swipe to the fifth screen
-        app.buttons["\(rootA11yId)PrimaryButton"].tap()
+        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
         XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
@@ -94,14 +94,14 @@ class OnboardingTests: BaseTestCase {
         try app.performAccessibilityAudit()
 
         // Finish onboarding
-        app.buttons["\(rootA11yId)PrimaryButton"].tap()
+        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
         let topSites = app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         mozWaitForElementToExist(topSites)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2793818
     func testFirstRunTourDarkMode() {
-        app.buttons["CloseButton"].tap()
+        app.buttons["CloseButton"].waitAndTap()
         switchThemeToDarkOrLight(theme: "Dark")
         app.terminate()
         app.launch()
@@ -120,7 +120,7 @@ class OnboardingTests: BaseTestCase {
         )
 
         // Swipe to the second screen
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         waitForElementsToExist(
             [
@@ -142,7 +142,7 @@ class OnboardingTests: BaseTestCase {
         XCTAssertTrue(app.buttons["\(rootA11yId)SecondaryButton"].exists)
 
         // Swipe to the fourth screen
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
         XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
@@ -152,7 +152,7 @@ class OnboardingTests: BaseTestCase {
         XCTAssertTrue(app.buttons["\(rootA11yId)SecondaryButton"].exists)
 
         // Swipe to the fifth screen
-        app.buttons["\(rootA11yId)PrimaryButton"].tap()
+        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.images["\(rootA11yId)ImageView"], timeout: TIMEOUT)
         XCTAssertTrue(app.images["\(rootA11yId)ImageView"].exists)
@@ -163,7 +163,7 @@ class OnboardingTests: BaseTestCase {
 
         // Finish onboarding
         let topSites = app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
-        app.buttons["\(rootA11yId)PrimaryButton"].tap()
+        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
         mozWaitForElementToExist(topSites)
     }
 
@@ -172,7 +172,7 @@ class OnboardingTests: BaseTestCase {
     func testOnboardingSignIn() {
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
         // Swipe to the second screen
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
         XCTAssertEqual("Stay encrypted when you hop between devices", app.staticTexts["\(rootA11yId)TitleLabel"].label)
@@ -181,31 +181,31 @@ class OnboardingTests: BaseTestCase {
         XCTAssertEqual("Sign In", app.buttons["\(rootA11yId)PrimaryButton"].label)
         XCTAssertEqual("Skip", app.buttons["\(rootA11yId)SecondaryButton"].label)
         // Tap on Sign In
-        app.buttons["\(rootA11yId)PrimaryButton"].tap()
+        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
         mozWaitForElementToExist(app.navigationBars["Sync and Save Data"])
         XCTAssertTrue(app.buttons["QRCodeSignIn.button"].exists)
         XCTAssertEqual("Ready to Scan", app.buttons["QRCodeSignIn.button"].label)
         XCTAssertTrue(app.buttons["EmailSignIn.button"].exists)
         XCTAssertEqual("Use Email Instead", app.buttons["EmailSignIn.button"].label)
-        app.buttons["Done"].tap()
-        app.buttons["CloseButton"].tap()
+        app.buttons["Done"].waitAndTap()
+        app.buttons["CloseButton"].waitAndTap()
     }
 
     // Smoketest
     // https://mozilla.testrail.io/index.php?/cases/view/2306816
     func testCloseTour() {
-        app.buttons["\(AccessibilityIdentifiers.Onboarding.closeButton)"].tap()
+        app.buttons["\(AccessibilityIdentifiers.Onboarding.closeButton)"].waitAndTap()
         let topSites = app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         mozWaitForElementToExist(topSites)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306815
     func testWhatsNewPage() {
-        app.buttons["\(AccessibilityIdentifiers.Onboarding.closeButton)"].tap()
+        app.buttons["\(AccessibilityIdentifiers.Onboarding.closeButton)"].waitAndTap()
         navigator.goto(BrowserTabMenu)
         navigator.performAction(Action.OpenWhatsNewPage)
         waitUntilPageLoad()
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
 
         // Extract version number from url
         let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].value
@@ -221,7 +221,7 @@ class OnboardingTests: BaseTestCase {
             app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField],
             value: "https://www.mozilla.org/en-US/firefox/ios/" + releaseVersion + "/releasenotes/"
         )
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
         waitForElementsToExist(
             [
                 app.staticTexts["Release Notes"],
@@ -240,23 +240,23 @@ class OnboardingTests: BaseTestCase {
         // Wait for the initial title label to appear
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
 
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
-        app.buttons["\(rootA11yId)PrimaryButton"].tap()
+        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
         currentScreen += 1
 
         let buttons = app.buttons.matching(identifier: "\(rootA11yId)MultipleChoiceButton")
         for i in 0..<buttons.count {
             let button = buttons.element(boundBy: i)
             if button.label == "Top" {
-                button.tap()
+                button.waitAndTap()
                 break
             }
         }
@@ -284,23 +284,23 @@ class OnboardingTests: BaseTestCase {
         // Wait for the initial title label to appear
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
 
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
-        app.buttons["\(rootA11yId)PrimaryButton"].tap()
+        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
         currentScreen += 1
 
         let buttons = app.buttons.matching(identifier: "\(rootA11yId)MultipleChoiceButton")
         for i in 0..<buttons.count {
             let button = buttons.element(boundBy: i)
             if button.label == "Bottom" {
-                button.tap()
+                button.waitAndTap()
                 break
             }
         }
@@ -323,16 +323,16 @@ class OnboardingTests: BaseTestCase {
         // Wait for the initial title label to appear
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
 
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
-        app.buttons["\(rootA11yId)SecondaryButton"].tap()
+        app.buttons["\(rootA11yId)SecondaryButton"].waitAndTap()
         currentScreen += 1
         mozWaitForElementToExist(app.staticTexts["\(rootA11yId)TitleLabel"])
-        app.buttons["\(rootA11yId)PrimaryButton"].tap()
+        app.buttons["\(rootA11yId)PrimaryButton"].waitAndTap()
         app.buttons["CloseButton"].waitAndTap()
         let topSites = app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         mozWaitForElementToExist(topSites)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -52,7 +52,7 @@ class PhotonActionSheetTests: BaseTestCase {
 //        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
 //        waitUntilPageLoad()
 //        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
-//        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
+//        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
 //
 //        // Wait to see the Share options sheet
 //        mozWaitForElementToExist(app.cells["Copy"], timeout: 15)
@@ -66,9 +66,9 @@ class PhotonActionSheetTests: BaseTestCase {
         // Temporarily disabled until url bar redesign work FXIOS-8172
         /*
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
-        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
         mozWaitForElementToExist(app.cells["Send Link to Device"], timeout: 10)
-        app.cells["Send Link to Device"].tap()
+        app.cells["Send Link to Device"].waitAndTap()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton])
         XCTAssertTrue(app.staticTexts["You are not signed in to your account."].exists)
         XCTAssertTrue(app.staticTexts["Please open Firefox, go to Settings and sign in to continue."].exists)
@@ -84,9 +84,9 @@ class PhotonActionSheetTests: BaseTestCase {
         // Launch "Share" from the hamburger menu instead of the share icon from the
         // awesome bar.
         // mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
-        // app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
+        // app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
         navigator.goto(ToolsBrowserTabMenu)
-        app.cells[AccessibilityIdentifiers.MainMenu.share].tap()
+        app.cells[AccessibilityIdentifiers.MainMenu.share].waitAndTap()
 
         if #unavailable(iOS 16) {
             waitForElementsToExist(
@@ -139,13 +139,13 @@ class PhotonActionSheetTests: BaseTestCase {
                 app.staticTexts["You are not signed in to your account."]
             ]
         )
-        app.navigationBars.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton].tap()
+        app.navigationBars.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton].waitAndTap()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323204
     func testShareSheetOpenAndCancel() {
         openNewShareSheet()
-        app.buttons["Cancel"].tap()
+        app.buttons["Cancel"].waitAndTap()
         // User is back to the BrowserTab where the sharesheet was launched
         let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
         mozWaitForElementToExist(url)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -66,9 +66,9 @@ class PhotonActionSheetTests: BaseTestCase {
         // Temporarily disabled until url bar redesign work FXIOS-8172
         /*
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
-        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
         mozWaitForElementToExist(app.cells["Send Link to Device"], timeout: 10)
-        app.cells["Send Link to Device"].waitAndTap()
+        app.cells["Send Link to Device"].tap()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton])
         XCTAssertTrue(app.staticTexts["You are not signed in to your account."].exists)
         XCTAssertTrue(app.staticTexts["Please open Firefox, go to Settings and sign in to continue."].exists)
@@ -84,7 +84,7 @@ class PhotonActionSheetTests: BaseTestCase {
         // Launch "Share" from the hamburger menu instead of the share icon from the
         // awesome bar.
         // mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
-        // app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
+        // app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
         navigator.goto(ToolsBrowserTabMenu)
         app.cells[AccessibilityIdentifiers.MainMenu.share].waitAndTap()
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -115,7 +115,7 @@ class PrivateBrowsingTest: BaseTestCase {
 
         // Go back to regular browser
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
-        app.cells.staticTexts["Homepage"].tap()
+        app.cells.staticTexts["Homepage"].waitAndTap()
         navigator.nowAt(NewTabScreen)
 
         // Go back to private browsing and check that the tab has been closed
@@ -229,7 +229,7 @@ class PrivateBrowsingTest: BaseTestCase {
         navigator.goto(TabTray)
         var numTab = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(4, numTab, "The number of counted tabs is not equal to \(String(describing: numTab))")
-        app.buttons[AccessibilityIdentifiers.TabTray.closeAllTabsButton].tap()
+        app.buttons[AccessibilityIdentifiers.TabTray.closeAllTabsButton].waitAndTap()
 
         // Validate Close All Tabs and Cancel options
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.deleteCloseAllButton])
@@ -238,7 +238,7 @@ class PrivateBrowsingTest: BaseTestCase {
         }
 
         // Tap on "Close All Tabs"
-        app.buttons[AccessibilityIdentifiers.TabTray.deleteCloseAllButton].tap()
+        app.buttons[AccessibilityIdentifiers.TabTray.deleteCloseAllButton].waitAndTap()
         if #unavailable(iOS 16) {
             // Wait for the screen to refresh first.
             mozWaitForElementToExist(
@@ -275,7 +275,7 @@ class PrivateBrowsingTest: BaseTestCase {
         mozWaitForElementToExist(newPrivateTab)
         scrollToElement(newPrivateTab)
         // Tap on "New private tab" option
-        newPrivateTab.tap()
+        newPrivateTab.waitAndTap()
         // Tap on "New private tab" option
         navigator.nowAt(NewTabScreen)
         if #available(iOS 16, *) {
@@ -306,7 +306,7 @@ fileprivate extension BaseTestCase {
             settingsTableView.swipeUp()
         }
         let closePrivateTabsSwitch = settingsTableView.switches["ClosePrivateTabs"]
-        closePrivateTabsSwitch.tap()
+        closePrivateTabsSwitch.waitAndTap()
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
@@ -40,7 +40,7 @@ class ReadingListTests: BaseTestCase {
 
         // Check to make sure the reading list is empty
         checkReadingListNumberOfItems(items: 0)
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
         // Add item to reading list and check that it appears
         addContentToReaderView()
         navigator.goto(BrowserTabMenu)
@@ -66,7 +66,7 @@ class ReadingListTests: BaseTestCase {
 
         // Initially reading list is empty
         checkReadingListNumberOfItems(items: 0)
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
         // Add item to reading list and check that it appears
         addContentToReaderView()
         navigator.goto(BrowserTabMenu)
@@ -76,7 +76,7 @@ class ReadingListTests: BaseTestCase {
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
         mozWaitForElementToExist(savedToReadingList)
         checkReadingListNumberOfItems(items: 1)
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
         updateScreenGraph()
         // Check that it appears on regular mode
         navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleRegularMode)
@@ -94,11 +94,11 @@ class ReadingListTests: BaseTestCase {
         addContentToReaderView()
 
         // Mark the content as read, so the mark as unread buttons appear
-        app.buttons["Mark as Read"].tap()
+        app.buttons["Mark as Read"].waitAndTap()
         mozWaitForElementToExist(app.buttons["Mark as Unread"])
 
         // Mark the content as unread, so the mark as read button appear
-        app.buttons["Mark as Unread"].tap()
+        app.buttons["Mark as Unread"].waitAndTap()
         mozWaitForElementToExist(app.buttons["Mark as Read"])
     }
 
@@ -131,7 +131,7 @@ class ReadingListTests: BaseTestCase {
         // Mark it as read/unread
         savedToReadingList.swipeLeft()
         mozWaitForElementToExist(app.tables.cells.buttons.staticTexts["Mark as  Read"])
-        app.tables["ReadingTable"].cells.buttons.element(boundBy: 1).tap()
+        app.tables["ReadingTable"].cells.buttons.element(boundBy: 1).waitAndTap()
         savedToReadingList.swipeLeft()
         mozWaitForElementToExist(app.tables.cells.buttons.staticTexts["Mark as  Unread"])
     }
@@ -160,7 +160,7 @@ class ReadingListTests: BaseTestCase {
         // First time Reading list is empty
         navigator.goto(LibraryPanel_ReadingList)
         checkReadingListNumberOfItems(items: 0)
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
         // Add item to Reading List from Page Options Menu
         updateScreenGraph()
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
@@ -188,7 +188,7 @@ class ReadingListTests: BaseTestCase {
 
         // Select to open in New Tab
         mozWaitForElementToExist(app.tables["Context Menu"])
-        app.tables.otherElements[StandardImageIdentifiers.Large.plus].tap()
+        app.tables.otherElements[StandardImageIdentifiers.Large.plus].waitAndTap()
         updateScreenGraph()
         // Now there should be two tabs open
         navigator.goto(HomePanelsScreen)
@@ -208,7 +208,7 @@ class ReadingListTests: BaseTestCase {
         mozWaitForElementToExist(savedToReadingList)
         savedToReadingList.press(forDuration: 1)
         mozWaitForElementToExist(app.tables["Context Menu"])
-        app.tables.otherElements[StandardImageIdentifiers.Large.cross].tap()
+        app.tables.otherElements[StandardImageIdentifiers.Large.cross].waitAndTap()
 
         // Verify the item has been removed
         mozWaitForElementToNotExist(app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"])
@@ -230,7 +230,7 @@ class ReadingListTests: BaseTestCase {
                 app.staticTexts[emptyReadingList3]
             ]
         )
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
         // Add item to reading list and check that it appears
         addContentToReaderView()
         navigator.goto(BrowserTabMenu)
@@ -238,7 +238,7 @@ class ReadingListTests: BaseTestCase {
         let savedToReadingList = app.tables["ReadingTable"].cells.staticTexts["The Book of Mozilla"]
         mozWaitForElementToExist(savedToReadingList)
         // Tap on an article
-        savedToReadingList.tap()
+        savedToReadingList.waitAndTap()
         // The article is displayed in Reader View
         mozWaitForElementToExist(app.buttons["Reader View"])
         // iOS 18 only: Reader View icon is enabled but is not selected.
@@ -246,7 +246,7 @@ class ReadingListTests: BaseTestCase {
             XCTAssertTrue(app.buttons["Reader View"].isSelected)
         }
         XCTAssertTrue(app.buttons["Reader View"].isEnabled)
-        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
         navigator.nowAt(NewTabScreen)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
@@ -153,7 +153,7 @@ private func createTestGraph(for test: XCTestCase, with app: XCUIApplication) ->
         screenState.gesture(forAction: TestActions.LoadURLByPasting, TestActions.LoadURL) { userState in
             UIPasteboard.general.string = userState.url ?? defaultURL
             app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].press(forDuration: 1.0)
-            app.tables["Context Menu"].cells[AccessibilityIdentifiers.Photon.pasteAndGoAction].tap()
+            app.tables["Context Menu"].cells[AccessibilityIdentifiers.Photon.pasteAndGoAction].waitAndTap()
         }
     }
 
@@ -192,15 +192,15 @@ private func createTestGraph(for test: XCTestCase, with app: XCUIApplication) ->
         screenState.backAction = {
             if isTablet {
                 // There is no Cancel option in iPad.
-                app.otherElements["PopoverDismissRegion"].tap()
+                app.otherElements["PopoverDismissRegion"].waitAndTap()
             } else {
-                app.buttons["PhotonMenu.close"].tap()
+                app.buttons["PhotonMenu.close"].waitAndTap()
             }
         }
     }
 
     let navigationControllerBackAction = {
-        app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap()
+        app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).waitAndTap()
     }
 
     map.addScreenState(SettingsScreen) { screenState in

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -18,9 +18,9 @@ class SearchSettingsUITests: BaseTestCase {
         mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine1])
 
         // Change to another browser and check it is set as default
-        defaultSearchEngine.tap()
+        defaultSearchEngine.waitAndTap()
         let listOfEngines = app.tables
-        listOfEngines.staticTexts[defaultSearchEngine2].tap()
+        listOfEngines.staticTexts[defaultSearchEngine2].waitAndTap()
         mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine2])
     }
 
@@ -35,7 +35,7 @@ class SearchSettingsUITests: BaseTestCase {
 
         // Check that it can be edited
         XCTAssertTrue(app.buttons["Edit"].isEnabled)
-        app.buttons["Edit"].tap()
+        app.buttons["Edit"].waitAndTap()
         XCTAssertTrue(app.buttons["Done"].isEnabled)
         if #unavailable(iOS 17) {
             mozWaitForElementToExist(app.tables.buttons["Delete \(customSearchEngine["name"]!)"])
@@ -68,9 +68,9 @@ class SearchSettingsUITests: BaseTestCase {
 
         // Select the custom engine as the default one
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
-        defaultSearchEngine.tap()
+        defaultSearchEngine.waitAndTap()
         let listOfEngines = app.tables
-        listOfEngines.staticTexts[customSearchEngine["name"]!].tap()
+        listOfEngines.staticTexts[customSearchEngine["name"]!].waitAndTap()
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
     }
@@ -85,13 +85,13 @@ class SearchSettingsUITests: BaseTestCase {
         addCustomSearchEngine()
         // Edit is enabled
         XCTAssertTrue(app.buttons["Edit"].isEnabled)
-        app.buttons["Edit"].tap()
+        app.buttons["Edit"].waitAndTap()
         XCTAssertTrue(app.buttons["Done"].isEnabled)
 
         // Navigate to the search engine picker and back
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
-        defaultSearchEngine.tap()
-        app.buttons["Cancel"].tap()
+        defaultSearchEngine.waitAndTap()
+        app.buttons["Cancel"].waitAndTap()
 
         // Check to see we're not in editing state, edit is enable and done does not appear
         XCTAssertTrue(app.buttons["Edit"].isEnabled)
@@ -110,15 +110,15 @@ class SearchSettingsUITests: BaseTestCase {
         // Add a custom search engine
         addCustomSearchEngine()
         XCTAssertTrue(app.buttons["Edit"].isEnabled)
-        app.buttons["Edit"].tap()
+        app.buttons["Edit"].waitAndTap()
         // Remove the custom search engine and check that edit is disabled
         let tablesQuery = app.tables
         if #unavailable(iOS 17) {
-            tablesQuery.buttons["Delete \(customSearchEngine["name"]!)"].tap()
+            tablesQuery.buttons["Delete \(customSearchEngine["name"]!)"].waitAndTap()
         } else {
-            tablesQuery.buttons["Remove \(customSearchEngine["name"]!)"].tap()
+            tablesQuery.buttons["Remove \(customSearchEngine["name"]!)"].waitAndTap()
         }
-        tablesQuery.buttons[AccessibilityIdentifiers.Settings.Search.deleteButton].tap()
+        tablesQuery.buttons[AccessibilityIdentifiers.Settings.Search.deleteButton].waitAndTap()
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -22,9 +22,9 @@ class SearchTests: BaseTestCase {
 
     private func suggestionsOnOff() {
         navigator.goto(SearchSettings)
-        app.tables.switches["Show Search Suggestions"].tap()
-        app.navigationBars["Search"].buttons["Settings"].tap()
-        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
+        app.tables.switches["Show Search Suggestions"].waitAndTap()
+        app.navigationBars["Search"].buttons["Settings"].waitAndTap()
+        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
     }
 
     private func validateSearchSuggestionText(typeText: String) {
@@ -50,10 +50,10 @@ class SearchTests: BaseTestCase {
         mozWaitForElementToExist(app.tables["SiteTable"].cells.firstMatch)
 
         // Disable Search suggestion
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
 
         waitForTabsButton()
-        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].waitAndTap()
         navigator.nowAt(BrowserTabMenu)
         suggestionsOnOff()
 
@@ -65,16 +65,16 @@ class SearchTests: BaseTestCase {
         mozWaitForElementToNotExist(app.tables["SiteTable"].cells.firstMatch)
 
         // Verify that previous choice is remembered
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
         navigator.nowAt(HomePanelsScreen)
         waitForTabsButton()
 
         typeOnSearchBar(text: "foobar")
         mozWaitForElementToNotExist(app.tables["SiteTable"].cells[SuggestedSite])
 
-        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
+        app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
         waitForTabsButton()
-        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].waitAndTap()
         navigator.nowAt(BrowserTabMenu)
 
         // Reset suggestion button, set it to on
@@ -156,7 +156,7 @@ class SearchTests: BaseTestCase {
         waitUntilPageLoad()
 
         // Go back, write part of moz, check the autocompletion
-        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].waitAndTap()
         navigator.nowAt(HomePanelsScreen)
         waitForTabsButton()
         typeOnSearchBar(text: "moz")
@@ -170,9 +170,9 @@ class SearchTests: BaseTestCase {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.goto(SearchSettings)
         // Open the list of default search engines and select the desired
-        app.tables.cells.element(boundBy: 0).tap()
+        app.tables.cells.element(boundBy: 0).waitAndTap()
         let tablesQuery2 = app.tables
-        tablesQuery2.staticTexts[searchEngine].tap()
+        tablesQuery2.staticTexts[searchEngine].waitAndTap()
 
         navigator.openURL("foo bar")
         mozWaitForElementToExist(app.webViews.firstMatch)
@@ -210,7 +210,7 @@ class SearchTests: BaseTestCase {
         // Click on the > button to get to that option only on iPhone
         if #available(iOS 16, *) {
             while !app.collectionViews.menuItems["Search with Firefox"].exists {
-                app.buttons["Forward"].firstMatch.tap()
+                app.buttons["Forward"].firstMatch.waitAndTap()
                 waitForElementsToExist(
                     [
                         app.collectionViews.menuItems.firstMatch,
@@ -220,7 +220,7 @@ class SearchTests: BaseTestCase {
             }
         } else {
             while !app.menuItems["Search with Firefox"].exists {
-                app.menuItems["Show more items"].firstMatch.tap()
+                app.menuItems["Show more items"].firstMatch.waitAndTap()
                 waitForElementsToExist(
                     [
                         app.menuItems.firstMatch,
@@ -275,10 +275,10 @@ class SearchTests: BaseTestCase {
             // Reload icon is displayed.
             mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton])
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].label, "New Tab")
-            app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
+            app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
             navigator.performAction(Action.CloseURLBarOpen)
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")
-            app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].tap()
+            app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].waitAndTap()
 
             mozWaitForElementToExist(addressBar)
             XCTAssertTrue(addressBar.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
@@ -332,7 +332,7 @@ class SearchTests: BaseTestCase {
 
             // In a new tab, tap on the URL bar
             navigator.goto(NewTabScreen)
-            urlBar.tap()
+            urlBar.waitAndTap()
 
             // The URL bar is focused and the keyboard is displayed
             validateUrlHasFocusAndKeyboardIsDisplayed()
@@ -346,14 +346,14 @@ class SearchTests: BaseTestCase {
             waitUntilPageLoad()
 
             // Tap on the URL bar
-            urlBar.tap()
+            urlBar.waitAndTap()
 
             // The URL bar is focused, Top Sites panel is displayed and the keyboard pops-up
             validateUrlHasFocusAndKeyboardIsDisplayed()
             mozWaitForElementToExist(app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
 
             // Tap the back icon <
-            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
+            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
 
             // The focused is dismissed from the URL bar
             let addressBar = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
@@ -370,7 +370,7 @@ class SearchTests: BaseTestCase {
         typeTextAndValidateSearchSuggestions(text: "g", isSwitchOn: true)
 
         // Tap on the "Append Arrow button"
-        app.tables.buttons[StandardImageIdentifiers.Large.appendUpLeft].firstMatch.tap()
+        app.tables.buttons[StandardImageIdentifiers.Large.appendUpLeft].firstMatch.waitAndTap()
 
         // The search suggestion fills the URL bar but does not conduct the search
         waitForValueContains(urlBarAddress, value: "g")
@@ -415,7 +415,7 @@ class SearchTests: BaseTestCase {
         typeTextAndValidateSearchSuggestions(text: "g", isSwitchOn: true)
 
         // Tap on the text letter "g"
-        app.tables.cells.firstMatch.tap()
+        app.tables.cells.firstMatch.waitAndTap()
         waitUntilPageLoad()
 
         // The search is conducted through the default search engine
@@ -430,7 +430,7 @@ class SearchTests: BaseTestCase {
         typeTextAndValidateSearchSuggestions(text: "g", isSwitchOn: false)
 
         // Enable "Show search suggestions" from Settings and type text in a new tab
-        app.tables.cells.firstMatch.tap()
+        app.tables.cells.firstMatch.waitAndTap()
         waitUntilPageLoad()
         createNewTabAfterModifyingSearchSuggestions(turnOnSwitch: true)
 
@@ -444,9 +444,9 @@ class SearchTests: BaseTestCase {
         mozWaitForElementToExist(showSearchSuggestions)
         let switchValue = showSearchSuggestions.value
         if switchValue as? String == "0", true && turnOnSwitch == true {
-            showSearchSuggestions.tap()
+            showSearchSuggestions.waitAndTap()
         } else if switchValue as? String == "1", true && turnOnSwitch == false {
-            showSearchSuggestions.tap()
+            showSearchSuggestions.waitAndTap()
         }
     }
 
@@ -493,8 +493,8 @@ class SearchTests: BaseTestCase {
 //        ]
 //        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
 //
-//        app.navigationBars["Search"].buttons["Settings"].tap()
-//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
+//        app.navigationBars["Search"].buttons["Settings"].waitAndTap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
 //
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -510,10 +510,10 @@ class SearchTests: BaseTestCase {
 //
 //        mozWaitForElementToNotExist(app.tables["SiteTable"])
 //        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
-//        privateModeSearchSuggestSwitch.tap()
+//        privateModeSearchSuggestSwitch.waitAndTap()
 //
-//        app.navigationBars["Search"].buttons["Settings"].tap()
-//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
+//        app.navigationBars["Search"].buttons["Settings"].waitAndTap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
 //
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -537,8 +537,8 @@ class SearchTests: BaseTestCase {
 //        ]
 //        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
 //
-//        app.navigationBars["Search"].buttons["Settings"].tap()
-//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
+//        app.navigationBars["Search"].buttons["Settings"].waitAndTap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
 //
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -554,10 +554,10 @@ class SearchTests: BaseTestCase {
 //
 //        mozWaitForElementToNotExist(app.tables["SiteTable"])
 //        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
-//        privateModeSearchSuggestSwitch.tap()
+//        privateModeSearchSuggestSwitch.waitAndTap()
 //
-//        app.navigationBars["Search"].buttons["Settings"].tap()
-//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
+//        app.navigationBars["Search"].buttons["Settings"].waitAndTap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
 //
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -493,8 +493,8 @@ class SearchTests: BaseTestCase {
 //        ]
 //        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
 //
-//        app.navigationBars["Search"].buttons["Settings"].waitAndTap()
-//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
+//        app.navigationBars["Search"].buttons["Settings"].tap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
 //
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -510,10 +510,10 @@ class SearchTests: BaseTestCase {
 //
 //        mozWaitForElementToNotExist(app.tables["SiteTable"])
 //        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
-//        privateModeSearchSuggestSwitch.waitAndTap()
+//        privateModeSearchSuggestSwitch.tap()
 //
-//        app.navigationBars["Search"].buttons["Settings"].waitAndTap()
-//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
+//        app.navigationBars["Search"].buttons["Settings"].tap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
 //
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -537,8 +537,8 @@ class SearchTests: BaseTestCase {
 //        ]
 //        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
 //
-//        app.navigationBars["Search"].buttons["Settings"].waitAndTap()
-//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
+//        app.navigationBars["Search"].buttons["Settings"].tap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
 //
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -554,10 +554,10 @@ class SearchTests: BaseTestCase {
 //
 //        mozWaitForElementToNotExist(app.tables["SiteTable"])
 //        mozWaitForElementToExist(privateModeSearchSuggestSwitch)
-//        privateModeSearchSuggestSwitch.waitAndTap()
+//        privateModeSearchSuggestSwitch.tap()
 //
-//        app.navigationBars["Search"].buttons["Settings"].waitAndTap()
-//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
+//        app.navigationBars["Search"].buttons["Settings"].tap()
+//        app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].tap()
 //
 //        navigator.nowAt(NewTabScreen)
 //        navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -26,7 +26,7 @@ class SettingsTests: BaseTestCase {
         }
         let helpMenu = settingsTableView.cells["Help"]
         XCTAssertTrue(helpMenu.isEnabled)
-        helpMenu.tap()
+        helpMenu.waitAndTap()
 
         waitUntilPageLoad()
         let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
@@ -60,15 +60,15 @@ class SettingsTests: BaseTestCase {
         XCTAssertEqual(value as? String, "0")
 
         // Switch on, Offer to open copied links, when opening firefox
-        app.tables.cells.switches["Offer to Open Copied Links, When opening Firefox"].tap()
+        app.tables.cells.switches["Offer to Open Copied Links, When opening Firefox"].waitAndTap()
 
         // Check Offer to open copied links, when opening firefox is on
         let value2 = app.tables.cells.switches["Offer to Open Copied Links, When opening Firefox"].value
         XCTAssertEqual(value2 as? String, "1")
 
-        app.navigationBars["Settings"].buttons["Done"].tap()
+        app.navigationBars["Settings"].buttons["Done"].waitAndTap()
 
-        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton].waitAndTap()
         app.staticTexts["Settings"].waitAndTap()
 
         // Check Offer to open copied links, when opening firefox is on
@@ -99,7 +99,7 @@ class SettingsTests: BaseTestCase {
 
         // Check that tapping on an element does nothing
         mozWaitForElementToExist(app.tables["OpenWithPage.Setting.Options"])
-        app.tables.cells.staticTexts["Airmail"].tap()
+        app.tables.cells.staticTexts["Airmail"].waitAndTap()
         XCTAssertFalse(app.tables.cells.staticTexts["Airmail"].isSelected)
 
         // Check that user can go back from that setting

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SiteLoadTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SiteLoadTest.swift
@@ -26,7 +26,7 @@ class SiteLoadTest: BaseTestCase {
 
             // clear the cache
             navigator.goto(ClearPrivateDataSettings)
-            app.tables.staticTexts["Clear Private Data"].tap()
+            app.tables.staticTexts["Clear Private Data"].waitAndTap()
             app.alerts.buttons["OK"].waitAndTap()
             navigator.goto(BrowserTab)
             mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SyncFAUITests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SyncFAUITests.swift
@@ -79,7 +79,7 @@ class SyncUITests: BaseTestCase {
         userState.fxaPassword = "atleasteight"
         navigator.performAction(Action.FxATypePasswordNewAccount)
         // Switching to the next text field is required to determine if the message still appears or not
-        app.webViews.secureTextFields.element(boundBy: 0).tap()
+        app.webViews.secureTextFields.element(boundBy: 0).waitAndTap()
         mozWaitForElementToNotExist(app.webViews.staticTexts["At least 8 characters"])
     }
 
@@ -120,7 +120,7 @@ class SyncUITests: BaseTestCase {
         let passMessage = "Your password is currently hidden."
         mozWaitForElementToExist(app.webViews.switches[passMessage])
         // Remove the password typed, Show (password) option should not be shown
-        app.keyboards.keys["delete"].tap()
+        app.keyboards.keys["delete"].waitAndTap()
         mozWaitForElementToNotExist(app.webViews.staticTexts[passMessage])
     }
 
@@ -137,7 +137,7 @@ class SyncUITests: BaseTestCase {
                 app.buttons["Ready to Scan"],
                 app.buttons["Use Email Instead"]]
         )
-        app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar].buttons["Close"].tap()
+        app.navigationBars[AccessibilityIdentifiers.Settings.FirefoxAccount.fxaNavigationBar].buttons["Close"].waitAndTap()
         mozWaitForElementToExist(app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell])
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
@@ -59,7 +59,7 @@ class TabCounterTests: BaseTestCase {
         if isTablet {
             app.otherElements["Tabs Tray"]
                 .collectionViews.cells.element(boundBy: 0)
-                .buttons[StandardImageIdentifiers.Large.cross].tap()
+                .buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
         } else {
             let navBarTabTrayButton = app.segmentedControls["navBarTabTray"].buttons.firstMatch
             mozWaitForElementToExist(navBarTabTrayButton)
@@ -68,10 +68,10 @@ class TabCounterTests: BaseTestCase {
             XCTAssertTrue(tabsOpenTabTray.hasSuffix("2"))
 
             app.otherElements["Tabs Tray"].cells
-                .element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].tap()
+                .element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
         }
 
-        app.otherElements["Tabs Tray"].cells.element(boundBy: 0).tap()
+        app.otherElements["Tabs Tray"].cells.element(boundBy: 0).waitAndTap()
         navigator.nowAt(NewTabScreen)
         waitForTabsButton()
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
@@ -8,7 +8,7 @@ let mozDeveloperWebsite = "https://developer.mozilla.org/en-US"
 let searchFieldPlaceholder = "Search MDN"
 class ThirdPartySearchTest: BaseTestCase {
     fileprivate func dismissKeyboardAssistant(forApp app: XCUIApplication) {
-        app.buttons["Done"].tap()
+        app.buttons["Done"].waitAndTap()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2443998
@@ -19,11 +19,11 @@ class ThirdPartySearchTest: BaseTestCase {
         app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
 
         // Perform a search using a custom search engine
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         app.textFields.firstMatch.waitAndTap()
         app.textFields.firstMatch.typeText("window")
-        app.scrollViews.otherElements.buttons["Mozilla Engine search"].tap()
+        app.scrollViews.otherElements.buttons["Mozilla Engine search"].waitAndTap()
         waitUntilPageLoad()
 
         guard let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].value
@@ -45,7 +45,7 @@ class ThirdPartySearchTest: BaseTestCase {
         dismissSearchScreen()
 
         // Perform a search to check
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
         app.textFields.firstMatch.typeText("window\n")
 
         waitUntilPageLoad()
@@ -66,7 +66,7 @@ class ThirdPartySearchTest: BaseTestCase {
 
         app.navigationBars["Search"].buttons["Settings"].waitAndTap()
         app.navigationBars["Settings"].buttons[AccessibilityIdentifiers.Settings.navigationBarItem].waitAndTap()
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         app.textFields.firstMatch.waitAndTap()
         app.textFields.firstMatch.typeText("window")
@@ -110,7 +110,7 @@ class ThirdPartySearchTest: BaseTestCase {
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(AddCustomSearchSettings)
-        app.textViews["customEngineTitle"].tap()
+        app.textViews["customEngineTitle"].waitAndTap()
         app.typeText("Feeling Lucky")
 
         let searchUrl = "http://www.google.com/search?q=&btnI"
@@ -122,18 +122,18 @@ class ThirdPartySearchTest: BaseTestCase {
         mozWaitForElementToExist(customengineurlTextView)
 
         UIPasteboard.general.string = searchUrl
-        customengineurlTextView.tap()
+        customengineurlTextView.waitAndTap()
         customengineurlTextView.press(forDuration: 2.0)
         let pasteOption = app.menuItems["Paste"]
         if pasteOption.exists {
-            pasteOption.tap()
+            pasteOption.waitAndTap()
         } else {
             var nrOfTaps = 3
             while !pasteOption.exists && nrOfTaps > 0 {
                 customengineurlTextView.press(forDuration: 2.0)
                 nrOfTaps -= 1
             }
-            pasteOption.tap()
+            pasteOption.waitAndTap()
         }
 
         app.buttons["customEngineSaveButton"].waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -140,10 +140,10 @@ class TodayWidgetTests: BaseTestCase {
         }
         if #unavailable(iOS 16) {
             mozWaitElementHittable(element: springboard.buttons["Remove Widget"], timeout: TIMEOUT)
-            springboard.buttons["Remove Widget"].tap()
+            springboard.buttons["Remove Widget"].waitAndTap()
         } else {
             mozWaitElementHittable(element: springboard.buttons[removeWidgetButton], timeout: TIMEOUT)
-            springboard.buttons[removeWidgetButton].tap()
+            springboard.buttons[removeWidgetButton].waitAndTap()
         }
 
         waitForElementsToExist(
@@ -154,7 +154,7 @@ class TodayWidgetTests: BaseTestCase {
         )
 
         mozWaitElementHittable(element: springboard.alerts.buttons["Remove"], timeout: TIMEOUT)
-        springboard.alerts.buttons["Remove"].tap()
+        springboard.alerts.buttons["Remove"].waitAndTap()
     }
 
     private func checkFirefoxAvailablesWidgets() {
@@ -210,13 +210,13 @@ class TodayWidgetTests: BaseTestCase {
         }
 
         mozWaitElementHittable(element: springboard.buttons[removeWidgetButton], timeout: TIMEOUT)
-        springboard.buttons[removeWidgetButton].tap()
+        springboard.buttons[removeWidgetButton].waitAndTap()
 
         mozWaitForElementToExist(springboard.alerts.buttons["Remove"])
         mozWaitForElementToExist(springboard.alerts.buttons["Cancel"])
 
         mozWaitElementHittable(element: springboard.alerts.buttons["Remove"], timeout: TIMEOUT)
-        springboard.alerts.buttons["Remove"].tap()
+        springboard.alerts.buttons["Remove"].waitAndTap()
     }
 
     private func checkFirefoxWidgetOptions() {
@@ -245,7 +245,7 @@ class TodayWidgetTests: BaseTestCase {
         mozWaitForElementToExist(springboard
             .buttons[editWidgetButton])
         springboard
-            .buttons[editWidgetButton].tap()
+            .buttons[editWidgetButton].waitAndTap()
     }
 
     private func longPressOnWidget(widgetType: String, duration: Double) {
@@ -257,7 +257,7 @@ class TodayWidgetTests: BaseTestCase {
     private func tapOnWidget(widgetType: String) {
         let widget = springboard.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", widgetType)).element
         mozWaitElementHittable(element: widget, timeout: TIMEOUT)
-        widget.tap()
+        widget.waitAndTap()
     }
 
     private func allowCopyFromOtherApps() {
@@ -267,41 +267,41 @@ class TodayWidgetTests: BaseTestCase {
             iOS_Settings.swipeUp()
         }
         // Tap the first Firefox entry
-        iOS_Settings.staticTexts["org.mozilla.ios.Fennec"].tap()
+        iOS_Settings.staticTexts["org.mozilla.ios.Fennec"].waitAndTap()
         // Wait for "Paste from Other Apps" button, tap it, then allow copying
         mozWaitForElementToExist(iOS_Settings.buttons["Paste from Other Apps"])
-        iOS_Settings.buttons["Paste from Other Apps"].tap()
+        iOS_Settings.buttons["Paste from Other Apps"].waitAndTap()
         mozWaitForElementToExist(iOS_Settings.staticTexts["Allow"])
-        iOS_Settings.staticTexts["Allow"].tap()
+        iOS_Settings.staticTexts["Allow"].waitAndTap()
     }
 
     private func addWidget(widgetName: String) {
         if iPad() {
             mozWaitForElementToExist(springboard.buttons["Add Widget"])
-            springboard.buttons["Add Widget"].tap()
+            springboard.buttons["Add Widget"].waitAndTap()
         } else {
             if #available(iOS 18, *) {
                 springboard.icons["Screen Time"].press(forDuration: 3)
                 if springboard.buttons["Edit Home Screen"].exists {
-                    springboard.buttons["Edit Home Screen"].tap()
+                    springboard.buttons["Edit Home Screen"].waitAndTap()
                 }
             }
-            springboard.buttons["Edit"].tap()
+            springboard.buttons["Edit"].waitAndTap()
             mozWaitForElementToExist(springboard.buttons["Add Widget"])
-            springboard.buttons["Add Widget"].tap()
+            springboard.buttons["Add Widget"].waitAndTap()
         }
         mozWaitElementHittable(element: springboard.searchFields["Search Widgets"], timeout: TIMEOUT)
-        springboard.searchFields["Search Widgets"].tap()
+        springboard.searchFields["Search Widgets"].waitAndTap()
         springboard.searchFields["Search Widgets"].typeText(widgetName)
         let predicate = NSPredicate(format: "label CONTAINS[c] %@", widgetName+" (")
         let cells = springboard.cells.matching(predicate)
-        cells.element.tap()
+        cells.element.waitAndTap()
     }
 
     private func findAndTapWidget(widgetType: String) {
         let widget = springboard.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", widgetType)).element
         mozWaitForElementToExist(widget)
-        widget.tap()
+        widget.waitAndTap()
     }
 
     private func removeWidgetIfExists(widgetType: String) {
@@ -313,11 +313,11 @@ class TodayWidgetTests: BaseTestCase {
     private func addAndSearchForWidget(widgetName: String) {
         addWidget(widgetName: widgetName)
         mozWaitElementHittable(element: springboard.searchFields["Search Widgets"], timeout: TIMEOUT)
-        springboard.searchFields["Search Widgets"].tap()
+        springboard.searchFields["Search Widgets"].waitAndTap()
         springboard.searchFields["Search Widgets"].typeText(widgetName)
         let predicate = NSPredicate(format: "label CONTAINS[c] %@", widgetName + " (")
         let cells = springboard.cells.matching(predicate)
-        cells.element.tap()
+        cells.element.waitAndTap()
     }
 
     // TESTS
@@ -339,15 +339,15 @@ class TodayWidgetTests: BaseTestCase {
         // Check available widgets
         checkFirefoxAvailablesWidgets()
         // Add Quick Action Widget
-        springboard.buttons[" Add Widget"].tap()
+        springboard.buttons[" Add Widget"].waitAndTap()
         springboard.swipeDown()
-        springboard.buttons["Done"].tap()
+        springboard.buttons["Done"].waitAndTap()
         // Check Quick Action widget options
         checkFirefoxWidgetOptions()
         // Edit Widget and check the options
-        springboard.buttons[editWidgetButton].tap()
+        springboard.buttons[editWidgetButton].waitAndTap()
         mozWaitElementHittable(element: newSearch, timeout: TIMEOUT)
-        newSearch.tap()
+        newSearch.waitAndTap()
         // Verify widget actions
         if #unavailable(iOS 17) {
             goToCopiedLink = springboard.staticTexts["Go to Copied Link"]
@@ -359,7 +359,7 @@ class TodayWidgetTests: BaseTestCase {
         XCTAssertTrue(goToCopiedLink.exists)
         XCTAssertTrue(newPrivateSearch.exists)
         XCTAssertTrue(clearPrivateTabs.exists)
-        newSearch.tap()
+        newSearch.waitAndTap()
         // Tap outside alert to close it
         mozWaitForElementToExist(newSearch)
         coordinate.tap()
@@ -398,19 +398,19 @@ class TodayWidgetTests: BaseTestCase {
         // Check available widgets
         checkFirefoxAvailablesWidgets()
         // Add Quick Action Widget
-        springboard.buttons[" Add Widget"].tap()
+        springboard.buttons[" Add Widget"].waitAndTap()
         springboard.swipeDown()
-        springboard.buttons["Done"].tap()
+        springboard.buttons["Done"].waitAndTap()
         // Verify options available in the Quick Action Widget
         checkFirefoxWidgetOptions()
         // Edit widget and interact with options
         if #unavailable(iOS 16) {
-            springboard.buttons["Edit Widget"].tap()
+            springboard.buttons["Edit Widget"].waitAndTap()
         } else {
-            springboard.buttons[editWidgetButton].tap()
+            springboard.buttons[editWidgetButton].waitAndTap()
         }
         mozWaitElementHittable(element: newSearch, timeout: TIMEOUT)
-        newSearch.tap()
+        newSearch.waitAndTap()
         if #unavailable(iOS 17) {
             goToCopiedLink = springboard.staticTexts["Go to Copied Link"]
             newPrivateSearch = springboard.staticTexts["New Private Search"]
@@ -424,7 +424,7 @@ class TodayWidgetTests: BaseTestCase {
         XCTAssertTrue(clearPrivateTabs.exists, "Clear Private Tabs button not found.")
         // Start a new private search
         mozWaitElementHittable(element: newPrivateSearch, timeout: TIMEOUT)
-        newPrivateSearch.tap()
+        newPrivateSearch.waitAndTap()
         // Tap outside the alert to dismiss it
         mozWaitForElementToExist(newPrivateSearch)
         coordinate.tap()
@@ -435,7 +435,7 @@ class TodayWidgetTests: BaseTestCase {
         // Handle different UI behavior on iPad and iPhone
         if !iPad() {
             mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
-            app.buttons["CloseButton"].tap()
+            app.buttons["CloseButton"].waitAndTap()
         }
         // Verify the presence of Private Mode message
         mozWaitForElementToExist(app.staticTexts["Leave no traces on this device"])
@@ -471,19 +471,19 @@ class TodayWidgetTests: BaseTestCase {
         addWidget(widgetName: "Fennec")
         checkFirefoxAvailablesWidgets()
         // Add Quick Action Widget
-        springboard.buttons[" Add Widget"].tap()
+        springboard.buttons[" Add Widget"].waitAndTap()
         springboard.swipeDown()
-        springboard.buttons["Done"].tap()
+        springboard.buttons["Done"].waitAndTap()
         // Check available options in Quick Action Widget
         checkFirefoxWidgetOptions()
         // Tap on Edit Widget and check the available options
         if #unavailable(iOS 16) {
-            springboard.buttons["Edit Widget"].tap()
+            springboard.buttons["Edit Widget"].waitAndTap()
         } else {
-            springboard.buttons[editWidgetButton].tap()
+            springboard.buttons[editWidgetButton].waitAndTap()
         }
         mozWaitElementHittable(element: newSearch, timeout: TIMEOUT)
-        newSearch.tap()
+        newSearch.waitAndTap()
         if #unavailable(iOS 17) {
             goToCopiedLink = springboard.staticTexts["Go to Copied Link"]
             newPrivateSearch = springboard.staticTexts["New Private Search"]
@@ -497,7 +497,7 @@ class TodayWidgetTests: BaseTestCase {
         XCTAssertTrue(clearPrivateTabs.exists, "Clear Private Tabs button not found.")
         // Tap Go To Copied Link
         mozWaitElementHittable(element: goToCopiedLink, timeout: TIMEOUT)
-        goToCopiedLink.tap()
+        goToCopiedLink.waitAndTap()
         // Tap outside the alert to close it
         coordinate.tap()
         // Copy the string to the clipboard
@@ -508,12 +508,12 @@ class TodayWidgetTests: BaseTestCase {
         // Handle paste alert
         if #available(iOS 16, *) {
             mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: TIMEOUT)
-            springboard.alerts.buttons["Allow Paste"].tap()
+            springboard.alerts.buttons["Allow Paste"].waitAndTap()
         }
         // Handle iPad/iPhone UI differences
         if !iPad() {
             mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
-            app.buttons["CloseButton"].tap()
+            app.buttons["CloseButton"].waitAndTap()
         }
         // Verify the copied string is in the URL field
         mozWaitForElementToExist(urlBarAddress, timeout: TIMEOUT)
@@ -546,11 +546,11 @@ class TodayWidgetTests: BaseTestCase {
         // Add Firefox Shortcut Widget
         springboard.swipeLeft()
         mozWaitForElementToExist(springboard.staticTexts["Firefox Shortcuts"])
-        springboard.buttons[" Add Widget"].tap()
+        springboard.buttons[" Add Widget"].waitAndTap()
         springboard.swipeDown()
-        springboard.buttons["Done"].tap()
+        springboard.buttons["Done"].waitAndTap()
         checkFirefoxShortcutsOptions()
-        springboard.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Firefox")).element.tap()
+        springboard.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Firefox")).element.waitAndTap()
         var elementToAssert = AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.privateModeToggleButton
         if iPad() {
             elementToAssert = AccessibilityIdentifiers.Browser.TopTabs.privateModeButton
@@ -584,19 +584,19 @@ class TodayWidgetTests: BaseTestCase {
         // Add Firefox Shortcut Widget
         springboard.swipeLeft()
         mozWaitForElementToExist(springboard.staticTexts["Firefox Shortcuts"])
-        springboard.buttons[" Add Widget"].tap()
+        springboard.buttons[" Add Widget"].waitAndTap()
         springboard.swipeDown()
-        springboard.buttons["Done"].tap()
+        springboard.buttons["Done"].waitAndTap()
         checkFirefoxShortcutsOptions()
         mozWaitElementHittable(element: springboard.buttons.matching(
             NSPredicate(format: "label CONTAINS[c] %@", "Private Tab")
         ).element.firstMatch, timeout: TIMEOUT)
         springboard.buttons.matching(NSPredicate(
             format: "label CONTAINS[c] %@", "Private Tab")
-        ).element.firstMatch.tap()
+        ).element.firstMatch.waitAndTap()
         if !iPad() {
             mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
-            app.buttons["CloseButton"].tap()
+            app.buttons["CloseButton"].waitAndTap()
         }
         // Verify the presence of Private Mode message
         mozWaitForElementToExist(app.staticTexts["Leave no traces on this device"])
@@ -635,22 +635,22 @@ class TodayWidgetTests: BaseTestCase {
         // Add Firefox Shortcut Widget
         springboard.swipeLeft()
         mozWaitForElementToExist(springboard.staticTexts["Firefox Shortcuts"])
-        springboard.buttons[" Add Widget"].tap()
+        springboard.buttons[" Add Widget"].waitAndTap()
         springboard.swipeDown()
-        springboard.buttons["Done"].tap()
+        springboard.buttons["Done"].waitAndTap()
         checkFirefoxShortcutsOptions()
         mozWaitElementHittable(element: springboard.buttons.matching(
             NSPredicate(format: "label CONTAINS[c] %@", "Copied Link")
         ).element, timeout: TIMEOUT)
         springboard.buttons.matching(NSPredicate(
             format: "label CONTAINS[c] %@", "Copied Link")
-        ).element.tap()
+        ).element.waitAndTap()
         mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: TIMEOUT)
-        springboard.alerts.buttons["Allow Paste"].tap()
+        springboard.alerts.buttons["Allow Paste"].waitAndTap()
         // Verify the copied string is in the URL field
         if !iPad() {
             mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
-            app.buttons["CloseButton"].tap()
+            app.buttons["CloseButton"].waitAndTap()
         }
         mozWaitForElementToExist(urlBarAddress, timeout: TIMEOUT)
         mozWaitForValueContains(urlBarAddress, value: copiedString, timeout: TIMEOUT)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -269,15 +269,12 @@ class TodayWidgetTests: BaseTestCase {
         // Tap the first Firefox entry
         iOS_Settings.staticTexts["org.mozilla.ios.Fennec"].waitAndTap()
         // Wait for "Paste from Other Apps" button, tap it, then allow copying
-        mozWaitForElementToExist(iOS_Settings.buttons["Paste from Other Apps"])
         iOS_Settings.buttons["Paste from Other Apps"].waitAndTap()
-        mozWaitForElementToExist(iOS_Settings.staticTexts["Allow"])
         iOS_Settings.staticTexts["Allow"].waitAndTap()
     }
 
     private func addWidget(widgetName: String) {
         if iPad() {
-            mozWaitForElementToExist(springboard.buttons["Add Widget"])
             springboard.buttons["Add Widget"].waitAndTap()
         } else {
             if #available(iOS 18, *) {
@@ -287,7 +284,6 @@ class TodayWidgetTests: BaseTestCase {
                 }
             }
             springboard.buttons["Edit"].waitAndTap()
-            mozWaitForElementToExist(springboard.buttons["Add Widget"])
             springboard.buttons["Add Widget"].waitAndTap()
         }
         mozWaitElementHittable(element: springboard.searchFields["Search Widgets"], timeout: TIMEOUT)
@@ -300,7 +296,6 @@ class TodayWidgetTests: BaseTestCase {
 
     private func findAndTapWidget(widgetType: String) {
         let widget = springboard.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", widgetType)).element
-        mozWaitForElementToExist(widget)
         widget.waitAndTap()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarMenuTests.swift
@@ -50,7 +50,7 @@ class ToolbarMenuTests: BaseTestCase {
         navigator.goto(BrowserTabMenu)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.MainMenu.HeaderView.mainButton])
         validateMenuOptions()
-        app.buttons["MainMenu.CloseMenuButton"].tap()
+        app.buttons["MainMenu.CloseMenuButton"].waitAndTap()
         XCUIDevice.shared.orientation = .landscapeLeft
         waitForElementsToExist(
             [
@@ -70,10 +70,10 @@ class ToolbarMenuTests: BaseTestCase {
             hamburgerMenu.isAbove(element: firstPocketCell),
             "Menu button is not below the pocket cells area"
         )
-        hamburgerMenu.tap()
+        hamburgerMenu.waitAndTap()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.MainMenu.HeaderView.mainButton])
         validateMenuOptions()
-        app.buttons["MainMenu.CloseMenuButton"].tap()
+        app.buttons["MainMenu.CloseMenuButton"].waitAndTap()
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.MainMenu.HeaderView.mainButton])
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -60,7 +60,7 @@ class ToolbarTests: BaseTestCase {
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
-        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.backButton].waitAndTap()
         XCTAssertEqual(valueMozilla, urlValueLong)
 
         waitUntilPageLoad()
@@ -71,7 +71,7 @@ class ToolbarTests: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
         mozWaitForElementToExist(app.cells.staticTexts[website1["label"]!])
-        app.cells.element(boundBy: 0).tap()
+        app.cells.element(boundBy: 0).waitAndTap()
         XCTAssertEqual(valueMozilla, urlValueLong)
 
         // Test to see if all the buttons are enabled.
@@ -94,7 +94,7 @@ class ToolbarTests: BaseTestCase {
         XCTAssertEqual(valueMozilla, urlValueLong)
 
         // Simulate pressing on backspace key should remove the text
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
         urlBarAddress.typeText("\u{8}")
 
         let value = urlBarAddress.value
@@ -149,7 +149,7 @@ class ToolbarTests: BaseTestCase {
             if #available(iOS 16, *) {
                 navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
                 navigator.performAction(Action.OpenNewTabFromTabTray)
-                app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
+                app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
                 validateAddNewTabButtonOnToolbar(isPrivate: true)
             }
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -55,7 +55,7 @@ class TopTabsTest: BaseTestCase {
         // Open link in a different tab and switch to it
         mozWaitForElementToExist(app.webViews.links.staticTexts["More information..."])
         app.webViews.links.staticTexts["More information..."].press(forDuration: 5)
-        app.buttons["Open in New Tab"].tap()
+        app.buttons["Open in New Tab"].waitAndTap()
         waitUntilPageLoad()
 
         // Open tab tray to check that both tabs are there
@@ -104,9 +104,9 @@ class TopTabsTest: BaseTestCase {
         mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
         // Close the tab using 'x' button
         if iPad() {
-            app.cells.buttons[StandardImageIdentifiers.Large.cross].tap()
+            app.cells.buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
         } else {
-            app.otherElements.cells.buttons[StandardImageIdentifiers.Large.cross].tap()
+            app.otherElements.cells.buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
         }
 
         // After removing only one tab it automatically goes to HomepanelView
@@ -278,7 +278,7 @@ class TopTabsTest: BaseTestCase {
             )
 
             // Open New Tab
-            app.cells.otherElements[StandardImageIdentifiers.Large.plus].tap()
+            app.cells.otherElements[StandardImageIdentifiers.Large.plus].waitAndTap()
             navigator.performAction(Action.CloseURLBarOpen)
 
             waitForTabsButton()
@@ -295,7 +295,7 @@ class TopTabsTest: BaseTestCase {
             mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
             app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].press(forDuration: 1)
             mozWaitForElementToExist(app.tables.cells.otherElements[StandardImageIdentifiers.Large.plus])
-            app.tables.cells.otherElements[StandardImageIdentifiers.Large.cross].tap()
+            app.tables.cells.otherElements[StandardImageIdentifiers.Large.cross].waitAndTap()
             navigator.nowAt(NewTabScreen)
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
 
@@ -312,7 +312,7 @@ class TopTabsTest: BaseTestCase {
             let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
             mozWaitForElementToExist(tabsButton)
             navigator.nowAt(NewTabScreen)
-            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].tap()
+            app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
             checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 1)
         }
     }
@@ -348,10 +348,10 @@ class TopTabsTest: BaseTestCase {
         let tabsTrayCell = app.otherElements["Tabs Tray"].cells
         // Go to a tab that is below the fold of the scrollable “Open Tabs” view
         if !iPad() {
-            tabsTrayCell.staticTexts.element(boundBy: 3).tap()
+            tabsTrayCell.staticTexts.element(boundBy: 3).waitAndTap()
         } else {
             XCTAssertEqual(tabsTrayCell.count, Int(numTab!))
-            tabsTrayCell.staticTexts.element(boundBy: 6).tap()
+            tabsTrayCell.staticTexts.element(boundBy: 6).waitAndTap()
         }
         // The current tab’s thumbnail is focused in the “Open Tabs” view
         navigator.nowAt(NewTabScreen)
@@ -382,7 +382,7 @@ class TopTabsTest: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         validateToastWhenClosingMultipleTabs()
         // Choose to undo the action
-        app.buttons["Undo"].tap()
+        app.buttons["Undo"].waitAndTap()
         waitUntilPageLoad()
         // Only the latest tab closed is restored
         navigator.nowAt(BrowserTab)
@@ -401,7 +401,7 @@ class TopTabsTest: BaseTestCase {
         navigator.performAction(Action.TogglePrivateMode)
         validateToastWhenClosingMultipleTabs()
         // Choose to undo the action
-        app.buttons["Undo"].tap()
+        app.buttons["Undo"].waitAndTap()
         // Only the latest tab closed is restored
         if !iPad() {
             let numTab = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value as? String
@@ -426,7 +426,7 @@ class TopTabsTest: BaseTestCase {
         navigator.goto(TabTray)
         // Close multiple tabs by pressing X button
         for _ in 0...3 {
-            app.collectionViews.cells["Homepage. Currently selected tab."].buttons["crossLarge"].tap()
+            app.collectionViews.cells["Homepage. Currently selected tab."].buttons["crossLarge"].waitAndTap()
             // A toast notification is displayed with the message "Tab Closed" and the Undo option
             waitForElementsToExist(
                 [
@@ -435,7 +435,7 @@ class TopTabsTest: BaseTestCase {
                 ]
             )
         }
-        app.collectionViews.buttons["crossLarge"].tap()
+        app.collectionViews.buttons["crossLarge"].waitAndTap()
         waitForElementsToExist(
             [
                 app.buttons["Undo"],
@@ -466,7 +466,7 @@ class TopTabsTest: BaseTestCase {
             ]
         )
         // Choose to close the tab
-        app.buttons["Close Tab"].tap()
+        app.buttons["Close Tab"].waitAndTap()
         // A toast notification is displayed with the message "Tab Closed" and the Undo option
         waitForElementsToExist(
             [
@@ -474,7 +474,7 @@ class TopTabsTest: BaseTestCase {
                 app.staticTexts["Tab Closed"]
             ]
         )
-        app.buttons["Undo"].tap()
+        app.buttons["Undo"].waitAndTap()
         mozWaitForElementToNotExist(app.buttons["Undo"])
         mozWaitForElementToNotExist(app.staticTexts["Tab Closed"])
         // The tab closed is restored
@@ -498,7 +498,7 @@ fileprivate extension BaseTestCase {
     }
 
     func closeTabTrayView(goBackToBrowserTab: String) {
-        app.cells.staticTexts[goBackToBrowserTab].firstMatch.tap()
+        app.cells.staticTexts[goBackToBrowserTab].firstMatch.waitAndTap()
         navigator.nowAt(BrowserTab)
     }
 }
@@ -618,8 +618,8 @@ class TopTabsTestIpad: IpadOnlyTestCase {
     func testUpdateTabCounter() {
         if skipPlatform { return }
         // Open three tabs by tapping on '+' button
-        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
-        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
         let numTab = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value as? String
         XCTAssertEqual("3", numTab)
@@ -628,7 +628,7 @@ class TopTabsTestIpad: IpadOnlyTestCase {
             .children(matching: .cell)
             .matching(identifier: "Homepage")
             .element(boundBy: 1).buttons["Remove page — Homepage"]
-            .tap()
+            .waitAndTap()
         waitForTabsButton()
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["3"])
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["2"])
@@ -638,7 +638,7 @@ class TopTabsTestIpad: IpadOnlyTestCase {
             .children(matching: .cell)
             .element(boundBy: 1)
             .buttons["Remove page — Homepage"]
-            .tap()
+            .waitAndTap()
         waitForTabsButton()
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["2"])
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].staticTexts["1"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -51,7 +51,7 @@ class TrackingProtectionTests: BaseTestCase {
                 ).label
             )
         }
-        app.otherElements.element(matching: .any, identifier: reloadWithWithoutProtectionButton).tap()
+        app.otherElements.element(matching: .any, identifier: reloadWithWithoutProtectionButton).waitAndTap()
         waitUntilPageLoad()
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon], timeout: 5)
         if #unavailable(iOS 16) {
@@ -62,8 +62,8 @@ class TrackingProtectionTests: BaseTestCase {
 
     private func enableStrictMode() {
         navigator.performAction(Action.EnableStrictMode)
-        app.buttons[buttonSettings].tap()
-        app.buttons[buttonDone].tap()
+        app.buttons[buttonSettings].waitAndTap()
+        app.buttons[buttonDone].waitAndTap()
     }
 
     func checkTrackingProtectionOn() -> Bool {
@@ -142,27 +142,27 @@ class TrackingProtectionTests: BaseTestCase {
         var switchValue = app.switches.firstMatch.value!
         // Need to make sure first the setting was not turned off previously
         if switchValue as? String == "0" {
-            app.switches.firstMatch.tap()
+            app.switches.firstMatch.waitAndTap()
         }
         switchValue = app.switches.firstMatch.value!
         XCTAssertEqual(switchValue as? String, "1")
 
-        app.switches.firstMatch.tap()
+        app.switches.firstMatch.waitAndTap()
         let switchValueOFF = app.switches.firstMatch.value!
         XCTAssertEqual(switchValueOFF as? String, "0")
 
         // Open TP Settings menu
-        // app.buttons["Privacy settings"].tap()
+        // app.buttons["Privacy settings"].waitAndTap()
         // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/23706
         navigator.goto(SettingsScreen)
         app.staticTexts["Tracking Protection"].waitAndTap()
         mozWaitForElementToExist(app.navigationBars["Tracking Protection"], timeout: 5)
         let switchSettingsValue = app.switches["prefkey.trackingprotection.normalbrowsing"].value!
         XCTAssertEqual(switchSettingsValue as? String, "1")
-        app.switches["prefkey.trackingprotection.normalbrowsing"].tap()
+        app.switches["prefkey.trackingprotection.normalbrowsing"].waitAndTap()
         // Disable ETP from setting and check that it applies to the site
-        app.buttons["Settings"].tap()
-        app.buttons["Done"].tap()
+        app.buttons["Settings"].waitAndTap()
+        app.buttons["Done"].waitAndTap()
         navigator.nowAt(BrowserTab)
         navigator.goto(TrackingProtectionContextMenuDetails)
         mozWaitForElementToExist(app.staticTexts["Connection not secure"], timeout: 5)
@@ -174,7 +174,7 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.nowAt(NewTabScreen)
         navigator.goto(TrackingProtectionSettings)
         // See Basic mode info
-        app.cells["Settings.TrackingProtectionOption.BlockListBasic"].buttons["More Info"].tap()
+        app.cells["Settings.TrackingProtectionOption.BlockListBasic"].buttons["More Info"].waitAndTap()
         waitForElementsToExist(
             [
                 app.navigationBars["Client.TPAccessoryInfo"],
@@ -187,14 +187,14 @@ class TrackingProtectionTests: BaseTestCase {
         mozWaitForElementToNotExist(app.cells.staticTexts["Tracking content"])
 
         // Go back to TP settings
-        app.buttons["Tracking Protection"].tap()
+        app.buttons["Tracking Protection"].waitAndTap()
 
         // See Strict mode info
-        app.cells["Settings.TrackingProtectionOption.BlockListStrict"].buttons["More Info"].tap()
+        app.cells["Settings.TrackingProtectionOption.BlockListStrict"].buttons["More Info"].waitAndTap()
         XCTAssertTrue(app.cells.staticTexts["Tracking content"].exists)
 
         // Go back to TP settings
-        app.buttons["Tracking Protection"].tap()
+        app.buttons["Tracking Protection"].waitAndTap()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307061
@@ -226,7 +226,7 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.openNewURL(urlString: "https://www.badssl.com")
         waitUntilPageLoad()
         mozWaitForElementToExist(app.links.staticTexts["expired"])
-        app.links.staticTexts["expired"].tap()
+        app.links.staticTexts["expired"].waitAndTap()
         waitUntilPageLoad()
         // The page is correctly displayed with the lock icon disabled
         mozWaitForElementToExist(

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -225,7 +225,6 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         navigator.openNewURL(urlString: "https://www.badssl.com")
         waitUntilPageLoad()
-        mozWaitForElementToExist(app.links.staticTexts["expired"])
         app.links.staticTexts["expired"].waitAndTap()
         waitUntilPageLoad()
         // The page is correctly displayed with the lock icon disabled

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/URLValidationTests.swift
@@ -14,9 +14,9 @@ class URLValidationTests: BaseTestCase {
         super.setUp()
         continueAfterFailure = true
         navigator.goto(SearchSettings)
-        app.tables.switches["Show Search Suggestions"].tap()
+        app.tables.switches["Show Search Suggestions"].waitAndTap()
         scrollToElement(app.tables.switches["FirefoxSuggestShowNonSponsoredSuggestions"])
-        app.tables.switches["FirefoxSuggestShowNonSponsoredSuggestions"].tap()
+        app.tables.switches["FirefoxSuggestShowNonSponsoredSuggestions"].waitAndTap()
         navigator.goto(NewTabScreen)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
@@ -10,7 +10,7 @@ class UrlBarTests: BaseTestCase {
         // Visit any website and select the URL bar
         navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
         waitUntilPageLoad()
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
         // The keyboard is brought up.
         XCTAssertTrue(urlBarAddress.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
         // Scroll on the page
@@ -36,12 +36,12 @@ class UrlBarTests: BaseTestCase {
         navigator.goto(SearchSettings)
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
         mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine1])
-        defaultSearchEngine.tap()
-        app.tables.staticTexts[defaultSearchEngine2].tap()
+        defaultSearchEngine.waitAndTap()
+        app.tables.staticTexts[defaultSearchEngine2].waitAndTap()
         mozWaitForElementToExist(app.tables.cells.staticTexts[defaultSearchEngine2])
         navigator.goto(SettingsScreen)
-        app.navigationBars.buttons["Done"].tap()
-        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].tap()
+        app.navigationBars.buttons["Done"].waitAndTap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
         tapUrlBarValidateKeyboardAndIcon()
         typeSearchTermAndHitGo(searchTerm: "Firefox")
         // The search is conducted correctly trough the default search engine
@@ -51,7 +51,7 @@ class UrlBarTests: BaseTestCase {
     private func tapUrlBarValidateKeyboardAndIcon() {
         // Tap on the URL bar
         waitForTabsButton()
-        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].tap()
+        app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
         // The keyboard pops up and the default search icon is correctly displayed in the URL bar
         XCTAssertTrue(urlBarAddress.value(forKey: "hasKeyboardFocus") as? Bool ?? false)
         let keyboardCount = app.keyboards.count

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
@@ -36,7 +36,7 @@ class ZoomingTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         navigator.goto(TabTray)
         if !app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].exists {
-            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
+            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].waitAndTap()
         }
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         validateZoomActions()
@@ -54,7 +54,7 @@ class ZoomingTests: BaseTestCase {
         zoomLevel = app.buttons[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
         XCTAssertEqual(zoomLevel.label, "Current Zoom Level: 175%")
         zoomOut()
-        zoomOutButton.tap()
+        zoomOutButton.waitAndTap()
         zoomLevel = app.staticTexts[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
         XCTAssertEqual(zoomLevel.label, "Current Zoom Level: 100%")
     }
@@ -66,7 +66,7 @@ class ZoomingTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         navigator.goto(TabTray)
         if !app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].exists {
-            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].tap()
+            app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].waitAndTap()
         }
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         validateZoomLevelOnSwitchingTabs()
@@ -113,7 +113,7 @@ class ZoomingTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         navigator.goto(TabTray)
         mozWaitForElementToExist(app.collectionViews.staticTexts.element)
-        app.collectionViews.staticTexts.element(boundBy: tab).tap()
+        app.collectionViews.staticTexts.element(boundBy: tab).waitAndTap()
         waitUntilPageLoad()
         // Tap on the hamburger menu -> Tap on Zoom
         navigator.nowAt(BrowserTab)
@@ -152,14 +152,14 @@ class ZoomingTests: BaseTestCase {
         swipeUp()
         swipeDown()
         zoomOut()
-        zoomOutButton.tap()
+        zoomOutButton.waitAndTap()
         zoomLevel = app.staticTexts[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
         XCTAssertEqual(zoomLevel.label, "Current Zoom Level: 100%")
         // Switch the device orientation to landscape
         XCUIDevice.shared.orientation = UIDeviceOrientation.landscapeLeft
         zoomOutLandscape()
         zoomInLandscape()
-        zoomInButton.tap()
+        zoomInButton.waitAndTap()
         mozWaitForElementToExist(app.staticTexts[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel])
         zoomLevel = app.staticTexts[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
         XCTAssertEqual(zoomLevel.label, "Current Zoom Level: 100%")
@@ -174,7 +174,7 @@ class ZoomingTests: BaseTestCase {
         for i in 0...3 {
             zoomLevel = app.buttons[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
             let previoustTextSize = bookOfMozillaTxt.frame.size.height
-            zoomInButton.tap()
+            zoomInButton.waitAndTap()
             mozWaitForElementToExist(bookOfMozillaTxt)
             let currentTextSize = bookOfMozillaTxt.frame.size.height
             XCTAssertTrue(currentTextSize != previoustTextSize)
@@ -186,7 +186,7 @@ class ZoomingTests: BaseTestCase {
         for i in 0...2 {
             zoomLevel = app.buttons[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
             let previoustTextSize = bookOfMozillaTxt.frame.size.height
-            zoomOutButton.tap()
+            zoomOutButton.waitAndTap()
             mozWaitForElementToExist(bookOfMozillaTxt)
             let currentTextSize = bookOfMozillaTxt.frame.size.height
             XCTAssertTrue(currentTextSize != previoustTextSize)
@@ -198,7 +198,7 @@ class ZoomingTests: BaseTestCase {
         for i in 0...2 {
             zoomLevel = app.buttons[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
             let previoustTextSize = bookOfMozillaTxt.frame.size.height
-            zoomOutButton.tap()
+            zoomOutButton.waitAndTap()
             mozWaitForElementToExist(bookOfMozillaTxt)
             let currentTextSize = bookOfMozillaTxt.frame.size.height
             XCTAssertTrue(currentTextSize != previoustTextSize)
@@ -210,7 +210,7 @@ class ZoomingTests: BaseTestCase {
         for i in 0...1 {
             zoomLevel = app.buttons[AccessibilityIdentifiers.ZoomPageBar.zoomPageZoomLevelLabel]
             let previoustTextSize = bookOfMozillaTxt.frame.size.height
-            zoomInButton.tap()
+            zoomInButton.waitAndTap()
             mozWaitForElementToExist(bookOfMozillaTxt)
             let currentTextSize = bookOfMozillaTxt.frame.size.height
             XCTAssertTrue(currentTextSize != previoustTextSize)
@@ -220,13 +220,13 @@ class ZoomingTests: BaseTestCase {
 
     private func tapZoomInButton(tapCount: Int) {
         for _ in 1...tapCount {
-            zoomInButton.tap()
+            zoomInButton.waitAndTap()
         }
     }
 
     private func tapZoomOutButton(tapCount: Int) {
         for _ in 1...tapCount {
-            zoomOutButton.tap()
+            zoomOutButton.waitAndTap()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
@@ -112,7 +112,6 @@ class ZoomingTests: BaseTestCase {
     private func selectTabTrayWebsites(tab: Int) {
         navigator.nowAt(BrowserTab)
         navigator.goto(TabTray)
-        mozWaitForElementToExist(app.collectionViews.staticTexts.element)
         app.collectionViews.staticTexts.element(boundBy: tab).waitAndTap()
         waitUntilPageLoad()
         // Tap on the hamburger menu -> Tap on Zoom


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Experiment with `waitAndTap()` throughout `XCUITests`.

Update: No regression detected. Let's do something to reduce future regression! 💪🏼 The failures are currently known.
https://storage.googleapis.com/mobile-reports/public/firefox-ios-M1/FullFunctionalTests/result_1307/build/reports/index.html

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

