### PR TITLE
Add FXIOS-10266 [Bookmarks Evolution] Prevent scaling title/url text when exceeding text field width

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
@@ -31,12 +31,14 @@ class EditBookmarkCell: UITableViewCell,
         view.addAction(UIAction(handler: { [weak self] _ in
             self?.titleTextFieldDidChange()
         }), for: .editingChanged)
+        view.adjustsFontSizeToFitWidth = true
     }
     private lazy var urlTextfield: TextField = .build { view in
         view.keyboardType = .URL
         view.addAction(UIAction(handler: { [weak self] _ in
             self?.urlTextFieldDidChane()
         }), for: .editingChanged)
+        view.adjustsFontSizeToFitWidth = true
     }
     var onTitleFieldUpdate: ((String) -> Void)?
     var onURLFieldUpdate: ((String) -> Void)?


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10266)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22476)

## :bulb: Description
- Prevent over-scaling bookmark title/url text with dynamic type to an non-legible size when text exceeds textfield width

 ### 🎥 Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/fd2cac0b-6771-4e97-a912-e970a60132dc

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/f036cd68-6ece-4333-ae86-c074ddc2408a

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

