### PR TITLE
Add FXIOS-11225 [Homepage] [JumpBackIn] fetching recent tabs

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -931,6 +931,7 @@
 		8A87B4342CC1A731003A9239 /* PocketMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A87B42E2CC1A3AA003A9239 /* PocketMiddlewareTests.swift */; };
 		8A87B4382CC1A92D003A9239 /* MockPocketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A87B4362CC1A910003A9239 /* MockPocketManager.swift */; };
 		8A88815E2B21071E009635AE /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A88815D2B21071E009635AE /* GCDWebServers */; };
+		8A8904132D511E6A00A5BB29 /* TabManagerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8904122D511E6A00A5BB29 /* TabManagerAction.swift */; };
 		8A8917692B57283B008B01EA /* LegacyHomepageHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8917682B57283B008B01EA /* LegacyHomepageHeaderCell.swift */; };
 		8A8BAE122B2107E400D774EB /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A8BAE112B2107E400D774EB /* GCDWebServers */; };
 		8A8BAE142B21110000D774EB /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 8A8BAE132B21110000D774EB /* GCDWebServers */; };
@@ -7813,6 +7814,7 @@
 		8A87B4302CC1A3BA003A9239 /* PocketManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PocketManagerTests.swift; path = "firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/PocketManagerTests.swift"; sourceTree = SOURCE_ROOT; };
 		8A87B4362CC1A910003A9239 /* MockPocketManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPocketManager.swift; sourceTree = "<group>"; };
 		8A880C432C63CFE200B77F23 /* MockLoginViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoginViewModelDelegate.swift; sourceTree = "<group>"; };
+		8A8904122D511E6A00A5BB29 /* TabManagerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerAction.swift; sourceTree = "<group>"; };
 		8A8917682B57283B008B01EA /* LegacyHomepageHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHomepageHeaderCell.swift; sourceTree = "<group>"; };
 		8A8D277A2CBFFD710076AD3A /* BrowserNavigationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserNavigationType.swift; sourceTree = "<group>"; };
 		8A8D277C2CC000BE0076AD3A /* NavigationBrowserAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBrowserAction.swift; sourceTree = "<group>"; };
@@ -10406,6 +10408,7 @@
 		219914032AF963E000153598 /* Action */ = {
 			isa = PBXGroup;
 			children = (
+				8A8904122D511E6A00A5BB29 /* TabManagerAction.swift */,
 				1D2F68AA2ACB262900524B92 /* RemoteTabsPanelAction.swift */,
 				219914042AF963F900153598 /* TabTrayAction.swift */,
 				219935E82B070F9000E5966F /* TabPanelAction.swift */,
@@ -16665,6 +16668,7 @@
 				BD4B2DE229BB4CD9005FAA50 /* SnackButton.swift in Sources */,
 				F85C7F0E2711C556004BDBA4 /* SettingsViewController.swift in Sources */,
 				0BDDB3442CA6E43100D501DF /* FolderHierarchyFetcher.swift in Sources */,
+				8A8904132D511E6A00A5BB29 /* TabManagerAction.swift in Sources */,
 				C8B509E3293FA39900AC013C /* AppVersionUpdateCheckerProtocol.swift in Sources */,
 				8AB53B3E2D41463900C97590 /* MessageCardAction.swift in Sources */,
 				E1AFBAF9292EA0330065E35E /* SendToDeviceHelper.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
@@ -2,8 +2,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Redux
 
-enum TabManagerAction: Action {
-    case tabManagerDidConnectToScene(TabManager)
+final class TabManagerAction: Action {
+    var recentTabs: [Tab]?
+
+    init(
+        recentTabs: [Tab]? = nil,
+        windowUUID: WindowUUID,
+        actionType: any ActionType
+    ) {
+        self.recentTabs = recentTabs
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
+
+enum TabManagerMiddlewareActionType: ActionType {
+    case fetchRecentTabs
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -35,8 +35,8 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
             self.resolveTabPanelViewActions(action: action, state: state)
         } else if let action = action as? MainMenuAction {
             self.resolveMainMenuActions(with: action, appState: state)
-        } else if let action = action as? HeaderAction {
-            self.resolveHomepageHeaderActions(with: action)
+        } else {
+            self.resolveHomepageActions(with: action)
         }
     }
 
@@ -876,11 +876,19 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
         }
     }
 
-    // MARK: - Homepage Header Actions
-    private func resolveHomepageHeaderActions(with action: HeaderAction) {
+    // MARK: - Homepage Related Actions
+    private func resolveHomepageActions(with action: Action) {
         switch action.actionType {
         case HeaderActionType.toggleHomepageMode:
             tabManager(for: action.windowUUID).switchPrivacyMode()
+        case HomepageActionType.initialize:
+            store.dispatch(
+                TabManagerAction(
+                    recentTabs: tabManager(for: action.windowUUID).recentlyAccessedNormalTabs,
+                    windowUUID: action.windowUUID,
+                    actionType: TabManagerMiddlewareActionType.fetchRecentTabs
+                )
+            )
         default:
             break
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -120,6 +120,10 @@ final class HomepageDiffableDataSource:
         with jumpBackInSectionState: JumpBackInSectionState
     ) -> [HomepageDiffableDataSource.HomeItem]? {
         // TODO: FXIOS-11226 Show items or hide items depending user prefs / feature flag
-        return jumpBackInSectionState.jumpBackInTabs.compactMap { .jumpBackIn($0) }
+        // TODO: FXIOS-11224 Configure items to display based on device sizes
+        let maxItemsToDisplay = 2
+        return jumpBackInSectionState.jumpBackInTabs
+            .prefix(maxItemsToDisplay)
+            .compactMap { .jumpBackIn($0) }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
@@ -4,6 +4,7 @@
 
 import Common
 import Redux
+import Storage
 
 /// State for the jump back in section that is used in the homepage view
 struct JumpBackInSectionState: StateType, Equatable, Hashable {
@@ -40,7 +41,8 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
         }
 
         switch action.actionType {
-        case HomepageActionType.initialize:
+        case TabManagerMiddlewareActionType.fetchRecentTabs:
+
             return handleInitializeAction(for: state, with: action)
         default:
             return defaultState(from: state)
@@ -51,14 +53,23 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
         for state: JumpBackInSectionState,
         with action: Action
     ) -> JumpBackInSectionState {
-        // TODO: FXIOS-11225 Update state from middleware
+        guard let tabManagerAction = action as? TabManagerAction,
+              let recentTabs = tabManagerAction.recentTabs
+        else {
+            return defaultState(from: state)
+        }
+
         return JumpBackInSectionState(
             windowUUID: state.windowUUID,
-            jumpBackInTabs: [JumpBackInTabState(
-                titleText: "JumpBack In Title",
-                descriptionText: "JumpBack In Description",
-                siteURL: "www.mozilla.com"
-            )]
+            jumpBackInTabs: recentTabs.compactMap { tab in
+                let itemURL = tab.lastKnownUrl?.absoluteString ?? ""
+                let site = Site.createBasicSite(url: itemURL, title: tab.displayTitle)
+                return JumpBackInTabState(
+                    titleText: site.title,
+                    descriptionText: site.tileURL.shortDisplayString.capitalized,
+                    siteURL: itemURL
+                )
+            }
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
@@ -8,6 +8,18 @@ import XCTest
 @testable import Client
 
 final class JumpBackInSectionStateTests: XCTestCase {
+    var mockProfile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+        mockProfile = MockProfile()
+    }
+
+    override func tearDown() {
+        mockProfile = nil
+        super.tearDown()
+    }
+
     func tests_initialState_returnsExpectedState() {
         let initialState = createSubject()
 
@@ -21,19 +33,19 @@ final class JumpBackInSectionStateTests: XCTestCase {
 
         let newState = reducer(
             initialState,
-            HomepageAction(
+            TabManagerAction(
+                recentTabs: [createTab(urlString: "www.mozilla.org")],
                 windowUUID: .XCTestDefaultUUID,
-                actionType: HomepageActionType.initialize
+                actionType: TabManagerMiddlewareActionType.fetchRecentTabs
             )
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertEqual(newState.jumpBackInTabs.count, 1)
-
-        XCTAssertEqual(newState.jumpBackInTabs.first?.titleText, "JumpBack In Title")
-        XCTAssertEqual(newState.jumpBackInTabs.first?.descriptionText, "JumpBack In Description")
-        XCTAssertEqual(newState.jumpBackInTabs.first?.siteURL, "www.mozilla.com")
-        XCTAssertEqual(newState.jumpBackInTabs.first?.accessibilityLabel, "JumpBack In Title, JumpBack In Description")
+        XCTAssertEqual(newState.jumpBackInTabs.first?.titleText, "www.mozilla.org")
+        XCTAssertEqual(newState.jumpBackInTabs.first?.descriptionText, "Www.Mozilla.Org")
+        XCTAssertEqual(newState.jumpBackInTabs.first?.siteURL, "www.mozilla.org")
+        XCTAssertEqual(newState.jumpBackInTabs.first?.accessibilityLabel, "www.mozilla.org, Www.Mozilla.Org")
     }
 
     // MARK: - Private
@@ -43,5 +55,11 @@ final class JumpBackInSectionStateTests: XCTestCase {
 
     private func jumpBackInSectionReducer() -> Reducer<JumpBackInSectionState> {
         return JumpBackInSectionState.reducer
+    }
+
+    func createTab(urlString: String) -> Tab {
+        let tab = Tab(profile: mockProfile, windowUUID: .XCTestDefaultUUID)
+        tab.url = URL(string: urlString)!
+        return tab
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
@@ -27,7 +27,7 @@ final class MockWindowManager: WindowManager {
     }
 
     func tabManager(for windowUUID: WindowUUID) -> TabManager {
-        wrappedManager.tabManager(for: windowUUID)
+        return MockTabManager()
     }
 
     func allWindowTabManagers() -> [TabManager] {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11225)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24421)

## :bulb: Description
Add fetching recent tabs for jump back in section
- Creates appropriate action to dispatch the recent tabs list from the tab manager middleware and update state
- Currently, showing 2 items at a time

Future PR will handle observing notifications, logic for how many jump back in cells to show + etc

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screeshot
| Recent Tabs |
| --- |
| <img src="https://github.com/user-attachments/assets/a1f169ec-4d5f-405a-a5c3-00654b8a59cd" width="250"> |

