### PR TITLE
Refactor FXIOS-8477 [WebEngine] Migrate WKNavigationDelegate & WKUIdelegate to their own class

### DIFF
--- a/BrowserKit/Sources/WebEngine/EngineTelemetryProxy.swift
+++ b/BrowserKit/Sources/WebEngine/EngineTelemetryProxy.swift
@@ -35,5 +35,5 @@ public enum EngineTelemetryEvent {
 /// Protocol for handling WebEngine telemetry events. These can be custom-handled
 /// by clients to be recorded through Glean or any other preferred API.
 public protocol EngineTelemetryProxy: AnyObject {
-    func handleTelemetry(session: EngineSession, event: EngineTelemetryEvent)
+    func handleTelemetry(event: EngineTelemetryEvent)
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKNavigationHandler.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKNavigationHandler.swift
@@ -10,7 +10,6 @@ protocol WKNavigationHandler: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView,
                  didCommit navigation: WKNavigation?)
-    
 
     func webView(_ webView: WKWebView,
                  didFinish navigation: WKNavigation?)

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKNavigationHandler.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKNavigationHandler.swift
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import WebKit
+
+protocol WKNavigationHandler {
+    func webView(_ webView: WKWebView,
+                 didCommit navigation: WKNavigation?)
+
+    func webView(_ webView: WKWebView,
+                 didFinish navigation: WKNavigation?)
+
+    func webView(_ webView: WKWebView,
+                 didFail navigation: WKNavigation?,
+                 withError error: Error)
+
+    func webView(_ webView: WKWebView,
+                 didFailProvisionalNavigation navigation: WKNavigation?,
+                 withError error: Error)
+
+    func webView(_ webView: WKWebView,
+                 didStartProvisionalNavigation navigation: WKNavigation?)
+
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationResponse: WKNavigationResponse,
+                 decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void)
+
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationAction: WKNavigationAction,
+                 preferences: WKWebpagePreferences,
+                 decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void)
+
+    func webView(_ webView: WKWebView,
+                 didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation?)
+
+    func webView(_ webView: WKWebView,
+                 didReceive challenge: URLAuthenticationChallenge,
+                 completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
+}
+
+class DefaultNavigationHandler: WKNavigationHandler {
+    private let session: SessionHandler
+    var telemetryProxy: EngineTelemetryProxy?
+
+    init(session: SessionHandler,
+         telemetryProxy: EngineTelemetryProxy? = nil) {
+        self.session = session
+        self.telemetryProxy = telemetryProxy
+    }
+
+    func webView(_ webView: WKWebView,
+                 didCommit navigation: WKNavigation?) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+        telemetryProxy?.handleTelemetry(event: .pageLoadStarted)
+
+        // TODO: Revisit possible duplicate delegate callbacks when navigating to URL in same origin [PR #19083] [FXIOS-8351]
+        session.commitURLChange()
+    }
+
+    func webView(_ webView: WKWebView,
+                 didFinish navigation: WKNavigation?) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+
+        if let url = webView.url {
+            session.fetchMetadata(withURL: url)
+        }
+        telemetryProxy?.handleTelemetry(event: .pageLoadFinished)
+    }
+
+    func webView(_ webView: WKWebView,
+                 didFail navigation: WKNavigation?,
+                 withError error: Error) {
+        telemetryProxy?.handleTelemetry(event: .didFailNavigation)
+        telemetryProxy?.handleTelemetry(event: .pageLoadCancelled)
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+    }
+
+    func webView(_ webView: WKWebView,
+                 didFailProvisionalNavigation navigation: WKNavigation?,
+                 withError error: Error) {
+        telemetryProxy?.handleTelemetry(event: .didFailProvisionalNavigation)
+        telemetryProxy?.handleTelemetry(event: .pageLoadCancelled)
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+    }
+
+    func webView(_ webView: WKWebView,
+                 didStartProvisionalNavigation navigation: WKNavigation?) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+    }
+
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationResponse: WKNavigationResponse,
+                 decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+        decisionHandler(.allow)
+    }
+
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationAction: WKNavigationAction,
+                 preferences: WKWebpagePreferences,
+                 decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
+        // TODO: FXIOS-8277 - Determine navigation calls with EngineSessionDelegate
+        decisionHandler(.allow, preferences)
+    }
+
+    func webView(_ webView: WKWebView,
+                 didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation?) {
+        // TODO: FXIOS-8275 - Handle didReceiveServerRedirectForProvisionalNavigation (epic part 3)
+    }
+
+    func webView(_ webView: WKWebView,
+                 didReceive challenge: URLAuthenticationChallenge,
+                 completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        // TODO: FXIOS-8276 - Handle didReceive challenge: URLAuthenticationChallenge (epic part 3)
+        completionHandler(.performDefaultHandling, nil)
+    }
+}

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKUIHandler.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKUIHandler.swift
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import WebKit
+
+protocol WKUIHandler: WKUIDelegate {
+    var delegate: EngineSessionDelegate? { get set }
+
+    func webView(_ webView: WKWebView,
+                 createWebViewWith configuration: WKWebViewConfiguration,
+                 for navigationAction: WKNavigationAction,
+                 windowFeatures: WKWindowFeatures) -> WKWebView?
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor () -> Void
+    )
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor (Bool) -> Void
+    )
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor (String?) -> Void
+    )
+
+    func webViewDidClose(_ webView: WKWebView)
+
+    func webView(
+        _ webView: WKWebView,
+        contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
+        completionHandler: @escaping @MainActor (UIContextMenuConfiguration?) -> Void
+    )
+
+    @available(iOS 15, *)
+    func webView(
+        _ webView: WKWebView,
+        requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        type: WKMediaCaptureType,
+        decisionHandler: @escaping @MainActor (WKPermissionDecision) -> Void
+    )
+}
+
+class DefaultUIHandler: NSObject, WKUIHandler {
+    weak var delegate: EngineSessionDelegate?
+
+    func webView(_ webView: WKWebView,
+                 createWebViewWith configuration: WKWebViewConfiguration,
+                 for navigationAction: WKNavigationAction,
+                 windowFeatures: WKWindowFeatures) -> WKWebView? {
+        // TODO: FXIOS-8243 - Handle popup windows with createWebViewWith in WebEngine (epic part 2)
+        return nil
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor () -> Void
+    ) {
+        // TODO: FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor (Bool) -> Void
+    ) {
+        // TODO: FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor (String?) -> Void
+    ) {
+        // TODO: FXIOS-8244 - Handle Javascript panel messages in WebEngine (epic part 3)
+    }
+
+    func webViewDidClose(_ webView: WKWebView) {
+        // TODO: FXIOS-8245 - Handle webViewDidClose in WebEngine (epic part 3)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
+        completionHandler: @escaping @MainActor (UIContextMenuConfiguration?) -> Void
+    ) {
+        completionHandler(delegate?.onProvideContextualMenu(linkURL: elementInfo.linkURL))
+    }
+
+    @available(iOS 15, *)
+    func webView(
+        _ webView: WKWebView,
+        requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        type: WKMediaCaptureType,
+        decisionHandler: @escaping @MainActor (WKPermissionDecision) -> Void
+    ) {
+        // TODO: FXIOS-8247 - Handle media capture in WebEngine (epic part 3)
+    }
+}

--- a/SampleBrowser/SampleBrowser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleBrowser/SampleBrowser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "2ef543ee21d63734e1c004ad6c870255e8716c50",
-        "version" : "7.12.0"
+        "revision" : "e6749919f9761d573d37a7d7e78b1b854c191d7f",
+        "version" : "8.1.3"
       }
     },
     {
@@ -43,6 +43,15 @@
       "state" : {
         "revision" : "5575af93efb776414f243e93d6af9f6258dc539a",
         "version" : "8.36.0"
+      }
+    },
+    {
+      "identity" : "swiftdraw",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/SwiftDraw",
+      "state" : {
+        "revision" : "a5c680f07b33f4cc9a451491b417b8119de23c6e",
+        "version" : "0.17.0"
       }
     },
     {

--- a/SampleBrowser/SampleBrowser/TelemetryHandler.swift
+++ b/SampleBrowser/SampleBrowser/TelemetryHandler.swift
@@ -6,7 +6,7 @@ import Foundation
 import WebEngine
 
 final class TelemetryHandler: EngineTelemetryProxy {
-    func handleTelemetry(session: EngineSession, event: EngineTelemetryEvent) {
+    func handleTelemetry(event: EngineTelemetryEvent) {
         switch event {
         case .didFailNavigation:
             print("Telemetry event triggered: Did fail navigation")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8477)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18825)

## :bulb: Description
This is a change to have smaller classes, `WKEngineSession` will be a huge thing at the end otherwise. It would be easier to reason about if we have those delegates calls separated IMO. What do you think? 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

