### PR TITLE
Bugfix FXIOS-10964 "URL Copied to Clipboard" - toast message is not displayed when copying it using the share option in context menu

### DIFF
--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -108,7 +108,7 @@ class LibraryCoordinator: BaseCoordinator,
         }
 
         let coordinator = ShareSheetCoordinator(
-            alertContainer: UIView(),
+            alertContainer: libraryViewController?.view ?? UIView(),
             router: router,
             profile: profile,
             parentCoordinator: self,

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -103,6 +103,7 @@ class ShareSheetCoordinator: BaseCoordinator,
             }
         case .copyToPasteboard:
             showToast(text: .LegacyAppMenu.AppMenuCopyURLConfirmMessage)
+            dequeueNotShownJSAlert()
         default:
             dequeueNotShownJSAlert()
         }

--- a/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/ShareSheetCoordinator.swift
@@ -101,7 +101,8 @@ class ShareSheetCoordinator: BaseCoordinator,
             default:
                 showSendToDevice(url: shareType.wrappedURL, relatedTab: nil)
             }
-
+        case .copyToPasteboard:
+            showToast(text: .LegacyAppMenu.AppMenuCopyURLConfirmMessage)
         default:
             dequeueNotShownJSAlert()
         }
@@ -154,6 +155,12 @@ class ShareSheetCoordinator: BaseCoordinator,
         router.present(alertController)
     }
 
+    private func showToast(text: String) {
+        SimpleToast().showAlertWithText(text,
+                                        bottomContainer: self.alertContainer,
+                                        theme: self.themeManager.getCurrentTheme(for: self.windowUUID))
+    }
+
     // MARK: DevicePickerViewControllerDelegate
 
     func devicePickerViewControllerDidCancel(_ devicePickerViewController: DevicePickerViewController) {
@@ -194,10 +201,8 @@ class ShareSheetCoordinator: BaseCoordinator,
             guard let self = self else { return }
             self.router.dismiss()
             self.parentCoordinator?.didFinish(from: self)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                SimpleToast().showAlertWithText(.LegacyAppMenu.AppMenuTabSentConfirmMessage,
-                                                bottomContainer: self.alertContainer,
-                                                theme: self.themeManager.getCurrentTheme(for: self.windowUUID))
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                self?.showToast(text: .LegacyAppMenu.AppMenuTabSentConfirmMessage)
             }
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10964)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23946)

## :bulb: Description
- Show toast for "URL Copied to Clipboard" when the copy option was selected from Share Sheet
- Pass LibraryViewController view as alertContainer to show the Toast fixing the toast to be shown from bookmarks

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

