### PR TITLE
Bugfix FXIOS-11110 [Bookmarks Evolution] Bookmarks panel empty state flicker

### DIFF
--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -380,6 +380,7 @@ class LibraryViewController: UIViewController, Themeable, BookmarksRefactorFeatu
         let controlbarHeight = segmentControlToolbar.frame.height
         segmentControlToolbar.transform = value ? .init(translationX: 0, y: -controlbarHeight) : .identity
         controllerContainerView.transform = value ? .init(translationX: 0, y: -controlbarHeight) : .identity
+        view.layoutIfNeeded()
     }
 }
 

--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -380,7 +380,11 @@ class LibraryViewController: UIViewController, Themeable, BookmarksRefactorFeatu
         let controlbarHeight = segmentControlToolbar.frame.height
         segmentControlToolbar.transform = value ? .init(translationX: 0, y: -controlbarHeight) : .identity
         controllerContainerView.transform = value ? .init(translationX: 0, y: -controlbarHeight) : .identity
-        view.layoutIfNeeded()
+
+        // Reload the current panel
+        guard let index = viewModel.selectedPanel?.rawValue,
+              let currentPanel = childPanelControllers[safe: index] else { return }
+        currentPanel.view.layoutIfNeeded()
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11110)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24225)

## :bulb: Description
- Fix flicker in empty state of a bookmark subfolder that would occur when moving the last bookmark out of the folder

### 🎥 Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/4bfaf63a-3dbc-4c47-b85b-8cf661dc7422

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/4b049690-14ea-402a-8fd5-ce4b9ab1f69c

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

