### PR TITLE
Bugfix FXIOS-11250 (Firefox iOS) Update settings screen's "Privacy Policy" and "Your Rights" links

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/About/YourRightsSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/About/YourRightsSetting.swift
@@ -8,7 +8,7 @@ import Foundation
 class YourRightsSetting: Setting {
     override var title: NSAttributedString? {
         guard let theme else { return nil }
-        return NSAttributedString(string: .AppSettingsYourRights,
+        return NSAttributedString(string: .AppSettingsTermsOfUse,
                                   attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary])
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/PrivacyPolicySetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/PrivacyPolicySetting.swift
@@ -22,7 +22,7 @@ class PrivacyPolicySetting: Setting {
         self.settingsDelegate = settingsDelegate
         super.init(
             title: NSAttributedString(
-                string: .AppSettingsPrivacyPolicy,
+                string: .AppSettingsPrivacyNotice,
                 attributes: [NSAttributedString.Key.foregroundColor: theme.colors.textPrimary]
             )
         )

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -7104,11 +7104,11 @@ extension String {
         tableName: nil,
         value: nil,
         comment: "Settings item that opens a tab containing the licenses. See http://mzl.la/1NSAWCG")
-    public static let AppSettingsYourRights = MZLocalizedString(
-        key: "Your Rights",
-        tableName: nil,
-        value: nil,
-        comment: "Your Rights settings section title")
+    public static let AppSettingsTermsOfUse = MZLocalizedString(
+        key: "Settings.TermsOfUse.Title.v137",
+        tableName: "Settings",
+        value: "Terms of Use",
+        comment: "Terms of Use settings section title")
     public static let AppSettingsShowTour = MZLocalizedString(
         key: "Show Tour",
         tableName: nil,
@@ -7129,11 +7129,11 @@ extension String {
         tableName: nil,
         value: nil,
         comment: "Open search section of settings")
-    public static let AppSettingsPrivacyPolicy = MZLocalizedString(
-        key: "Privacy Policy",
-        tableName: nil,
-        value: nil,
-        comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/")
+    public static let AppSettingsPrivacyNotice = MZLocalizedString(
+        key: "Settings.PrivacyNotice.Title.v137",
+        tableName: "Settings",
+        value: "Privacy Notice",
+        comment: "Show Firefox Browser Privacy Notice page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/")
     public static let AppSettingsTitle = MZLocalizedString(
         key: "Settings",
         tableName: nil,
@@ -7746,6 +7746,16 @@ extension String {
                 tableName: nil,
                 value: "Open this link in external app?",
                 comment: "Question shown to user when tapping an SMS or MailTo link that opens the external app for those.")
+            public static let AppSettingsPrivacyPolicy = MZLocalizedString(
+                key: "Privacy Policy",
+                tableName: nil,
+                value: nil,
+                comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/")
+            public static let AppSettingsYourRights = MZLocalizedString(
+                key: "Your Rights",
+                tableName: nil,
+                value: nil,
+                comment: "Your Rights settings section title")
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11250)

## :bulb: Description
Updated title for Privacy Policy and Your Rights settings

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

