### PR TITLE
Add FXIOS-11047 [Homepage] [Bookmarks] initial view + state

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -965,6 +965,10 @@
 		8A9D31662D13586500171502 /* MockFolderHierarchyFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31652D13586100171502 /* MockFolderHierarchyFetcher.swift */; };
 		8A9D31682D135A1300171502 /* MockBookmarksSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31672D135A1300171502 /* MockBookmarksSaver.swift */; };
 		8A9D316A2D135EB000171502 /* EditBookmarkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9D31692D135EB000171502 /* EditBookmarkViewModelTests.swift */; };
+		8A9E04192D4D07EF0022ED90 /* BookmarksCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9E04182D4D07EA0022ED90 /* BookmarksCell.swift */; };
+		8A9E041B2D4D08350022ED90 /* BookmarkState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9E041A2D4D08350022ED90 /* BookmarkState.swift */; };
+		8A9E041D2D4D09240022ED90 /* BookmarksSectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9E041C2D4D09230022ED90 /* BookmarksSectionState.swift */; };
+		8A9E041F2D4D0B7A0022ED90 /* BookmarksSectionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9E041E2D4D0B7A0022ED90 /* BookmarksSectionStateTests.swift */; };
 		8A9E46BD2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9E46BC2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift */; };
 		8A9F0B5627C595F300FE09AE /* ImageIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */; };
 		8A9F0B5727C59E1700FE09AE /* ImageIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */; };
@@ -996,7 +1000,7 @@
 		8AB30ECA2B6C03C700BD9A9B /* DataClearanceAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB30EC92B6C03C700BD9A9B /* DataClearanceAnimation.swift */; };
 		8AB53B3A2D4138F200C97590 /* MessageCardMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB53B392D4138ED00C97590 /* MessageCardMiddleware.swift */; };
 		8AB53B3E2D41463900C97590 /* MessageCardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB53B3D2D41463400C97590 /* MessageCardAction.swift */; };
-		8AB5958828413F6C0090F4AE /* BookmarksCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958728413F6C0090F4AE /* BookmarksCell.swift */; };
+		8AB5958828413F6C0090F4AE /* LegacyBookmarksCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB5958728413F6C0090F4AE /* LegacyBookmarksCell.swift */; };
 		8AB5958A284145B30090F4AE /* HomepageSectionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */; };
 		8AB8571D27D929350075C173 /* TopSitesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8571C27D929350075C173 /* TopSitesViewModel.swift */; };
 		8AB8571F27D931B40075C173 /* EmptyTopSiteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8571E27D931B40075C173 /* EmptyTopSiteCell.swift */; };
@@ -7825,6 +7829,10 @@
 		8A9D31652D13586100171502 /* MockFolderHierarchyFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFolderHierarchyFetcher.swift; sourceTree = "<group>"; };
 		8A9D31672D135A1300171502 /* MockBookmarksSaver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBookmarksSaver.swift; sourceTree = "<group>"; };
 		8A9D31692D135EB000171502 /* EditBookmarkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditBookmarkViewModelTests.swift; sourceTree = "<group>"; };
+		8A9E04182D4D07EA0022ED90 /* BookmarksCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksCell.swift; sourceTree = "<group>"; };
+		8A9E041A2D4D08350022ED90 /* BookmarkState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkState.swift; sourceTree = "<group>"; };
+		8A9E041C2D4D09230022ED90 /* BookmarksSectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksSectionState.swift; sourceTree = "<group>"; };
+		8A9E041E2D4D0B7A0022ED90 /* BookmarksSectionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksSectionStateTests.swift; sourceTree = "<group>"; };
 		8A9E46BC2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStatusBarScrollDelegate.swift; sourceTree = "<group>"; };
 		8A9F0B5527C595F300FE09AE /* ImageIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageIdentifiers.swift; sourceTree = "<group>"; };
 		8AA020EE2B9A37E500771DE0 /* NimbusSplashScreenFeatureLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusSplashScreenFeatureLayer.swift; sourceTree = "<group>"; };
@@ -7854,7 +7862,7 @@
 		8AB30EC92B6C03C700BD9A9B /* DataClearanceAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataClearanceAnimation.swift; sourceTree = "<group>"; };
 		8AB53B392D4138ED00C97590 /* MessageCardMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardMiddleware.swift; sourceTree = "<group>"; };
 		8AB53B3D2D41463400C97590 /* MessageCardAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCardAction.swift; sourceTree = "<group>"; };
-		8AB5958728413F6C0090F4AE /* BookmarksCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksCell.swift; sourceTree = "<group>"; };
+		8AB5958728413F6C0090F4AE /* LegacyBookmarksCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyBookmarksCell.swift; sourceTree = "<group>"; };
 		8AB59589284145B30090F4AE /* HomepageSectionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageSectionHandler.swift; sourceTree = "<group>"; };
 		8AB8571C27D929350075C173 /* TopSitesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesViewModel.swift; sourceTree = "<group>"; };
 		8AB8571E27D931B40075C173 /* EmptyTopSiteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTopSiteCell.swift; sourceTree = "<group>"; };
@@ -11777,6 +11785,7 @@
 			children = (
 				8AED23072D4012B1000FF624 /* MessageCardStateTests.swift */,
 				8A6E63CA2D4A6F230040D355 /* JumpBackInSectionStateTests.swift */,
+				8A9E041E2D4D0B7A0022ED90 /* BookmarksSectionStateTests.swift */,
 				8A106D622D416F82009AD7E4 /* MessageCardMiddlewareTests.swift */,
 				8AEF41612D15EDBA0013925D /* TopSitesMiddlewareTests.swift */,
 				8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */,
@@ -11922,6 +11931,7 @@
 		8A7D08E12CAAF79F0035999C /* Homepage Rebuild */ = {
 			isa = PBXGroup;
 			children = (
+				8A9E04172D4D07E30022ED90 /* Bookmark */,
 				8A6E63C32D4946600040D355 /* JumpBackIn */,
 				8AED23022D400020000FF624 /* MessageCard */,
 				8A62B15B2CED40800045F46E /* ContextMenu */,
@@ -12081,6 +12091,16 @@
 				8A9B87AE2C1B39EA0042B894 /* SearchListSection.swift */,
 			);
 			path = Search;
+			sourceTree = "<group>";
+		};
+		8A9E04172D4D07E30022ED90 /* Bookmark */ = {
+			isa = PBXGroup;
+			children = (
+				8A9E04182D4D07EA0022ED90 /* BookmarksCell.swift */,
+				8A9E041A2D4D08350022ED90 /* BookmarkState.swift */,
+				8A9E041C2D4D09230022ED90 /* BookmarksSectionState.swift */,
+			);
+			path = Bookmark;
 			sourceTree = "<group>";
 		};
 		8AAEB9FF2BF510E4000C02B5 /* Survey */ = {
@@ -13091,7 +13111,7 @@
 		C87DC86027B2CC21006EFCE2 /* Bookmarks */ = {
 			isa = PBXGroup;
 			children = (
-				8AB5958728413F6C0090F4AE /* BookmarksCell.swift */,
+				8AB5958728413F6C0090F4AE /* LegacyBookmarksCell.swift */,
 				966206CC2698DE1E005C0A55 /* BookmarksViewModel.swift */,
 				5A3A7DCD2886F7880065F81A /* BookmarksDataAdaptor.swift */,
 			);
@@ -16856,6 +16876,7 @@
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
 				E1442FD2294782D9003680B0 /* UIViewController+Extension.swift in Sources */,
 				E653422D1C5944F90039DD9E /* BrowserPrompts.swift in Sources */,
+				8A9E04192D4D07EF0022ED90 /* BookmarksCell.swift in Sources */,
 				E127313C28B6AD99006F39D2 /* WallpaperSettingsViewController.swift in Sources */,
 				43D4BCBA2972082400775FB5 /* CreditCardSettingsViewModel.swift in Sources */,
 				DF529EA12AB1B421003C5373 /* FakespotReliabilityScoreView.swift in Sources */,
@@ -17002,6 +17023,7 @@
 				E1A6AB4828CA833000EBEBDD /* WallpaperBaseViewController.swift in Sources */,
 				8A1CBB972BE0182C008BE4D4 /* MicrosurveyPromptMiddleware.swift in Sources */,
 				4331A9BB27193DF0005E8080 /* ContextualHintViewController.swift in Sources */,
+				8A9E041D2D4D09240022ED90 /* BookmarksSectionState.swift in Sources */,
 				39EF434E260A73950011E22E /* Experiments.swift in Sources */,
 				81F617CB2C877EC7003799BF /* MainMenuTelemetry.swift in Sources */,
 				E15DE7C0293A670700B32667 /* PhotonActionSheetSeparator.swift in Sources */,
@@ -17294,7 +17316,7 @@
 				81C3E6092C93261A00A19A5A /* MainMenuDetailsViewController.swift in Sources */,
 				8ADC2A182A33775F00543DAA /* FxASignInViewParameters.swift in Sources */,
 				EBA3B2D22268F57E00728BDB /* BadgeWithBackdrop.swift in Sources */,
-				8AB5958828413F6C0090F4AE /* BookmarksCell.swift in Sources */,
+				8AB5958828413F6C0090F4AE /* LegacyBookmarksCell.swift in Sources */,
 				8A83B7482A264FB7002FF9AC /* LibraryCoordinator.swift in Sources */,
 				E1CD81C2290C62A600124B27 /* HostingTableViewCell.swift in Sources */,
 				8AA020EF2B9A37E500771DE0 /* NimbusSplashScreenFeatureLayer.swift in Sources */,
@@ -17324,6 +17346,7 @@
 				59A68D66379CFA85C4EAF00B /* TwoLineImageOverlayCell.swift in Sources */,
 				0A49784A2C53E63200B1E82A /* TrackingProtectionViewController.swift in Sources */,
 				0AFE9BF12CF47DFC003DB4D1 /* PrivacyPreferencesViewController.swift in Sources */,
+				8A9E041B2D4D08350022ED90 /* BookmarkState.swift in Sources */,
 				8A04136928258DF600D20B10 /* SponsoredTileTelemetry.swift in Sources */,
 				D04CD718215EBD85004FF5B0 /* SettingsLoadingView.swift in Sources */,
 				0B8BF3702CA2D60B00E9812D /* BookmarksViewController.swift in Sources */,
@@ -17467,6 +17490,7 @@
 				81DAB2F32C88F14400F4BE98 /* MainMenuCoordinatorTests.swift in Sources */,
 				8A359EF62A1FE840004A5BB7 /* MockAdjustWrapper.swift in Sources */,
 				8AC225662B6D403200CDA7FD /* HomepageTelemetryTests.swift in Sources */,
+				8A9E041F2D4D0B7A0022ED90 /* BookmarksSectionStateTests.swift in Sources */,
 				1D558A582BED7ECB001EF527 /* MockWindowManager.swift in Sources */,
 				C8DC90D22A067C6D0008832B /* MarkupAttributionUtilityTests.swift in Sources */,
 				BA1C68BC2B7ED153000D9397 /* MockWebKit.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Bookmarks/BookmarksViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/Bookmarks/BookmarksViewModel.swift
@@ -127,7 +127,7 @@ extension BookmarksViewModel: HomepageViewModelProtocol, FeatureFlaggable {
 extension BookmarksViewModel: HomepageSectionHandler {
     func configure(_ cell: UICollectionViewCell,
                    at indexPath: IndexPath) -> UICollectionViewCell {
-        guard let bookmarksCell = cell as? BookmarksCell else { return UICollectionViewCell() }
+        guard let bookmarksCell = cell as? LegacyBookmarksCell else { return UICollectionViewCell() }
 
         if let item = bookmarkItems[safe: indexPath.row] {
             let site = Site.createBasicSite(url: item.url, title: item.title, isBookmarked: true)

--- a/firefox-ios/Client/Frontend/Home/Bookmarks/LegacyBookmarksCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Bookmarks/LegacyBookmarksCell.swift
@@ -1,0 +1,134 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import SiteImageView
+import Shared
+
+/// A cell used in FxHomeScreen's Bookmarks section.
+class LegacyBookmarksCell: UICollectionViewCell, ReusableCell {
+    private struct UX {
+        static let containerSpacing: CGFloat = 16
+        static let heroImageSize = CGSize(width: 126, height: 82)
+        static let generalSpacing: CGFloat = 8
+    }
+
+    // MARK: - UI Elements
+    private var rootContainer: UIView = .build { view in
+        view.backgroundColor = .clear
+        view.layer.cornerRadius = HomepageViewModel.UX.generalCornerRadius
+    }
+
+    private var heroImageView: HeroImageView = .build { _ in }
+
+    let itemTitle: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.caption1.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    // MARK: - Inits
+
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+
+        isAccessibilityElement = true
+        accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.Bookmarks.itemCell
+
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        itemTitle.text = nil
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        rootContainer.layer.shadowPath = UIBezierPath(roundedRect: rootContainer.bounds,
+                                                      cornerRadius: HomepageViewModel.UX.generalCornerRadius).cgPath
+    }
+
+    func configure(viewModel: BookmarksCellViewModel, theme: Theme) {
+        let heroImageViewModel = HomepageHeroImageViewModel(urlStringRequest: viewModel.site.url,
+                                                            heroImageSize: UX.heroImageSize)
+        heroImageView.setHeroImage(heroImageViewModel)
+        itemTitle.text = viewModel.site.title
+        accessibilityLabel = viewModel.accessibilityLabel
+        applyTheme(theme: theme)
+    }
+
+    // MARK: - Helpers
+
+    private func setupLayout() {
+        contentView.backgroundColor = .clear
+        rootContainer.addSubviews(heroImageView, itemTitle)
+        contentView.addSubview(rootContainer)
+
+        NSLayoutConstraint.activate([
+            rootContainer.topAnchor.constraint(equalTo: contentView.topAnchor),
+            rootContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            rootContainer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            rootContainer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            heroImageView.topAnchor.constraint(equalTo: rootContainer.topAnchor,
+                                               constant: UX.containerSpacing),
+            heroImageView.leadingAnchor.constraint(equalTo: rootContainer.leadingAnchor,
+                                                   constant: UX.containerSpacing),
+            heroImageView.trailingAnchor.constraint(equalTo: rootContainer.trailingAnchor,
+                                                    constant: -UX.containerSpacing),
+            heroImageView.heightAnchor.constraint(equalToConstant: UX.heroImageSize.height),
+            heroImageView.widthAnchor.constraint(equalToConstant: UX.heroImageSize.width),
+
+            itemTitle.topAnchor.constraint(equalTo: heroImageView.bottomAnchor,
+                                           constant: UX.generalSpacing),
+            itemTitle.leadingAnchor.constraint(equalTo: heroImageView.leadingAnchor),
+            itemTitle.trailingAnchor.constraint(equalTo: heroImageView.trailingAnchor),
+            itemTitle.bottomAnchor.constraint(equalTo: rootContainer.bottomAnchor,
+                                              constant: -UX.generalSpacing),
+        ])
+    }
+
+    private func setupShadow(theme: Theme) {
+        rootContainer.layer.shadowPath = UIBezierPath(roundedRect: rootContainer.bounds,
+                                                      cornerRadius: HomepageViewModel.UX.generalCornerRadius).cgPath
+
+        rootContainer.layer.shadowColor = theme.colors.shadowDefault.cgColor
+        rootContainer.layer.shadowOpacity = HomepageViewModel.UX.shadowOpacity
+        rootContainer.layer.shadowOffset = HomepageViewModel.UX.shadowOffset
+        rootContainer.layer.shadowRadius = HomepageViewModel.UX.shadowRadius
+    }
+}
+
+// MARK: - ThemeApplicable
+extension LegacyBookmarksCell: ThemeApplicable {
+    func applyTheme(theme: Theme) {
+        itemTitle.textColor = theme.colors.textPrimary
+        let heroImageColors = HeroImageViewColor(faviconTintColor: theme.colors.iconPrimary,
+                                                 faviconBackgroundColor: theme.colors.layer1,
+                                                 faviconBorderColor: theme.colors.layer1)
+        heroImageView.updateHeroImageTheme(with: heroImageColors)
+
+        adjustBlur(theme: theme)
+    }
+}
+
+// MARK: - Blurrable
+extension LegacyBookmarksCell: Blurrable {
+    func adjustBlur(theme: Theme) {
+        // If blur is disabled set background color
+        if shouldApplyWallpaperBlur {
+            rootContainer.layoutIfNeeded()
+            rootContainer.addBlurEffectWithClearBackgroundAndClipping(using: .systemThickMaterial)
+        } else {
+            rootContainer.removeVisualEffectView()
+            rootContainer.backgroundColor = theme.colors.layer5
+            setupShadow(theme: theme)
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarkState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarkState.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Storage
+
+struct BookmarkState: Equatable, Hashable {
+    let site: Site
+    var accessibilityLabel: String {
+        return "\(site.title)"
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksCell.swift
@@ -7,8 +7,8 @@ import Foundation
 import SiteImageView
 import Shared
 
-/// A cell used in FxHomeScreen's Bookmarks section.
-class BookmarksCell: UICollectionViewCell, ReusableCell {
+/// A cell used in homepage's Bookmarks section.
+final class BookmarksCell: UICollectionViewCell, ReusableCell, ThemeApplicable, Blurrable {
     private struct UX {
         static let containerSpacing: CGFloat = 16
         static let heroImageSize = CGSize(width: 126, height: 82)
@@ -50,16 +50,19 @@ class BookmarksCell: UICollectionViewCell, ReusableCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        rootContainer.layer.shadowPath = UIBezierPath(roundedRect: rootContainer.bounds,
-                                                      cornerRadius: HomepageViewModel.UX.generalCornerRadius).cgPath
+        rootContainer.layer.shadowPath = UIBezierPath(
+            roundedRect: rootContainer.bounds,
+            cornerRadius: HomepageViewModel.UX.generalCornerRadius).cgPath
     }
 
-    func configure(viewModel: BookmarksCellViewModel, theme: Theme) {
-        let heroImageViewModel = HomepageHeroImageViewModel(urlStringRequest: viewModel.site.url,
-                                                            heroImageSize: UX.heroImageSize)
+    func configure(state: BookmarkState, theme: Theme) {
+        let heroImageViewModel = HomepageHeroImageViewModel(
+            urlStringRequest: state.site.url,
+            heroImageSize: UX.heroImageSize
+        )
         heroImageView.setHeroImage(heroImageViewModel)
-        itemTitle.text = viewModel.site.title
-        accessibilityLabel = viewModel.accessibilityLabel
+        itemTitle.text = state.site.title
+        accessibilityLabel = state.accessibilityLabel
         applyTheme(theme: theme)
     }
 
@@ -103,10 +106,8 @@ class BookmarksCell: UICollectionViewCell, ReusableCell {
         rootContainer.layer.shadowOffset = HomepageViewModel.UX.shadowOffset
         rootContainer.layer.shadowRadius = HomepageViewModel.UX.shadowRadius
     }
-}
 
-// MARK: - ThemeApplicable
-extension BookmarksCell: ThemeApplicable {
+    // MARK: - ThemeApplicable
     func applyTheme(theme: Theme) {
         itemTitle.textColor = theme.colors.textPrimary
         let heroImageColors = HeroImageViewColor(faviconTintColor: theme.colors.iconPrimary,
@@ -116,10 +117,8 @@ extension BookmarksCell: ThemeApplicable {
 
         adjustBlur(theme: theme)
     }
-}
 
-// MARK: - Blurrable
-extension BookmarksCell: Blurrable {
+    // MARK: - Blurrable
     func adjustBlur(theme: Theme) {
         // If blur is disabled set background color
         if shouldApplyWallpaperBlur {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksSectionState.swift
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import Storage
+
+/// State for the bookmark section that is used in the homepage view
+struct BookmarksSectionState: StateType, Equatable, Hashable {
+    var windowUUID: WindowUUID
+    var bookmarks: [BookmarkState]
+
+    init(windowUUID: WindowUUID) {
+        self.init(
+            windowUUID: windowUUID,
+            bookmarks: []
+        )
+    }
+
+    private init(
+        windowUUID: WindowUUID,
+        bookmarks: [BookmarkState]
+    ) {
+        self.windowUUID = windowUUID
+        self.bookmarks = bookmarks
+    }
+
+    static let reducer: Reducer<Self> = { state, action in
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
+        else {
+            return defaultState(from: state)
+        }
+
+        switch action.actionType {
+        case HomepageActionType.initialize:
+            return handleInitializeAction(for: state, with: action)
+        default:
+            return defaultState(from: state)
+        }
+    }
+
+    private static func handleInitializeAction(
+        for state: BookmarksSectionState,
+        with action: Action
+    ) -> BookmarksSectionState {
+        // TODO: FXIOS-11051 Update state from middleware
+        return BookmarksSectionState(
+            windowUUID: state.windowUUID,
+            bookmarks: [
+                BookmarkState(
+                    site: Site.createBasicSite(
+                        url: "www.mozilla.org",
+                        title: "Bookmarks Title"
+                    )
+                )
+            ]
+        )
+    }
+
+    static func defaultState(from state: BookmarksSectionState) -> BookmarksSectionState {
+        return BookmarksSectionState(
+            windowUUID: state.windowUUID,
+            bookmarks: state.bookmarks
+        )
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -18,6 +18,7 @@ final class HomepageDiffableDataSource:
         case messageCard
         case topSites(NumberOfTilesPerRow)
         case jumpBackIn
+        case bookmarks
         case pocket(TextColor?)
         case customizeHomepage
     }
@@ -28,6 +29,7 @@ final class HomepageDiffableDataSource:
         case topSite(TopSiteState, TextColor?)
         case topSiteEmpty
         case jumpBackIn(JumpBackInTabState)
+        case bookmark(BookmarkState)
         case pocket(PocketStoryState)
         case pocketDiscover(PocketDiscoverState)
         case customizeHomepage
@@ -39,6 +41,7 @@ final class HomepageDiffableDataSource:
                 TopSiteCell.self,
                 EmptyTopSiteCell.self,
                 JumpBackInCell.self,
+                BookmarksCell.self,
                 PocketStandardCell.self,
                 PocketDiscoverCell.self,
                 CustomizeHomepageSectionCell.self
@@ -68,6 +71,10 @@ final class HomepageDiffableDataSource:
             snapshot.appendSections([.jumpBackIn])
             snapshot.appendItems(tabs, toSection: .jumpBackIn)
         }
+
+        // TODO: FXIOS-11051 Update showing bookmarks
+        snapshot.appendSections([.bookmarks])
+        snapshot.appendItems(state.bookmarkState.bookmarks.compactMap { .bookmark($0) }, toSection: .bookmarks)
 
         if let stories = getPocketStories(with: state.pocketState) {
             snapshot.appendSections([.pocket(textColor)])

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageSectionLayoutProvider.swift
@@ -64,6 +64,11 @@ final class HomepageSectionLayoutProvider {
         struct JumpBackInConstants {
             static let itemHeight: CGFloat = 112
         }
+
+        struct BookmarksConstants {
+            static let cellHeight: CGFloat = 110
+            static let cellWidth: CGFloat = 150
+        }
     }
 
     private var logger: Logger
@@ -106,6 +111,8 @@ final class HomepageSectionLayoutProvider {
                 topInsets: UX.spacingBetweenSections,
                 bottomInsets: UX.spacingBetweenSections
             )
+        case .bookmarks:
+            return createBookmarksSectionLayout(for: traitCollection)
         }
     }
 
@@ -237,6 +244,34 @@ final class HomepageSectionLayoutProvider {
                     leading: leadingInset,
                     bottom: UX.spacingBetweenSections,
                     trailing: leadingInset)
+
+        return section
+    }
+
+    private func createBookmarksSectionLayout(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(UX.BookmarksConstants.cellWidth),
+            heightDimension: .estimated(UX.BookmarksConstants.cellHeight)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(UX.BookmarksConstants.cellWidth),
+            heightDimension: .estimated(UX.BookmarksConstants.cellHeight)
+        )
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+
+        let section = NSCollectionLayoutSection(group: group)
+
+        let leadingInset = UX.leadingInset(traitCollection: traitCollection)
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: leadingInset,
+            bottom: UX.spacingBetweenSections,
+            trailing: 0)
+
+        section.interGroupSpacing = UX.interGroupSpacing
+        section.orthogonalScrollingBehavior = .continuous
 
         return section
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -397,6 +397,15 @@ final class HomepageViewController: UIViewController,
             jumpBackInCell.configure(state: state, theme: currentTheme)
             return jumpBackInCell
 
+        case .bookmark(let state):
+            guard let bookmarksCell = collectionView?.dequeueReusableCell(
+                cellType: BookmarksCell.self,
+                for: indexPath
+            ) else {
+                return UICollectionViewCell()
+            }
+            bookmarksCell.configure(state: state, theme: currentTheme)
+            return bookmarksCell
         case .pocket(let story):
             guard let pocketCell = collectionView?.dequeueReusableCell(
                 cellType: PocketStandardCell.self,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -13,6 +13,7 @@ struct HomepageState: ScreenState, Equatable {
     let messageState: MessageCardState
     let topSitesState: TopSitesSectionState
     let jumpBackInState: JumpBackInSectionState
+    let bookmarkState: BookmarksSectionState
     let pocketState: PocketState
     let wallpaperState: WallpaperState
 
@@ -32,6 +33,7 @@ struct HomepageState: ScreenState, Equatable {
             messageState: homepageState.messageState,
             topSitesState: homepageState.topSitesState,
             jumpBackInState: homepageState.jumpBackInState,
+            bookmarkState: homepageState.bookmarkState,
             pocketState: homepageState.pocketState,
             wallpaperState: homepageState.wallpaperState
         )
@@ -44,6 +46,7 @@ struct HomepageState: ScreenState, Equatable {
             messageState: MessageCardState(windowUUID: windowUUID),
             topSitesState: TopSitesSectionState(windowUUID: windowUUID),
             jumpBackInState: JumpBackInSectionState(windowUUID: windowUUID),
+            bookmarkState: BookmarksSectionState(windowUUID: windowUUID),
             pocketState: PocketState(windowUUID: windowUUID),
             wallpaperState: WallpaperState(windowUUID: windowUUID)
         )
@@ -55,6 +58,7 @@ struct HomepageState: ScreenState, Equatable {
         messageState: MessageCardState,
         topSitesState: TopSitesSectionState,
         jumpBackInState: JumpBackInSectionState,
+        bookmarkState: BookmarksSectionState,
         pocketState: PocketState,
         wallpaperState: WallpaperState
     ) {
@@ -63,6 +67,7 @@ struct HomepageState: ScreenState, Equatable {
         self.messageState = messageState
         self.topSitesState = topSitesState
         self.jumpBackInState = jumpBackInState
+        self.bookmarkState = bookmarkState
         self.pocketState = pocketState
         self.wallpaperState = wallpaperState
     }
@@ -81,6 +86,7 @@ struct HomepageState: ScreenState, Equatable {
                 messageState: MessageCardState.reducer(state.messageState, action),
                 topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
                 jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
+                bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
                 pocketState: PocketState.reducer(state.pocketState, action),
                 wallpaperState: WallpaperState.reducer(state.wallpaperState, action)
             )
@@ -95,6 +101,7 @@ struct HomepageState: ScreenState, Equatable {
         var pocketState = state.pocketState
         var topSitesState = state.topSitesState
         var jumpBackInState = state.jumpBackInState
+        var bookmarkState = state.bookmarkState
         var wallpaperState = state.wallpaperState
 
         if let action {
@@ -102,6 +109,7 @@ struct HomepageState: ScreenState, Equatable {
             messageState = MessageCardState.reducer(state.messageState, action)
             pocketState = PocketState.reducer(state.pocketState, action)
             jumpBackInState = JumpBackInSectionState.reducer(state.jumpBackInState, action)
+            bookmarkState = BookmarksSectionState.reducer(state.bookmarkState, action)
             topSitesState = TopSitesSectionState.reducer(state.topSitesState, action)
             wallpaperState = WallpaperState.reducer(state.wallpaperState, action)
         }
@@ -112,6 +120,7 @@ struct HomepageState: ScreenState, Equatable {
             messageState: messageState,
             topSitesState: topSitesState,
             jumpBackInState: jumpBackInState,
+            bookmarkState: bookmarkState,
             pocketState: pocketState,
             wallpaperState: wallpaperState
         )

--- a/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageSectionType.swift
@@ -35,7 +35,7 @@ enum HomepageSectionType: Int, CaseIterable {
         case .pocket: return ""
         // JumpBackIn has more than 1 cell type, dequeuing is done through FxHomeSectionHandler protocol
         case .jumpBackIn: return ""
-        case .bookmarks: return BookmarksCell.cellIdentifier
+        case .bookmarks: return LegacyBookmarksCell.cellIdentifier
         case .historyHighlights: return HistoryHighlightsCell.cellIdentifier
         case .customizeHome: return CustomizeHomepageSectionCell.cellIdentifier
         }
@@ -49,7 +49,7 @@ enum HomepageSectionType: Int, CaseIterable {
                 LegacyJumpBackInCell.self,
                 PocketDiscoverCell.self,
                 LegacyPocketStandardCell.self,
-                BookmarksCell.self,
+                LegacyBookmarksCell.self,
                 HistoryHighlightsCell.self,
                 CustomizeHomepageSectionCell.self,
                 SyncedTabCell.self

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -38,8 +38,8 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.updateSnapshot(state: HomepageState(windowUUID: .XCTestDefaultUUID), numberOfCellsPerRow: 4)
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfSections, 3)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .jumpBackIn, .customizeHomepage])
+        XCTAssertEqual(snapshot.numberOfSections, 4)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .jumpBackIn, .bookmarks, .customizeHomepage])
 
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .customizeHomepage).count, 1)
@@ -104,7 +104,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .topSites(4)), 8)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites(4), .jumpBackIn, .customizeHomepage])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .topSites(4), .jumpBackIn, .bookmarks, .customizeHomepage])
     }
 
     func test_updateSnapshot_withValidState_returnPocketStories() throws {
@@ -123,7 +123,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil)), 21)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .jumpBackIn, .pocket(nil), .customizeHomepage])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .jumpBackIn, .bookmarks, .pocket(nil), .customizeHomepage])
     }
 
     func test_updateSnapshot_withValidState_returnMessageCard() throws {
@@ -148,7 +148,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .messageCard), 1)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .messageCard).first, HomepageItem.messageCard(configuration))
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .jumpBackIn, .customizeHomepage])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .messageCard, .jumpBackIn, .bookmarks, .customizeHomepage])
     }
 
     private func createSites(count: Int = 30) -> [TopSiteState] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/BookmarksSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/BookmarksSectionStateTests.swift
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+final class BookmarksSectionStateTests: XCTestCase {
+    func tests_initialState_returnsExpectedState() {
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(initialState.bookmarks, [])
+    }
+
+    func test_initializeAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = bookmarksSectionReducer()
+
+        let newState = reducer(
+            initialState,
+            HomepageAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.initialize
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.bookmarks.count, 1)
+
+        XCTAssertEqual(newState.bookmarks.first?.site.url, "www.mozilla.org")
+        XCTAssertEqual(newState.bookmarks.first?.site.title, "Bookmarks Title")
+        XCTAssertEqual(newState.bookmarks.first?.accessibilityLabel, "Bookmarks Title")
+    }
+
+    // MARK: - Private
+    private func createSubject() -> BookmarksSectionState {
+        return BookmarksSectionState(windowUUID: .XCTestDefaultUUID)
+    }
+
+    private func bookmarksSectionReducer() -> Reducer<BookmarksSectionState> {
+        return BookmarksSectionState.reducer
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11047)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Add initial view for one bookmark item (using mock data)
- Copied over `BookmarksCell` and rename `LegacyBookmarksCell` - made changes to use state instead of view model; clean up how extensions were used
- Added state for individual bookmark item `BookmarkState` and state for the section `BookmarkSectionState`
- Add section state as a substate to `HomepageState`
- Add appropriate code in our diffable datasource logic + view controller to display a bookmark cell

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)


## Screenshots
| Initial Bookmarks View |
| --- |
| <img src="https://github.com/user-attachments/assets/1b1d4328-621e-4f2b-b5d5-3389c39130cc" width="250"> |