### PR TITLE
Bugfix FXIOS-11007 Avoid loading view when removing UI for memory leak fix

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -131,7 +131,7 @@ protocol NewJSPromptAlertControllerDelegate: AnyObject {
 class NewJSPromptAlertController: UIAlertController {
     var alertInfo: NewJSAlertInfo?
     weak var delegate: NewJSPromptAlertControllerDelegate?
-    private var handledAction: Bool = false
+    private var handledAction = false
     private var dismissalResult: Any?
 
     convenience init(

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -49,6 +49,7 @@ class TabDisplayPanelViewController: UIViewController,
     }
 
     func removeTabPanel() {
+        guard isViewLoaded else { return }
         view.removeConstraints(view.constraints)
         view.subviews.forEach { $0.removeFromSuperview() }
         view.removeFromSuperview()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11007)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24042)

## :bulb: Description

Bandaid for a Sentry crash, avoid loading the view unnecessarily during tab tray dismissal if it's not needed. This avoids the subsequent Redux subscription and tab tray refresh action that is causing the crash for FXIOS-11007 I believe.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

