### PR TITLE
Bugfix FXIOS-11081 [Bookmarks Evolution] Bookmarks disclosure button tint color

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -258,7 +258,7 @@ class OneLineTableViewCell: UITableViewCell,
 
         switch customization {
         case .regular:
-            accessoryView?.tintColor = accessoryView is UIButton ? theme.colors.iconPrimary : theme.colors.iconSecondary
+            accessoryView?.tintColor = isAccessoryViewInteractive ? theme.colors.iconPrimary : theme.colors.iconSecondary
             leftImageView.tintColor = theme.colors.textPrimary
             titleLabel.textColor = theme.colors.textPrimary
         case .newFolder:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11081)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24166)

## :bulb: Description
- Fix bookmarks cell "..." disclosure button tint color for all themes

### 📷 Screenshots
| Before | After |
| ------------- | ------------- |
| <img width="559" alt="Screenshot 2025-01-16 at 1 05 38 PM" src="https://github.com/user-attachments/assets/c6a40c9c-c5cb-4511-b269-0e535262fd63" /> | <img width="559" alt="Screenshot 2025-01-16 at 1 06 32 PM" src="https://github.com/user-attachments/assets/e310ad51-48d5-451f-a34d-635ae4d1bfff" /> |
| <img width="559" alt="Screenshot 2025-01-16 at 1 05 44 PM" src="https://github.com/user-attachments/assets/91b56f48-dea9-4a20-b36e-07025e13d071" /> | <img width="559" alt="Screenshot 2025-01-16 at 1 06 35 PM" src="https://github.com/user-attachments/assets/4e6aac2b-d894-4f3e-a006-d0f5672f3c4d" /> |
| <img width="559" alt="Screenshot 2025-01-16 at 1 05 51 PM" src="https://github.com/user-attachments/assets/2afa00d8-2d43-431f-8acf-559684017e5a" /> | <img width="559" alt="Screenshot 2025-01-16 at 1 06 42 PM" src="https://github.com/user-attachments/assets/21670714-74da-4659-abe3-2a6ff64d7a2b" /> |

You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

