### PR TITLE
Bugfix FXIOS-11141 [Bookmarks Evolution] Ensure accessory view respects safe area

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -90,8 +90,12 @@ class OneLineTableViewCell: UITableViewCell,
         super.layoutSubviews()
         updateReorderControl()
 
+        // Position the accessory at the trailing edge of the cell, accounting for safe area and padding
         if let accessoryView {
-            accessoryView.frame.origin.x = frame.width - accessoryView.frame.width - UX.accessoryViewTrailingPadding
+            accessoryView.frame.origin.x = frame.width
+            - accessoryView.frame.width
+            - UX.accessoryViewTrailingPadding
+            - safeAreaInsets.right
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11141)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24276)

## :bulb: Description
- Ensure the accessory view ("..." button or ">" image) of each bookmark or folder cell respects the safe area insets so that they are not blocked behind the notch / dynamic island

| Before | After |
| ------------- | ------------- |
| <img width="1000" alt="Screenshot 2025-01-22 at 2 48 24 PM" src="https://github.com/user-attachments/assets/839d1e3b-4f82-4051-bc61-71e0b99d65d4" /> | <img width="1000" alt="Screenshot 2025-01-22 at 2 46 51 PM" src="https://github.com/user-attachments/assets/6f737639-9fe2-4b4c-8c83-25c8698c7edf" /> |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

