### PR TITLE
Bugfix FXIOS-10665 ⁃ [Felt privacy-Unified panel][Accessibility] - Incorrect announcement for the toggle of ETP

### DIFF
--- a/BrowserKit/Sources/Shared/NotificationConstants.swift
+++ b/BrowserKit/Sources/Shared/NotificationConstants.swift
@@ -57,7 +57,7 @@ extension Notification.Name {
 
     public static let TrackingProtectionViewControllerDidDismiss =
     Notification.Name("TrackingProtectionViewControllerDidDismiss")
-    
+
     public static let TrackingProtectionViewControllerDidAppear =
     Notification.Name("TrackingProtectionViewControllerDidAppear")
 

--- a/BrowserKit/Sources/Shared/NotificationConstants.swift
+++ b/BrowserKit/Sources/Shared/NotificationConstants.swift
@@ -55,6 +55,12 @@ extension Notification.Name {
 
     public static let FakespotViewControllerDidAppear = Notification.Name("FakespotViewControllerDidAppear")
 
+    public static let TrackingProtectionViewControllerDidDismiss =
+    Notification.Name("TrackingProtectionViewControllerDidDismiss")
+    
+    public static let TrackingProtectionViewControllerDidAppear =
+    Notification.Name("TrackingProtectionViewControllerDidAppear")
+
     public static let FileDidDownload = Notification.Name("FileDidDownload")
 
     public static let SearchBarPositionDidChange = Notification.Name("SearchBarPositionDidChange")

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -56,6 +56,8 @@ class TabLocationView: UIView, FeatureFlaggable {
     let windowUUID: WindowUUID
     let logger: Logger
 
+    var isTrackingProtectionDisplayed: Bool = false
+
     /// Tracking protection button, gets updated from tabDidChangeContentBlocking
     var blockerStatus: BlockerStatus = .noBlockedURLs {
         didSet {
@@ -204,7 +206,9 @@ class TabLocationView: UIView, FeatureFlaggable {
             forObserver: self,
             observing: [
                 .FakespotViewControllerDidDismiss,
-                .FakespotViewControllerDidAppear
+                .FakespotViewControllerDidAppear,
+                .TrackingProtectionViewControllerDidDismiss,
+                .TrackingProtectionViewControllerDidAppear
             ]
         )
         register(self, forTabEvents: .didGainFocus, .didToggleDesktopMode, .didChangeContentBlocking)
@@ -452,7 +456,7 @@ private extension TabLocationView {
             self.trackingProtectionButton.isHidden = true
         }
 
-        if wasHidden != readerModeButton.isHidden {
+        if wasHidden != readerModeButton.isHidden && !isTrackingProtectionDisplayed {
             UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged, argument: nil)
             if !readerModeButton.isHidden {
                 // Delay the Reader Mode accessibility announcement briefly to prevent interruptions.
@@ -479,6 +483,10 @@ extension TabLocationView: Notifiable {
             shoppingButton.isSelected = false
         case .FakespotViewControllerDidAppear:
             shoppingButton.isSelected = true
+        case .TrackingProtectionViewControllerDidDismiss:
+            isTrackingProtectionDisplayed = false
+        case .TrackingProtectionViewControllerDidAppear:
+            isTrackingProtectionDisplayed = true
         default: break
         }
     }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -173,6 +173,16 @@ class TrackingProtectionViewController: UIViewController,
         }
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        notificationCenter.post(name: .TrackingProtectionViewControllerDidAppear, withObject: windowUUID)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        notificationCenter.post(name: .TrackingProtectionViewControllerDidDismiss, withObject: windowUUID)
+    }
+
     private func setupView() {
         constraints.removeAll()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10665)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23328)

## :bulb: Description
Fixed accessibility for toggle for ETP screen

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

