### PR TITLE
Refactor FXIOS-7301 [Swiftlint] Remove 1 closure_body_length violation from RustLogins.swift and decrease threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -102,8 +102,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 60
-  error: 60
+  warning: 53
+  error: 53
 
 file_header:
   required_string: |

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1170,4 +1170,10 @@ public class RustLogins: LoginsProtocol {
             }
         }
     }
+
+    private func handleIllegalStateAction(completion: @escaping (Result<String, NSError>) -> Void) {
+        // If none of the above cases apply, we're in a state that shouldn't be
+        // possible but is disallowed nonetheless
+        completion(.failure(LoginEncryptionKeyError.illegalState as NSError))
+    }
 }

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1080,9 +1080,7 @@ public class RustLogins: LoginsProtocol {
             case (.none, .none):
                 self.handleFirstTimeCallOrClearedKeychainAction(rustKeys: rustKeys, completion: completion)
             default:
-                // If none of the above cases apply, we're in a state that shouldn't be
-                // possible but is disallowed nonetheless
-                completion(.failure(LoginEncryptionKeyError.illegalState as NSError))
+                self.handleIllegalStateAction(completion: completion)
             }
         }
     }

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1074,7 +1074,7 @@ public class RustLogins: LoginsProtocol {
                                              key: key,
                                              completion: completion)
             case (.some(key), .none):
-                self.handleUnexpectedKey(rustKeys: rustKeys, completion: completion)
+                self.handleUnexpectedKeyAction(rustKeys: rustKeys, completion: completion)
             case (.none, .some(encryptedCanaryPhrase)):
                 self.handleMissingKeyAction(rustKeys: rustKeys, completion: completion)
             case (.none, .none):
@@ -1144,8 +1144,8 @@ public class RustLogins: LoginsProtocol {
         }
     }
 
-    private func handleUnexpectedKey(rustKeys: RustLoginEncryptionKeys,
-                                     completion: @escaping (Result<String, NSError>) -> Void) {
+    private func handleUnexpectedKeyAction(rustKeys: RustLoginEncryptionKeys,
+                                           completion: @escaping (Result<String, NSError>) -> Void) {
         // The key is present, but we didn't expect it to be there.
 
         self.logger.log("Logins key lost due to storage malfunction, new one generated",

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1078,7 +1078,7 @@ public class RustLogins: LoginsProtocol {
             case (.none, .some(encryptedCanaryPhrase)):
                 self.handleMissingKeyAction(rustKeys: rustKeys, completion: completion)
             case (.none, .none):
-                self.handleFirstTimeCallOrClearedKeychain(rustKeys: rustKeys, completion: completion)
+                self.handleFirstTimeCallOrClearedKeychainAction(rustKeys: rustKeys, completion: completion)
             default:
                 // If none of the above cases apply, we're in a state that shouldn't be
                 // possible but is disallowed nonetheless
@@ -1136,8 +1136,8 @@ public class RustLogins: LoginsProtocol {
         self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
     }
 
-    private func handleFirstTimeCallOrClearedKeychain(rustKeys: RustLoginEncryptionKeys,
-                                                      completion: @escaping (Result<String, NSError>) -> Void) {
+    private func handleFirstTimeCallOrClearedKeychainAction(rustKeys: RustLoginEncryptionKeys,
+                                                            completion: @escaping (Result<String, NSError>) -> Void) {
         // We didn't expect the key to be present, which either means this is a first-time
         // call or the key data has been cleared from the keychain.
 

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1082,13 +1082,7 @@ public class RustLogins: LoginsProtocol {
                 GleanMetrics.LoginsStoreKeyRegeneration.other.record()
                 self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
             case (.none, .some(encryptedCanaryPhrase)):
-                // We expected the key to be present, but it's gone missing on us.
-
-                self.logger.log("Logins key lost, new one generated",
-                                level: .warning,
-                                category: .storage)
-                GleanMetrics.LoginsStoreKeyRegeneration.lost.record()
-                self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
+                self.handleMissingKey(rustKeys: rustKeys, completion: completion)
             case (.none, .none):
                 // We didn't expect the key to be present, which either means this is a first-time
                 // call or the key data has been cleared from the keychain.

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1078,37 +1078,7 @@ public class RustLogins: LoginsProtocol {
             case (.none, .some(encryptedCanaryPhrase)):
                 self.handleMissingKeyAction(rustKeys: rustKeys, completion: completion)
             case (.none, .none):
-                // We didn't expect the key to be present, which either means this is a first-time
-                // call or the key data has been cleared from the keychain.
-
-                self.hasSyncedLogins().upon { result in
-                    guard result.failureValue == nil else {
-                        completion(.failure(result.failureValue! as NSError))
-                        return
-                    }
-
-                    guard let hasLogins = result.successValue else {
-                        let msg = "Failed to verify logins count before attempting to reset key"
-                        completion(.failure(LoginEncryptionKeyError.dbRecordCountVerificationError(msg) as NSError))
-                        return
-                    }
-
-                    if hasLogins {
-                        // Since the key data isn't present and we have login records in
-                        // the database, we both clear the database and reset the key.
-                        GleanMetrics.LoginsStoreKeyRegeneration.keychainDataLost.record()
-                        self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
-                    } else {
-                        // There are no records in the database so we don't need to wipe any
-                        // existing login records. We just need to create a new key.
-                        do {
-                            let key = try rustKeys.createAndStoreKey()
-                            completion(.success(key))
-                        } catch let error as NSError {
-                            completion(.failure(error))
-                        }
-                    }
-                }
+                self.handleFirstTimeCallOrClearedKeychain(rustKeys: rustKeys, completion: completion)
             default:
                 // If none of the above cases apply, we're in a state that shouldn't be
                 // possible but is disallowed nonetheless

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1151,7 +1151,7 @@ public class RustLogins: LoginsProtocol {
     }
 
     private func handleMissingKey(rustKeys: RustLoginEncryptionKeys,
-                                     completion: @escaping (Result<String, NSError>) -> Void) {
+                                  completion: @escaping (Result<String, NSError>) -> Void) {
         // We expected the key to be present, but it's gone missing on us.
 
         self.logger.log("Logins key lost, new one generated",

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1074,13 +1074,7 @@ public class RustLogins: LoginsProtocol {
                                              key: key,
                                              completion: completion)
             case (.some(key), .none):
-                // The key is present, but we didn't expect it to be there.
-
-                self.logger.log("Logins key lost due to storage malfunction, new one generated",
-                                level: .warning,
-                                category: .storage)
-                GleanMetrics.LoginsStoreKeyRegeneration.other.record()
-                self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
+                self.handleUnexpectedKey(rustKeys: rustKeys, completion: completion)
             case (.none, .some(encryptedCanaryPhrase)):
                 self.handleMissingKeyAction(rustKeys: rustKeys, completion: completion)
             case (.none, .none):

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1082,7 +1082,7 @@ public class RustLogins: LoginsProtocol {
                 GleanMetrics.LoginsStoreKeyRegeneration.other.record()
                 self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
             case (.none, .some(encryptedCanaryPhrase)):
-                self.handleMissingKey(rustKeys: rustKeys, completion: completion)
+                self.handleMissingKeyAction(rustKeys: rustKeys, completion: completion)
             case (.none, .none):
                 // We didn't expect the key to be present, which either means this is a first-time
                 // call or the key data has been cleared from the keychain.
@@ -1150,8 +1150,8 @@ public class RustLogins: LoginsProtocol {
         }
     }
 
-    private func handleMissingKey(rustKeys: RustLoginEncryptionKeys,
-                                  completion: @escaping (Result<String, NSError>) -> Void) {
+    private func handleMissingKeyAction(rustKeys: RustLoginEncryptionKeys,
+                                        completion: @escaping (Result<String, NSError>) -> Void) {
         // We expected the key to be present, but it's gone missing on us.
 
         self.logger.log("Logins key lost, new one generated",

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1155,4 +1155,15 @@ public class RustLogins: LoginsProtocol {
             completion(.failure(error))
         }
     }
+
+    private func handleMissingKey(rustKeys: RustLoginEncryptionKeys,
+                                     completion: @escaping (Result<String, NSError>) -> Void) {
+        // We expected the key to be present, but it's gone missing on us.
+
+        self.logger.log("Logins key lost, new one generated",
+                        level: .warning,
+                        category: .storage)
+        GleanMetrics.LoginsStoreKeyRegeneration.lost.record()
+        self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
+    }
 }

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1150,6 +1150,17 @@ public class RustLogins: LoginsProtocol {
         }
     }
 
+    private func handleUnexpectedKey(rustKeys: RustLoginEncryptionKeys,
+                                     completion: @escaping (Result<String, NSError>) -> Void) {
+        // The key is present, but we didn't expect it to be there.
+
+        self.logger.log("Logins key lost due to storage malfunction, new one generated",
+                        level: .warning,
+                        category: .storage)
+        GleanMetrics.LoginsStoreKeyRegeneration.other.record()
+        self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
+    }
+
     private func handleMissingKeyAction(rustKeys: RustLoginEncryptionKeys,
                                         completion: @escaping (Result<String, NSError>) -> Void) {
         // We expected the key to be present, but it's gone missing on us.

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1069,27 +1069,10 @@ public class RustLogins: LoginsProtocol {
         getKeychainData(rustKeys: rustKeys) { (key, encryptedCanaryPhrase) in
             switch(key, encryptedCanaryPhrase) {
             case (.some(key), .some(encryptedCanaryPhrase)):
-                // We expected the key to be present, and it is.
-                do {
-                    let canaryIsValid = try checkCanary(canary: encryptedCanaryPhrase!,
-                                                        text: rustKeys.canaryPhrase,
-                                                        encryptionKey: key!)
-                    if canaryIsValid {
-                        completion(.success(key!))
-                    } else {
-                        self.logger.log("Logins key was corrupted, new one generated",
-                                        level: .warning,
-                                        category: .storage)
-                        GleanMetrics.LoginsStoreKeyRegeneration.corrupt.record()
-                        self.resetLoginsAndKey(rustKeys: rustKeys, completion: completion)
-                    }
-                } catch let error as NSError {
-                    self.logger.log("Error validating logins encryption key",
-                                    level: .warning,
-                                    category: .storage,
-                                    description: error.localizedDescription)
-                    completion(.failure(error))
-                }
+                self.handleExpectedKey(rustKeys: rustKeys,
+                                       encryptedCanaryPhrase: encryptedCanaryPhrase,
+                                       key: key,
+                                       completion: completion)
             case (.some(key), .none):
                 // The key is present, but we didn't expect it to be there.
 

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -1069,10 +1069,10 @@ public class RustLogins: LoginsProtocol {
         getKeychainData(rustKeys: rustKeys) { (key, encryptedCanaryPhrase) in
             switch(key, encryptedCanaryPhrase) {
             case (.some(key), .some(encryptedCanaryPhrase)):
-                self.handleExpectedKey(rustKeys: rustKeys,
-                                       encryptedCanaryPhrase: encryptedCanaryPhrase,
-                                       key: key,
-                                       completion: completion)
+                self.handleExpectedKeyAction(rustKeys: rustKeys,
+                                             encryptedCanaryPhrase: encryptedCanaryPhrase,
+                                             key: key,
+                                             completion: completion)
             case (.some(key), .none):
                 // The key is present, but we didn't expect it to be there.
 
@@ -1129,10 +1129,10 @@ public class RustLogins: LoginsProtocol {
         }
     }
 
-    private func handleExpectedKey(rustKeys: RustLoginEncryptionKeys,
-                                   encryptedCanaryPhrase: String?,
-                                   key: String?,
-                                   completion: @escaping (Result<String, NSError>) -> Void) {
+    private func handleExpectedKeyAction(rustKeys: RustLoginEncryptionKeys,
+                                         encryptedCanaryPhrase: String?,
+                                         key: String?,
+                                         completion: @escaping (Result<String, NSError>) -> Void) {
         // We expected the key to be present, and it is.
         do {
             let canaryIsValid = try checkCanary(canary: encryptedCanaryPhrase!,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR removes 1 `closure_body_length` violation from the `RustLogins.swift` file. Also, this PR decrease the warning and error threshold to 53.

Unlike other PRs (e.g. https://github.com/mozilla-mobile/firefox-ios/pull/24128/files), in this one, I named the functions based on the comments within each code block instead of using the enum cases. I believe this approach makes the function's intention clearer in this case. Feel free to share any suggestions.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

