### PR TITLE
Refactor FXIOS-7301 [Swiftlint] Remove 1 closure_body_length violation from TopSitesSectionState.swift and decrease threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -102,8 +102,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 64
-  error: 64
+  warning: 60
+  error: 60
 
 file_header:
   required_string: |

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -125,6 +125,23 @@ struct TopSitesSectionState: StateType, Equatable {
         )
     }
 
+    private static func handleUpdatedNumberOfTilesPerRowAction(action: Action, state: Self) -> TopSitesSectionState {
+        guard let topSitesAction = action as? TopSitesAction,
+              let numberOfTilesPerRow = topSitesAction.numberOfTilesPerRow
+        else {
+            return defaultState(from: state)
+        }
+
+        let filteredSites = filter(sites: state.topSitesData, with: state.numberOfRows, and: numberOfTilesPerRow)
+        return TopSitesSectionState(
+            windowUUID: state.windowUUID,
+            topSitesData: filteredSites,
+            numberOfRows: state.numberOfRows,
+            numberOfTilesPerRow: numberOfTilesPerRow,
+            shouldShowSection: state.shouldShowSection
+        )
+    }
+
     /// Filters the top sites to be displayed in the view based on user preferences and layout configuration.
     /// - Parameters:
     ///   - sites: The full list of sites fetched from the top sites manager.

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -129,6 +129,22 @@ struct TopSitesSectionState: StateType, Equatable {
         )
     }
 
+    private static func handleToggleShowSectionSettingAction(action: Action, state: Self) -> TopSitesSectionState {
+        guard let topSitesAction = action as? TopSitesAction,
+              let isEnabled = topSitesAction.isEnabled
+        else {
+            return defaultState(from: state)
+        }
+
+        return TopSitesSectionState(
+            windowUUID: state.windowUUID,
+            topSitesData: state.topSitesData,
+            numberOfRows: state.numberOfRows,
+            numberOfTilesPerRow: state.numberOfTilesPerRow,
+            shouldShowSection: isEnabled
+        )
+    }
+
     /// Filters the top sites to be displayed in the view based on user preferences and layout configuration.
     /// - Parameters:
     ///   - sites: The full list of sites fetched from the top sites manager.

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -117,6 +117,23 @@ struct TopSitesSectionState: StateType, Equatable {
         }
     }
 
+    private static func handleRetrievedUpdatedSitesAction(action: Action, state: Self) -> TopSitesSectionState {
+        guard let topSitesAction = action as? TopSitesAction,
+              let sites = topSitesAction.topSites
+        else {
+            return defaultState(from: state)
+        }
+        let numberOfTilesPerRow = topSitesAction.numberOfTilesPerRow ?? state.numberOfTilesPerRow
+        let filteredSites = filter(sites: sites, with: state.numberOfRows, and: numberOfTilesPerRow)
+        return TopSitesSectionState(
+            windowUUID: state.windowUUID,
+            topSitesData: filteredSites,
+            numberOfRows: state.numberOfRows,
+            numberOfTilesPerRow: numberOfTilesPerRow,
+            shouldShowSection: !filteredSites.isEmpty && state.shouldShowSection
+        )
+    }
+
     /// Filters the top sites to be displayed in the view based on user preferences and layout configuration.
     /// - Parameters:
     ///   - sites: The full list of sites fetched from the top sites manager.

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -54,20 +54,7 @@ struct TopSitesSectionState: StateType, Equatable {
 
         switch action.actionType {
         case TopSitesMiddlewareActionType.retrievedUpdatedSites:
-            guard let topSitesAction = action as? TopSitesAction,
-                  let sites = topSitesAction.topSites
-            else {
-                return defaultState(from: state)
-            }
-            let numberOfTilesPerRow = topSitesAction.numberOfTilesPerRow ?? state.numberOfTilesPerRow
-            let filteredSites = filter(sites: sites, with: state.numberOfRows, and: numberOfTilesPerRow)
-            return TopSitesSectionState(
-                windowUUID: state.windowUUID,
-                topSitesData: filteredSites,
-                numberOfRows: state.numberOfRows,
-                numberOfTilesPerRow: numberOfTilesPerRow,
-                shouldShowSection: !filteredSites.isEmpty && state.shouldShowSection
-            )
+            return handleRetrievedUpdatedSitesAction(action: action, state: state)
         case TopSitesActionType.updatedNumberOfRows:
             guard let topSitesAction = action as? TopSitesAction,
                   let numberOfRows = topSitesAction.numberOfRows

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -121,6 +121,23 @@ struct TopSitesSectionState: StateType, Equatable {
         )
     }
 
+    private static func handleUpdatedNumberOfRowsAction(action: Action, state: Self) -> TopSitesSectionState {
+        guard let topSitesAction = action as? TopSitesAction,
+              let numberOfRows = topSitesAction.numberOfRows
+        else {
+            return defaultState(from: state)
+        }
+
+        let filteredSites = filter(sites: state.topSitesData, with: numberOfRows, and: state.numberOfTilesPerRow)
+        return TopSitesSectionState(
+            windowUUID: state.windowUUID,
+            topSitesData: filteredSites,
+            numberOfRows: numberOfRows,
+            numberOfTilesPerRow: state.numberOfTilesPerRow,
+            shouldShowSection: state.shouldShowSection
+        )
+    }
+
     /// Filters the top sites to be displayed in the view based on user preferences and layout configuration.
     /// - Parameters:
     ///   - sites: The full list of sites fetched from the top sites manager.

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -58,20 +58,7 @@ struct TopSitesSectionState: StateType, Equatable {
         case TopSitesActionType.updatedNumberOfRows:
             return handleUpdatedNumberOfRowsAction(action: action, state: state)
         case TopSitesActionType.updatedNumberOfTilesPerRow:
-            guard let topSitesAction = action as? TopSitesAction,
-                  let numberOfTilesPerRow = topSitesAction.numberOfTilesPerRow
-            else {
-                return defaultState(from: state)
-            }
-
-            let filteredSites = filter(sites: state.topSitesData, with: state.numberOfRows, and: numberOfTilesPerRow)
-            return TopSitesSectionState(
-                windowUUID: state.windowUUID,
-                topSitesData: filteredSites,
-                numberOfRows: state.numberOfRows,
-                numberOfTilesPerRow: numberOfTilesPerRow,
-                shouldShowSection: state.shouldShowSection
-            )
+            return handleUpdatedNumberOfTilesPerRowAction(action: action, state: state)
         case TopSitesActionType.toggleShowSectionSetting:
             guard let topSitesAction = action as? TopSitesAction,
                   let isEnabled = topSitesAction.isEnabled

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -60,19 +60,7 @@ struct TopSitesSectionState: StateType, Equatable {
         case TopSitesActionType.updatedNumberOfTilesPerRow:
             return handleUpdatedNumberOfTilesPerRowAction(action: action, state: state)
         case TopSitesActionType.toggleShowSectionSetting:
-            guard let topSitesAction = action as? TopSitesAction,
-                  let isEnabled = topSitesAction.isEnabled
-            else {
-                return defaultState(from: state)
-            }
-
-            return TopSitesSectionState(
-                windowUUID: state.windowUUID,
-                topSitesData: state.topSitesData,
-                numberOfRows: state.numberOfRows,
-                numberOfTilesPerRow: state.numberOfTilesPerRow,
-                shouldShowSection: isEnabled
-            )
+            return handleToggleShowSectionSettingAction(action: action, state: state)
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -56,20 +56,7 @@ struct TopSitesSectionState: StateType, Equatable {
         case TopSitesMiddlewareActionType.retrievedUpdatedSites:
             return handleRetrievedUpdatedSitesAction(action: action, state: state)
         case TopSitesActionType.updatedNumberOfRows:
-            guard let topSitesAction = action as? TopSitesAction,
-                  let numberOfRows = topSitesAction.numberOfRows
-            else {
-                return defaultState(from: state)
-            }
-
-            let filteredSites = filter(sites: state.topSitesData, with: numberOfRows, and: state.numberOfTilesPerRow)
-            return TopSitesSectionState(
-                windowUUID: state.windowUUID,
-                topSitesData: filteredSites,
-                numberOfRows: numberOfRows,
-                numberOfTilesPerRow: state.numberOfTilesPerRow,
-                shouldShowSection: state.shouldShowSection
-            )
+            return handleUpdatedNumberOfRowsAction(action: action, state: state)
         case TopSitesActionType.updatedNumberOfTilesPerRow:
             guard let topSitesAction = action as? TopSitesAction,
                   let numberOfTilesPerRow = topSitesAction.numberOfTilesPerRow


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `TopSitesSectionState.swift` file. Also, this PR decrease the warning and error threshold to 60. 

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

