### PR TITLE
Add FXIOS-11053 [Homepage] [Bookmarks] Handle long press

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuConfiguration.swift
@@ -13,6 +13,8 @@ struct ContextMenuConfiguration: Equatable {
         switch item {
         case .topSite(let state, _):
             return state.site
+        case .bookmark(let state):
+            return Site.createBasicSite(url: state.site.url, title: state.site.title)
         case .pocket(let state):
             return Site.createBasicSite(url: state.url?.absoluteString ?? "", title: state.title)
         case .pocketDiscover(let state):

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -52,6 +52,8 @@ struct ContextMenuState {
         switch configuration.homepageSection {
         case .topSites:
             actions = [getTopSitesActions(site: site)]
+        case .bookmarks:
+            actions = [getBookmarksActions(site: site)]
         case .pocket:
             actions = [getPocketActions(site: site)]
         default:
@@ -162,6 +164,18 @@ struct ContextMenuState {
             dispatchOpenNewTabAction(siteURL: url, isPrivate: false, selectNewTab: true)
             // TODO: FXIOS-10171 - Add telemetry
         }).items
+    }
+
+    // MARK: - Homepage Bookmarks section item's context menu actions
+    private func getBookmarksActions(site: Site) -> [PhotonRowActions] {
+        guard let siteURL = site.url.asURL else { return [] }
+
+        let openInNewTabAction = getOpenInNewTabAction(siteURL: siteURL)
+        let openInNewPrivateTabAction = getOpenInNewPrivateTabAction(siteURL: siteURL)
+        let shareAction = getShareAction(siteURL: site.url)
+        let bookmarkAction = getBookmarkAction(site: site)
+
+        return [openInNewTabAction, openInNewPrivateTabAction, bookmarkAction, shareAction]
     }
 
     // MARK: - Pocket item's context menu actions

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -21,6 +21,15 @@ final class HomepageDiffableDataSource:
         case bookmarks
         case pocket(TextColor?)
         case customizeHomepage
+
+        var canHandleLongPress: Bool {
+            switch self {
+            case .topSites, .jumpBackIn, .bookmarks, .pocket:
+                return true
+            default:
+                return false
+            }
+        }
     }
 
     enum HomeItem: Hashable {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -554,13 +554,15 @@ final class HomepageViewController: UIViewController,
               let sourceView = collectionView?.cellForItem(at: indexPath)
         else {
             self.logger.log(
-                "Item selected at \(point) but does not navigate to context menu",
+                "Item selected at \(point) but cannot be determined to navigate to context menu",
                 level: .debug,
                 category: .homepage
             )
             return
         }
-        navigateToContextMenu(for: section, and: item, sourceView: sourceView)
+        if section.canHandleLongPress {
+            navigateToContextMenu(for: section, and: item, sourceView: sourceView)
+        }
     }
 
     // MARK: Dispatch Actions

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -554,7 +554,7 @@ final class HomepageViewController: UIViewController,
               let sourceView = collectionView?.cellForItem(at: indexPath)
         else {
             self.logger.log(
-                "Item selected at \(point) but cannot be determined to navigate to context menu",
+                "Unable to handle whether context menu should be presented for item at \(point)",
                 level: .debug,
                 category: .homepage
             )

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -554,7 +554,7 @@ final class HomepageViewController: UIViewController,
               let sourceView = collectionView?.cellForItem(at: indexPath)
         else {
             self.logger.log(
-                "Unable to handle whether context menu should be presented for item at \(point)",
+                "Context menu handling skipped: No valid indexPath, item, section or sourceView found at \(point)",
                 level: .debug,
                 category: .homepage
             )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11053)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24111)

## :bulb: Description
Add showing context menu / photon action sheet when long pressing on bookmark items.
Also includes adding a boolean to check which sections can show the context menu or not.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

# Screenshots
https://github.com/user-attachments/assets/9978f79e-c41f-4607-b621-d7fcd8fe3150