### PR TITLE
Bugfix FXIOS-11013 [Bookmarks Evolution] Incorrect edit bookmark and folder theming in landscape dark mode

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
@@ -101,7 +101,7 @@ class EditBookmarkCell: UITableViewCell,
         urlTextfield.applyTheme(theme: theme)
         titleTextfield.applyTheme(theme: theme)
         textFieldsDivder.backgroundColor = theme.colors.borderPrimary
-        contentView.backgroundColor = theme.colors.layer2
+        backgroundColor = theme.colors.layer5
     }
 
     private func urlTextFieldDidChane() {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
@@ -60,6 +60,6 @@ class EditFolderCell: UITableViewCell,
 
     func applyTheme(theme: any Theme) {
         titleTextField.applyTheme(theme: theme)
-        contentView.backgroundColor = theme.colors.layer2
+        backgroundColor = theme.colors.layer5
     }
 }

--- a/firefox-ios/Client/Telemetry/GleanUsageReporting.swift
+++ b/firefox-ios/Client/Telemetry/GleanUsageReporting.swift
@@ -42,7 +42,7 @@ class GleanUsageReporting: GleanUsageReportingApi {
 class GleanLifecycleObserver {
     private let gleanUsageReportingApi: GleanUsageReportingApi
     private var id: TimerId?
-    private var isObserving: Bool = false
+    private var isObserving = false
 
     init(gleanUsageReportingApi: GleanUsageReportingApi = GleanUsageReporting()) {
         self.gleanUsageReportingApi = gleanUsageReportingApi


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11013)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24060)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### Previous Edit Theming: 
<img width="1141" alt="Screenshot 2025-01-14 at 1 25 10 PM" src="https://github.com/user-attachments/assets/8e44034f-2c53-4366-9aac-bf2d1e0cbf49" />
<img width="1122" alt="Screenshot 2025-01-14 at 1 25 28 PM" src="https://github.com/user-attachments/assets/b1778eba-4869-4f90-ac53-c8095921610c" />

### New Edit Folder Theming:
<img width="759" alt="Screenshot 2025-01-14 at 1 15 18 PM" src="https://github.com/user-attachments/assets/3da1f4b9-fcb3-4955-9acc-341d590ab445" />
<img width="759" alt="Screenshot 2025-01-14 at 1 15 55 PM" src="https://github.com/user-attachments/assets/3e4bc0a1-6d10-4a30-b04d-86431413a3e6" />
<img width="767" alt="Screenshot 2025-01-14 at 1 16 17 PM" src="https://github.com/user-attachments/assets/32b46042-159b-40f7-9772-89b10177ab7e" />

### New Edit Bookmark Theming:
<img width="772" alt="Screenshot 2025-01-14 at 1 20 15 PM" src="https://github.com/user-attachments/assets/f03703ca-c490-4aa0-be1d-618759e18570" />
<img width="772" alt="Screenshot 2025-01-14 at 1 20 38 PM" src="https://github.com/user-attachments/assets/57aa5405-bc51-466e-b5e6-d4bb9dd49180" />
<img width="776" alt="Screenshot 2025-01-14 at 1 21 10 PM" src="https://github.com/user-attachments/assets/2f25be84-2759-48d8-bf88-52659666813e" />



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

