### PR TITLE
Refactor FXIOS-9353 #20714 Improving BVC viewDidLoad

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -763,43 +763,47 @@ class BrowserViewController: UIViewController,
         setupNotifications()
 
         DispatchQueue.main.async {
-            self.overlayManager.setURLBar(urlBarView: self.urlBarView)
-
-            // Update theme of already existing views
-            let theme = self.currentTheme()
-            self.header.applyTheme(theme: theme)
-            self.overKeyboardContainer.applyTheme(theme: theme)
-            self.bottomContainer.applyTheme(theme: theme)
-            self.bottomContentStackView.applyTheme(theme: theme)
-            self.statusBarOverlay.hasTopTabs = ToolbarHelper().shouldShowTopTabs(for: self.traitCollection)
-            self.statusBarOverlay.applyTheme(theme: theme)
-
-            KeyboardHelper.defaultHelper.addDelegate(self)
-            self.listenForThemeChange(self.view)
-            self.setupAccessibleActions()
-
-            self.clipboardBarDisplayHandler = ClipboardBarDisplayHandler(prefs: self.profile.prefs,
-                                                                         tabManager: self.tabManager)
-            self.clipboardBarDisplayHandler?.delegate = self
-
-            self.navigationToolbarContainer.toolbarDelegate = self
-            self.scrollController.header = self.header
-            self.scrollController.overKeyboardContainer = self.overKeyboardContainer
-            self.scrollController.bottomContainer = self.bottomContainer
-
-            // Setup UIDropInteraction to handle dragging and dropping
-            // links into the view from other apps.
-            let dropInteraction = UIDropInteraction(delegate: self)
-            self.view.addInteraction(dropInteraction)
-
-            // Feature flag for credit card until we fully enable this feature
-            let autofillCreditCardStatus = self.featureFlags.isFeatureEnabled(
-                .creditCardAutofillStatus, checking: .buildOnly)
-            // We need to update autofill status on sync manager as there could be delay from nimbus
-            // in getting the value. When the delay happens the credit cards might not sync
-            // as the default value is false
-            self.profile.syncManager?.updateCreditCardAutofillStatus(value: autofillCreditCardStatus)
+            self.setupNonEssentialUI()
         }
+    }
+
+    private func setupNonEssentialUI() {
+        overlayManager.setURLBar(urlBarView: urlBarView)
+
+        // Update theme of already existing views
+        let theme = currentTheme()
+        header.applyTheme(theme: theme)
+        overKeyboardContainer.applyTheme(theme: theme)
+        bottomContainer.applyTheme(theme: theme)
+        bottomContentStackView.applyTheme(theme: theme)
+        statusBarOverlay.hasTopTabs = ToolbarHelper().shouldShowTopTabs(for: traitCollection)
+        statusBarOverlay.applyTheme(theme: theme)
+
+        KeyboardHelper.defaultHelper.addDelegate(self)
+        listenForThemeChange(view)
+        setupAccessibleActions()
+
+        clipboardBarDisplayHandler = ClipboardBarDisplayHandler(prefs: profile.prefs,
+                                                                     tabManager: tabManager)
+        clipboardBarDisplayHandler?.delegate = self
+
+        navigationToolbarContainer.toolbarDelegate = self
+        scrollController.header = header
+        scrollController.overKeyboardContainer = overKeyboardContainer
+        scrollController.bottomContainer = bottomContainer
+
+        // Setup UIDropInteraction to handle dragging and dropping
+        // links into the view from other apps.
+        let dropInteraction = UIDropInteraction(delegate: self)
+        view.addInteraction(dropInteraction)
+
+        // Feature flag for credit card until we fully enable this feature
+        let autofillCreditCardStatus = featureFlags.isFeatureEnabled(
+            .creditCardAutofillStatus, checking: .buildOnly)
+        // We need to update autofill status on sync manager as there could be delay from nimbus
+        // in getting the value. When the delay happens the credit cards might not sync
+        // as the default value is false
+        profile.syncManager?.updateCreditCardAutofillStatus(value: autofillCreditCardStatus)
     }
 
     private func setupAccessibleActions() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -751,7 +751,7 @@ class BrowserViewController: UIViewController,
         setupEssentialUI()
         subscribeToRedux()
 
-        DispatchQueue.global(qos: .background).async {
+        Task(priority: .background) {
             // App startup telemetry accesses RustLogins to queryLogins, shouldn't be on the app startup critical path
             self.trackStartupTelemetry()
         }
@@ -762,12 +762,6 @@ class BrowserViewController: UIViewController,
         setupConstraints()
         setupNotifications()
 
-        DispatchQueue.main.async {
-            self.setupNonEssentialUI()
-        }
-    }
-
-    private func setupNonEssentialUI() {
         overlayManager.setURLBar(urlBarView: urlBarView)
 
         // Update theme of already existing views
@@ -784,7 +778,7 @@ class BrowserViewController: UIViewController,
         setupAccessibleActions()
 
         clipboardBarDisplayHandler = ClipboardBarDisplayHandler(prefs: profile.prefs,
-                                                                     tabManager: tabManager)
+                                                                tabManager: tabManager)
         clipboardBarDisplayHandler?.delegate = self
 
         navigationToolbarContainer.toolbarDelegate = self

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -768,10 +768,6 @@ class BrowserViewController: UIViewController,
             // in getting the value. When the delay happens the credit cards might not sync
             // as the default value is false
             self.profile.syncManager?.updateCreditCardAutofillStatus(value: autofillCreditCardStatus)
-
-            self.creditCardInitialSetupTelemetry()
-
-            FakespotUtils().addSettingTelemetry()
         }
     }
 
@@ -781,7 +777,7 @@ class BrowserViewController: UIViewController,
 
         DispatchQueue.main.async {
             self.overlayManager.setURLBar(urlBarView: self.urlBarView)
-            self.updateToolbarStateForTraitCollection(self.traitCollection)
+//            self.updateToolbarStateForTraitCollection(self.traitCollection)
 
             // Update theme of already existing views
             let theme = self.currentTheme()
@@ -4371,6 +4367,8 @@ extension BrowserViewController {
         trackAccessibility()
         trackNotificationPermission()
         appStartupTelemetry.sendStartupTelemetry()
+        creditCardInitialSetupTelemetry()
+        FakespotUtils().addSettingTelemetry()
     }
 
     func trackAccessibility() {

--- a/firefox-ios/Client/Frontend/PasswordManagement/LoginDataSource.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/LoginDataSource.swift
@@ -8,7 +8,7 @@ import Shared
 /// Data source for handling LoginData objects from a Cursor
 class LoginDataSource: NSObject, UITableViewDataSource {
     // in case there are no items to run cellForRowAt on, use an empty state view
-    private let emptyStateView = NoLoginsView()
+    private lazy var emptyStateView = NoLoginsView()
     var viewModel: PasswordManagerViewModel
 
     let boolSettings: (BoolSetting, BoolSetting)

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerViewModel.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerViewModel.swift
@@ -46,7 +46,7 @@ final class PasswordManagerViewModel {
     var hasLoadedBreaches = false
     var theme: Theme
 
-    init(profile: Profile, searchController: UISearchController, theme: Theme, loginProvider: LoginProvider) {
+    init(profile: Profile, searchController: UISearchController?, theme: Theme, loginProvider: LoginProvider) {
         self.profile = profile
         self.searchController = searchController
         self.theme = theme

--- a/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
@@ -37,10 +37,9 @@ final class AppStartupTelemetry {
 
     // MARK: Logins
     func queryLogins() {
-        let searchController = UISearchController()
         let loginsViewModel = PasswordManagerViewModel(
             profile: profile,
-            searchController: searchController,
+            searchController: nil,
             theme: LightTheme(),
             loginProvider: profile.logins
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9353)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20714)

## :bulb: Description
I started profiling the start up of the app, and this is a first attempt at improving the BVC load time since it has a big impact. This is a little step since we gotta start somewhere, and small incremental changes in that area makes more sense to ensure there's no breakage. My intent there is to move some things off the main thread when we first load BVC. I noticed:
- We were creating an unused `UISearchController` under the `AppStartUpTelemetry`, this had impact on launch time (see screenshot).
![UISearchController](https://github.com/user-attachments/assets/aa19f77f-5fc2-447d-b1eb-702bf3b2a874)
- I moved the app start up telemetry off the main thread with a delay, since some of those telemetry are accessing RustLogins which seems to be unneeded on the main thread when we're trying to load the app.
- Non UI tasks where also moved on a background thread.
- `updateToolbarStateForTraitCollection` was removed from the `viewDidLoad` since it's also present in `viewWillAppear`, so that seems like a duplicate call not needed.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

