### PR TITLE
Bugfix FXIOS-11009 - [Toolbar Redesign]  One tap new tab doesn't open a new tab when custom homepage url is set

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4254,6 +4254,7 @@ extension BrowserViewController: TopTabsDelegate {
         let homePageURL = HomeButtonHomePageAccessors.getHomePage(profile.prefs)
 
         if shouldLoadCustomHomePage, let url = homePageURL {
+            openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
             tabManager.selectedTab?.loadRequest(PrivilegedRequest(url: url) as URLRequest)
         } else {
             openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)

--- a/firefox-ios/Client/Frontend/Browser/PrivilegedRequest.swift
+++ b/firefox-ios/Client/Frontend/Browser/PrivilegedRequest.swift
@@ -25,7 +25,7 @@ private let REQUEST_KEY_PRIVILEGED = "privileged"
  PrivilegedRequest(), but the value of doing this is not clear as these requests should work fine
  as regular URLRequest().
  **/
-class PrivilegedRequest: NSMutableURLRequest {
+final class PrivilegedRequest: NSMutableURLRequest {
     override init(url: URL, cachePolicy: NSURLRequest.CachePolicy, timeoutInterval: TimeInterval) {
         func getUrl() -> URL {
             if InternalURL.isValid(url: url), let result = InternalURL.authorize(url: url) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11009)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24045)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

