### PR TITLE
Bugfix FXIOS-10853 #23668 Flaky history unit tests

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -1147,6 +1147,10 @@ class TabWebView: WKWebView, MenuHelperWebViewInterface, ThemeApplicable {
     init(frame: CGRect, configuration: WKWebViewConfiguration, windowUUID: WindowUUID) {
         self.windowUUID = windowUUID
         super.init(frame: frame, configuration: configuration)
+
+        if #available(iOS 16.0, *) {
+            isFindInteractionEnabled = true
+        }
     }
 
     required init?(coder: NSCoder) {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -1147,10 +1147,6 @@ class TabWebView: WKWebView, MenuHelperWebViewInterface, ThemeApplicable {
     init(frame: CGRect, configuration: WKWebViewConfiguration, windowUUID: WindowUUID) {
         self.windowUUID = windowUUID
         super.init(frame: frame, configuration: configuration)
-
-        if #available(iOS 16.0, *) {
-            isFindInteractionEnabled = true
-        }
     }
 
     required init?(coder: NSCoder) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
@@ -186,6 +186,7 @@ class HistoryPanelViewModelTests: XCTestCase {
         XCTAssertEqual(section, .lastHour)
     }
 
+    // Laurie
     func testGroupBelongToSection_ForToday() {
         let date = Calendar.current.date(byAdding: .hour, value: -2, to: Date()) ?? Date()
         let timestamp = date.toMicrosecondsSince1970()
@@ -235,6 +236,7 @@ class HistoryPanelViewModelTests: XCTestCase {
         XCTAssertEqual(section, .lastMonth)
     }
 
+    // Laurie
     func testShouldAddGroupToSections_ForToday() {
         let date = Calendar.current.date(byAdding: .hour, value: -2, to: Date()) ?? Date()
         let timestamp = date.toMicrosecondsSince1970()
@@ -268,23 +270,31 @@ class HistoryPanelViewModelTests: XCTestCase {
         addSiteVisit(profile, url: "https://apple.com/", title: "Apple")
     }
 
-    private func addSiteVisit(_ profile: MockProfile, url: String, title: String) {
+    private func addSiteVisit(_ profile: MockProfile,
+                              url: String,
+                              title: String,
+                              file: StaticString = #file,
+                              line: UInt = #line) {
         let visitObservation = VisitObservation(url: url, title: title, visitType: .link)
         let result = profile.places.applyObservation(visitObservation: visitObservation)
 
-        XCTAssertEqual(true, result.value.isSuccess, "Site added: \(url).")
+        XCTAssertEqual(true, result.value.isSuccess, "Site added: \(url).", file: file, line: line)
     }
 
-    private func clear(profile: MockProfile) {
+    private func clear(profile: MockProfile,
+                       file: StaticString = #file,
+                       line: UInt = #line) {
         let result = profile.places.deleteEverythingHistory()
-        XCTAssertTrue(result.value.isSuccess, "History cleared.")
+        XCTAssertTrue(result.value.isSuccess, "History cleared.", file: file, line: line)
     }
 
-    private func fetchHistory(completion: @escaping (Bool) -> Void) {
+    private func fetchHistory(file: StaticString = #file,
+                              line: UInt = #line,
+                              completion: @escaping (Bool) -> Void) {
         let expectation = self.expectation(description: "Wait for history")
 
         subject.reloadData { success in
-            XCTAssertNotNil(success)
+            XCTAssertNotNil(success, file: file, line: line)
             completion(success)
             expectation.fulfill()
         }
@@ -293,11 +303,13 @@ class HistoryPanelViewModelTests: XCTestCase {
     }
 
     private func fetchSearchHistory(searchTerm: String,
+                                    file: StaticString = #file,
+                                    line: UInt = #line,
                                     completion: @escaping (Bool) -> Void) {
         let expectation = self.expectation(description: "Wait for history search")
 
         subject.performSearch(term: searchTerm) { hasResults in
-            XCTAssertNotNil(hasResults)
+            XCTAssertNotNil(hasResults, file: file, line: line)
             completion(hasResults)
             expectation.fulfill()
         }
@@ -305,7 +317,9 @@ class HistoryPanelViewModelTests: XCTestCase {
         waitForExpectations(timeout: 5)
     }
 
-    private func createSearchTermGroup(timestamp: MicrosecondTimestamp) -> ASGroup<Site> {
+    private func createSearchTermGroup(timestamp: MicrosecondTimestamp,
+                                       file: StaticString = #file,
+                                       line: UInt = #line) -> ASGroup<Site> {
         var groupSites = [Site]()
         for index in 0...3 {
             var site = Site.createBasicSite(url: "http://site\(index).com", title: "Site \(index)")
@@ -318,7 +332,9 @@ class HistoryPanelViewModelTests: XCTestCase {
             )
             XCTAssertTrue(
                 profile.places.applyObservation(visitObservation: visit).value.isSuccess,
-                "Site added: \(site.url)."
+                "Site added: \(site.url).",
+                file: file,
+                line: line
             )
             groupSites.append(site)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
@@ -186,9 +186,8 @@ class HistoryPanelViewModelTests: XCTestCase {
         XCTAssertEqual(section, .lastHour)
     }
 
-    // Laurie
     func testGroupBelongToSection_ForToday() {
-        let date = Calendar.current.date(byAdding: .hour, value: -2, to: Date()) ?? Date()
+        let date = Calendar.current.date(byAdding: .hour, value: -3, to: Date()) ?? Date()
         let timestamp = date.toMicrosecondsSince1970()
         let searchTermGroup = createSearchTermGroup(timestamp: timestamp)
 
@@ -236,9 +235,8 @@ class HistoryPanelViewModelTests: XCTestCase {
         XCTAssertEqual(section, .lastMonth)
     }
 
-    // Laurie
     func testShouldAddGroupToSections_ForToday() {
-        let date = Calendar.current.date(byAdding: .hour, value: -2, to: Date()) ?? Date()
+        let date = Calendar.current.date(byAdding: .hour, value: -3, to: Date()) ?? Date()
         let timestamp = date.toMicrosecondsSince1970()
         let searchTermGroup = createSearchTermGroup(timestamp: timestamp)
         subject.visibleSections.append(.today)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10853)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23668)

## :bulb: Description
I think the failure can happen since the `today` date used `-2` to remove time on the current `Date()`. This could result into that test falling into the switch case of `.lastHour` when fetching which sections it is, since the current hour can change while the test is running. I changed the test to use `-3` so this use case would not happen anymore. Let's see if that fixes the problem in Bitrise, not sure this is indeed the problem... we'll see!

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

