### PR TITLE
Improved MTE-4192 - share tests for iOS 17 and 15

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
@@ -169,7 +169,8 @@ class ShareLongPressTests: BaseTestCase {
         }
         app.buttons["Share Link"].waitAndTap()
         if #available(iOS 16, *) {
-            app.collectionViews.cells[option].waitAndTap()
+            mozWaitForElementToExist(app.collectionViews.cells[option])
+            app.collectionViews.cells[option].tapOnApp()
         } else {
             app.buttons[option].waitAndTap()
         }
@@ -190,7 +191,8 @@ class ShareLongPressTests: BaseTestCase {
         app.tables["Context Menu"].cells.otherElements["shareLarge"].waitAndTap()
         // Tap the Reminders button in the menu
         if #available(iOS 16, *) {
-            app.collectionViews.cells[option].waitAndTap()
+            mozWaitForElementToExist(app.collectionViews.cells[option])
+            app.collectionViews.cells[option].tapOnApp()
         } else {
             app.buttons[option].waitAndTap()
         }
@@ -208,7 +210,8 @@ class ShareLongPressTests: BaseTestCase {
         app.tables["Context Menu"].cells.otherElements["shareLarge"].waitAndTap()
         // Tap the Reminders button in the menu
         if #available(iOS 16, *) {
-            app.collectionViews.cells[option].waitAndTap()
+            mozWaitForElementToExist(app.collectionViews.cells[option])
+            app.collectionViews.cells[option].tapOnApp()
         } else {
             app.buttons[option].waitAndTap()
         }
@@ -229,7 +232,8 @@ class ShareLongPressTests: BaseTestCase {
         app.tables["Context Menu"].cells.otherElements["shareLarge"].waitAndTap()
         // Tap the Reminders button in the menu
         if #available(iOS 16, *) {
-            app.collectionViews.cells[option].waitAndTap()
+            mozWaitForElementToExist(app.collectionViews.cells[option])
+            app.collectionViews.cells[option].tapOnApp()
         } else {
             app.buttons[option].waitAndTap()
         }
@@ -243,7 +247,8 @@ class ShareLongPressTests: BaseTestCase {
             .staticTexts.firstMatch.press(forDuration: 1.5)
         app.tables["Context Menu"].cells.otherElements["shareLarge"].waitAndTap()
         if #available(iOS 16, *) {
-            app.collectionViews.cells[option].waitAndTap()
+            mozWaitForElementToExist(app.collectionViews.cells[option])
+            app.collectionViews.cells[option].tapOnApp()
         } else {
             app.buttons[option].waitAndTap()
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
@@ -96,7 +96,7 @@ class ShareMenuTests: BaseTestCase {
         validateMarkupTool()
     }
 
-    // https://mozilla.testrail.io/index.php?/cases/view/2864293
+    // https://mozilla.testrail.io/index.php?/cases/view/2864065
     func testSharePdfFilePrint() {
         reachShareMenuLayoutAndSelectOption(option: "Print", url: pdfUrl)
         validatePrintLayout()
@@ -155,7 +155,7 @@ class ShareMenuTests: BaseTestCase {
             mozWaitForElementToExist(app.buttons["autofill"])
             mozWaitForElementToExist(app.buttons["Done"])
         } else {
-            mozWaitForElementToExist(app.buttons["Colour picker"])
+            mozWaitForElementToExist(app.buttons["Color picker"])
         }
     }
 
@@ -169,7 +169,8 @@ class ShareMenuTests: BaseTestCase {
         // Tap the Share button in the menu
         navigator.performAction(Action.ShareBrowserTabMenuOption)
         if #available(iOS 16, *) {
-            app.collectionViews.cells[option].waitAndTap()
+            mozWaitForElementToExist(app.collectionViews.cells[option])
+            app.collectionViews.cells[option].tapOnApp()
         } else {
             app.buttons[option].waitAndTap()
         }
@@ -183,7 +184,8 @@ class ShareMenuTests: BaseTestCase {
         // Tap the Share button in the menu
         navigator.performAction(Action.ShareBrowserTabMenuOption)
         if #available(iOS 16, *) {
-            app.collectionViews.cells[option].waitAndTap()
+            mozWaitForElementToExist(app.collectionViews.cells[option])
+            app.collectionViews.cells[option].tapOnApp()
         } else {
             app.buttons[option].waitAndTap()
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
@@ -155,7 +155,7 @@ class ShareToolbarTests: BaseTestCase {
             mozWaitForElementToExist(app.buttons["autofill"])
             mozWaitForElementToExist(app.buttons["Done"])
         } else {
-            mozWaitForElementToExist(app.buttons["Colour picker"])
+            mozWaitForElementToExist(app.buttons["Color picker"])
         }
     }
 
@@ -167,7 +167,8 @@ class ShareToolbarTests: BaseTestCase {
         app.buttons["Reader View"].waitAndTap()
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
         if #available(iOS 16, *) {
-            app.collectionViews.cells[option].waitAndTap()
+            mozWaitForElementToExist(app.collectionViews.cells[option])
+            app.collectionViews.cells[option].tapOnApp()
         } else {
             app.buttons[option].waitAndTap()
         }
@@ -178,7 +179,8 @@ class ShareToolbarTests: BaseTestCase {
         waitUntilPageLoad()
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
         if #available(iOS 16, *) {
-            app.collectionViews.cells[option].waitAndTap()
+            mozWaitForElementToExist(app.collectionViews.cells[option])
+            app.collectionViews.cells[option].tapOnApp()
         } else {
             app.buttons[option].waitAndTap()
         }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4192

## :bulb: Description
On M1 the share tests are flaky for lower iOS versions, its seems we need a tapOnApp call to make sure the option is selected. I have verified this solution directly on M1 and it seem to work.
