### PR TITLE
Bugfix FXIOS-10478 Multiple instances of homepage logo cell

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -40,7 +40,6 @@ class BrowserCoordinator: BaseCoordinator,
     var webviewController: WebviewViewController?
     var legacyHomepageViewController: LegacyHomepageViewController?
     var homepageViewController: HomepageViewController?
-    var privateViewController: PrivateHomepageViewController?
     var errorViewController: NativeErrorPageViewController?
 
     private var profile: Profile
@@ -160,13 +159,15 @@ class BrowserCoordinator: BaseCoordinator,
     }
 
     func showPrivateHomepage(overlayManager: OverlayModeManager) {
-        let privateHomepageController = PrivateHomepageViewController(windowUUID: windowUUID, overlayManager: overlayManager)
+        let privateHomepageController = PrivateHomepageViewController(
+            windowUUID: windowUUID,
+            overlayManager: overlayManager
+        )
         privateHomepageController.parentCoordinator = self
         guard browserViewController.embedContent(privateHomepageController) else {
             logger.log("Unable to embed private homepage", level: .debug, category: .coordinator)
             return
         }
-        self.privateViewController = privateHomepageController
     }
 
     func navigateFromHomePanel(to url: URL, visitType: VisitType, isGoogleTopSite: Bool) {

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -40,7 +40,7 @@ final class PrivateHomepageViewController:
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
 
-    var parentCoordinator: PrivateHomepageDelegate?
+    weak var parentCoordinator: PrivateHomepageDelegate?
 
     private let overlayManager: OverlayModeManager
     private let logger: Logger
@@ -72,7 +72,7 @@ final class PrivateHomepageViewController:
             })
     }
 
-    private lazy var scrollContainer: UIStackView = .build { stackView in
+    private let scrollContainer: UIStackView = .build { stackView in
         stackView.axis = .vertical
         stackView.spacing = UX.scrollContainerStackSpacing
     }
@@ -85,7 +85,9 @@ final class PrivateHomepageViewController:
             link: .FirefoxHomepage.FeltPrivacyUI.Link
         )
         messageCard.configure(with: messageCardModel, and: themeManager.getCurrentTheme(for: windowUUID))
-        messageCard.privateBrowsingLinkTapped = learnMore
+        messageCard.privateBrowsingLinkTapped = { [weak self] in
+            self?.learnMore()
+        }
         return messageCard
     }()
 
@@ -132,6 +134,10 @@ final class PrivateHomepageViewController:
             homepageHeaderCell.configure(with: headerViewModel)
         }
         applyTheme()
+    }
+
+    deinit {
+        scrollView.removeFromSuperview()
     }
 
     private func setupLayout() {

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -137,6 +137,7 @@ final class PrivateHomepageViewController:
     }
 
     deinit {
+        // TODO: FXIOS-11187 - Investigate further on privateMessageCardCell memory leaking during viewing private tab.
         scrollView.removeFromSuperview()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -150,7 +150,6 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
 
         XCTAssertNotNil(subject.homepageViewController)
         XCTAssertNil(subject.webviewController)
-        XCTAssertNil(subject.privateViewController)
     }
 
     func testShowNewHomepage_hasSameInstance() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10478)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22942)

## :bulb: Description
While working on the Homepage Rebuild project, I notice that there were some memory leaks with the `HomepageLogoHeaderCell` (see screenshots below). After investigating, it seems this was created due to having multiple instances of `PrivateHomepageViewController`. 

The solution in this PR to fix the multiple instances of `PrivateHomepageViewController` was to remove the reference on `BrowserCoordinator` and only initialize when needed. When the reference between BVC to the view controller gets removed, then the private homepage should get deallocated. 

I noticed that while `PrivateHomepageViewController` was no longer leaking, there were still multiple instances of `PrivateMessageCardCell`. It seems it was being retained by the `scrollView`, so the fix for this was to remove the scroll view during deallocation.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
**Before Change**
| HomepageLogoHeaderCell | PrivateHomepageViewController leaks | PrivateMessageCardCell
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/185da956-0002-4144-9d70-8828102953c2) |  ![image](https://github.com/user-attachments/assets/90860db2-8628-4420-ac77-e1b5602a7e4e) | ![image](https://github.com/user-attachments/assets/a9b64944-f303-4142-a8a7-a9000f7c69ed) |

**After Change**
| HomepageLogoHeaderCell (2 instances for private + normal) | PrivateHomepage leaks |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/641fa4fd-e08f-4a4b-ab7e-946f4eaa09b6) | ![image](https://github.com/user-attachments/assets/7e3e8e05-410b-43ec-a42b-1dd047826579) |

