### PR TITLE
Bugfix MTE-4135 L10n screenshots for Focus

### DIFF
--- a/focus-ios/Blockzilla.xcodeproj/xcshareddata/xcschemes/FocusSnapshotTests.xcscheme
+++ b/focus-ios/Blockzilla.xcodeproj/xcshareddata/xcschemes/FocusSnapshotTests.xcscheme
@@ -46,11 +46,6 @@
                BlueprintName = "SnapshotTests"
                ReferencedContainer = "container:Blockzilla.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "MarketingTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/focus-ios/focus-ios-tests/ScreenshotTests/BaseTestCaseL10n.swift
+++ b/focus-ios/focus-ios-tests/ScreenshotTests/BaseTestCaseL10n.swift
@@ -8,6 +8,7 @@ class BaseTestCaseL10n: XCTestCase {
     let app = XCUIApplication()
     let testRunningFirstRun = ["test01FirstRunScreens"]
 
+    @MainActor
     override func setUp() {
         super.setUp()
         continueAfterFailure = false

--- a/focus-ios/focus-ios-tests/ScreenshotTests/MarketingTests.swift
+++ b/focus-ios/focus-ios-tests/ScreenshotTests/MarketingTests.swift
@@ -16,9 +16,10 @@ class MarketingTests: BaseTestCaseL10n {
 
         snapshot("Home")
         // Go to ETP Menu
+        waitForExistence(app.buttons["HomeView.settingsButton"])
         app.buttons["HomeView.settingsButton"].tap()
-        waitForExistence(app.tables.cells["Settings"])
-        app.tables.cells["Settings"].tap()
+        app.images["icon_settings"].tap()
+        waitForExistence(app.tables.cells["settingsViewController.defaultBrowserCell"])
         waitForExistence(app.cells["settingsViewController.trackingCell"])
         app.cells["settingsViewController.trackingCell"].tap()
         snapshot("Settings-TP")
@@ -44,8 +45,7 @@ class MarketingTests: BaseTestCaseL10n {
         }
         app.textFields.firstMatch.tap()
         app.textFields.firstMatch.typeText("https://www.mozilla.org/de/firefox/browsers/mobile/focus\n")
-        waitForExistence(app.webViews.buttons["Close"])
-        app.webViews.buttons["Close"].tap()
+        waitForNoExistence(app.progressIndicators.firstMatch)
         snapshot("Website-Focus")
     }
 
@@ -58,8 +58,8 @@ class MarketingTests: BaseTestCaseL10n {
         }
         saveTopSite(TopSite: "mozilla.org")
         saveTopSite(TopSite: "pocket.com")
-        saveTopSite(TopSite: "relay.com")
-        saveTopSite(TopSite: "monitor.com")
+        saveTopSite(TopSite: "relay.firefox.com")
+        saveTopSite(TopSite: "monitor.mozilla.org")
 
         app.buttons["URLBar.deleteButton"].tap()
         waitForExistence(app.buttons["URLBar.cancelButton"], timeout: 15)
@@ -71,9 +71,10 @@ class MarketingTests: BaseTestCaseL10n {
         app.textFields.firstMatch.tap()
         app.textFields.firstMatch.typeText(TopSite)
         app.textFields.firstMatch.typeText("\n")
+        waitForNoExistence(app.progressIndicators.firstMatch, timeoutValue: 45)
         waitForExistence(app.buttons["HomeView.settingsButton"])
         app.buttons["HomeView.settingsButton"].tap()
-        waitForExistence(app.cells["icon_shortcuts_add"])
-        app.tables.cells["icon_shortcuts_add"].tap()
+        waitForExistence(app.images["icon_shortcuts_add"])
+        app.images["icon_shortcuts_add"].tap()
     }
 }

--- a/focus-ios/focus-ios-tests/ScreenshotTests/MarketingTests.swift
+++ b/focus-ios/focus-ios-tests/ScreenshotTests/MarketingTests.swift
@@ -75,6 +75,7 @@ class MarketingTests: BaseTestCaseL10n {
         waitForNoExistence(app.progressIndicators.firstMatch, timeoutValue: 45)
         waitForExistence(app.buttons["HomeView.settingsButton"])
         app.buttons["HomeView.settingsButton"].tap()
+        waitForExistence(app.collectionViews.images["icon_settings"])
         waitForExistence(app.images["icon_shortcuts_add"])
         app.images["icon_shortcuts_add"].tap()
     }

--- a/focus-ios/focus-ios-tests/ScreenshotTests/MarketingTests.swift
+++ b/focus-ios/focus-ios-tests/ScreenshotTests/MarketingTests.swift
@@ -43,9 +43,10 @@ class MarketingTests: BaseTestCaseL10n {
         } else {
             waitForExistence(app.buttons["URLBar.cancelButton"], timeout: 15)
         }
+        waitForExistence(app.textFields.firstMatch)
         app.textFields.firstMatch.tap()
         app.textFields.firstMatch.typeText("https://www.mozilla.org/de/firefox/browsers/mobile/focus\n")
-        waitForNoExistence(app.progressIndicators.firstMatch)
+        waitForNoExistence(app.progressIndicators.firstMatch, timeoutValue: 45)
         snapshot("Website-Focus")
     }
 

--- a/focus-ios/focus-ios-tests/ScreenshotTests/MarketingTests.swift
+++ b/focus-ios/focus-ios-tests/ScreenshotTests/MarketingTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 
 class MarketingTests: BaseTestCaseL10n {
+    @MainActor
     func testSettingsView() {
         if iPad() {
             app.windows.element(boundBy: 0).tap()
@@ -34,6 +35,7 @@ class MarketingTests: BaseTestCaseL10n {
         waitForExistence(app.cells["DuckDuckGo"])
     }
 
+    @MainActor
     func testVisitSite() {
         if iPad() {
             app.windows.element(boundBy: 0).tap()
@@ -47,6 +49,7 @@ class MarketingTests: BaseTestCaseL10n {
         snapshot("Website-Focus")
     }
 
+    @MainActor
     func testPinTopSites() {
         if iPad() {
             app.windows.element(boundBy: 0).tap()

--- a/focus-ios/focus-ios-tests/ScreenshotTests/SnapshotTests.swift
+++ b/focus-ios/focus-ios-tests/ScreenshotTests/SnapshotTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 
 class SnapshotTests: BaseTestCaseL10n {
+    @MainActor
     func test01FirstRunScreens() {
         waitForExistence(app.collectionViews.cells.images["icon_background"], timeout: 10)
         snapshot("00FirstRun")
@@ -13,6 +14,7 @@ class SnapshotTests: BaseTestCaseL10n {
         snapshot("01FirstRun")
     }
 
+    @MainActor
     func test02Settings() {
         dismissURLBarFocused()
         openSettings()
@@ -47,6 +49,7 @@ class SnapshotTests: BaseTestCaseL10n {
         snapshot("AddedCustomURL")
     }
 
+    @MainActor
     func test03About() {
         dismissURLBarFocused()
         openSettings()
@@ -55,6 +58,7 @@ class SnapshotTests: BaseTestCaseL10n {
         snapshot("13About")
     }
 
+    @MainActor
     func test05SafariIntegration() {
         dismissURLBarFocused()
         openSettings()
@@ -63,6 +67,7 @@ class SnapshotTests: BaseTestCaseL10n {
         snapshot("15SafariIntegrationInstructions")
     }
 
+    @MainActor
     func test06Theme() {
         dismissURLBarFocused()
         openSettings()
@@ -76,6 +81,7 @@ class SnapshotTests: BaseTestCaseL10n {
         snapshot("Settings-theme2")
     }
 
+    @MainActor
     func test07PasteAndGo() {
         // Inject a string into clipboard
         let clipboardString = "Hello world"
@@ -94,6 +100,7 @@ class SnapshotTests: BaseTestCaseL10n {
         snapshot("18PasteAndGo")
     }
 
+    @MainActor
     func test10CustomSearchEngines() {
         dismissURLBarFocused()
         app.buttons["HomeView.settingsButton"].tap()
@@ -109,6 +116,7 @@ class SnapshotTests: BaseTestCaseL10n {
         app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap()
     }
 
+    @MainActor
     func test11WebsiteView() {
         app.textFields.firstMatch.tap()
         app.textFields.firstMatch.typeText("example.com")
@@ -121,6 +129,7 @@ class SnapshotTests: BaseTestCaseL10n {
         snapshot("07YourBrowsingHistoryHasBeenErased")
     }
 
+    @MainActor
     func test12RemoveShortcut() {
         loadWebPage("mozilla.org")
         waitForWebPageLoad()

--- a/focus-ios/focus-ios-tests/ScreenshotTests/SnapshotTests.swift
+++ b/focus-ios/focus-ios-tests/ScreenshotTests/SnapshotTests.swift
@@ -27,8 +27,7 @@ class SnapshotTests: BaseTestCaseL10n {
         app.cells["settingsViewController.siriOpenURLCell"].tap()
         snapshot("SiriMenu")
         app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap()
-        waitForExistence(app.cells["settingsViewController.siriOpenURLCell"])
-        app.swipeDown()
+        openSettings()
 
         // Tracking Protection menu
         waitForExistence(app.cells["settingsViewController.trackingCell"])

--- a/focus-ios/focus-ios-tests/ScreenshotTests/SnapshotTests.swift
+++ b/focus-ios/focus-ios-tests/ScreenshotTests/SnapshotTests.swift
@@ -10,6 +10,7 @@ class SnapshotTests: BaseTestCaseL10n {
         waitForExistence(app.collectionViews.cells.images["icon_background"], timeout: 10)
         snapshot("00FirstRun")
         app.collectionViews.cells.images["icon_background"].swipeLeft()
+        waitForNoExistence(app.collectionViews.cells.images["icon_background"])
         waitForExistence(app.collectionViews.cells.images["icon_hugging_focus"], timeout: 3)
         snapshot("01FirstRun")
     }

--- a/focus-ios/l10n-screenshots.sh
+++ b/focus-ios/l10n-screenshots.sh
@@ -30,7 +30,7 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-DEVICE="iPhone 14"
+DEVICE="iPhone 16"
 
 for lang in $LOCALES; do
     # start simple with Focus only


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4135)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

I made the Focus L10n screenshot tests, including the `MarketingTests`, to work again. Here's a sample run of multiple locales:
https://github.com/clarmso/firefox-ios-tools-experiment/actions/runs/13202209882/job/36856700790

Note that some tests are flaky. Sometimes, the simulator did not start on Github Actions runners. But the workflow proof that the screenshot can be generated.

Here are some sample screenshots generated on my computer:
<img src="https://github.com/user-attachments/assets/1dfc4866-63a4-4aee-9875-db63ad255afb" width="150" />
<img src="https://github.com/user-attachments/assets/c6fb77ff-6050-47f1-8fdf-6f2e3955269d" width="150" />
<img src="https://github.com/user-attachments/assets/78e7dc91-842b-4f64-88db-7f7a9fe7a1a9" width="150" />
<img src="https://github.com/user-attachments/assets/82c30feb-9330-4a08-a596-dcd22215ae6f" width="150" />

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

