### PR TITLE
Bugfix FXIOS-11295 [Toolbar] Address bar not changing text color when switching theme

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -155,10 +155,7 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
         tintColor = colors.layerSelectedText
         clearButtonTintColor = colors.iconPrimary
         markedTextStyle = [NSAttributedString.Key.backgroundColor: colors.layerAutofillText]
-
-        if isEditing {
-            textColor = colors.textPrimary
-        }
+        textColor = colors.textPrimary
 
         attributedPlaceholder = NSAttributedString(
             string: placeholder ?? "",

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -521,6 +521,10 @@ final class LocationView: UIView,
         lockIconImageColor = colors.iconPrimary
 
         setLockIconImage()
+
+        // Applying the theme to urlTextField can cause the url formatting to get removed
+        // so we apply it again
+        formatAndTruncateURLTextField()
     }
 
     // MARK: - UIGestureRecognizerDelegate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11295)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24564)

## :bulb: Description
Fixes the address bar color after switching themes.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

