### PR TITLE
Add FXIOS-11070 [Bookmarks Evolution] Record missing telemetry

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1749,6 +1749,8 @@ class BrowserViewController: UIViewController,
     internal func openBookmarkEditPanel() {
         guard !profile.isShutdown else { return }
 
+        TelemetryWrapper.recordEvent(category: .action, method: .change, object: .bookmark, value: .addBookmarkToast)
+
         // Open refactored bookmark edit view
         if isBookmarkRefactorEnabled {
             guard let url = tabManager.selectedTab?.url else { return }
@@ -1762,13 +1764,6 @@ class BrowserViewController: UIViewController,
             }
         // Open legacy bookmark edit view
         } else {
-            TelemetryWrapper.recordEvent(
-                category: .action,
-                method: .change,
-                object: .bookmark,
-                value: .addBookmarkToast
-            )
-
             // Fetch the last added bookmark in the mobile folder, which is the default location for all bookmarks
             // added on mobile when the bookmark refactor is not enabled
             profile.places.getBookmarksTree(

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
@@ -55,6 +55,11 @@ struct DefaultBookmarksSaver: BookmarksSaver, BookmarksRefactorFeatureFlagProvid
                     guard let folder = bookmark as? BookmarkFolderData else { return deferMaybe(nil) }
 
                     if folder.parentGUID == nil {
+                        TelemetryWrapper.recordEvent(category: .action,
+                                                     method: .tap,
+                                                     object: .bookmark,
+                                                     value: .bookmarkAddFolder)
+
                         let position: UInt32? = parentFolderGUID == BookmarkRoots.MobileFolderGUID ? 0 : nil
                         return profile.places.createFolder(parentGUID: parentFolderGUID,
                                                            title: folder.title,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11070)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24140)

## :bulb: Description
- Add the following events such that the bookmarks refactor has telemetry parity with legacy bookmarks:
  - “Folder added” telemetry when a folder is created
  - “Edit bookmark” view is opened via “Bookmark added” toast action

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

