### PR TITLE
Add FXIOS-11051 [Homepage] [Bookmarks] updating homepage when adding bookmarks

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -896,6 +896,9 @@
 		8A7653C228A2E57D00924ABF /* PocketDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */; };
 		8A7653C528A2E69100924ABF /* MockPocketAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */; };
 		8A76B01629F6EB3900A82607 /* ScreenshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A76B01529F6EB3900A82607 /* ScreenshotService.swift */; };
+		8A7835332D50FEFF0052E328 /* BookmarksMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7835322D50FEFC0052E328 /* BookmarksMiddleware.swift */; };
+		8A7835352D5100970052E328 /* BookmarksAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7835342D5100970052E328 /* BookmarksAction.swift */; };
+		8A7835372D5107810052E328 /* BookmarksMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7835362D5107810052E328 /* BookmarksMiddlewareTests.swift */; };
 		8A7892052CF91FEF00490CA4 /* UnifiedAdsCallbackTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7892042CF91FE100490CA4 /* UnifiedAdsCallbackTelemetry.swift */; };
 		8A7892072CF9228700490CA4 /* UnifiedAdsCallbackTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7892062CF9228000490CA4 /* UnifiedAdsCallbackTelemetryTests.swift */; };
 		8A7A26E129D4785900EA76F1 /* MockRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A26E029D4785900EA76F1 /* MockRouter.swift */; };
@@ -7753,6 +7756,9 @@
 		8A7653C128A2E57D00924ABF /* PocketDataAdaptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDataAdaptorTests.swift; sourceTree = "<group>"; };
 		8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPocketAPI.swift; sourceTree = "<group>"; };
 		8A76B01529F6EB3900A82607 /* ScreenshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotService.swift; sourceTree = "<group>"; };
+		8A7835322D50FEFC0052E328 /* BookmarksMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksMiddleware.swift; sourceTree = "<group>"; };
+		8A7835342D5100970052E328 /* BookmarksAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksAction.swift; sourceTree = "<group>"; };
+		8A7835362D5107810052E328 /* BookmarksMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksMiddlewareTests.swift; sourceTree = "<group>"; };
 		8A7892042CF91FE100490CA4 /* UnifiedAdsCallbackTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedAdsCallbackTelemetry.swift; sourceTree = "<group>"; };
 		8A7892062CF9228000490CA4 /* UnifiedAdsCallbackTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedAdsCallbackTelemetryTests.swift; sourceTree = "<group>"; };
 		8A7A26E029D4785900EA76F1 /* MockRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRouter.swift; sourceTree = "<group>"; };
@@ -11784,6 +11790,7 @@
 				8AED23072D4012B1000FF624 /* MessageCardStateTests.swift */,
 				8A6E63CA2D4A6F230040D355 /* JumpBackInSectionStateTests.swift */,
 				8A9E041E2D4D0B7A0022ED90 /* BookmarksSectionStateTests.swift */,
+				8A7835362D5107810052E328 /* BookmarksMiddlewareTests.swift */,
 				8A106D622D416F82009AD7E4 /* MessageCardMiddlewareTests.swift */,
 				8AEF41612D15EDBA0013925D /* TopSitesMiddlewareTests.swift */,
 				8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */,
@@ -12097,6 +12104,8 @@
 				8A9E04182D4D07EA0022ED90 /* BookmarksCell.swift */,
 				8A9E041A2D4D08350022ED90 /* BookmarkState.swift */,
 				8A9E041C2D4D09230022ED90 /* BookmarksSectionState.swift */,
+				8A7835322D50FEFC0052E328 /* BookmarksMiddleware.swift */,
+				8A7835342D5100970052E328 /* BookmarksAction.swift */,
 			);
 			path = Bookmark;
 			sourceTree = "<group>";
@@ -16828,6 +16837,7 @@
 				216A0D7B2A40F08B008077BA /* ThemeSettingsAction.swift in Sources */,
 				8A454D302CB81697009436D9 /* PocketMiddleware.swift in Sources */,
 				C2506C932A6A863600F2B76E /* HistoryCoordinator.swift in Sources */,
+				8A7835352D5100970052E328 /* BookmarksAction.swift in Sources */,
 				8A46F5AE2C9E4389005B6422 /* RemoteSettingsUtils.swift in Sources */,
 				8A3EF8012A2FCFC900796E3A /* FasterInactiveTabs.swift in Sources */,
 				CA7FC7D324A6A9B70012F347 /* PasswordManagerDataSourceHelper.swift in Sources */,
@@ -17224,6 +17234,7 @@
 				8ADC2A1F2A3399BD00543DAA /* LicenseAndAcknowledgementsSetting.swift in Sources */,
 				8CCCB08B2AE26B5C0073ADB9 /* ReportResponse.swift in Sources */,
 				21A43CDD291461C700B1206D /* ReaderModeFontTypeButton.swift in Sources */,
+				8A7835332D50FEFF0052E328 /* BookmarksMiddleware.swift in Sources */,
 				D3BE7B261B054D4400641031 /* main.swift in Sources */,
 				0A686B3E2CE253AB0090E146 /* PDFDocument+Extension.swift in Sources */,
 				810CD9C32BB3484F00E290C2 /* OnboardingMultipleChoiceCardViewController.swift in Sources */,
@@ -17628,6 +17639,7 @@
 				C23889E52A50329200429673 /* MockParentCoordinator.swift in Sources */,
 				21D8843F2A7959D000AF144C /* HomePageSettingViewControllerTests.swift in Sources */,
 				C2D80BED2AAF3C6B00CDF7A9 /* MockBrowserCoordinator.swift in Sources */,
+				8A7835372D5107810052E328 /* BookmarksMiddlewareTests.swift in Sources */,
 				45D5EDC0292D619000311934 /* MockablePinnedSites.swift in Sources */,
 				5AE371852A4DD6FE0092A760 /* PasswordManagerCoordinatorDelegateMock.swift in Sources */,
 				1D558A5B2BEE7D07001EF527 /* WindowSimpleTabsCoordinator.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksAction.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Redux
+import Common
+
+final class BookmarksAction: Action {
+    let bookmarks: [BookmarkState]?
+
+    init(bookmarks: [BookmarkState]? = nil,
+         windowUUID: WindowUUID,
+         actionType: any ActionType
+    ) {
+        self.bookmarks = bookmarks
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
+
+enum BookmarksActionType: ActionType {
+    case fetchBookmarks
+}
+
+enum BookmarksMiddlewareActionType: ActionType {
+    case initialize
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksMiddleware.swift
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import Storage
+
+final class BookmarksMiddleware {
+    private let bookmarksHandler: BookmarksHandler
+    private let bookmarkItemsLimit: UInt = 8
+
+    init(profile: Profile = AppContainer.shared.resolve()) {
+        self.bookmarksHandler = profile.places
+    }
+
+    lazy var bookmarksProvider: Middleware<AppState> = { state, action in
+        let windowUUID = action.windowUUID
+
+        switch action.actionType {
+        case HomepageActionType.initialize, BookmarksActionType.fetchBookmarks:
+            self.handleInitializeBookmarksAction(windowUUID: windowUUID)
+        default:
+           break
+        }
+    }
+
+    private func handleInitializeBookmarksAction(windowUUID: WindowUUID) {
+        bookmarksHandler.getRecentBookmarks(limit: bookmarkItemsLimit) { [weak self] bookmarks in
+            let bookmarks = bookmarks.map {
+                BookmarkState(
+                    site: Site.createBasicSite(
+                        url: $0.url,
+                        title: $0.title,
+                        isBookmarked: true
+                    )
+                )
+            }
+            self?.dispatchBookmarksAction(windowUUID: windowUUID, updatedBookmarks: bookmarks)
+        }
+    }
+
+    private func dispatchBookmarksAction(windowUUID: WindowUUID, updatedBookmarks: [BookmarkState]) {
+        let newAction = BookmarksAction(
+            bookmarks: updatedBookmarks,
+            windowUUID: windowUUID,
+            actionType: BookmarksMiddlewareActionType.initialize
+        )
+        store.dispatch(newAction)
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksSectionState.swift
@@ -33,7 +33,7 @@ struct BookmarksSectionState: StateType, Equatable, Hashable {
         }
 
         switch action.actionType {
-        case HomepageActionType.initialize:
+        case BookmarksMiddlewareActionType.initialize:
             return handleInitializeAction(for: state, with: action)
         default:
             return defaultState(from: state)
@@ -44,17 +44,14 @@ struct BookmarksSectionState: StateType, Equatable, Hashable {
         for state: BookmarksSectionState,
         with action: Action
     ) -> BookmarksSectionState {
-        // TODO: FXIOS-11051 Update state from middleware
+        guard let bookmarksAction = action as? BookmarksAction,
+              let bookmarks = bookmarksAction.bookmarks
+        else {
+            return defaultState(from: state)
+        }
         return BookmarksSectionState(
             windowUUID: state.windowUUID,
-            bookmarks: [
-                BookmarkState(
-                    site: Site.createBasicSite(
-                        url: "www.mozilla.org",
-                        title: "Bookmarks Title"
-                    )
-                )
-            ]
+            bookmarks: bookmarks
         )
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -72,9 +72,10 @@ final class HomepageDiffableDataSource:
             snapshot.appendItems(tabs, toSection: .jumpBackIn)
         }
 
-        // TODO: FXIOS-11051 Update showing bookmarks
-        snapshot.appendSections([.bookmarks])
-        snapshot.appendItems(state.bookmarkState.bookmarks.compactMap { .bookmark($0) }, toSection: .bookmarks)
+        if let bookmarks = getBookmarks(with: state.bookmarkState) {
+            snapshot.appendSections([.bookmarks])
+            snapshot.appendItems(bookmarks, toSection: .bookmarks)
+        }
 
         if let stories = getPocketStories(with: state.pocketState) {
             snapshot.appendSections([.pocket(textColor)])
@@ -121,5 +122,12 @@ final class HomepageDiffableDataSource:
     ) -> [HomepageDiffableDataSource.HomeItem]? {
         // TODO: FXIOS-11226 Show items or hide items depending user prefs / feature flag
         return jumpBackInSectionState.jumpBackInTabs.compactMap { .jumpBackIn($0) }
+    }
+
+    private func getBookmarks(
+        with bookmarksSectionState: BookmarksSectionState
+    ) -> [HomepageDiffableDataSource.HomeItem]? {
+        // TODO: FXIOS-11226 Show items or hide items depending user prefs / feature flag
+        return bookmarksSectionState.bookmarks.compactMap { .bookmark($0) }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -79,12 +79,17 @@ final class HomepageViewController: UIViewController,
         homepageState = HomepageState(windowUUID: windowUUID)
         super.init(nibName: nil, bundle: nil)
 
-        setupNotifications(forObserver: self, observing: [UIApplication.didBecomeActiveNotification,
-                                                          .FirefoxAccountChanged,
-                                                          .PrivateDataClearedHistory,
-                                                          .ProfileDidFinishSyncing,
-                                                          .TopSitesUpdated,
-                                                          .DefaultSearchEngineUpdated])
+        setupNotifications(forObserver: self, observing: [
+            UIApplication.didBecomeActiveNotification,
+            .FirefoxAccountChanged,
+            .PrivateDataClearedHistory,
+            .ProfileDidFinishSyncing,
+            .TopSitesUpdated,
+            .DefaultSearchEngineUpdated,
+            .BookmarksUpdated,
+            .RustPlacesOpened
+        ])
+
         subscribeToRedux()
     }
 
@@ -660,6 +665,13 @@ final class HomepageViewController: UIViewController,
                 TopSitesAction(
                     windowUUID: self.windowUUID,
                     actionType: TopSitesActionType.fetchTopSites
+                )
+            )
+        case .BookmarksUpdated, .RustPlacesOpened:
+            store.dispatch(
+                BookmarksAction(
+                    windowUUID: self.windowUUID,
+                    actionType: BookmarksActionType.fetchBookmarks
                 )
             )
         default: break

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -76,7 +76,8 @@ let middlewares = [
     PasswordGeneratorMiddleware().passwordGeneratorProvider,
     PocketMiddleware().pocketSectionProvider,
     NativeErrorPageMiddleware().nativeErrorPageProvider,
-    WallpaperMiddleware().wallpaperProvider
+    WallpaperMiddleware().wallpaperProvider,
+    BookmarksMiddleware().bookmarksProvider
 ]
 
 // In order for us to mock and test the middlewares easier,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -45,25 +45,31 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         let sut = createSubject()
 
         XCTAssertEqual(mockThemeManager?.getCurrentThemeCallCount, 0)
-        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 6)
-        XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
-                                                           .FirefoxAccountChanged,
-                                                           .PrivateDataClearedHistory,
-                                                           .ProfileDidFinishSyncing,
-                                                           .TopSitesUpdated,
-                                                           .DefaultSearchEngineUpdated])
-
-        sut.loadViewIfNeeded()
-
-        XCTAssertEqual(mockThemeManager?.getCurrentThemeCallCount, 1)
-        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 7)
+        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 8)
         XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
                                                            .FirefoxAccountChanged,
                                                            .PrivateDataClearedHistory,
                                                            .ProfileDidFinishSyncing,
                                                            .TopSitesUpdated,
                                                            .DefaultSearchEngineUpdated,
-                                                           .ThemeDidChange])
+                                                           .BookmarksUpdated,
+                                                           .RustPlacesOpened
+        ])
+
+        sut.loadViewIfNeeded()
+
+        XCTAssertEqual(mockThemeManager?.getCurrentThemeCallCount, 1)
+        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 9)
+        XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
+                                                           .FirefoxAccountChanged,
+                                                           .PrivateDataClearedHistory,
+                                                           .ProfileDidFinishSyncing,
+                                                           .TopSitesUpdated,
+                                                           .DefaultSearchEngineUpdated,
+                                                           .BookmarksUpdated,
+                                                           .RustPlacesOpened,
+                                                           .ThemeDidChange
+        ])
     }
 
     // MARK: - Deinit State

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/BookmarksMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/BookmarksMiddlewareTests.swift
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+
+@testable import Client
+
+final class BookmarksMiddlewareTests: XCTestCase, StoreTestUtility {
+    var mockProfile: MockProfile!
+    var mockStore: MockStoreForMiddleware<AppState>!
+
+    override func setUp() {
+        super.setUp()
+        mockProfile = MockProfile()
+        DependencyHelperMock().bootstrapDependencies()
+        setupStore()
+    }
+
+    override func tearDown() {
+        mockProfile = nil
+        DependencyHelperMock().reset()
+        resetStore()
+        super.tearDown()
+    }
+
+    func test_initializeAction_getBookmarksData() throws {
+        let subject = createSubject()
+
+        let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
+        let expectation = XCTestExpectation(description: "Homepage action initialize dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.bookmarksProvider(AppState(), action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? BookmarksAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? BookmarksMiddlewareActionType)
+
+        XCTAssertEqual(actionType, BookmarksMiddlewareActionType.initialize)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+    }
+
+    // MARK: - Helpers
+    private func createSubject() -> BookmarksMiddleware {
+        return BookmarksMiddleware(profile: mockProfile)
+    }
+
+    // MARK: StoreTestUtility
+    func setupAppState() -> AppState {
+        return AppState(
+            activeScreens: ActiveScreensState(
+                screens: [
+                    .homepage(
+                        HomepageState(
+                            windowUUID: .XCTestDefaultUUID
+                        )
+                    ),
+                ]
+            )
+        )
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    // In order to avoid flaky tests, we should reset the store
+    // similar to production
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/BookmarksSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/BookmarksSectionStateTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Redux
+import Storage
 import XCTest
 
 @testable import Client
@@ -28,8 +29,29 @@ final class BookmarksSectionStateTests: XCTestCase {
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertEqual(newState.bookmarks.count, 1)
+        XCTAssertEqual(newState.bookmarks.count, 0)
+    }
 
+    func test_fetchBookmarksAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = bookmarksSectionReducer()
+
+        let newState = reducer(
+            initialState,
+            BookmarksAction(
+                bookmarks: [BookmarkState(
+                    site: Site.createBasicSite(
+                        url: "www.mozilla.org",
+                        title: "Bookmarks Title"
+                    )
+                )],
+                windowUUID: .XCTestDefaultUUID,
+                actionType: BookmarksMiddlewareActionType.initialize
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.bookmarks.count, 1)
         XCTAssertEqual(newState.bookmarks.first?.site.url, "www.mozilla.org")
         XCTAssertEqual(newState.bookmarks.first?.site.title, "Bookmarks Title")
         XCTAssertEqual(newState.bookmarks.first?.accessibilityLabel, "Bookmarks Title")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11051)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Update bookmark section in homepage when adding / removing bookmarks
- Added middleware to handle retrieving recent bookmarks from `RustPlaces`
- Added appropriate actions to fetch bookmarks (one on initialization and then fetching bookmarks when notification has been observed)
- Added tests

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots 
https://github.com/user-attachments/assets/ea1a8dc5-048a-4294-b188-c4d23b9064b6