### PR TITLE
Add FXIOS-11052 [Homepage] [Bookmarks] Handle bookmark selection

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import enum MozillaAppServices.VisitType
 
 /// View types that the browser coordinator can navigate to
 enum BrowserNavigationDestination: Equatable {
@@ -36,6 +37,7 @@ struct NavigationDestination: Equatable {
     let isPrivate: Bool?
     let selectNewTab: Bool?
     let isGoogleTopSite: Bool?
+    let visitType: VisitType?
     let contextMenuConfiguration: ContextMenuConfiguration?
 
     init(
@@ -44,6 +46,7 @@ struct NavigationDestination: Equatable {
         isPrivate: Bool? = nil,
         selectNewTab: Bool? = nil,
         isGoogleTopSite: Bool? = nil,
+        visitType: VisitType? = nil,
         contextMenuConfiguration: ContextMenuConfiguration? = nil
     ) {
         self.destination = destination
@@ -51,6 +54,7 @@ struct NavigationDestination: Equatable {
         self.isPrivate = isPrivate
         self.selectNewTab = selectNewTab
         self.isGoogleTopSite = isGoogleTopSite
+        self.visitType = visitType
         self.contextMenuConfiguration = contextMenuConfiguration
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2174,13 +2174,17 @@ class BrowserViewController: UIViewController,
         case .settings(let section):
             navigationHandler?.show(settings: section)
         case .link:
-            guard let url = type.url else {
-                logger.log("url should not be nil when navigating for a link type", level: .warning, category: .coordinator)
+            guard let url = type.url, let visitType = type.visitType else {
+                logger.log(
+                    "url or visitType should not be nil when navigating for a link type, instead received \(String(describing: type.url)) and \(String(describing: type.visitType))",
+                    level: .warning,
+                    category: .coordinator
+                )
                 return
             }
             navigationHandler?.navigateFromHomePanel(
                 to: url,
-                visitType: .link,
+                visitType: visitType,
                 isGoogleTopSite: type.isGoogleTopSite ?? false
             )
         case .newTab:

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -619,6 +619,16 @@ final class HomepageViewController: UIViewController,
         )
     }
 
+    private func dispatchNavigationBrowserAction(with destination: NavigationDestination, actionType: ActionType) {
+        store.dispatch(
+            NavigationBrowserAction(
+                navigationDestination: destination,
+                windowUUID: self.windowUUID,
+                actionType: actionType
+            )
+        )
+    }
+
     // MARK: - UICollectionViewDelegate
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let item = dataSource?.itemIdentifier(for: indexPath) else {
@@ -631,17 +641,21 @@ final class HomepageViewController: UIViewController,
         }
         switch item {
         case .topSite(let state, _):
-            store.dispatch(
-                NavigationBrowserAction(
-                    navigationDestination: NavigationDestination(
-                        .link,
-                        url: state.site.url.asURL,
-                        isGoogleTopSite: state.isGoogleURL
-                    ),
-                    windowUUID: self.windowUUID,
-                    actionType: NavigationBrowserActionType.tapOnCell
-                )
+            let destination = NavigationDestination(
+                .link,
+                url: state.site.url.asURL,
+                isGoogleTopSite: state.isGoogleURL,
+                visitType: .link
             )
+            dispatchNavigationBrowserAction(with: destination, actionType: NavigationBrowserActionType.tapOnCell)
+        case .bookmark(let config):
+            let destination = NavigationDestination(
+                .link,
+                url: URIFixup.getURL(config.site.url),
+                isGoogleTopSite: false,
+                visitType: .bookmark
+            )
+            dispatchNavigationBrowserAction(with: destination, actionType: NavigationBrowserActionType.tapOnCell)
         case .pocket(let story):
             store.dispatch(
                 NavigationBrowserAction(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11052)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24110)

## :bulb: Description
Handle tapping on bookmark cells navigates to the appropriate web page
- Update existing NavigationBrowserAction to include `visitType` since we need to pass in a `.bookmark` type instead of the `.link` type

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots

https://github.com/user-attachments/assets/533e9db6-faa3-451e-87ea-cdce2b4e9289

