### PR TITLE
Bugfix FXIOS-11127 ⁃ [Felt privacy - unified panel] - ETP toggle is disabled when tapping on secure connection and returning to panel

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -147,6 +147,7 @@ class TrackingProtectionViewController: UIViewController,
         setupNotifications(forObserver: self,
                            observing: [.DynamicFontChanged])
         scrollView.delegate = self
+        updateViewDetails()
     }
 
     override func viewDidLayoutSubviews() {
@@ -160,7 +161,8 @@ class TrackingProtectionViewController: UIViewController,
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        updateViewDetails()
+        updateBlockedTrackersCount()
+        updateConnectionStatus()
         applyTheme()
         getCertificates(for: model.url) { [weak self] certificates in
             if let certificates {
@@ -436,9 +438,6 @@ class TrackingProtectionViewController: UIViewController,
         headerContainer.setupDetails(subtitle: model.websiteTitle,
                                      title: model.displayTitle,
                                      icon: headerIcon)
-
-        updateBlockedTrackersCount()
-        updateConnectionStatus()
 
         toggleView.setupDetails(isOn: !model.isURLSafelisted())
         model.isProtectionEnabled = toggleView.toggleIsOn


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11127)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24262)

## :bulb: Description
Fixed ETP toggle when navigate to another ETP screen

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

