### PR TITLE
Bugfix FXIOS-11216 Bugzilla 1941525

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3277,13 +3277,12 @@ class BrowserViewController: UIViewController,
         TelemetryWrapper.recordEvent(category: .action, method: .scan, object: .qrCodeURL)
     }
 
-    func didScanQRCodeWithText(_ text: String) {
+    func didScanQRCodeWithTextContent(_ content: TextContentDetector.DetectedType?, rawText text: String) {
         TelemetryWrapper.recordEvent(category: .action, method: .scan, object: .qrCodeText)
         let defaultAction: () -> Void = { [weak self] in
             guard let tab = self?.tabManager.selectedTab else { return }
             self?.submitSearchText(text, forTab: tab)
         }
-        let content = TextContentDetector.detectTextContent(text)
         switch content {
         case .some(.link(let url)):
             UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
@@ -319,7 +319,7 @@ extension FirefoxAccountSignInViewController: QRCodeViewControllerDelegate {
         }
     }
 
-    func didScanQRCodeWithText(_ text: String) {
+    func didScanQRCodeWithTextContent(_ content: TextContentDetector.DetectedType?, rawText: String) {
         logger.log("FirefoxAccountSignInVC Error: `didScanQRCodeWithText` should not be called",
                    level: .info,
                    category: .sync)

--- a/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
@@ -320,7 +320,7 @@ extension FirefoxAccountSignInViewController: QRCodeViewControllerDelegate {
     }
 
     func didScanQRCodeWithTextContent(_ content: TextContentDetector.DetectedType?, rawText: String) {
-        logger.log("FirefoxAccountSignInVC Error: `didScanQRCodeWithText` should not be called",
+        logger.log("FirefoxAccountSignInVC Error: `didScanQRCodeWithTextContent` should not be called",
                    level: .info,
                    category: .sync)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockQRCodeParentCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockQRCodeParentCoordinator.swift
@@ -13,7 +13,7 @@ class MockQRCodeViewControllerDelegate: QRCodeViewControllerDelegate {
         didScanQRCodeWithUrlCalled += 1
     }
 
-    func didScanQRCodeWithText(_ text: String) {
+    func didScanQRCodeWithTextContent(_ content: TextContentDetector.DetectedType?, rawText: String) {
         didScanQRCodeWithTextCalled += 1
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11216)
[Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1941525)

## :bulb: Description

Security ticket. Please see linked Bugzilla for additional details.

**Note**: I am seeing a related but separate issue when scanning multiple text QR codes in a row, the first one triggers the expected `metadataOutput` callback but the subsequent scans do not, which bypasses all of our related logic entirely. This is already reproducible on `main` so it isn't a regression introduced by the changes in this PR, I'm taking a closer look right now however since it is a separate bug I don't think it needs to hold up review of this PR. (cc @lmarceau) 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

