### PR TITLE
Refactor FXIOS-11120 #24247 [Sponsored tiles] Ensure we use production endpoint in beta

### DIFF
--- a/firefox-ios/Client/FeatureFlags/CoreFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/CoreFlaggableFeature.swift
@@ -13,7 +13,6 @@ enum CoreFeatureFlagID {
     case adjustEnvironmentProd
     case useMockData
     case useStagingContileAPI
-    case useStagingSponsoredPocketStoriesAPI
     case useStagingFakespotAPI
 }
 

--- a/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
+++ b/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
@@ -158,15 +158,11 @@ class LegacyFeatureFlagsManager: HasNimbusFeatureFlags {
         coreFeatures[.useMockData] = useMockData
 
         let useStagingContileAPI = CoreFlaggableFeature(withID: .useStagingContileAPI,
-                                                        enabledFor: [.beta, .developer])
-        let useStagingSponsoredPocketStoriesAPI = CoreFlaggableFeature(withID: .useStagingSponsoredPocketStoriesAPI,
-                                                                       enabledFor: [.beta, .developer])
-
+                                                        enabledFor: [.developer])
         let useStagingFakespotAPI = CoreFlaggableFeature(withID: .useStagingFakespotAPI,
                                                          enabledFor: [])
 
         coreFeatures[.useStagingContileAPI] = useStagingContileAPI
-        coreFeatures[.useStagingSponsoredPocketStoriesAPI] = useStagingSponsoredPocketStoriesAPI
         coreFeatures[.useStagingFakespotAPI] = useStagingFakespotAPI
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11120)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24247)

## :bulb: Description
Ensure we use production endpoint in beta + cleanup `useStagingSponsoredPocketStoriesAPI` which turns out we are not using.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

