### PR TITLE
Bugfix FXIOS-10547 [ShareTo] Queued background tabs shouldn't require a title to be opened

### DIFF
--- a/firefox-ios/Storage/SQL/SQLiteQueue.swift
+++ b/firefox-ios/Storage/SQL/SQLiteQueue.swift
@@ -13,18 +13,16 @@ open class SQLiteQueue: TabQueue {
     }
 
     open func addToQueue(_ tab: ShareItem) -> Success {
-        let args: Args = [tab.url, tab.title]
-        return db.run("INSERT OR IGNORE INTO queue (url, title) VALUES (?, ?)", withArgs: args)
+        return db.run("INSERT OR IGNORE INTO queue (url) VALUES (?)", withArgs: [tab.url])
     }
 
     fileprivate func factory(_ row: SDRow) -> ShareItem {
-        let title = row["title"] as? String ?? ""
         let url = row["url"] as? String ?? ""
-        return ShareItem(url: url, title: title)
+        return ShareItem(url: url, title: "")
     }
 
     open func getQueuedTabs(completion: @escaping ([ShareItem]) -> Void) {
-        let sql = "SELECT url, title FROM queue"
+        let sql = "SELECT url FROM queue"
         let deferredResponse = db.runQuery(sql, args: nil, factory: self.factory) >>== { cursor in
             return deferMaybe(cursor.asArray())
         }

--- a/firefox-ios/Storage/SQL/SQLiteQueue.swift
+++ b/firefox-ios/Storage/SQL/SQLiteQueue.swift
@@ -18,9 +18,8 @@ open class SQLiteQueue: TabQueue {
     }
 
     fileprivate func factory(_ row: SDRow) -> ShareItem {
-        guard let url = row["url"] as? String, let title = row["title"] as? String else {
-            return ShareItem(url: "", title: "")
-        }
+        let title = row["title"] as? String ?? ""
+        let url = row["url"] as? String ?? ""
         return ShareItem(url: url, title: title)
     }
 


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10547)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23110)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Drops `title` as a hard requirement for background tabs to open.
- Drops `title` from select and insert statements. 
- Essentially reverts https://github.com/mozilla-mobile/firefox-ios/pull/22979 which caused the regression.

⚠️ I asked in the channel about our approach to dropping columns from tables and migrations. Will update once I have an answer. Ideally we should drop `title` from `queue`.

**How to reproduce the issue**
- Open Safari.
- Go to youtube.com.
- Pick a video.
- Click the share button in the youtube app not Safari.
- In the share menu click Firefox and choose Load in background.
- Open Firefox.
- Without the fix nothing happens.
- With the fix applied a new tab with the correct youtube video should open.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

