### PR TITLE
Bugfix [Sync] fix: drop login encryption key from localEncryptionKeys

### DIFF
--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -363,9 +363,8 @@ public class RustSyncManager: NSObject, SyncManager {
                  self.profile?.tabs.registerWithSyncManager()
                  rustEngines.append(engine.rawValue)
              case .passwords:
-                 if let key = loginKey {
+                 if loginKey != nil {
                      self.profile?.logins.registerWithSyncManager()
-                     localEncryptionKeys[engine.rawValue] = key
                      rustEngines.append(engine.rawValue)
                  }
              case .creditcards:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11186)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24367)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Drops local encryption for the logins engine. Otherwise sync manager panics. Similar to [this android bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1943847).
## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

