### PR TITLE
Bugfix FXIOS-11284 - [Toolbar Redesign] Toolbar is still selected when we open a deeplink

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2591,6 +2591,7 @@ class BrowserViewController: UIViewController,
     // MARK: - Handle Deeplink open URL / query
 
     func handle(query: String, isPrivate: Bool) {
+        cancelEditMode()
         openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
         if isToolbarRefactorEnabled {
             openBrowser(searchTerm: query)
@@ -2601,7 +2602,8 @@ class BrowserViewController: UIViewController,
     }
 
     func handle(url: URL?, isPrivate: Bool, options: Set<Route.SearchOptions>? = nil) {
-        if let url = url {
+        cancelEditMode()
+        if let url {
             switchToTabForURLOrOpen(url, isPrivate: isPrivate) {
                 AppEventQueue.signal(event: .recordStartupTimeOpenURLComplete)
             }
@@ -2615,7 +2617,8 @@ class BrowserViewController: UIViewController,
     }
 
     func handle(url: URL?, tabId: String, isPrivate: Bool = false) {
-        if let url = url {
+        cancelEditMode()
+        if let url {
             switchToTabForURLOrOpen(url, uuid: tabId, isPrivate: isPrivate) {
                 AppEventQueue.signal(event: .recordStartupTimeOpenURLComplete)
             }
@@ -2626,8 +2629,17 @@ class BrowserViewController: UIViewController,
     }
 
     func handleQRCode() {
+        cancelEditMode()
         openBlankNewTab(focusLocationField: false, isPrivate: false)
         navigationHandler?.showQRCode(delegate: self)
+    }
+
+    // MARK: - Toolbar Refactor Deeplink Helper Method.
+    private func cancelEditMode() {
+        if isToolbarRefactorEnabled {
+            let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.cancelEdit)
+            store.dispatch(action)
+        }
     }
 
     func closeAllPrivateTabs() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11284)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24540)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Cancel edit mode when handling deeplinks.

### Video
https://github.com/user-attachments/assets/37c82ac9-e6d0-43cd-872f-7f8cc64ce023

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

