### PR TITLE
Add FXIOS-11203 [Homepage] [JumpBackIn] Section header

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -885,6 +885,7 @@
 		8A6E63C72D4946B90040D355 /* JumpBackInSectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63C62D4946B40040D355 /* JumpBackInSectionState.swift */; };
 		8A6E63C92D4948BE0040D355 /* JumpBackInTabState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63C82D4948BE0040D355 /* JumpBackInTabState.swift */; };
 		8A6E63CB2D4A6F230040D355 /* JumpBackInSectionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63CA2D4A6F230040D355 /* JumpBackInSectionStateTests.swift */; };
+		8A6E63CF2D4A7FB70040D355 /* SectionHeaderState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63CE2D4A7FB70040D355 /* SectionHeaderState.swift */; };
 		8A6E8DEB2B275BA9000C4301 /* PrivateHomepageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E8DE92B275B49000C4301 /* PrivateHomepageViewControllerTests.swift */; };
 		8A720C5E2A4C85DA0003018A /* AccountSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */; };
 		8A720C602A4C8B700003018A /* SharedSettingsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */; };
@@ -7732,6 +7733,7 @@
 		8A6E63C62D4946B40040D355 /* JumpBackInSectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInSectionState.swift; sourceTree = "<group>"; };
 		8A6E63C82D4948BE0040D355 /* JumpBackInTabState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInTabState.swift; sourceTree = "<group>"; };
 		8A6E63CA2D4A6F230040D355 /* JumpBackInSectionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInSectionStateTests.swift; sourceTree = "<group>"; };
+		8A6E63CE2D4A7FB70040D355 /* SectionHeaderState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderState.swift; sourceTree = "<group>"; };
 		8A6E8DE92B275B49000C4301 /* PrivateHomepageViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateHomepageViewControllerTests.swift; sourceTree = "<group>"; };
 		8A720C5D2A4C85DA0003018A /* AccountSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsDelegate.swift; sourceTree = "<group>"; };
 		8A720C5F2A4C8B700003018A /* SharedSettingsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSettingsDelegate.swift; sourceTree = "<group>"; };
@@ -11907,6 +11909,15 @@
 			path = JumpBackIn;
 			sourceTree = "<group>";
 		};
+		8A6E63CD2D4A7FA60040D355 /* SectionHeader */ = {
+			isa = PBXGroup;
+			children = (
+				8A2DAD4A2CC02AA00067ECD0 /* LabelButtonHeaderView.swift */,
+				8A6E63CE2D4A7FB70040D355 /* SectionHeaderState.swift */,
+			);
+			path = SectionHeader;
+			sourceTree = "<group>";
+		};
 		8A7653C028A2E54800924ABF /* Pocket */ = {
 			isa = PBXGroup;
 			children = (
@@ -11930,6 +11941,7 @@
 			isa = PBXGroup;
 			children = (
 				8A9E04172D4D07E30022ED90 /* Bookmark */,
+				8A6E63CD2D4A7FA60040D355 /* SectionHeader */,
 				8A6E63C32D4946600040D355 /* JumpBackIn */,
 				8AED23022D400020000FF624 /* MessageCard */,
 				8A62B15B2CED40800045F46E /* ContextMenu */,
@@ -11940,7 +11952,6 @@
 				8AA0A6622CAC40AA00AC7EB3 /* HomepageDiffableDataSource.swift */,
 				8AA0A6642CAC6B7100AC7EB3 /* HomepageSectionLayoutProvider.swift */,
 				8AF347DC2CADD0E100624036 /* Redux */,
-				8A2DAD4A2CC02AA00067ECD0 /* LabelButtonHeaderView.swift */,
 			);
 			path = "Homepage Rebuild";
 			sourceTree = "<group>";
@@ -16852,6 +16863,7 @@
 				8A4EA0DD2C0117F200E4E4F1 /* MicrosurveyModel.swift in Sources */,
 				8C44A9D22A6A99FE009A1AA7 /* ShoppingProduct.swift in Sources */,
 				63F7A9AA2C7529ED005846F5 /* NativeErrorPageModel.swift in Sources */,
+				8A6E63CF2D4A7FB70040D355 /* SectionHeaderState.swift in Sources */,
 				63F7A9AC2C752BB0005846F5 /* NativeErrorPageViewController.swift in Sources */,
 				C88E7A572A0553360072E638 /* OnboardingButtonInfoModel.swift in Sources */,
 				AB9A0C012C6CBC9100BFA22A /* TrackingProtectionDetailsViewController.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
@@ -33,4 +33,5 @@ enum NavigationBrowserActionType: ActionType {
     // cell related
     case tapOnCell
     case longPressOnCell
+    case tapOnJumpBackInShowAllButton
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
@@ -10,6 +10,7 @@ enum BrowserNavigationDestination: Equatable {
     case contextMenu
     case settings(Route.SettingsSection)
     case trackingProtectionSettings
+    case tabTray
 
     // Webpage views
     case link

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -160,6 +160,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
             NavigationBrowserActionType.tapOnTrackingProtection,
             NavigationBrowserActionType.tapOnCell,
             NavigationBrowserActionType.tapOnLink,
+            NavigationBrowserActionType.tapOnJumpBackInShowAllButton,
             NavigationBrowserActionType.longPressOnCell,
             NavigationBrowserActionType.tapOnOpenInNewTab,
             NavigationBrowserActionType.tapOnSettingsSection,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2156,6 +2156,7 @@ class BrowserViewController: UIViewController,
         store.dispatch(action)
     }
 
+    /// Used to handle general navigation for views that can be presented from multiple places
     private func handleNavigation(to type: NavigationDestination) {
         switch type.destination {
         case .contextMenu:
@@ -2197,6 +2198,8 @@ class BrowserViewController: UIViewController,
                 toastContainer: config.toastContainer,
                 popoverArrowDirection: config.popoverArrowDirection
             )
+        case .tabTray:
+            navigationHandler?.showTabTray(selectedPanel: .tabs)
         }
     }
 
@@ -2220,6 +2223,7 @@ class BrowserViewController: UIViewController,
             guard let button = state.buttonTapped else { return }
             presentRefreshLongPressAction(from: button)
         case .tabTray:
+            // TODO: FXIOS-11248 Use NavigationBrowserAction instead of GeneralBrowserAction to open tab tray
             focusOnTabSegment()
         case .share:
             // User tapped the Share button in the toolbar

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -17,7 +17,7 @@ final class HomepageDiffableDataSource:
         case header
         case messageCard
         case topSites(NumberOfTilesPerRow)
-        case jumpBackIn
+        case jumpBackIn(TextColor?)
         case bookmarks
         case pocket(TextColor?)
         case customizeHomepage
@@ -68,8 +68,8 @@ final class HomepageDiffableDataSource:
         }
 
         if let tabs = getJumpBackInTabs(with: state.jumpBackInState) {
-            snapshot.appendSections([.jumpBackIn])
-            snapshot.appendItems(tabs, toSection: .jumpBackIn)
+            snapshot.appendSections([.jumpBackIn(textColor)])
+            snapshot.appendItems(tabs, toSection: .jumpBackIn(textColor))
         }
 
         // TODO: FXIOS-11051 Update showing bookmarks

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -63,6 +63,7 @@ final class HomepageSectionLayoutProvider {
 
         struct JumpBackInConstants {
             static let itemHeight: CGFloat = 112
+            static let sectionHeaderHeight: CGFloat = 34
         }
 
         struct BookmarksConstants {
@@ -238,6 +239,18 @@ final class HomepageSectionLayoutProvider {
                                                        count: 1)
 
         let section = NSCollectionLayoutSection(group: group)
+
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .estimated(UX.JumpBackInConstants.sectionHeaderHeight)
+        )
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        section.boundarySupplementaryItems = [header]
+
         let leadingInset = UX.leadingInset(traitCollection: traitCollection)
         section.contentInsets = NSDirectionalEdgeInsets(
                     top: 0,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -487,6 +487,16 @@ final class HomepageViewController: UIViewController,
         with sectionLabelCell: LabelButtonHeaderView
     ) -> LabelButtonHeaderView? {
         switch section {
+        case .jumpBackIn(let textColor):
+            sectionLabelCell.configure(
+                state: homepageState.jumpBackInState.sectionHeaderState,
+                moreButtonAction: { [weak self] _ in
+                    self?.navigateToTabTray()
+                },
+                textColor: textColor,
+                theme: currentTheme
+            )
+            return sectionLabelCell
         case .pocket(let textColor):
             sectionLabelCell.configure(
                 state: homepageState.pocketState.sectionHeaderState,
@@ -590,6 +600,16 @@ final class HomepageViewController: UIViewController,
                 navigationDestination: NavigationDestination(.contextMenu, contextMenuConfiguration: configuration),
                 windowUUID: windowUUID,
                 actionType: NavigationBrowserActionType.longPressOnCell
+            )
+        )
+    }
+
+    private func navigateToTabTray() {
+        store.dispatch(
+            NavigationBrowserAction(
+                navigationDestination: NavigationDestination(.tabTray),
+                windowUUID: windowUUID,
+                actionType: NavigationBrowserActionType.tapOnJumpBackInShowAllButton
             )
         )
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
@@ -10,6 +10,14 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
     var windowUUID: WindowUUID
     var jumpBackInTabs: [JumpBackInTabState]
 
+    let sectionHeaderState = SectionHeaderState(
+        title: .FirefoxHomeJumpBackInSectionTitle,
+        a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.jumpBackIn,
+        isButtonHidden: false,
+        buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn,
+        buttonTitle: .BookmarksSavedShowAllText
+    )
+
     init(windowUUID: WindowUUID) {
         self.init(
             windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketState.swift
@@ -7,24 +7,6 @@ import Foundation
 import Redux
 import Shared
 
-struct SectionHeaderState: Equatable {
-    var sectionHeaderTitle: String
-    var sectionTitleA11yIdentifier: String
-    var isSectionHeaderButtonHidden: Bool
-    var sectionButtonA11yIdentifier: String?
-
-    init(
-        sectionHeaderTitle: String = .FirefoxHomepage.Pocket.SectionTitle,
-        sectionTitleA11yIdentifier: String = AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket,
-        isSectionHeaderButtonHidden: Bool = true,
-        sectionButtonA11yIdentifier: String? = nil) {
-        self.sectionHeaderTitle = sectionHeaderTitle
-        self.sectionTitleA11yIdentifier = sectionTitleA11yIdentifier
-        self.isSectionHeaderButtonHidden = isSectionHeaderButtonHidden
-        self.sectionButtonA11yIdentifier = sectionButtonA11yIdentifier
-    }
-}
-
 struct PocketDiscoverState: Equatable, Hashable {
     var title: String
     var url: URL?
@@ -36,7 +18,11 @@ struct PocketState: StateType, Equatable {
     let pocketData: [PocketStoryState]
     let shouldShowSection: Bool
 
-    let sectionHeaderState = SectionHeaderState()
+    let sectionHeaderState = SectionHeaderState(
+        title: .FirefoxHomepage.Pocket.SectionTitle,
+        a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.pocket
+    )
+
     let pocketDiscoverItem = PocketDiscoverState(
         title: .FirefoxHomepage.Pocket.DiscoverMore,
         url: PocketProvider.MoreStoriesURL

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/LabelButtonHeaderView.swift
@@ -16,7 +16,6 @@ class LabelButtonHeaderView: UICollectionReusableView,
         static let bottomSpace: CGFloat = 10
         static let bottomButtonSpace: CGFloat = 6
         static let leadingInset: CGFloat = 0
-        static let trailingInset: CGFloat = 16
     }
 
     // MARK: - UIElements
@@ -72,8 +71,7 @@ class LabelButtonHeaderView: UICollectionReusableView,
 
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor,
-                                                constant: -UX.trailingInset),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.bottomSpace),
         ])
 
@@ -104,18 +102,19 @@ class LabelButtonHeaderView: UICollectionReusableView,
 
     func configure(
         state: SectionHeaderState,
+        moreButtonAction: ((UIButton) -> Void)? = nil,
         textColor: UIColor?,
         theme: Theme
     ) {
-        self.title = state.sectionHeaderTitle
-        titleLabel.accessibilityIdentifier = state.sectionTitleA11yIdentifier
+        self.title = state.title
+        titleLabel.accessibilityIdentifier = state.a11yIdentifier
 
-        moreButton.isHidden = state.isSectionHeaderButtonHidden
-        if !state.isSectionHeaderButtonHidden {
+        moreButton.isHidden = state.isButtonHidden
+        if !state.isButtonHidden {
             let moreButtonViewModel = ActionButtonViewModel(
                 title: .BookmarksSavedShowAllText,
-                a11yIdentifier: state.sectionButtonA11yIdentifier,
-                touchUpAction: nil
+                a11yIdentifier: state.buttonA11yIdentifier,
+                touchUpAction: moreButtonAction
             )
             moreButton.configure(
                 viewModel: moreButtonViewModel

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/SectionHeaderState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/SectionHeader/SectionHeaderState.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Redux
+
+struct SectionHeaderState: Equatable, Hashable {
+    let title: String
+    let a11yIdentifier: String
+    var isButtonHidden: Bool = true
+    var buttonA11yIdentifier: String?
+    var buttonTitle: String?
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -39,7 +39,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfSections, 4)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .jumpBackIn, .bookmarks, .customizeHomepage])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .jumpBackIn(nil), .bookmarks, .customizeHomepage])
 
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .customizeHomepage).count, 1)
@@ -104,7 +104,14 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .topSites(4)), 8)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites(4), .jumpBackIn, .bookmarks, .customizeHomepage])
+        let expectedSections: [HomepageSection] = [
+            .header,
+            .topSites(4),
+            .jumpBackIn(nil),
+            .bookmarks,
+            .customizeHomepage
+        ]
+        XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
     }
 
     func test_updateSnapshot_withValidState_returnPocketStories() throws {
@@ -123,7 +130,14 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil)), 21)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .jumpBackIn, .bookmarks, .pocket(nil), .customizeHomepage])
+        let expectedSections: [HomepageSection] = [
+            .header,
+            .jumpBackIn(nil),
+            .bookmarks,
+            .pocket(nil),
+            .customizeHomepage
+        ]
+        XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
     }
 
     func test_updateSnapshot_withValidState_returnMessageCard() throws {
@@ -148,7 +162,8 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .messageCard), 1)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .messageCard).first, HomepageItem.messageCard(configuration))
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .jumpBackIn, .bookmarks, .customizeHomepage])
+        let expectedSections: [HomepageSection] = [.header, .messageCard, .jumpBackIn(nil), .bookmarks, .customizeHomepage]
+        XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
     }
 
     private func createSites(count: Int = 30) -> [TopSiteState] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/LabelButtonHeaderViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/LabelButtonHeaderViewTests.swift
@@ -9,7 +9,7 @@ import Common
 
 final class LabelButtonHeaderViewTests: XCTestCase {
     let theme = DarkTheme()
-    let sectionHeaderState = SectionHeaderState()
+    let sectionHeaderState = SectionHeaderState(title: "test title", a11yIdentifier: "test a11y identifier")
 
     func test_configure_withStateColor_appliesStateColorOverThemeColors() {
         let view = createSubject()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11203)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Add section header for JumpBackIn section
- Includes showing header text and adding the supplementary view
- Includes adding the show more button, which opens to the normal tab tray when tapped on
- Reorganize section header code

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
https://github.com/user-attachments/assets/0fd49fb2-0028-4dbe-b26f-1369a5eac0fc