### PR TITLE
Add MTE-4167 Github actions that update bitrise steps

### DIFF
--- a/.github/workflows/update-bitrise-steps.yml
+++ b/.github/workflows/update-bitrise-steps.yml
@@ -5,7 +5,7 @@ on:
   #  - cron: "0 3 * * 0" # Runs every Sunday at 03:00 UTC
   push:
     branches:
-      - mb/MTE-4167_update_bitrise_steps  
+      - mb/MTE-4167_update_bitrise_steps
   workflow_dispatch: # Allow manual triggering
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install requests
-            
+
       # Step 4: Run the script to update Bitrise steps
       - name: Run update script
         id: update_script
@@ -73,9 +73,9 @@ jobs:
           # team-reviewers: firefox ios
           reviewers: mdotb-moz,clarmso,isabelrios
 
-       # Step 8: Send a message to slack if there is a failure
+        # Step 8: Send a message to slack if there is a failure
 
-notify-on-failure:
+  notify-on-failure:
     runs-on: ubuntu-latest
     needs: update-steps
     if: failure() # Trigger only if the 'update-steps' job fails
@@ -85,7 +85,7 @@ notify-on-failure:
         uses: slackapi/slack-github-action@v2.0.0
         with:
           payload-templated: true
-          webhook: ${{ secrets.WEBHOOK_SLACK_TOKEN }} 
+          webhook: ${{ secrets.WEBHOOK_SLACK_TOKEN }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/update-bitrise-steps.yml
+++ b/.github/workflows/update-bitrise-steps.yml
@@ -1,0 +1,93 @@
+name: Update Outdated Bitrise Steps Versions
+
+on:
+  schedule:
+    - cron: "0 3 * * 0" # Runs every Sunday at 03:00 UTC
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  update-steps:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Check out the repository
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Step 2: Set up Python
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      # Step 3: Install dependencies
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+            
+      # Step 4: Run the script to update Bitrise steps
+      - name: Run update script
+        id: update_script
+        run: |
+          python ./test-fixtures/update_bitrise_steps.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Step 5: Determine the PR Version Number
+      - name: Determine PR Version Number
+        id: versioning
+        run: |
+          # This step is used to determine the next version number for the PR title
+          # The output includes debugging for the piped commands that generate
+          # the version number and the last line is the version number itself
+
+          output=$(bash test-fixtures/ci/get-next-pr-version)
+          echo "$output"
+          next_version=$(echo "$output" | tail -n 1) # get the last line of the output
+          echo "Next version is: v${next_version}"
+          echo "next_version=${next_version}" >> $GITHUB_ENV
+          echo "current_date=$current_date" >> $GITHUB_ENV
+
+      # Step 6: Check for changes
+      - name: Commit changes if any
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet || git commit -am "Update outdated Bitrise steps"
+          git push -u origin update/bitrise-steps || echo "No changes to push."
+
+      # Step 7: Create a Pull Request
+      - name: Create a Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/bitrise-steps
+          commit-message: "Update [v${{ env.next_version }}] outdated Bitrise steps ${{ env.current_date }}"
+          title: "Bump [v${{ env.next_version }}] Update outdated Bitrise steps ${{ env.current_date }}"
+          body: |
+            This PR updates the outdated Bitrise steps to their latest versions.
+          # team-reviewers: firefox ios
+          reviewers: mdotb-moz,clarmso,isabelrios
+
+       # Step 8: Send a message to slack if there is a failure
+
+notify-on-failure:
+    runs-on: ubuntu-latest
+    needs: update-steps
+    if: failure() # Trigger only if the 'update-steps' job fails
+    steps:
+      - name: Report to Slack
+        id: slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          payload-templated: true
+          webhook: ${{ secrets.WEBHOOK_SLACK_TOKEN }} 
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "🚨 *GitHub Action Failed* 🚨\nThe workflow to update Bitrise steps has failed.\n*Repository*: <https://github.com/${{ github.repository }}|${{ github.repository }}>\n*Workflow*: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Logs>\n*Branch*: ${{ github.ref_name }}\n*Commit*: <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>",
+              "channel": "mobile-alerts-sandbox",
+              "username": "GitHub Actions Bot",
+              "icon_emoji": ":octocat:"
+            }

--- a/.github/workflows/update-bitrise-steps.yml
+++ b/.github/workflows/update-bitrise-steps.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run update script
         id: update_script
         run: |
-          python ./test-fixtures/update_bitrise_steps.py
+          python ./test-fixtures/update_bitrise_step.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-bitrise-steps.yml
+++ b/.github/workflows/update-bitrise-steps.yml
@@ -1,11 +1,8 @@
 name: Update Outdated Bitrise Steps Versions
 
 on:
-  # schedule:
-  #  - cron: "0 3 * * 0" # Runs every Sunday at 03:00 UTC
-  push:
-    branches:
-      - mb/MTE-4167_update_bitrise_steps
+  schedule:
+   - cron: "0 3 * * 0" # Runs every Sunday at 03:00 UTC
   workflow_dispatch: # Allow manual triggering
 
 jobs:
@@ -33,7 +30,7 @@ jobs:
       - name: Run update script
         id: update_script
         run: |
-          python ./test-fixtures/update_bitrise_step.py
+          python ./test-fixtures/update_bitrise_steps.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -70,7 +67,6 @@ jobs:
           title: "Bump [v${{ env.next_version }}] Update outdated Bitrise steps ${{ env.current_date }}"
           body: |
             This PR updates the outdated Bitrise steps to their latest versions.
-          # team-reviewers: firefox ios
           reviewers: mdotb-moz,clarmso,isabelrios
 
         # Step 8: Send a message to slack if there is a failure

--- a/.github/workflows/update-bitrise-steps.yml
+++ b/.github/workflows/update-bitrise-steps.yml
@@ -1,8 +1,11 @@
 name: Update Outdated Bitrise Steps Versions
 
 on:
-  schedule:
-    - cron: "0 3 * * 0" # Runs every Sunday at 03:00 UTC
+  # schedule:
+  #  - cron: "0 3 * * 0" # Runs every Sunday at 03:00 UTC
+  push:
+    branches:
+      - mb/MTE-4167_update_bitrise_steps  
   workflow_dispatch: # Allow manual triggering
 
 jobs:

--- a/test-fixtures/update_bitrise_steps.py
+++ b/test-fixtures/update_bitrise_steps.py
@@ -1,0 +1,66 @@
+import os
+import requests
+import re
+
+# Define constants
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # Navigate one level up from "test"
+BITRISE_YML = os.path.join(BASE_DIR, "bitrise.yml")
+BITRISE_STEPLIB_URL = "https://api.github.com/repos/bitrise-io/bitrise-steplib/contents/steps"
+
+# GitHub Access Token
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+
+def fetch_latest_version(step_id):
+    """Fetch the latest version of a step from the Bitrise Step Library."""
+    try:
+        url = f"{BITRISE_STEPLIB_URL}/{step_id}"
+        headers = {"Authorization": f"token {GITHUB_TOKEN}"}
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        items = response.json()
+        # Filter out directories that represent versions
+        versions = [
+            item["name"] for item in items
+            if all(c.isdigit() or c == '.' for c in item["name"])
+        ]
+        if not versions:
+            print(f"No valid versions found for step {step_id}.")
+            return None
+        latest_version = sorted(versions, key=lambda x: list(map(int, x.split('.'))))[-1]
+        return latest_version
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching latest version for {step_id}: {e}")
+        return None
+
+def update_bitrise_yaml():
+    """Update outdated steps in the Bitrise YAML file."""
+    # Load the existing YAML
+    with open(BITRISE_YML, "r") as file:
+        content = file.readlines()
+
+    # Placeholder for updated steps
+    updated_lines = []
+    updated_steps = []
+
+    for line in content:
+        match = re.match(r"^\s*-\s*([a-zA-Z0-9\-_]+)@([\d\.]+):", line)
+        if match:
+            step_id, current_version = match.groups()
+            latest_version = fetch_latest_version(step_id)
+            if current_version != latest_version:
+                updated_steps.append(f"{step_id}: {current_version} -> {latest_version}")
+                line = line.replace(f"{step_id}@{current_version}", f"{step_id}@{latest_version}")
+        updated_lines.append(line)
+
+    # Write back the updated file
+    with open(BITRISE_YML, "w") as file:
+        file.writelines(updated_lines)
+
+    if updated_steps:
+        print("Updated steps:")
+        print("\n".join(updated_steps))
+    else:
+        print("No updates were necessary.")
+
+if __name__ == "__main__":
+    update_bitrise_yaml()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4167)

## :bulb: Description
We need a way to check and update the workflow steps of bitrise. This PR checks the actual version of each step and update it if there is a new version available in bitrise steps library. This PR also creates a PR and, in case of failure, send a message to slack.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

