### PR TITLE
Add FXIOS-11297 [Homepage] [JumpBackIn] fetching most recent synced tab

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1033,6 +1033,7 @@
 		8AB893A92C73CBBD00DAEED7 /* CreditCardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB893A82C73CBBD00DAEED7 /* CreditCardProvider.swift */; };
 		8ABA9C8D28931223002C0077 /* MockDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */; };
 		8ABA9C8E28931288002C0077 /* JumpBackInDataAdaptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA9C8A28931207002C0077 /* JumpBackInDataAdaptorTests.swift */; };
+		8ABB15C92D5A4E3900A4635C /* RemoteTabsMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABB15C82D5A4E3900A4635C /* RemoteTabsMiddlewareTests.swift */; };
 		8ABC5AEE284532C900FEA552 /* PocketDiscoverCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABC5AED284532C900FEA552 /* PocketDiscoverCell.swift */; };
 		8ABCFEA32B45C36100C2988A /* PrivateBrowsingTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABCFEA22B45C36100C2988A /* PrivateBrowsingTelemetry.swift */; };
 		8ABCFEA62B45CB4C00C2988A /* PrivateBrowsingTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABCFEA42B45CAC300C2988A /* PrivateBrowsingTelemetryTests.swift */; };
@@ -7973,6 +7974,7 @@
 		8AB893A82C73CBBD00DAEED7 /* CreditCardProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardProvider.swift; sourceTree = "<group>"; };
 		8ABA9C8A28931207002C0077 /* JumpBackInDataAdaptorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JumpBackInDataAdaptorTests.swift; sourceTree = "<group>"; };
 		8ABA9C8C28931223002C0077 /* MockDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDispatchQueue.swift; sourceTree = "<group>"; };
+		8ABB15C82D5A4E3900A4635C /* RemoteTabsMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsMiddlewareTests.swift; sourceTree = "<group>"; };
 		8ABC5AED284532C900FEA552 /* PocketDiscoverCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketDiscoverCell.swift; sourceTree = "<group>"; };
 		8ABCFEA22B45C36100C2988A /* PrivateBrowsingTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTelemetry.swift; sourceTree = "<group>"; };
 		8ABCFEA42B45CAC300C2988A /* PrivateBrowsingTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTelemetryTests.swift; sourceTree = "<group>"; };
@@ -10579,6 +10581,7 @@
 				219935ED2B07B9B300E5966F /* Legacy */,
 				1D8487B52AD6038100F7527C /* RemoteTabPanelStateTests.swift */,
 				1D3C90872ACE1AF400304C87 /* RemoteTabPanelTests.swift */,
+				8ABB15C82D5A4E3900A4635C /* RemoteTabsMiddlewareTests.swift */,
 				219935F02B07DFA200E5966F /* TabDisplayPanelTests.swift */,
 				21ED80B22AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift */,
 				21F2A2D32B0D194A00626AEC /* TabsPanelStateTests.swift */,
@@ -17743,6 +17746,7 @@
 				61A1644A2CE7BE8A001D6058 /* WallpaperMiddlewareTests.swift in Sources */,
 				C8B394362A0ED55D00700E49 /* MockOnboardingCardDelegate.swift in Sources */,
 				8A5604F829DF0D2600035CA3 /* BrowserCoordinatorTests.swift in Sources */,
+				8ABB15C92D5A4E3900A4635C /* RemoteTabsMiddlewareTests.swift in Sources */,
 				C787D8C32C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift in Sources */,
 				39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */,
 				630FE1352C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -140,7 +140,7 @@ class RemoteTabsPanelMiddleware {
         profile.getCachedClientsAndTabs(completion: completion)
     }
 
-    /// Retrieves the the most recently used tab from a list of desktop clients tabs.
+    /// Retrieves the most recently used tab from a list of desktop clients tabs.
     ///
     /// This method filters the provided `clientAndTabs` list to include only desktop clients that have at least one tab.
     /// Then, it finds the most recently used tab for each client and then determines the most recent tab across all clients.

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -127,21 +127,38 @@ class RemoteTabsPanelMiddleware {
     }
 
     private func handleFetchingMostRecentRemoteTab(windowUUID: WindowUUID) {
-        // TODO: FXIOS-11297 Should properly fetch the most recent tabs
         let completion = { (result: [ClientAndTabs]?) in
-            guard let remoteClient = result?.first?.client, let remoteTab = result?.first?.tabs.first else { return }
+            guard let mostRecentSyncedTab = self.retrieveConfigurationForMostRecentTab(from: result) else { return }
             store.dispatch(
                 RemoteTabsAction(
-                    mostRecentSyncedTab: RemoteTabConfiguration(
-                        client: remoteClient,
-                        tab: remoteTab
-                    ),
+                    mostRecentSyncedTab: mostRecentSyncedTab,
                     windowUUID: windowUUID,
                     actionType: RemoteTabsMiddlewareActionType.fetchedMostRecentSyncedTab
                 )
             )
         }
         profile.getCachedClientsAndTabs(completion: completion)
+    }
+
+    /// Retrieves the the most recently used tab from a list of desktop clients tabs.
+    ///
+    /// This method filters the provided `clientAndTabs` list to include only desktop clients that have at least one tab.
+    /// Then, it finds the most recently used tab for each client and then determines the most recent tab across all clients.
+    /// If a valid tab is found, it returns a `RemoteTabConfiguration` containing the client and tab details.
+    ///
+    /// - Parameter clientAndTabs: An optional array of `ClientAndTabs`, representing synced clients and their tabs.
+    /// - Returns: A `RemoteTabConfiguration` containing the most recently used tab’s details,
+    /// or `nil` if no valid tab exists.
+    private func retrieveConfigurationForMostRecentTab(from clientAndTabs: [ClientAndTabs]?) -> RemoteTabConfiguration? {
+        let mostRecentTabsPerClient = clientAndTabs?
+            .filter { !$0.tabs.isEmpty && ClientType.fromFxAType($0.client.type) == .Desktop }
+            .compactMap { client in
+                client.tabs
+                    .max(by: { $0.lastUsed < $1.lastUsed })
+                    .map { RemoteTabConfiguration(client: client.client, tab: $0) }
+            }
+
+        return mostRecentTabsPerClient?.max(by: { $0.tab.lastUsed < $1.tab.lastUsed })
     }
 
     // MARK: - Notifications

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabsMiddlewareTests.swift
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import Storage
+import XCTest
+
+@testable import Client
+
+final class RemoteTabsMiddlewareTests: XCTestCase, StoreTestUtility {
+    var mockProfile: MockProfile!
+    var mockStore: MockStoreForMiddleware<AppState>!
+    var appState: AppState!
+
+    override func setUp() {
+        super.setUp()
+        mockProfile = MockProfile()
+        DependencyHelperMock().bootstrapDependencies()
+        setupStore()
+    }
+
+    override func tearDown() {
+        mockProfile = nil
+        DependencyHelperMock().reset()
+        resetStore()
+        super.tearDown()
+    }
+
+    func test_homepageInitializeAction_returnsMostRecentTab() throws {
+        let subject = createSubject()
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+
+        let expectation = XCTestExpectation(description: "Most recent tab should be returned")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.remoteTabsPanelProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? RemoteTabsAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? RemoteTabsMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, RemoteTabsMiddlewareActionType.fetchedMostRecentSyncedTab)
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.client.name, "Fake client")
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.tab.title, "Mozilla 3")
+        XCTAssertEqual(actionCalled.mostRecentSyncedTab?.tab.URL.absoluteString, "www.mozilla.org")
+    }
+
+    // MARK: - Helpers
+    private func createSubject() -> RemoteTabsPanelMiddleware {
+        mockProfile.mockClientAndTabs = [
+            ClientAndTabs(
+                client: remoteDesktopClient(),
+                tabs: remoteTabs(
+                    idRange: 1...3
+                ))
+        ]
+        return RemoteTabsPanelMiddleware(profile: mockProfile)
+    }
+
+    func remoteDesktopClient(name: String = "Fake client") -> RemoteClient {
+        return RemoteClient(guid: nil,
+                            name: name,
+                            modified: 1,
+                            type: "desktop",
+                            formfactor: nil,
+                            os: nil,
+                            version: nil,
+                            fxaDeviceId: nil)
+    }
+
+    func remoteTabs(idRange: ClosedRange<Int> = 1...1) -> [RemoteTab] {
+        var remoteTabs: [RemoteTab] = []
+
+        for index in idRange {
+            let tab = RemoteTab(clientGUID: String(index),
+                                URL: URL(string: "www.mozilla.org")!,
+                                title: "Mozilla \(index)",
+                                history: [],
+                                lastUsed: UInt64(index),
+                                icon: nil,
+                                inactive: false)
+            remoteTabs.append(tab)
+        }
+        return remoteTabs
+    }
+
+    // MARK: StoreTestUtility
+    func setupAppState() -> Client.AppState {
+        appState = AppState()
+        return appState
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11297)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Fetch the most recent tab appropriately by following existing logic + simplifying. We want to fetch the most recent tab from all desktop clients. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
Test steps:
1. View Jumpback In section
2. Logged into synced account
3. Navigate to the remote tabs panel and ensure that you are synced with the latest tabs
4. Verify that your desktop tab appears in the Jump back in section

| iPhone |
| --- |
| <img src="https://github.com/user-attachments/assets/31ce3dd0-be00-4a0d-a3b1-e7d1fad8decf" width="250"> |