### PR TITLE
Bugfix FXIOS-10853 #23668 Flaky history unit tests 

### DIFF
--- a/BrowserKit/Sources/Shared/TimeConstants.swift
+++ b/BrowserKit/Sources/Shared/TimeConstants.swift
@@ -128,7 +128,7 @@ extension Date {
     public static var yesterday: Date { return Date().dayBefore }
     public static var tomorrow: Date { return Date().dayAfter }
     public var lastHour: Date {
-        return Calendar.current.date(byAdding: .hour, value: -1, to: Date()) ?? Date()
+        return Calendar.current.date(byAdding: .hour, value: -1, to: self) ?? Date()
     }
     public var lastTwoWeek: Date {
         return Calendar.current.date(byAdding: .day, value: -14, to: noon) ?? Date()
@@ -160,16 +160,19 @@ extension Date {
         return Calendar.current.isDateInYesterday(self)
     }
 
-    public func isWithinLast7Days() -> Bool {
-        return (Date().lastWeek ... Date()).contains(self)
+    /// Comparison date is used to control unit tests outcome.
+    public func isWithinLast7Days(comparisonDate: Date = Date()) -> Bool {
+        return (comparisonDate.lastWeek ... comparisonDate).contains(self)
     }
 
-    public func isWithinLast14Days() -> Bool {
-        return (Date().lastTwoWeek ... Date()).contains(self)
+    /// Comparison date is used to control unit tests outcome.
+    public func isWithinLast14Days(comparisonDate: Date = Date()) -> Bool {
+        return (comparisonDate.lastTwoWeek ... comparisonDate).contains(self)
     }
 
-    public func isWithinLastHour() -> Bool {
-        return (Date().lastHour ... Date()).contains(self)
+    /// Comparison date is used to control unit tests outcome.
+    public func isWithinLastHour(comparisonDate: Date = Date()) -> Bool {
+        return (comparisonDate.lastHour ... comparisonDate).contains(self)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanelViewModel.swift
@@ -198,9 +198,11 @@ class HistoryPanelViewModel: FeatureFlaggable {
     /// Based on the latest visit of the group items gets the section where the group should be added
     /// if the section is available (visible) and not hidden returns it if not returns nil
     /// - Parameter group: ASGroup
+    /// - Parameter comparisonDate: Comparison date is used to control unit tests outcome.
     /// - Returns: Section where group should be added
-    func shouldAddGroupToSections(group: ASGroup<Site>) -> HistoryPanelViewModel.Sections? {
-        guard let section = groupBelongsToSection(asGroup: group),
+    func shouldAddGroupToSections(group: ASGroup<Site>,
+                                  comparisonDate: Date = Date()) -> HistoryPanelViewModel.Sections? {
+        guard let section = groupBelongsToSection(asGroup: group, comparisonDate: comparisonDate),
                 visibleSections.contains(section),
               !hiddenSections.contains(section) else {
             return nil
@@ -210,7 +212,11 @@ class HistoryPanelViewModel: FeatureFlaggable {
     }
 
     /// This helps us place an ASGroup<Site> in the correct section.
-    func groupBelongsToSection(asGroup: ASGroup<Site>) -> HistoryPanelViewModel.Sections? {
+    /// - Parameters:
+    ///   - asGroup: ASGroup
+    ///   - comparisonDate: Comparison date is used to control unit tests outcome.
+    /// - Returns: Section where group should be added
+    func groupBelongsToSection(asGroup: ASGroup<Site>, comparisonDate: Date = Date()) -> HistoryPanelViewModel.Sections? {
         guard let individualItem = asGroup.groupedItems.last,
               let lastVisit = individualItem.latestVisit
         else { return nil }
@@ -218,15 +224,15 @@ class HistoryPanelViewModel: FeatureFlaggable {
         let groupDate = TimeInterval.timeIntervalSince1970ToDate(
             timeInterval: TimeInterval.fromMicrosecondTimestamp(lastVisit.date)
         )
-        if groupDate.isWithinLastHour() {
+        if groupDate.isWithinLastHour(comparisonDate: comparisonDate) {
             return .lastHour
         } else if groupDate.isToday() {
             return .today
         } else if groupDate.isYesterday() {
             return .yesterday
-        } else if groupDate.isWithinLast7Days() {
+        } else if groupDate.isWithinLast7Days(comparisonDate: comparisonDate) {
             return .lastWeek
-        } else if groupDate.isWithinLast14Days() {
+        } else if groupDate.isWithinLast14Days(comparisonDate: comparisonDate) {
             // Since two weeks falls within here, lastMonth will have an ASGroup, if it exists.
             return .lastMonth
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/HistoryPanelViewModelTests.swift
@@ -176,10 +176,13 @@ class HistoryPanelViewModelTests: XCTestCase {
     }
 
     func testGroupBelongToSection_ForLastHour() {
-        let searchTermGroup = createSearchTermGroup(timestamp: Date().toMicrosecondsSince1970())
+        let controlledCurrentDate = Date().noon
+        let searchTermDate = Calendar.current.date(byAdding: .minute, value: -30, to: controlledCurrentDate)!
+        let searchTermGroup = createSearchTermGroup(timestamp: searchTermDate.toMicrosecondsSince1970())
 
-        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup) else {
-            XCTFail("Expected to return today section")
+        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup,
+                                                               comparisonDate: controlledCurrentDate) else {
+            XCTFail("Expected to return lastHour section")
             return
         }
 
@@ -187,11 +190,12 @@ class HistoryPanelViewModelTests: XCTestCase {
     }
 
     func testGroupBelongToSection_ForToday() {
-        let date = Calendar.current.date(byAdding: .hour, value: -3, to: Date()) ?? Date()
-        let timestamp = date.toMicrosecondsSince1970()
-        let searchTermGroup = createSearchTermGroup(timestamp: timestamp)
+        let controlledCurrentDate = Date().noon
+        let searchTermDate = Calendar.current.date(byAdding: .hour, value: -2, to: controlledCurrentDate)!
+        let searchTermGroup = createSearchTermGroup(timestamp: searchTermDate.toMicrosecondsSince1970())
 
-        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup) else {
+        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup,
+                                                               comparisonDate: controlledCurrentDate) else {
             XCTFail("Expected to return today section")
             return
         }
@@ -200,11 +204,13 @@ class HistoryPanelViewModelTests: XCTestCase {
     }
 
     func testGroupBelongToSection_ForYesterday() {
-        let yesterday = Date.yesterday
-        let searchTermGroup = createSearchTermGroup(timestamp: yesterday.toMicrosecondsSince1970())
+        let controlledCurrentDate = Date().noon
+        let searchTermDate = Calendar.current.date(byAdding: .day, value: -1, to: controlledCurrentDate)!
+        let searchTermGroup = createSearchTermGroup(timestamp: searchTermDate.toMicrosecondsSince1970())
 
-        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup) else {
-            XCTFail("Expected to return today section")
+        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup,
+                                                               comparisonDate: controlledCurrentDate) else {
+            XCTFail("Expected to return yesterday section")
             return
         }
 
@@ -212,11 +218,13 @@ class HistoryPanelViewModelTests: XCTestCase {
     }
 
     func testGroupBelongToSection_ForLastWeek() {
-        let yesterday = Date().lastWeek
-        let searchTermGroup = createSearchTermGroup(timestamp: yesterday.toMicrosecondsSince1970())
+        let controlledCurrentDate = Date().noon
+        let searchTermDate = Calendar.current.date(byAdding: .day, value: -6, to: controlledCurrentDate)!
+        let searchTermGroup = createSearchTermGroup(timestamp: searchTermDate.toMicrosecondsSince1970())
 
-        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup) else {
-            XCTFail("Expected to return today section")
+        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup,
+                                                               comparisonDate: controlledCurrentDate) else {
+            XCTFail("Expected to return lastWeek section")
             return
         }
 
@@ -224,11 +232,13 @@ class HistoryPanelViewModelTests: XCTestCase {
     }
 
     func testGroupBelongToSection_ForTwoLastWeek() {
-        let yesterday = Date().lastTwoWeek
-        let searchTermGroup = createSearchTermGroup(timestamp: yesterday.toMicrosecondsSince1970())
+        let controlledCurrentDate = Date().noon
+        let searchTermDate = Calendar.current.date(byAdding: .day, value: -13, to: controlledCurrentDate)!
+        let searchTermGroup = createSearchTermGroup(timestamp: searchTermDate.toMicrosecondsSince1970())
 
-        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup) else {
-            XCTFail("Expected to return today section")
+        guard let section = self.subject.groupBelongsToSection(asGroup: searchTermGroup,
+                                                               comparisonDate: controlledCurrentDate) else {
+            XCTFail("Expected to return lastMonth section")
             return
         }
 
@@ -236,12 +246,13 @@ class HistoryPanelViewModelTests: XCTestCase {
     }
 
     func testShouldAddGroupToSections_ForToday() {
-        let date = Calendar.current.date(byAdding: .hour, value: -3, to: Date()) ?? Date()
-        let timestamp = date.toMicrosecondsSince1970()
-        let searchTermGroup = createSearchTermGroup(timestamp: timestamp)
+        let controlledCurrentDate = Date().noon
+        let searchTermDate = Calendar.current.date(byAdding: .hour, value: -2, to: controlledCurrentDate)!
+        let searchTermGroup = createSearchTermGroup(timestamp: searchTermDate.toMicrosecondsSince1970())
         subject.visibleSections.append(.today)
 
-        guard let section = self.subject.shouldAddGroupToSections(group: searchTermGroup) else {
+        guard let section = self.subject.shouldAddGroupToSections(group: searchTermGroup,
+                                                                  comparisonDate: controlledCurrentDate) else {
             XCTFail("Expected to return today section")
             return
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10853)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23668)

## :bulb: Description
Current problem is we use the `Date()` directly in unit tests to compare if we are within a certain range, but only on certain extension methods. This isn't reliable for unit tests, since removing time on a certain date can make you change day (example: if you are at 1 am and you remove an hour to the date, you will fall into the yesterday case). 

To make the unit tests reliable, we need to inject a Date we control. I am using `.noon` for time comparison so we don't fall into another day by removing/adding time. With those changes, the test shouldn't fail whatever the time is while the CI is ran.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

