### PR TITLE
Bugfix FXIOS-10655 ⁃ [Felt privacy-Unified panel] - The name in the Common Name should be blue and underlined on the certificate sheet

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesCell.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesCell.swift
@@ -62,15 +62,21 @@ final class CertificatesCell: UITableViewCell, ReusableCell, ThemeApplicable {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(theme: Theme, sectionTitle: String, items: CertificateItems) {
+    func configure(theme: Theme, sectionTitle: String, items: CertificateItems, isIssuerName: Bool = false) {
         applyTheme(theme: theme)
         sectionLabel.text = sectionTitle
         for (key, value) in items {
+            let isUnderlined = isIssuerName && key == .Menu.EnhancedTrackingProtection.certificateCommonName
             let stackView = getSectionItemStackView()
-            let titleLabel = getItemLabel(theme: theme, with: key, isTitle: true)
+            let titleLabel = getItemLabel(theme: theme, with: key, isTitle: true, isUnderlined: isUnderlined)
             titleLabel.widthAnchor.constraint(equalToConstant: UX.sectionLabelWidth).isActive = true
             stackView.addArrangedSubview(titleLabel)
-            stackView.addArrangedSubview(getItemLabel(theme: theme, with: value, isTitle: false))
+            stackView.addArrangedSubview(getItemLabel(
+                theme: theme,
+                with: value,
+                isTitle: false,
+                isUnderlined: isUnderlined
+            ))
             allSectionItemsStackView.addArrangedSubview(stackView)
         }
     }
@@ -80,14 +86,24 @@ final class CertificatesCell: UITableViewCell, ReusableCell, ThemeApplicable {
         sectionLabel.textColor = theme.colors.textPrimary
     }
 
-    private func getItemLabel(theme: Theme, with title: String, isTitle: Bool) -> UILabel {
-        let itemLabel: UILabel = .build { label in
-            label.font = FXFontStyles.Bold.headline.scaledFont()
-            label.textColor = isTitle ? theme.colors.textSecondary : theme.colors.textPrimary
-            label.text = title
-            label.textAlignment = isTitle ? .right : .left
-            label.numberOfLines = 0
-            label.lineBreakMode = .byWordWrapping
+    private func getItemLabel(theme: Theme, with title: String, isTitle: Bool, isUnderlined: Bool) -> UILabel {
+        let itemLabel: UILabel = .build()
+        itemLabel.font = FXFontStyles.Bold.headline.scaledFont()
+        itemLabel.textAlignment = isTitle ? .right : .left
+        itemLabel.numberOfLines = 0
+        itemLabel.lineBreakMode = .byWordWrapping
+        if isUnderlined, !isTitle {
+            let attributedString = NSAttributedString(
+                string: title,
+                attributes: [
+                    .underlineStyle: NSUnderlineStyle.single.rawValue
+                ]
+            )
+            itemLabel.textColor = theme.colors.textAccent
+            itemLabel.attributedText = attributedString
+        } else {
+            itemLabel.textColor = isTitle ? theme.colors.textSecondary : theme.colors.textPrimary
+            itemLabel.text = title
         }
         return itemLabel
     }

--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
@@ -240,7 +240,8 @@ class CertificatesViewController: UIViewController,
                                sectionTitle: .Menu.EnhancedTrackingProtection.certificateIssuerName,
                                items: [(.Menu.EnhancedTrackingProtection.certificateIssuerCountry, country),
                                        (.Menu.EnhancedTrackingProtection.certificateIssuerOrganization, organization),
-                                       (.Menu.EnhancedTrackingProtection.certificateCommonName, commonName)])
+                                       (.Menu.EnhancedTrackingProtection.certificateCommonName, commonName)],
+                               isIssuerName: true)
             }
 
         case .validity:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10655)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23315)

## :bulb: Description
Added underline for Issuer Name category, for common name

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

