### PR TITLE
Bugfix FXIOS-11126 Fix MOZ_CHANNEL flag typo

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -25689,6 +25689,7 @@
 					"-ObjC",
 					"-ld_classic",
 				);
+				OTHER_SWIFT_FLAGS = "$(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_$(CHANNEL)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(MOZ_BUNDLE_ID)";
 				PRODUCT_MODULE_NAME = Client;
 				PRODUCT_NAME = Client;

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -25689,7 +25689,6 @@
 					"-ObjC",
 					"-ld_classic",
 				);
-				OTHER_SWIFT_FLAGS = "$(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_$(CHANNEL)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(MOZ_BUNDLE_ID)";
 				PRODUCT_MODULE_NAME = Client;
 				PRODUCT_NAME = Client;

--- a/firefox-ios/Client/Configuration/FirefoxBeta.xcconfig
+++ b/firefox-ios/Client/Configuration/FirefoxBeta.xcconfig
@@ -9,5 +9,5 @@ MOZ_BUNDLE_DISPLAY_NAME = Firefox Beta
 MOZ_BUNDLE_ID = org.mozilla.ios.FirefoxBeta
 CODE_SIGN_ENTITLEMENTS = Client/Entitlements/FirefoxBetaApplication.entitlements
 CHANNEL = BETA
-OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANEL_$(CHANNEL)
+OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_$(CHANNEL)
 MOZ_INTERNAL_URL_SCHEME = firefox-beta


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11126)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24261)

## :bulb: Description
- Fix a typo in a flag name in the beta project file that caused the feature flag debug settings to not appear in the UI

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

