### PR TITLE
Refactor FXIOS-11011 [Bookmarks Evolution] Update bookmark toast strings

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1716,11 +1716,6 @@ class BrowserViewController: UIViewController,
     }
 
     private func showBookmarkToast(bookmarkURL: URL? = nil, title: String? = nil, action: BookmarkAction) {
-        func showAddBookmarkToast(folderName: String) {
-            let message = String(format: .Bookmarks.Menu.SavedBookmarkToastLabel, folderName)
-            showToast(message: message, toastAction: .bookmarkPage)
-        }
-
         switch action {
         case .add:
             if !isBookmarkRefactorEnabled {
@@ -1733,11 +1728,12 @@ class BrowserViewController: UIViewController,
                 profile.places.getBookmark(guid: recentBookmarkFolderGuid).uponQueue(.main) { result in
                     guard let bookmarkFolder = result.successValue as? BookmarkFolderData else { return }
                     let folderName = bookmarkFolder.title
-                    showAddBookmarkToast(folderName: folderName)
+                    let message = String(format: .Bookmarks.Menu.SavedBookmarkToastLabel, folderName)
+                    self.showToast(message: message, toastAction: .bookmarkPage)
                 }
             // If recent bookmarks folder is nil or the mobile (default) folder
             } else {
-                showAddBookmarkToast(folderName: .Bookmarks.Menu.SavedBookmarkToastDefaultFolderLabel)
+                showToast(message: .Bookmarks.Menu.SavedBookmarkToastDefaultFolderLabel, toastAction: .bookmarkPage)
             }
         case .remove:
             self.showToast(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -191,12 +191,12 @@ extension String {
                 key: "Bookmarks.Menu.SavedBookmarkToastLabel.v136",
                 tableName: "Bookmarks",
                 value: "Saved in \"%@\"",
-                comment: "The label displayed in the toast when saving a bookmark via the menu. The placeholder represents the folder where the bookmark is saved to")
+                comment: "The label displayed in the toast notification when saving a bookmark via the menu to a custom folder. The placeholder represents the custom name of the folder, created by the user, where the bookmark will be saved to")
             public static let SavedBookmarkToastDefaultFolderLabel = MZLocalizedString(
                 key: "Bookmarks.Menu.SavedBookmarkToastDefaultFolderLabel.v136",
                 tableName: "Bookmarks",
-                value: "Bookmarks",
-                comment: "Label describing the name of the default folder that a bookmark is saved to when a recent folder is not set. This label is used for the saved bookmark toast. The toast would read: (Saved in \"Bookmarks\")")
+                value: "Saved in \"Bookmarks\"",
+                comment: "The label displayed in the toast notification when saving a bookmark via the menu to the default folder. \"Bookmarks\" is the name of the default folder where the bookmark will be saved to.")
         }
 
         public struct EmptyState {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11011)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24054)

## :bulb: Description
- Update the string used by the "save bookmark" toast notification when saving a bookmark to the default "Bookmarks" folder to use a hardcoded string instead of formatting a templated string
- Update string translation comments

### 📝 Notes:
- There is no user-facing impact

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

