### PR TITLE
Refactor FXIOS [Clean up] Remove unused Tab show and hide content

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ReaderMode.swift
@@ -17,7 +17,6 @@ extension BrowserViewController: ReaderModeDelegate {
         // Update reader mode state if is the selected tab. Otherwise it will update once is active
         if tabManager.selectedTab === tab {
             self.showReaderModeBar(animated: true)
-            tab.showContent(true)
         }
     }
 

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -800,28 +800,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         return contentScriptManager.getContentScript(name)
     }
 
-    func hideContent(_ animated: Bool = false) {
-        webView?.isUserInteractionEnabled = false
-        if animated {
-            UIView.animate(withDuration: 0.25, animations: { () in
-                self.webView?.alpha = 0.0
-            })
-        } else {
-            webView?.alpha = 0.0
-        }
-    }
-
-    func showContent(_ animated: Bool = false) {
-        webView?.isUserInteractionEnabled = true
-        if animated {
-            UIView.animate(withDuration: 0.25, animations: { () in
-                self.webView?.alpha = 1.0
-            })
-        } else {
-            webView?.alpha = 1.0
-        }
-    }
-
     func addLoginAlert(_ alert: SaveLoginAlert) {
         // Only one login alert can show per tab
         guard loginAlert == nil else { return }


### PR DESCRIPTION
## :scroll: Tickets
No ticket

## :bulb: Description
We never `hideContent`, so `showContent` is not needed as well. Reader mode still works as expected with this change

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

