### PR TITLE
Bugfix FXIOS-11136 [Toolbar Redesign] Cancel URL edit mode before switching tabs via toast

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3718,6 +3718,11 @@ extension BrowserViewController: HomePanelDelegate {
                                 theme: currentTheme(),
                                 completion: { buttonPressed in
             if buttonPressed {
+                let toolbarAction = ToolbarAction(
+                    windowUUID: self.windowUUID,
+                    actionType: ToolbarActionType.cancelEdit
+                )
+                store.dispatch(toolbarAction)
                 self.tabManager.selectTab(tab)
             }
         })


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11136)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24273)

## :bulb: Description
- Exit the URL bar edit mode when switching to a webpage opened in a new tab from the homepage

### 🎥 Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/0cdc5b43-5444-42c2-88de-552e36e905f4

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/e6895638-42bb-4625-9e07-c2dfc3697400

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

