### PR TITLE
Add FXIOS-11134 [Homepage] [MessageCard] handling actions for the card

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -364,7 +364,7 @@ final class HomepageViewController: UIViewController,
                 return UICollectionViewCell()
             }
 
-            messageCardCell.configure(with: config, theme: currentTheme)
+            messageCardCell.configure(with: config, windowUUID: windowUUID, theme: currentTheme)
             return messageCardCell
         case .topSite(let site, let textColor):
             guard let topSiteCell = collectionView?.dequeueReusableCell(cellType: TopSiteCell.self, for: indexPath) else {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/HomepageMessageCardCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/HomepageMessageCardCell.swift
@@ -34,6 +34,8 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
 
     // MARK: - Properties
     private var kvoToken: NSKeyValueObservation?
+    private var windowUUID: WindowUUID?
+    private var logger: Logger = DefaultLogger.shared
 
     // MARK: - UI
 
@@ -97,7 +99,8 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
         kvoToken?.invalidate()
     }
 
-    func configure(with config: MessageCardConfiguration, theme: Theme) {
+    func configure(with config: MessageCardConfiguration, windowUUID: WindowUUID, theme: Theme) {
+        self.windowUUID = windowUUID
         applyGleanMessage(with: config.title, description: config.description, buttonLabel: config.buttonLabel)
         applyTheme(theme: theme)
         ctaButton.applyTheme(theme: theme)
@@ -207,13 +210,39 @@ class HomepageMessageCardCell: UICollectionViewCell, ReusableCell {
     // MARK: Actions
     @objc
     private func dismissCard() {
-        // TODO: FXIOS-11134 - Handle message actions
+        guard let windowUUID else {
+            logger.log(
+                "windowUUID is nil when dismissing homepage message card",
+                level: .warning,
+                category: .homepage
+            )
+            return
+        }
+        store.dispatch(
+            MessageCardAction(
+                windowUUID: windowUUID,
+                actionType: MessageCardActionType.tappedOnCloseButton
+            )
+        )
     }
 
     /// The surface needs to handle CTAs a certain way when there's a message.
     @objc
     func handleCTA() {
-        // TODO: FXIOS-11134 - Handle message actions
+        guard let windowUUID else {
+            logger.log(
+                "windowUUID is nil when tapping on action button on homepage message card",
+                level: .warning,
+                category: .homepage
+            )
+            return
+        }
+        store.dispatch(
+            MessageCardAction(
+                windowUUID: windowUUID,
+                actionType: MessageCardActionType.tappedOnActionButton
+            )
+        )
     }
 }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardAction.swift
@@ -18,6 +18,11 @@ final class MessageCardAction: Action {
     }
 }
 
+enum MessageCardActionType: ActionType {
+    case tappedOnActionButton
+    case tappedOnCloseButton
+}
+
 enum MessageCardMiddlewareActionType: ActionType {
     case initialize
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardMiddleware.swift
@@ -26,6 +26,12 @@ final class MessageCardMiddleware {
         switch action.actionType {
         case HomepageActionType.initialize:
             self.handleInitializeMessageCardAction(windowUUID: windowUUID)
+        case MessageCardActionType.tappedOnActionButton:
+            guard let message = self.message else { return }
+            self.messagingManager.onMessagePressed(message, window: windowUUID, shouldExpire: true)
+        case MessageCardActionType.tappedOnCloseButton:
+            guard let message = self.message else { return }
+            self.messagingManager.onMessageDismissed(message)
         default:
            break
         }
@@ -40,7 +46,9 @@ final class MessageCardMiddleware {
             )
             dispatchMessageCardAction(windowUUID: windowUUID, config: config)
             messagingManager.onMessageDisplayed(message)
+            self.message = message
         } else {
+            self.message = nil
             return
         }
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/MessageCard/MessageCardState.swift
@@ -35,6 +35,8 @@ struct MessageCardState: StateType, Equatable, Hashable {
         switch action.actionType {
         case MessageCardMiddlewareActionType.initialize:
             return handleInitializeAction(for: state, with: action)
+        case MessageCardActionType.tappedOnActionButton, MessageCardActionType.tappedOnCloseButton:
+            return handleTappingAction(for: state, with: action)
         default:
             return defaultState(from: state)
         }
@@ -49,6 +51,14 @@ struct MessageCardState: StateType, Equatable, Hashable {
         return MessageCardState(
             windowUUID: state.windowUUID,
             messageCardConfiguration: messageCardConfiguration
+        )
+    }
+
+    /// Tapping an action on the card should dismiss the message card and we do this by setting the configuration to nil
+    private static func handleTappingAction(for state: MessageCardState, with action: Action) -> MessageCardState {
+        return MessageCardState(
+            windowUUID: state.windowUUID,
+            messageCardConfiguration: nil
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardMiddlewareTests.swift
@@ -72,6 +72,46 @@ final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(messagingManager.onMessageDisplayedCalled, 0)
     }
 
+    func test_tappedOnActionButton_performsActionAndDismissesMessageCard() throws {
+        let messagingManager = MockGleanPlumbMessageManagerProtocol()
+        let message = createMessage(with: MockMessageData(surface: .newTabCard))
+        messagingManager.message = message
+        let subject = createSubject(messagingManager: messagingManager)
+
+        let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
+
+        subject.messageCardProvider(AppState(), action)
+
+        let secondaryAction = MessageCardAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: MessageCardActionType.tappedOnActionButton
+        )
+
+        subject.messageCardProvider(AppState(), secondaryAction)
+
+        XCTAssertEqual(messagingManager.onMessagePressedCalled, 1)
+    }
+
+    func test_tappedOnCloseButton_dismissesMessageCard() throws {
+        let messagingManager = MockGleanPlumbMessageManagerProtocol()
+        let message = createMessage(with: MockMessageData(surface: .newTabCard))
+        messagingManager.message = message
+        let subject = createSubject(messagingManager: messagingManager)
+
+        let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
+
+        subject.messageCardProvider(AppState(), action)
+
+        let secondaryAction = MessageCardAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: MessageCardActionType.tappedOnCloseButton
+        )
+
+        subject.messageCardProvider(AppState(), secondaryAction)
+
+        XCTAssertEqual(messagingManager.onMessageDismissedCalled, 1)
+    }
+
     // MARK: - Helpers
     private func createSubject(messagingManager: GleanPlumbMessageManagerProtocol) -> MessageCardMiddleware {
         return MessageCardMiddleware(messagingManager: messagingManager)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/MessageCardStateTests.swift
@@ -37,6 +37,49 @@ final class MessageCardStateTests: XCTestCase {
         XCTAssertEqual(newState.messageCardConfiguration?.description, "Example Description")
         XCTAssertEqual(newState.messageCardConfiguration?.buttonLabel, "Example Button")
     }
+
+    func test_tappedOnActionButton_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = messageCardReducer()
+
+        let newState = reducer(
+            initialState,
+            MessageCardAction(
+                messageCardConfiguration: MessageCardConfiguration(
+                    title: "Example Title",
+                    description: "Example Description",
+                    buttonLabel: "Example Button"
+                ),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MessageCardActionType.tappedOnActionButton
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertNil(newState.messageCardConfiguration)
+    }
+
+    func test_tappedOnCloseButtonAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = messageCardReducer()
+
+        let newState = reducer(
+            initialState,
+            MessageCardAction(
+                messageCardConfiguration: MessageCardConfiguration(
+                    title: "Example Title",
+                    description: "Example Description",
+                    buttonLabel: "Example Button"
+                ),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MessageCardActionType.tappedOnCloseButton
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertNil(newState.messageCardConfiguration)
+    }
+
     // MARK: - Private
     private func createSubject() -> MessageCardState {
         return MessageCardState(windowUUID: .XCTestDefaultUUID)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11134)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24269)

## :bulb: Description
Handle actions on homepage message card:
* Tapping on closing dismisses the card as well as trigger the appropriate call for the mobile messaging system
* Tapping on primary action button presents instructions sheet and also dismisses the card

Created 2 actions one for tapping on close button and one for tapping on action card. The middleware responds to the actions by calling the appropriate method from the mobile messaging system and the state updates the view but setting the message configuration to nil (which hides the message card from being shown).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots 
https://github.com/user-attachments/assets/2dbd2ff4-f759-4aa8-b2ef-8b9e7399c209