### PR TITLE
Bugfix FXIOS-10650 ⁃ [Felt privacy-Unified panel] - ETP toggle not displayed in the panel anymore after disabling it from settings

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionToggleView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionToggleView.swift
@@ -107,8 +107,14 @@ final class TrackingProtectionToggleView: UIView, ThemeApplicable {
         toggleSwitch.isHidden = isHidden
     }
 
-    func setStatusLabelText(with text: String) {
+    func setStatusLabelText(with text: String, and isAccessibilityTrait: Bool) {
         toggleStatusLabel.text = text
+        toggleLabelsContainer.accessibilityHint = text
+        if isAccessibilityTrait {
+            toggleLabelsContainer.accessibilityTraits = .button
+        } else {
+            toggleLabelsContainer.accessibilityTraits.remove(.button)
+        }
     }
 
     func setupDetails(isOn: Bool) {

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -76,7 +76,10 @@ class TrackingProtectionViewController: UIViewController,
     private let connectionHorizontalLine: UIView = .build()
 
     // MARK: Toggle View
-    private let toggleView: TrackingProtectionToggleView = .build()
+    private lazy var toggleView: TrackingProtectionToggleView = .build { [weak self] view in
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self?.openSettingsTapped))
+        view.addGestureRecognizer(tapGesture)
+    }
 
     // MARK: Clear Cookies View
     private lazy var clearCookiesButton: TrackingProtectionButton = .build { button in
@@ -566,6 +569,17 @@ class TrackingProtectionViewController: UIViewController,
         )
     }
 
+    @objc
+    func openSettingsTapped() {
+        let isContentBlockingConfigEnabled = profile?.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? true
+        if !isContentBlockingConfigEnabled {
+            store.dispatch(
+                TrackingProtectionAction(windowUUID: windowUUID,
+                                         actionType: TrackingProtectionActionType.tappedShowSettings)
+            )
+        }
+    }
+
     private func showBlockedTrackersController() {
         blockedTrackersVC = BlockedTrackersTableViewController(with: model.getBlockedTrackersModel(),
                                                                windowUUID: windowUUID)
@@ -636,11 +650,13 @@ class TrackingProtectionViewController: UIViewController,
     private func updateProtectionViewStatus() {
         let isContentBlockingConfigEnabled = profile?.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? true
         if toggleView.toggleIsOn, isContentBlockingConfigEnabled {
-            toggleView.setStatusLabelText(with: .Menu.EnhancedTrackingProtection.switchOnText)
+            toggleView.setStatusLabelText(with: .Menu.EnhancedTrackingProtection.switchOnText,
+                                          and: !isContentBlockingConfigEnabled)
             trackersView.setVisibility(isHidden: false)
             model.isProtectionEnabled = true
         } else {
-            toggleView.setStatusLabelText(with: .Menu.EnhancedTrackingProtection.switchOffText)
+            toggleView.setStatusLabelText(with: .Menu.EnhancedTrackingProtection.switchOffText,
+                                          and: !isContentBlockingConfigEnabled)
             trackersView.setVisibility(isHidden: true)
             model.isProtectionEnabled = false
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10650)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23306)

## :bulb: Description
Added a button on the toggle view when ETP is disabled from settings

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

