### PR TITLE
Add FXIOS-11303 [Homepage] [Bookmarks] show / hide section

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Bookmark/BookmarksAction.swift
@@ -8,18 +8,22 @@ import Common
 
 final class BookmarksAction: Action {
     let bookmarks: [BookmarkConfiguration]?
+    var isEnabled: Bool?
 
     init(bookmarks: [BookmarkConfiguration]? = nil,
+         isEnabled: Bool? = nil,
          windowUUID: WindowUUID,
          actionType: any ActionType
     ) {
         self.bookmarks = bookmarks
+        self.isEnabled = isEnabled
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 
 enum BookmarksActionType: ActionType {
     case fetchBookmarks
+    case toggleShowSectionSetting
 }
 
 enum BookmarksMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -144,9 +144,9 @@ final class HomepageDiffableDataSource:
     }
 
     private func getBookmarks(
-        with bookmarksSectionState: BookmarksSectionState
+        with state: BookmarksSectionState
     ) -> [HomepageDiffableDataSource.HomeItem]? {
-        // TODO: FXIOS-11226 Show items or hide items depending user prefs / feature flag
-        return bookmarksSectionState.bookmarks.compactMap { .bookmark($0) }
+        guard state.shouldShowSection, !state.bookmarks.isEmpty else { return nil }
+        return state.bookmarks.compactMap { .bookmark($0) }
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -156,7 +156,15 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
                 prefKey: PrefsKeys.UserFeatureFlagPrefs.BookmarksSection,
                 defaultValue: true,
                 titleText: .Settings.Homepage.CustomizeFirefoxHome.Bookmarks
-            )
+            ) { value in
+                store.dispatch(
+                    BookmarksAction(
+                        isEnabled: value,
+                        windowUUID: self.windowUUID,
+                        actionType: BookmarksActionType.toggleShowSectionSetting
+                    )
+                )
+            }
             sectionItems.append(bookmarksSetting)
         }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -4,6 +4,7 @@
 
 import XCTest
 import Storage
+import MozillaAppServices
 
 @testable import Client
 
@@ -38,8 +39,8 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         dataSource.updateSnapshot(state: HomepageState(windowUUID: .XCTestDefaultUUID), numberOfCellsPerRow: 4)
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfSections, 4)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .jumpBackIn(nil), .bookmarks(nil), .customizeHomepage])
+        XCTAssertEqual(snapshot.numberOfSections, 3)
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .jumpBackIn(nil), .customizeHomepage])
 
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .header).count, 1)
         XCTAssertEqual(snapshot.itemIdentifiers(inSection: .customizeHomepage).count, 1)
@@ -108,7 +109,6 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             .header,
             .topSites(4),
             .jumpBackIn(nil),
-            .bookmarks(nil),
             .customizeHomepage
         ]
         XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
@@ -133,7 +133,6 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         let expectedSections: [HomepageSection] = [
             .header,
             .jumpBackIn(nil),
-            .bookmarks(nil),
             .pocket(nil),
             .customizeHomepage
         ]
@@ -165,6 +164,36 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         let expectedSections: [HomepageSection] = [
             .header,
             .messageCard,
+            .jumpBackIn(nil),
+            .customizeHomepage
+        ]
+        XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
+    }
+
+    func test_updateSnapshot_withValidState_returnBookmarks() throws {
+        let dataSource = try XCTUnwrap(diffableDataSource)
+
+        let state = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            BookmarksAction(
+                bookmarks: [BookmarkConfiguration(
+                    site: Site.createBasicSite(
+                        url: "www.mozilla.org",
+                        title: "Title 1",
+                        isBookmarked: true
+                    )
+                )],
+                windowUUID: .XCTestDefaultUUID,
+                actionType: BookmarksMiddlewareActionType.initialize
+            )
+        )
+
+        dataSource.updateSnapshot(state: state, numberOfCellsPerRow: 4)
+
+        let snapshot = dataSource.snapshot()
+        XCTAssertEqual(snapshot.numberOfItems(inSection: .bookmarks(nil)), 1)
+        let expectedSections: [HomepageSection] = [
+            .header,
             .jumpBackIn(nil),
             .bookmarks(nil),
             .customizeHomepage

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/BookmarksSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/BookmarksSectionStateTests.swift
@@ -9,6 +9,16 @@ import XCTest
 @testable import Client
 
 final class BookmarksSectionStateTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        DependencyHelperMock().reset()
+        super.tearDown()
+    }
+
     func tests_initialState_returnsExpectedState() {
         let initialState = createSubject()
 
@@ -55,6 +65,40 @@ final class BookmarksSectionStateTests: XCTestCase {
         XCTAssertEqual(newState.bookmarks.first?.site.url, "www.mozilla.org")
         XCTAssertEqual(newState.bookmarks.first?.site.title, "Bookmarks Title")
         XCTAssertEqual(newState.bookmarks.first?.accessibilityLabel, "Bookmarks Title")
+    }
+
+    func test_toggleShowSectionSetting_withToggleOn_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = bookmarksSectionReducer()
+
+        let newState = reducer(
+            initialState,
+            BookmarksAction(
+                isEnabled: true,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: BookmarksActionType.toggleShowSectionSetting
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertTrue(newState.shouldShowSection)
+    }
+
+    func test_toggleShowSectionSetting_withToggleOff_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = bookmarksSectionReducer()
+
+        let newState = reducer(
+            initialState,
+            BookmarksAction(
+                isEnabled: false,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: BookmarksActionType.toggleShowSectionSetting
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(newState.shouldShowSection)
     }
 
     // MARK: - Private


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11303)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24583)

## :bulb: Description
Implement show / hiding section via user settings. 
- Created new action to dispatch when user toggles setting
- Update state based on the action
- Update diffable datasource check on whether to show section or if bookmarks are empty

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshot

https://github.com/user-attachments/assets/119d2064-7e9b-408f-b412-a5959206211f


