### PR TITLE
Bugfix FXIOS-11228 Settings height bug

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -51,7 +51,6 @@ class AppSettingsTableViewController: SettingsTableViewController,
     private var applicationHelper: ApplicationHelper
     private let logger: Logger
     private let gleanUsageReportingMetricsService: GleanUsageReportingMetricsService
-    private var hasAppearedBefore = false
 
     weak var parentCoordinator: SettingsFlowDelegate?
 
@@ -101,12 +100,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if hasAppearedBefore {
-            // Only reload if we're returning from a child view
-            askedToReload()
-        }
-
-        hasAppearedBefore = true
+        askedToReload()
     }
 
     // MARK: - Actions

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -51,6 +51,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
     private var applicationHelper: ApplicationHelper
     private let logger: Logger
     private let gleanUsageReportingMetricsService: GleanUsageReportingMetricsService
+    private var hasAppearedBefore = false
 
     weak var parentCoordinator: SettingsFlowDelegate?
 
@@ -97,9 +98,15 @@ class AppSettingsTableViewController: SettingsTableViewController,
         configureAccessibilityIdentifiers()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        askedToReload()
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if hasAppearedBefore {
+            // Only reload if we're returning from a child view
+            askedToReload()
+        }
+
+        hasAppearedBefore = true
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11228)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24426)

## :bulb: Description
Small change, but annoying bug squashed 🐛 This reload was added as a fix for https://github.com/mozilla-mobile/firefox-ios/issues/15363. Since it was reloading after the view appeared, the cell height was changing for some cells that has their `detailTextLabel.attributedText` set. 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

