### PR TITLE
Bugfix MTE-4133 Enable retries in fastlane

### DIFF
--- a/firefox-ios/l10n-screenshots.sh
+++ b/firefox-ios/l10n-screenshots.sh
@@ -34,7 +34,7 @@ for lang in $LOCALES; do
     echo "$(date) Snapshotting $lang"
     mkdir "l10n-screenshots/$lang"
     fastlane snapshot --project firefox-ios/Client.xcodeproj --scheme L10nSnapshotTests \
-        --number_of_retries 0 \
+        --number_of_retries 3 \
         --skip_open_summary \
         --xcargs "-maximum-parallel-testing-workers 2" \
         --derived_data_path l10n-screenshots-dd \
@@ -46,7 +46,7 @@ for lang in $LOCALES; do
     if [ "$?" != "0" ]; then
         echo "Fastlane exited with code: $?"
         exit $?
-    elif grep -q "** TEST FAILED **"; then
+    elif grep -q "TEST FAILED" "output.txt"; then
         echo "Test/compilation failed"
         exit 1
     elif grep -q "Caught error" "output.txt"; then


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4133)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
`number_of_retries` is default to `1`. Let's enable retries so that we will get some screenshots in just in case of flaky tests.

See https://docs.fastlane.tools/actions/snapshot/ for the default values

Bitrise L10nBuild workflow: https://app.bitrise.io/build/bc7e1954-3780-4157-afeb-51e10ad9ff3d?tab=log

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

