### PR TITLE
Refactor FXIOS-11070 [Bookmarks Evolution] Bookmarks telemetry cleanup

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
@@ -11,7 +11,6 @@ import Storage
 class ActionProviderBuilder {
     private var actions = [UIAction]()
     private var taskId = UIBackgroundTaskIdentifier(rawValue: 0)
-    private let bookmarksTelemetry = BookmarksTelemetry()
 
     func build() -> [UIAction] {
         return actions
@@ -45,9 +44,10 @@ class ActionProviderBuilder {
                 title: .ContextMenuBookmarkLink,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
                 identifier: UIAction.Identifier("linkContextMenu.bookmarkLink")
-            ) { [weak self] _ in
+            ) { _ in
                 addBookmark(url.absoluteString, title, nil)
-                self?.bookmarksTelemetry.addBookmark(eventLabel: .contextMenu)
+                let bookmarksTelemetry = BookmarksTelemetry()
+                bookmarksTelemetry.addBookmark(eventLabel: .pageActionMenu)
             }
         )
     }
@@ -58,9 +58,10 @@ class ActionProviderBuilder {
                 title: .RemoveBookmarkContextMenuTitle,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
                 identifier: UIAction.Identifier("linkContextMenu.removeBookmarkLink")
-            ) { [weak self] _ in
+            ) { _ in
                 removeBookmark(url, title, nil)
-                self?.bookmarksTelemetry.deleteBookmark(eventLabel: .contextMenu)
+                let bookmarksTelemetry = BookmarksTelemetry()
+                bookmarksTelemetry.deleteBookmark(eventLabel: .pageActionMenu)
             }
         )
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1758,7 +1758,8 @@ class BrowserViewController: UIViewController,
     internal func openBookmarkEditPanel() {
         guard !profile.isShutdown else { return }
 
-        TelemetryWrapper.recordEvent(category: .action, method: .change, object: .bookmark, value: .addBookmarkToast)
+        let bookmarksTelemetry = BookmarksTelemetry()
+        bookmarksTelemetry.editBookmark(eventLabel: .addBookmarkToast)
 
         // Open refactored bookmark edit view
         if isBookmarkRefactorEnabled {

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -735,12 +735,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
 
             // The method in BVC also handles the toast for this use case
             self.delegate?.addBookmark(url: url.absoluteString, title: tab.title, site: nil)
-            TelemetryWrapper.recordEvent(
-                category: .action,
-                method: .add,
-                object: .bookmark,
-                value: .pageActionMenu
-            )
+            let bookmarksTelemetry = BookmarksTelemetry()
+            bookmarksTelemetry.addBookmark(eventLabel: .pageActionMenu)
         }
     }
 
@@ -757,13 +753,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
                 )
                 self.removeBookmarkShortcut()
             }
-
-            TelemetryWrapper.recordEvent(
-                category: .action,
-                method: .delete,
-                object: .bookmark,
-                value: .pageActionMenu
-            )
+            let bookmarksTelemetry = BookmarksTelemetry()
+            bookmarksTelemetry.deleteBookmark(eventLabel: .pageActionMenu)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -92,7 +92,7 @@ class TopSitesViewModel {
         let isBookmarkedSite = profile.places.isBookmarked(url: homeTopSite.site.url).value.successValue ?? false
         if isBookmarkedSite {
             let bookmarksTelemetry = BookmarksTelemetry()
-            bookmarksTelemetry.openBookmarksSite(eventLabel: BookmarksTelemetry.EventLabel.topSites)
+            bookmarksTelemetry.openBookmarksSite(eventLabel: .topSites)
         }
 
         TelemetryWrapper.recordEvent(category: .action,

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksTelemetry.swift
@@ -12,7 +12,8 @@ struct BookmarksTelemetry {
         case bookmarksPanel = "bookmarks-panel"
         case topSites = "top-sites"
         case activityStream = "activity-stream"
-        case contextMenu = "page-action-menu"
+        case pageActionMenu = "page-action-menu"
+        case addBookmarkToast = "add-bookmark-toast"
     }
 
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksFolderCell.swift
@@ -104,8 +104,6 @@ extension BookmarkItemData: BookmarksFolderCell {
             return
         }
         libraryPanelDelegate?.libraryPanel(didSelectURL: url, visitType: .bookmark)
-        let bookmarksTelemetry = BookmarksTelemetry()
-        bookmarksTelemetry.openBookmarksSite(eventLabel: BookmarksTelemetry.EventLabel.bookmarksPanel)
     }
 }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/BookmarksSaver.swift
@@ -138,6 +138,9 @@ struct DefaultBookmarksSaver: BookmarksSaver, BookmarksRefactorFeatureFlagProvid
             let position: UInt32? = parentFolderGUID == BookmarkRoots.MobileFolderGUID ? 0 : nil
 
             if folder.parentGUID == nil {
+                let bookmarksTelemetry = BookmarksTelemetry()
+                bookmarksTelemetry.addBookmarkFolder()
+
                 profile.places.createFolder(parentGUID: parentFolderGUID,
                                             title: folder.title,
                                             position: position) { result in

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -475,6 +475,7 @@ bookmarks:
       following:
       * Page Action Menu
       * Share Menu
+      * Activity stream
 
     labels:
       - page-action-menu

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarksTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarksTelemetryTests.swift
@@ -46,7 +46,7 @@ final class BookmarksTelemetryTests: XCTestCase {
     }
 
     func testRecordBookmark_WhenOpenedSite_ThenGleanIsCalled() throws {
-        subject?.openBookmarksSite(eventLabel: BookmarksTelemetry.EventLabel.bookmarksPanel)
+        subject?.openBookmarksSite(eventLabel: .bookmarksPanel)
 
         let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents?[0] as? LabeledMetricType<CounterMetricType>)
         let expectedMetricType = type(of: GleanMetrics.Bookmarks.open)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11070)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24140)

## :bulb: Description
- Various bookmarks telemetry cleanup (see comments)
- See [spreadsheet](https://docs.google.com/spreadsheets/d/1BJYkOHID1v5sXOFzbbSXYgC9f_umMEcXmRgiZbVHfsI/edit?gid=0#gid=0) for full bookmarks telemetry audit

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

