### PR TITLE
Bugfix FXIOS-11312 ⁃ [Felt privacy-Unified panel][Intermittent] - Incorrect display of the secure connection section and certificate after a specific scenario (on certain websites)

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesHandler.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesHandler.swift
@@ -45,7 +45,7 @@ class CertificatesHandler {
 // Define a function to get the certificates for a given URL
 func getCertificates(for url: URL, completion: @escaping ([Certificate]?) -> Void) {
     // Create a URL session with a custom delegate
-    let session = URLSession(configuration: .default,
+    let session = URLSession(configuration: .ephemeral,
                              delegate: CertificateDelegate(completion: completion),
                              delegateQueue: nil)
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionDetailsViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionDetailsViewController.swift
@@ -43,7 +43,7 @@ class TrackingProtectionDetailsViewController: UIViewController, Themeable {
     private let baseView: UIStackView = .build { stackView in
         stackView.axis = .vertical
         stackView.accessibilityIdentifier = AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.containerView
-        stackView.distribution = .fillProportionally
+        stackView.distribution = .fill
     }
 
     private let headerView: NavigationHeaderView = .build { header in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11312)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24602)

## :bulb: Description
Fixed getting and displaying certificates

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

