### PR TITLE
Bugfix FXIOS-10654 ⁃ [Felt privacy-Unified panel] - Some dividing lines are missing from the certificate sheet

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesHeaderView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesHeaderView.swift
@@ -8,6 +8,7 @@ import Common
 class CertificatesHeaderView: UITableViewHeaderFooterView, ReusableCell {
     private struct UX {
         static let headerStackViewSpacing = 16.0
+        static let separatorHeight = 1.0
     }
 
     let headerStackView: UIStackView = .build { stack in
@@ -16,6 +17,9 @@ class CertificatesHeaderView: UITableViewHeaderFooterView, ReusableCell {
         stack.alignment = .fill
         stack.spacing = UX.headerStackViewSpacing
     }
+
+    let separatorBottomView: UIView = .build()
+    let separatorTopView: UIView = .build()
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
@@ -28,11 +32,24 @@ class CertificatesHeaderView: UITableViewHeaderFooterView, ReusableCell {
 
     private func setupHeaderView() {
         addSubview(headerStackView)
+        addSubview(separatorTopView)
+        addSubview(separatorBottomView)
         NSLayoutConstraint.activate([
+            separatorTopView.leadingAnchor.constraint(equalTo: headerStackView.leadingAnchor),
+            separatorTopView.trailingAnchor.constraint(equalTo: headerStackView.trailingAnchor),
+            separatorTopView.bottomAnchor.constraint(equalTo: headerStackView.topAnchor,
+                                                     constant: -UX.headerStackViewSpacing),
+            separatorTopView.heightAnchor.constraint(equalToConstant: UX.separatorHeight),
+
             self.leadingAnchor.constraint(equalTo: headerStackView.leadingAnchor),
             self.trailingAnchor.constraint(equalTo: headerStackView.trailingAnchor),
-            self.topAnchor.constraint(equalTo: headerStackView.topAnchor),
-            self.bottomAnchor.constraint(equalTo: headerStackView.bottomAnchor)
+            self.topAnchor.constraint(equalTo: separatorTopView.topAnchor, constant: -16),
+            self.bottomAnchor.constraint(equalTo: headerStackView.bottomAnchor),
+
+            separatorBottomView.leadingAnchor.constraint(equalTo: headerStackView.leadingAnchor),
+            separatorBottomView.trailingAnchor.constraint(equalTo: headerStackView.trailingAnchor),
+            separatorBottomView.topAnchor.constraint(equalTo: headerStackView.bottomAnchor),
+            separatorBottomView.heightAnchor.constraint(equalToConstant: UX.separatorHeight)
         ])
     }
 
@@ -46,6 +63,9 @@ class CertificatesHeaderView: UITableViewHeaderFooterView, ReusableCell {
             headerStackView.addArrangedSubview(item)
         }
 
+        contentView.backgroundColor = theme.colors.layer5
         headerStackView.backgroundColor = theme.colors.layer5
+        separatorBottomView.backgroundColor = theme.colors.borderPrimary
+        separatorTopView.backgroundColor = theme.colors.borderPrimary
     }
 }

--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
@@ -34,6 +34,7 @@ class CertificatesViewController: UIViewController,
     // MARK: - UI
     struct UX {
         static let titleLabelMargin = 8.0
+        static let titleLabelTopMargin = 2.0
         static let titleLabelMinHeight = 60.0
         static let headerStackViewMargin = 8.0
         static let headerStackViewTopMargin = 20.0
@@ -43,19 +44,20 @@ class CertificatesViewController: UIViewController,
         label.font = FXFontStyles.Bold.title1.scaledFont()
         label.text = .Menu.EnhancedTrackingProtection.certificatesTitle
         label.textAlignment = .left
+        label.adjustsFontSizeToFitWidth = true
     }
 
     private let headerView: NavigationHeaderView = .build { header in
         header.accessibilityIdentifier = AccessibilityIdentifiers.EnhancedTrackingProtection.CertificatesScreen.headerView
     }
 
-    // TODO: FXIOS-9980 Tracking Protection Certificates Screen tableView header text is a little bit cutted off
     let certificatesTableView: UITableView = .build { tableView in
         tableView.allowsSelection = false
         tableView.register(CertificatesCell.self, forCellReuseIdentifier: CertificatesCell.cellIdentifier)
         tableView.register(CertificatesHeaderView.self,
                            forHeaderFooterViewReuseIdentifier: CertificatesHeaderView.cellIdentifier)
         tableView.sectionHeaderTopPadding = 0
+        tableView.separatorInset = .zero
     }
 
     // MARK: - Variables
@@ -140,9 +142,6 @@ class CertificatesViewController: UIViewController,
     private func setupTitleConstraints() {
         view.addSubview(titleLabel)
         NSLayoutConstraint.activate([
-            titleLabel.heightAnchor.constraint(
-                greaterThanOrEqualToConstant: UX.titleLabelMinHeight
-            ),
             titleLabel.leadingAnchor.constraint(
                 equalTo: view.leadingAnchor,
                 constant: UX.titleLabelMargin
@@ -152,7 +151,8 @@ class CertificatesViewController: UIViewController,
                 constant: -UX.titleLabelMargin
             ),
             titleLabel.topAnchor.constraint(
-                equalTo: headerView.bottomAnchor
+                equalTo: headerView.bottomAnchor,
+                constant: UX.titleLabelTopMargin
             )
         ])
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10654)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23314)

## :bulb: Description
Added missing dividers for Certificates screen

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

