### PR TITLE
 Refactor FXIOS-11071 bookmarks telemetry into it's own struct

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		21E78A7228F9A93100F8D687 /* UIDeviceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E78A7128F9A93100F8D687 /* UIDeviceInterface.swift */; };
 		21EA466A2B04130500AAAB2D /* TabsPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EA46692B04130500AAAB2D /* TabsPanelState.swift */; };
 		21ED80B32AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ED80B22AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift */; };
+		21EEAA192D3852B300595119 /* BookmarksTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EEAA182D3852B300595119 /* BookmarksTelemetry.swift */; };
 		21F2A2D22B0BC85200626AEC /* InactiveTabsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F2A2D12B0BC85200626AEC /* InactiveTabsModel.swift */; };
 		21F2A2D42B0D194A00626AEC /* TabsPanelStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F2A2D32B0D194A00626AEC /* TabsPanelStateTests.swift */; };
 		21FA8FAE2AE856460013B815 /* TabsCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FA8FAD2AE856460013B815 /* TabsCoordinatorTests.swift */; };
@@ -2701,6 +2702,7 @@
 		21E78A7128F9A93100F8D687 /* UIDeviceInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceInterface.swift; sourceTree = "<group>"; };
 		21EA46692B04130500AAAB2D /* TabsPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsPanelState.swift; sourceTree = "<group>"; };
 		21ED80B22AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayDiffableDataSourceTests.swift; sourceTree = "<group>"; };
+		21EEAA182D3852B300595119 /* BookmarksTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksTelemetry.swift; sourceTree = "<group>"; };
 		21F2A2D12B0BC85200626AEC /* InactiveTabsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabsModel.swift; sourceTree = "<group>"; };
 		21F2A2D32B0D194A00626AEC /* TabsPanelStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsPanelStateTests.swift; sourceTree = "<group>"; };
 		21FA8FAD2AE856460013B815 /* TabsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -11582,6 +11584,7 @@
 				0BBC50942CA1F7F900CB7248 /* BookmarksRefactorFeatureFlagProvider.swift */,
 				C7CDBEFC2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift */,
 				0B8BF36F2CA2D60B00E9812D /* BookmarksViewController.swift */,
+				21EEAA182D3852B300595119 /* BookmarksTelemetry.swift */,
 			);
 			path = Bookmarks;
 			sourceTree = "<group>";
@@ -16298,6 +16301,7 @@
 				D04CD74A216CF86B004FF5B0 /* SiriShortcuts.swift in Sources */,
 				EB9A179F20E6C1A200B12184 /* ThemedTableViewController.swift in Sources */,
 				E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */,
+				21EEAA192D3852B300595119 /* BookmarksTelemetry.swift in Sources */,
 				E1A6AB4628CA6A4C00EBEBDD /* String+Extension.swift in Sources */,
 				1D2F68AF2ACB272500524B92 /* RemoteTabsTableViewController.swift in Sources */,
 				ED07C0ED2CCAE745006C0627 /* SearchEngineSelectionAction.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 		21EA466A2B04130500AAAB2D /* TabsPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EA46692B04130500AAAB2D /* TabsPanelState.swift */; };
 		21ED80B32AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ED80B22AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift */; };
 		21EEAA192D3852B300595119 /* BookmarksTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EEAA182D3852B300595119 /* BookmarksTelemetry.swift */; };
+		21EEAA1B2D3AE3B300595119 /* BookmarksTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EEAA1A2D3AE3B300595119 /* BookmarksTelemetryTests.swift */; };
 		21F2A2D22B0BC85200626AEC /* InactiveTabsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F2A2D12B0BC85200626AEC /* InactiveTabsModel.swift */; };
 		21F2A2D42B0D194A00626AEC /* TabsPanelStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F2A2D32B0D194A00626AEC /* TabsPanelStateTests.swift */; };
 		21FA8FAE2AE856460013B815 /* TabsCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FA8FAD2AE856460013B815 /* TabsCoordinatorTests.swift */; };
@@ -2703,6 +2704,7 @@
 		21EA46692B04130500AAAB2D /* TabsPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsPanelState.swift; sourceTree = "<group>"; };
 		21ED80B22AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayDiffableDataSourceTests.swift; sourceTree = "<group>"; };
 		21EEAA182D3852B300595119 /* BookmarksTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksTelemetry.swift; sourceTree = "<group>"; };
+		21EEAA1A2D3AE3B300595119 /* BookmarksTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksTelemetryTests.swift; sourceTree = "<group>"; };
 		21F2A2D12B0BC85200626AEC /* InactiveTabsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabsModel.swift; sourceTree = "<group>"; };
 		21F2A2D32B0D194A00626AEC /* TabsPanelStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsPanelStateTests.swift; sourceTree = "<group>"; };
 		21FA8FAD2AE856460013B815 /* TabsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -10147,6 +10149,7 @@
 				0B7FC3D12CAE811B005C5CCE /* DefaultBookmarksSaverTests.swift */,
 				8AED868228CA3B3400351A50 /* BookmarkPanelViewModelTests.swift */,
 				0B7CF8842CAC1B7000DC02F8 /* Legacy */,
+				21EEAA1A2D3AE3B300595119 /* BookmarksTelemetryTests.swift */,
 			);
 			path = Bookmarks;
 			sourceTree = "<group>";
@@ -17494,6 +17497,7 @@
 				C83B7DD629BBB49D005565C2 /* SurveySurfaceManagerTests.swift in Sources */,
 				E1E6F8CE29D4B7E700068D8D /* GleanPlumbContextProviderTests.swift in Sources */,
 				C8DC90D02A067C5B0008832B /* MarkupParseUtilityTests.swift in Sources */,
+				21EEAA1B2D3AE3B300595119 /* BookmarksTelemetryTests.swift in Sources */,
 				0BA8964C1A250E6500C1010C /* TestBookmarks.swift in Sources */,
 				8AF3B15C2AF99C77009BB262 /* ReadingListPanelTests.swift in Sources */,
 				8AF99B5429EF2AF100108DEC /* MockLogger.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -103,7 +103,8 @@ class BookmarksCoordinator: BaseCoordinator,
     }
 
     func showBookmarkDetail(for node: FxBookmarkNode, folder: FxBookmarkNode, completion: (() -> Void)? = nil) {
-        TelemetryWrapper.recordEvent(category: .action, method: .change, object: .bookmark, value: .bookmarksPanel)
+        let bookmarksTelemetry = BookmarksTelemetry()
+        bookmarksTelemetry.editBookmark(eventLabel: .bookmarksPanel)
         if isBookmarkRefactorEnabled {
             router.push(makeDetailController(for: node, folder: folder))
         } else {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
@@ -11,6 +11,7 @@ import Storage
 class ActionProviderBuilder {
     private var actions = [UIAction]()
     private var taskId = UIBackgroundTaskIdentifier(rawValue: 0)
+    private let bookmarksTelemetry = BookmarksTelemetry()
 
     func build() -> [UIAction] {
         return actions
@@ -44,12 +45,9 @@ class ActionProviderBuilder {
                 title: .ContextMenuBookmarkLink,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
                 identifier: UIAction.Identifier("linkContextMenu.bookmarkLink")
-            ) { _ in
+            ) { [weak self] _ in
                 addBookmark(url.absoluteString, title, nil)
-                TelemetryWrapper.recordEvent(category: .action,
-                                             method: .add,
-                                             object: .bookmark,
-                                             value: .contextMenu)
+                self?.bookmarksTelemetry.addBookmark(eventLabel: .contextMenu)
             }
         )
     }
@@ -60,12 +58,9 @@ class ActionProviderBuilder {
                 title: .RemoveBookmarkContextMenuTitle,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
                 identifier: UIAction.Identifier("linkContextMenu.removeBookmarkLink")
-            ) { _ in
+            ) { [weak self] _ in
                 removeBookmark(url, title, nil)
-                TelemetryWrapper.recordEvent(category: .action,
-                                             method: .delete,
-                                             object: .bookmark,
-                                             value: .contextMenu)
+                self?.bookmarksTelemetry.deleteBookmark(eventLabel: .contextMenu)
             }
         )
     }

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -37,6 +37,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol,
     weak var browserNavigationHandler: BrowserNavigationHandler?
     weak var delegate: ContextHelperDelegate?
     var getPopoverSourceRect: ((UIView?) -> CGRect)?
+    private let bookmarksTelemetry = BookmarksTelemetry()
 
     init(
         viewModel: HomepageViewModel,
@@ -208,8 +209,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol,
 
             let url = URL(string: site.url)
             self.delegate?.homePanelDidRequestBookmarkToast(url: url, action: .remove)
-
-            TelemetryWrapper.recordEvent(category: .action, method: .delete, object: .bookmark, value: .activityStream)
+            self.bookmarksTelemetry.deleteBookmark(eventLabel: .activityStream)
         })
     }
 
@@ -234,8 +234,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol,
             site.setBookmarked(true)
 
             self.delegate?.homePanelDidRequestBookmarkToast(url: nil, action: .add)
-
-            TelemetryWrapper.recordEvent(category: .action, method: .add, object: .bookmark, value: .activityStream)
+            self.bookmarksTelemetry.addBookmark(eventLabel: .activityStream)
         })
     }
 

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -81,7 +81,7 @@ class TopSitesViewModel {
         let isBookmarkedSite = profile.places.isBookmarked(url: homeTopSite.site.url).value.successValue ?? false
         if isBookmarkedSite {
             let bookmarksTelemetry = BookmarksTelemetry()
-            bookmarksTelemetry.openBookmarksSite(eventValue: BookmarksTelemetry.EventLabel.topSites)
+            bookmarksTelemetry.openBookmarksSite(eventLabel: BookmarksTelemetry.EventLabel.topSites)
         }
 
         TelemetryWrapper.recordEvent(category: .action,

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -80,10 +80,8 @@ class TopSitesViewModel {
         // Bookmarks from topSites
         let isBookmarkedSite = profile.places.isBookmarked(url: homeTopSite.site.url).value.successValue ?? false
         if isBookmarkedSite {
-            TelemetryWrapper.recordEvent(category: .action,
-                                         method: .open,
-                                         object: .bookmark,
-                                         value: .openBookmarksFromTopSites)
+            let bookmarksTelemetry = BookmarksTelemetry()
+            bookmarksTelemetry.openBookmarksSite(eventValue: BookmarksTelemetry.EventLabel.topSites)
         }
 
         TelemetryWrapper.recordEvent(category: .action,

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
@@ -11,26 +11,35 @@ struct BookmarksTelemetry {
     enum EventLabel: String {
         case bookmarksPanel = "bookmarks-panel"
         case topSites = "top-sites"
+        case activityStream = "activity-stream"
+        case contextMenu = "page-action-menu"
     }
 
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.gleanWrapper = gleanWrapper
     }
 
-    func addBookmarkFolder() {
-        gleanWrapper.recordEvent(for: GleanMetrics.Bookmarks.folderAdd)
+    func addBookmark(eventLabel: EventLabel) {
+        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.add,
+                                 label: eventLabel.rawValue)
     }
 
-    func deleteBookmark() {
+    func deleteBookmark(eventLabel: EventLabel) {
         gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.delete,
-                                 label: EventLabel.bookmarksPanel.rawValue)
+                                 label: eventLabel.rawValue)
     }
 
     func openBookmarksSite(eventLabel: EventLabel) {
-        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.open, label: eventLabel.rawValue)
+        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.open,
+                                 label: eventLabel.rawValue)
     }
 
     func editBookmark(eventLabel: EventLabel) {
-        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.edit, label: eventLabel.rawValue)
+        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.edit,
+                                 label: eventLabel.rawValue)
     }
+
+     func addBookmarkFolder() {
+         gleanWrapper.recordEvent(for: GleanMetrics.Bookmarks.folderAdd)
+     }
 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
@@ -21,7 +21,7 @@ struct BookmarksTelemetry {
         gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.delete, label: label)
     }
 
-    func openBookmarksPanel(isSwipeGesture: Bool) {
+    func openBookmarksPanel() {
         gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.open, label: label)
     }
 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
@@ -7,7 +7,11 @@ import Glean
 
 struct BookmarksTelemetry {
     private let gleanWrapper: GleanWrapper
-    private let label = "bookmarks-panel"
+
+    enum EventLabel: String {
+        case bookmarksPanel = "bookmarks-panel"
+        case topSites = "top-sites"
+    }
 
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.gleanWrapper = gleanWrapper
@@ -18,10 +22,11 @@ struct BookmarksTelemetry {
     }
 
     func deleteBookmark() {
-        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.delete, label: label)
+        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.delete,
+                                 label: EventLabel.bookmarksPanel.rawValue)
     }
 
-    func openBookmarksPanel() {
-        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.open, label: label)
+    func openBookmarksSite(eventValue: EventLabel) {
+        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.open, label: eventValue.rawValue)
     }
 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
@@ -26,7 +26,11 @@ struct BookmarksTelemetry {
                                  label: EventLabel.bookmarksPanel.rawValue)
     }
 
-    func openBookmarksSite(eventValue: EventLabel) {
-        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.open, label: eventValue.rawValue)
+    func openBookmarksSite(eventLabel: EventLabel) {
+        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.open, label: eventLabel.rawValue)
+    }
+
+    func editBookmark(eventLabel: EventLabel) {
+        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.edit, label: eventLabel.rawValue)
     }
 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+struct BookmarksTelemetry {
+    private let gleanWrapper: GleanWrapper
+    private let label = "bookmarks-panel"
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
+    func addBookmarkFolder() {
+        gleanWrapper.recordEvent(for: GleanMetrics.Bookmarks.folderAdd)
+    }
+
+    func deleteBookmark() {
+        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.delete, label: label)
+    }
+
+    func openBookmarksPanel(isSwipeGesture: Bool) {
+        gleanWrapper.recordLabel(for: GleanMetrics.Bookmarks.open, label: label)
+    }
+}

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -29,6 +29,7 @@ class BookmarksViewController: SiteTableViewController,
     let viewModel: BookmarksPanelViewModel
     var bookmarksSaver: BookmarksSaver?
     private var logger: Logger
+    private let bookmarksTelemetry = BookmarksTelemetry()
 
     // MARK: - Toolbar items
     var bottomToolbarItems: [UIBarButtonItem] {
@@ -556,11 +557,7 @@ class BookmarksViewController: SiteTableViewController,
             guard let strongSelf = self else { completion(false); return }
 
             strongSelf.deleteBookmarkNodeAtIndexPath(indexPath)
-            TelemetryWrapper.recordEvent(category: .action,
-                                         method: .delete,
-                                         object: .bookmark,
-                                         value: .bookmarksPanel,
-                                         extras: ["gesture": "swipe"])
+            strongSelf.bookmarksTelemetry.deleteBookmark()
             completion(true)
         }
 
@@ -737,11 +734,7 @@ extension BookmarksViewController: LibraryPanelContextMenu {
                                                  iconString: StandardImageIdentifiers.Large.bookmarkSlash,
                                                  tapHandler: { _ in
             self.deleteBookmarkNodeAtIndexPath(indexPath)
-            TelemetryWrapper.recordEvent(category: .action,
-                                         method: .delete,
-                                         object: .bookmark,
-                                         value: .bookmarksPanel,
-                                         extras: ["gesture": "long-press"])
+            self.bookmarksTelemetry.deleteBookmark()
         }).items
         actions.append(removeAction)
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -557,7 +557,7 @@ class BookmarksViewController: SiteTableViewController,
             guard let strongSelf = self else { completion(false); return }
 
             strongSelf.deleteBookmarkNodeAtIndexPath(indexPath)
-            strongSelf.bookmarksTelemetry.deleteBookmark()
+            strongSelf.bookmarksTelemetry.deleteBookmark(eventLabel: .bookmarksPanel)
             completion(true)
         }
 
@@ -734,7 +734,7 @@ extension BookmarksViewController: LibraryPanelContextMenu {
                                                  iconString: StandardImageIdentifiers.Large.bookmarkSlash,
                                                  tapHandler: { _ in
             self.deleteBookmarkNodeAtIndexPath(indexPath)
-            self.bookmarksTelemetry.deleteBookmark()
+            self.bookmarksTelemetry.deleteBookmark(eventLabel: .bookmarksPanel)
         }).items
         actions.append(removeAction)
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
@@ -26,7 +26,7 @@ class EditBookmarkCell: UITableViewCell,
         view.distribution = .fillProportionally
         view.spacing = 10.0
     }
-    private lazy var textFieldsDivder: UIView = .build()
+    private lazy var textFieldsDivider: UIView = .build()
     private lazy var titleTextfield: TextField = .build { view in
         view.addAction(UIAction(handler: { [weak self] _ in
             self?.titleTextFieldDidChange()
@@ -36,7 +36,7 @@ class EditBookmarkCell: UITableViewCell,
     private lazy var urlTextfield: TextField = .build { view in
         view.keyboardType = .URL
         view.addAction(UIAction(handler: { [weak self] _ in
-            self?.urlTextFieldDidChane()
+            self?.urlTextFieldDidChange()
         }), for: .editingChanged)
         view.adjustsFontSizeToFitWidth = true
     }
@@ -54,7 +54,7 @@ class EditBookmarkCell: UITableViewCell,
 
     private func setupSubviews() {
         textFieldsContainerView.addArrangedSubview(titleTextfield)
-        textFieldsContainerView.addArrangedSubview(textFieldsDivder)
+        textFieldsContainerView.addArrangedSubview(textFieldsDivider)
         textFieldsContainerView.addArrangedSubview(urlTextfield)
         contentView.addSubviews(faviconImageView, textFieldsContainerView)
 
@@ -70,8 +70,8 @@ class EditBookmarkCell: UITableViewCell,
             faviconImageView.widthAnchor.constraint(equalToConstant: faviconDynamicSize),
             faviconImageView.heightAnchor.constraint(equalToConstant: faviconDynamicSize),
 
-            textFieldsDivder.heightAnchor.constraint(equalToConstant: UX.textFieldDividerHeight),
-            textFieldsDivder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
+            textFieldsDivider.heightAnchor.constraint(equalToConstant: UX.textFieldDividerHeight),
+            textFieldsDivider.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
                                                        constant: -UX.textFieldDividerTrailingPadding),
 
             textFieldsContainerView.leadingAnchor.constraint(equalTo: faviconImageView.trailingAnchor,
@@ -100,11 +100,11 @@ class EditBookmarkCell: UITableViewCell,
     func applyTheme(theme: any Theme) {
         urlTextfield.applyTheme(theme: theme)
         titleTextfield.applyTheme(theme: theme)
-        textFieldsDivder.backgroundColor = theme.colors.borderPrimary
+        textFieldsDivider.backgroundColor = theme.colors.borderPrimary
         backgroundColor = theme.colors.layer5
     }
 
-    private func urlTextFieldDidChane() {
+    private func urlTextFieldDidChange() {
         onURLFieldUpdate?(urlTextfield.text ?? "")
     }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
@@ -72,7 +72,7 @@ class EditBookmarkCell: UITableViewCell,
 
             textFieldsDivider.heightAnchor.constraint(equalToConstant: UX.textFieldDividerHeight),
             textFieldsDivider.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
-                                                       constant: -UX.textFieldDividerTrailingPadding),
+                                                        constant: -UX.textFieldDividerTrailingPadding),
 
             textFieldsContainerView.leadingAnchor.constraint(equalTo: faviconImageView.trailingAnchor,
                                                              constant: UX.textFieldContainerLeadingPadding),

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -12,7 +12,7 @@ class EditBookmarkViewController: UIViewController,
     private struct UX {
         static let bookmarkCellTopPadding: CGFloat = 25.0
         static let folderHeaderIdentifier = "folderHeaderIdentifier"
-        static let folderHeaderHorizzontalPadding: CGFloat = 16.0
+        static let folderHeaderHorizontalPadding: CGFloat = 16.0
         static let folderHeaderBottomPadding: CGFloat = 8.0
     }
 
@@ -273,9 +273,9 @@ class EditBookmarkViewController: UIViewController,
         configuration.textProperties.font = FXFontStyles.Regular.callout.scaledFont()
         configuration.textProperties.color = theme.colors.textSecondary
         let layoutMargins = NSDirectionalEdgeInsets(top: 0,
-                                                    leading: UX.folderHeaderHorizzontalPadding,
+                                                    leading: UX.folderHeaderHorizontalPadding,
                                                     bottom: UX.folderHeaderBottomPadding,
-                                                    trailing: UX.folderHeaderHorizzontalPadding)
+                                                    trailing: UX.folderHeaderHorizontalPadding)
         configuration.directionalLayoutMargins = layoutMargins
         header.contentConfiguration = configuration
         header.directionalLayoutMargins = .zero

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -11,7 +11,7 @@ class EditFolderViewController: UIViewController,
                                 Themeable {
     private struct UX {
         static let editFolderCellTopPadding: CGFloat = 25.0
-        static let parentFolderHeaderHorizzontalPadding: CGFloat = 16.0
+        static let parentFolderHeaderHorizontalPadding: CGFloat = 16.0
         static let parentFolderHeaderBottomPadding: CGFloat = 8.0
         static let parentFolderHeaderIdentifier = "parentFolderHeaderIdentifier"
     }
@@ -246,9 +246,9 @@ class EditFolderViewController: UIViewController,
         configuration.textProperties.font = FXFontStyles.Regular.callout.scaledFont()
         configuration.textProperties.color = theme.colors.textSecondary
         let layoutMargins = NSDirectionalEdgeInsets(top: 0,
-                                                    leading: UX.parentFolderHeaderHorizzontalPadding,
+                                                    leading: UX.parentFolderHeaderHorizontalPadding,
                                                     bottom: UX.parentFolderHeaderBottomPadding,
-                                                    trailing: UX.parentFolderHeaderHorizzontalPadding)
+                                                    trailing: UX.parentFolderHeaderHorizontalPadding)
         configuration.directionalLayoutMargins = layoutMargins
         header.contentConfiguration = configuration
         header.directionalLayoutMargins = .zero

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -105,7 +105,7 @@ extension BookmarkItemData: BookmarksFolderCell {
         }
         libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .bookmark)
         let bookmarksTelemetry = BookmarksTelemetry()
-        bookmarksTelemetry.openBookmarksSite(eventValue: BookmarksTelemetry.EventLabel.bookmarksPanel)
+        bookmarksTelemetry.openBookmarksSite(eventLabel: BookmarksTelemetry.EventLabel.bookmarksPanel)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -105,7 +105,7 @@ extension BookmarkItemData: BookmarksFolderCell {
         }
         libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .bookmark)
         let bookmarksTelemetry = BookmarksTelemetry()
-        bookmarksTelemetry.openBookmarksPanel()
+        bookmarksTelemetry.openBookmarksSite(eventValue: BookmarksTelemetry.EventLabel.bookmarksPanel)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -104,7 +104,8 @@ extension BookmarkItemData: BookmarksFolderCell {
             return
         }
         libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .bookmark)
-        TelemetryWrapper.recordEvent(category: .action, method: .open, object: .bookmark, value: .bookmarksPanel)
+        let bookmarksTelemetry = BookmarksTelemetry()
+        bookmarksTelemetry.openBookmarksPanel()
     }
 }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarkDetailPanel.swift
@@ -379,10 +379,8 @@ class LegacyBookmarkDetailPanel: SiteTableViewController, BookmarksRefactorFeatu
                     return deferMaybe(BookmarkDetailPanelError())
                 }
 
-                TelemetryWrapper.recordEvent(category: .action,
-                                             method: .tap,
-                                             object: .bookmark,
-                                             value: .bookmarkAddFolder)
+                let bookmarksTelemetry = BookmarksTelemetry()
+                bookmarksTelemetry.addBookmarkFolder()
 
                 return profile.places.createFolder(parentGUID: parentBookmarkFolder.guid,
                                                    title: bookmarkItemOrFolderTitle,

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
@@ -549,9 +549,9 @@ extension LegacyBookmarksPanel: LibraryPanelContextMenu {
 
         let removeAction = SingleActionViewModel(title: .RemoveBookmarkContextMenuTitle,
                                                  iconString: StandardImageIdentifiers.Large.bookmarkSlash,
-                                                 tapHandler: { _ in
-            self.deleteBookmarkNodeAtIndexPath(indexPath)
-            self.bookmarksTelemetry.deleteBookmark()
+                                                 tapHandler: { [weak self] _ in
+            self?.deleteBookmarkNodeAtIndexPath(indexPath)
+            self?.bookmarksTelemetry.deleteBookmark()
         }).items
         actions.append(removeAction)
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
@@ -43,6 +43,7 @@ class LegacyBookmarksPanel: SiteTableViewController,
     var state: LibraryPanelMainState
     let viewModel: BookmarksPanelViewModel
     private var logger: Logger
+    private let bookmarksTelemetry = BookmarksTelemetry()
 
     // MARK: - Toolbar items
     var bottomToolbarItems: [UIBarButtonItem] {
@@ -482,11 +483,7 @@ class LegacyBookmarksPanel: SiteTableViewController,
             guard let strongSelf = self else { completion(false); return }
 
             strongSelf.deleteBookmarkNodeAtIndexPath(indexPath)
-            TelemetryWrapper.recordEvent(category: .action,
-                                         method: .delete,
-                                         object: .bookmark,
-                                         value: .bookmarksPanel,
-                                         extras: ["gesture": "swipe"])
+            strongSelf.bookmarksTelemetry.deleteBookmark()
             completion(true)
         }
 
@@ -554,11 +551,7 @@ extension LegacyBookmarksPanel: LibraryPanelContextMenu {
                                                  iconString: StandardImageIdentifiers.Large.bookmarkSlash,
                                                  tapHandler: { _ in
             self.deleteBookmarkNodeAtIndexPath(indexPath)
-            TelemetryWrapper.recordEvent(category: .action,
-                                         method: .delete,
-                                         object: .bookmark,
-                                         value: .bookmarksPanel,
-                                         extras: ["gesture": "long-press"])
+            self.bookmarksTelemetry.deleteBookmark()
         }).items
         actions.append(removeAction)
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
@@ -483,7 +483,7 @@ class LegacyBookmarksPanel: SiteTableViewController,
             guard let strongSelf = self else { completion(false); return }
 
             strongSelf.deleteBookmarkNodeAtIndexPath(indexPath)
-            strongSelf.bookmarksTelemetry.deleteBookmark()
+            strongSelf.bookmarksTelemetry.deleteBookmark(eventLabel: .bookmarksPanel)
             completion(true)
         }
 
@@ -551,7 +551,7 @@ extension LegacyBookmarksPanel: LibraryPanelContextMenu {
                                                  iconString: StandardImageIdentifiers.Large.bookmarkSlash,
                                                  tapHandler: { [weak self] _ in
             self?.deleteBookmarkNodeAtIndexPath(indexPath)
-            self?.bookmarksTelemetry.deleteBookmark()
+            self?.bookmarksTelemetry.deleteBookmark(eventLabel: .bookmarksPanel)
         }).items
         actions.append(removeAction)
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
@@ -137,10 +137,8 @@ struct DefaultBookmarksSaver: BookmarksSaver, BookmarksRefactorFeatureFlagProvid
         guard let folder = bookmark as? BookmarkFolderData else { return deferMaybe(nil) }
 
         if folder.parentGUID == nil {
-            TelemetryWrapper.recordEvent(category: .action,
-                                         method: .tap,
-                                         object: .bookmark,
-                                         value: .bookmarkAddFolder)
+            let bookmarksTelemetry = BookmarksTelemetry()
+            bookmarksTelemetry.addBookmarkFolder()
 
             let position: UInt32? = parentFolderGUID == BookmarkRoots.MobileFolderGUID ? 0 : nil
             return profile.places.createFolder(parentGUID: parentFolderGUID,

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -823,8 +823,6 @@ extension TelemetryWrapper {
             GleanMetrics.Bookmarks.viewList[from.rawValue].add()
         case (.action, .add, .bookmark, let from?, _):
             GleanMetrics.Bookmarks.add[from.rawValue].add()
-        case (.action, .change, .bookmark, let from?, _):
-            GleanMetrics.Bookmarks.edit[from.rawValue].add()
         case(.information, .view, .mobileBookmarks, .doesHaveMobileBookmarks, _):
             GleanMetrics.Bookmarks.hasMobileBookmarks.set(true)
         case(.information, .view, .mobileBookmarks, .doesNotHaveMobileBookmarks, _):

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -823,8 +823,6 @@ extension TelemetryWrapper {
             GleanMetrics.Bookmarks.viewList[from.rawValue].add()
         case (.action, .add, .bookmark, let from?, _):
             GleanMetrics.Bookmarks.add[from.rawValue].add()
-        case (.action, .open, .bookmark, let from?, _):
-            GleanMetrics.Bookmarks.open[from.rawValue].add()
         case (.action, .change, .bookmark, let from?, _):
             GleanMetrics.Bookmarks.edit[from.rawValue].add()
         case(.information, .view, .mobileBookmarks, .doesHaveMobileBookmarks, _):

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -823,8 +823,6 @@ extension TelemetryWrapper {
             GleanMetrics.Bookmarks.viewList[from.rawValue].add()
         case (.action, .add, .bookmark, let from?, _):
             GleanMetrics.Bookmarks.add[from.rawValue].add()
-        case (.action, .delete, .bookmark, let from?, _):
-            GleanMetrics.Bookmarks.delete[from.rawValue].add()
         case (.action, .open, .bookmark, let from?, _):
             GleanMetrics.Bookmarks.open[from.rawValue].add()
         case (.action, .change, .bookmark, let from?, _):
@@ -837,8 +835,6 @@ extension TelemetryWrapper {
             if let quantity = extras?[EventExtraKey.mobileBookmarksQuantity.rawValue] as? Int64 {
                 GleanMetrics.Bookmarks.mobileBookmarksCount.set(quantity)
             }
-        case(.action, .tap, .bookmark, .bookmarkAddFolder, _):
-            GleanMetrics.Bookmarks.folderAdd.record()
         // MARK: Reader Mode
         case (.action, .tap, .readerModeOpenButton, _, _):
             GleanMetrics.ReaderMode.open.add()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarksTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarksTelemetryTests.swift
@@ -23,19 +23,19 @@ final class BookmarksTelemetryTests: XCTestCase {
         super.tearDown()
     }
 
-    func testRecordBookmark_WhenAddedFolder_ThenGleanIsCalled() throws {
-        subject?.addBookmarkFolder()
+    func testRecordBookmark_WhenAddedBookmark_ThenGleanIsCalled() throws {
+        subject?.addBookmark(eventLabel: .bookmarksPanel)
 
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvent as? EventMetricType<NoExtras>)
-        let expectedMetricType = type(of: GleanMetrics.Bookmarks.folderAdd)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvent as? LabeledMetricType<CounterMetricType>)
+        let expectedMetricType = type(of: GleanMetrics.Bookmarks.add)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
-        XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssertEqual(gleanWrapper.recordLabelCalled, 1)
     }
 
     func testRecordBookmark_WhenDeletedBookmark_ThenGleanIsCalled() throws {
-        subject?.deleteBookmark()
+        subject?.deleteBookmark(eventLabel: .bookmarksPanel)
 
         let savedMetric = try XCTUnwrap(gleanWrapper.savedEvent as? LabeledMetricType<CounterMetricType>)
         let expectedMetricType = type(of: GleanMetrics.Bookmarks.delete)
@@ -65,5 +65,16 @@ final class BookmarksTelemetryTests: XCTestCase {
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
         XCTAssertEqual(gleanWrapper.recordLabelCalled, 1)
+    }
+
+    func testRecordBookmark_WhenAddedFolder_ThenGleanIsCalled() throws {
+        subject?.addBookmarkFolder()
+
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvent as? EventMetricType<NoExtras>)
+        let expectedMetricType = type(of: GleanMetrics.Bookmarks.folderAdd)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarksTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarksTelemetryTests.swift
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+import XCTest
+
+@testable import Client
+
+final class BookmarksTelemetryTests: XCTestCase {
+    var subject: BookmarksTelemetry?
+    var gleanWrapper: MockGleanWrapper!
+
+    override func setUp() {
+        super.setUp()
+        gleanWrapper = MockGleanWrapper()
+        subject = BookmarksTelemetry(gleanWrapper: gleanWrapper)
+    }
+
+    override func tearDown() {
+        subject = nil
+        gleanWrapper = nil
+        super.tearDown()
+    }
+
+    func testRecordBookmark_WhenAddedFolder_ThenGleanIsCalled() throws {
+        subject?.addBookmarkFolder()
+
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvent as? EventMetricType<NoExtras>)
+        let expectedMetricType = type(of: GleanMetrics.Bookmarks.folderAdd)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
+    }
+
+    func testRecordBookmark_WhenDeletedBookmark_ThenGleanIsCalled() throws {
+        subject?.deleteBookmark()
+
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvent as? LabeledMetricType<CounterMetricType>)
+        let expectedMetricType = type(of: GleanMetrics.Bookmarks.delete)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(gleanWrapper.recordLabelCalled, 1)
+    }
+
+    func testRecordBookmark_WhenOpenPanel_ThenGleanIsCalled() throws {
+        subject?.openBookmarksSite(eventValue: BookmarksTelemetry.EventLabel.bookmarksPanel)
+
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvent as? LabeledMetricType<CounterMetricType>)
+        let expectedMetricType = type(of: GleanMetrics.Bookmarks.open)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(gleanWrapper.recordLabelCalled, 1)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarksTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarksTelemetryTests.swift
@@ -45,11 +45,22 @@ final class BookmarksTelemetryTests: XCTestCase {
         XCTAssertEqual(gleanWrapper.recordLabelCalled, 1)
     }
 
-    func testRecordBookmark_WhenOpenPanel_ThenGleanIsCalled() throws {
-        subject?.openBookmarksSite(eventValue: BookmarksTelemetry.EventLabel.bookmarksPanel)
+    func testRecordBookmark_WhenOpenedSite_ThenGleanIsCalled() throws {
+        subject?.openBookmarksSite(eventLabel: BookmarksTelemetry.EventLabel.bookmarksPanel)
 
         let savedMetric = try XCTUnwrap(gleanWrapper.savedEvent as? LabeledMetricType<CounterMetricType>)
         let expectedMetricType = type(of: GleanMetrics.Bookmarks.open)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(gleanWrapper.recordLabelCalled, 1)
+    }
+
+    func testRecordBookmark_WhenEditedSite_ThenGleanIsCalled() throws {
+        subject?.editBookmark(eventLabel: .bookmarksPanel)
+
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvent as? LabeledMetricType<CounterMetricType>)
+        let expectedMetricType = type(of: GleanMetrics.Bookmarks.edit)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -16,7 +16,7 @@ class TelemetryWrapperTests: XCTestCase {
         DependencyHelperMock().bootstrapDependencies()
         // Due to changes allow certain custom pings to implement their own opt-out
         // independent of Glean, custom pings may need to be registered manually in
-        // tests in order to puth them in a state in which they can collect data.
+        // tests in order to put them in a state in which they can collect data.
         Glean.shared.registerPings(GleanMetrics.Pings.shared)
         Glean.shared.resetGlean(clearStores: true)
         Experiments.events.clearEvents()
@@ -29,15 +29,6 @@ class TelemetryWrapperTests: XCTestCase {
     }
 
     // MARK: - Bookmarks
-
-    func test_userAddedBookmarkFolder_GleanIsCalled() {
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .tap,
-                                     object: .bookmark,
-                                     value: .bookmarkAddFolder)
-
-        testEventMetricRecordingSuccess(metric: GleanMetrics.Bookmarks.folderAdd)
-    }
 
     func test_hasMobileBookmarks_GleanIsCalled() {
         TelemetryWrapper.recordEvent(category: .information,
@@ -75,18 +66,6 @@ class TelemetryWrapperTests: XCTestCase {
         testQuantityMetricSuccess(metric: GleanMetrics.Bookmarks.mobileBookmarksCount,
                                   expectedValue: 13,
                                   failureMessage: "Incorrect mobile bookmarks quantity returned.")
-    }
-
-    func test_topSitesTileIsBookmarked_GleanIsCalled() {
-        TelemetryWrapper.recordEvent(category: .action,
-                                     method: .open,
-                                     object: .bookmark,
-                                     value: .openBookmarksFromTopSites)
-
-        testLabeledMetricSuccess(metric: GleanMetrics.Bookmarks.open)
-
-        let label = TelemetryWrapper.EventValue.openBookmarksFromTopSites.rawValue
-        XCTAssertNotNil(GleanMetrics.Bookmarks.open[label].testGetValue())
     }
 
     // MARK: - Top Site


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11071)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24145)

## :bulb: Description
WIP I have moved some events to `BookmarksTelemetry` struct I'm opening the PR as a draft to gather feedback before working on the rest of events

- Create `BookmarksTelemetry` struct 
- Replace telemetry calls to add bookmarks folder, open bookmark site and delete bookmarks from `TelemetryWrapper` to the `BookmarksTelemetry` functions
- Add unit test

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

