### PR TITLE
Bug 1945884 - focus: Remove explicit usage-reporting mapping to Glean baseline ping

### DIFF
--- a/focus-ios/Blockzilla/AppDelegate.swift
+++ b/focus-ios/Blockzilla/AppDelegate.swift
@@ -371,10 +371,7 @@ extension AppDelegate {
         Glean.shared.registerPings(GleanMetrics.Pings.shared)
 
         let channel = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" ? "testflight" : "release"
-        let configuration = Configuration(
-            channel: channel,
-            pingSchedule: ["baseline": ["usage-reporting"]]
-        )
+        let configuration = Configuration(channel: channel)
 
         Glean.shared.initialize(
             uploadEnabled: TelemetryManager.shared.isGleanEnabled,


### PR DESCRIPTION
Same as #24548, but for focus now.