### PR TITLE
Bugfix MTE-4100 Update file path for URLExtensions.swift

### DIFF
--- a/test-fixtures/ci/uri_update.py
+++ b/test-fixtures/ci/uri_update.py
@@ -24,7 +24,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 CONFIG = {
     "URI_WEBSITE": "https://www.iana.org/assignments/uri-schemes/uri-schemes-1.csv",
-    "IOS_URI_PATH": "firefox-ios/Shared/Extensions/",
+    "IOS_URI_PATH": "BrowserKit/Sources/Shared/Extensions/",
     "IOS_URIS_FILE": "URLExtensions.swift",
     "RETRIES": 2,
     "BACKOFF_FACTOR": 0.3,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4100)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24127)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

The Github Actions job "Update URIs and Create PR" started to fail in Dec 2024:

https://github.com/mozilla-mobile/firefox-ios/actions/workflows/firefox-ios-update-uri.yml

The file `URLExtensions.swift` has been moved to a different location (see https://github.com/mozilla-mobile/firefox-ios/pull/23527). 

I have tested the change by running the command `python test-fixtures/ci/uri_update.py` on my command line.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

