### PR TITLE
Add FXIOS-11094 [Bookmarks Evolution] A11y button trait for "New folder" button

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -251,6 +251,7 @@ class EditBookmarkViewController: UIViewController,
         cell.indentationLevel = 0
         cell.accessoryType = .none
         cell.selectionStyle = .default
+        cell.accessibilityTraits = .button
         cell.customization = .newFolder
         cell.applyTheme(theme: theme)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11094)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24188)

## :bulb: Description
- Add the `.button` accessibility trait to the "New folder" cell found in the parent folder selector when editing a bookmark

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

