### PR TITLE
Fix - MTE-4225 - share markup tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
@@ -142,21 +142,8 @@ class ShareMenuTests: BaseTestCase {
 
     private func validateMarkupTool() {
         // The Markup tool opens
-        waitForElementsToExist(
-            [
-                app.buttons["Undo"],
-                app.buttons["Redo"]
-            ]
-        )
-        if #available(iOS 17, *) {
-            mozWaitForElementToExist(app.buttons["PKPalette-Multicolor-Swatch"])
-        }
-        if #available(iOS 16, *) {
-            mozWaitForElementToExist(app.buttons["autofill"])
-            mozWaitForElementToExist(app.buttons["Done"])
-        } else {
-            mozWaitForElementToExist(app.buttons["Color picker"])
-        }
+        mozWaitForElementToExist(app.switches["Markup"])
+        mozWaitForElementToExist(app.buttons["Done"])
     }
 
     private func reachReaderModeShareMenuLayoutAndSelectOption(option: String) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
@@ -142,21 +142,8 @@ class ShareToolbarTests: BaseTestCase {
 
     private func validateMarkupTool() {
         // The Markup tool opens
-        waitForElementsToExist(
-            [
-                app.buttons["Undo"],
-                app.buttons["Redo"]
-            ]
-        )
-        if #available(iOS 17, *) {
-            mozWaitForElementToExist(app.buttons["PKPalette-Multicolor-Swatch"])
-        }
-        if #available(iOS 16, *) {
-            mozWaitForElementToExist(app.buttons["autofill"])
-            mozWaitForElementToExist(app.buttons["Done"])
-        } else {
-            mozWaitForElementToExist(app.buttons["Color picker"])
-        }
+        mozWaitForElementToExist(app.switches["Markup"])
+        mozWaitForElementToExist(app.buttons["Done"])
     }
 
     private func reachReaderModeShareMenuLayoutAndSelectOption(option: String) {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4225

## :bulb: Description
The markup tool behaves differently and opens with the options on or off and this is causing our tests to be flaky.
Since this tool is os native it has different options between versions and since we cant handle much the way it behaves i have decided that validating the  common elements between os versions is enough to determine that we reached this tool.
