### PR TITLE
Refactor FXIOS-8398 Replace external alert snackbar with AlertController

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -625,11 +625,10 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         if !(url.scheme?.contains("firefox") ?? true) {
+            // Try to open the custom scheme URL, if it doesn't work we show an error alert
             UIApplication.shared.open(url, options: [:]) { openedURL in
                 // Do not show error message for JS navigated links or
                 // redirect as it's not the result of a user action.
-                // TODO: Laurie - Check syntheticClickType
-
                 if !openedURL, navigationAction.navigationType == .linkActivated {
                     let alert = UIAlertController(
                         title: nil,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -507,8 +507,7 @@ extension BrowserViewController: WKNavigationDelegate {
         // gives us the exact same behaviour as Safari.
         if ["sms", "tel", "facetime", "facetime-audio"].contains(url.scheme) {
             if url.scheme == "sms" { // All the other types show a native prompt
-                // TODO: Laurie - Add string
-                showExternalAlert(withText: "Open sms in an external application?") { _ in
+                showExternalAlert(withText: .ExternalSmsLinkConfirmation) { _ in
                     UIApplication.shared.open(url, options: [:])
                 }
             } else {
@@ -560,8 +559,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
         // Handles custom mailto URL schemes.
         if url.scheme == "mailto" {
-            // TODO: Laurie - Add string
-            showExternalAlert(withText: "Open email in the default mail application?") { _ in
+            showExternalAlert(withText: .ExternalMailLinkConfirmation) { _ in
                 if let mailToMetadata = url.mailToMetadata(),
                    let mailScheme = self.profile.prefs.stringForKey(PrefsKeys.KeyMailToOption),
                    mailScheme != "mailto" {
@@ -633,10 +631,9 @@ extension BrowserViewController: WKNavigationDelegate {
                 // TODO: Laurie - Check syntheticClickType
 
                 if !openedURL, navigationAction.navigationType == .linkActivated {
-                    // TODO: Laurie - Add string
                     let alert = UIAlertController(
                         title: nil,
-                        message: "The application required to open that link can't be found.",
+                        message: .ExternalInvalidLinkMessage,
                         preferredStyle: .alert
                     )
                     alert.addAction(UIAlertAction(title: .OKString, style: .default, handler: nil))
@@ -1063,9 +1060,8 @@ private extension BrowserViewController {
                                       message: text,
                                       preferredStyle: .alert)
 
-        // TODO: Laurie - Add string
         let okOption = UIAlertAction(
-            title: "Open",
+            title: .ExternalOpenMessage,
             style: .default,
             handler: completion
         )

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -173,7 +173,7 @@ class BrowserViewController: UIViewController,
     var bottomContainer: BaseAlphaStackView = .build { _ in }
 
     // Alert content that appears on top of the content
-    // ex: Find In Page, SnackBars
+    // ex: Find In Page, SnackBar from LoginsHelper
     var bottomContentStackView: BaseAlphaStackView = .build { stackview in
         stackview.isClearBackground = true
     }

--- a/firefox-ios/Client/Frontend/Widgets/TimerSnackBar.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TimerSnackBar.swift
@@ -23,41 +23,6 @@ class TimerSnackBar: SnackBar {
         fatalError("init(coder:) has not been implemented")
     }
 
-    static func showAppStoreConfirmationBar(
-        forTab tab: Tab,
-        appStoreURL: URL,
-        theme: Theme,
-        completion: @escaping (Bool) -> Void
-    ) {
-        let bar = TimerSnackBar(
-            text: .ExternalLinkAppStoreConfirmationTitle,
-            img: UIImage(named: StandardImageIdentifiers.Large.globe)?.withRenderingMode(.alwaysOriginal))
-        let openAppStore = SnackButton(
-            title: .AppStoreString,
-            accessibilityIdentifier: "ConfirmOpenInAppStore",
-            bold: true
-        ) { bar in
-            tab.removeSnackbar(bar)
-            UIApplication.shared.open(appStoreURL, options: [:])
-            completion(true)
-        }
-        let cancelButton = SnackButton(
-            title: .NotNowString,
-            accessibilityIdentifier: "CancelOpenInAppStore",
-            bold: false
-        ) { bar in
-            tab.removeSnackbar(bar)
-            completion(false)
-        }
-        bar.applyTheme(theme: theme)
-        cancelButton.applyTheme(theme: theme)
-        openAppStore.applyTheme(theme: theme)
-
-        bar.addButton(cancelButton)
-        bar.addButton(openAppStore)
-        tab.addSnackbar(bar)
-    }
-
     override func show() {
         self.timer = Timer(
             timeInterval: timeout,

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4946,11 +4946,30 @@ extension String {
         tableName: nil,
         value: "Open this link in the App Store?",
         comment: "Question shown to user when tapping a link that opens the App Store app")
-    public static let ExternalLinkGenericConfirmation = MZLocalizedString(
-        key: "ExternalLink.AppStore.GenericConfirmationTitle",
-        tableName: nil,
-        value: "Open this link in external app?",
-        comment: "Question shown to user when tapping an SMS or MailTo link that opens the external app for those.")
+    public static let ExternalSmsLinkConfirmation = MZLocalizedString(
+        key: "ExternalLink.ExternalSmsLinkConfirmation",
+        tableName: "ExternalLink",
+        value: "Open sms in an external application?",
+        comment: "Question shown to user when tapping an SMS link that opens the external app for those."
+    )
+    public static let ExternalMailLinkConfirmation = MZLocalizedString(
+        key: "ExternalLink.ExternalMailLinkConfirmation",
+        tableName: "ExternalLink",
+        value: "Open email in the default mail application?",
+        comment: "Question shown to user when tapping a mail link that opens the external app for those."
+    )
+    public static let ExternalInvalidLinkMessage = MZLocalizedString(
+        key: "ExternalLink.ExternalInvalidLinkMessage",
+        tableName: "ExternalLink",
+        value: "The application required to open that link can't be found.",
+        comment: "A statement shown to user when tapping an external link and the link doesn't work."
+    )
+    public static let ExternalOpenMessage = MZLocalizedString(
+        key: "ExternalLink.ExternalOpenMessage",
+        tableName: "ExternalLink",
+        value: "Open",
+        comment: "The call to action button for a user to open an external link."
+    )
 }
 
 // MARK: Enhanced Tracking Protection/Unified Trust Panel
@@ -7695,6 +7714,13 @@ extension String {
                 tableName: "Settings",
                 value: "Learn More.",
                 comment: "Title for a link that explains how Mozilla send crash reports.")
+        }
+        struct v136 {
+            public static let ExternalLinkGenericConfirmation = MZLocalizedString(
+                key: "ExternalLink.AppStore.GenericConfirmationTitle",
+                tableName: nil,
+                value: "Open this link in external app?",
+                comment: "Question shown to user when tapping an SMS or MailTo link that opens the external app for those.")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8398)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18618)

## :bulb: Description
- Replace Snackbar when we open sms, email, app store or external custom scheme links with a native `UIAlertController` prompt.
- Fixed AppStore alert tab deletion (history wasn't empty as the comment said, so the use case [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1435288) wasn't working anymore).
- Note; we only use the `Snackbar` for `LoginsHelper` now. Maybe we can revisit and clean this ugly alert at one point 🤞 
- Still waiting for strings content review, but wanted to get feedback on the PR in the meantime

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

