### PR TITLE
Bugfix FXIOS-10559 [Password Generator] Swipe to close the password generator prompt gesture is hard to use

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -260,7 +260,6 @@ public class BottomSheetViewController: UIViewController,
             })
         case .ended:
             let velocity = recognizer.velocity(in: view)
-            print("viewTranslation.y: \(viewTranslation.y), height: \(contentView.bounds.height)")
             if viewTranslation.y >= 200 || viewTranslation.y >= contentView.bounds.height / 2 || velocity.y >= 700 {
                 dismissSheetViewController()
             } else {

--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -259,7 +259,8 @@ public class BottomSheetViewController: UIViewController,
                 self.sheetView.transform = CGAffineTransform(translationX: 0, y: self.viewTranslation.y)
             })
         case .ended:
-            if viewTranslation.y < 200 {
+            let velocity = recognizer.velocity(in: view)
+            if viewTranslation.y < 100 && velocity.y < 700 {
                 UIView.animate(withDuration: UX.animationDuration,
                                delay: 0,
                                usingSpringWithDamping: UX.springWithDamping,

--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -260,7 +260,10 @@ public class BottomSheetViewController: UIViewController,
             })
         case .ended:
             let velocity = recognizer.velocity(in: view)
-            if viewTranslation.y < 100 && velocity.y < 700 {
+            print("viewTranslation.y: \(viewTranslation.y), height: \(contentView.bounds.height)")
+            if viewTranslation.y >= 200 || viewTranslation.y >= contentView.bounds.height / 2 || velocity.y >= 700 {
+                dismissSheetViewController()
+            } else {
                 UIView.animate(withDuration: UX.animationDuration,
                                delay: 0,
                                usingSpringWithDamping: UX.springWithDamping,
@@ -269,8 +272,6 @@ public class BottomSheetViewController: UIViewController,
                                animations: {
                     self.sheetView.transform = .identity
                 })
-            } else {
-                dismissSheetViewController()
             }
         default:
             break


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10559)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23126)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Changed how far down users have to swipe on the bottomsheet before it dismisses -- now if you've swiped over 50% the height of the bottomsheet, even if it doesn't meet the 200px threshold it will dismiss
Users' velocity of swipe now affects whether or not the bottomsheet is dismissed -- It is often the case that if you swipe down fast, you want the bottomsheet to dismiss.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

