### PR TITLE
Bugfix FXIOS-11078 [Bookmarks Evolution] Incorrect index path resolution for context menu after row reorder

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -502,6 +502,7 @@ class BookmarksViewController: SiteTableViewController,
 
                 let contextButton = createContextButton()
                 contextButton.addAction(UIAction { [weak self] _ in
+                    guard let indexPath = tableView.indexPath(for: cell) else { return }
                     self?.presentContextMenu(for: indexPath)
                 }, for: .touchUpInside)
                 viewModel.accessoryView = contextButton


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11078)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24160)

## :bulb: Description
- Open the context menu corresponding to the correct cell via the "..." disclosure button after reordering list of bookmarks

### 📝 Discussion:
- Previously, we were capturing the index path of each cell when the table was loaded, causing the wrong context menu to be opened if the "..." disclosure button was pressed and the cell was in a different position than originally. We now dynamically lookup the cell's index path before opening the context menu.

### 🎥 Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/cf736b03-c896-4013-88d1-1d26c4c41246

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/b8ed7b58-7979-4bec-9aa0-6a98d4c89e74

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

