### PR TITLE
Bugfix FXIOS-11034 Avoid non-MT access in `closeTab()`

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -352,6 +352,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
     /// - Parameters:
     ///   - tabUUID: UUID of the tab to be closed/removed
     /// - Returns: If is the last tab to be closed used to trigger dismissTabTray action
+    @MainActor
     private func closeTab(with tabUUID: TabUUID, uuid: WindowUUID, isPrivate: Bool) async -> Bool {
         let tabManager = tabManager(for: uuid)
         // In non-private mode, if:


### PR DESCRIPTION
## :scroll: Tickets
Partial fix for broader issue mentioned in [11034](https://mozilla-hub.atlassian.net/browse/FXIOS-11034)
https://github.com/mozilla-mobile/firefox-ios/issues/24085

## :bulb: Description

Avoid non-MT access to `tabs` collection within `closeTab`. Although the principal function it calls (`removeTab`) is already `@MainActor` the getters called beforehand are still problematic, as they can end up reading the `tabs` array in a background thread while work on the MT may be writing to it.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

