### PR TITLE
Bugfix FXIOS-11149 [Bookmarks Evolution] Rtl support for desktop bookmark cell chevron

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LocalDesktopFolder.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LocalDesktopFolder.swift
@@ -53,7 +53,9 @@ class LocalDesktopFolder: FxBookmarkNode,
 
 extension LocalDesktopFolder: BookmarksFolderCell {
     func getViewModel() -> OneLineTableViewCellViewModel {
-        let image = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
+        let image = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?
+            .withRenderingMode(.alwaysTemplate)
+            .imageFlippedForRightToLeftLayoutDirection()
         let accessoryView = isBookmarkRefactorEnabled ? UIImageView(image: image) : nil
 
         return OneLineTableViewCellViewModel(title: LegacyLocalizedRootBookmarkFolderStrings[guid],


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11149)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24290)

## :bulb: Description
- Fix the "Desktop bookmarks" folder's chevron so that it is flipped in RTL languages

| Before | After |
| ------------- | ------------- |
| ![IMG_0487](https://github.com/user-attachments/assets/e6a2c4ef-809f-4675-a421-f7ca13e9a8fe) | ![IMG_0486](https://github.com/user-attachments/assets/6541673d-ea32-4ae7-a687-c0ed7f56a4eb) |


## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

