### PR TITLE
Refactor FXIOS-11046 [Homepage Rebuild] [TopSites] Try to improve topsite rendering on the homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -43,7 +43,7 @@ final class HomepageDiffableDataSource:
         }
     }
 
-    func updateSnapshot(state: HomepageState) {
+    func updateSnapshot(state: HomepageState, numberOfCellsPerRow: Int) {
         var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeItem>()
 
         let textColor = state.wallpaperState.wallpaperConfiguration.textColor
@@ -55,9 +55,9 @@ final class HomepageDiffableDataSource:
         snapshot.appendSections([.messageCard])
         snapshot.appendItems([.messageCard(state.messageState)], toSection: .messageCard)
 
-        if let topSites = getTopSites(with: state.topSitesState, and: textColor) {
-            snapshot.appendSections([.topSites(state.topSitesState.numberOfTilesPerRow)])
-            snapshot.appendItems(topSites, toSection: .topSites(state.topSitesState.numberOfTilesPerRow))
+        if let topSites = getTopSites(with: state.topSitesState, and: textColor, numberOfCellsPerRow: numberOfCellsPerRow) {
+            snapshot.appendSections([.topSites(state.topSitesState.numberOfRows)])
+            snapshot.appendItems(topSites, toSection: .topSites(state.topSitesState.numberOfRows))
         }
 
         if let stories = getPocketStories(with: state.pocketState) {
@@ -87,10 +87,15 @@ final class HomepageDiffableDataSource:
     ///   - textColor: text color from wallpaper configuration
     private func getTopSites(
         with topSitesState: TopSitesSectionState,
-        and textColor: TextColor?
+        and textColor: TextColor?,
+        numberOfCellsPerRow: Int
     ) -> [HomepageDiffableDataSource.HomeItem]? {
         guard topSitesState.shouldShowSection else { return nil }
-        let topSites: [HomeItem] = topSitesState.topSitesData.compactMap { .topSite($0, textColor) }
+        let topSites: [HomeItem] = topSitesState.topSitesData.prefix(
+            topSitesState.numberOfRows * numberOfCellsPerRow
+        ).compactMap {
+            .topSite($0, textColor)
+        }
         guard !topSites.isEmpty else { return nil }
         return topSites
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -56,8 +56,8 @@ final class HomepageDiffableDataSource:
         snapshot.appendItems([.messageCard(state.messageState)], toSection: .messageCard)
 
         if let topSites = getTopSites(with: state.topSitesState, and: textColor, numberOfCellsPerRow: numberOfCellsPerRow) {
-            snapshot.appendSections([.topSites(state.topSitesState.numberOfRows)])
-            snapshot.appendItems(topSites, toSection: .topSites(state.topSitesState.numberOfRows))
+            snapshot.appendSections([.topSites(numberOfCellsPerRow)])
+            snapshot.appendItems(topSites, toSection: .topSites(numberOfCellsPerRow))
         }
 
         if let stories = getPocketStories(with: state.pocketState) {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -67,17 +67,19 @@ final class HomepageSectionLayoutProvider {
 
     func createLayoutSection(
         for section: HomepageSection,
-        with traitCollection: UITraitCollection
+        with traitCollection: UITraitCollection,
+        size: CGSize
     ) -> NSCollectionLayoutSection {
         switch section {
         case .header:
             return createHeaderSectionLayout(for: traitCollection)
         case .messageCard:
             return createMessageCardSectionLayout(for: traitCollection)
-        case .topSites(let numberOfTilesPerRow):
+        case .topSites(let numberOfRows):
             return createTopSitesSectionLayout(
                 for: traitCollection,
-                numberOfTilesPerRow: numberOfTilesPerRow
+                size: size,
+                numberOfRows: numberOfRows
             )
         case .pocket:
             return createPocketSectionLayout(for: traitCollection)
@@ -174,8 +176,16 @@ final class HomepageSectionLayoutProvider {
 
     private func createTopSitesSectionLayout(
         for traitCollection: UITraitCollection,
-        numberOfTilesPerRow: Int
+        size: CGSize,
+        numberOfRows: Int
     ) -> NSCollectionLayoutSection {
+        let numberOfTilesPerRow = TopSitesDimensionCalculator.numberOfTilesPerRow(
+            availableWidth: size.width,
+            leadingInset: HomepageSectionLayoutProvider.UX.leadingInset(
+                traitCollection: traitCollection
+            )
+        )
+
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0 / CGFloat(numberOfTilesPerRow)),
             heightDimension: .estimated(UX.TopSitesConstants.cellEstimatedSize.height)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -67,19 +67,17 @@ final class HomepageSectionLayoutProvider {
 
     func createLayoutSection(
         for section: HomepageSection,
-        with traitCollection: UITraitCollection,
-        size: CGSize
+        with traitCollection: UITraitCollection
     ) -> NSCollectionLayoutSection {
         switch section {
         case .header:
             return createHeaderSectionLayout(for: traitCollection)
         case .messageCard:
             return createMessageCardSectionLayout(for: traitCollection)
-        case .topSites(let numberOfRows):
+        case .topSites(let numberOfTilesPerRow):
             return createTopSitesSectionLayout(
                 for: traitCollection,
-                size: size,
-                numberOfRows: numberOfRows
+                numberOfTilesPerRow: numberOfTilesPerRow
             )
         case .pocket:
             return createPocketSectionLayout(for: traitCollection)
@@ -176,16 +174,8 @@ final class HomepageSectionLayoutProvider {
 
     private func createTopSitesSectionLayout(
         for traitCollection: UITraitCollection,
-        size: CGSize,
-        numberOfRows: Int
+        numberOfTilesPerRow: Int
     ) -> NSCollectionLayoutSection {
-        let numberOfTilesPerRow = TopSitesDimensionCalculator.numberOfTilesPerRow(
-            availableWidth: size.width,
-            leadingInset: HomepageSectionLayoutProvider.UX.leadingInset(
-                traitCollection: traitCollection
-            )
-        )
-
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0 / CGFloat(numberOfTilesPerRow)),
             heightDimension: .estimated(UX.TopSitesConstants.cellEstimatedSize.height)

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -59,7 +59,6 @@ final class HomepageViewController: UIViewController,
     private let overlayManager: OverlayModeManager
     private let logger: Logger
     private let toastContainer: UIView
-    private let mainQueue: DispatchQueueInterface
 
     // MARK: - Initializers
     init(windowUUID: WindowUUID,
@@ -68,8 +67,7 @@ final class HomepageViewController: UIViewController,
          statusBarScrollDelegate: StatusBarScrollDelegate? = nil,
          toastContainer: UIView,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
-         logger: Logger = DefaultLogger.shared,
-         mainQueue: DispatchQueueInterface = DispatchQueue.main
+         logger: Logger = DefaultLogger.shared
     ) {
         self.windowUUID = windowUUID
         self.themeManager = themeManager
@@ -78,7 +76,6 @@ final class HomepageViewController: UIViewController,
         self.statusBarScrollDelegate = statusBarScrollDelegate
         self.toastContainer = toastContainer
         self.logger = logger
-        self.mainQueue = mainQueue
         homepageState = HomepageState(windowUUID: windowUUID)
         super.init(nibName: nil, bundle: nil)
 
@@ -111,7 +108,6 @@ final class HomepageViewController: UIViewController,
         store.dispatch(
             HomepageAction(
                 showiPadSetup: shouldUseiPadSetup(),
-                numberOfTilesPerRow: numberOfTilesPerRow(for: availableWidth),
                 windowUUID: windowUUID,
                 actionType: HomepageActionType.initialize
             )
@@ -125,13 +121,6 @@ final class HomepageViewController: UIViewController,
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         wallpaperView.updateImageForOrientationChange()
-        store.dispatch(
-            TopSitesAction(
-                numberOfTilesPerRow: numberOfTilesPerRow(for: size.width),
-                windowUUID: self.windowUUID,
-                actionType: TopSitesActionType.updatedNumberOfTilesPerRow
-            )
-        )
     }
 
     // called when the homepage is displayed to make sure it's scrolled to top
@@ -188,12 +177,13 @@ final class HomepageViewController: UIViewController,
     /// - Parameter availableWidth: The total width available for displaying the tiles, determined by the view's size.
     /// - Returns: The number of tiles that can fit in a single row within the available width.
     private func numberOfTilesPerRow(for availableWidth: CGFloat) -> Int {
-        return TopSitesDimensionImplementation().getNumberOfTilesPerRow(
+        let tiles = TopSitesDimensionCalculator.numberOfTilesPerRow(
             availableWidth: availableWidth,
             leadingInset: HomepageSectionLayoutProvider.UX.leadingInset(
                 traitCollection: traitCollection
             )
         )
+        return tiles
     }
 
     // MARK: - Redux
@@ -217,9 +207,9 @@ final class HomepageViewController: UIViewController,
     }
 
     func newState(state: HomepageState) {
-        homepageState = state
+        guard self.homepageState != state else { return }
         wallpaperView.wallpaperState = state.wallpaperState
-        dataSource?.updateSnapshot(state: state)
+        dataSource?.updateSnapshot(state: state, numberOfCellsPerRow: numberOfTilesPerRow(for: availableWidth))
     }
 
     func unsubscribeFromRedux() {
@@ -318,7 +308,8 @@ final class HomepageViewController: UIViewController,
 
             return sectionProvider.createLayoutSection(
                 for: section,
-                with: environment.traitCollection
+                with: environment.traitCollection,
+                size: environment.container.contentSize
             )
         }
         return layout
@@ -647,17 +638,12 @@ final class HomepageViewController: UIViewController,
                 .FirefoxAccountChanged,
                 .TopSitesUpdated,
                 .DefaultSearchEngineUpdated:
-            // To ensure that `numberOfTilesPerRow` is calculated on the main thread
-            mainQueue.ensureMainThread { [weak self] in
-                guard let self else { return }
-                store.dispatch(
-                    TopSitesAction(
-                        numberOfTilesPerRow: self.numberOfTilesPerRow(for: availableWidth),
-                        windowUUID: self.windowUUID,
-                        actionType: TopSitesActionType.fetchTopSites
-                    )
+            store.dispatch(
+                TopSitesAction(
+                    windowUUID: self.windowUUID,
+                    actionType: TopSitesActionType.fetchTopSites
                 )
-            }
+            )
         default: break
         }
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -207,7 +207,7 @@ final class HomepageViewController: UIViewController,
     }
 
     func newState(state: HomepageState) {
-        guard self.homepageState != state else { return }
+        self.homepageState = state
         wallpaperView.wallpaperState = state.wallpaperState
         dataSource?.updateSnapshot(state: state, numberOfCellsPerRow: numberOfTilesPerRow(for: availableWidth))
     }
@@ -308,8 +308,7 @@ final class HomepageViewController: UIViewController,
 
             return sectionProvider.createLayoutSection(
                 for: section,
-                with: environment.traitCollection,
-                size: environment.container.contentSize
+                with: environment.traitCollection
             )
         }
         return layout

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -7,11 +7,9 @@ import Redux
 
 final class HomepageAction: Action {
     var showiPadSetup: Bool?
-    var numberOfTilesPerRow: Int?
 
-    init(showiPadSetup: Bool? = nil, numberOfTilesPerRow: Int? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
+    init(showiPadSetup: Bool? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
         self.showiPadSetup = showiPadSetup
-        self.numberOfTilesPerRow = numberOfTilesPerRow
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesAction.swift
@@ -8,13 +8,11 @@ import Redux
 final class TopSitesAction: Action {
     var topSites: [TopSiteState]?
     var numberOfRows: Int?
-    var numberOfTilesPerRow: Int?
     var isEnabled: Bool?
 
     init(
         topSites: [TopSiteState]? = nil,
         numberOfRows: Int? = nil,
-        numberOfTilesPerRow: Int? = nil,
         isEnabled: Bool? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
@@ -22,7 +20,6 @@ final class TopSitesAction: Action {
         self.isEnabled = isEnabled
         self.topSites = topSites
         self.numberOfRows = numberOfRows
-        self.numberOfTilesPerRow = numberOfTilesPerRow
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
@@ -30,7 +27,6 @@ final class TopSitesAction: Action {
 enum TopSitesActionType: ActionType {
     case fetchTopSites
     case updatedNumberOfRows
-    case updatedNumberOfTilesPerRow
     case toggleShowSectionSetting
     case toggleShowSponsoredSettings
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesDimensionImplementation.swift
@@ -4,12 +4,12 @@
 
 import Common
 
-struct TopSitesDimensionImplementation {
+struct TopSitesDimensionCalculator {
     /// Updates the number of tiles (top sites) per row the user will see. This depends on the UI interface the user has.
     /// - Parameter availableWidth: available width size depending on device
     /// - Parameter leadingInset: padding for top site section
     /// - Parameter cellWidth: width of individual top site tiles
-    func getNumberOfTilesPerRow(availableWidth: CGFloat, leadingInset: CGFloat) -> Int {
+    static func numberOfTilesPerRow(availableWidth: CGFloat, leadingInset: CGFloat) -> Int {
         let cellWidth = HomepageSectionLayoutProvider.UX.TopSitesConstants.cellEstimatedSize.width
         var availableWidth = availableWidth - leadingInset * 2
         var numberOfTiles = 0

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesManager.swift
@@ -28,7 +28,7 @@ protocol TopSitesManagerInterface {
     /// - Parameters:
     ///   - otherSites: Contains the user's pinned sites, history, and default suggested sites.
     ///   - sponsoredSites: Contains the sponsored sites.
-    func recalculateTopSites(otherSites: [TopSiteState], sponsoredSites: [Site]) async -> [TopSiteState]
+    func recalculateTopSites(otherSites: [TopSiteState], sponsoredSites: [Site]) -> [TopSiteState]
 
     /// Removes the site out of the top sites.
     /// If site is pinned it removes it from pinned and top sites list.
@@ -78,12 +78,12 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
         self.maxTopSites = maxTopSites
     }
 
-    func recalculateTopSites(otherSites: [TopSiteState], sponsoredSites: [Site]) async -> [TopSiteState] {
+    func recalculateTopSites(otherSites: [TopSiteState], sponsoredSites: [Site]) -> [TopSiteState] {
         let availableSpaceCount = getAvailableSpaceCount(with: otherSites)
         let googleTopSite = addGoogleTopSite(with: availableSpaceCount)
 
         let updatedSpaceCount = getUpdatedSpaceCount(with: googleTopSite, and: availableSpaceCount)
-        let sponsoredSites = await filterSponsoredSites(contiles: sponsoredSites, with: updatedSpaceCount, and: otherSites)
+        let sponsoredSites = filterSponsoredSites(contiles: sponsoredSites, with: updatedSpaceCount, and: otherSites)
 
         let totalTopSites = googleTopSite + sponsoredSites + otherSites
 
@@ -146,7 +146,7 @@ class TopSitesManager: TopSitesManagerInterface, FeatureFlaggable {
         contiles: [Site],
         with availableSpaceCount: Int,
         and otherSites: [TopSiteState]
-    ) async -> [TopSiteState] {
+    ) -> [TopSiteState] {
         guard availableSpaceCount > 0, shouldLoadSponsoredTiles else { return [] }
 
         guard !contiles.isEmpty else { return [] }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -74,15 +74,15 @@ final class TopSitesMiddleware {
                     self.updateTopSites(
                         for: action.windowUUID,
                         otherSites: self.otherSites,
-                        sponsoredTiles: self.sponsoredTiles
+                        sponsoredTiles: self.sponsoredSites
                     )
                 }
                 group.addTask {
-                    self.sponsoredTiles = await self.topSitesManager.fetchSponsoredSites()
+                    self.sponsoredSites = await self.topSitesManager.fetchSponsoredSites()
                     self.updateTopSites(
                         for: action.windowUUID,
                         otherSites: self.otherSites,
-                        sponsoredTiles: self.sponsoredTiles
+                        sponsoredTiles: self.sponsoredSites
                     )
                 }
 
@@ -90,7 +90,7 @@ final class TopSitesMiddleware {
                 updateTopSites(
                     for: action.windowUUID,
                     otherSites: self.otherSites,
-                    sponsoredTiles: self.sponsoredTiles
+                    sponsoredTiles: self.sponsoredSites
                 )
             }
         }
@@ -99,7 +99,7 @@ final class TopSitesMiddleware {
     private func updateTopSites(
         for windowUUID: WindowUUID,
         otherSites: [TopSiteState],
-        sponsoredTiles: [SponsoredTile]
+        sponsoredTiles: [Site]
     ) {
         let topSites = self.topSitesManager.recalculateTopSites(
             otherSites: otherSites,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesMiddleware.swift
@@ -92,7 +92,7 @@ final class TopSitesMiddleware {
         sponsoredTiles: [Site],
         numberOfTilesPerRow: Int? = nil
     ) async {
-        let topSites = await self.topSitesManager.recalculateTopSites(
+        let topSites = self.topSitesManager.recalculateTopSites(
             otherSites: otherSites,
             sponsoredSites: sponsoredSites
         )

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -14,7 +14,6 @@ struct TopSitesSectionState: StateType, Equatable {
     var windowUUID: WindowUUID
     let topSitesData: [TopSiteState]
     let numberOfRows: Int
-    let numberOfTilesPerRow: Int
     let shouldShowSection: Bool
 
     init(profile: Profile = AppContainer.shared.resolve(), windowUUID: WindowUUID) {
@@ -27,7 +26,6 @@ struct TopSitesSectionState: StateType, Equatable {
             windowUUID: windowUUID,
             topSitesData: [],
             numberOfRows: numberOfRows,
-            numberOfTilesPerRow: HomepageSectionLayoutProvider.UX.TopSitesConstants.minCards,
             shouldShowSection: shouldShowSection
         )
     }
@@ -36,13 +34,11 @@ struct TopSitesSectionState: StateType, Equatable {
         windowUUID: WindowUUID,
         topSitesData: [TopSiteState],
         numberOfRows: Int,
-        numberOfTilesPerRow: Int,
         shouldShowSection: Bool
     ) {
         self.windowUUID = windowUUID
         self.topSitesData = topSitesData
         self.numberOfRows = numberOfRows
-        self.numberOfTilesPerRow = numberOfTilesPerRow
         self.shouldShowSection = shouldShowSection
     }
 
@@ -57,8 +53,6 @@ struct TopSitesSectionState: StateType, Equatable {
             return handleRetrievedUpdatedSitesAction(action: action, state: state)
         case TopSitesActionType.updatedNumberOfRows:
             return handleUpdatedNumberOfRowsAction(action: action, state: state)
-        case TopSitesActionType.updatedNumberOfTilesPerRow:
-            return handleUpdatedNumberOfTilesPerRowAction(action: action, state: state)
         case TopSitesActionType.toggleShowSectionSetting:
             return handleToggleShowSectionSettingAction(action: action, state: state)
         default:
@@ -72,14 +66,12 @@ struct TopSitesSectionState: StateType, Equatable {
         else {
             return defaultState(from: state)
         }
-        let numberOfTilesPerRow = topSitesAction.numberOfTilesPerRow ?? state.numberOfTilesPerRow
-        let filteredSites = filter(sites: sites, with: state.numberOfRows, and: numberOfTilesPerRow)
+
         return TopSitesSectionState(
             windowUUID: state.windowUUID,
-            topSitesData: filteredSites,
+            topSitesData: sites,
             numberOfRows: state.numberOfRows,
-            numberOfTilesPerRow: numberOfTilesPerRow,
-            shouldShowSection: !filteredSites.isEmpty && state.shouldShowSection
+            shouldShowSection: !sites.isEmpty && state.shouldShowSection
         )
     }
 
@@ -90,29 +82,10 @@ struct TopSitesSectionState: StateType, Equatable {
             return defaultState(from: state)
         }
 
-        let filteredSites = filter(sites: state.topSitesData, with: numberOfRows, and: state.numberOfTilesPerRow)
         return TopSitesSectionState(
             windowUUID: state.windowUUID,
-            topSitesData: filteredSites,
+            topSitesData: state.topSitesData,
             numberOfRows: numberOfRows,
-            numberOfTilesPerRow: state.numberOfTilesPerRow,
-            shouldShowSection: state.shouldShowSection
-        )
-    }
-
-    private static func handleUpdatedNumberOfTilesPerRowAction(action: Action, state: Self) -> TopSitesSectionState {
-        guard let topSitesAction = action as? TopSitesAction,
-              let numberOfTilesPerRow = topSitesAction.numberOfTilesPerRow
-        else {
-            return defaultState(from: state)
-        }
-
-        let filteredSites = filter(sites: state.topSitesData, with: state.numberOfRows, and: numberOfTilesPerRow)
-        return TopSitesSectionState(
-            windowUUID: state.windowUUID,
-            topSitesData: filteredSites,
-            numberOfRows: state.numberOfRows,
-            numberOfTilesPerRow: numberOfTilesPerRow,
             shouldShowSection: state.shouldShowSection
         )
     }
@@ -128,23 +101,8 @@ struct TopSitesSectionState: StateType, Equatable {
             windowUUID: state.windowUUID,
             topSitesData: state.topSitesData,
             numberOfRows: state.numberOfRows,
-            numberOfTilesPerRow: state.numberOfTilesPerRow,
             shouldShowSection: isEnabled
         )
-    }
-
-    /// Filters the top sites to be displayed in the view based on user preferences and layout configuration.
-    /// - Parameters:
-    ///   - sites: The full list of sites fetched from the top sites manager.
-    ///   - numberOfRows: The maximum number of rows to display, determined by user preferences or default value.
-    ///   - numberOfTilesPerRow: The number of tiles displayed per row, determined by the view's layout.
-    /// - Returns: A list of top sites to be displayed, limited to the specified number of rows and tiles per row.
-    private static func filter(
-        sites: [TopSiteState],
-        with numberOfRows: Int,
-        and numberOfTilesPerRow: Int
-    ) -> [TopSiteState] {
-        return Array(sites.prefix(numberOfRows * numberOfTilesPerRow))
     }
 
     static func defaultState(from state: TopSitesSectionState) -> TopSitesSectionState {
@@ -152,7 +110,6 @@ struct TopSitesSectionState: StateType, Equatable {
             windowUUID: state.windowUUID,
             topSitesData: state.topSitesData,
             numberOfRows: state.numberOfRows,
-            numberOfTilesPerRow: state.numberOfTilesPerRow,
             shouldShowSection: state.shouldShowSection
         )
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -35,7 +35,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
     func test_updateSnapshot_hasCorrectData() throws {
         let dataSource = try XCTUnwrap(diffableDataSource)
 
-        dataSource.updateSnapshot(state: HomepageState(windowUUID: .XCTestDefaultUUID))
+        dataSource.updateSnapshot(state: HomepageState(windowUUID: .XCTestDefaultUUID), numberOfCellsPerRow: 4)
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfSections, 3)
@@ -73,7 +73,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             )
         )
 
-        dataSource.updateSnapshot(state: updatedState)
+        dataSource.updateSnapshot(state: updatedState, numberOfCellsPerRow: 4)
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(.systemCyan)), 21)
@@ -100,16 +100,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             )
         )
 
-        let finalState = HomepageState.reducer(
-            updatedState,
-            TopSitesAction(
-                numberOfTilesPerRow: 4,
-                windowUUID: .XCTestDefaultUUID,
-                actionType: TopSitesActionType.updatedNumberOfTilesPerRow
-            )
-        )
-
-        dataSource.updateSnapshot(state: finalState)
+        dataSource.updateSnapshot(state: updatedState, numberOfCellsPerRow: 4)
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .topSites(4)), 8)
@@ -128,7 +119,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             )
         )
 
-        dataSource.updateSnapshot(state: state)
+        dataSource.updateSnapshot(state: state, numberOfCellsPerRow: 4)
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil)), 21)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -187,8 +187,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
             overlayManager: mockOverlayManager,
             statusBarScrollDelegate: statusBarScrollDelegate,
             toastContainer: UIView(),
-            notificationCenter: notificationCenter,
-            mainQueue: MockDispatchQueue()
+            notificationCenter: notificationCenter
         )
         trackForMemoryLeaks(homepageViewController)
         return homepageViewController

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Mock/MockTopSitesManager.swift
@@ -28,7 +28,7 @@ final class MockTopSitesManager: TopSitesManagerInterface {
         return contiles.compactMap { Site.createSponsoredSite(fromContile: $0) }
     }
 
-    func recalculateTopSites(otherSites: [TopSiteState], sponsoredSites: [Site]) async -> [TopSiteState] {
+    func recalculateTopSites(otherSites: [TopSiteState], sponsoredSites: [Site]) -> [TopSiteState] {
         recalculateTopSitesCalledCount += 1
         return createSites(subtitle: ": total top sites")
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
@@ -28,7 +28,6 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
     func test_homepageInitializeAction_returnsTopSitesSection() throws {
         let subject = createSubject(topSitesManager: mockTopSitesManager)
         let action = HomepageAction(
-            numberOfTilesPerRow: 4,
             windowUUID: .XCTestDefaultUUID,
             actionType: HomepageActionType.initialize
         )
@@ -50,18 +49,15 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
         let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
-        let numberOfTilesPerRow = try XCTUnwrap(actionsCalled.compactMap { $0.numberOfTilesPerRow } as? [Int])
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 3)
         XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites, .retrievedUpdatedSites])
-        XCTAssertEqual(numberOfTilesPerRow, [4, 4, 4])
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 
     func test_fetchTopSitesAction_returnsTopSitesSection() throws {
         let subject = createSubject(topSitesManager: mockTopSitesManager)
         let action = TopSitesAction(
-            numberOfTilesPerRow: 4,
             windowUUID: .XCTestDefaultUUID,
             actionType: TopSitesActionType.fetchTopSites
         )
@@ -83,11 +79,9 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
         let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
-        let numberOfTilesPerRow = try XCTUnwrap(actionsCalled.compactMap { $0.numberOfTilesPerRow } as? [Int])
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 3)
         XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites, .retrievedUpdatedSites])
-        XCTAssertEqual(numberOfTilesPerRow, [4, 4, 4])
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
@@ -45,13 +45,13 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(mockTopSitesManager.getOtherSitesCalledCount, 1)
         XCTAssertEqual(mockTopSitesManager.fetchSponsoredSitesCalledCount, 1)
-        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 2)
+        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 3)
 
         let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
         let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
-        XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites])
+        XCTAssertEqual(mockStore.dispatchedActions.count, 3)
+        XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites, .retrievedUpdatedSites])
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 
@@ -75,13 +75,13 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(mockTopSitesManager.getOtherSitesCalledCount, 1)
         XCTAssertEqual(mockTopSitesManager.fetchSponsoredSitesCalledCount, 1)
-        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 2)
+        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 3)
 
         let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
         let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
-        XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites])
+        XCTAssertEqual(mockStore.dispatchedActions.count, 3)
+        XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites, .retrievedUpdatedSites])
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
@@ -33,7 +33,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         )
 
         let expectation = XCTestExpectation(description: "All relevant top sites middleware actions are dispatched")
-        expectation.expectedFulfillmentCount = 3
+        expectation.expectedFulfillmentCount = 2
 
         mockStore.dispatchCalled = {
             expectation.fulfill()
@@ -45,13 +45,13 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(mockTopSitesManager.getOtherSitesCalledCount, 1)
         XCTAssertEqual(mockTopSitesManager.fetchSponsoredSitesCalledCount, 1)
-        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 3)
+        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 2)
 
         let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
         let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 3)
-        XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites, .retrievedUpdatedSites])
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
+        XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites])
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 
@@ -63,7 +63,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         )
 
         let expectation = XCTestExpectation(description: "All top sites middleware actions are dispatched")
-        expectation.expectedFulfillmentCount = 3
+        expectation.expectedFulfillmentCount = 2
 
         mockStore.dispatchCalled = {
             expectation.fulfill()
@@ -75,13 +75,13 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(mockTopSitesManager.getOtherSitesCalledCount, 1)
         XCTAssertEqual(mockTopSitesManager.fetchSponsoredSitesCalledCount, 1)
-        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 3)
+        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 2)
 
         let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
         let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 3)
-        XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites, .retrievedUpdatedSites])
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
+        XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites])
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesMiddlewareTests.swift
@@ -33,7 +33,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         )
 
         let expectation = XCTestExpectation(description: "All relevant top sites middleware actions are dispatched")
-        expectation.expectedFulfillmentCount = 2
+        expectation.expectedFulfillmentCount = 3
 
         mockStore.dispatchCalled = {
             expectation.fulfill()
@@ -63,7 +63,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         )
 
         let expectation = XCTestExpectation(description: "All top sites middleware actions are dispatched")
-        expectation.expectedFulfillmentCount = 2
+        expectation.expectedFulfillmentCount = 3
 
         mockStore.dispatchCalled = {
             expectation.fulfill()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
@@ -72,27 +72,6 @@ final class TopsSitesSectionStateTests: XCTestCase {
         XCTAssertEqual(newState.topSitesData.compactMap { $0.title }, [])
     }
 
-    func test_retrievedUpdatedStoriesAction_withNumberOfTilesPerRow_returnsDefaultState() throws {
-        let initialState = createSubject()
-        let reducer = topSiteReducer()
-
-        let exampleTopSites = createSites(count: 15)
-
-        let newState = reducer(
-            initialState,
-            TopSitesAction(
-                topSites: exampleTopSites,
-                numberOfTilesPerRow: 1,
-                windowUUID: .XCTestDefaultUUID,
-                actionType: TopSitesMiddlewareActionType.retrievedUpdatedSites
-            )
-        )
-
-        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertEqual(newState.topSitesData.count, 2)
-        XCTAssertEqual(newState.topSitesData.compactMap { $0.title }, ["Title 0", "Title 1"])
-    }
-
     func test_updatedNumberOfRows_returnsExpectedState() throws {
         let initialState = createSubject()
         let reducer = topSiteReducer()
@@ -108,23 +87,6 @@ final class TopsSitesSectionStateTests: XCTestCase {
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertEqual(newState.numberOfRows, 4)
-    }
-
-    func test_updatedNumberOfTilesPerRow_returnsExpectedState() throws {
-        let initialState = createSubject()
-        let reducer = topSiteReducer()
-
-        let newState = reducer(
-            initialState,
-            TopSitesAction(
-                numberOfTilesPerRow: 8,
-                windowUUID: .XCTestDefaultUUID,
-                actionType: TopSitesActionType.updatedNumberOfTilesPerRow
-            )
-        )
-
-        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertEqual(newState.numberOfTilesPerRow, 8)
     }
 
     func test_toggleShowSectionSetting_withToggleOn_returnsExpectedState() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesDimensionImplementationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesDimensionImplementationTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 @testable import Client
 
-class TopSitesDimensionImplementationTests: XCTestCase {
+class TopSitesDimensionCalculatorTests: XCTestCase {
     struct UX {
         struct DeviceSize {
             static let iPhone14 = CGSize(width: 390, height: 844)
@@ -16,11 +16,10 @@ class TopSitesDimensionImplementationTests: XCTestCase {
     }
 
     func test_getNumberOfTilesPerRow_withPortraitIphone_showsExpectedRowNumber() {
-        let subject = createSubject()
         let trait = MockTraitCollection().getTraitCollection()
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .phone)
 
-        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+        let numberOfTilesPerRow = TopSitesDimensionCalculator.numberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPhone14.width,
             leadingInset: leadingInset
         )
@@ -29,11 +28,10 @@ class TopSitesDimensionImplementationTests: XCTestCase {
     }
 
     func test_getNumberOfTilesPerRow_withLandscapeIphone_showsExpectedRowNumber() {
-        let subject = createSubject()
         let trait = MockTraitCollection().getTraitCollection()
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .phone)
 
-        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+        let numberOfTilesPerRow = TopSitesDimensionCalculator.numberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPhone14.height,
             leadingInset: leadingInset
         )
@@ -42,11 +40,10 @@ class TopSitesDimensionImplementationTests: XCTestCase {
     }
 
     func test_getNumberOfTilesPerRow_withPortraitIpadRegular_showsExpectedRowNumber() {
-        let subject = createSubject()
         let trait = MockTraitCollection().getTraitCollection()
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
 
-        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+        let numberOfTilesPerRow = TopSitesDimensionCalculator.numberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPadAir.width,
             leadingInset: leadingInset
         )
@@ -55,11 +52,10 @@ class TopSitesDimensionImplementationTests: XCTestCase {
     }
 
     func test_getNumberOfTilesPerRow_withLandscapeIpadRegular_showsDefaultRowNumber() {
-        let subject = createSubject()
         let trait = MockTraitCollection().getTraitCollection()
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
 
-        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+        let numberOfTilesPerRow = TopSitesDimensionCalculator.numberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPadAir.height,
             leadingInset: leadingInset
         )
@@ -68,11 +64,10 @@ class TopSitesDimensionImplementationTests: XCTestCase {
     }
 
     func test_getNumberOfTilesPerRow_withPortraitIpadCompact_showsDefaultRowNumber() {
-        let subject = createSubject()
         let trait = MockTraitCollection().getTraitCollection()
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
 
-        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+        let numberOfTilesPerRow = TopSitesDimensionCalculator.numberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPadAirCompactSplit.width,
             leadingInset: leadingInset
         )
@@ -81,20 +76,14 @@ class TopSitesDimensionImplementationTests: XCTestCase {
     }
 
     func test_getNumberOfTilesPerRow_withLandscapeIpadCompact_showsDefaultRowNumber() {
-        let subject = createSubject()
         let trait = MockTraitCollection().getTraitCollection()
         let leadingInset = HomepageSectionLayoutProvider.UX.leadingInset(traitCollection: trait, interfaceIdiom: .pad)
 
-        let numberOfTilesPerRow = subject.getNumberOfTilesPerRow(
+        let numberOfTilesPerRow = TopSitesDimensionCalculator.numberOfTilesPerRow(
             availableWidth: UX.DeviceSize.iPadAirCompactSplit.height,
             leadingInset: leadingInset
         )
 
         XCTAssertEqual(numberOfTilesPerRow, 4)
-    }
-
-    func createSubject() -> TopSitesDimensionImplementation {
-        let subject = TopSitesDimensionImplementation()
-        return subject
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/TopSitesManagerTests.swift
@@ -26,9 +26,9 @@ final class TopSitesManagerTests: XCTestCase {
     }
 
     // MARK: Google Top Site
-    func test_recalculateTopSites_shouldShowGoogle_returnGoogleTopSite() async throws {
+    func test_recalculateTopSites_shouldShowGoogle_returnGoogleTopSite() throws {
         let subject = try createSubject(googleTopSiteManager: MockGoogleTopSiteManager())
-        let topSites = await subject.recalculateTopSites(otherSites: [], sponsoredSites: [])
+        let topSites = subject.recalculateTopSites(otherSites: [], sponsoredSites: [])
 
         XCTAssertEqual(topSites.count, 1)
         XCTAssertEqual(topSites.first?.isPinned, true)
@@ -36,17 +36,17 @@ final class TopSitesManagerTests: XCTestCase {
         XCTAssertEqual(topSites.first?.title, "Google Test")
     }
 
-    func test_recalculateTopSites_noGoogleSiteData_returnNoGoogleTopSite() async throws {
+    func test_recalculateTopSites_noGoogleSiteData_returnNoGoogleTopSite() throws {
         let subject = try createSubject()
-        let topSites = await subject.recalculateTopSites(otherSites: [], sponsoredSites: [])
+        let topSites = subject.recalculateTopSites(otherSites: [], sponsoredSites: [])
 
         XCTAssertEqual(topSites.count, 0)
         XCTAssertNil(topSites.first)
     }
 
-    func test_recalculateTopSites_withOtherSitesAndShouldShowGoogle_returnGoogleTopSite() async throws {
+    func test_recalculateTopSites_withOtherSitesAndShouldShowGoogle_returnGoogleTopSite() throws {
         let subject = try createSubject(googleTopSiteManager: MockGoogleTopSiteManager())
-        let topSites = await subject.recalculateTopSites(
+        let topSites = subject.recalculateTopSites(
             otherSites: createOtherSites(),
             sponsoredSites: createSponsoredSites()
         )
@@ -57,9 +57,9 @@ final class TopSitesManagerTests: XCTestCase {
         XCTAssertEqual(topSites.first?.title, "Google Test")
     }
 
-     func test_recalculateTopSites_withOtherSitesAndNoGoogleSite_returnNoGoogleTopSite() async throws {
+     func test_recalculateTopSites_withOtherSitesAndNoGoogleSite_returnNoGoogleTopSite() throws {
          let subject = try createSubject()
-         let topSites = await subject.recalculateTopSites(
+         let topSites = subject.recalculateTopSites(
             otherSites: createOtherSites(),
             sponsoredSites: createSponsoredSites()
          )
@@ -148,10 +148,10 @@ final class TopSitesManagerTests: XCTestCase {
         XCTAssertEqual(topSites.count, 0)
     }
 
-    func test_recalculateTopSites_shouldShowSponsoredSites_returnOnlyMaxSponsoredSites() async throws {
+    func test_recalculateTopSites_shouldShowSponsoredSites_returnOnlyMaxSponsoredSites() throws {
         // Max contiles is currently at 2, so it should add 2 contiles only.
         let subject = try createSubject()
-        let topSites = await subject.recalculateTopSites(
+        let topSites = subject.recalculateTopSites(
             otherSites: createOtherSites(),
             sponsoredSites: createSponsoredSites()
         )
@@ -174,12 +174,12 @@ final class TopSitesManagerTests: XCTestCase {
         XCTAssertEqual(topSites.compactMap { $0.title }, expectedTitles)
     }
 
-    func test_recalculateTopSites_shouldNotShowSponsoredSites_returnNoSponsoredSites() async throws {
+    func test_recalculateTopSites_shouldNotShowSponsoredSites_returnNoSponsoredSites() throws {
         profile?.prefs.setBool(false, forKey: PrefsKeys.UserFeatureFlagPrefs.SponsoredShortcuts)
 
         let subject = try createSubject()
 
-        let topSites = await subject.recalculateTopSites(
+        let topSites = subject.recalculateTopSites(
             otherSites: [],
             sponsoredSites: createSponsoredSites()
         )
@@ -217,23 +217,23 @@ final class TopSitesManagerTests: XCTestCase {
     }
 
     // MARK: Tiles space calculation
-    func test_recalculateTopSites_maxCountZero_returnNoSites() async throws {
+    func test_recalculateTopSites_maxCountZero_returnNoSites() throws {
         let subject = try createSubject(
             googleTopSiteManager: MockGoogleTopSiteManager(),
             maxCount: 0
         )
 
-        let topSites = await subject.recalculateTopSites(
+        let topSites = subject.recalculateTopSites(
             otherSites: createOtherSites(),
             sponsoredSites: createSponsoredSites()
         )
         XCTAssertEqual(topSites.count, 0)
     }
 
-    func test_recalculateTopSites_noAvailableSpace_returnOnlyPinnedSites() async throws {
+    func test_recalculateTopSites_noAvailableSpace_returnOnlyPinnedSites() throws {
         let subject = try createSubject(googleTopSiteManager: MockGoogleTopSiteManager(), maxCount: 2)
 
-        let topSites = await subject.recalculateTopSites(
+        let topSites = subject.recalculateTopSites(
             otherSites: MockTopSiteHistoryManager.defaultSuccessData.compactMap { TopSiteState(site: $0) },
             sponsoredSites: createSponsoredSites()
         )
@@ -244,10 +244,10 @@ final class TopSitesManagerTests: XCTestCase {
         XCTAssertEqual(topSites.compactMap { $0.site.url }, ["www.mozilla.com", "www.firefox.com"])
     }
 
-    func test_recalculateTopSites_duplicatePinnedTile_doesNotShowDuplicateSponsoredSite() async throws {
+    func test_recalculateTopSites_duplicatePinnedTile_doesNotShowDuplicateSponsoredSite() throws {
         let subject = try createSubject()
 
-        let topSites = await subject.recalculateTopSites(
+        let topSites = subject.recalculateTopSites(
             otherSites: MockTopSiteHistoryManager.duplicateTile.compactMap { TopSiteState(site: $0) },
             sponsoredSites: MockSponsoredProvider.defaultSuccessData.compactMap { Site.createSponsoredSite(fromContile: $0) }
         )
@@ -259,9 +259,9 @@ final class TopSitesManagerTests: XCTestCase {
         XCTAssertEqual(topSites.compactMap { $0.site.url }, ["https://mozilla.com", "https://firefox.com"])
     }
 
-    func test_recalculateTopSites_andNoPinnedSites_returnGoogleAndSponsoredSites() async throws {
+    func test_recalculateTopSites_andNoPinnedSites_returnGoogleAndSponsoredSites() throws {
         let subject = try createSubject(googleTopSiteManager: MockGoogleTopSiteManager(), maxCount: 2)
-        let topSites = await subject.recalculateTopSites(
+        let topSites = subject.recalculateTopSites(
             otherSites: MockTopSiteHistoryManager.noPinnedData.compactMap { TopSiteState(site: $0) },
             sponsoredSites: MockSponsoredProvider.defaultSuccessData.compactMap { Site.createSponsoredSite(fromContile: $0) }
         )
@@ -273,10 +273,10 @@ final class TopSitesManagerTests: XCTestCase {
         XCTAssertEqual(topSites.compactMap { $0.site.url }, ["https://www.google.com/webhp?client=firefox-b-1-m&channel=ts", "https://firefox.com"])
     }
 
-    func test_recalculateTopSites_availableSpace_returnSitesInOrder() async throws {
+    func test_recalculateTopSites_availableSpace_returnSitesInOrder() throws {
         let subject = try createSubject(googleTopSiteManager: MockGoogleTopSiteManager())
 
-        let topSites = await subject.recalculateTopSites(
+        let topSites = subject.recalculateTopSites(
             otherSites: MockTopSiteHistoryManager.defaultSuccessData.compactMap { TopSiteState(site: $0) },
             sponsoredSites: MockSponsoredProvider.defaultSuccessData.compactMap { Site.createSponsoredSite(fromContile: $0) }
         )
@@ -301,10 +301,10 @@ final class TopSitesManagerTests: XCTestCase {
         XCTAssertEqual(topSites.compactMap { $0.site.url }, expectedURLs)
     }
 
-    func test_recalculateTopSites_matchingSponsoredAndHistoryBasedTiles_removeDuplicates() async throws {
+    func test_recalculateTopSites_matchingSponsoredAndHistoryBasedTiles_removeDuplicates() throws {
         let subject = try createSubject()
 
-        let topSites = await subject.recalculateTopSites(
+        let topSites = subject.recalculateTopSites(
             otherSites: MockTopSiteHistoryManager.noPinnedData.compactMap { TopSiteState(site: $0) },
             sponsoredSites: MockSponsoredProvider.defaultSuccessData.compactMap { Site.createSponsoredSite(fromContile: $0) }
         )
@@ -324,7 +324,7 @@ final class TopSitesManagerTests: XCTestCase {
     }
 
     // MARK: - Search engine
-    func test_searchEngine_sponsoredSite_getsRemoved() async throws {
+    func test_searchEngine_sponsoredSite_getsRemoved() throws {
         let searchEngine = OpenSearchEngine(engineID: "Firefox",
                                             shortName: "Firefox",
                                             image: UIImage(),
@@ -336,7 +336,7 @@ final class TopSitesManagerTests: XCTestCase {
             searchEngineManager: MockSearchEnginesManager(searchEngines: [searchEngine])
         )
 
-        let topSites = await subject.recalculateTopSites(
+        let topSites = subject.recalculateTopSites(
             otherSites: [],
             sponsoredSites: MockSponsoredProvider.defaultSuccessData.compactMap { Site.createSponsoredSite(fromContile: $0) }
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11046)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24102)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
In order to display top sites on the homepage we need to know the `NumberOfRows` which is configured via a user setting and `NumberOfCellsPerRow` which is only calculated via the width of the view. It makes sense that `NumberOfRows` would live on the state since it is configurable with information that is outside of the view, but there is really no reason for `NumberOfCellsPerRow` to live on the state since it is only a calculation based on information from the view. This PR attempts to simplify that logic so that `NumberOfCellsPerRow` is removed from the state and actions.

https://github.com/user-attachments/assets/6be4867f-601a-4b6c-aacc-0e02e93ba669

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

