### PR TITLE
Refactor FXIOS-7301 [Swiftlint] Remove 1 closure_body_length violation from MainMenuDetailState.swift and decrease threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -102,8 +102,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 68
-  error: 68
+  warning: 64
+  error: 64
 
 file_header:
   required_string: |

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
@@ -95,13 +95,7 @@ struct MainMenuDetailsState: ScreenState, Equatable {
             GeneralBrowserActionType.showReaderMode:
             return handleDismissableAction(state: state)
         case MainMenuDetailsActionType.tapEditBookmark:
-            return MainMenuDetailsState(
-                windowUUID: state.windowUUID,
-                menuElements: state.menuElements,
-                submenuType: state.submenuType,
-                isHomepage: state.isHomepage,
-                navigationDestination: MenuNavigationDestination(.editBookmark)
-            )
+            return handleTapEditBookmarkAction(state: state)
         case MainMenuDetailsActionType.tapZoom:
             return MainMenuDetailsState(
                 windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
@@ -164,6 +164,16 @@ struct MainMenuDetailsState: ScreenState, Equatable {
         )
     }
 
+    private static func handleTapEditBookmarkAction(state: Self) -> MainMenuDetailsState {
+        return MainMenuDetailsState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuElements,
+            submenuType: state.submenuType,
+            isHomepage: state.isHomepage,
+            navigationDestination: MenuNavigationDestination(.editBookmark)
+        )
+    }
+
     static func defaultState(from state: MainMenuDetailsState) -> MainMenuDetailsState {
         return MainMenuDetailsState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
@@ -152,6 +152,35 @@ struct MainMenuDetailsState: ScreenState, Equatable {
         }
     }
 
+    private static func handleShowScreenAction(action: Action, state: Self) -> MainMenuDetailsState {
+        guard let screenAction = action as? ScreenAction,
+              screenAction.screen == .mainMenuDetails,
+              let menuState = store.state.screenState(
+                MainMenuState.self,
+                for: .mainMenu,
+                window: action.windowUUID),
+              let currentTabInfo = menuState.currentTabInfo,
+              let currentSubmenu = menuState.currentSubmenuView
+              // let toolbarState = store.state.screenState(
+              //   ToolbarState.self,
+              //   for: .toolbar,
+              //   window: action.windowUUID),
+              // let readerModeState = toolbarState.addressToolbar.readerModeState
+        else { return defaultState(from: state) }
+
+        return MainMenuDetailsState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuConfigurator.generateMenuElements(
+                with: currentTabInfo,
+                for: currentSubmenu,
+                and: action.windowUUID,
+                readerState: nil
+            ),
+            submenuType: currentSubmenu,
+            isHomepage: state.isHomepage
+        )
+    }
+
     static func defaultState(from state: MainMenuDetailsState) -> MainMenuDetailsState {
         return MainMenuDetailsState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
@@ -97,13 +97,7 @@ struct MainMenuDetailsState: ScreenState, Equatable {
         case MainMenuDetailsActionType.tapEditBookmark:
             return handleTapEditBookmarkAction(state: state)
         case MainMenuDetailsActionType.tapZoom:
-            return MainMenuDetailsState(
-                windowUUID: state.windowUUID,
-                menuElements: state.menuElements,
-                submenuType: state.submenuType,
-                isHomepage: state.isHomepage,
-                navigationDestination: MenuNavigationDestination(.zoom)
-            )
+            return handleTapZoomAction(state: state)
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
@@ -84,13 +84,7 @@ struct MainMenuDetailsState: ScreenState, Equatable {
         case ScreenActionType.showScreen:
             return handleShowScreenAction(action: action, state: state)
         case MainMenuDetailsActionType.tapBackToMainMenu:
-            return MainMenuDetailsState(
-                windowUUID: state.windowUUID,
-                menuElements: state.menuElements,
-                submenuType: state.submenuType,
-                isHomepage: state.isHomepage,
-                shouldGoBackToMenu: true
-            )
+            return handleTapBackToMainMenuAction(state: state)
         case MainMenuDetailsActionType.tapDismissView,
             MainMenuDetailsActionType.tapAddToBookmarks,
             MainMenuDetailsActionType.tapAddToShortcuts,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
@@ -160,6 +160,16 @@ struct MainMenuDetailsState: ScreenState, Equatable {
         )
     }
 
+    private static func handleDismissableAction(state: Self) -> MainMenuDetailsState {
+        return MainMenuDetailsState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuElements,
+            submenuType: state.submenuType,
+            isHomepage: state.isHomepage,
+            shouldDismiss: true
+        )
+    }
+
     static func defaultState(from state: MainMenuDetailsState) -> MainMenuDetailsState {
         return MainMenuDetailsState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
@@ -168,6 +168,16 @@ struct MainMenuDetailsState: ScreenState, Equatable {
         )
     }
 
+    private static func handleTapZoomAction(state: Self) -> MainMenuDetailsState {
+        return MainMenuDetailsState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuElements,
+            submenuType: state.submenuType,
+            isHomepage: state.isHomepage,
+            navigationDestination: MenuNavigationDestination(.zoom)
+        )
+    }
+
     static func defaultState(from state: MainMenuDetailsState) -> MainMenuDetailsState {
         return MainMenuDetailsState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
@@ -82,32 +82,7 @@ struct MainMenuDetailsState: ScreenState, Equatable {
 
         switch action.actionType {
         case ScreenActionType.showScreen:
-            guard let screenAction = action as? ScreenAction,
-                  screenAction.screen == .mainMenuDetails,
-                  let menuState = store.state.screenState(
-                    MainMenuState.self,
-                    for: .mainMenu,
-                    window: action.windowUUID),
-                  let currentTabInfo = menuState.currentTabInfo,
-                  let currentSubmenu = menuState.currentSubmenuView
-                  // let toolbarState = store.state.screenState(
-                  //   ToolbarState.self,
-                  //   for: .toolbar,
-                  //   window: action.windowUUID),
-                  // let readerModeState = toolbarState.addressToolbar.readerModeState
-            else { return defaultState(from: state) }
-
-            return MainMenuDetailsState(
-                windowUUID: state.windowUUID,
-                menuElements: state.menuConfigurator.generateMenuElements(
-                    with: currentTabInfo,
-                    for: currentSubmenu,
-                    and: action.windowUUID,
-                    readerState: nil
-                ),
-                submenuType: currentSubmenu,
-                isHomepage: state.isHomepage
-            )
+            return handleShowScreenAction(action: action, state: state)
         case MainMenuDetailsActionType.tapBackToMainMenu:
             return MainMenuDetailsState(
                 windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
@@ -156,6 +156,16 @@ struct MainMenuDetailsState: ScreenState, Equatable {
         )
     }
 
+    private static func handleTapBackToMainMenuAction(state: Self) -> MainMenuDetailsState {
+        return MainMenuDetailsState(
+            windowUUID: state.windowUUID,
+            menuElements: state.menuElements,
+            submenuType: state.submenuType,
+            isHomepage: state.isHomepage,
+            shouldGoBackToMenu: true
+        )
+    }
+
     static func defaultState(from state: MainMenuDetailsState) -> MainMenuDetailsState {
         return MainMenuDetailsState(
             windowUUID: state.windowUUID,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuDetailState.swift
@@ -93,13 +93,7 @@ struct MainMenuDetailsState: ScreenState, Equatable {
             MainMenuDetailsActionType.tapRemoveFromReadingList,
             MainMenuDetailsActionType.tapToggleNightMode,
             GeneralBrowserActionType.showReaderMode:
-            return MainMenuDetailsState(
-                windowUUID: state.windowUUID,
-                menuElements: state.menuElements,
-                submenuType: state.submenuType,
-                isHomepage: state.isHomepage,
-                shouldDismiss: true
-            )
+            return handleDismissableAction(state: state)
         case MainMenuDetailsActionType.tapEditBookmark:
             return MainMenuDetailsState(
                 windowUUID: state.windowUUID,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `MainMenuDetailState.swift` file. Also, this PR decrease the warning and error threshold to 64. 

When I extracted the "show screen action" into a new function, I kept the comments in the code. Let me know if you think it would be better to remove them.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

