### PR TITLE
Bugfix FXIOS-10651 ⁃ [Trust Panel] The trust panel sheet is misaligned with notched displays in landscape mode

### DIFF
--- a/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
@@ -92,6 +92,7 @@ class EnhancedTrackingProtectionCoordinator: BaseCoordinator,
                 }
                 enhancedTrackingProtectionMenuVC.asPopover = true
                 guard let trackingProtectionNavController = trackingProtectionNavController else { return }
+                trackingProtectionNavController.sheetPresentationController?.prefersEdgeAttachedInCompactHeight = true
                 router.present(trackingProtectionNavController, animated: true, completion: nil)
             } else {
                 guard let trackingProtectionNavController = trackingProtectionNavController else { return }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10651)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23307)

## :bulb: Description
Fixed ETP screen in landscape mode

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

