### PR TITLE
Add FXIOS-11200 [Homepage] [JumpBackIn] initial state + view

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -881,6 +881,10 @@
 		8A6B799D2CDBDAE4003C3077 /* MockContileProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B799C2CDBDAE4003C3077 /* MockContileProvider.swift */; };
 		8A6B79A02CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B799F2CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift */; };
 		8A6E13982A71BA4E00A88FA8 /* TabWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */; };
+		8A6E63C52D4946760040D355 /* JumpBackInCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63C42D49466C0040D355 /* JumpBackInCell.swift */; };
+		8A6E63C72D4946B90040D355 /* JumpBackInSectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63C62D4946B40040D355 /* JumpBackInSectionState.swift */; };
+		8A6E63C92D4948BE0040D355 /* JumpBackInTabState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63C82D4948BE0040D355 /* JumpBackInTabState.swift */; };
+		8A6E63CB2D4A6F230040D355 /* JumpBackInSectionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63CA2D4A6F230040D355 /* JumpBackInSectionStateTests.swift */; };
 		8A6E8DEB2B275BA9000C4301 /* PrivateHomepageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E8DE92B275B49000C4301 /* PrivateHomepageViewControllerTests.swift */; };
 		8A720C5E2A4C85DA0003018A /* AccountSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */; };
 		8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */; };
@@ -951,7 +955,7 @@
 		8A96C4BB28F9E7B300B75884 /* XCTestCaseRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */; };
 		8A97E6EA2C58487900F94793 /* AddressLocaleFeatureValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A97E6E92C58487900F94793 /* AddressLocaleFeatureValidator.swift */; };
 		8A97E6EF2C584C4900F94793 /* AddressLocaleFeatureValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A97E6ED2C584AC300F94793 /* AddressLocaleFeatureValidatorTests.swift */; };
-		8A9AC465276CEC4E0047F5B0 /* JumpBackInCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9AC464276CEC4E0047F5B0 /* JumpBackInCell.swift */; };
+		8A9AC465276CEC4E0047F5B0 /* LegacyJumpBackInCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9AC464276CEC4E0047F5B0 /* LegacyJumpBackInCell.swift */; };
 		8A9AC46B276D11280047F5B0 /* PocketViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9AC46A276D11280047F5B0 /* PocketViewModel.swift */; };
 		8A9B87AD2C1B39100042B894 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9B87AC2C1B39100042B894 /* SearchViewModel.swift */; };
 		8A9B87AF2C1B39EA0042B894 /* SearchListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9B87AE2C1B39EA0042B894 /* SearchListSection.swift */; };
@@ -7720,6 +7724,10 @@
 		8A6B799C2CDBDAE4003C3077 /* MockContileProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockContileProvider.swift; sourceTree = "<group>"; };
 		8A6B799F2CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGoogleTopSiteManager.swift; sourceTree = "<group>"; };
 		8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabWebViewTests.swift; sourceTree = "<group>"; };
+		8A6E63C42D49466C0040D355 /* JumpBackInCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInCell.swift; sourceTree = "<group>"; };
+		8A6E63C62D4946B40040D355 /* JumpBackInSectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInSectionState.swift; sourceTree = "<group>"; };
+		8A6E63C82D4948BE0040D355 /* JumpBackInTabState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInTabState.swift; sourceTree = "<group>"; };
+		8A6E63CA2D4A6F230040D355 /* JumpBackInSectionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInSectionStateTests.swift; sourceTree = "<group>"; };
 		8A6E8DE92B275B49000C4301 /* PrivateHomepageViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateHomepageViewControllerTests.swift; sourceTree = "<group>"; };
 		8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSettingsDelegate.swift; sourceTree = "<group>"; };
@@ -7806,7 +7814,7 @@
 		8A99DB9A27C6DD3E007EA6BD /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/BookmarkPanelDeleteConfirm.strings; sourceTree = "<group>"; };
 		8A99DB9B27C6DD3E007EA6BD /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/WidgetIntents.strings; sourceTree = "<group>"; };
 		8A99DB9C27C6DD3E007EA6BD /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/Localizable.strings; sourceTree = "<group>"; };
-		8A9AC464276CEC4E0047F5B0 /* JumpBackInCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInCell.swift; sourceTree = "<group>"; };
+		8A9AC464276CEC4E0047F5B0 /* LegacyJumpBackInCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyJumpBackInCell.swift; sourceTree = "<group>"; };
 		8A9AC46A276D11280047F5B0 /* PocketViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketViewModel.swift; sourceTree = "<group>"; };
 		8A9B87AC2C1B39100042B894 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		8A9B87AE2C1B39EA0042B894 /* SearchListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListSection.swift; sourceTree = "<group>"; };
@@ -11766,6 +11774,7 @@
 			isa = PBXGroup;
 			children = (
 				8AED23072D4012B1000FF624 /* MessageCardStateTests.swift */,
+				8A6E63CA2D4A6F230040D355 /* JumpBackInSectionStateTests.swift */,
 				8A106D622D416F82009AD7E4 /* MessageCardMiddlewareTests.swift */,
 				8AEF41612D15EDBA0013925D /* TopSitesMiddlewareTests.swift */,
 				8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */,
@@ -11879,6 +11888,16 @@
 			path = Microsurvey;
 			sourceTree = "<group>";
 		};
+		8A6E63C32D4946600040D355 /* JumpBackIn */ = {
+			isa = PBXGroup;
+			children = (
+				8A6E63C62D4946B40040D355 /* JumpBackInSectionState.swift */,
+				8A6E63C82D4948BE0040D355 /* JumpBackInTabState.swift */,
+				8A6E63C42D49466C0040D355 /* JumpBackInCell.swift */,
+			);
+			path = JumpBackIn;
+			sourceTree = "<group>";
+		};
 		8A7653C028A2E54800924ABF /* Pocket */ = {
 			isa = PBXGroup;
 			children = (
@@ -11901,6 +11920,7 @@
 		8A7D08E12CAAF79F0035999C /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
+				8A6E63C32D4946600040D355 /* JumpBackIn */,
 				8AED23022D400020000FF624 /* MessageCard */,
 				8A62B15B2CED40800045F46E /* ContextMenu */,
 				8A454D3D2CB9B896009436D9 /* TopSites */,
@@ -12325,7 +12345,7 @@
 		8AE80BC02891C77800BC12EA /* Cell */ = {
 			isa = PBXGroup;
 			children = (
-				8A9AC464276CEC4E0047F5B0 /* JumpBackInCell.swift */,
+				8A9AC464276CEC4E0047F5B0 /* LegacyJumpBackInCell.swift */,
 				E1877A822875DEDE00F5BDF2 /* SyncedTabCell.swift */,
 			);
 			path = Cell;
@@ -16659,6 +16679,7 @@
 				AB9CBC032C53B64C00102610 /* TrackingProtectionMiddleware.swift in Sources */,
 				D87F84AC20B891160091F2DA /* TopTabDisplayManager.swift in Sources */,
 				D0C95EF6201A55A800E4E51C /* BrowserViewController+UIDropInteractionDelegate.swift in Sources */,
+				8A6E63C52D4946760040D355 /* JumpBackInCell.swift in Sources */,
 				D31CF65C1CC1959A001D0BD0 /* PrivilegedRequest.swift in Sources */,
 				8A6A796D27F773550022D6C6 /* HomepageContextMenuHelper.swift in Sources */,
 				8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */,
@@ -16821,6 +16842,7 @@
 				C88E7A572A0553360072E638 /* OnboardingButtonInfoModel.swift in Sources */,
 				AB9A0C012C6CBC9100BFA22A /* TrackingProtectionDetailsViewController.swift in Sources */,
 				21B548952B1E5F1400DC1DF8 /* InactiveTabsManager.swift in Sources */,
+				8A6E63C92D4948BE0040D355 /* JumpBackInTabState.swift in Sources */,
 				C8F457A81F1FD75A000CB895 /* BrowserViewController+WebViewDelegates.swift in Sources */,
 				964FA97728A2A55C0024BB3B /* ContextualHintPrefsKeysProvider.swift in Sources */,
 				8A1E3BDF28CBA81E003388C4 /* SponsoredContentFilterUtility.swift in Sources */,
@@ -17101,7 +17123,7 @@
 				392ED7E41D0AEF56009D9B62 /* NewTabAccessors.swift in Sources */,
 				0A5E6F402CF88A7900C1DFC9 /* SwitchDetailedView.swift in Sources */,
 				1D2F68AD2ACB266300524B92 /* RemoteTabsPanelState.swift in Sources */,
-				8A9AC465276CEC4E0047F5B0 /* JumpBackInCell.swift in Sources */,
+				8A9AC465276CEC4E0047F5B0 /* LegacyJumpBackInCell.swift in Sources */,
 				8CE1E4322B8C76AE0026530B /* LoginStorage.swift in Sources */,
 				4347B398298D6D7B0045F677 /* CreditCardTableViewModel.swift in Sources */,
 				1DFE57FD27BADD7D0025DE58 /* HomepageViewModel.swift in Sources */,
@@ -17155,6 +17177,7 @@
 				E134D5802B31FF3100C6B17B /* FakespotAdLinkButton.swift in Sources */,
 				8AE0BF4F2819B10E00F33EC4 /* TopSitesSettingsViewController.swift in Sources */,
 				ED7A08DD2CF6749B0035EC8F /* ShareType.swift in Sources */,
+				8A6E63C72D4946B90040D355 /* JumpBackInSectionState.swift in Sources */,
 				8A8DDEBF276259A900E7B97A /* RatingPromptManager.swift in Sources */,
 				8AB8571D27D929350075C173 /* TopSitesViewModel.swift in Sources */,
 				E177989A2BD7D44200F6F0EB /* ToolbarState.swift in Sources */,
@@ -17443,6 +17466,7 @@
 				1D558A582BED7ECB001EF527 /* MockWindowManager.swift in Sources */,
 				C8DC90D22A067C6D0008832B /* MarkupAttributionUtilityTests.swift in Sources */,
 				BA1C68BC2B7ED153000D9397 /* MockWebKit.swift in Sources */,
+				8A6E63CB2D4A6F230040D355 /* JumpBackInSectionStateTests.swift in Sources */,
 				8A6B799B2CDBCF3D003C3077 /* TopSitesManagerTests.swift in Sources */,
 				21737FB72878A4BD000A9A92 /* HistoryPanelViewModelTests.swift in Sources */,
 				43B658D929CE251C00C9EF08 /* CreditCardInputViewModelTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -17,6 +17,7 @@ final class HomepageDiffableDataSource:
         case header
         case messageCard
         case topSites(NumberOfTilesPerRow)
+        case jumpBackIn
         case pocket(TextColor?)
         case customizeHomepage
     }
@@ -26,6 +27,7 @@ final class HomepageDiffableDataSource:
         case messageCard(MessageCardConfiguration)
         case topSite(TopSiteState, TextColor?)
         case topSiteEmpty
+        case jumpBackIn(JumpBackInTabState)
         case pocket(PocketStoryState)
         case pocketDiscover(PocketDiscoverState)
         case customizeHomepage
@@ -36,6 +38,7 @@ final class HomepageDiffableDataSource:
                 HomepageMessageCardCell.self,
                 TopSiteCell.self,
                 EmptyTopSiteCell.self,
+                JumpBackInCell.self,
                 PocketStandardCell.self,
                 PocketDiscoverCell.self,
                 CustomizeHomepageSectionCell.self
@@ -59,6 +62,11 @@ final class HomepageDiffableDataSource:
         if let topSites = getTopSites(with: state.topSitesState, and: textColor, numberOfCellsPerRow: numberOfCellsPerRow) {
             snapshot.appendSections([.topSites(numberOfCellsPerRow)])
             snapshot.appendItems(topSites, toSection: .topSites(numberOfCellsPerRow))
+        }
+
+        if let tabs = getJumpBackInTabs(with: state.jumpBackInState) {
+            snapshot.appendSections([.jumpBackIn])
+            snapshot.appendItems(tabs, toSection: .jumpBackIn)
         }
 
         if let stories = getPocketStories(with: state.pocketState) {
@@ -99,5 +107,12 @@ final class HomepageDiffableDataSource:
         }
         guard !topSites.isEmpty else { return nil }
         return topSites
+    }
+
+    private func getJumpBackInTabs(
+        with jumpBackInSectionState: JumpBackInSectionState
+    ) -> [HomepageDiffableDataSource.HomeItem]? {
+        // TODO: FXIOS-11226 Show items or hide items depending user prefs / feature flag
+        return jumpBackInSectionState.jumpBackInTabs.compactMap { .jumpBackIn($0) }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -60,6 +60,10 @@ final class HomepageSectionLayoutProvider {
             static let cellEstimatedSize = CGSize(width: 85, height: 94)
             static let minCards = 4
         }
+
+        struct JumpBackInConstants {
+            static let itemHeight: CGFloat = 112
+        }
     }
 
     private var logger: Logger
@@ -92,6 +96,8 @@ final class HomepageSectionLayoutProvider {
                 for: traitCollection,
                 numberOfTilesPerRow: numberOfTilesPerRow
             )
+        case .jumpBackIn:
+            return createJumpBackInSectionLayout(for: traitCollection)
         case .pocket:
             return createPocketSectionLayout(for: traitCollection)
         case .customizeHomepage:
@@ -204,6 +210,33 @@ final class HomepageSectionLayoutProvider {
             trailing: leadingInset
         )
         section.interGroupSpacing = UX.standardSpacing
+
+        return section
+    }
+
+    private func createJumpBackInSectionLayout(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        // TODO: FXIOS-11224 Update section layout for jump back in
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .estimated(UX.JumpBackInConstants.itemHeight)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .estimated(UX.JumpBackInConstants.itemHeight)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
+                                                       subitem: item,
+                                                       count: 1)
+
+        let section = NSCollectionLayoutSection(group: group)
+        let leadingInset = UX.leadingInset(traitCollection: traitCollection)
+        section.contentInsets = NSDirectionalEdgeInsets(
+                    top: 0,
+                    leading: leadingInset,
+                    bottom: UX.spacingBetweenSections,
+                    trailing: leadingInset)
 
         return section
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -387,6 +387,16 @@ final class HomepageViewController: UIViewController,
             emptyCell.applyTheme(theme: currentTheme)
             return emptyCell
 
+        case .jumpBackIn(let state):
+            guard let jumpBackInCell = collectionView?.dequeueReusableCell(
+                cellType: JumpBackInCell.self,
+                for: indexPath
+            ) else {
+                return UICollectionViewCell()
+            }
+            jumpBackInCell.configure(state: state, theme: currentTheme)
+            return jumpBackInCell
+
         case .pocket(let story):
             guard let pocketCell = collectionView?.dequeueReusableCell(
                 cellType: PocketStandardCell.self,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInCell.swift
@@ -2,23 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import UIKit
-import SiteImageView
 import Common
-import Shared
+import SiteImageView
 
-struct JumpBackInCellViewModel {
-    let titleText: String
-    let descriptionText: String
-    let siteURL: String
-    var accessibilityLabel: String {
-        return "\(titleText), \(descriptionText)"
-    }
-}
-
-// MARK: - JumpBackInCell
 /// A cell used in Home page Jump Back In section
-class JumpBackInCell: UICollectionViewCell, ReusableCell {
+final class JumpBackInCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurrable, Notifiable {
     struct UX {
         static let interItemSpacing = NSCollectionLayoutSpacing.fixed(8)
         static let interGroupSpacing: CGFloat = 8
@@ -39,7 +27,7 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
     // contains imageContainer and textContainer
     private let contentStack: UIStackView = .build { stackView in
         stackView.backgroundColor = .clear
-        stackView.spacing = 16
+        stackView.spacing = UX.cellSpacing
         stackView.axis = .horizontal
         stackView.alignment = .leading
     }
@@ -105,23 +93,25 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        contentView.layer.shadowPath = UIBezierPath(roundedRect: contentView.bounds,
-                                                    cornerRadius: HomepageViewModel.UX.generalCornerRadius).cgPath
+        contentView.layer.shadowPath = UIBezierPath(
+            roundedRect: contentView.bounds,
+            cornerRadius: HomepageViewModel.UX.generalCornerRadius
+        ).cgPath
     }
 
     // MARK: - Helpers
 
-    func configure(viewModel: JumpBackInCellViewModel, theme: Theme) {
-        let heroImageViewModel = HomepageHeroImageViewModel(urlStringRequest: viewModel.siteURL,
+    func configure(state: JumpBackInTabState, theme: Theme) {
+        let heroImageViewModel = HomepageHeroImageViewModel(urlStringRequest: state.siteURL,
                                                             heroImageSize: UX.heroImageSize)
         heroImage.setHeroImage(heroImageViewModel)
 
-        let faviconViewModel = FaviconImageViewModel(siteURLString: viewModel.siteURL)
+        let faviconViewModel = FaviconImageViewModel(siteURLString: state.siteURL)
         websiteImage.setFavicon(faviconViewModel)
 
-        itemTitle.text = viewModel.titleText
-        websiteLabel.text = viewModel.descriptionText
-        accessibilityLabel = viewModel.accessibilityLabel
+        itemTitle.text = state.titleText
+        websiteLabel.text = state.descriptionText
+        accessibilityLabel = state.accessibilityLabel
         adjustLayout()
 
         applyTheme(theme: theme)
@@ -207,25 +197,9 @@ class JumpBackInCell: UICollectionViewCell, ReusableCell {
         contentView.layer.shadowColor = theme.colors.shadowDefault.cgColor
         contentView.layer.shadowOpacity = HomepageViewModel.UX.shadowOpacity
     }
-}
 
-// MARK: - ThemeApplicable
-extension JumpBackInCell: ThemeApplicable {
-    func applyTheme(theme: Theme) {
-        itemTitle.textColor = theme.colors.textPrimary
-        websiteLabel.textColor = theme.colors.textSecondary
-        adjustBlur(theme: theme)
-        let heroImageColors = HeroImageViewColor(faviconTintColor: theme.colors.iconPrimary,
-                                                 faviconBackgroundColor: theme.colors.layer1,
-                                                 faviconBorderColor: theme.colors.layer1)
-        heroImage.updateHeroImageTheme(with: heroImageColors)
-    }
-}
-
-// MARK: - Blurrable
-extension JumpBackInCell: Blurrable {
+    // MARK: - Blurrable
     func adjustBlur(theme: Theme) {
-        // Add blur
         if shouldApplyWallpaperBlur {
             contentView.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
             contentView.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
@@ -235,10 +209,19 @@ extension JumpBackInCell: Blurrable {
             setupShadow(theme: theme)
         }
     }
-}
 
-// MARK: - Notifiable
-extension JumpBackInCell: Notifiable {
+    // MARK: - ThemeApplicable
+    func applyTheme(theme: Theme) {
+        itemTitle.textColor = theme.colors.textPrimary
+        websiteLabel.textColor = theme.colors.textSecondary
+        adjustBlur(theme: theme)
+        let heroImageColors = HeroImageViewColor(faviconTintColor: theme.colors.iconPrimary,
+                                                 faviconBackgroundColor: theme.colors.layer1,
+                                                 faviconBorderColor: theme.colors.layer1)
+        heroImage.updateHeroImageTheme(with: heroImageColors)
+    }
+
+    // MARK: - Notifiable
     func handleNotifications(_ notification: Notification) {
         ensureMainThread { [weak self] in
             switch notification.name {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+
+/// State for the jump back in section that is used in the homepage view
+struct JumpBackInSectionState: StateType, Equatable, Hashable {
+    var windowUUID: WindowUUID
+    var jumpBackInTabs: [JumpBackInTabState]
+
+    init(windowUUID: WindowUUID) {
+        self.init(
+            windowUUID: windowUUID,
+            jumpBackInTabs: []
+        )
+    }
+
+    private init(
+        windowUUID: WindowUUID,
+        jumpBackInTabs: [JumpBackInTabState]
+    ) {
+        self.windowUUID = windowUUID
+        self.jumpBackInTabs = jumpBackInTabs
+    }
+
+    static let reducer: Reducer<Self> = { state, action in
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
+        else {
+            return defaultState(from: state)
+        }
+
+        switch action.actionType {
+        case HomepageActionType.initialize:
+            return handleInitializeAction(for: state, with: action)
+        default:
+            return defaultState(from: state)
+        }
+    }
+
+    private static func handleInitializeAction(
+        for state: JumpBackInSectionState,
+        with action: Action
+    ) -> JumpBackInSectionState {
+        // TODO: FXIOS-11225 Update state from middleware
+        return JumpBackInSectionState(
+            windowUUID: state.windowUUID,
+            jumpBackInTabs: [JumpBackInTabState(
+                titleText: "JumpBack In Title",
+                descriptionText: "JumpBack In Description",
+                siteURL: "www.mozilla.com"
+            )]
+        )
+    }
+
+    static func defaultState(from state: JumpBackInSectionState) -> JumpBackInSectionState {
+        return JumpBackInSectionState(
+            windowUUID: state.windowUUID,
+            jumpBackInTabs: state.jumpBackInTabs
+        )
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInTabState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInTabState.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct JumpBackInTabState: Equatable, Hashable {
+    let titleText: String
+    let descriptionText: String
+    let siteURL: String
+    var accessibilityLabel: String {
+        return "\(titleText), \(descriptionText)"
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -9,11 +9,12 @@ struct HomepageState: ScreenState, Equatable {
     var windowUUID: WindowUUID
 
     // Homepage sections state in the order they appear on the collection view
-   let headerState: HeaderState
-   let messageState: MessageCardState
-   let topSitesState: TopSitesSectionState
-   let pocketState: PocketState
-   let wallpaperState: WallpaperState
+    let headerState: HeaderState
+    let messageState: MessageCardState
+    let topSitesState: TopSitesSectionState
+    let jumpBackInState: JumpBackInSectionState
+    let pocketState: PocketState
+    let wallpaperState: WallpaperState
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let homepageState = store.state.screenState(
@@ -30,6 +31,7 @@ struct HomepageState: ScreenState, Equatable {
             headerState: homepageState.headerState,
             messageState: homepageState.messageState,
             topSitesState: homepageState.topSitesState,
+            jumpBackInState: homepageState.jumpBackInState,
             pocketState: homepageState.pocketState,
             wallpaperState: homepageState.wallpaperState
         )
@@ -41,6 +43,7 @@ struct HomepageState: ScreenState, Equatable {
             headerState: HeaderState(windowUUID: windowUUID),
             messageState: MessageCardState(windowUUID: windowUUID),
             topSitesState: TopSitesSectionState(windowUUID: windowUUID),
+            jumpBackInState: JumpBackInSectionState(windowUUID: windowUUID),
             pocketState: PocketState(windowUUID: windowUUID),
             wallpaperState: WallpaperState(windowUUID: windowUUID)
         )
@@ -51,6 +54,7 @@ struct HomepageState: ScreenState, Equatable {
         headerState: HeaderState,
         messageState: MessageCardState,
         topSitesState: TopSitesSectionState,
+        jumpBackInState: JumpBackInSectionState,
         pocketState: PocketState,
         wallpaperState: WallpaperState
     ) {
@@ -58,6 +62,7 @@ struct HomepageState: ScreenState, Equatable {
         self.headerState = headerState
         self.messageState = messageState
         self.topSitesState = topSitesState
+        self.jumpBackInState = jumpBackInState
         self.pocketState = pocketState
         self.wallpaperState = wallpaperState
     }
@@ -75,6 +80,7 @@ struct HomepageState: ScreenState, Equatable {
                 headerState: HeaderState.reducer(state.headerState, action),
                 messageState: MessageCardState.reducer(state.messageState, action),
                 topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
+                jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
                 pocketState: PocketState.reducer(state.pocketState, action),
                 wallpaperState: WallpaperState.reducer(state.wallpaperState, action)
             )
@@ -88,12 +94,14 @@ struct HomepageState: ScreenState, Equatable {
         var messageState = state.messageState
         var pocketState = state.pocketState
         var topSitesState = state.topSitesState
+        var jumpBackInState = state.jumpBackInState
         var wallpaperState = state.wallpaperState
 
         if let action {
             headerState = HeaderState.reducer(state.headerState, action)
             messageState = MessageCardState.reducer(state.messageState, action)
             pocketState = PocketState.reducer(state.pocketState, action)
+            jumpBackInState = JumpBackInSectionState.reducer(state.jumpBackInState, action)
             topSitesState = TopSitesSectionState.reducer(state.topSitesState, action)
             wallpaperState = WallpaperState.reducer(state.wallpaperState, action)
         }
@@ -103,6 +111,7 @@ struct HomepageState: ScreenState, Equatable {
             headerState: headerState,
             messageState: messageState,
             topSitesState: topSitesState,
+            jumpBackInState: jumpBackInState,
             pocketState: pocketState,
             wallpaperState: wallpaperState
         )

--- a/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
@@ -46,7 +46,7 @@ enum HomepageSectionType: Int, CaseIterable {
                 LegacyHomepageMessageCardCell.self,
                 TopSiteItemCell.self,
                 EmptyTopSiteCell.self,
-                JumpBackInCell.self,
+                LegacyJumpBackInCell.self,
                 PocketDiscoverCell.self,
                 LegacyPocketStandardCell.self,
                 BookmarksCell.self,

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/LegacyJumpBackInCell.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/Cell/LegacyJumpBackInCell.swift
@@ -1,0 +1,251 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import SiteImageView
+import Common
+import Shared
+
+struct JumpBackInCellViewModel {
+    let titleText: String
+    let descriptionText: String
+    let siteURL: String
+    var accessibilityLabel: String {
+        return "\(titleText), \(descriptionText)"
+    }
+}
+
+// MARK: - JumpBackInCell
+/// A cell used in Home page Jump Back In section
+class LegacyJumpBackInCell: UICollectionViewCell, ReusableCell {
+    struct UX {
+        static let interItemSpacing = NSCollectionLayoutSpacing.fixed(8)
+        static let interGroupSpacing: CGFloat = 8
+        static let generalCornerRadius: CGFloat = 12
+        static let cellSpacing: CGFloat = 16
+        static let heroImageSize =  CGSize(width: 108, height: 80)
+        static let fallbackFaviconSize = CGSize(width: 36, height: 36)
+        static let websiteIconSize = CGSize(width: 24, height: 24)
+    }
+
+    // MARK: - Variables
+    var notificationCenter: NotificationProtocol = NotificationCenter.default
+    private var websiteIconFirstBaselineConstraint: NSLayoutConstraint?
+    private var websiteIconCenterConstraint: NSLayoutConstraint?
+
+    // MARK: - UI Elements
+
+    // contains imageContainer and textContainer
+    private let contentStack: UIStackView = .build { stackView in
+        stackView.backgroundColor = .clear
+        stackView.spacing = 16
+        stackView.axis = .horizontal
+        stackView.alignment = .leading
+    }
+
+    // Contains the heroImage and fallbackFaviconImage
+    private var imageContainer: UIView = .build { view in
+        view.backgroundColor = .clear
+    }
+
+    private var heroImage: HeroImageView = .build { _ in }
+    private let websiteImage: FaviconImageView = .build { _ in }
+
+    // contains itemTitle and websiteContainer
+    private let textContainer: UIView = .build { view in
+        view.backgroundColor = .clear
+    }
+
+    private let itemTitle: UILabel = .build { label in
+        label.adjustsFontForContentSizeCategory = true
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
+        label.numberOfLines = 2
+    }
+
+    // Contains the websiteImage and websiteLabel
+    private var websiteContainer: UIView = .build { view in
+        view.backgroundColor = .clear
+    }
+
+    private var websiteLabel: UILabel = .build { label in
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 2
+        label.font = FXFontStyles.Bold.caption1.scaledFont()
+        label.textColor = .label
+    }
+
+    // MARK: - Inits
+
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+
+        isAccessibilityElement = true
+        accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.JumpBackIn.itemCell
+
+        setupNotifications(forObserver: self,
+                           observing: [.DynamicFontChanged])
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        websiteLabel.text = nil
+        itemTitle.text = nil
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        contentView.layer.shadowPath = UIBezierPath(roundedRect: contentView.bounds,
+                                                    cornerRadius: HomepageViewModel.UX.generalCornerRadius).cgPath
+    }
+
+    // MARK: - Helpers
+
+    func configure(viewModel: JumpBackInCellViewModel, theme: Theme) {
+        let heroImageViewModel = HomepageHeroImageViewModel(urlStringRequest: viewModel.siteURL,
+                                                            heroImageSize: UX.heroImageSize)
+        heroImage.setHeroImage(heroImageViewModel)
+
+        let faviconViewModel = FaviconImageViewModel(siteURLString: viewModel.siteURL)
+        websiteImage.setFavicon(faviconViewModel)
+
+        itemTitle.text = viewModel.titleText
+        websiteLabel.text = viewModel.descriptionText
+        accessibilityLabel = viewModel.accessibilityLabel
+        adjustLayout()
+
+        applyTheme(theme: theme)
+    }
+
+    private func setupLayout() {
+        imageContainer.addSubviews(heroImage)
+        textContainer.addSubviews(itemTitle, websiteContainer)
+        websiteContainer.addSubviews(websiteImage, websiteLabel)
+        contentStack.addArrangedSubview(imageContainer)
+        contentStack.addArrangedSubview(textContainer)
+        contentView.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            contentStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: UX.cellSpacing),
+            contentStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: UX.cellSpacing),
+            contentStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.cellSpacing),
+            contentStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -UX.cellSpacing),
+
+            // Image container, hero image
+            heroImage.heightAnchor.constraint(equalToConstant: UX.heroImageSize.height),
+            heroImage.widthAnchor.constraint(equalToConstant: UX.heroImageSize.width),
+
+            heroImage.topAnchor.constraint(equalTo: imageContainer.topAnchor),
+            heroImage.leadingAnchor.constraint(equalTo: imageContainer.leadingAnchor),
+            heroImage.trailingAnchor.constraint(equalTo: imageContainer.trailingAnchor),
+            heroImage.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor),
+
+            itemTitle.leadingAnchor.constraint(equalTo: textContainer.leadingAnchor),
+            itemTitle.trailingAnchor.constraint(equalTo: textContainer.trailingAnchor),
+            itemTitle.topAnchor.constraint(equalTo: textContainer.topAnchor),
+
+            websiteLabel.topAnchor.constraint(equalTo: websiteContainer.firstBaselineAnchor),
+            websiteLabel.leadingAnchor.constraint(equalTo: websiteImage.trailingAnchor, constant: 8),
+            websiteLabel.trailingAnchor.constraint(equalTo: websiteContainer.trailingAnchor),
+            websiteLabel.bottomAnchor.constraint(equalTo: websiteContainer.bottomAnchor, constant: -4),
+
+            // Website container, it's image and label
+            websiteContainer.topAnchor.constraint(greaterThanOrEqualTo: itemTitle.bottomAnchor, constant: 8),
+            websiteContainer.leadingAnchor.constraint(equalTo: textContainer.leadingAnchor),
+            websiteContainer.trailingAnchor.constraint(equalTo: textContainer.trailingAnchor),
+            websiteContainer.bottomAnchor.constraint(equalTo: textContainer.bottomAnchor),
+
+            websiteImage.heightAnchor.constraint(equalToConstant: UX.websiteIconSize.height),
+            websiteImage.widthAnchor.constraint(equalToConstant: UX.websiteIconSize.width),
+            websiteImage.leadingAnchor.constraint(equalTo: textContainer.leadingAnchor),
+
+            textContainer.heightAnchor.constraint(greaterThanOrEqualTo: imageContainer.heightAnchor)
+        ])
+
+        websiteIconCenterConstraint = websiteLabel.centerYAnchor.constraint(
+            equalTo: websiteImage.centerYAnchor
+        ).priority(UILayoutPriority(999))
+        websiteIconFirstBaselineConstraint = websiteLabel.firstBaselineAnchor.constraint(
+            equalTo: websiteImage.bottomAnchor,
+            constant: -UX.websiteIconSize.height / 2)
+
+        websiteLabel.setContentCompressionResistancePriority(UILayoutPriority(1000), for: .vertical)
+
+        adjustLayout()
+    }
+
+    private func adjustLayout() {
+        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+
+        if contentSizeCategory.isAccessibilityCategory {
+            contentStack.axis = .vertical
+        } else {
+            contentStack.axis = .horizontal
+        }
+
+        // Center favicon on smaller font sizes. On bigger font sizes align with first baseline
+        websiteIconCenterConstraint?.isActive = !contentSizeCategory.isAccessibilityCategory
+        websiteIconFirstBaselineConstraint?.isActive = contentSizeCategory.isAccessibilityCategory
+    }
+
+    private func setupShadow(theme: Theme) {
+        contentView.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
+        contentView.layer.shadowPath = UIBezierPath(roundedRect: contentView.bounds,
+                                                    cornerRadius: HomepageViewModel.UX.generalCornerRadius).cgPath
+        contentView.layer.shadowRadius = HomepageViewModel.UX.shadowRadius
+        contentView.layer.shadowOffset = HomepageViewModel.UX.shadowOffset
+        contentView.layer.shadowColor = theme.colors.shadowDefault.cgColor
+        contentView.layer.shadowOpacity = HomepageViewModel.UX.shadowOpacity
+    }
+}
+
+// MARK: - ThemeApplicable
+extension LegacyJumpBackInCell: ThemeApplicable {
+    func applyTheme(theme: Theme) {
+        itemTitle.textColor = theme.colors.textPrimary
+        websiteLabel.textColor = theme.colors.textSecondary
+        adjustBlur(theme: theme)
+        let heroImageColors = HeroImageViewColor(faviconTintColor: theme.colors.iconPrimary,
+                                                 faviconBackgroundColor: theme.colors.layer1,
+                                                 faviconBorderColor: theme.colors.layer1)
+        heroImage.updateHeroImageTheme(with: heroImageColors)
+    }
+}
+
+// MARK: - Blurrable
+extension LegacyJumpBackInCell: Blurrable {
+    func adjustBlur(theme: Theme) {
+        // Add blur
+        if shouldApplyWallpaperBlur {
+            contentView.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
+            contentView.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
+        } else {
+            contentView.removeVisualEffectView()
+            contentView.backgroundColor = theme.colors.layer5
+            setupShadow(theme: theme)
+        }
+    }
+}
+
+// MARK: - Notifiable
+extension LegacyJumpBackInCell: Notifiable {
+    func handleNotifications(_ notification: Notification) {
+        ensureMainThread { [weak self] in
+            switch notification.name {
+            case .DynamicFontChanged:
+                self?.adjustLayout()
+            default: break
+            }
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/JumpBackIn/JumpBackInViewModel.swift
@@ -186,7 +186,7 @@ private extension JumpBackInViewModel {
 
 // MARK: - Private: Configure UI
 private extension JumpBackInViewModel {
-    func configureJumpBackInCellForTab(item: Tab, cell: JumpBackInCell, indexPath: IndexPath) {
+    func configureJumpBackInCellForTab(item: Tab, cell: LegacyJumpBackInCell, indexPath: IndexPath) {
         let itemURL = item.lastKnownUrl?.absoluteString ?? ""
         let site = Site.createBasicSite(url: itemURL, title: item.displayTitle)
         let descriptionText = site.tileURL.shortDisplayString.capitalized
@@ -237,7 +237,7 @@ private extension JumpBackInViewModel {
                                                      heightDimension: .estimated(UX.syncedTabCellHeight))
         let nestedGroup = NSCollectionLayoutGroup.vertical(layoutSize: nestedGroupSize,
                                                            subitems: [jumpBackInItem, jumpBackInItem])
-        nestedGroup.interItemSpacing = JumpBackInCell.UX.interItemSpacing
+        nestedGroup.interItemSpacing = LegacyJumpBackInCell.UX.interItemSpacing
 
         // Main Group
         let mainGroupHeight: CGFloat = UX.syncedTabCellHeight
@@ -254,7 +254,7 @@ private extension JumpBackInViewModel {
         }
         let mainGroup = NSCollectionLayoutGroup.horizontal(layoutSize: mainGroupSize,
                                                            subitems: subItems)
-        mainGroup.interItemSpacing = JumpBackInCell.UX.interItemSpacing
+        mainGroup.interItemSpacing = LegacyJumpBackInCell.UX.interItemSpacing
 
         return NSCollectionLayoutSection(group: mainGroup)
     }
@@ -276,12 +276,12 @@ private extension JumpBackInViewModel {
         // Main Group
         let groupWidth = sectionLayout.widthDimension
         let groupHeight: CGFloat = syncedTabCellHeight + UX.jumpBackInCellHeight
-            + JumpBackInCell.UX.interItemSpacing.spacing
+            + LegacyJumpBackInCell.UX.interItemSpacing.spacing
         let groupSize = NSCollectionLayoutSize(widthDimension: groupWidth,
                                                heightDimension: .estimated(groupHeight))
         let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize,
                                                      subitems: [jumpBackInItem, syncedTabItem])
-        group.interItemSpacing = JumpBackInCell.UX.interItemSpacing
+        group.interItemSpacing = LegacyJumpBackInCell.UX.interItemSpacing
 
         return NSCollectionLayoutSection(group: group)
     }
@@ -338,7 +338,7 @@ extension JumpBackInViewModel: HomepageViewModelProtocol {
                                                         leading: leadingInset,
                                                         bottom: HomepageViewModel.UX.spacingBetweenSections,
                                                         trailing: 0)
-        section.interGroupSpacing = JumpBackInCell.UX.interGroupSpacing
+        section.interGroupSpacing = LegacyJumpBackInCell.UX.interGroupSpacing
 
         return section
     }
@@ -386,9 +386,9 @@ extension JumpBackInViewModel: HomepageSectionHandler {
     func configure(_ collectionView: UICollectionView,
                    at indexPath: IndexPath) -> UICollectionViewCell {
         if let jumpBackInItemRow = sectionLayout.indexOfJumpBackInItem(for: indexPath) {
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: JumpBackInCell.cellIdentifier,
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LegacyJumpBackInCell.cellIdentifier,
                                                           for: indexPath)
-            guard let jumpBackInCell = cell as? JumpBackInCell else { return UICollectionViewCell() }
+            guard let jumpBackInCell = cell as? LegacyJumpBackInCell else { return UICollectionViewCell() }
 
             if let item = jumpBackInList.tabs[safe: jumpBackInItemRow] {
                 configureJumpBackInCellForTab(item: item, cell: jumpBackInCell, indexPath: indexPath)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -38,8 +38,8 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.updateSnapshot(state: HomepageState(windowUUID: .XCTestDefaultUUID), numberOfCellsPerRow: 4)
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfSections, 2)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .customizeHomepage])
+        XCTAssertEqual(snapshot.numberOfSections, 3)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .jumpBackIn, .customizeHomepage])
 
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .customizeHomepage).count, 1)
@@ -104,7 +104,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .topSites(4)), 8)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites(4), .customizeHomepage])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites(4), .jumpBackIn, .customizeHomepage])
     }
 
     func test_updateSnapshot_withValidState_returnPocketStories() throws {
@@ -123,7 +123,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil)), 21)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .pocket(nil), .customizeHomepage])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .jumpBackIn, .pocket(nil), .customizeHomepage])
     }
 
     func test_updateSnapshot_withValidState_returnMessageCard() throws {
@@ -148,7 +148,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .messageCard), 1)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .messageCard).first, HomepageItem.messageCard(configuration))
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .customizeHomepage])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .jumpBackIn, .customizeHomepage])
     }
 
     private func createSites(count: Int = 30) -> [TopSiteState] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+final class JumpBackInSectionStateTests: XCTestCase {
+    func tests_initialState_returnsExpectedState() {
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(initialState.jumpBackInTabs, [])
+    }
+
+    func test_initializeAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = jumpBackInSectionReducer()
+
+        let newState = reducer(
+            initialState,
+            HomepageAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.initialize
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.jumpBackInTabs.count, 1)
+
+        XCTAssertEqual(newState.jumpBackInTabs.first?.titleText, "JumpBack In Title")
+        XCTAssertEqual(newState.jumpBackInTabs.first?.descriptionText, "JumpBack In Description")
+        XCTAssertEqual(newState.jumpBackInTabs.first?.siteURL, "www.mozilla.com")
+        XCTAssertEqual(newState.jumpBackInTabs.first?.accessibilityLabel, "JumpBack In Title, JumpBack In Description")
+    }
+
+    // MARK: - Private
+    private func createSubject() -> JumpBackInSectionState {
+        return JumpBackInSectionState(windowUUID: .XCTestDefaultUUID)
+    }
+
+    private func jumpBackInSectionReducer() -> Reducer<JumpBackInSectionState> {
+        return JumpBackInSectionState.reducer
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11200)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24391)

## :bulb: Description
Add initial view for one jumpBackIn item (using mock data)

- Copied over `JumpBackInCell` and rename `LegacyJumpBackInCell` - made changes to use state instead of view model; clean up how extensions were used
- Added state for individual jump back in item `JumpBackInTabState` and state for jumpback in section `JumpBackInSectionState`
- Add section state as a substate to `HomepageState`
- Add appropriate code in our diffable datasource logic + view controller to display a jump back in cell

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

| Title |
| --- |
| <img src="https://github.com/user-attachments/assets/00a71e4b-1115-4633-a201-d9f59a496c6a" width="250"> |