### PR TITLE
Bugfix FXIOS-11237-11238 Regression on settings change

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -51,6 +51,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
     private var applicationHelper: ApplicationHelper
     private let logger: Logger
     private let gleanUsageReportingMetricsService: GleanUsageReportingMetricsService
+    private var hasAppearedBefore = false
 
     weak var parentCoordinator: SettingsFlowDelegate?
 
@@ -97,10 +98,15 @@ class AppSettingsTableViewController: SettingsTableViewController,
         configureAccessibilityIdentifiers()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
 
-        askedToReload()
+        if hasAppearedBefore {
+            // Only reload if we're returning from a child view
+            askedToReload()
+        }
+
+        hasAppearedBefore = true
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## :scroll: Tickets
Ticket 1
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11238)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24443)

Ticket 2
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11237)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24442)

## :bulb: Description
Changes in https://github.com/mozilla-mobile/firefox-ios/pull/24427 caused some regressions. Apparently reloading in `viewWillAppear` doesn't work, but `viewDidAppear` works. One way to easily fix is by using a boolean. I am not a fan of this, but without putting too much time this is what I came up with. Let me know if you think of a better way. Tagging @dicarobinho since I saw you assigned yourselves one of the tickets, so maybe you have some ideas. Thank you!

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

