### PR TITLE
Refactor FXIOS-11276 Silence webpack warning for JS file size

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,4 +98,7 @@ module.exports = {
       Assets: path.resolve(__dirname, "firefox-ios/Client/Assets"),
     },
   },
+  performance: {
+    hints: false,
+  },
 };


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11276)
[Github Issue](https://github.com/mozilla-mobile/firefox-ios/issues/24528)

## :bulb: Description

Minor internal refactor for our `bootstrap.sh`. Silences warning about size of our JS files.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

