### PR TITLE
Refactor FXIOS-11076 [Swiftlint] Fix closure line length error in BookmarksSaver.swift

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
@@ -29,54 +29,9 @@ struct DefaultBookmarksSaver: BookmarksSaver, BookmarksRefactorFeatureFlagProvid
             let operation: Deferred<Maybe<GUID?>>? = {
                 switch bookmark.type {
                 case .bookmark:
-                    guard let bookmark = bookmark as? BookmarkItemData else { return deferMaybe(nil) }
-
-                    if bookmark.parentGUID == nil {
-                        let position: UInt32? = parentFolderGUID == BookmarkRoots.MobileFolderGUID ? 0 : nil
-                        return profile.places.createBookmark(parentGUID: parentFolderGUID,
-                                                             url: bookmark.url,
-                                                             title: bookmark.title,
-                                                             position: position).bind { result in
-                            return result.isFailure ? deferMaybe(BookmarkDetailPanelError())
-                                                    : deferMaybe(result.successValue)
-                        }
-                    } else {
-                        let position: UInt32? = parentFolderGUID == bookmark.parentGUID ? bookmark.position : nil
-                        return profile.places.updateBookmarkNode(guid: bookmark.guid,
-                                                                 parentGUID: parentFolderGUID,
-                                                                 position: position,
-                                                                 title: bookmark.title,
-                                                                 url: bookmark.url).bind { result in
-                            return result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : deferMaybe(nil)
-                        }
-                    }
-
+                    return saveBookmark(bookmark: bookmark, parentFolderGUID: parentFolderGUID)
                 case .folder:
-                    guard let folder = bookmark as? BookmarkFolderData else { return deferMaybe(nil) }
-
-                    if folder.parentGUID == nil {
-                        TelemetryWrapper.recordEvent(category: .action,
-                                                     method: .tap,
-                                                     object: .bookmark,
-                                                     value: .bookmarkAddFolder)
-
-                        let position: UInt32? = parentFolderGUID == BookmarkRoots.MobileFolderGUID ? 0 : nil
-                        return profile.places.createFolder(parentGUID: parentFolderGUID,
-                                                           title: folder.title,
-                                                           position: position).bind { result in
-                            return result.isFailure ? deferMaybe(BookmarkDetailPanelError())
-                                                    : deferMaybe(result.successValue)
-                        }
-                    } else {
-                        let position: UInt32? = parentFolderGUID == folder.parentGUID ? folder.position : nil
-                        return profile.places.updateBookmarkNode( guid: folder.guid,
-                                                                  parentGUID: parentFolderGUID,
-                                                                  position: position,
-                                                                  title: folder.title).bind { result in
-                            return result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : deferMaybe(nil)
-                        }
-                    }
-
+                    return saveFolder(bookmark: bookmark, parentFolderGUID: parentFolderGUID)
                 default:
                     return nil
                 }
@@ -152,5 +107,56 @@ struct DefaultBookmarksSaver: BookmarksSaver, BookmarksRefactorFeatureFlagProvid
         let recentBookmarkFolderGuid = profile.prefs.stringForKey(PrefsKeys.RecentBookmarkFolder)
         let parentGuid = (isBookmarkRefactorEnabled ? recentBookmarkFolderGuid : nil) ?? BookmarkRoots.MobileFolderGUID
         _ = await save(bookmark: bookmarkData, parentFolderGUID: parentGuid)
+    }
+
+    private func saveBookmark(bookmark: FxBookmarkNode, parentFolderGUID: String) -> Deferred<Maybe<GUID?>>? {
+        guard let bookmark = bookmark as? BookmarkItemData else { return deferMaybe(nil) }
+
+        if bookmark.parentGUID == nil {
+            let position: UInt32? = parentFolderGUID == BookmarkRoots.MobileFolderGUID ? 0 : nil
+            return profile.places.createBookmark(parentGUID: parentFolderGUID,
+                                                 url: bookmark.url,
+                                                 title: bookmark.title,
+                                                 position: position).bind { result in
+                return result.isFailure ? deferMaybe(BookmarkDetailPanelError())
+                                        : deferMaybe(result.successValue)
+            }
+        } else {
+            let position: UInt32? = parentFolderGUID == bookmark.parentGUID ? bookmark.position : nil
+            return profile.places.updateBookmarkNode(guid: bookmark.guid,
+                                                     parentGUID: parentFolderGUID,
+                                                     position: position,
+                                                     title: bookmark.title,
+                                                     url: bookmark.url).bind { result in
+                return result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : deferMaybe(nil)
+            }
+        }
+    }
+
+    private func saveFolder(bookmark: FxBookmarkNode, parentFolderGUID: String) -> Deferred<Maybe<GUID?>>? {
+        guard let folder = bookmark as? BookmarkFolderData else { return deferMaybe(nil) }
+
+        if folder.parentGUID == nil {
+            TelemetryWrapper.recordEvent(category: .action,
+                                         method: .tap,
+                                         object: .bookmark,
+                                         value: .bookmarkAddFolder)
+
+            let position: UInt32? = parentFolderGUID == BookmarkRoots.MobileFolderGUID ? 0 : nil
+            return profile.places.createFolder(parentGUID: parentFolderGUID,
+                                               title: folder.title,
+                                               position: position).bind { result in
+                return result.isFailure ? deferMaybe(BookmarkDetailPanelError())
+                                        : deferMaybe(result.successValue)
+            }
+        } else {
+            let position: UInt32? = parentFolderGUID == folder.parentGUID ? folder.position : nil
+            return profile.places.updateBookmarkNode( guid: folder.guid,
+                                                      parentGUID: parentFolderGUID,
+                                                      position: position,
+                                                      title: folder.title).bind { result in
+                return result.isFailure ? deferMaybe(BookmarkDetailPanelError()) : deferMaybe(nil)
+            }
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11076)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24157)

## :bulb: Description
- Fix closure line length error in `BookmarksSaver.swift`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

