### PR TITLE
Bugfix FXIOS-11150 [Bookmarks Evolution] RTL support for edit bookmark/folder text fields

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
@@ -32,6 +32,8 @@ class EditBookmarkCell: UITableViewCell,
             self?.titleTextFieldDidChange()
         }), for: .editingChanged)
         view.adjustsFontSizeToFitWidth = true
+        let layoutDirection = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute)
+        view.textAlignment = layoutDirection == .rightToLeft ? .right : .left
     }
     private lazy var urlTextfield: TextField = .build { view in
         view.keyboardType = .URL
@@ -39,6 +41,8 @@ class EditBookmarkCell: UITableViewCell,
             self?.urlTextFieldDidChange()
         }), for: .editingChanged)
         view.adjustsFontSizeToFitWidth = true
+        let layoutDirection = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute)
+        view.textAlignment = layoutDirection == .rightToLeft ? .right : .left
     }
     var onTitleFieldUpdate: ((String) -> Void)?
     var onURLFieldUpdate: ((String) -> Void)?

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkCell.swift
@@ -32,8 +32,7 @@ class EditBookmarkCell: UITableViewCell,
             self?.titleTextFieldDidChange()
         }), for: .editingChanged)
         view.adjustsFontSizeToFitWidth = true
-        let layoutDirection = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute)
-        view.textAlignment = layoutDirection == .rightToLeft ? .right : .left
+        view.textAlignment = .natural
     }
     private lazy var urlTextfield: TextField = .build { view in
         view.keyboardType = .URL
@@ -41,8 +40,7 @@ class EditBookmarkCell: UITableViewCell,
             self?.urlTextFieldDidChange()
         }), for: .editingChanged)
         view.adjustsFontSizeToFitWidth = true
-        let layoutDirection = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute)
-        view.textAlignment = layoutDirection == .rightToLeft ? .right : .left
+        view.textAlignment = .natural
     }
     var onTitleFieldUpdate: ((String) -> Void)?
     var onURLFieldUpdate: ((String) -> Void)?

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
@@ -17,6 +17,8 @@ class EditFolderCell: UITableViewCell,
         view.addAction(UIAction(handler: { [weak self] _ in
             self?.titleTextFieldDidChange()
         }), for: .editingChanged)
+        let layoutDirection = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute)
+        view.textAlignment = layoutDirection == .rightToLeft ? .right : .left
     }
     var onTitleFieldUpdate: ((String) -> Void)?
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderCell.swift
@@ -17,8 +17,7 @@ class EditFolderCell: UITableViewCell,
         view.addAction(UIAction(handler: { [weak self] _ in
             self?.titleTextFieldDidChange()
         }), for: .editingChanged)
-        let layoutDirection = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute)
-        view.textAlignment = layoutDirection == .rightToLeft ? .right : .left
+        view.textAlignment = .natural
     }
     var onTitleFieldUpdate: ((String) -> Void)?
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11150)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24291)

## :bulb: Description
- Right-justify placeholder and input text for bookmark title/url and folder title text fields when using an RTL language 

| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 16 - 2025-01-23 at 20 48 15](https://github.com/user-attachments/assets/647292d2-1870-46fb-a74b-736362ab8d4f) | ![Simulator Screenshot - iPhone 16 - 2025-01-23 at 20 51 22](https://github.com/user-attachments/assets/43831750-bd37-461d-a157-4e8c2af331c4) |
| ![Simulator Screenshot - iPhone 16 - 2025-01-23 at 20 49 18](https://github.com/user-attachments/assets/c7e06114-ad58-46f7-8da3-96d8dc099df9) | ![Simulator Screenshot - iPhone 16 - 2025-01-23 at 20 51 46](https://github.com/user-attachments/assets/6e2abc1e-3138-423f-adb5-6a3990446f1f) |
| ![Simulator Screenshot - iPhone 16 - 2025-01-23 at 20 49 35](https://github.com/user-attachments/assets/d777f8fd-6b77-4d62-996e-84b8ce0298b9) | ![Simulator Screenshot - iPhone 16 - 2025-01-23 at 20 52 06](https://github.com/user-attachments/assets/e47f47b6-887b-4331-b928-582561f85702)|

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

