### PR TITLE
Add FXIOS-11007 Logs related to view will disappear and redux actions

### DIFF
--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -70,7 +70,7 @@ public class Store<State: StateType>: DefaultDispatchStore {
     }
 
     public func dispatch(_ action: Action) {
-        logger.log("Dispatched action: \(action.displayString())", level: .info, category: .redux)
+        logger.log("Dispatched action: \(action.debugDescription)", level: .info, category: .redux)
 
         guard Thread.isMainThread else {
             DispatchQueue.main.async { [weak self] in self?.dispatch(action) }

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -104,7 +104,7 @@ class AppLaunchUtil {
             AppEventQueue.signal(event: .accountManagerInitialized)
         }
 
-        // Add swizzle on UIViewControllers to automatically log when there's a new view showing
+        // Add swizzle on UIViewControllers to automatically log when there's a new view appearing or disappearing
         UIViewController.loggerSwizzle()
 
         // Add swizzle on top of UIControl to automatically log when there's an action sent

--- a/firefox-ios/Client/Extensions/UIViewController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIViewController+Extension.swift
@@ -120,11 +120,26 @@ extension UIViewController {
         case remoteScreenTime = "STWebRemoteViewController"
     }
 
-    /// Add a swizzle on top of the viewWillAppear function to log whenever a view controller will appear.
-    /// Needs to be only called once on app launch.
+    /// Add a swizzle on top of the viewWillAppear and viewWillDisappear functions to log whenever
+    /// a view controller will appear and disappear. Needs to be only called once on app launch.
     static func loggerSwizzle() {
+        viewWillAppearSwizzle()
+        viewWillDisappearSwizzle()
+    }
+
+    private static func viewWillAppearSwizzle() {
         let originalSelector = #selector(UIViewController.viewWillAppear(_:))
         let swizzledSelector = #selector(UIViewController.loggerViewWillAppear(_:))
+
+        guard let originalMethod = class_getInstanceMethod(self, originalSelector),
+              let swizzleMethod = class_getInstanceMethod(self, swizzledSelector) else { return }
+
+        method_exchangeImplementations(originalMethod, swizzleMethod)
+    }
+
+    private static func viewWillDisappearSwizzle() {
+        let originalSelector = #selector(UIViewController.viewWillDisappear(_:))
+        let swizzledSelector = #selector(UIViewController.loggerViewWillDisappear(_:))
 
         guard let originalMethod = class_getInstanceMethod(self, originalSelector),
               let swizzledMethod = class_getInstanceMethod(self, swizzledSelector) else { return }
@@ -140,5 +155,15 @@ extension UIViewController {
         }
 
         loggerViewWillAppear(animated)
+    }
+
+    @objc
+    private func loggerViewWillDisappear(_ animated: Bool) {
+        let values: [String] = LoggerIgnoreViewController.allCases.map { $0.rawValue }
+        if !values.contains("\(type(of: self))") {
+            DefaultLogger.shared.log("\(type(of: self)) will disappear", level: .info, category: .lifecycle)
+        }
+
+        loggerViewWillDisappear(animated)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11007)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24042)

## :bulb: Description
I was thinking we could add log call when the `viewWillDisappear` is called for VCs, similar to the one we have with `viewWillAppear`. I'm also proposing we start using the `Action.debugDescription` to log more information in Sentry breadcrumbs. I think those will make it easier to understand some issues related to redux/window/deinit management in the future.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

