### PR TITLE
Add FXIOS-11032 [Bookmarks Evolution] A11y label for "..." disclosure button

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -388,6 +388,7 @@ class BookmarksViewController: SiteTableViewController,
         let contextButton = UIButton()
         contextButton.configuration = buttonConfig
         contextButton.frame = CGRect(width: 44, height: 44)
+        contextButton.accessibilityLabel = .Bookmarks.Menu.MoreOptionsA11yLabel
 
         return contextButton
     }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -197,6 +197,11 @@ extension String {
                 tableName: "Bookmarks",
                 value: "Saved in “Bookmarks”",
                 comment: "The label displayed in the toast notification when saving a bookmark via the menu to the default folder. \"Bookmarks\" is the name of the default folder where the bookmark will be saved to.")
+            public static let MoreOptionsA11yLabel = MZLocalizedString(
+                key: "Bookmarks.Menu.MoreOptionsA11yLabel.v136",
+                tableName: "Bookmarks",
+                value: "More options",
+                comment: "Accessibility label for the \"...\" disclosure button located within every bookmark site cell in the bookmarks panel. Pressing this button opens a modal with more actions.")
         }
 
         public struct EmptyState {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11032)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24081)

## :bulb: Description
- Add an a11y label for the "..." disclosure button located in bookmark site cells in the bookmarks panel

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

