### PR TITLE
Add FXIOS-11133 [Homepage] [MessageCard] Middleware for message card

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -737,6 +737,7 @@
 		8A0A1BA02B2200FD00E8706F /* PrivateHomepageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0A1B9F2B2200FD00E8706F /* PrivateHomepageViewController.swift */; };
 		8A0A1BA32B22030100E8706F /* PrivateMessageCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0A1BA22B22030100E8706F /* PrivateMessageCardCell.swift */; };
 		8A0D32842A61E1CC007D976D /* StatusBarOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */; };
+		8A106D632D416F82009AD7E4 /* MessageCardMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A106D622D416F82009AD7E4 /* MessageCardMiddlewareTests.swift */; };
 		8A11C80F2731916E00AC7318 /* defaultOnlyTestList.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */; };
 		8A11C8112731CFD700AC7318 /* ReaderModeStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */; };
 		8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */; };
@@ -988,6 +989,8 @@
 		8AAEBA0B2BF53AF6000C02B5 /* MicrosurveyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAEBA092BF53AB5000C02B5 /* MicrosurveyStateTests.swift */; };
 		8AB30EC82B6C038600BD9A9B /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 8AB30EC72B6C038600BD9A9B /* Lottie */; };
 		8AB30ECA2B6C03C700BD9A9B /* DataClearanceAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB30EC92B6C03C700BD9A9B /* DataClearanceAnimation.swift */; };
+		8AB53B3A2D4138F200C97590 /* MessageCardMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB53B392D4138ED00C97590 /* MessageCardMiddleware.swift */; };
+		8AB53B3E2D41463900C97590 /* MessageCardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB53B3D2D41463400C97590 /* MessageCardAction.swift */; };
 		8AB5958828413F6C0090F4AE /* BookmarksCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958728413F6C0090F4AE /* BookmarksCell.swift */; };
 		8AB5958A284145B30090F4AE /* HomepageSectionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */; };
 		8AB8571D27D929350075C173 /* TopSitesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8571C27D929350075C173 /* TopSitesViewModel.swift */; };
@@ -7566,6 +7569,7 @@
 		8A0D32832A61E1CC007D976D /* StatusBarOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarOverlay.swift; sourceTree = "<group>"; };
 		8A0E5F3D2BFBA49400DE052B /* MicrosurveyCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyCoordinatorTests.swift; sourceTree = "<group>"; };
 		8A0F46E89E106C66C6C29F07 /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/ErrorPages.strings; sourceTree = "<group>"; };
+		8A106D622D416F82009AD7E4 /* MessageCardMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardMiddlewareTests.swift; sourceTree = "<group>"; };
 		8A11C80D2731916E00AC7318 /* defaultOnlyTestList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = defaultOnlyTestList.json; sourceTree = "<group>"; };
 		8A11C8102731CFD700AC7318 /* ReaderModeStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleTests.swift; sourceTree = "<group>"; };
 		8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
@@ -7826,6 +7830,8 @@
 		8AAEBA092BF53AB5000C02B5 /* MicrosurveyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyStateTests.swift; sourceTree = "<group>"; };
 		8AB04613B101195AADCC1F1B /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = "cs.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		8AB30EC92B6C03C700BD9A9B /* DataClearanceAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataClearanceAnimation.swift; sourceTree = "<group>"; };
+		8AB53B392D4138ED00C97590 /* MessageCardMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardMiddleware.swift; sourceTree = "<group>"; };
+		8AB53B3D2D41463400C97590 /* MessageCardAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardAction.swift; sourceTree = "<group>"; };
 		8AB5958728413F6C0090F4AE /* BookmarksCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksCell.swift; sourceTree = "<group>"; };
 		8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageSectionHandler.swift; sourceTree = "<group>"; };
 		8AB8571C27D929350075C173 /* TopSitesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesViewModel.swift; sourceTree = "<group>"; };
@@ -11745,6 +11751,7 @@
 			isa = PBXGroup;
 			children = (
 				8AED23072D4012B1000FF624 /* MessageCardStateTests.swift */,
+				8A106D622D416F82009AD7E4 /* MessageCardMiddlewareTests.swift */,
 				8AEF41612D15EDBA0013925D /* TopSitesMiddlewareTests.swift */,
 				8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */,
 				8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */,
@@ -12333,6 +12340,8 @@
 		8AED23022D400020000FF624 /* MessageCard */ = {
 			isa = PBXGroup;
 			children = (
+				8AB53B3D2D41463400C97590 /* MessageCardAction.swift */,
+				8AB53B392D4138ED00C97590 /* MessageCardMiddleware.swift */,
 				8AED23032D40002A000FF624 /* MessageCardState.swift */,
 				8AED23052D400098000FF624 /* HomepageMessageCardCell.swift */,
 			);
@@ -16573,6 +16582,7 @@
 				F85C7F0E2711C556004BDBA4 /* SettingsViewController.swift in Sources */,
 				0BDDB3442CA6E43100D501DF /* FolderHierarchyFetcher.swift in Sources */,
 				C8B509E3293FA39900AC013C /* AppVersionUpdateCheckerProtocol.swift in Sources */,
+				8AB53B3E2D41463900C97590 /* MessageCardAction.swift in Sources */,
 				E1AFBAF9292EA0330065E35E /* SendToDeviceHelper.swift in Sources */,
 				E17798982BD6B44B00F6F0EB /* AddressToolbarContainer.swift in Sources */,
 				21D151262AFC28960062D891 /* TabManagerMiddleware.swift in Sources */,
@@ -17088,6 +17098,7 @@
 				612194E82CE50A9B001664BB /* WallpaperState.swift in Sources */,
 				DAE6DF1B29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift in Sources */,
 				0EC57D082CA6FCA5002E3F04 /* PasswordGeneratorHeaderView.swift in Sources */,
+				8AB53B3A2D4138F200C97590 /* MessageCardMiddleware.swift in Sources */,
 				8AB8574A27D97CE90075C173 /* HomePanelDelegate.swift in Sources */,
 				2137786529832C8900D01309 /* OverlayModeManager.swift in Sources */,
 				8AF99B4D29EF076800108DEC /* WebviewViewController.swift in Sources */,
@@ -17632,6 +17643,7 @@
 				8A635ECD289437A8006378BA /* SyncedTabCellTests.swift in Sources */,
 				8A97E6EF2C584C4900F94793 /* AddressLocaleFeatureValidatorTests.swift in Sources */,
 				8ABE9F1D2CB462730080E1DF /* RemoteSettingsFetchConfigTests.swift in Sources */,
+				8A106D632D416F82009AD7E4 /* MessageCardMiddlewareTests.swift in Sources */,
 				E1E425322B5A2E9700899550 /* DownloadTests.swift in Sources */,
 				5AB4237C28A1947A003BC40C /* MockNotificationCenter.swift in Sources */,
 				8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewProviderTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -23,7 +23,7 @@ final class HomepageDiffableDataSource:
 
     enum HomeItem: Hashable {
         case header(HeaderState)
-        case messageCard(MessageCardState)
+        case messageCard(MessageCardConfiguration)
         case topSite(TopSiteState, TextColor?)
         case topSiteEmpty
         case pocket(PocketStoryState)
@@ -51,9 +51,10 @@ final class HomepageDiffableDataSource:
         snapshot.appendSections([.header])
         snapshot.appendItems([.header(state.headerState)], toSection: .header)
 
-        // TODO: FXIOS-11133 - Handle whether to show / hide message card from message card manager
-        snapshot.appendSections([.messageCard])
-        snapshot.appendItems([.messageCard(state.messageState)], toSection: .messageCard)
+        if let configuration = state.messageState.messageCardConfiguration {
+            snapshot.appendSections([.messageCard])
+            snapshot.appendItems([.messageCard(configuration)], toSection: .messageCard)
+        }
 
         if let topSites = getTopSites(with: state.topSitesState, and: textColor) {
             snapshot.appendSections([.topSites(state.topSitesState.numberOfTilesPerRow)])

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -366,7 +366,7 @@ final class HomepageViewController: UIViewController,
 
             return headerCell
 
-        case .messageCard(let state):
+        case .messageCard(let config):
             guard let messageCardCell = collectionView?.dequeueReusableCell(
                 cellType: HomepageMessageCardCell.self,
                 for: indexPath
@@ -374,7 +374,7 @@ final class HomepageViewController: UIViewController,
                 return UICollectionViewCell()
             }
 
-            messageCardCell.configure(state: state, theme: currentTheme)
+            messageCardCell.configure(with: config, theme: currentTheme)
             return messageCardCell
         case .topSite(let site, let textColor):
             guard let topSiteCell = collectionView?.dequeueReusableCell(cellType: TopSiteCell.self, for: indexPath) else {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/HomepageMessageCardCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/HomepageMessageCardCell.swift
@@ -97,8 +97,8 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
         kvoToken?.invalidate()
     }
 
-    func configure(state: MessageCardState, theme: Theme) {
-        applyGleanMessage(with: state.title, description: state.description, buttonLabel: state.buttonLabel)
+    func configure(with config: MessageCardConfiguration, theme: Theme) {
+        applyGleanMessage(with: config.title, description: config.description, buttonLabel: config.buttonLabel)
         applyTheme(theme: theme)
         ctaButton.applyTheme(theme: theme)
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardAction.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Redux
+import Common
+
+final class MessageCardAction: Action {
+    let messageCardConfiguration: MessageCardConfiguration?
+
+    init(messageCardConfiguration: MessageCardConfiguration? = nil,
+         windowUUID: WindowUUID,
+         actionType: any ActionType
+    ) {
+        self.messageCardConfiguration = messageCardConfiguration
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
+
+enum MessageCardMiddlewareActionType: ActionType {
+    case initialize
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardMiddleware.swift
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Redux
+
+struct MessageCardConfiguration: Hashable {
+    let title: String?
+    let description: String?
+    let buttonLabel: String?
+}
+
+final class MessageCardMiddleware {
+    private var message: GleanPlumbMessage?
+    private let messagingManager: GleanPlumbMessageManagerProtocol
+
+    init(messagingManager: GleanPlumbMessageManagerProtocol = Experiments.messaging) {
+        self.messagingManager = messagingManager
+    }
+
+    lazy var messageCardProvider: Middleware<AppState> = { state, action in
+        let windowUUID = action.windowUUID
+
+        switch action.actionType {
+        case HomepageActionType.initialize:
+            self.handleInitializeMessageCardAction(windowUUID: windowUUID)
+        default:
+           break
+        }
+    }
+
+    private func handleInitializeMessageCardAction(windowUUID: WindowUUID) {
+        if let message = messagingManager.getNextMessage(for: .newTabCard) {
+            let config = MessageCardConfiguration(
+                title: message.title,
+                description: message.text,
+                buttonLabel: message.buttonLabel
+            )
+            dispatchMessageCardAction(windowUUID: windowUUID, config: config)
+            messagingManager.onMessageDisplayed(message)
+        } else {
+            return
+        }
+    }
+
+    private func dispatchMessageCardAction(windowUUID: WindowUUID, config: MessageCardConfiguration) {
+        let newAction = MessageCardAction(
+            messageCardConfiguration: config,
+            windowUUID: windowUUID,
+            actionType: MessageCardMiddlewareActionType.initialize
+        )
+        store.dispatch(newAction)
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardState.swift
@@ -9,29 +9,21 @@ import Shared
 /// State for the message cell that is used in the homepage view
 struct MessageCardState: StateType, Equatable, Hashable {
     var windowUUID: WindowUUID
-    var title: String?
-    var description: String?
-    var buttonLabel: String?
+    var messageCardConfiguration: MessageCardConfiguration?
 
     init(windowUUID: WindowUUID) {
         self.init(
             windowUUID: windowUUID,
-            title: nil,
-            description: nil,
-            buttonLabel: nil
+            messageCardConfiguration: nil
         )
     }
 
     private init(
         windowUUID: WindowUUID,
-        title: String?,
-        description: String?,
-        buttonLabel: String?
+        messageCardConfiguration: MessageCardConfiguration?
     ) {
         self.windowUUID = windowUUID
-        self.title = title
-        self.description = description
-        self.buttonLabel = buttonLabel
+        self.messageCardConfiguration = messageCardConfiguration
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -41,7 +33,7 @@ struct MessageCardState: StateType, Equatable, Hashable {
         }
 
         switch action.actionType {
-        case HomepageActionType.initialize:
+        case MessageCardMiddlewareActionType.initialize:
             return handleInitializeAction(for: state, with: action)
         default:
             return defaultState(from: state)
@@ -49,21 +41,21 @@ struct MessageCardState: StateType, Equatable, Hashable {
     }
 
     private static func handleInitializeAction(for state: MessageCardState, with action: Action) -> MessageCardState {
-        // TODO: FXIOS-11133 - Pull appropriate data from message card manager
+        guard let messageCardAction = action as? MessageCardAction,
+              let messageCardConfiguration = messageCardAction.messageCardConfiguration
+        else {
+            return defaultState(from: state)
+        }
         return MessageCardState(
             windowUUID: state.windowUUID,
-            title: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerTitle,
-            description: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerDescription,
-            buttonLabel: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerButton
+            messageCardConfiguration: messageCardConfiguration
         )
     }
 
     static func defaultState(from state: MessageCardState) -> MessageCardState {
         return MessageCardState(
             windowUUID: state.windowUUID,
-            title: state.title,
-            description: state.description,
-            buttonLabel: state.buttonLabel
+            messageCardConfiguration: state.messageCardConfiguration
         )
     }
 }

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -63,6 +63,7 @@ extension AppState {
 let middlewares = [
     FeltPrivacyMiddleware().privacyManagerProvider,
     MainMenuMiddleware().mainMenuProvider,
+    MessageCardMiddleware().messageCardProvider,
     MicrosurveyMiddleware().microsurveyProvider,
     MicrosurveyPromptMiddleware().microsurveyProvider,
     RemoteTabsPanelMiddleware().remoteTabsPanelProvider,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/MessageCard/HomepageMessageCardViewModelTests.swift
@@ -168,7 +168,7 @@ class MockMessageDataProtocol: MessageDataProtocol {
     var isControl = true
     var title: String? = "Test"
     var text: String = "This is a test"
-    var buttonLabel: String?
+    var buttonLabel: String? = "This is a test button label"
     var experiment: String?
     var actionParams: [String: String] = [:]
     var microsurveyConfig: MicrosurveyConfig?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -38,8 +38,8 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.updateSnapshot(state: HomepageState(windowUUID: .XCTestDefaultUUID))
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfSections, 3)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .customizeHomepage])
+        XCTAssertEqual(snapshot.numberOfSections, 2)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .customizeHomepage])
 
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .customizeHomepage).count, 1)
@@ -113,7 +113,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .topSites(4)), 8)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .topSites(4), .customizeHomepage])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites(4), .customizeHomepage])
     }
 
     func test_updateSnapshot_withValidState_returnPocketStories() throws {
@@ -132,7 +132,32 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil)), 21)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .pocket(nil), .customizeHomepage])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .pocket(nil), .customizeHomepage])
+    }
+
+    func test_updateSnapshot_withValidState_returnMessageCard() throws {
+        let dataSource = try XCTUnwrap(diffableDataSource)
+        let configuration = MessageCardConfiguration(
+            title: "Example Title",
+            description: "Example Description",
+            buttonLabel: "Example Button"
+        )
+
+        let state = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            MessageCardAction(
+                messageCardConfiguration: configuration,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MessageCardMiddlewareActionType.initialize
+            )
+        )
+
+        dataSource.updateSnapshot(state: state)
+
+        let snapshot = dataSource.snapshot()
+        XCTAssertEqual(snapshot.numberOfItems(inSection: .messageCard), 1)
+        XCTAssertEqual(snapshot.itemIdentifiers(inSection: .messageCard).first, HomepageItem.messageCard(configuration))
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .customizeHomepage])
     }
 
     private func createSites(count: Int = 30) -> [TopSiteState] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardMiddlewareTests.swift
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
+    var mockStore: MockStoreForMiddleware<AppState>!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        setupStore()
+    }
+
+    override func tearDown() {
+        DependencyHelperMock().reset()
+        resetStore()
+        super.tearDown()
+    }
+
+    func test_initializeAction_getMessageCardData() throws {
+        let messagingManager = MockGleanPlumbMessageManagerProtocol()
+        let message = createMessage()
+        messagingManager.message = message
+        let subject = createSubject(messagingManager: messagingManager)
+
+        let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
+        let expectation = XCTestExpectation(description: "Homepage action initialize dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.messageCardProvider(AppState(), action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? MessageCardAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? MessageCardMiddlewareActionType)
+
+        XCTAssertEqual(actionType, MessageCardMiddlewareActionType.initialize)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionCalled.messageCardConfiguration?.title, "Test")
+        XCTAssertEqual(actionCalled.messageCardConfiguration?.description, "This is a test")
+        XCTAssertEqual(actionCalled.messageCardConfiguration?.buttonLabel, "This is a test button label")
+        XCTAssertEqual(messagingManager.onMessageDisplayedCalled, 1)
+    }
+
+    func test_initializeAction_withInvalidSurface_doesNotGetMessageCardData() throws {
+        let messagingManager = MockGleanPlumbMessageManagerProtocol()
+        let message = createMessage(with: MockMessageData(surface: .microsurvey))
+        messagingManager.message = message
+        let subject = createSubject(messagingManager: messagingManager)
+
+        let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
+        let expectation = XCTestExpectation(description: "Homepage action initialize dispatched")
+        expectation.isInverted = true
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.messageCardProvider(AppState(), action)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertEqual(messagingManager.onMessageDisplayedCalled, 0)
+    }
+
+    // MARK: - Helpers
+    private func createSubject(messagingManager: GleanPlumbMessageManagerProtocol) -> MessageCardMiddleware {
+        return MessageCardMiddleware(messagingManager: messagingManager)
+    }
+
+    func createMessage(with data: MessageDataProtocol = MockMessageDataProtocol()) -> GleanPlumbMessage {
+        let metadata = GleanPlumbMessageMetaData(id: "",
+                                                 impressions: 0,
+                                                 dismissals: 0,
+                                                 isExpired: false)
+
+        return GleanPlumbMessage(id: "12345",
+                                 data: data,
+                                 action: "",
+                                 triggerIfAll: [],
+                                 exceptIfAny: [],
+                                 style: MockStyleDataProtocol(),
+                                 metadata: metadata)
+    }
+
+    // MARK: StoreTestUtility
+    func setupAppState() -> AppState {
+        return AppState(
+            activeScreens: ActiveScreensState(
+                screens: [
+                    .homepage(
+                        HomepageState(
+                            windowUUID: .XCTestDefaultUUID
+                        )
+                    ),
+                ]
+            )
+        )
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    // In order to avoid flaky tests, we should reset the store
+    // similar to production
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardStateTests.swift
@@ -12,9 +12,7 @@ final class MessageCardStateTests: XCTestCase {
         let initialState = createSubject()
 
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertNil(initialState.title)
-        XCTAssertNil(initialState.description)
-        XCTAssertNil(initialState.buttonLabel)
+        XCTAssertNil(initialState.messageCardConfiguration)
     }
 
     func test_initializeAction_returnsExpectedState() {
@@ -23,17 +21,21 @@ final class MessageCardStateTests: XCTestCase {
 
         let newState = reducer(
             initialState,
-            HomepageAction(
+            MessageCardAction(
+                messageCardConfiguration: MessageCardConfiguration(
+                    title: "Example Title",
+                    description: "Example Description",
+                    buttonLabel: "Example Button"
+                ),
                 windowUUID: .XCTestDefaultUUID,
-                actionType: HomepageActionType.initialize
+                actionType: MessageCardMiddlewareActionType.initialize
             )
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertEqual(newState.title, "Switch Your Default Browser")
-        let expectedDescription = "Set links from websites, emails, and Messages to open automatically in Firefox."
-        XCTAssertEqual(newState.description, expectedDescription)
-        XCTAssertEqual(newState.buttonLabel, "Learn How")
+        XCTAssertEqual(newState.messageCardConfiguration?.title, "Example Title")
+        XCTAssertEqual(newState.messageCardConfiguration?.description, "Example Description")
+        XCTAssertEqual(newState.messageCardConfiguration?.buttonLabel, "Example Button")
     }
     // MARK: - Private
     private func createSubject() -> MessageCardState {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11133)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24268)

## :bulb: Description
This PR adds the support of using our messaging feature via Nimbus to power the homepage message card. This only handles showing and hiding the card when the message is eligible to be shown. Eligibility for this message is based on our configurations in `messaging-evergreen-messages.fml.yaml` for the default browser message.

* Add middleware for message card that holds our mobile messaging dependency that conforms to `GleanPlumbMessageManagerProtocol`.
* Use `MessageCardConfiguration` to hold the string values used to display on the message card.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Tests Steps
1. Launch the app on device and ensure that its not a default browser
2. Launch the app 4 times

| Screenshot |
| --- |
| <img src="https://github.com/user-attachments/assets/342177f4-c419-49fd-b237-eae8c7806fe7" width="250"> |
