### PR TITLE
Add FXIOS-11033 [Bookmarks Evolution] A11y button traits for tableview cells

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -507,6 +507,7 @@ class BookmarksViewController: SiteTableViewController,
                 viewModel.accessoryView = contextButton
             }
 
+            cell.accessibilityTraits = .button
             cell.configure(viewModel: viewModel)
             cell.applyTheme(theme: currentTheme())
             return cell

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -237,6 +237,7 @@ class EditBookmarkViewController: UIViewController,
         let canShowAccessoryView = viewModel.shouldShowDisclosureIndicator(isFolderSelected: isFolderSelected)
         cell.accessoryType = canShowAccessoryView ? .checkmark : .none
         cell.selectionStyle = .default
+        cell.accessibilityTraits = .button
         cell.customization = .regular
         cell.applyTheme(theme: theme)
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -207,6 +207,7 @@ class EditFolderViewController: UIViewController,
         let canShowAccessoryView = viewModel.shouldShowDisclosureIndicator(isFolderSelected: isFolderSelected)
         cell.accessoryType = canShowAccessoryView ? .checkmark : .none
         cell.selectionStyle = .default
+        cell.accessibilityTraits = .button
         cell.customization = .regular
         cell.applyTheme(theme: theme)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11033)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24083)

## :bulb: Description
- Add the `button` accessibility trait to tableview cells in the bookmarks panel, edit bookmark view (parent folder section), and edit folder view  (parent folder section) 

### 📝 Discussion: 
- This previously worked in the `LegacyBookmarksPanel` implicitly because we were using the `.disclosureIndicator` `accessoryType`, which automatically gave the cells the `button` accessibility trait. Now that we use a custom `accessoryView` in each of the cells in the table in `BookmarksViewController`, we no longer need the `.disclosureIndicator` `accessoryType`, and instead use `.none`
- The `button` trait never worked for the parent folder selector in the `LegacyBookmarkDetailPanel`, so that has now been remedied in the `EditBookmarkViewController` and `EditFolderViewController`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

