### PR TITLE
Add FXIOS-11002 [Homepage] action for showing / hiding sponsored sites

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesAction.swift
@@ -32,6 +32,7 @@ enum TopSitesActionType: ActionType {
     case updatedNumberOfRows
     case updatedNumberOfTilesPerRow
     case toggleShowSectionSetting
+    case toggleShowSponsoredSettings
 }
 
 enum TopSitesMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
@@ -99,6 +99,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
 
     // MARK: Sponsored tiles (Contiles)
     func fetchSponsoredSites() async -> [SponsoredTile] {
+        guard shouldLoadSponsoredTiles else { return [] }
         let contiles = await withCheckedContinuation { continuation in
             if featureFlags.isFeatureEnabled(.unifiedAds, checking: .buildOnly) {
                 unifiedAdsProvider.fetchTiles { [weak self] result in

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -35,7 +35,8 @@ final class TopSitesMiddleware {
     lazy var topSitesProvider: Middleware<AppState> = { state, action in
         switch action.actionType {
         case HomepageActionType.initialize,
-            TopSitesActionType.fetchTopSites:
+            TopSitesActionType.fetchTopSites,
+            TopSitesActionType.toggleShowSponsoredSettings:
             self.getTopSitesDataAndUpdateState(for: action)
         case ContextMenuActionType.tappedOnPinTopSite:
             guard let site = self.getSite(for: action) else { return }

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -45,7 +45,14 @@ class TopSitesSettingsViewController: SettingsTableViewController, FeatureFlagga
                     prefKey: PrefsKeys.UserFeatureFlagPrefs.SponsoredShortcuts,
                     defaultValue: true,
                     titleText: .Settings.Homepage.Shortcuts.SponsoredShortcutsToggle
-                )
+                ) { _ in
+                    store.dispatch(
+                        TopSitesAction(
+                            windowUUID: self.windowUUID,
+                            actionType: TopSitesActionType.toggleShowSponsoredSettings
+                        )
+                    )
+                }
             ]
             let toggleSection = SettingSection(title: nil, children: toggleSettings)
             sections.append(toggleSection)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11002)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24035)

## :bulb: Description
Add logic to hide or show sponsored sites based on toggle setting.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots

https://github.com/user-attachments/assets/1aa8f161-6c08-40c7-9064-f6fd7ace9ab9

