### PR TITLE
Add MTE-4193 Modify the python script to keep the same version of git clone step

### DIFF
--- a/test-fixtures/update_bitrise_steps.py
+++ b/test-fixtures/update_bitrise_steps.py
@@ -10,8 +10,17 @@ BITRISE_STEPLIB_URL = "https://api.github.com/repos/bitrise-io/bitrise-steplib/c
 # GitHub Access Token
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 
+# Step versions that should NOT be updated
+LOCKED_VERSIONS = {
+    "git-clone": "6.2"
+}
+
 def fetch_latest_version(step_id):
     """Fetch the latest version of a step from the Bitrise Step Library."""
+    if step_id in LOCKED_VERSIONS:
+        print(f"Skipping update for {step_id}, keeping version {LOCKED_VERSIONS[step_id]}")
+        return LOCKED_VERSIONS[step_id]  # Return locked version
+
     try:
         url = f"{BITRISE_STEPLIB_URL}/{step_id}"
         headers = {"Authorization": f"token {GITHUB_TOKEN}"}

--- a/test-fixtures/update_bitrise_steps.py
+++ b/test-fixtures/update_bitrise_steps.py
@@ -11,6 +11,11 @@ BITRISE_STEPLIB_URL = "https://api.github.com/repos/bitrise-io/bitrise-steplib/c
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 
 # Step versions that should NOT be updated
+"""
+We need to lock this version because the new version of git-clone step brokes the decision 
+to run UI test step due to the change in the variables available. Once we investigate this
+failure in the workflow, eventually we can remove the locked version.
+"""
 LOCKED_VERSIONS = {
     "git-clone": "6.2"
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4193)


## :bulb: Description
We realize that the step git-clone of bitrise.yml cannot be updated to the last version available. If we update it the workflow fails. Now the python script [test-fixtures/update_bitrise_steps.py] that updates all the steps in the bitrise.yml file maintain the actual version only for git-clone step and update all the other steps.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

