### PR TITLE
Bugfix FXIOS-11138 [ToS] Landscape mode should not be supported for 'Terms of Service' card to maintain consistency with the other Onboarding Cards

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Views/TermsOfServiceViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/TermsOfServiceViewController.swift
@@ -287,3 +287,14 @@ class TermsOfServiceViewController: UIViewController, Themeable {
         configure()
     }
 }
+
+// MARK: UIViewController setup
+extension TermsOfServiceViewController {
+    override var shouldAutorotate: Bool {
+        return false
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
+}

--- a/firefox-ios/Client/Frontend/Onboarding/Views/TermsOfServiceViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/TermsOfServiceViewController.swift
@@ -111,6 +111,14 @@ class TermsOfServiceViewController: UIViewController, Themeable {
     }
 
     // MARK: - View setup
+    override var shouldAutorotate: Bool {
+        return false
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
+
     private func configure() {
         agreementContent.removeAllArrangedViews()
         let termsOfServiceLink = String(format: .Onboarding.TermsOfService.TermsOfUseLink, AppName.shortName.rawValue)
@@ -285,16 +293,5 @@ class TermsOfServiceViewController: UIViewController, Themeable {
         subtitleLabel.textColor = theme.colors.textSecondary
         confirmationButton.applyTheme(theme: theme)
         configure()
-    }
-}
-
-// MARK: UIViewController setup
-extension TermsOfServiceViewController {
-    override var shouldAutorotate: Bool {
-        return false
-    }
-
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return .portrait
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11138)

## :bulb: Description
Don't allow to display TermsOfServiceViewController in landscape

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

