### PR TITLE
Bugfix FXIOS-11144 ⁃ [Onboarding cards] Opening a SUMO page from Onboarding cards while internet connection is OFF, shows a blank page

### DIFF
--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/AboutHomeHandler.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/AboutHomeHandler.swift
@@ -6,7 +6,7 @@ class AboutHomeHandler: InternalSchemeResponse {
     static let path = "about/home"
 
     // Return a blank page, the webview delegate will look at the current URL and load the home panel based on that
-    func response(forRequest request: URLRequest) -> (URLResponse, Data)? {
+    func response(forRequest request: URLRequest, useOldErrorPage: Bool = false) -> (URLResponse, Data)? {
         guard let url = request.url else { return nil }
         let response = InternalSchemeHandler.response(forUrl: url)
         // Blank page with a color matching the background of the panels which
@@ -25,7 +25,7 @@ class AboutHomeHandler: InternalSchemeResponse {
 class AboutLicenseHandler: InternalSchemeResponse {
     static let path = "about/license"
 
-    func response(forRequest request: URLRequest) -> (URLResponse, Data)? {
+    func response(forRequest request: URLRequest, useOldErrorPage: Bool = false) -> (URLResponse, Data)? {
         guard let url = request.url else { return nil }
         let response = InternalSchemeHandler.response(forUrl: url)
         guard let path = Bundle.main.path(forResource: "Licenses", ofType: "html"),

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -161,7 +161,7 @@ class ErrorPageHandler: InternalSchemeResponse, FeatureFlaggable {
         return NativeErrorPageFeatureFlag().isNICErrorPageEnabled
     }
 
-    func response(forRequest request: URLRequest) -> (URLResponse, Data)? {
+    func response(forRequest request: URLRequest, useOldErrorPage: Bool) -> (URLResponse, Data)? {
         guard let url = request.url,
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let code = components.valueForQuery("code"),
@@ -174,9 +174,9 @@ class ErrorPageHandler: InternalSchemeResponse, FeatureFlaggable {
             CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue
         )
 
-        if isNativeErrorPageEnabled {
+        if isNativeErrorPageEnabled && !useOldErrorPage {
             return responseForNativeErrorPage(request: request)
-        } else if isNICErrorPageEnabled && (errCode == noInternetErrorCode) {
+        } else if isNICErrorPageEnabled && (errCode == noInternetErrorCode) && !useOldErrorPage {
             return responseForNativeErrorPage(request: request)
         } else {
             return responseForErrorWebPage(request: request)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11144)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24277)

## :bulb: Description
Handle internet connection error for PrivacyPolicyViewController

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

