### PR TITLE
Remove MTE-4239 Comment the cron in update-bitrise-steps.yml due to some issues under investigation

### DIFF
--- a/.github/workflows/update-bitrise-steps.yml
+++ b/.github/workflows/update-bitrise-steps.yml
@@ -1,8 +1,8 @@
 name: Update Outdated Bitrise Steps Versions
 
 on:
-  schedule:
-    - cron: "0 3 * * 0" # Runs every Sunday at 03:00 UTC
+  #schedule:
+  #  - cron: "0 3 * * 0" # Runs every Sunday at 03:00 UTC
   workflow_dispatch: # Allow manual triggering
     inputs:
       branchName:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4239)

## :bulb: Description
We have a github actions that runs every sunday to check if the bitrise steps are outdated. The action creates a new PR if some steps are outdated. There are some problems with some steps that we need to investigate further, so this PR just comment the cron for now.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

