### PR TITLE
Refactor FXIOS-10205 [Swiftlint] Refactor how we handle .swiftlint.yml to use nested configurations

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -142,8 +142,9 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - firefox-ios/Client/ContentBlocker/ContentBlockerGenerator/Package.swift
   - Package.swift
   - firefox-ios/Build/Intermediates.noindex/Client.build/Fennec-iphoneos/WidgetKitExtension.build/DerivedSources/IntentDefinitionGenerated/WidgetIntents/*
-  # Temporarly ignore focus-ios folder
-  - focus-ios/
+  # Focus specific
+  - Blockzilla/Generated/
+  - focus-ios-tests/tools/Localizations
 
 included:
   - /Users/vagrant/git

--- a/SampleBrowser/SampleBrowser.xcodeproj/project.pbxproj
+++ b/SampleBrowser/SampleBrowser.xcodeproj/project.pbxproj
@@ -296,6 +296,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8A46020B2B0FE20800FFD17F /* Build configuration list for PBXNativeTarget "SampleBrowser" */;
 			buildPhases = (
+				EE20F75A2D3AC5CA00A3F5DF /* Swiftlint */,
 				8A4601DD2B0FE20500FFD17F /* Sources */,
 				8A4601DE2B0FE20500FFD17F /* Frameworks */,
 				8A4601DF2B0FE20500FFD17F /* Resources */,
@@ -362,6 +363,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		EE20F75A2D3AC5CA00A3F5DF /* Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Swiftlint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nMODIFIED_FILES=$(git diff --name-only --diff-filter=ACM | grep -e '\\.swift$')\n\nSWIFTLINT_ROOT=\"${SRCROOT}/..\"\n\nif which swiftlint > /dev/null; then\n    # Move to the location of the root Swiftlint config file in\n    # order to use nested configurations\n    cd ${SWIFTLINT_ROOT}\n\n    swiftlint lint ${MODIFIED_FILES}\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\" \nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		8A4601DD2B0FE20500FFD17F /* Sources */ = {

--- a/SampleComponentLibraryApp/SampleComponentLibraryApp.xcodeproj/project.pbxproj
+++ b/SampleComponentLibraryApp/SampleComponentLibraryApp.xcodeproj/project.pbxproj
@@ -241,10 +241,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8A2FE6782A55EE3F0036B6AF /* Build configuration list for PBXNativeTarget "SampleComponentLibraryApp" */;
 			buildPhases = (
+				8A2FE6922A55F1880036B6AF /* Swiftlint */,
 				8A2FE64A2A55EE3D0036B6AF /* Sources */,
 				8A2FE64C2A55EE3D0036B6AF /* Resources */,
 				8A2FE64B2A55EE3D0036B6AF /* Frameworks */,
-				8A2FE6922A55F1880036B6AF /* Swiftlint */,
 			);
 			buildRules = (
 			);
@@ -321,7 +321,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nMODIFIED_FILES=$(git diff --name-only --diff-filter=ACM | grep -e '\\.swift$')\n\nSWIFTLINT_ROOT=\"${SRCROOT}/..\"\n\nif which swiftlint > /dev/null; then\n    # Move to the location of the root Swiftlint config file in\n    # order to use nested configurations\n    cd ${SWIFTLINT_ROOT}\n\n    swiftlint lint ${MODIFIED_FILES}\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\" \nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -504,6 +504,7 @@ workflows:
     - swiftlint-extended@1:
         inputs:
         - linting_path: "$BITRISE_SOURCE_DIR"
+        - lint_config_file: ""  # Don't pass a config file to make use of nested configurations
     - deploy-to-bitrise-io@2.9.2: {}
     - script@1:
         inputs:

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -15872,7 +15872,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nMODIFIED_FILES=$(git diff --name-only --diff-filter=ACM | grep -e '\\.swift$')\n\nif which swiftlint > /dev/null; then\n    for file in $MODIFIED_FILES; do\n        swiftlint lint \"${SRCROOT}/../${file}\" --config \"${SRCROOT}/../.swiftlint.yml\"\n    done\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\" \nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nMODIFIED_FILES=$(git diff --name-only --diff-filter=ACM | grep -e '\\.swift$')\n\nSWIFTLINT_ROOT=\"${SRCROOT}/..\"\n\nif which swiftlint > /dev/null; then\n    # Move to the location of the root Swiftlint config file in\n    # order to use nested configurations\n    cd ${SWIFTLINT_ROOT}\n\n    swiftlint lint ${MODIFIED_FILES}\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\" \nfi\n";
 		};
 		E6639F191BF11E3A002D0853 /* Conditionally Add Settings Bundle */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/focus-ios/.swiftlint.yml
+++ b/focus-ios/.swiftlint.yml
@@ -1,142 +1,17 @@
-only_rules: # Only enforce these rules, ignore all others
-  # - line_length
-  - class_delegate_protocol
-  - blanket_disable_command
-  - closure_spacing
-  - closure_parameter_position
-  - colon
-  - comma
-  - comment_spacing
-  - compiler_protocol_init
-  - computed_accessors_order
-  - control_statement
-  - duplicate_conditions
-  - dynamic_inline
-  - empty_enum_arguments
-  - empty_parameters
-  - empty_parentheses_with_trailing_closure
-  - for_where
-  - force_try
-  - implicit_getter
-  - inclusive_language
-  - invalid_swiftlint_command
-  - large_tuple
-  - leading_whitespace
-  - legacy_cggeometry_functions
-  - legacy_constant
-  - legacy_constructor
-  - legacy_hashing
-  - legacy_nsgeometry_functions
-  - mark
-  - no_space_in_method_call
-  - ns_number_init_as_function_reference
-  - operator_whitespace
-  - orphaned_doc_comment
-  - private_over_fileprivate
-  - protocol_property_accessors_order
-  - redundant_discardable_let
-  - redundant_objc_attribute
-  - redundant_optional_initialization
-  - redundant_string_enum_value
-  - redundant_void_return
-  - return_arrow_whitespace
-  - statement_position
-  - switch_case_alignment
-  - syntactic_sugar
-  - trailing_newline
-  - trailing_semicolon
-  - trailing_whitespace
-  - unavailable_condition
-  - unneeded_override
-  - unneeded_synthesized_initializer
-  - unused_optional_binding
-  - unused_setter_value
-  - vertical_parameter_alignment
-  - vertical_whitespace
-  - void_function_in_ternary
-  - void_return
+# Swiftlint configuration overloads that will be applied to all files
+# in this folder and all its children recursively, unless another
+# nested configuration takes over.
+# https://github.com/realm/SwiftLint#nested-configurations.
+
+# Those rules currently trigger some violations in focus-ios.
+# Once those violations are resolved, rules can be removed from this configuration overload.
+disabled_rules:
+  - line_length
   - file_header
-  - redundant_type_annotation
+  - force_cast
+  - accessibility_label_for_image
+  - accessibility_trait_for_button
   - attributes
-  - closing_brace
-  - closure_end_indentation
-  - contains_over_filter_count
-  - contains_over_filter_is_empty
-  - contains_over_first_not_nil
-  - contains_over_range_nil_comparison
-  - empty_collection_literal
-  - empty_count
-  - empty_string
-  - empty_xctest_method
-  - explicit_init
-  - first_where
-  - discouraged_assert
-  - duplicate_imports
-  - duplicate_enum_cases
-  - last_where
-  - modifier_order
-  - multiline_arguments
-  - opening_brace
-  - overridden_super_call
-  - vertical_parameter_alignment_on_call
-  - vertical_whitespace_closing_braces
-  - vertical_whitespace_opening_braces
-  - yoda_condition
-
-# These rules were originally opted into. Disabling for now to get
-# Swiftlint up and running.
-
-  # - deployment_target
-  # - discouraged_optional_collection
-  # - prohibited_interface_builder
-  # - prohibited_super_call
-  # - protocol_property_accessors_order
-
-# line_length:
-#   warning: 125
-#   ignores_urls: true
-#   ignores_interpolated_strings: true
-
-# file_header:
-#   required_string: |
-#                     // This Source Code Form is subject to the terms of the Mozilla Public
-#                     // License, v. 2.0. If a copy of the MPL was not distributed with this
-#                     // file, You can obtain one at http://mozilla.org/MPL/2.0/
-
-analyzer_rules: # Rules run by `swiftlint analyze`
-  - unused_import
-
-excluded: # paths to ignore during linting. Takes precedence over `included`.
-  - build/
-  - .build/
-  - firefox-ios/Client/Assets/Search/get_supported_locales.swift
-  - firefox-ios/Client/Generated
-  - firefox-ios/fastlane/
-  - firefox-ios/FxA
-  - firefox-ios/FxAClient
-  - firefox-ios/Source/ExcludedFolder
-  - firefox-ios/Source/ExcludedFile.swift
-  - firefox-ios/Storage/ThirdParty/SwiftData.swift
-  - firefox-ios/Sync/Generated/Metrics.swift
-  - firefox-ios/Storage/Generated/Metrics.swift
-  - firefox-ios/ThirdParty
-  - focus-ios-tests/tools/Localizations
-  - test-fixtures/tmp
-  - firefox-ios/firefox-ios-tests/Tests/UITests/
-  - l10n-screenshots-dd/
-  - DerivedData/
-  # Package.swift files need a custom header for swift-tools-version
-  # so must be excluded due to file_header rule
-  - firefox-ios/Package.swift
-  - BrowserKit/Package.swift
-  - BrowserKit/.build/
-  - firefox-ios/Client/ContentBlocker/ContentBlockerGenerator/Package.swift
-  - Package.swift
-  - firefox-ios/Build/Intermediates.noindex/Client.build/Fennec-iphoneos/WidgetKitExtension.build/DerivedSources/IntentDefinitionGenerated/WidgetIntents/*
-  # Temporary for Focus
-  - Blockzilla/Generated/
-  - /Users/vagrant/git/DerivedData/
-  - /Users/vagrant/git/firefox-ios/
-
-# reporter: "json" # reporter type (xcode, json, csv, checkstyle)
-reporter: "xcode" # reporter type (xcode, json, csv, checkstyle)
+  - trailing_whitespace
+  - vertical_whitespace
+  

--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -2503,7 +2503,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n    swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nMODIFIED_FILES=$(git diff --name-only --diff-filter=ACM | grep -e '\\.swift$')\n\nSWIFTLINT_ROOT=\"${SRCROOT}/..\"\n\nif which swiftlint > /dev/null; then\n    # Move to the location of the root Swiftlint config file in\n    # order to use nested configurations\n    cd ${SWIFTLINT_ROOT}\n\n    swiftlint lint ${MODIFIED_FILES}\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\" \nfi\n";
 		};
 		D5D067F9252F939600C35227 /* Glean */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11042)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24094)

## :bulb: Description

This PRs covers the required steps to move to using nested configurations for Swiftlint, in order to have a shared root configuration that can be tweaked if needed for certain source subsets.

As discussed with @FilippoZazzeroni in #24094:
- Exclude paths from `focus-ios/.swiftlint.yml` were merged into the root configuration
- `focus-ios/.swiftlint.yml` now only disables the rules from root configuration that trigger some violations
- Each sub project's Swiftlint run phase was updated to use nested configurations instead of `--config`
- Bitrise swiftlint phase was updated to use nested configurations instead of `--config`

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

