### PR TITLE
Localize FXIOS-11077 [Bookmarks Evolution] Clarify "Sign in to Sync" comment

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -217,10 +217,10 @@ extension String {
                     value: "Save sites as you browse. We’ll also grab bookmarks from other synced devices.",
                     comment: "The body text for the placeholder screen shown when there are no saved bookmarks, located at the root level of the bookmarks panel within the libray modal")
                 public static let ButtonTitle = MZLocalizedString(
-                    key: "Bookmarks.EmptyState.Root.ButtonTitle.v135",
+                    key: "Bookmarks.EmptyState.Root.ButtonTitle.v135.v2",
                     tableName: "Bookmarks",
                     value: "Sign in to Sync",
-                    comment: "The button title for the sign in button on the placeholder screen shown when there are no saved bookmarks, located at the root level of the bookmarks panel within the library modal. This button triggers the sign in flow, allowing users to sign in to their Mozilla Account to sync data")
+                    comment: "The button title for the sign in button on the placeholder screen shown when there are no saved bookmarks, located at the root level of the bookmarks panel within the library modal. This button triggers the sign in flow, allowing users to sign in to their Mozilla Account to sync data. In this string, \"Sync\" is used as a verb, and is capitalized as per convention to title case text for buttons in iOS")
             }
             public struct Nested {
                 public static let Title = MZLocalizedString(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -217,7 +217,7 @@ extension String {
                     value: "Save sites as you browse. We’ll also grab bookmarks from other synced devices.",
                     comment: "The body text for the placeholder screen shown when there are no saved bookmarks, located at the root level of the bookmarks panel within the libray modal")
                 public static let ButtonTitle = MZLocalizedString(
-                    key: "Bookmarks.EmptyState.Root.ButtonTitle.v135.v2",
+                    key: "Bookmarks.EmptyState.Root.ButtonTitle.v136",
                     tableName: "Bookmarks",
                     value: "Sign in to Sync",
                     comment: "The button title for the sign in button on the placeholder screen shown when there are no saved bookmarks, located at the root level of the bookmarks panel within the library modal. This button triggers the sign in flow, allowing users to sign in to their Mozilla Account to sync data. In this string, \"Sync\" is used as a verb, and is capitalized as per convention to title case text for buttons in iOS")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11077)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24159)

## :bulb: Description
- Bumped "Sign in to Sync" string version, updating the comment to translators to clarify that "Sync" is used as a verb, and capitalized due to iOS title casing convention for buttons

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

