### PR TITLE
Bugfix FXIOS-10652 ⁃ Felt privacy-Unified panel] - "Privacy settings"  and "View certificate" are not underlined

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/LinkButton.swift
@@ -59,6 +59,16 @@ open class LinkButton: UIButton, ThemeApplicable {
         configuration = updatedConfiguration
     }
 
+    public func applyUnderline(underlinedText: String) {
+        let attributedString = NSAttributedString(
+            string: underlinedText,
+            attributes: [
+                .underlineStyle: NSUnderlineStyle.single.rawValue
+            ]
+        )
+        setAttributedTitle(attributedString, for: .normal)
+    }
+
     // MARK: ThemeApplicable
 
     public func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionDetailsViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionDetailsViewController.swift
@@ -175,6 +175,7 @@ class TrackingProtectionDetailsViewController: UIViewController, Themeable {
             font: FXFontStyles.Regular.footnote.scaledFont()
         )
         viewCertificatesButton.configure(viewModel: certificatesButtonViewModel)
+        viewCertificatesButton.applyUnderline(underlinedText: model.viewCertificatesButtonTitle)
         baseView.addArrangedSubview(viewCertificatesButton)
     }
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -402,6 +402,7 @@ class TrackingProtectionViewController: UIViewController,
             font: FXFontStyles.Regular.footnote.scaledFont()
         )
         settingsLinkButton.configure(viewModel: settingsButtonViewModel)
+        settingsLinkButton.applyUnderline(underlinedText: model.settingsButtonTitle)
     }
 
     private func setupProtectionSettingsView() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10652)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23309)

## :bulb: Description
Added underline for LinkedButtons

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

