### PR TITLE
Fix FXIOS-11101 Bugfix close button 

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -536,19 +536,24 @@ class TabTrayViewController: UIViewController,
 
     private func showCloseAllConfirmation() {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        let closeAction = UIAlertAction(title: "Close All Tabs", style: .destructive) { _ in
+        let closeAction = UIAlertAction(title: .LegacyAppMenu.AppMenuCloseAllTabsTitleString, style: .destructive) { _ in
             self.closeAllTabs()
         }
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        let cancelAction = UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel, style: .cancel, handler: nil)
         alertController.addAction(closeAction)
         alertController.addAction(cancelAction)
         
-        // Per iPad, specifica la sorgente del popover
+        
         if let popoverController = alertController.popoverPresentationController {
             popoverController.sourceView = self.view
             popoverController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
             popoverController.permittedArrowDirections = []
         }
+        
+        
+        alertController.accessibilityIdentifier = "closeAllTabsActionSheet"
+        closeAction.accessibilityIdentifier = "closeAllTabsButton"
+        cancelAction.accessibilityIdentifier = "cancelButton"
         
         present(alertController, animated: true, completion: nil)
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -543,7 +543,6 @@ class TabTrayViewController: UIViewController,
         alertController.addAction(closeAction)
         alertController.addAction(cancelAction)
         
-        
         if let popoverController = alertController.popoverPresentationController {
             popoverController.sourceView = self.view
             popoverController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
@@ -551,7 +550,6 @@ class TabTrayViewController: UIViewController,
         }
         
         
-        alertController.accessibilityIdentifier = "closeAllTabsActionSheet"
         closeAction.accessibilityIdentifier = "closeAllTabsButton"
         cancelAction.accessibilityIdentifier = "cancelButton"
         

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -549,7 +549,6 @@ class TabTrayViewController: UIViewController,
             popoverController.permittedArrowDirections = []
         }
         
-        
         closeAction.accessibilityIdentifier = "closeAllTabsButton"
         cancelAction.accessibilityIdentifier = "cancelButton"
         


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11101)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24206)

## :bulb: Description
Resolved an issue where the "Close All" pop-up would not reappear after being dismissed.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment @Mergifyio backport release/v135`)

