### PR TITLE
Bugfix FXIOS-11164 [ToS] “Set as Default Browser” onboarding card's privacy notice link is redundant with the ToS onboarding card’s privacy notice link

### DIFF
--- a/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -78,7 +78,10 @@ class LaunchCoordinator: BaseCoordinator,
     // MARK: - Intro
     private func presentIntroOnboarding(with manager: IntroScreenManager,
                                         isFullScreen: Bool) {
-        let onboardingModel = NimbusOnboardingFeatureLayer().getOnboardingModel(for: .freshInstall)
+        let onboardingModel = NimbusOnboardingFeatureLayer().getOnboardingModel(
+            for: .freshInstall,
+            and: TermsOfServiceManager(prefs: profile.prefs)
+        )
         let telemetryUtility = OnboardingTelemetryUtility(with: onboardingModel)
         let introViewModel = IntroViewModel(introScreenManager: manager,
                                             profile: profile,

--- a/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayerProtocol.swift
+++ b/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingFeatureLayerProtocol.swift
@@ -7,6 +7,7 @@ import Foundation
 protocol NimbusOnboardingFeatureLayerProtocol {
     func getOnboardingModel(
         for onboardingType: OnboardingType,
-        from nimbus: FxNimbus
+        from nimbus: FxNimbus,
+        and termsOfServiceManager: TermsOfServiceManager?
     ) -> OnboardingViewModel
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11164)

## :bulb: Description
Implemented a solution for hiding Privacy Notice Link from Welcome onboarding when user already saw the ToS screen.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

