### PR TITLE
Bugfix MTE-4076 Bump python version for Bitrise Xcode Check and Update

### DIFF
--- a/.github/workflows/firefox-ios-update.yml
+++ b/.github/workflows/firefox-ios-update.yml
@@ -1,6 +1,7 @@
 name: Bitrise Xcode Check and Update
 
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: '0 */6 * * *'
 

--- a/.github/workflows/firefox-ios-update.yml
+++ b/.github/workflows/firefox-ios-update.yml
@@ -1,7 +1,6 @@
 name: Bitrise Xcode Check and Update
 
 on:
-  workflow_dispatch: {}
   schedule:
     - cron: '0 */6 * * *'
 

--- a/.github/workflows/firefox-ios-update.yml
+++ b/.github/workflows/firefox-ios-update.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: [3.7.17]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4076)

## :bulb: Description

This Github Actions has been failing since late last week. Python 3.7 is not found in the Github Actions runner.
https://github.com/mozilla-mobile/firefox-ios/actions/runs/12746905997

Let's bump the version to the latest 3.7.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

