### PR TITLE
Bugfix FXIOS-8027- PayPal not working

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1120,7 +1120,7 @@ private extension BrowserViewController {
 
     // The WKNavigationAction request for Paypal popUp is empty which causes that we open a blank page in
     // createWebViewWith. We will show Paypal popUp in page like mobile devices using the mobile User Agent
-    // so we will block so we will block the creation of a new Webview with this check
+    // so we will block the creation of a new Webview with this check
     func isPayPalPopUp(_ navigationAction: WKNavigationAction) -> Bool {
         return navigationAction.sourceFrame.request.url?.baseDomain == "paypal.com"
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -31,6 +31,8 @@ extension BrowserViewController: WKUIDelegate {
             return nil
         }
 
+        guard !isPayPalPopUp(navigationAction) else { return nil }
+
         if navigationAction.canOpenExternalApp, let url = navigationAction.request.url {
             UIApplication.shared.open(url)
             return nil
@@ -203,6 +205,21 @@ extension BrowserViewController: WKUIDelegate {
         completionHandler(contextMenuConfiguration(for: url, webView: webView))
     }
 
+    func webView(_ webView: WKWebView,
+                 requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+                 initiatedByFrame frame: WKFrameInfo,
+                 type: WKMediaCaptureType,
+                 decisionHandler: @escaping (WKPermissionDecision) -> Void) {
+        // If the tab isn't the selected one or we're on the homepage, do not show the media capture prompt
+        guard tabManager.selectedTab?.webView == webView, !contentContainer.hasLegacyHomepage else {
+            decisionHandler(.deny)
+            return
+        }
+
+        decisionHandler(.prompt)
+    }
+
+    // MARK: - Helpers
     private func contextMenuConfiguration(for url: URL, webView: WKWebView) -> UIContextMenuConfiguration {
         return UIContextMenuConfiguration(identifier: nil,
                                           previewProvider: contextMenuPreviewProvider(for: url, webView: webView),
@@ -387,20 +404,6 @@ extension BrowserViewController: WKUIDelegate {
 
     func assignWebView(_ webView: WKWebView?) {
         pendingDownloadWebView = webView
-    }
-
-    func webView(_ webView: WKWebView,
-                 requestMediaCapturePermissionFor origin: WKSecurityOrigin,
-                 initiatedByFrame frame: WKFrameInfo,
-                 type: WKMediaCaptureType,
-                 decisionHandler: @escaping (WKPermissionDecision) -> Void) {
-        // If the tab isn't the selected one or we're on the homepage, do not show the media capture prompt
-        guard tabManager.selectedTab?.webView == webView, !contentContainer.hasLegacyHomepage else {
-            decisionHandler(.deny)
-            return
-        }
-
-        decisionHandler(.prompt)
     }
 
     func writeToPhotoAlbum(image: UIImage) {
@@ -1113,6 +1116,13 @@ private extension BrowserViewController {
         }
 
         return false
+    }
+
+    // The WKNavigationAction request for Paypal popUp is empty which causes that we open a blank page in
+    // createWebViewWith. We will show Paypal popUp in page like mobile devices using the mobile User Agent
+    // so we will block so we will block the creation of a new Webview with this check
+    func isPayPalPopUp(_ navigationAction: WKNavigationAction) -> Bool {
+        return navigationAction.sourceFrame.request.url?.baseDomain == "paypal.com"
     }
 
     func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
@@ -20,4 +20,16 @@ final class UserAgentTests: XCTestCase {
             XCTAssertEqual(agent, UserAgent.getUserAgent(domain: domain, platform: .Mobile))
         }
     }
+
+    func testGetUserAgentDesktop_withPaypalDomain_returnMobileUserAgent() {
+        let paypalDomain = "paypal.com"
+        XCTAssertEqual(UserAgent.mobileUserAgent(),
+                       UserAgent.getUserAgent(domain: paypalDomain, platform: .Desktop))
+    }
+
+    func testGetUserAgentMobile_withPaypalDomain_returnProperUserAgent() {
+        let paypalDomain = "paypal.com"
+        XCTAssertEqual(UserAgent.mobileUserAgent(),
+                       UserAgent.getUserAgent(domain: paypalDomain, platform: .Mobile))
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8027)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/17911)

## :bulb: Description
Continue the work done in https://github.com/mozilla-mobile/firefox-ios/pull/24497
- I've added unit test for Paypal user agent to cover the changes done in the previous PR
- Block `createWebViewWith` if it is Paypal popup because the logic we have creates a new blank page tab because WKNavigationAction request is empty.
- Reorganize functions

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

