### PR TITLE
Bugfix FXIOS-9699 [webcompat] Force mobile UA for PayPal

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -104,12 +104,11 @@ struct CustomUserAgentConstant {
     private static let customDesktopUA = UserAgentBuilder.defaultDesktopUserAgent().clone(extensions: "Version/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
 
     static let customMobileUAForDomain = [
-        "paypal.com": defaultMobileUA,
-        "yahoo.com": defaultMobileUA,
         "disneyplus.com": customDesktopUA
     ]
 
     static let customDesktopUAForDomain = [
+        "paypal.com": defaultMobileUA,
         "firefox.com": defaultMobileUA
     ]
 }


### PR DESCRIPTION
## :scroll: Tickets
Jira tickets: FXIOS-8027 (FXIOS-11230), FXIOS-9699
Github issues: #17911 (#24431), #21314

## :bulb: Description

This moves the UAstring override for PayPal.com from the mobile section (where it defaults to the default anyways) to the desktop section, which correlates with the default setting for iPads; where most of the issues occur.

(Also: removes the default for yahoo.com, that also sends just default…)

NB: This is not a real fix of the underlying issue https://github.com/mozilla-mobile/firefox-ios/issues/17911#issuecomment-1868026639 (as PayPal explicitly states that it should not be used from within WebViews, so whenever they insist on opening a popup the bug would demonstrate again) — this is just signaling them a mobile device, to open the widget in the same frame/tab, thus avoiding the about:blank breakage.

(In other words, getting desktop mode behavior for PayPal checkout buttons on par with with mobile mode, where issues are not being reported, for consistency.)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
