### PR TITLE
Refactor FXIOS-11016 #24065 Reenable cleanupHistoryIfNeeded

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -11,7 +11,7 @@ import TabDataStore
 
 import class MozillaAppServices.Viaduct
 
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
     let logger = DefaultLogger.shared
     var notificationCenter: NotificationProtocol = NotificationCenter.default
     var orientationLock = UIInterfaceOrientationMask.all
@@ -164,7 +164,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Cleanup can be a heavy operation, take it out of the startup path. Instead check after a few seconds.
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
-            self?.profile.cleanupHistoryIfNeeded()
+            if self?.featureFlags.isFeatureEnabled(.cleanupHistoryReenabled, checking: .buildOnly) ?? false {
+                self?.profile.cleanupHistoryIfNeeded()
+            }
             self?.ratingPromptManager.updateData()
         }
 

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -164,8 +164,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Cleanup can be a heavy operation, take it out of the startup path. Instead check after a few seconds.
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
-            // TODO: testing to see if this fixes https://mozilla-hub.atlassian.net/browse/FXIOS-7632
-            // self?.profile.cleanupHistoryIfNeeded()
+            self?.profile.cleanupHistoryIfNeeded()
             self?.ratingPromptManager.updateData()
         }
 

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -9,7 +9,7 @@ import Kingfisher
 
 import class MozillaAppServices.HardcodedNimbusFeatures
 
-class UITestAppDelegate: AppDelegate, FeatureFlaggable {
+class UITestAppDelegate: AppDelegate {
     lazy var dirForTestProfile = { return "\(self.appRootDir())/profile.testProfile" }()
 
     private var internalProfile: Profile?

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -15,6 +15,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case bottomSearchBar
     case contextualHintForToolbar
     case creditCardAutofillStatus
+    case cleanupHistoryReenabled
     case fakespotBackInStock
     case fakespotFeature
     case fakespotProductAds
@@ -109,6 +110,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .bookmarksRefactor,
                 .accountSettingsRedux,
                 .addressAutofillEdit,
+                .cleanupHistoryReenabled,
                 .creditCardAutofillStatus,
                 .closeRemoteTabs,
                 .fakespotBackInStock,

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -24,6 +24,9 @@ final class NimbusFeatureFlagLayer {
                 .isToolbarCFREnabled:
             return checkAwesomeBarFeature(for: featureID, from: nimbus)
 
+        case .cleanupHistoryReenabled:
+            return checkCleanupHistoryReenabled(from: nimbus)
+
         case .contextualHintForToolbar:
             return checkNimbusForContextualHintsFeature(for: featureID, from: nimbus)
 
@@ -142,6 +145,11 @@ final class NimbusFeatureFlagLayer {
 
     private func checkBookmarksRefactor(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.bookmarkRefactorFeature.value().enabled
+    }
+
+    private func checkCleanupHistoryReenabled(from nimbus: FxNimbus) -> Bool {
+        let config = nimbus.features.cleanupHistoryReenabled.value()
+        return config.enabled
     }
 
     private func checkGeneralFeature(for featureID: NimbusFeatureFlagID,

--- a/firefox-ios/nimbus-features/cleanupHistoryReenabled.yaml
+++ b/firefox-ios/nimbus-features/cleanupHistoryReenabled.yaml
@@ -1,0 +1,19 @@
+# The configuration file for the cleanupHistoryIfNeeded re-enabling functionnality
+features:
+  cleanup-history-reenabled:
+    description: >
+      This feature flag will help us slowly re-enable the cleanupHistoryIfNeeded functionnality at startup of the app
+    variables:
+      enabled:
+        description: >
+          When true the cleanupHistoryIfNeeded will be run
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: true
+      - channel: developer
+        value:
+          enabled: true
+

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -17,6 +17,7 @@ include:
   - nimbus-features/addressAutofillFeature.yaml
   - nimbus-features/autofillFeature.yaml
   - nimbus-features/bookmarkRefactorFeature.yaml
+  - nimbus-features/cleanupHistoryReenabled.yaml
   - nimbus-features/contextualHintFeature.yaml
   - nimbus-features/fakespotFeature.yaml
   - nimbus-features/feltPrivacyFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11016)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24065)

## :bulb: Description
Reenable cleanupHistoryIfNeeded as it was disabled a while back for an incident in v119.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

