### PR TITLE
Bugfix FXIOS-10904 Focus iOS: Send usage.profile_id in usage-deletion-request ping

### DIFF
--- a/focus-ios/Blockzilla/metrics.yaml
+++ b/focus-ios/Blockzilla/metrics.yaml
@@ -823,6 +823,7 @@ usage:
     expires: never
     send_in_pings:
       - usage-reporting
+      - usage-deletion-request
 
   duration:
     type: timespan


### PR DESCRIPTION
Follow up to https://github.com/mozilla-mobile/firefox-ios/pull/24339 which added `usage-deletion-request` ping. We need to have `usage.profile_id` metric sent in this ping to be able to join it with `usage-reporting` pings for deletions of collected data. This follows the [setup in Android](https://github.com/mozilla/gecko-dev/blob/7155490f5c68797988a25a9e3cd0e1c191d50efa/mobile/android/fenix/app/metrics.yaml#L12213-L12215).

## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/FXIOS-10904

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

