### PR TITLE
Implemented MTE-4229 - partial swipe for auto tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -373,9 +373,9 @@ class BaseTestCase: XCTestCase {
         var nrOfSwipes = 0
         while(!element.isVisible() || isHittable && !element.isHittable) && nrOfSwipes < maxNumberOfScreenSwipes {
             if swipe == "down" {
-                swipeableElement.swipeDown()
+                swipeableElement.partialSwipeDown()
             } else {
-                swipeableElement.swipeUp()
+                swipeableElement.partialSwipeUp()
             }
             usleep(1000)
             nrOfSwipes += 1
@@ -602,6 +602,33 @@ extension XCUIElement {
             self.typeText(String(character))
             Thread.sleep(forTimeInterval: delay)
         }
+    }
+
+    // Swipe up a little less than half the element
+    func partialSwipeUp(distance: CGFloat = 0.5) {
+        let elementBounds = self.frame
+        let centerX = elementBounds.width/2
+        let centerY = elementBounds.height/2
+        // Start cooordinate about from the center of the element, end coordinate at the top
+        let startCoordinate = coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+            .withOffset(CGVector(dx: centerX, dy: centerY))
+        let endCoordinate = coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+            .withOffset(CGVector(dx: centerX, dy: centerY - (elementBounds.size.height/2) * distance))
+        startCoordinate.press(forDuration: 0, thenDragTo: endCoordinate)
+    }
+
+    // Swipe down a little less than half the element
+    func partialSwipeDown(distance: CGFloat = 0.5) {
+        let elementBounds = self.frame
+        let centerX = elementBounds.width/2
+        let centerY = elementBounds.height/2
+        // Start cooordinate about from the center of the element, end coordinate at the bottom
+        // Done rather than top to middle to avoid pulling down the notification bar
+        let startCoordinate = coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+            .withOffset(CGVector(dx: centerX, dy: centerY))
+        let endCoordinate = coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+            .withOffset(CGVector(dx: centerX, dy: centerY + (elementBounds.size.height/2) * distance))
+        startCoordinate.press(forDuration: 0, thenDragTo: endCoordinate)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -154,12 +154,12 @@ class SettingsTests: BaseTestCase {
             table.cells[settingsQuery.CreditCards.title], table.cells[settingsQuery.Address.title],
             table.cells[settingsQuery.ClearData.title], app.switches[settingsQuery.ClosePrivateTabs.title],
             table.cells[settingsQuery.ContentBlocker.title], table.cells[settingsQuery.Notifications.title],
+            table.cells[settingsQuery.PrivacyPolicy.title], table.cells[settingsQuery.SendFeedback.title],
             table.cells[settingsQuery.ShowIntroduction.title],
             table.cells[settingsQuery.SendData.sendTechnicalDataTitle],
             table.cells[settingsQuery.SendData.sendDailyUsagePingTitle],
             table.cells[settingsQuery.SendData.sendCrashReportsTitle],
             table.cells[settingsQuery.StudiesToggle.title], table.cells[settingsQuery.Version.title],
-            table.cells[settingsQuery.PrivacyPolicy.title], table.cells[settingsQuery.SendFeedback.title],
             table.cells[settingsQuery.Help.title], table.cells[settingsQuery.RateOnAppStore.title],
             table.cells[settingsQuery.Licenses.title], table.cells[settingsQuery.YourRights.title]
         ]


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4229

## :bulb: Description
Sometimes tests like testLongTapRecentlySavedLink fail because when scrolling to reach the element the view goes lower or above the element because swipeUp and swipeDown actions dont stop the scrolling right away. Implemented partialSwipe that has half the scroll and reaches the desired element without passing it.
Note: Tested every test that uses scrollToElement and no issues found