### PR TITLE
Add FXIOS-11030 [Bookmarks Evolution] Support dynamic type for bookmarks accessory views

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -726,6 +726,7 @@ class SearchViewController: SiteTableViewController,
                 appendButton.frame = CGRect(width: SearchViewControllerUX.AppendButtonSize,
                                             height: SearchViewControllerUX.AppendButtonSize)
                 oneLineCell.accessoryView = indexPath.row > 0 ? appendButton : nil
+                oneLineCell.isAccessoryViewInteractive = true
                 cell = oneLineCell
             }
         case .openedTabs:

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -387,7 +387,6 @@ class BookmarksViewController: SiteTableViewController,
         buttonConfig.automaticallyUpdateForSelection = true
         let contextButton = UIButton()
         contextButton.configuration = buttonConfig
-        contextButton.frame = CGRect(width: 44, height: 44)
         contextButton.accessibilityLabel = .Bookmarks.Menu.MoreOptionsA11yLabel
 
         return contextButton

--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -228,7 +228,7 @@ class OneLineTableViewCell: UITableViewCell,
     // To simplify setup, OneLineTableViewCell now has a viewModel
     // Use it for new code, replace when possible in old code
     func configure(viewModel: OneLineTableViewCellViewModel) {
-        self.isAccessoryViewInteractive = viewModel.accessoryView is UIButton
+        isAccessoryViewInteractive = viewModel.accessoryView is UIButton
 
         titleLabel.text = viewModel.title
         accessoryView = createAccessoryView(accessoryView: viewModel.accessoryView)

--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -36,10 +36,9 @@ class OneLineTableViewCell: UITableViewCell,
         static let shortLeadingMargin: CGFloat = 5
         static let longLeadingMargin: CGFloat = 13
         static let cornerRadius: CGFloat = 5
-        static let accessoryViewTrailingPaddingForImage: CGFloat = 16
-        // Icon buttons typically have a minimum padding of 44px, so for them to be vertically aligned with image
-        // accessory views (24px width), they would need 10px less trailing padding
-        static let accessoryViewTrailingPaddingForButton: CGFloat = 6
+        static let accessoryViewIconSize: CGFloat = 24
+        static let accessoryViewSize: CGFloat = 44
+        static let accessoryViewTrailingPadding: CGFloat = 6
     }
 
     var reorderControlImageView: UIImageView? {
@@ -69,6 +68,8 @@ class OneLineTableViewCell: UITableViewCell,
         separatorLine.isHidden = true
     }
 
+    var isAccessoryViewInteractive = false
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupLayout()
@@ -90,9 +91,7 @@ class OneLineTableViewCell: UITableViewCell,
         updateReorderControl()
 
         if let accessoryView {
-            let accessoryPadding = accessoryView is UIButton ? UX.accessoryViewTrailingPaddingForButton
-                                                             : UX.accessoryViewTrailingPaddingForImage
-            accessoryView.frame.origin.x = frame.width - accessoryView.frame.width - accessoryPadding
+            accessoryView.frame.origin.x = frame.width - accessoryView.frame.width - UX.accessoryViewTrailingPadding
         }
     }
 
@@ -183,6 +182,40 @@ class OneLineTableViewCell: UITableViewCell,
         selectedBackgroundView = selectedView
     }
 
+    private func createAccessoryView(accessoryView: UIView?) -> UIView? {
+        guard let accessoryView else { return nil }
+        let isButton = accessoryView is UIButton
+        let iconSize = min(UIFontMetrics.default.scaledValue(for: UX.accessoryViewIconSize), UX.accessoryViewIconSize * 2)
+        let accessoryViewSize = isButton ? UX.accessoryViewSize : iconSize
+
+        let customAccessoryView: UIView = {
+            let view = UIView()
+            view.addSubview(accessoryView)
+
+            if isButton {
+                if let button = accessoryView as? UIButton {
+                    if var buttonConfig = button.configuration {
+                        buttonConfig.image = buttonConfig.image?.createScaled(CGSize(width: iconSize,
+                                                                                     height: iconSize))
+                        button.configuration = buttonConfig
+                    }
+                }
+            }
+            accessoryView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                accessoryView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                accessoryView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+                accessoryView.widthAnchor.constraint(equalToConstant: accessoryViewSize),
+                accessoryView.heightAnchor.constraint(equalToConstant: accessoryViewSize)
+            ])
+
+            return view
+        }()
+
+        customAccessoryView.frame = CGRect(x: 0, y: 0, width: UX.accessoryViewSize, height: UX.accessoryViewSize)
+        return customAccessoryView
+    }
+
     override func prepareForReuse() {
         super.prepareForReuse()
 
@@ -196,10 +229,12 @@ class OneLineTableViewCell: UITableViewCell,
     // To simplify setup, OneLineTableViewCell now has a viewModel
     // Use it for new code, replace when possible in old code
     func configure(viewModel: OneLineTableViewCellViewModel) {
+        self.isAccessoryViewInteractive = viewModel.accessoryView is UIButton
+
         titleLabel.text = viewModel.title
-        accessoryView = viewModel.accessoryView
+        accessoryView = createAccessoryView(accessoryView: viewModel.accessoryView)
         accessoryType = viewModel.accessoryType
-        editingAccessoryView = viewModel.editingAccessoryView
+        editingAccessoryView =  createAccessoryView(accessoryView: viewModel.editingAccessoryView)
 
         if let image = viewModel.leftImageView {
             leftImageView.manuallySetImage(image)

--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -193,14 +193,13 @@ class OneLineTableViewCell: UITableViewCell,
             view.addSubview(accessoryView)
 
             if isButton {
-                if let button = accessoryView as? UIButton {
-                    if var buttonConfig = button.configuration {
-                        buttonConfig.image = buttonConfig.image?.createScaled(CGSize(width: iconSize,
-                                                                                     height: iconSize))
-                        button.configuration = buttonConfig
-                    }
-                }
+                let button = accessoryView as? UIButton
+                var buttonConfig = button?.configuration
+                let image = buttonConfig?.image?.createScaled(CGSize(width: iconSize, height: iconSize))
+                buttonConfig?.image = image
+                button?.configuration = buttonConfig
             }
+
             accessoryView.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
                 accessoryView.centerXAnchor.constraint(equalTo: view.centerXAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11030)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24080)

## :bulb: Description
- Scale the size of the accessory views in the bookmarks panel with dynamic type 

### 🎥 Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/cae600f9-9bfc-47b5-b035-d8acfe70b3b3

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/d55b5d3a-cf56-404c-b579-4c3712699007

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

