### PR TITLE
Add FXIOS-11132 [Homepage] [Message] initial state + view for message card

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1075,6 +1075,9 @@
 		8AEAD9F32C3D7B3E001A2C5A /* FeatureFlagsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEAD9F22C3D7B3E001A2C5A /* FeatureFlagsSettings.swift */; };
 		8AEAD9F52C3D7BA9001A2C5A /* FeatureFlagsDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEAD9F42C3D7BA9001A2C5A /* FeatureFlagsDebugViewController.swift */; };
 		8AEAD9F92C3DB0CD001A2C5A /* MicrosurveyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEAD9F62C3DB0BF001A2C5A /* MicrosurveyTests.swift */; };
+		8AED23042D40002D000FF624 /* MessageCardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED23032D40002A000FF624 /* MessageCardState.swift */; };
+		8AED23062D400098000FF624 /* HomepageMessageCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED23052D400098000FF624 /* HomepageMessageCardCell.swift */; };
+		8AED23082D4012B8000FF624 /* MessageCardStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED23072D4012B1000FF624 /* MessageCardStateTests.swift */; };
 		8AED23C527AC1F9500DE7E97 /* BaseAlphaStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED23C427AC1F9500DE7E97 /* BaseAlphaStackView.swift */; };
 		8AED868328CA3B3400351A50 /* BookmarkPanelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED868228CA3B3400351A50 /* BookmarkPanelViewModelTests.swift */; };
 		8AEDB11529F9F00400F2A53B /* SceneContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEDB11429F9F00400F2A53B /* SceneContainer.swift */; };
@@ -7899,6 +7902,9 @@
 		8AEAD9F22C3D7B3E001A2C5A /* FeatureFlagsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsSettings.swift; sourceTree = "<group>"; };
 		8AEAD9F42C3D7BA9001A2C5A /* FeatureFlagsDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsDebugViewController.swift; sourceTree = "<group>"; };
 		8AEAD9F62C3DB0BF001A2C5A /* MicrosurveyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyTests.swift; sourceTree = "<group>"; };
+		8AED23032D40002A000FF624 /* MessageCardState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardState.swift; sourceTree = "<group>"; };
+		8AED23052D400098000FF624 /* HomepageMessageCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageMessageCardCell.swift; sourceTree = "<group>"; };
+		8AED23072D4012B1000FF624 /* MessageCardStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardStateTests.swift; sourceTree = "<group>"; };
 		8AED23C427AC1F9500DE7E97 /* BaseAlphaStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAlphaStackView.swift; sourceTree = "<group>"; };
 		8AED868228CA3B3400351A50 /* BookmarkPanelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkPanelViewModelTests.swift; sourceTree = "<group>"; };
 		8AEDB11429F9F00400F2A53B /* SceneContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneContainer.swift; sourceTree = "<group>"; };
@@ -11722,6 +11728,7 @@
 		8A552AC22CB43A7000564C98 /* Redux */ = {
 			isa = PBXGroup;
 			children = (
+				8AED23072D4012B1000FF624 /* MessageCardStateTests.swift */,
 				8AEF41612D15EDBA0013925D /* TopSitesMiddlewareTests.swift */,
 				8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */,
 				8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */,
@@ -11856,6 +11863,7 @@
 		8A7D08E12CAAF79F0035999C /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
+				8AED23022D400020000FF624 /* MessageCard */,
 				8A62B15B2CED40800045F46E /* ContextMenu */,
 				8A454D3D2CB9B896009436D9 /* TopSites */,
 				8A454D2A2CB7079A009436D9 /* Header */,
@@ -12306,6 +12314,15 @@
 				8AE9FD252CF662FF001053EE /* UnifiedAdsProvider.swift */,
 			);
 			path = UnifiedAds;
+			sourceTree = "<group>";
+		};
+		8AED23022D400020000FF624 /* MessageCard */ = {
+			isa = PBXGroup;
+			children = (
+				8AED23032D40002A000FF624 /* MessageCardState.swift */,
+				8AED23052D400098000FF624 /* HomepageMessageCardCell.swift */,
+			);
+			path = MessageCard;
 			sourceTree = "<group>";
 		};
 		8AED23C327AC1F8700DE7E97 /* Components */ = {
@@ -16544,6 +16561,7 @@
 				96C11E9B2864C2DD00840E7C /* DependencyHelper.swift in Sources */,
 				8CE1E4382B8C76C80026530B /* LoginListViewModel.swift in Sources */,
 				0B8BF3722CA2DA4600E9812D /* EditBookmarkViewController.swift in Sources */,
+				8AED23042D40002D000FF624 /* MessageCardState.swift in Sources */,
 				F18859502A3E454E0004AA7B /* EnhancedTrackingProtectionCoordinator.swift in Sources */,
 				2386E4E624F8358E0072EF17 /* HomepageMessageCard.swift in Sources */,
 				21618A8C2A438A0900A5189E /* ActiveScreenAction.swift in Sources */,
@@ -16564,6 +16582,7 @@
 				39F4C10A2045DB2E00746155 /* FocusHelper.swift in Sources */,
 				E4CD9F2D1A6DC91200318571 /* TabLocationView.swift in Sources */,
 				81CAE4DB2B1A2C220040C78A /* BrowserViewControllerState.swift in Sources */,
+				8AED23062D400098000FF624 /* HomepageMessageCardCell.swift in Sources */,
 				C8BD87602A0C248000CD803A /* OnboardingButtonsModel.swift in Sources */,
 				0BB5B2881AC0A2B90052877D /* SnackBar.swift in Sources */,
 				E1442FCF294782D9003680B0 /* UIView+Screenshot.swift in Sources */,
@@ -17328,6 +17347,7 @@
 				8C8D8C7A2AA067AD00490D32 /* FakespotCoordinatorTests.swift in Sources */,
 				C8E531CA29E5F7D300E03FEF /* URLScannerTests.swift in Sources */,
 				5AC7110729F822E60011ED11 /* MockTabSessionStore.swift in Sources */,
+				8AED23082D4012B8000FF624 /* MessageCardStateTests.swift in Sources */,
 				8AEE284B276A973400C7104D /* RatingPromptManagerTests.swift in Sources */,
 				8AF10D9129D7761A0086351D /* MockLaunchScreenManager.swift in Sources */,
 				5A9A09D828B2E8F000B6F51E /* MockHistoryDeletionProtocol.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -15,6 +15,7 @@ final class HomepageDiffableDataSource:
     typealias NumberOfTilesPerRow = Int
     enum HomeSection: Hashable {
         case header
+        case messageCard
         case topSites(NumberOfTilesPerRow)
         case pocket(TextColor?)
         case customizeHomepage
@@ -22,6 +23,7 @@ final class HomepageDiffableDataSource:
 
     enum HomeItem: Hashable {
         case header(HeaderState)
+        case messageCard(MessageCardState)
         case topSite(TopSiteState, TextColor?)
         case topSiteEmpty
         case pocket(PocketStoryState)
@@ -31,6 +33,7 @@ final class HomepageDiffableDataSource:
         static var cellTypes: [ReusableCell.Type] {
             return [
                 HomepageHeaderCell.self,
+                HomepageMessageCardCell.self,
                 TopSiteCell.self,
                 EmptyTopSiteCell.self,
                 PocketStandardCell.self,
@@ -47,6 +50,10 @@ final class HomepageDiffableDataSource:
 
         snapshot.appendSections([.header])
         snapshot.appendItems([.header(state.headerState)], toSection: .header)
+
+        // TODO: FXIOS-11133 - Handle whether to show / hide message card from message card manager
+        snapshot.appendSections([.messageCard])
+        snapshot.appendItems([.messageCard(state.messageState)], toSection: .messageCard)
 
         if let topSites = getTopSites(with: state.topSitesState, and: textColor) {
             snapshot.appendSections([.topSites(state.topSitesState.numberOfTilesPerRow)])

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -72,6 +72,8 @@ final class HomepageSectionLayoutProvider {
         switch section {
         case .header:
             return createHeaderSectionLayout(for: traitCollection)
+        case .messageCard:
+            return createMessageCardSectionLayout(for: traitCollection)
         case .topSites(let numberOfTilesPerRow):
             return createTopSitesSectionLayout(
                 for: traitCollection,
@@ -103,6 +105,27 @@ final class HomepageSectionLayoutProvider {
             leading: leadingInset,
             bottom: UX.HeaderConstants.bottomSpacing,
             trailing: leadingInset)
+
+        return section
+    }
+
+    private func createMessageCardSectionLayout(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                              heightDimension: .estimated(180))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                               heightDimension: .estimated(180))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
+
+        let section = NSCollectionLayoutSection(group: group)
+
+        let horizontalInset = UX.leadingInset(traitCollection: traitCollection)
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: horizontalInset,
+            bottom: UX.spacingBetweenSections,
+            trailing: horizontalInset)
 
         return section
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -366,6 +366,16 @@ final class HomepageViewController: UIViewController,
 
             return headerCell
 
+        case .messageCard(let state):
+            guard let messageCardCell = collectionView?.dequeueReusableCell(
+                cellType: HomepageMessageCardCell.self,
+                for: indexPath
+            ) else {
+                return UICollectionViewCell()
+            }
+
+            messageCardCell.configure(state: state, theme: currentTheme)
+            return messageCardCell
         case .topSite(let site, let textColor):
             guard let topSiteCell = collectionView?.dequeueReusableCell(cellType: TopSiteCell.self, for: indexPath) else {
                 return UICollectionViewCell()

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/HomepageMessageCardCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/HomepageMessageCardCell.swift
@@ -7,12 +7,12 @@ import ComponentLibrary
 import Shared
 import UIKit
 
-/// The Legacy Home Tab Banner is the card that appears at the top of the Firefox Homepage.
+/// The card that appears at the top of the Firefox Homepage and is powered by the mobile messaging system.
 ///
-/// The Legacy HomeTabBanner is one UI surface that is being targeted for experimentation with `GleanPlumb` AKA Messaging.
+/// This UI surface is being targeted for experimentation with `GleanPlumb` AKA Messaging.
 /// When there are GleanPlumbMessages, the card will get populated with that data. Otherwise, we'll continue showing the
 /// default browser message AKA the evergreen.
-class LegacyHomepageMessageCardCell: UICollectionViewCell, ReusableCell {
+class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
     typealias a11y = AccessibilityIdentifiers.FirefoxHomepage.HomeTabBanner
     typealias BannerCopy = String.FirefoxHomepage.HomeTabBanner.EvergreenMessage
 
@@ -25,10 +25,14 @@ class LegacyHomepageMessageCardCell: UICollectionViewCell, ReusableCell {
         static let standardSpacing: CGFloat = 16
         static let topCardSafeSpace: CGFloat = 16
         static let bottomCardSafeSpace: CGFloat = 32
+
+        // Shadow
+        static let shadowRadius: CGFloat = 4
+        static let shadowOffset = CGSize(width: 0, height: 2)
+        static let shadowOpacity: Float = 1 // shadow opacity set to 0.16 through shadowDefault themed color
     }
 
     // MARK: - Properties
-    private var viewModel: HomepageMessageCardViewModel?
     private var kvoToken: NSKeyValueObservation?
 
     // MARK: - UI
@@ -93,13 +97,8 @@ class LegacyHomepageMessageCardCell: UICollectionViewCell, ReusableCell {
         kvoToken?.invalidate()
     }
 
-    func configure(viewModel: HomepageMessageCardViewModel, theme: Theme) {
-        self.viewModel = viewModel
-
-        if let message = viewModel.getMessage(for: .newTabCard) {
-            applyGleanMessage(message)
-        }
-
+    func configure(state: MessageCardState, theme: Theme) {
+        applyGleanMessage(with: state.title, description: state.description, buttonLabel: state.buttonLabel)
         applyTheme(theme: theme)
         ctaButton.applyTheme(theme: theme)
     }
@@ -167,9 +166,9 @@ class LegacyHomepageMessageCardCell: UICollectionViewCell, ReusableCell {
 
     private func setupShadow(theme: Theme) {
         cardView.layer.shadowColor = theme.colors.shadowDefault.cgColor
-        cardView.layer.shadowOffset = HomepageViewModel.UX.shadowOffset
-        cardView.layer.shadowOpacity = HomepageViewModel.UX.shadowOpacity
-        cardView.layer.shadowRadius = HomepageViewModel.UX.shadowRadius
+        cardView.layer.shadowOffset = UX.shadowOffset
+        cardView.layer.shadowOpacity = UX.shadowOpacity
+        cardView.layer.shadowRadius = UX.shadowRadius
         updateShadowPath()
     }
 
@@ -181,8 +180,8 @@ class LegacyHomepageMessageCardCell: UICollectionViewCell, ReusableCell {
     // MARK: - Message setup
 
     /// Apply message data, including handling of cases where certain parts of the message are missing.
-    private func applyGleanMessage(_ message: GleanPlumbMessage) {
-        if let buttonLabel = message.buttonLabel {
+    private func applyGleanMessage(with title: String?, description: String?, buttonLabel: String?) {
+        if let buttonLabel {
             let buttonViewModel = PrimaryRoundedButtonViewModel(
                 title: buttonLabel,
                 a11yIdentifier: a11y.ctaButton
@@ -196,30 +195,30 @@ class LegacyHomepageMessageCardCell: UICollectionViewCell, ReusableCell {
             cardView.isUserInteractionEnabled = true
         }
 
-        if let title = message.title {
+        if let title {
             bannerTitle.text = title
         } else {
             textStackView.removeArrangedView(titleContainerView)
         }
 
-        descriptionText.text = message.text
+        descriptionText.text = description
     }
 
     // MARK: Actions
     @objc
     private func dismissCard() {
-        viewModel?.handleMessageDismiss()
+        // TODO: FXIOS-11134 - Handle message actions
     }
 
     /// The surface needs to handle CTAs a certain way when there's a message.
     @objc
     func handleCTA() {
-        viewModel?.handleMessagePressed()
+        // TODO: FXIOS-11134 - Handle message actions
     }
 }
 
 // MARK: - Notifiable
-extension LegacyHomepageMessageCardCell: Blurrable {
+extension HomepageMessageCardCell: Blurrable {
     func adjustBlur(theme: Theme) {
         if shouldApplyWallpaperBlur {
             cardView.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
@@ -232,7 +231,7 @@ extension LegacyHomepageMessageCardCell: Blurrable {
 }
 
 // MARK: - ThemeApplicable
-extension LegacyHomepageMessageCardCell: ThemeApplicable {
+extension HomepageMessageCardCell: ThemeApplicable {
     func applyTheme(theme: Theme) {
         bannerTitle.textColor = theme.colors.textPrimary
         descriptionText.textColor = theme.colors.textPrimary

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardState.swift
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import Shared
+
+/// State for the message cell that is used in the homepage view
+struct MessageCardState: StateType, Equatable, Hashable {
+    var windowUUID: WindowUUID
+    var title: String?
+    var description: String?
+    var buttonLabel: String?
+
+    init(windowUUID: WindowUUID) {
+        self.init(
+            windowUUID: windowUUID,
+            title: nil,
+            description: nil,
+            buttonLabel: nil
+        )
+    }
+
+    private init(
+        windowUUID: WindowUUID,
+        title: String?,
+        description: String?,
+        buttonLabel: String?
+    ) {
+        self.windowUUID = windowUUID
+        self.title = title
+        self.description = description
+        self.buttonLabel = buttonLabel
+    }
+
+    static let reducer: Reducer<Self> = { state, action in
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
+        else {
+            return defaultState(from: state)
+        }
+
+        switch action.actionType {
+        case HomepageActionType.initialize:
+            return handleInitializeAction(for: state, with: action)
+        default:
+            return defaultState(from: state)
+        }
+    }
+
+    private static func handleInitializeAction(for state: MessageCardState, with action: Action) -> MessageCardState {
+        // TODO: FXIOS-11133 - Pull appropriate data from message card manager
+        return MessageCardState(
+            windowUUID: state.windowUUID,
+            title: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerTitle,
+            description: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerDescription,
+            buttonLabel: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerButton
+        )
+    }
+
+    static func defaultState(from state: MessageCardState) -> MessageCardState {
+        return MessageCardState(
+            windowUUID: state.windowUUID,
+            title: state.title,
+            description: state.description,
+            buttonLabel: state.buttonLabel
+        )
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -10,6 +10,7 @@ struct HomepageState: ScreenState, Equatable {
 
     // Homepage sections state in the order they appear on the collection view
    let headerState: HeaderState
+   let messageState: MessageCardState
    let topSitesState: TopSitesSectionState
    let pocketState: PocketState
    let wallpaperState: WallpaperState
@@ -27,6 +28,7 @@ struct HomepageState: ScreenState, Equatable {
         self.init(
             windowUUID: homepageState.windowUUID,
             headerState: homepageState.headerState,
+            messageState: homepageState.messageState,
             topSitesState: homepageState.topSitesState,
             pocketState: homepageState.pocketState,
             wallpaperState: homepageState.wallpaperState
@@ -37,6 +39,7 @@ struct HomepageState: ScreenState, Equatable {
         self.init(
             windowUUID: windowUUID,
             headerState: HeaderState(windowUUID: windowUUID),
+            messageState: MessageCardState(windowUUID: windowUUID),
             topSitesState: TopSitesSectionState(windowUUID: windowUUID),
             pocketState: PocketState(windowUUID: windowUUID),
             wallpaperState: WallpaperState(windowUUID: windowUUID)
@@ -46,12 +49,14 @@ struct HomepageState: ScreenState, Equatable {
     private init(
         windowUUID: WindowUUID,
         headerState: HeaderState,
+        messageState: MessageCardState,
         topSitesState: TopSitesSectionState,
         pocketState: PocketState,
         wallpaperState: WallpaperState
     ) {
         self.windowUUID = windowUUID
         self.headerState = headerState
+        self.messageState = messageState
         self.topSitesState = topSitesState
         self.pocketState = pocketState
         self.wallpaperState = wallpaperState
@@ -68,6 +73,7 @@ struct HomepageState: ScreenState, Equatable {
             return HomepageState(
                 windowUUID: state.windowUUID,
                 headerState: HeaderState.reducer(state.headerState, action),
+                messageState: MessageCardState.reducer(state.messageState, action),
                 topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
                 pocketState: PocketState.reducer(state.pocketState, action),
                 wallpaperState: WallpaperState.reducer(state.wallpaperState, action)
@@ -79,12 +85,14 @@ struct HomepageState: ScreenState, Equatable {
 
     private static func defaultState(from state: HomepageState, action: Action?) -> HomepageState {
         var headerState = state.headerState
+        var messageState = state.messageState
         var pocketState = state.pocketState
         var topSitesState = state.topSitesState
         var wallpaperState = state.wallpaperState
 
         if let action {
             headerState = HeaderState.reducer(state.headerState, action)
+            messageState = MessageCardState.reducer(state.messageState, action)
             pocketState = PocketState.reducer(state.pocketState, action)
             topSitesState = TopSitesSectionState.reducer(state.topSitesState, action)
             wallpaperState = WallpaperState.reducer(state.wallpaperState, action)
@@ -93,6 +101,7 @@ struct HomepageState: ScreenState, Equatable {
         return HomepageState(
             windowUUID: state.windowUUID,
             headerState: headerState,
+            messageState: messageState,
             topSitesState: topSitesState,
             pocketState: pocketState,
             wallpaperState: wallpaperState

--- a/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
@@ -28,7 +28,7 @@ enum HomepageSectionType: Int, CaseIterable {
     var cellIdentifier: String {
         switch self {
         case .homepageHeader: return LegacyHomepageHeaderCell.cellIdentifier
-        case .messageCard: return HomepageMessageCardCell.cellIdentifier
+        case .messageCard: return LegacyHomepageMessageCardCell.cellIdentifier
         // Top sites has more than 1 cell type, dequeuing is done through FxHomeSectionHandler protocol
         case .topSites: return ""
         // Pocket has more than 1 cell type, dequeuing is done through FxHomeSectionHandler protocol
@@ -43,7 +43,7 @@ enum HomepageSectionType: Int, CaseIterable {
 
     static var cellTypes: [ReusableCell.Type] {
         return [LegacyHomepageHeaderCell.self,
-                HomepageMessageCardCell.self,
+                LegacyHomepageMessageCardCell.self,
                 TopSiteItemCell.self,
                 EmptyTopSiteCell.self,
                 JumpBackInCell.self,

--- a/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/MessageCard/HomepageMessageCardViewModel.swift
@@ -108,7 +108,7 @@ extension HomepageMessageCardViewModel: HomepageViewModelProtocol {
 // MARK: - HomepageSectionHandler
 extension HomepageMessageCardViewModel: HomepageSectionHandler {
     func configure(_ cell: UICollectionViewCell, at indexPath: IndexPath) -> UICollectionViewCell {
-        guard let messageCell = cell as? HomepageMessageCardCell else {
+        guard let messageCell = cell as? LegacyHomepageMessageCardCell else {
             return UICollectionViewCell()
         }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
@@ -218,7 +218,7 @@ class MockGleanPlumbMessageManagerProtocol: GleanPlumbMessageManagerProtocol {
 }
 
 // MARK: SpyHomepageMessageCardCell
-class SpyHomepageMessageCardCell: HomepageMessageCardCell {
+class SpyHomepageMessageCardCell: LegacyHomepageMessageCardCell {
     var configureCalled = 0
     override func configure(viewModel: HomepageMessageCardViewModel, theme: Theme) {
         configureCalled += 1

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -38,8 +38,8 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.updateSnapshot(state: HomepageState(windowUUID: .XCTestDefaultUUID))
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfSections, 2)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .customizeHomepage])
+        XCTAssertEqual(snapshot.numberOfSections, 3)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .customizeHomepage])
 
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .customizeHomepage).count, 1)
@@ -113,7 +113,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .topSites(4)), 8)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites(4), .customizeHomepage])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .topSites(4), .customizeHomepage])
     }
 
     func test_updateSnapshot_withValidState_returnPocketStories() throws {
@@ -132,7 +132,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil)), 21)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .pocket(nil), .customizeHomepage])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .pocket(nil), .customizeHomepage])
     }
 
     private func createSites(count: Int = 30) -> [TopSiteState] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardStateTests.swift
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+final class MessageCardStateTests: XCTestCase {
+    func tests_initialState_returnsExpectedState() {
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertNil(initialState.title)
+        XCTAssertNil(initialState.description)
+        XCTAssertNil(initialState.buttonLabel)
+    }
+
+    func test_initializeAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = messageCardReducer()
+
+        let newState = reducer(
+            initialState,
+            HomepageAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.initialize
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertNil(initialState.title)
+        XCTAssertNil(initialState.description)
+        XCTAssertNil(initialState.buttonLabel)
+    }
+    // MARK: - Private
+    private func createSubject() -> MessageCardState {
+        return MessageCardState(windowUUID: .XCTestDefaultUUID)
+    }
+
+    private func messageCardReducer() -> Reducer<MessageCardState> {
+        return MessageCardState.reducer
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardStateTests.swift
@@ -30,9 +30,10 @@ final class MessageCardStateTests: XCTestCase {
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertNil(initialState.title)
-        XCTAssertNil(initialState.description)
-        XCTAssertNil(initialState.buttonLabel)
+        XCTAssertEqual(newState.title, "Switch Your Default Browser")
+        let expectedDescription = "Set links from websites, emails, and Messages to open automatically in Firefox."
+        XCTAssertEqual(newState.description, expectedDescription)
+        XCTAssertEqual(newState.buttonLabel, "Learn How")
     }
     // MARK: - Private
     private func createSubject() -> MessageCardState {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11132)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24267)

## :bulb: Description
Add initial view and state for the message card section for the new homepage.
* Added `MessageCardState` with mock string
* Copied over previous homepage message card view and made modifications to use state instead of view model
* Add message section to diffable and add configs for compositional layout + message card cells

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshot
| iPhone |
| --- |
| <img src="https://github.com/user-attachments/assets/de4ab14b-ad88-4904-9614-3494ba60e51f" width="250"> |
