### PR TITLE
Fix MTE-4139 - testLockIconCloseMenu test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -253,10 +253,10 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         navigator.goto(TrackingProtectionContextMenuDetails)
         mozWaitForElementToExist(
-            app.staticTexts[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusButton])
+            app.buttons[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusButton])
         navigator.performAction(Action.CloseTPContextMenu)
         mozWaitForElementToNotExist(
-            app.staticTexts[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusButton])
+            app.buttons[AccessibilityIdentifiers.EnhancedTrackingProtection.MainScreen.securityStatusButton])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307063


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4139

## :bulb: Description
Recent changes on tracking protection lead to testLockIconCloseMenu test to fail.
Small fix by changing the element to button
