### PR TITLE
Refactor FXIOS [Localization] Update to typographical apostrophe

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4966,7 +4966,7 @@ extension String {
     public static let ExternalInvalidLinkMessage = MZLocalizedString(
         key: "ExternalLink.ExternalInvalidLinkMessage.v136",
         tableName: "ExternalLink",
-        value: "The application required to open that link can't be found.",
+        value: "The application required to open that link can’t be found.",
         comment: "A statement shown to user when tapping an external link and the link doesn't work."
     )
     public static let ExternalOpenMessage = MZLocalizedString(


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
As commented [here](https://github.com/mozilla-l10n/firefoxios-l10n/pull/261#pullrequestreview-2588225742), the string need to use [typographical apostrophe](https://mozilla-l10n.github.io/documentation/misc/documentation_styleguide.html?highlight=apostrope#typography).

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

