### PR TITLE
Refactor FXIOS-10713 [Sponsored tiles] Turning unified ads to false in Beta v135

### DIFF
--- a/firefox-ios/nimbus-features/unifiedAds.yaml
+++ b/firefox-ios/nimbus-features/unifiedAds.yaml
@@ -12,7 +12,7 @@ features:
     defaults:
       - channel: beta
         value:
-          enabled: true
+          enabled: false
       - channel: developer
         value:
           enabled: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10713)

## :bulb: Description
Further changes needed on the API, it will be released in v136. This PR ensures we use the old Sponsored tile endpoint in Beta for v135.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

