### PR TITLE
Add FXIOS-11317 check to requestMediaCapturePermissionFor delegate for new homepage and private homepage

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
@@ -44,7 +44,7 @@ extension BrowserViewController {
         guard let tab = tabManager.selectedTab,
               let url = tab.canonicalURL?.displayURL else { return }
 
-        if !contentContainer.hasLegacyHomepage {
+        if !contentContainer.hasAnyHomepage {
             addBookmark(url: url.absoluteString, title: tab.title)
         }
     }
@@ -60,7 +60,7 @@ extension BrowserViewController {
             store.dispatch(GeneralBrowserAction(windowUUID: windowUUID,
                                                 actionType: GeneralBrowserActionType.reloadWebsite))
         } else {
-            if !contentContainer.hasLegacyHomepage {
+            if !contentContainer.hasAnyHomepage {
                 tab.reload()
             }
         }
@@ -77,7 +77,7 @@ extension BrowserViewController {
             store.dispatch(GeneralBrowserAction(windowUUID: windowUUID,
                                                 actionType: GeneralBrowserActionType.reloadWebsiteNoCache))
         } else {
-            if !contentContainer.hasLegacyHomepage {
+            if !contentContainer.hasAnyHomepage {
                 tab.reload(bypassCache: true)
             }
         }
@@ -94,7 +94,7 @@ extension BrowserViewController {
             store.dispatch(GeneralBrowserAction(windowUUID: windowUUID,
                                                 actionType: GeneralBrowserActionType.navigateBack))
         } else {
-            if !contentContainer.hasLegacyHomepage {
+            if !contentContainer.hasAnyHomepage {
                 tab.goBack()
             }
         }
@@ -111,7 +111,7 @@ extension BrowserViewController {
             store.dispatch(GeneralBrowserAction(windowUUID: windowUUID,
                                                 actionType: GeneralBrowserActionType.navigateForward))
         } else {
-            if !contentContainer.hasLegacyHomepage {
+            if !contentContainer.hasAnyHomepage {
                 tab.goForward()
             }
         }
@@ -134,7 +134,7 @@ extension BrowserViewController {
     private func findInPage(withText text: String) {
         guard let tab = tabManager.selectedTab else { return }
 
-        if !contentContainer.hasLegacyHomepage {
+        if !contentContainer.hasAnyHomepage {
             self.tab(tab, didSelectFindInPageForSelection: text)
         }
     }
@@ -341,7 +341,7 @@ extension BrowserViewController {
     func zoomIn() {
         guard let currentTab = tabManager.selectedTab else { return }
 
-        if !contentContainer.hasLegacyHomepage {
+        if !contentContainer.hasAnyHomepage {
             currentTab.zoomIn()
         }
     }
@@ -350,7 +350,7 @@ extension BrowserViewController {
     func zoomOut() {
         guard let currentTab = tabManager.selectedTab else { return }
 
-        if !contentContainer.hasLegacyHomepage {
+        if !contentContainer.hasAnyHomepage {
             currentTab.zoomOut()
         }
     }
@@ -359,7 +359,7 @@ extension BrowserViewController {
     func resetZoom() {
         guard let currentTab = tabManager.selectedTab else { return }
 
-        if !contentContainer.hasLegacyHomepage {
+        if !contentContainer.hasAnyHomepage {
             currentTab.resetZoom()
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -155,7 +155,7 @@ extension BrowserViewController: URLBarDelegate {
 
     func urlBarDidPressScrollToTop(_ urlBar: URLBarView) {
         guard let selectedTab = tabManager.selectedTab else { return }
-        if !contentContainer.hasLegacyHomepage {
+        if !contentContainer.hasAnyHomepage {
             // Only scroll to top if we are not showing the home view controller
             selectedTab.webView?.scrollView.setContentOffset(CGPoint.zero, animated: true)
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -211,7 +211,7 @@ extension BrowserViewController: WKUIDelegate {
                  type: WKMediaCaptureType,
                  decisionHandler: @escaping (WKPermissionDecision) -> Void) {
         // If the tab isn't the selected one or we're on the homepage, do not show the media capture prompt
-        guard tabManager.selectedTab?.webView == webView, !contentContainer.hasLegacyHomepage else {
+        guard tabManager.selectedTab?.webView == webView, !contentContainer.hasAnyHomepage else {
             decisionHandler(.deny)
             return
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -211,7 +211,7 @@ extension BrowserViewController: WKUIDelegate {
                  type: WKMediaCaptureType,
                  decisionHandler: @escaping (WKPermissionDecision) -> Void) {
         // If the tab isn't the selected one or we're on the homepage, do not show the media capture prompt
-        guard tabManager.selectedTab?.webView == webView, !contentContainer.hasAnyHomepage else {
+        guard tabManager.selectedTab?.webView === webView, !contentContainer.hasAnyHomepage else {
             decisionHandler(.deny)
             return
         }
@@ -1127,7 +1127,7 @@ private extension BrowserViewController {
 
     func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {
         // Only display a JS Alert if we are selected and there isn't anything being shown
-        return ((tabManager.selectedTab == nil ? false : tabManager.selectedTab!.webView == webView))
+        return ((tabManager.selectedTab == nil ? false : tabManager.selectedTab!.webView === webView))
             && (self.presentedViewController == nil)
     }
 

--- a/firefox-ios/Client/Frontend/Components/ContentContainer.swift
+++ b/firefox-ios/Client/Frontend/Components/ContentContainer.swift
@@ -37,6 +37,10 @@ class ContentContainer: UIView {
         return type == .homepage
     }
 
+    var hasAnyHomepage: Bool {
+        return hasLegacyHomepage || hasHomepage || hasPrivateHomepage
+    }
+
     var hasWebView: Bool {
         return type == .webview
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -108,7 +108,7 @@ final class ContentContainerTests: XCTestCase {
         XCTAssertFalse(subject.canAdd(content: webview))
     }
 
-    // MARK: - hashasLegacyHomepage
+    // MARK: - hasLegacyHomepage
 
     func testHasHomepage_trueWhenHomepage() {
         let subject = ContentContainer(frame: .zero)
@@ -182,6 +182,44 @@ final class ContentContainerTests: XCTestCase {
         subject.add(content: webview)
 
         XCTAssertFalse(subject.hasPrivateHomepage)
+    }
+
+    // MARK: - hasAnyHomepage
+
+    func testHasHomepage_trueWhenAddedLegacyHomepage() {
+        let subject = ContentContainer(frame: .zero)
+        let homepage = createHomepage()
+        subject.add(content: homepage)
+
+        XCTAssertTrue(subject.hasAnyHomepage)
+    }
+
+    func testHasAnyHomepage_returnsTrueWhenAddedNewHomepage() {
+        let subject = ContentContainer(frame: .zero)
+        let homepage = HomepageViewController(
+            windowUUID: .XCTestDefaultUUID,
+            overlayManager: overlayModeManager,
+            toastContainer: UIView()
+        )
+        subject.add(content: homepage)
+
+        XCTAssertTrue(subject.hasAnyHomepage)
+    }
+
+    func testHasAnyHomepage_returnsTrueWhenAddedPrivate() {
+        let subject = ContentContainer(frame: .zero)
+        let privateHomepage = PrivateHomepageViewController(
+            windowUUID: .XCTestDefaultUUID,
+            overlayManager: overlayModeManager
+        )
+        subject.add(content: privateHomepage)
+
+        XCTAssertTrue(subject.hasAnyHomepage)
+    }
+
+    func testHasAnyHomepage_returnsFalseWhenNil() {
+        let subject = ContentContainer(frame: .zero)
+        XCTAssertFalse(subject.hasAnyHomepage)
     }
 
     // MARK: - contentView


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11317)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24617)

## :bulb: Description
- Add `hasAnyHomepage` and use to denied permission 
- Unit test

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

