### PR TITLE
Bugfix FXIOS-11222 [Bookmarks Evolution] Fix bookmarks empty state string

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
@@ -66,9 +66,12 @@ final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
 
     func configure(isRoot: Bool, isSignedIn: Bool) {
         titleLabel.text = isRoot ? .Bookmarks.EmptyState.Root.Title : .Bookmarks.EmptyState.Nested.Title
-        bodyLabel.text = isRoot ? isSignedIn ? .Bookmarks.EmptyState.Root.BodySignedIn
-                                             : .Bookmarks.EmptyState.Root.BodySignedOut
-                                : .Bookmarks.EmptyState.Nested.Body
+        if isRoot {
+            bodyLabel.text = isSignedIn ? .Bookmarks.EmptyState.Root.BodySignedIn
+                                        : .Bookmarks.EmptyState.Root.BodySignedOut
+        } else {
+            bodyLabel.text = .Bookmarks.EmptyState.Nested.Body
+        }
         logoImage.image = UIImage(named: isRoot ? ImageIdentifiers.noBookmarksInRoot : ImageIdentifiers.noBookmarksInFolder)
         signInButton.isHidden = !isRoot || isSignedIn
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
@@ -66,7 +66,8 @@ final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
 
     func configure(isRoot: Bool, isSignedIn: Bool) {
         titleLabel.text = isRoot ? .Bookmarks.EmptyState.Root.Title : .Bookmarks.EmptyState.Nested.Title
-        bodyLabel.text = isRoot ? isSignedIn ? .Bookmarks.EmptyState.Root.BodySignedIn : .Bookmarks.EmptyState.Root.BodySignedOut
+        bodyLabel.text = isRoot ? isSignedIn ? .Bookmarks.EmptyState.Root.BodySignedIn
+                                             : .Bookmarks.EmptyState.Root.BodySignedOut
                                 : .Bookmarks.EmptyState.Nested.Body
         logoImage.image = UIImage(named: isRoot ? ImageIdentifiers.noBookmarksInRoot : ImageIdentifiers.noBookmarksInFolder)
         signInButton.isHidden = !isRoot || isSignedIn

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksFolderEmptyStateView.swift
@@ -66,7 +66,8 @@ final class BookmarksFolderEmptyStateView: UIView, ThemeApplicable {
 
     func configure(isRoot: Bool, isSignedIn: Bool) {
         titleLabel.text = isRoot ? .Bookmarks.EmptyState.Root.Title : .Bookmarks.EmptyState.Nested.Title
-        bodyLabel.text = isRoot ? .Bookmarks.EmptyState.Root.Body : .Bookmarks.EmptyState.Nested.Body
+        bodyLabel.text = isRoot ? isSignedIn ? .Bookmarks.EmptyState.Root.BodySignedIn : .Bookmarks.EmptyState.Root.BodySignedOut
+                                : .Bookmarks.EmptyState.Nested.Body
         logoImage.image = UIImage(named: isRoot ? ImageIdentifiers.noBookmarksInRoot : ImageIdentifiers.noBookmarksInFolder)
         signInButton.isHidden = !isRoot || isSignedIn
     }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -211,11 +211,16 @@ extension String {
                     tableName: "Bookmarks",
                     value: "No bookmarks yet",
                     comment: "The title for the placeholder screen shown when there are no saved bookmarks, located at the root level of the bookmarks panel within the libray modal")
-                public static let Body = MZLocalizedString(
+                public static let BodySignedIn = MZLocalizedString(
                     key: "Bookmarks.EmptyState.Root.Body.v135",
                     tableName: "Bookmarks",
                     value: "Save sites as you browse. We’ll also grab bookmarks from other synced devices.",
-                    comment: "The body text for the placeholder screen shown when there are no saved bookmarks, located at the root level of the bookmarks panel within the libray modal")
+                    comment: "The body text for the placeholder screen shown when the user is signed in and there are no saved bookmarks, located at the root level of the bookmarks panel within the libray modal")
+                public static let BodySignedOut = MZLocalizedString(
+                    key: "Bookmarks.EmptyState.Root.BodySignedOut.v135",
+                    tableName: "Bookmarks",
+                    value: "Save sites as you browse. Sign in to grab bookmarks from other synced devices.",
+                    comment: "The body text for the placeholder screen shown when the user is signed out and there are no saved bookmarks, located at the root level of the bookmarks panel within the libray modal")
                 public static let ButtonTitle = MZLocalizedString(
                     key: "Bookmarks.EmptyState.Root.ButtonTitle.v136",
                     tableName: "Bookmarks",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11222)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24417)

## :bulb: Description
- Add the empty state body string for when the user is signed out of sync.

| Before | After |
| ------------- | ------------- |
| <img width="559" alt="Screenshot 2025-01-29 at 3 03 04 PM" src="https://github.com/user-attachments/assets/38d4a291-3fa5-4db2-9bed-12dae0f62b49" /> | <img width="559" alt="Screenshot 2025-01-29 at 2 59 48 PM" src="https://github.com/user-attachments/assets/87ecab1f-20a3-4019-8f98-1ef33038d689" /> |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

