### PR TITLE
Refactor FXIOS-11184 [WebEngine] Update WKEngineSession reload

### DIFF
--- a/BrowserKit/Sources/WebEngine/EngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSession.swift
@@ -23,6 +23,7 @@ public protocol EngineSession {
     func stopLoading()
 
     /// Reloads the current URL.
+    /// - Parameter bypassCache: Bypass the cache and fully reload from the origin
     func reload(bypassCache: Bool)
 
     /// Navigates back in the history of this session.

--- a/BrowserKit/Sources/WebEngine/EngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSession.swift
@@ -23,7 +23,7 @@ public protocol EngineSession {
     func stopLoading()
 
     /// Reloads the current URL.
-    func reload()
+    func reload(bypassCache: Bool)
 
     /// Navigates back in the history of this session.
     func goBack()
@@ -71,4 +71,10 @@ public protocol EngineSession {
 
     /// Change the page zoom scale.
     func updatePageZoom(_ change: ZoomChangeValue)
+}
+
+extension EngineSession {
+    func reload(bypassCache: Bool = false) {
+        reload(bypassCache: bypassCache)
+    }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -65,10 +65,6 @@ protocol WKEngineWebView: UIView {
 
     // MARK: Custom WKEngineView functions
 
-    /// Use JS to redirect the page without adding a history entry
-    /// - Parameter url: The URL to replace the location with
-    func replaceLocation(with url: URL)
-
     func addObserver(
         _ observer: NSObject,
         forKeyPath keyPath: String,
@@ -118,14 +114,6 @@ extension WKEngineWebView {
                 completion(nil, error)
             }
         }
-    }
-
-    func replaceLocation(with url: URL) {
-        let charactersToReplace = CharacterSet(charactersIn: "'")
-        guard let safeUrl = url.absoluteString
-            .addingPercentEncoding(withAllowedCharacters: charactersToReplace.inverted) else { return }
-
-        evaluateJavascriptInDefaultContentWorld("location.replace('\(safeUrl)')")
     }
 }
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKInternalURL.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKInternalURL.swift
@@ -5,9 +5,10 @@
 import Foundation
 import Common
 
-/// Internal URLs helps with error pages, session restore and about pages
+/// Internal URLs helps with error pages and about pages
 protocol InternalURL {
     var isAuthorized: Bool { get }
+    var isAboutHomeURL: Bool { get }
 
     func authorize()
     func stripAuthorization()
@@ -98,5 +99,24 @@ final class WKInternalURL: InternalURL {
 
     private var isErrorPage: Bool {
         return WKInternalURL.Path.errorpage.matches(url.path)
+    }
+
+    var isAboutHomeURL: Bool {
+        if let urlParam = extractedUrlParam,
+            let internalUrlParam = WKInternalURL(urlParam) {
+            return internalUrlParam.aboutComponent?.hasPrefix("home") ?? false
+        }
+        return aboutComponent?.hasPrefix("home") ?? false
+    }
+
+    /// Return the path after "about/" in the URI.
+    private var aboutComponent: String? {
+        let aboutPath = "/about/"
+        stripAuthorization()
+
+        if url.path.hasPrefix(aboutPath) {
+            return String(url.path.dropFirst(aboutPath.count))
+        }
+        return nil
     }
 }

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockWKEngineWebView.swift
@@ -29,7 +29,6 @@ class MockWKEngineWebView: UIView, WKEngineWebView {
     var loadCalled = 0
     var loadFileURLCalled = 0
     var reloadFromOriginCalled = 0
-    var replaceLocationCalled = 0
     var stopLoadingCalled = 0
     var goBackCalled = 0
     var goForwardCalled = 0
@@ -70,11 +69,6 @@ class MockWKEngineWebView: UIView, WKEngineWebView {
     func reloadFromOrigin() -> WKNavigation? {
         reloadFromOriginCalled += 1
         return nil
-    }
-
-    func replaceLocation(with url: URL) {
-        self.url = url
-        replaceLocationCalled += 1
     }
 
     func stopLoading() {

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -46,7 +46,6 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.load(url: url)
 
         XCTAssertEqual(webViewProvider.webView.loadCalled, 0)
-        prepareForTearDown(subject!)
     }
 
     func testLoadURLGivenNotAURLThenDoesntLoad() {
@@ -56,7 +55,6 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.load(url: url)
 
         XCTAssertEqual(webViewProvider.webView.loadCalled, 0)
-        prepareForTearDown(subject!)
     }
 
     func testLoadURLGivenNormalURLThenLoad() {
@@ -67,7 +65,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(webViewProvider.webView.loadCalled, 1)
         XCTAssertEqual(webViewProvider.webView.url?.absoluteString, url)
-        prepareForTearDown(subject!)
     }
 
     func testLoadURLGivenReaderModeURLThenLoad() {
@@ -79,7 +76,6 @@ final class WKEngineSessionTests: XCTestCase {
         XCTAssertEqual(webViewProvider.webView.loadCalled, 1)
         XCTAssertEqual(webViewProvider.webView.url?.absoluteString,
                        "http://localhost:0/reader-mode/page?url=http%3A%2F%2Fexample%2Ecom")
-        prepareForTearDown(subject!)
     }
 
     func testLoadURLGivenFileURLThenLoadFileURL() {
@@ -92,7 +88,6 @@ final class WKEngineSessionTests: XCTestCase {
         XCTAssertEqual(webViewProvider.webView.loadFileURLCalled, 1)
         XCTAssertEqual(webViewProvider.webView.url?.absoluteString, "file://path/to/abc/dirA/A.html")
         XCTAssertEqual(webViewProvider.webView.loadFileReadAccessURL?.absoluteString, "file://path/to/abc/dirA/")
-        prepareForTearDown(subject!)
     }
 
     // MARK: Stop URL
@@ -103,7 +98,6 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.stopLoading()
 
         XCTAssertEqual(webViewProvider.webView.stopLoadingCalled, 1)
-        prepareForTearDown(subject!)
     }
 
     // MARK: Go back
@@ -114,7 +108,6 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.goBack()
 
         XCTAssertEqual(webViewProvider.webView.goBackCalled, 1)
-        prepareForTearDown(subject!)
     }
 
     // MARK: Go forward
@@ -125,7 +118,6 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.goForward()
 
         XCTAssertEqual(webViewProvider.webView.goForwardCalled, 1)
-        prepareForTearDown(subject!)
     }
 
     // MARK: Scroll to top
@@ -138,7 +130,6 @@ final class WKEngineSessionTests: XCTestCase {
         let scrollView = webViewProvider.webView.engineScrollView as? MockEngineScrollView
         XCTAssertEqual(scrollView?.setContentOffsetCalled, 1)
         XCTAssertEqual(scrollView?.savedContentOffset, CGPoint.zero)
-        prepareForTearDown(subject!)
     }
 
     // MARK: Find in page
@@ -150,7 +141,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(webViewProvider.webView.evaluateJavaScriptCalled, 1)
         XCTAssertEqual(webViewProvider.webView.savedJavaScript, "__firefox__.find(\"Banana\")")
-        prepareForTearDown(subject!)
     }
 
     func testFindInPageTextGivenFindNextThenJavascriptCalled() {
@@ -160,7 +150,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(webViewProvider.webView.evaluateJavaScriptCalled, 1)
         XCTAssertEqual(webViewProvider.webView.savedJavaScript, "__firefox__.findNext(\"Banana\")")
-        prepareForTearDown(subject!)
     }
 
     func testFindInPageTextGivenFindPreviousThenJavascriptCalled() {
@@ -170,7 +159,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(webViewProvider.webView.evaluateJavaScriptCalled, 1)
         XCTAssertEqual(webViewProvider.webView.savedJavaScript, "__firefox__.findPrevious(\"Banana\")")
-        prepareForTearDown(subject!)
     }
 
     func testFindInPageTextGivenMaliciousAlertCodeThenIsSanitized() {
@@ -181,7 +169,6 @@ final class WKEngineSessionTests: XCTestCase {
         XCTAssertEqual(webViewProvider.webView.evaluateJavaScriptCalled, 1)
         let result = "__firefox__.find(\"\'; alert(\'Malicious code injected!\'); \'\")"
         XCTAssertEqual(webViewProvider.webView.savedJavaScript, result)
-        prepareForTearDown(subject!)
     }
 
     func testFindInPageTextGivenMaliciousBrokenJsStringCodeThenIsSanitized() {
@@ -191,7 +178,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(webViewProvider.webView.evaluateJavaScriptCalled, 1)
         XCTAssertEqual(webViewProvider.webView.savedJavaScript, "__firefox__.find(\"; maliciousFunction(); \")")
-        prepareForTearDown(subject!)
     }
 
     func testFindInPageDoneThenJavascriptCalled() {
@@ -201,7 +187,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(webViewProvider.webView.evaluateJavaScriptCalled, 1)
         XCTAssertEqual(webViewProvider.webView.savedJavaScript, "__firefox__.findDone()")
-        prepareForTearDown(subject!)
     }
 
     func testFindInPageDelegateIsSetProperly() {
@@ -215,7 +200,6 @@ final class WKEngineSessionTests: XCTestCase {
         script.userContentController(didReceiveMessage: ["currentResult": 10])
 
         XCTAssertEqual(findInPageDelegate.didUpdateCurrentResultCalled, 1)
-        prepareForTearDown(subject!)
     }
 
     // MARK: Reload
@@ -226,10 +210,9 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.reload()
 
         XCTAssertEqual(webViewProvider.webView.reloadFromOriginCalled, 1)
-        prepareForTearDown(subject!)
     }
 
-    func testReloadWhenErrorPageThenReplaceLocation() {
+    func testReloadWhenErrorPageThenLoadOriginalErrorPage() {
         let subject = createSubject()
         let errorPageURL = "errorpage"
         let internalURL = "internal://local/errorpage?url=\(errorPageURL)"
@@ -238,9 +221,45 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.reload()
 
         XCTAssertEqual(webViewProvider.webView.reloadFromOriginCalled, 0)
-        XCTAssertEqual(webViewProvider.webView.replaceLocationCalled, 1)
+        XCTAssertEqual(webViewProvider.webView.loadCalled, 2)
         XCTAssertEqual(webViewProvider.webView.url?.absoluteString, errorPageURL)
-        prepareForTearDown(subject!)
+    }
+
+    func testReloadWhenHomepageThenLoadHomepageAsPrivileged() throws {
+        let subject = createSubject()
+        let internalURL = "internal://local/about/home"
+        subject?.load(url: internalURL)
+
+        subject?.reload()
+
+        XCTAssertEqual(webViewProvider.webView.reloadFromOriginCalled, 0)
+        XCTAssertEqual(webViewProvider.webView.loadCalled, 2)
+        let url = try XCTUnwrap(webViewProvider.webView.url)
+        XCTAssertTrue(url.absoluteString.contains("internal://local/about/home?uuidkey="))
+    }
+
+    func testReloadWhenBypassCacheThenReloadBypassingCache() {
+        let subject = createSubject()
+        let url = "https://www.example.com"
+        subject?.load(url: url)
+
+        subject?.reload(bypassCache: true)
+
+        XCTAssertEqual(webViewProvider.webView.reloadFromOriginCalled, 0)
+        XCTAssertEqual(webViewProvider.webView.loadCalled, 2)
+        XCTAssertEqual(webViewProvider.webView.url?.absoluteString, url)
+    }
+
+    func testReloadWhenReloadFromOriginFailsThenRestoreWebviewWithLastRequest() {
+        let subject = createSubject()
+        let url = "https://www.example.com"
+        subject?.load(url: url)
+
+        subject?.reload()
+
+        XCTAssertEqual(webViewProvider.webView.reloadFromOriginCalled, 1)
+        XCTAssertEqual(webViewProvider.webView.loadCalled, 2)
+        XCTAssertEqual(webViewProvider.webView.url?.absoluteString, url)
     }
 
     // MARK: Restore
@@ -253,7 +272,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(webViewProvider.webView.interactionState as? Data, restoredState)
         XCTAssertEqual(webViewProvider.webView.loadCalled, 0)
-        prepareForTearDown(subject!)
     }
 
     func testRestoreWhenHasLastRequestThenLoadISCalled() {
@@ -265,18 +283,16 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(webViewProvider.webView.interactionState as? Data, restoredState)
         XCTAssertEqual(webViewProvider.webView.loadCalled, 2, "Load calls it once, then restore calls it again")
-        prepareForTearDown(subject!)
     }
 
     // MARK: Observers
 
     func testAddObserversWhenCreatedSubjectThenObserversAreAdded() {
-        let subject = createSubject()
+        _ = createSubject()
         let expectedCount = WKEngineKVOConstants.allCases.count
         XCTAssertEqual(webViewProvider.webView.addObserverCalled,
                        expectedCount,
                        "There are \(expectedCount) KVO Constants")
-        prepareForTearDown(subject!)
     }
 
     func testRemoveObserversWhenCloseIsCalledThenObserversAreRemoved() {
@@ -288,7 +304,6 @@ final class WKEngineSessionTests: XCTestCase {
         XCTAssertEqual(webViewProvider.webView.removeObserverCalled,
                        expectedCount,
                        "There are \(expectedCount) KVO Constants")
-        prepareForTearDown(subject!)
     }
 
     func testCanGoBackGivenWebviewStateThenCallsNavigationStateChanged() {
@@ -305,7 +320,6 @@ final class WKEngineSessionTests: XCTestCase {
         XCTAssertEqual(engineSessionDelegate.onNavigationStateChangeCalled, 1)
         XCTAssertTrue(engineSessionDelegate.savedCanGoBack!)
         XCTAssertFalse(engineSessionDelegate.savedCanGoForward!)
-        prepareForTearDown(subject!)
     }
 
     func testCanGoForwardGivenWebviewStateThenCallsNavigationStateChanged() {
@@ -322,7 +336,6 @@ final class WKEngineSessionTests: XCTestCase {
         XCTAssertEqual(engineSessionDelegate.onNavigationStateChangeCalled, 1)
         XCTAssertFalse(engineSessionDelegate.savedCanGoBack!)
         XCTAssertTrue(engineSessionDelegate.savedCanGoForward!)
-        prepareForTearDown(subject!)
     }
 
     func testEstimatedProgressGivenWebviewStateThenCallsOnProgress() {
@@ -337,7 +350,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(engineSessionDelegate.onProgressCalled, 1)
         XCTAssertEqual(engineSessionDelegate.savedProgressValue, 70)
-        prepareForTearDown(subject!)
     }
 
     func testLoadingGivenNoChangeThenDoesNotCallOnLoadingStateChange() {
@@ -350,7 +362,6 @@ final class WKEngineSessionTests: XCTestCase {
                               context: nil)
 
         XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 0)
-        prepareForTearDown(subject!)
     }
 
     func testLoadingGivenOldKeyThenDoesNotCallOnLoadingStateChange() {
@@ -363,7 +374,6 @@ final class WKEngineSessionTests: XCTestCase {
                               context: nil)
 
         XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 0)
-        prepareForTearDown(subject!)
     }
 
     func testLoadingGivenNewKeyThenCallsOnLoadingStateChange() {
@@ -377,7 +387,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 1)
         XCTAssertTrue(engineSessionDelegate.savedLoading!)
-        prepareForTearDown(subject!)
     }
 
     func testTitleChangeGivenEmptyTitleThenDoesntCallDelegate() {
@@ -392,7 +401,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertNil(subject?.sessionData.title)
         XCTAssertEqual(engineSessionDelegate.onTitleChangeCalled, 0)
-        prepareForTearDown(subject!)
     }
 
     func testTitleChangeGivenATitleThenCallsDelegate() {
@@ -408,7 +416,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(subject?.sessionData.title, expectedTitle)
         XCTAssertEqual(engineSessionDelegate.onTitleChangeCalled, 1)
-        prepareForTearDown(subject!)
     }
 
     func testURLChangeGivenNilURLThenDoesntCallDelegate() {
@@ -422,7 +429,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertNil(subject?.sessionData.url)
         XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 0)
-        prepareForTearDown(subject!)
     }
 
     func testURLChangeGivenAboutBlankWithNilURLThenDoesntCallDelegate() {
@@ -436,7 +442,6 @@ final class WKEngineSessionTests: XCTestCase {
                               context: nil)
 
         XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 0)
-        prepareForTearDown(subject!)
     }
 
     func testURLChangeGivenNotTheSameOriginThenDoesntCallDelegate() {
@@ -450,7 +455,6 @@ final class WKEngineSessionTests: XCTestCase {
                               context: nil)
 
         XCTAssertEqual(engineSessionDelegate.onLoadingStateChangeCalled, 0)
-        prepareForTearDown(subject!)
     }
 
     func testURLChangeGivenAboutBlankWithURLThenCallsDelegate() {
@@ -467,7 +471,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(subject?.sessionData.url, aboutBlankURL)
         XCTAssertEqual(engineSessionDelegate.onLocationChangedCalled, 1)
-        prepareForTearDown(subject!)
     }
 
     func testURLChangeGivenLoadedURLWithURLThenCallsDelegate() {
@@ -484,7 +487,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(subject?.sessionData.url, loadedURL)
         XCTAssertEqual(engineSessionDelegate.onLocationChangedCalled, 1)
-        prepareForTearDown(subject!)
     }
 
     // MARK: Page Zoom
@@ -497,7 +499,6 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.updatePageZoom(.increase)
         // Assert zoom increased by expected step
         XCTAssertEqual(webViewProvider.webView.pageZoom, 1.0 + ZoomChangeValue.defaultStepIncrease)
-        prepareForTearDown(subject!)
     }
 
     func testDecreaseZoom() {
@@ -508,7 +509,6 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.updatePageZoom(.decrease)
         // Assert zoom decreased by expected step
         XCTAssertEqual(webViewProvider.webView.pageZoom, 1.0 - ZoomChangeValue.defaultStepIncrease)
-        prepareForTearDown(subject!)
     }
 
     func testSetZoomLevelAndReset() {
@@ -524,8 +524,6 @@ final class WKEngineSessionTests: XCTestCase {
         subject?.updatePageZoom(.reset)
         // Check default zoom of 1.0
         XCTAssertEqual(webViewProvider.webView.pageZoom, 1.0)
-
-        prepareForTearDown(subject!)
     }
 
     // MARK: Metadata parser
@@ -544,7 +542,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(metadataFetcher.fetchFromSessionCalled, 1)
         XCTAssertEqual(metadataFetcher.savedURL, loadedURL)
-        prepareForTearDown(subject!)
     }
 
     func testFetchMetadataGivenDidFinishNavigationThenFetchMetadata() {
@@ -559,27 +556,24 @@ final class WKEngineSessionTests: XCTestCase {
 
 //        XCTAssertEqual(metadataFetcher.fetchFromSessionCalled, 1)
 //        XCTAssertEqual(metadataFetcher.savedURL, loadedURL)
-        prepareForTearDown(subject!)
     }
 
     // MARK: User script manager
 
     func testUserScriptWhenSubjectCreatedThenInjectionIntoWebviewCalled() {
-        let subject = createSubject()
+        _ = createSubject()
         XCTAssertEqual(userScriptManager.injectUserScriptsIntoWebViewCalled, 1)
-        prepareForTearDown(subject!)
     }
 
     // MARK: Content script manager
 
     func testContentScriptGivenInitContentScriptsThenAreAddedAtInit() {
-        let subject = createSubject()
+        _ = createSubject()
 
         XCTAssertEqual(contentScriptManager.addContentScriptCalled, 2)
         XCTAssertEqual(contentScriptManager.savedContentScriptNames.count, 2)
         XCTAssertEqual(contentScriptManager.savedContentScriptNames[0], FindInPageContentScript.name())
         XCTAssertEqual(contentScriptManager.savedContentScriptNames[1], AdsTelemetryContentScript.name())
-        prepareForTearDown(subject!)
     }
 
     func testContentScriptWhenCloseCalledThenUninstallIsCalled() {
@@ -601,7 +595,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(engineSessionDelegate.findInPageCalled, 1)
         XCTAssertEqual(engineSessionDelegate.savedFindInPageSelection, expectedSelection)
-        prepareForTearDown(subject!)
     }
 
     func testSearchGivenSelectionThenCallsDelegate() {
@@ -613,7 +606,6 @@ final class WKEngineSessionTests: XCTestCase {
 
         XCTAssertEqual(engineSessionDelegate.searchCalled, 1)
         XCTAssertEqual(engineSessionDelegate.savedSearchSelection, expectedSelection)
-        prepareForTearDown(subject!)
     }
 
     // MARK: Helper
@@ -630,13 +622,12 @@ final class WKEngineSessionTests: XCTestCase {
 
         trackForMemoryLeaks(subject, file: file, line: line)
 
-        return subject
-    }
+        // Each registered teardown block is run once, in last-in, first-out order, executed serially.
+        // Order is important here since the close() function needs to be called before we check for leaks
+        addTeardownBlock { [weak subject] in
+            subject?.close()
+        }
 
-    // Adding a special teardown since as part of tracking memory leaks, we can't use an instance variable on the
-    // test suite. A normal instance `tearDown` is called after a `addTeardownBlock`. To ensure we still can
-    // `trackForMemoryLeaks` we need to always close any engine session that is opened, otherwise leaks happens.
-    func prepareForTearDown(_ subject: WKEngineSession) {
-        subject.close()
+        return subject
     }
 }

--- a/BrowserKit/Tests/WebEngineTests/WKInternalURLTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKInternalURLTests.swift
@@ -100,4 +100,27 @@ final class WKInternalURLTests: XCTestCase {
         let subject = WKInternalURL(url)
         XCTAssertNil(subject?.originalURLFromErrorPage)
     }
+
+    // MARK: About home URL
+
+    func testIsAboutHomeURLWhenBasicURLThenNotHomepage() {
+        let url = URL(string: "www.example.com")!
+
+        let subject = WKInternalURL(url)
+        XCTAssertNil(subject?.isAboutHomeURL)
+    }
+
+    func testIsAboutHomeURLWhenAboutLicensePageThenNotHomepage() {
+        let url = URL(string: "internal://local/about/license")!
+
+        let subject = WKInternalURL(url)!
+        XCTAssertFalse(subject.isAboutHomeURL)
+    }
+
+    func testIsAboutHomeURLWhenAboutHomeThenIsHomepage() {
+        let url = URL(string: "internal://local/about/home")!
+
+        let subject = WKInternalURL(url)!
+        XCTAssertTrue(subject.isAboutHomeURL)
+    }
 }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -218,14 +218,11 @@ class BrowserCoordinator: BaseCoordinator,
     func show(webView: WKWebView) {
         // Keep the webviewController in memory, update to newest webview when needed
         if let webviewController = webviewController {
-            webviewController.update(webView: webView, isPrivate: tabManager.selectedTab?.isPrivate ?? false)
+            webviewController.update(webView: webView)
             browserViewController.frontEmbeddedContent(webviewController)
             logger.log("Webview content was updated", level: .info, category: .coordinator)
         } else {
-            let webviewViewController = WebviewViewController(
-                webView: webView,
-                isPrivate: tabManager.selectedTab?.isPrivate ?? false
-            )
+            let webviewViewController = WebviewViewController(webView: webView)
             webviewController = webviewViewController
             let isEmbedded = browserViewController.embedContent(webviewViewController)
             logger.log("Webview controller was created and embedded \(isEmbedded)", level: .info, category: .coordinator)

--- a/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebView/WebviewViewController.swift
@@ -10,7 +10,7 @@ class WebviewViewController: UIViewController, ContentContainable, Screenshotabl
     private var webView: WKWebView
     var contentType: ContentType = .webview
 
-    init(webView: WKWebView, isPrivate: Bool = false) {
+    init(webView: WKWebView) {
         self.webView = webView
         super.init(nibName: nil, bundle: nil)
     }
@@ -35,7 +35,7 @@ class WebviewViewController: UIViewController, ContentContainable, Screenshotabl
         ])
     }
 
-    func update(webView: WKWebView, isPrivate: Bool = false) {
+    func update(webView: WKWebView) {
         self.webView = webView
         setupWebView()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11184)

## :bulb: Description
This will be a series of PR to update the `WKEngineSession` to bring it up to speed with the current production code. This first PR is to update the `reload` function and have a similar functionality like the one under the `Tab.swift` one. One key difference I am trying here is how we manage the homepage and the restore function. 
- I am checking if we have a `internalUrl.isAboutHomeURL` and load the page directly. In production code we manage this code path by ensuring we don't fall into the `reloadFromOrigin` case, and under the `restore` function we load the request as privileged. Result is now in both code base we call the `load` function to load the homepage as privileged.
- I am not calling the `restore` function under the `reload` function here like done in production code. We don't have `interactionState` available under the `reload`, and it doesn't feel right to make the `interactionState` optional just so I could use this `restore` function under the `reload` one.
- Tests were added, and I found a way to remove the `prepareForTearDown` method 🎉 

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

