### PR TITLE
Bugfix FXIOS-11130 [ToS] - "Welcome to Firefox" is announced when opening the manage bottom sheet

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPreferencesViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPreferencesViewController.swift
@@ -88,6 +88,11 @@ final class PrivacyPreferencesViewController: UIViewController,
         listenForThemeChange(view)
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        UIAccessibility.post(notification: .screenChanged, argument: view)
+    }
+
     // MARK: - View setup
     private func setupLayout() {
         view.addSubview(titleLabel)
@@ -184,6 +189,8 @@ final class PrivacyPreferencesViewController: UIViewController,
     }
 
     private func setupAccessibility() {
+        contentView.accessibilityElements = [technicalDataSwitch, crashReportsSwitch]
+        view.accessibilityElements = [titleLabel, doneButton, contentScrollView]
         let identifiers = AccessibilityIdentifiers.TermsOfService.PrivacyNotice.self
         titleLabel.accessibilityIdentifier = identifiers.title
         doneButton.accessibilityIdentifier = identifiers.doneButton


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11130)

## :bulb: Description
Fixed Voice Over/Accessibility for Privacy Preference screen

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

