### PR TITLE
Replace FXIOS-11247 Replace usage of UIColor.Photon.White100

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TopTabFader.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabFader.swift
@@ -16,7 +16,7 @@ class TopTabFader: UIView {
 
     private lazy var hMaskLayer: CAGradientLayer = {
         let hMaskLayer = CAGradientLayer()
-        let innerColor = UIColor.Photon.White100.cgColor
+        let innerColor = UIColor.white.cgColor
         let outerColor = UIColor(white: 1, alpha: 0.0).cgColor
 
         hMaskLayer.anchorPoint = .zero

--- a/firefox-ios/Client/Frontend/Theme/LegacyThemeManager/photon-colors.swift
+++ b/firefox-ios/Client/Frontend/Theme/LegacyThemeManager/photon-colors.swift
@@ -15,8 +15,6 @@ extension UIColor {
 
         static let Purple60 = UIColor(rgb: 0x952bb9)
 
-        static let White100 = UIColor(rgb: 0xffffff)
-
         static let Grey60 = UIColor(rgb: 0x4a4a4f)
     }
 }

--- a/firefox-ios/Client/Frontend/Widgets/GradientProgressBar.swift
+++ b/firefox-ios/Client/Frontend/Widgets/GradientProgressBar.swift
@@ -79,7 +79,7 @@ open class GradientProgressBar: UIProgressView {
         alphaMaskLayer.anchorPoint = .zero
         alphaMaskLayer.position = .zero
 
-        alphaMaskLayer.backgroundColor = UIColor.Photon.White100.cgColor
+        alphaMaskLayer.backgroundColor = UIColor.white.cgColor
     }
 
     private func setupGradientLayer() {

--- a/firefox-ios/CredentialProvider/Extensions/UIColorExtension.swift
+++ b/firefox-ios/CredentialProvider/Extensions/UIColorExtension.swift
@@ -11,13 +11,13 @@ extension UIColor {
         }
 
         static var cellBackgroundColor: UIColor {
-            return UIColor(named: "credentialCellColor") ?? UIColor.Photon.White100
+            return UIColor(named: "credentialCellColor") ?? UIColor.white
         }
 
         static var tableViewBackgroundColor: UIColor = .systemGroupedBackground
 
         static var welcomeScreenBackgroundColor: UIColor {
-            return UIColor(named: "launchScreenBackgroundColor") ?? UIColor.Photon.White100
+            return UIColor(named: "launchScreenBackgroundColor") ?? UIColor.white
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11247)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24460)

## :bulb: Description
- Replace usage of UIColor.Photon.White100
- Remove UIColor.Photon.White100 in photon-colors

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

