### PR TITLE
Bugfix FXIOS-10658 ⁃ [Felt privacy-Unified panel] - Incorrect announcement of the trackers section

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -125,9 +125,9 @@ struct AccessibilityIdentifiers {
             static let domainHeaderLabel = "TrackingProtection.DomainHeaderLabel"
             static let statusTitleLabel = "TrackingProtection.ConnectionStatusTitleLabel"
             static let statusBodyLabel = "TrackingProtection.ConnectionStatusBodyLabel"
-            static let trackersBlockedLabel = "TrackingProtection.TrackersBlockedLabel"
-            static let securityStatusLabel = "TrackingProtection.ConnectionSecurityStatusLabel"
-            static let toggleViewTitleLabel = "TrackingProtection.ToggleViewTitleLabel"
+            static let trackersBlockedButton = "TrackingProtection.TrackersBlockedButton"
+            static let securityStatusButton = "TrackingProtection.ConnectionSecurityStatusButton"
+            static let toggleViewLabelsContainer = "TrackingProtection.ToggleViewLabelsContainer"
             static let toggleViewBodyLabel = "TrackingProtection.ToggleViewBodyLabel"
             static let closeButton = "TrackingProtection.CloseButton"
             static let faviconImage = "TrackingProtection.FaviconImage"
@@ -139,6 +139,9 @@ struct AccessibilityIdentifiers {
             static let containerView = "TrackingProtectionDetails.BaseView"
             static let connectionView = "TrackingProtectionDetails.ConnectionView"
             static let certificatesButton = "TrackingProtectionDetails.CertificatesButton"
+            static let closeButton = "TrackingProtectionDetails.CloseButton"
+            static let backButton = "TrackingProtectionDetails.BackButton"
+            static let titleLabel = "TrackingProtectionDetails.TitleLabel"
         }
 
         struct BlockedTrackers {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
@@ -31,31 +31,6 @@ struct DefaultBookmarksSaver: BookmarksSaver, BookmarksRefactorFeatureFlagProvid
                 case .bookmark:
                     return saveBookmark(bookmark: bookmark, parentFolderGUID: parentFolderGUID)
                 case .folder:
-                    guard let folder = bookmark as? BookmarkFolderData else { return deferMaybe(nil) }
-
-                    if folder.parentGUID == nil {
-                        TelemetryWrapper.recordEvent(category: .action,
-                                                     method: .tap,
-                                                     object: .bookmark,
-                                                     value: .bookmarkAddFolder)
-
-                        let position: UInt32? = parentFolderGUID == BookmarkRoots.MobileFolderGUID ? 0 : nil
-                        return profile.places.createFolder(parentGUID: parentFolderGUID,
-                                                           title: folder.title,
-                                                           position: position).bind { result in
-                            return result.isFailure ? deferMaybe(BookmarkDetailPanelError())
-                                                    : deferMaybe(result.successValue)
-                        }
-                    } else {
-                        let position: UInt32? = parentFolderGUID == folder.parentGUID ? folder.position : nil
-                        return profile.places.updateBookmarkNode( guid: folder.guid,
-                                                                  parentGUID: parentFolderGUID,
-                                                                  position: position,
-                                                                  title: folder.title).bind { result in
-                            return result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : deferMaybe(nil)
-                        }
-                    }
-
                     return saveFolder(bookmark: bookmark, parentFolderGUID: parentFolderGUID)
                 default:
                     return nil

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
@@ -77,8 +77,7 @@ struct DefaultBookmarksSaver: BookmarksSaver, BookmarksRefactorFeatureFlagProvid
                         }
                     }
 
-                default:
-                    return nil
+                default: return nil
                 }
             }()
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersTableController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersTableController.swift
@@ -81,6 +81,7 @@ class BlockedTrackersTableViewController: UIViewController,
         constraints.removeAll()
         setupNavigationView()
         setupTableView()
+        setupAccessibilityIdentifiers()
         setupHeaderViewActions()
         NSLayoutConstraint.activate(constraints)
     }
@@ -192,6 +193,17 @@ class BlockedTrackersTableViewController: UIViewController,
         navigationView.dismissMenuCallback = { [weak self] in
             self?.navigationController?.dismissVC()
         }
+    }
+
+    // MARK: Accessibility
+    private func setupAccessibilityIdentifiers() {
+        navigationView.setupAccessibility(
+            closeButtonA11yLabel: .Menu.EnhancedTrackingProtection.AccessibilityLabels.CloseButton,
+            closeButtonA11yId: AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.closeButton,
+            titleA11yId: AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.titleLabel,
+            backButtonA11yLabel: .Menu.EnhancedTrackingProtection.AccessibilityLabels.BackButton,
+            backButtonA11yId: AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.backButton
+        )
     }
 
     // MARK: Notifications

--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
@@ -264,7 +264,13 @@ class CertificatesViewController: UIViewController,
 
     // MARK: Accessibility
     private func setupAccessibilityIdentifiers() {
-        // TODO: FXIOS-9829 Enhanced Tracking Protection certificates details screen accessibility identifiers
+        headerView.setupAccessibility(
+            closeButtonA11yLabel: .Menu.EnhancedTrackingProtection.AccessibilityLabels.CloseButton,
+            closeButtonA11yId: AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.closeButton,
+            titleA11yId: AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.titleLabel,
+            backButtonA11yLabel: .Menu.EnhancedTrackingProtection.AccessibilityLabels.BackButton,
+            backButtonA11yId: AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.backButton
+        )
     }
 
     // MARK: View Transitions

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
@@ -46,7 +46,7 @@ class TrackingProtectionModel {
     let statusBodyLabelA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.statusBodyLabel
     let trackersBlockedButtonA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.trackersBlockedButton
     let securityStatusButtonA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusButton
-    let toggleViewLabelsContainerA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.toggleViewLabelsContainer
+    let toggleViewContainerA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.toggleViewLabelsContainer
     let toggleViewBodyLabelA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.toggleViewBodyLabel
     let closeButtonA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.closeButton
     let closeButtonA11yLabel = String.Menu.EnhancedTrackingProtection.closeButtonAccessibilityLabel

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionModel.swift
@@ -44,9 +44,9 @@ class TrackingProtectionModel {
     let domainHeaderLabelA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.domainHeaderLabel
     let statusTitleLabelA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.statusTitleLabel
     let statusBodyLabelA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.statusBodyLabel
-    let trackersBlockedLabelA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.trackersBlockedLabel
-    let securityStatusLabelA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusLabel
-    let toggleViewTitleLabelA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.toggleViewTitleLabel
+    let trackersBlockedButtonA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.trackersBlockedButton
+    let securityStatusButtonA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusButton
+    let toggleViewLabelsContainerA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.toggleViewLabelsContainer
     let toggleViewBodyLabelA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.toggleViewBodyLabel
     let closeButtonA11yId = AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.closeButton
     let closeButtonA11yLabel = String.Menu.EnhancedTrackingProtection.closeButtonAccessibilityLabel

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionDetailsViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionDetailsViewController.swift
@@ -191,6 +191,13 @@ class TrackingProtectionDetailsViewController: UIViewController, Themeable {
     // MARK: Accessibility
     private func setupAccessibilityIdentifiers() {
         view.accessibilityIdentifier = AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.mainView
+        headerView.setupAccessibility(
+            closeButtonA11yLabel: .Menu.EnhancedTrackingProtection.AccessibilityLabels.CloseButton,
+            closeButtonA11yId: AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.closeButton,
+            titleA11yId: AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.titleLabel,
+            backButtonA11yLabel: .Menu.EnhancedTrackingProtection.AccessibilityLabels.BackButton,
+            backButtonA11yId: AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.backButton
+        )
     }
 
     // MARK: View Transitions

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionBlockedTrackersView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionBlockedTrackersView.swift
@@ -24,6 +24,7 @@ final class TrackingProtectionBlockedTrackersView: UIView, ThemeApplicable {
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
+        label.isAccessibilityElement = false
     }
 
     private let trackersDetailArrow: UIImageView = .build { image in
@@ -117,7 +118,9 @@ final class TrackingProtectionBlockedTrackersView: UIView, ThemeApplicable {
     }
 
     func setupDetails(for trackersBlocked: Int?) {
-        trackersLabel.text = getTrackerString(for: trackersBlocked)
+        let trackersString = getTrackerString(for: trackersBlocked)
+        trackersButton.accessibilityLabel = trackersString
+        trackersLabel.text = trackersString
         shieldImage.image = UIImage(imageLiteralResourceName: StandardImageIdentifiers.Large.shield)
             .withRenderingMode(.alwaysTemplate)
         if let trackersBlocked {
@@ -126,10 +129,10 @@ final class TrackingProtectionBlockedTrackersView: UIView, ThemeApplicable {
     }
 
     func setupAccessibilityIdentifiers(arrowImageA11yId: String,
-                                       trackersBlockedLabelA11yId: String,
+                                       trackersBlockedButtonA11yId: String,
                                        shieldImageA11yId: String) {
         trackersDetailArrow.accessibilityIdentifier = arrowImageA11yId
-        trackersLabel.accessibilityIdentifier = trackersBlockedLabelA11yId
+        trackersButton.accessibilityIdentifier = trackersBlockedButtonA11yId
         shieldImage.accessibilityIdentifier = shieldImageA11yId
     }
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionConnectionStatusView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionConnectionStatusView.swift
@@ -23,6 +23,7 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
+        label.isAccessibilityElement = false
     }
 
     private let connectionDetailArrow: UIImageView = .build { image in
@@ -103,9 +104,9 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
         NSLayoutConstraint.activate(viewConstraints)
     }
 
-    func setupAccessibilityIdentifiers(arrowImageA11yId: String, securityStatusLabelA11yId: String) {
+    func setupAccessibilityIdentifiers(arrowImageA11yId: String, securityStatusButtonA11yId: String) {
         connectionDetailArrow.accessibilityIdentifier = arrowImageA11yId
-        connectionStatusLabel.accessibilityIdentifier = securityStatusLabelA11yId
+        connectionButton.accessibilityIdentifier = securityStatusButtonA11yId
     }
 
     func adjustLayout() {
@@ -136,6 +137,7 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
                              theme: Theme) {
         connectionStatusImage.image = image
         connectionStatusLabel.text = text
+        connectionButton.accessibilityLabel = text
         connectionStatusImage.tintColor = theme.colors.iconSecondary
         connectionDetailArrow.isHidden = !isConnectionSecure
     }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionToggleView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionToggleView.swift
@@ -17,12 +17,14 @@ final class TrackingProtectionToggleView: UIView, ThemeApplicable {
         stack.alignment = .leading
         stack.axis = .vertical
         stack.spacing = TPMenuUX.UX.headerLabelDistance
+        stack.isAccessibilityElement = true
     }
 
     private let toggleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.body.scaledFont()
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
+        label.isAccessibilityElement = false
     }
 
     private let toggleSwitch: UISwitch = .build { toggleSwitch in
@@ -33,6 +35,7 @@ final class TrackingProtectionToggleView: UIView, ThemeApplicable {
         label.font = FXFontStyles.Regular.caption1.scaledFont()
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
+        label.isAccessibilityElement = false
     }
 
     private var viewConstraints: [NSLayoutConstraint] = []
@@ -109,15 +112,18 @@ final class TrackingProtectionToggleView: UIView, ThemeApplicable {
     }
 
     func setupDetails(isOn: Bool) {
-        toggleSwitch.isOn = isOn
-        toggleLabel.text = .Menu.EnhancedTrackingProtection.switchTitle
-        toggleStatusLabel.text = isOn ?
+        let title: String = .Menu.EnhancedTrackingProtection.switchTitle
+        let subtitle: String = isOn ?
             .Menu.EnhancedTrackingProtection.switchOnText : .Menu.EnhancedTrackingProtection.switchOffText
+        toggleSwitch.isOn = isOn
+        toggleLabel.text = title
+        toggleStatusLabel.text = subtitle
+        toggleLabelsContainer.accessibilityLabel = title
+        toggleLabelsContainer.accessibilityHint = subtitle
     }
 
-    func setupAccessibilityIdentifiers(toggleViewTitleLabelA11yId: String, toggleViewBodyLabelA11yId: String) {
-        toggleLabel.accessibilityIdentifier = toggleViewTitleLabelA11yId
-        toggleStatusLabel.accessibilityIdentifier = toggleViewBodyLabelA11yId
+    func setupAccessibilityIdentifiers(toggleViewLabelsContainerA11yId: String) {
+        toggleLabelsContainer.accessibilityIdentifier = toggleViewLabelsContainerA11yId
     }
 
     func setupActions() {

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -502,7 +502,7 @@ class TrackingProtectionViewController: UIViewController,
             arrowImageA11yId: model.arrowImageA11yId,
             securityStatusButtonA11yId: model.securityStatusButtonA11yId)
         toggleView.setupAccessibilityIdentifiers(
-            toggleViewLabelsContainerA11yId: model.toggleViewLabelsContainerA11yId)
+            toggleViewLabelsContainerA11yId: model.toggleViewContainerA11yId)
         headerContainer.setupAccessibility(closeButtonA11yLabel: model.closeButtonA11yLabel,
                                            closeButtonA11yId: model.closeButtonA11yId)
         clearCookiesButton.accessibilityIdentifier = model.clearCookiesButtonA11yId

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -496,14 +496,13 @@ class TrackingProtectionViewController: UIViewController,
         connectionDetailsHeaderView.setupAccessibilityIdentifiers(foxImageA11yId: model.foxImageA11yId)
         trackersView.setupAccessibilityIdentifiers(
             arrowImageA11yId: model.arrowImageA11yId,
-            trackersBlockedLabelA11yId: model.trackersBlockedLabelA11yId,
+            trackersBlockedButtonA11yId: model.trackersBlockedButtonA11yId,
             shieldImageA11yId: model.settingsA11yId)
         connectionStatusView.setupAccessibilityIdentifiers(
             arrowImageA11yId: model.arrowImageA11yId,
-            securityStatusLabelA11yId: model.securityStatusLabelA11yId)
+            securityStatusButtonA11yId: model.securityStatusButtonA11yId)
         toggleView.setupAccessibilityIdentifiers(
-            toggleViewTitleLabelA11yId: model.toggleViewTitleLabelA11yId,
-            toggleViewBodyLabelA11yId: model.toggleViewBodyLabelA11yId)
+            toggleViewLabelsContainerA11yId: model.toggleViewLabelsContainerA11yId)
         headerContainer.setupAccessibility(closeButtonA11yLabel: model.closeButtonA11yLabel,
                                            closeButtonA11yId: model.closeButtonA11yId)
         clearCookiesButton.accessibilityIdentifier = model.clearCookiesButtonA11yId

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4957,6 +4957,19 @@ extension String {
 extension String {
     public struct Menu {
         public struct EnhancedTrackingProtection {
+            public struct AccessibilityLabels {
+                public static let CloseButton = MZLocalizedString(
+                    key: "MainMenu.Account.AccessibilityLabels.CloseButton.v137",
+                    tableName: "EnhancedTrackingProtection",
+                    value: "Close",
+                    comment: "The accessibility label for the close button in the EnhancedTrackingProtection screen header navigation view.")
+                public static let BackButton = MZLocalizedString(
+                    key: "MainMenu.Account.AccessibilityLabels.BackButton.v137",
+                    tableName: "EnhancedTrackingProtection",
+                    value: "Back",
+                    comment: "The accessibility label for the back button in the EnhancedTrackingProtection screen header navigation view.")
+            }
+
             public static let onTitle = MZLocalizedString(
                 key: "Menu.EnhancedTrackingProtection.On.Title.v128",
                 tableName: "EnhancedTrackingProtection",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -253,10 +253,10 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         navigator.goto(TrackingProtectionContextMenuDetails)
         mozWaitForElementToExist(
-            app.staticTexts[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusLabel])
+            app.staticTexts[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusButton])
         navigator.performAction(Action.CloseTPContextMenu)
         mozWaitForElementToNotExist(
-            app.staticTexts[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusLabel])
+            app.staticTexts[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusButton])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307063


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10658)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23318)

## :bulb: Description
Fixed some accessibility Voice Over elements:
1. Announcement of trackers section
2. Announcement of connection status section
3. Announcement of ETP section (title and subtitle)
4. Fixed the header for submenus (for Trackers, Connection Status and Certificates)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

