### PR TITLE
Bugfix FXIOS-11281 #24536 Fix toast under Tab tray

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -461,8 +461,7 @@ class TabTrayViewController: UIViewController,
                                                    constant: Toast.UX.toastSidePadding),
                     toast.trailingAnchor.constraint(equalTo: self.view.trailingAnchor,
                                                     constant: -Toast.UX.toastSidePadding),
-                    toast.bottomAnchor.constraint(equalTo: self.view.bottomAnchor,
-                                                  constant: -self.toolbarHeight)
+                    toast.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
                 ]
             }
             shownToast = toast


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11281)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24536)

## :bulb: Description
Fixing constraints issue on iPad with toast in the tab tray. Made sure this is also working on iPhone.

### 🎥 Screenshots
<details>
<summary>iPad toast</summary>

![Simulator Screenshot - iPad Air (5th generation) - 2025-02-04 at 11 04 43](https://github.com/user-attachments/assets/ea8aab9a-e202-4a3f-8f87-6d7faad3cbbb)

</details>

<details>
<summary>iPhone toast</summary>

![Simulator Screenshot - iPhone 16 - 2025-02-04 at 11 03 59](https://github.com/user-attachments/assets/b41388ef-2c0c-46a7-9534-cad6d583b271)


</details>


## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

