### PR TITLE
Bugfix FXIOS-10663 ⁃ [Felt privacy-Unified panel] - Back button from the submenus and from the certificate overlaps the site name

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
@@ -23,8 +23,11 @@ public final class NavigationHeaderView: UIView {
         label.textAlignment = .center
         label.font = FXFontStyles.Regular.headline.scaledFont()
         label.numberOfLines = 2
+        label.lineBreakMode = .byTruncatingTail
         label.accessibilityTraits.insert(.header)
         label.isAccessibilityElement = false
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     }
 
     private lazy var closeButton: CloseButton = .build { button in
@@ -37,6 +40,8 @@ public final class NavigationHeaderView: UIView {
                         for: .normal)
         button.titleLabel?.adjustsFontSizeToFitWidth = true
         button.addTarget(self, action: #selector(self.backButtonTapped), for: .touchUpInside)
+        button.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        button.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     }
 
     private let horizontalLine: UIView = .build()
@@ -62,26 +67,20 @@ public final class NavigationHeaderView: UIView {
         closeButton.removeConstraints(closeButton.constraints)
         viewConstraints.removeAll()
         viewConstraints.append(contentsOf: [
-            backButton.leadingAnchor.constraint(
-                equalTo: leadingAnchor,
-                constant: UX.imageMargins
-            ),
+            backButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.imageMargins),
             backButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            backButton.trailingAnchor.constraint(lessThanOrEqualTo: titleLabel.leadingAnchor,
+                                                 constant: -UX.horizontalMargin),
 
-            titleLabel.topAnchor.constraint(
-                equalTo: topAnchor,
-                constant: UX.baseDistance
-            ),
-            titleLabel.bottomAnchor.constraint(
-                equalTo: bottomAnchor,
-                constant: -UX.baseDistance
-            ),
+            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: backButton.trailingAnchor,
+                                                constant: UX.horizontalMargin),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: closeButton.leadingAnchor,
+                                                 constant: -UX.horizontalMargin),
             titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: UX.baseDistance),
+            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.baseDistance),
 
-            closeButton.trailingAnchor.constraint(
-                equalTo: trailingAnchor,
-                constant: -UX.horizontalMargin
-            ),
+            closeButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.horizontalMargin),
             closeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
 
             horizontalLine.leadingAnchor.constraint(equalTo: leadingAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10663)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23324)

## :bulb: Description
Fixed navigationHeader by stop overlapping labels

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

