### PR TITLE
Bugfix FXIOS-11149 [Bookmarks Evolution] RTL support for bookmark folder cell accessory views

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -116,8 +116,8 @@ extension FxBookmarkNode {
     }
 
     var chevronImage: UIImage? {
-        return UIImage(
-            named: StandardImageIdentifiers.Large.chevronRight
-        )?.withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
+        return UIImage(named: StandardImageIdentifiers.Large.chevronRight)?
+            .withRenderingMode(.alwaysTemplate)
+            .imageFlippedForRightToLeftLayoutDirection()
     }
 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -116,6 +116,8 @@ extension FxBookmarkNode {
     }
 
     var chevronImage: UIImage? {
-        return UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
+        return UIImage(
+            named: StandardImageIdentifiers.Large.chevronRight
+        )?.withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
     }
 }

--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -92,10 +92,14 @@ class OneLineTableViewCell: UITableViewCell,
 
         // Position the accessory at the trailing edge of the cell, accounting for safe area and padding
         if let accessoryView {
-            accessoryView.frame.origin.x = frame.width
-            - accessoryView.frame.width
-            - UX.accessoryViewTrailingPadding
-            - safeAreaInsets.right
+            if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
+                accessoryView.frame.origin.x = UX.accessoryViewTrailingPadding + safeAreaInsets.left
+            } else {
+                accessoryView.frame.origin.x = frame.width
+                    - accessoryView.frame.width
+                    - UX.accessoryViewTrailingPadding
+                    - safeAreaInsets.right
+            }
         }
     }
 
@@ -200,7 +204,13 @@ class OneLineTableViewCell: UITableViewCell,
                 let button = accessoryView as? UIButton
                 var buttonConfig = button?.configuration
                 let image = buttonConfig?.image?.createScaled(
-                    CGSize(width: iconSize, height: iconSize)).withRenderingMode(.alwaysTemplate)
+                    CGSize(
+                        width: iconSize,
+                        height: iconSize
+                    )
+                ).withRenderingMode(
+                    .alwaysTemplate
+                ).imageFlippedForRightToLeftLayoutDirection()
                 buttonConfig?.image = image
                 button?.configuration = buttonConfig
             }

--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -204,13 +204,7 @@ class OneLineTableViewCell: UITableViewCell,
                 let button = accessoryView as? UIButton
                 var buttonConfig = button?.configuration
                 let image = buttonConfig?.image?.createScaled(
-                    CGSize(
-                        width: iconSize,
-                        height: iconSize
-                    )
-                ).withRenderingMode(
-                    .alwaysTemplate
-                ).imageFlippedForRightToLeftLayoutDirection()
+                    CGSize(width: iconSize, height: iconSize)).withRenderingMode(.alwaysTemplate)
                 buttonConfig?.image = image
                 button?.configuration = buttonConfig
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11149)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24290)

## :bulb: Description
- Position and mirror the ">" accessory view for bookmark folders cells correctly in RTL languages

| Before | After |
| ------------- | ------------- |
| <img width="559" alt="Screenshot 2025-01-23 at 7 44 20 PM" src="https://github.com/user-attachments/assets/dc366771-5192-4419-a7b8-a47a01e29e9f" /> | <img width="559" alt="Screenshot 2025-01-23 at 7 43 14 PM" src="https://github.com/user-attachments/assets/a8ffadbf-0128-4a4c-9647-b3d5704f5819" /> |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

