### PR TITLE
Bugfix FXIOS-11019 [Sent from Firefox] WhatsApp Shares should not append webpage title to the end

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1871,6 +1871,7 @@
 		ED67B2962D0C921600BDC599 /* ShareTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED67B2952D0C921600BDC599 /* ShareTelemetry.swift */; };
 		ED67B2982D0C940C00BDC599 /* ShareTelemetryActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED67B2972D0C940C00BDC599 /* ShareTelemetryActivityItemProvider.swift */; };
 		ED6C8DAC2CE6A4BB00D7F7F3 /* Sentry-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = ED6C8DAB2CE6A4BB00D7F7F3 /* Sentry-Dynamic */; };
+		ED6D46E02D3573F80045E4ED /* TitleActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED67B2932D0B80E200BDC599 /* TitleActivityItemProviderTests.swift */; };
 		ED70CD812CE3BD2C0018761B /* MockStoreForMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED70CD802CE3BD2C0018761B /* MockStoreForMiddleware.swift */; };
 		ED7A08DB2CF674730035EC8F /* ShareMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A08DA2CF674730035EC8F /* ShareMessage.swift */; };
 		ED7A08DD2CF6749B0035EC8F /* ShareType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A08DC2CF6749B0035EC8F /* ShareType.swift */; };
@@ -17327,6 +17328,7 @@
 				8A6B799B2CDBCF3D003C3077 /* TopSitesManagerTests.swift in Sources */,
 				21737FB72878A4BD000A9A92 /* HistoryPanelViewModelTests.swift in Sources */,
 				43B658D929CE251C00C9EF08 /* CreditCardInputViewModelTests.swift in Sources */,
+				ED6D46E02D3573F80045E4ED /* TitleActivityItemProviderTests.swift in Sources */,
 				C8501F5128510DA1003B09AB /* WallpaperMigrationUtilityTests.swift in Sources */,
 				5A70EF1D295E3C3500790249 /* TestSetup.swift in Sources */,
 				E1442FDA294782F7003680B0 /* UIPasteboard+Extension.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -126,7 +126,12 @@ class ShareManager: NSObject, FeatureFlaggable {
             } else {
                 // For feature parity with Safari, we use this provider to decide to which apps we should (or should not)
                 // share a display title and/or subject line
-                activityItems.append(TitleActivityItemProvider(title: tab.displayTitle))
+                activityItems.append(
+                    TitleActivityItemProvider(
+                        title: tab.displayTitle,
+                        applySentFromFirefoxTreatment: isSentFromFirefoxEnabled
+                    )
+                )
             }
         }
 

--- a/firefox-ios/Client/Frontend/Share/TitleActivityItemProvider.swift
+++ b/firefox-ios/Client/Frontend/Share/TitleActivityItemProvider.swift
@@ -16,7 +16,12 @@ import Foundation
 /// Note that not all applications use the Subject. For example OmniFocus ignores it, so we need to do both.
 
 class TitleActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
+    private struct ActivityIdentifiers {
+        static let whatsApp = "net.whatsapp.WhatsApp.ShareExtension"
+    }
+
     private let title: String
+    private let applySentFromFirefoxTreatment: Bool // FXIOS-9879 For the Sent from Firefox experiment
 
     /// We do not want to append titles to website URL shares to the pasteboard, Messages, and Mail body.
     /// However, this provider will append the title to the Mail subject line.
@@ -26,8 +31,9 @@ class TitleActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
         UIActivity.ActivityType.mail
     ]
 
-    init(title: String) {
+    init(title: String, applySentFromFirefoxTreatment: Bool = false) {
         self.title = title
+        self.applySentFromFirefoxTreatment = applySentFromFirefoxTreatment
 
         super.init(placeholderItem: title)
     }
@@ -38,6 +44,9 @@ class TitleActivityItemProvider: UIActivityItemProvider, @unchecked Sendable {
     ) -> Any? {
         // For excluded activites, we don't want to provide any content
         if let activityType = activityType, TitleActivityItemProvider.activityTypesToIgnore.contains(activityType) {
+            return NSNull()
+        } else if applySentFromFirefoxTreatment, activityType?.rawValue == ActivityIdentifiers.whatsApp {
+            // FXIOS-9879 For the Sent from Firefox experiment, we never want a title, just the explicit share text
             return NSNull()
         }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareManagerTests.swift
@@ -356,10 +356,9 @@ final class ShareManagerTests: XCTestCase {
         XCTAssertEqual(activityItems.count, 5)
         XCTAssertEqual(urlDataIdentifier, UTType.plainText.identifier)
         XCTAssertEqual(itemForActivity as? String, expectedShareContentA)
-        XCTAssertEqual(
-            itemForTitleActivity as? String,
-            testWebpageDisplayTitle,
-            "When no explicit share message is set, we expect to see the webpage's title."
+        XCTAssertTrue(
+            itemForTitleActivity is NSNull,
+            "With Sent from Firefox shares to WhatsApp, never append an additional title."
         )
         XCTAssertTrue(itemForShareActivity is NSNull)
     }
@@ -407,15 +406,14 @@ final class ShareManagerTests: XCTestCase {
         XCTAssertEqual(activityItems.count, 5)
         XCTAssertEqual(urlDataIdentifier, UTType.plainText.identifier)
         XCTAssertEqual(itemForActivity as? String, expectedShareContentB)
-        XCTAssertEqual(
-            itemForTitleActivity as? String,
-            testWebpageDisplayTitle,
-            "When no explicit share message is set, we expect to see the webpage's title."
+        XCTAssertTrue(
+            itemForTitleActivity is NSNull,
+            "With Sent from Firefox shares to WhatsApp, never append an additional title."
         )
         XCTAssertTrue(itemForShareActivity is NSNull)
     }
 
-    func testGetActivityItems_forTab_withSentFromFirefoxEnabled_doesNotImpactOtherShares() throws {
+    func testGetActivityItems_forTab_withSentFromFirefoxEnabled_doesNotImpactMail() throws {
         setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: true)
 
         let mailActivity = UIActivity.ActivityType.mail
@@ -459,6 +457,55 @@ final class ShareManagerTests: XCTestCase {
         XCTAssertTrue(
             itemForTitleActivity is NSNull,
             "When no explicit share message, TitleActivityItemProvider item should not be shared to excluded activity Mail."
+        )
+        XCTAssertTrue(itemForShareActivity is NSNull)
+    }
+
+    func testGetActivityItems_forTab_withSentFromFirefoxEnabled_doesNotImpactAirDrop() throws {
+        setupNimbusSentFromFirefoxTesting(isEnabled: true, isTreatmentA: true)
+
+        let mailActivity = UIActivity.ActivityType.airDrop
+
+        let activityItems = ShareManager.getActivityItems(
+            forShareType: .tab(url: testWebURL, tab: testTab),
+            withExplicitShareMessage: nil
+        )
+
+        // Check we get all types of share items for tabs below:
+        let urlActivityItemProvider = try XCTUnwrap(activityItems[safe: 0] as? URLActivityItemProvider)
+        let urlDataIdentifier = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            dataTypeIdentifierForActivityType: mailActivity
+        )
+        let itemForActivity = urlActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: mailActivity
+        )
+
+        // The rest of the content should be unchanged from other tests:
+        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabWebView)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        let itemForTitleActivity = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: mailActivity
+        )
+
+        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? ShareTelemetryActivityItemProvider)
+        let itemForShareActivity = telemetryActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: mailActivity
+        )
+
+        XCTAssertEqual(activityItems.count, 5)
+        XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
+        XCTAssertEqual(itemForActivity as? URL, testWebURL)
+        XCTAssertEqual(
+            itemForTitleActivity as? String,
+            testWebpageDisplayTitle,
+            "When no explicit share message is set, we expect to see the webpage's title."
         )
         XCTAssertTrue(itemForShareActivity is NSNull)
     }
@@ -621,10 +668,9 @@ final class ShareManagerTests: XCTestCase {
         XCTAssertEqual(activityItems.count, 5)
         XCTAssertEqual(urlDataIdentifier, UTType.plainText.identifier)
         XCTAssertEqual(itemForActivity as? String, expectedShareContentA)
-        XCTAssertEqual(
-            itemForTitleActivity as? String,
-            testWebpageDisplayTitle,
-            "When no explicit share message is set, we expect to see the webpage's title."
+        XCTAssertTrue(
+            itemForTitleActivity is NSNull,
+            "With Sent from Firefox shares to WhatsApp, never append an additional title."
         )
         XCTAssertTrue(itemForShareActivity is NSNull)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/TitleActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/TitleActivityItemProviderTests.swift
@@ -77,6 +77,42 @@ final class TitleActivityItemProviderTests: XCTestCase {
         XCTAssertEqual(subtitle, testMessage)
     }
 
+    // MARK: - Sent from Firefox experiment WhatsApp tab share override
+
+    func testOveridesWhatsAppShareItem_forApplySentFromFirefoxTreatment_toWhatsApp() {
+        let testActivityType = UIActivity.ActivityType(rawValue: "net.whatsapp.WhatsApp.ShareExtension")
+
+        let titleActivityItemProvider = TitleActivityItemProvider(title: testMessage, applySentFromFirefoxTreatment: true)
+        let itemForActivity = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+        let subtitle = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            subjectForActivityType: testActivityType
+        )
+
+        XCTAssertTrue(itemForActivity is NSNull, "When applying Sent from Firefox treatment, don't append title to items")
+        XCTAssertEqual(subtitle, testMessage)
+    }
+
+    func testBasicBehaviour_whenApplySentFromFirefoxTreatment_forUnrelatedActivity() {
+        let testActivityType = UIActivity.ActivityType.mail
+
+        let titleActivityItemProvider = TitleActivityItemProvider(title: testMessage, applySentFromFirefoxTreatment: true)
+        let itemForActivity = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            itemForActivityType: testActivityType
+        )
+        let subtitle = titleActivityItemProvider.activityViewController(
+            createStubActivityViewController(),
+            subjectForActivityType: testActivityType
+        )
+
+        XCTAssertTrue(itemForActivity is NSNull, "When applying Sent from Firefox treatment, don't append title to items")
+        XCTAssertEqual(subtitle, testMessage)
+    }
+
     // MARK: - Helpers
 
     private func createStubActivityViewController() -> UIActivityViewController {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/TitleActivityItemProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/TitleActivityItemProviderTests.swift
@@ -79,7 +79,7 @@ final class TitleActivityItemProviderTests: XCTestCase {
 
     // MARK: - Sent from Firefox experiment WhatsApp tab share override
 
-    func testOveridesWhatsAppShareItem_forApplySentFromFirefoxTreatment_toWhatsApp() {
+    func testOveridesWhatsAppShareItem_forApplySentFromFirefoxTreatment() {
         let testActivityType = UIActivity.ActivityType(rawValue: "net.whatsapp.WhatsApp.ShareExtension")
 
         let titleActivityItemProvider = TitleActivityItemProvider(title: testMessage, applySentFromFirefoxTreatment: true)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11019)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24068)

## :bulb: Description
Please see the QA screenshot in the ticket for an example of the undesired behavour: we do NOT want the webpage title to follow the "sent from firefox" download link.

This PR should remove this. Unit tests have also been updated accordingly.

### Testing Notes

Please test the following with an iPhone that has a WhatsApp account:
- Open `sentFromFirefoxFeature.yaml` and ensure the developer branch `enabled` is set to `true` (should be default)
- Launch the app and open a webpage, and then share from the toolbar share button or Menu > Tools > Share
- Choose WhatsApp in the share sheet
- Make sure the webpage title does NOT appear in the preview share content... (a screenshot would be awesome 🙏 )

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

