### PR TITLE
Bugfix FXIOS-10803 [UX Fundamentals] Closing tabs on iPad via 'X' button does not show Undo toast

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4303,6 +4303,10 @@ extension BrowserViewController: TopTabsDelegate {
     func topTabsDidPressPrivateMode() {
         updateZoomPageBarVisibility(visible: false)
     }
+
+    func topTabsShowCloseTabsToast() {
+        showToast(message: .TabsTray.CloseTabsToast.SingleTabTitle, toastAction: .closeTab)
+    }
 }
 
 extension BrowserViewController: DevicePickerViewControllerDelegate, InstructionsViewDelegate {

--- a/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
@@ -45,14 +45,6 @@ protocol TabDisplayerDelegate: AnyObject {
     func cellFactory(for cell: UICollectionViewCell, using tab: Tab) -> UICollectionViewCell
 }
 
-enum TabDisplaySection: Int, CaseIterable {
-    case regularTabs
-}
-
-enum TabDisplayType: Int {
-    case TopTabTray
-}
-
 // Regular tab order persistence for TabDisplayManager
 struct TabDisplayOrder: Codable {
     static let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
@@ -62,6 +54,18 @@ struct TabDisplayOrder: Codable {
 /// This class is only used in top tabs, but it was used beforehand in the tab tray. Some clean up was done,
 /// but the code is not as clear as it could be since this class had multiple purposes.
 class TopTabDisplayManager: NSObject {
+    private struct UX {
+        static let tabCornerRadius: CGFloat = 8
+    }
+
+    enum TabDisplayType: Int {
+        case TopTabTray
+    }
+
+    enum TabDisplaySection: Int, CaseIterable {
+        case regularTabs
+    }
+
     // MARK: - Variables
     private var performingChainedOperations = false
     var isInactiveViewExpanded = false
@@ -476,7 +480,7 @@ extension TopTabDisplayManager: UICollectionViewDropDelegate {
 
         let path = UIBezierPath(
             roundedRect: cell.cellBackground.frame,
-            cornerRadius: TopTabsUX.TabCornerRadius
+            cornerRadius: UX.tabCornerRadius
         )
         previewParams.visiblePath = path
 

--- a/firefox-ios/Client/Frontend/Browser/TopTabsLayout.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsLayout.swift
@@ -9,9 +9,18 @@ protocol TopTabsScrollDelegate: AnyObject {
 }
 
 class TopTabsLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
+    struct UX {
+        static let separatorWidth: CGFloat = 1
+        static let minTabWidth: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 130 : 76
+        static let maxTabWidth: CGFloat = 220
+        static let faderPading: CGFloat = 8
+        static let separatorYOffset: CGFloat = 7
+        static let separatorHeight: CGFloat = 32
+    }
+
     weak var tabSelectionDelegate: TabSelectionDelegate?
     weak var scrollViewDelegate: TopTabsScrollDelegate?
-    let HeaderFooterWidth = TopTabsUX.SeparatorWidth + TopTabsUX.FaderPading
+    let headerFooterWidth = UX.separatorWidth + UX.faderPading
 
     @objc
     func collectionView(
@@ -19,7 +28,7 @@ class TopTabsLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
         layout collectionViewLayout: UICollectionViewLayout,
         minimumInteritemSpacingForSectionAt section: Int
     ) -> CGFloat {
-        return TopTabsUX.SeparatorWidth
+        return UX.separatorWidth
     }
 
     @objc
@@ -30,7 +39,7 @@ class TopTabsLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
     ) -> CGSize {
         let items = collectionView.numberOfItems(inSection: 0)
         var width = collectionView.frame.width / CGFloat(items)
-        width = max(TopTabsUX.MinTabWidth, min(width, TopTabsUX.MaxTabWidth))
+        width = max(UX.minTabWidth, min(width, UX.maxTabWidth))
         return CGSize(width: width, height: collectionView.frame.height)
     }
 
@@ -49,7 +58,7 @@ class TopTabsLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
         layout collectionViewLayout: UICollectionViewLayout,
         minimumLineSpacingForSectionAt section: Int
     ) -> CGFloat {
-        return TopTabsUX.SeparatorWidth
+        return UX.separatorWidth
     }
 
     @objc
@@ -84,13 +93,13 @@ extension TopTabsLayoutDelegate: UICollectionViewDelegate {
 
 class TopTabsViewLayout: UICollectionViewFlowLayout {
     var decorationAttributeArr: [Int: UICollectionViewLayoutAttributes?] = [:]
-    let separatorYOffset = TopTabsUX.SeparatorYOffset
-    let separatorSize = TopTabsUX.SeparatorHeight
+    let separatorYOffset = TopTabsLayoutDelegate.UX.separatorYOffset
+    let separatorSize = TopTabsLayoutDelegate.UX.separatorHeight
     let SeparatorZIndex = -2 /// Prevent the header/footer from appearing above the Tabs
 
     override func prepare() {
         super.prepare()
-        self.minimumLineSpacing = TopTabsUX.SeparatorWidth
+        self.minimumLineSpacing = TopTabsLayoutDelegate.UX.separatorWidth
         scrollDirection = .horizontal
     }
 

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -7,30 +7,22 @@ import Shared
 import WebKit
 import Common
 
-struct TopTabsUX {
-    static let TopTabsViewHeight: CGFloat = 44
-    static let TopTabsBackgroundShadowWidth: CGFloat = 12
-    static let MinTabWidth: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 130 : 76
-    static let MaxTabWidth: CGFloat = 220
-    static let FaderPading: CGFloat = 8
-    static let SeparatorWidth: CGFloat = 1
-    static let AnimationSpeed: TimeInterval = 0.1
-    static let SeparatorYOffset: CGFloat = 7
-    static let SeparatorHeight: CGFloat = 32
-    static let TabCornerRadius: CGFloat = 8
-}
-
 protocol TopTabsDelegate: AnyObject {
     func topTabsDidPressTabs()
     func topTabsDidPressNewTab(_ isPrivate: Bool)
     func topTabsDidLongPressNewTab(button: UIButton)
     func topTabsDidChangeTab()
     func topTabsDidPressPrivateMode()
+    func topTabsShowCloseTabsToast()
 }
 
 class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFlaggable {
     private struct UX {
         static let trailingEdgeSpace: CGFloat = 10
+        static let topTabsViewHeight: CGFloat = 44
+        static let topTabsBackgroundShadowWidth: CGFloat = 12
+        static let faderPading: CGFloat = 8
+        static let animationSpeed: TimeInterval = 0.1
     }
 
     // MARK: - Properties
@@ -256,11 +248,11 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
                 } else {
                     // Padding is added to ensure the tab is completely visible (none of the tab is under the fader)
                     let padFrame = frame.insetBy(
-                        dx: -(TopTabsUX.TopTabsBackgroundShadowWidth+TopTabsUX.FaderPading),
+                        dx: -(UX.topTabsBackgroundShadowWidth+UX.faderPading),
                         dy: 0
                     )
                     if animated {
-                        UIView.animate(withDuration: TopTabsUX.AnimationSpeed, animations: {
+                        UIView.animate(withDuration: UX.animationSpeed, animations: {
                             self.collectionView.scrollRectToVisible(padFrame, animated: true)
                         })
                     } else {
@@ -284,7 +276,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
         view.addSubview(privateModeButton)
 
         NSLayoutConstraint.activate([
-            view.heightAnchor.constraint(equalToConstant: TopTabsUX.TopTabsViewHeight),
+            view.heightAnchor.constraint(equalToConstant: UX.topTabsViewHeight),
 
             newTab.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             newTab.widthAnchor.constraint(equalTo: view.heightAnchor),
@@ -373,6 +365,7 @@ extension TopTabsViewController: TabDisplayerDelegate {
 extension TopTabsViewController: TopTabCellDelegate {
     func tabCellDidClose(_ cell: UICollectionViewCell) {
         topTabDisplayManager.closeActionPerformed(forCell: cell)
+        delegate?.topTabsShowCloseTabsToast()
         NotificationCenter.default.post(name: .TopTabsTabClosed, object: nil, userInfo: windowUUID.userInfo)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10803)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23568)

## :bulb: Description
- Add delegate function to show Undo close tab toast
- Small changes to UX struct and enum to organize TopTabDisplayManager and related classes

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

