### PR TITLE
Refactor FXIOS-11023 [Glean] Use glean wrapper for DefaultShareTelemetry

### DIFF
--- a/firefox-ios/Client/Frontend/Share/ShareTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTelemetry.swift
@@ -16,6 +16,12 @@ protocol ShareTelemetry {
 }
 
 struct DefaultShareTelemetry: ShareTelemetry {
+    private let gleanWrapper: gleanWrapper
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
     func sharedTo(
         activityType: UIActivity.ActivityType?,
         shareType: ShareType,
@@ -30,6 +36,6 @@ struct DefaultShareTelemetry: ShareTelemetry {
             isOptedInSentFromFirefox: isOptedInSentFromFirefox,
             shareType: shareType.typeName
         )
-        GleanMetrics.ShareSheet.sharedTo.record(extra)
+        gleanWrapper.recordEvent(for: GleanMetrics.ShareSheet.sharedTo, extras: extra)
     }
 }

--- a/firefox-ios/Client/Frontend/Share/ShareTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTelemetry.swift
@@ -16,7 +16,7 @@ protocol ShareTelemetry {
 }
 
 struct DefaultShareTelemetry: ShareTelemetry {
-    private let gleanWrapper: gleanWrapper
+    private let gleanWrapper: GleanWrapper
 
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.gleanWrapper = gleanWrapper

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
@@ -138,6 +138,6 @@ final class ShareTelemetryTests: XCTestCase {
     }
 
     func createSubject() -> ShareTelemetry {
-        return DefaultShareTelemetry(gleanWrapper: gleanWrapper)
+        return DefaultShareTelemetry(gleanWrapper: GleanWrapper)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareTelemetryTests.swift
@@ -9,6 +9,7 @@ import XCTest
 
 final class ShareTelemetryTests: XCTestCase {
     private let testWebURL = URL(string: "https://mozilla.org")!
+    var gleanWrapper: MockGleanWrapper!
 
     // For telemetry extras
     let activityIdentifierKey = "activity_identifier"
@@ -19,11 +20,7 @@ final class ShareTelemetryTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        // Due to changes allow certain custom pings to implement their own opt-out
-        // independent of Glean, custom pings may need to be registered manually in
-        // tests in order to puth them in a state in which they can collect data.
-        Glean.shared.registerPings(GleanMetrics.Pings.shared)
-        Glean.shared.resetGlean(clearStores: true)
+        gleanWrapper = MockGleanWrapper()
     }
 
     func testSharedTo_withNoActivityType() throws {
@@ -42,14 +39,27 @@ final class ShareTelemetryTests: XCTestCase {
             isOptedInSentFromFirefox: testIsOptedInSentFromFirefox
         )
 
-        testEventMetricRecordingSuccess(metric: GleanMetrics.ShareSheet.sharedTo)
+        let savedEvent = try XCTUnwrap(
+            gleanWrapper.savedEvent as? EventMetricType<GleanMetrics.ShareSheet.SharedToExtra>
+        )
 
-        let resultValue = try XCTUnwrap(GleanMetrics.ShareSheet.sharedTo.testGetValue())
-        XCTAssertEqual(resultValue[0].extra?[activityIdentifierKey], "unknown")
-        XCTAssertEqual(resultValue[0].extra?[shareTypeKey], testShareType.typeName)
-        XCTAssertEqual(resultValue[0].extra?[hasShareMessageKey], String(testHasShareMessage))
-        XCTAssertEqual(resultValue[0].extra?[hasIsEnrolledInSentFromFirefoxKey], String(testIsEnrolledInSentFromFirefox))
-        XCTAssertEqual(resultValue[0].extra?[hasIsOptedInSentFromFirefoxKey], String(testIsOptedInSentFromFirefox))
+        let savedExtras = try XCTUnwrap(
+            gleanWrapper.savedExtras as? GleanMetrics.ShareSheet.SharedToExtra
+        )
+
+        let extraRecord = savedExtras.toExtraRecord()
+
+        let expectedMetricType = type(of: GleanMetrics.ShareSheet.sharedTo)
+        let resultMetricType = type(of: savedEvent)
+
+        let message = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+        XCTAssert(resultMetricType == expectedMetricType, message.text)
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(extraRecord[activityIdentifierKey], "unknown")
+        XCTAssertEqual(extraRecord[shareTypeKey], testShareType.typeName)
+        XCTAssertEqual(extraRecord[hasShareMessageKey], String(testHasShareMessage))
+        XCTAssertEqual(extraRecord[hasIsEnrolledInSentFromFirefoxKey], String(testIsEnrolledInSentFromFirefox))
+        XCTAssertEqual(extraRecord[hasIsOptedInSentFromFirefoxKey], String(testIsOptedInSentFromFirefox))
     }
 
     func testSharedTo_withActivityType() throws {
@@ -68,14 +78,25 @@ final class ShareTelemetryTests: XCTestCase {
             isOptedInSentFromFirefox: testIsOptedInSentFromFirefox
         )
 
-        testEventMetricRecordingSuccess(metric: GleanMetrics.ShareSheet.sharedTo)
+        let savedEvent = try XCTUnwrap(
+            gleanWrapper.savedEvent as? EventMetricType<GleanMetrics.ShareSheet.SharedToExtra>
+        )
+        let savedExtras = try XCTUnwrap(
+            gleanWrapper.savedExtras as? GleanMetrics.ShareSheet.SharedToExtra
+        )
+        let extraRecord = savedExtras.toExtraRecord()
 
-        let resultValue = try XCTUnwrap(GleanMetrics.ShareSheet.sharedTo.testGetValue())
-        XCTAssertEqual(resultValue[0].extra?[activityIdentifierKey], testActivityType.rawValue)
-        XCTAssertEqual(resultValue[0].extra?[shareTypeKey], testShareType.typeName)
-        XCTAssertEqual(resultValue[0].extra?[hasShareMessageKey], String(testHasShareMessage))
-        XCTAssertEqual(resultValue[0].extra?[hasIsEnrolledInSentFromFirefoxKey], String(testIsEnrolledInSentFromFirefox))
-        XCTAssertEqual(resultValue[0].extra?[hasIsOptedInSentFromFirefoxKey], String(testIsOptedInSentFromFirefox))
+        let expectedMetricType = type(of: GleanMetrics.ShareSheet.sharedTo)
+        let resultMetricType = type(of: savedEvent)
+
+        let message = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+        XCTAssert(resultMetricType == expectedMetricType, message.text)
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(extraRecord[activityIdentifierKey], testActivityType.rawValue)
+        XCTAssertEqual(extraRecord[shareTypeKey], testShareType.typeName)
+        XCTAssertEqual(extraRecord[hasShareMessageKey], String(testHasShareMessage))
+        XCTAssertEqual(extraRecord[hasIsEnrolledInSentFromFirefoxKey], String(testIsEnrolledInSentFromFirefox))
+        XCTAssertEqual(extraRecord[hasIsOptedInSentFromFirefoxKey], String(testIsOptedInSentFromFirefox))
     }
 
     func testSharedTo_enrolledAndOptedInSentFromFirefox() throws {
@@ -94,17 +115,29 @@ final class ShareTelemetryTests: XCTestCase {
             isOptedInSentFromFirefox: testIsOptedInSentFromFirefox
         )
 
-        testEventMetricRecordingSuccess(metric: GleanMetrics.ShareSheet.sharedTo)
+        let savedEvent = try XCTUnwrap(
+            gleanWrapper.savedEvent as? EventMetricType<GleanMetrics.ShareSheet.SharedToExtra>
+        )
+        let savedExtras = try XCTUnwrap(
+            gleanWrapper.savedExtras as? GleanMetrics.ShareSheet.SharedToExtra
+        )
 
-        let resultValue = try XCTUnwrap(GleanMetrics.ShareSheet.sharedTo.testGetValue())
-        XCTAssertEqual(resultValue[0].extra?[activityIdentifierKey], testActivityType.rawValue)
-        XCTAssertEqual(resultValue[0].extra?[shareTypeKey], testShareType.typeName)
-        XCTAssertEqual(resultValue[0].extra?[hasShareMessageKey], String(testHasShareMessage))
-        XCTAssertEqual(resultValue[0].extra?[hasIsEnrolledInSentFromFirefoxKey], String(testIsEnrolledInSentFromFirefox))
-        XCTAssertEqual(resultValue[0].extra?[hasIsOptedInSentFromFirefoxKey], String(testIsOptedInSentFromFirefox))
+        let extraRecord = savedExtras.toExtraRecord()
+
+        let expectedMetricType = type(of: GleanMetrics.ShareSheet.sharedTo)
+        let resultMetricType = type(of: savedEvent)
+
+        let message = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+        XCTAssert(resultMetricType == expectedMetricType, message.text)
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(extraRecord[activityIdentifierKey], testActivityType.rawValue)
+        XCTAssertEqual(extraRecord[shareTypeKey], testShareType.typeName)
+        XCTAssertEqual(extraRecord[hasShareMessageKey], String(testHasShareMessage))
+        XCTAssertEqual(extraRecord[hasIsEnrolledInSentFromFirefoxKey], String(testIsEnrolledInSentFromFirefox))
+        XCTAssertEqual(extraRecord[hasIsOptedInSentFromFirefoxKey], String(testIsOptedInSentFromFirefox))
     }
 
     func createSubject() -> ShareTelemetry {
-        return DefaultShareTelemetry()
+        return DefaultShareTelemetry(gleanWrapper: gleanWrapper)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11023)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24072)

## :bulb: Description
Updated DefaultShareTelemetry + unit tests to use glean wrapper.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

