### PR TITLE
Bugfix FXIOS-11333 #24663 [Crash] Adding TopSiteData ContileProvider strongSelf closure

### DIFF
--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -169,7 +169,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
             }
 
             if let sites = sites {
-                self?.historySites = sites
+                strongSelf.historySites = sites
             }
             dispatchGroup.leave()
         }

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -130,21 +130,23 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
 
         if featureFlags.isFeatureEnabled(.unifiedAds, checking: .buildOnly) {
             unifiedAdsProvider.fetchTiles { [weak self] result in
+                guard let strongSelf = self else { return }
                 if case .success(let unifiedTiles) = result {
-                    self?.contiles = UnifiedAdsConverter.convert(unifiedTiles: unifiedTiles)
+                    strongSelf.contiles = UnifiedAdsConverter.convert(unifiedTiles: unifiedTiles)
                 } else {
-                    self?.contiles = []
+                    strongSelf.contiles = []
                 }
-                self?.dispatchGroup.leave()
+                strongSelf.dispatchGroup.leave()
             }
         } else {
             contileProvider.fetchContiles { [weak self] result in
+                guard let strongSelf = self else { return }
                 if case .success(let contiles) = result {
-                    self?.contiles = contiles
+                    strongSelf.contiles = contiles
                 } else {
-                    self?.contiles = []
+                    strongSelf.contiles = []
                 }
-                self?.dispatchGroup.leave()
+                strongSelf.dispatchGroup.leave()
             }
         }
     }

--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/TopSitesDataAdaptor.swift
@@ -130,10 +130,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
 
         if featureFlags.isFeatureEnabled(.unifiedAds, checking: .buildOnly) {
             unifiedAdsProvider.fetchTiles { [weak self] result in
-                guard let strongSelf = self else {
-                    dispatchGroup.leave()
-                    return
-                }
+                guard let strongSelf = self else { return }
 
                 if case .success(let unifiedTiles) = result {
                     strongSelf.contiles = UnifiedAdsConverter.convert(unifiedTiles: unifiedTiles)
@@ -144,10 +141,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
             }
         } else {
             contileProvider.fetchContiles { [weak self] result in
-                guard let strongSelf = self else {
-                    dispatchGroup.leave()
-                    return
-                }
+                guard let strongSelf = self else { return }
 
                 if case .success(let contiles) = result {
                     strongSelf.contiles = contiles
@@ -163,10 +157,7 @@ class TopSitesDataAdaptorImplementation: TopSitesDataAdaptor, FeatureFlaggable {
         dispatchGroup.enter()
 
         topSiteHistoryManager.getTopSites { [weak self] sites in
-            guard let strongSelf = self else {
-                dispatchGroup.leave()
-                return
-            }
+            guard let strongSelf = self else { return }
 
             if let sites = sites {
                 strongSelf.historySites = sites

--- a/firefox-ios/Providers/TopSitesProvider.swift
+++ b/firefox-ios/Providers/TopSitesProvider.swift
@@ -82,10 +82,7 @@ private extension TopSitesProviderImplementation {
     func getFrecencySites(group: DispatchGroup, numberOfMaxItems: Int) {
         group.enter()
         DispatchQueue.global().async { [weak self] in
-            guard let strongSelf = self else {
-                group.leave()
-                return
-            }
+            guard let strongSelf = self else { return }
             // It's possible that the top sites fetch is the
             // very first use of places, lets make sure that
             // our connection is open
@@ -96,10 +93,7 @@ private extension TopSitesProviderImplementation {
             placesFetcher.getTopFrecentSiteInfos(limit: numberOfMaxItems,
                                                  thresholdOption: FrecencyThresholdOption.none)
                 .uponQueue(.global()) { [weak self] result in
-                    guard let strongSelf = self else {
-                        group.leave()
-                        return
-                    }
+                    guard let strongSelf = self else { return }
 
                     if let sites = result.successValue {
                         strongSelf.frecencySites = sites
@@ -115,10 +109,7 @@ private extension TopSitesProviderImplementation {
         pinnedSiteFetcher
             .getPinnedTopSites()
             .uponQueue(.global()) { [weak self] result in
-                guard let strongSelf = self else {
-                    group.leave()
-                    return
-                }
+                guard let strongSelf = self else { return }
 
                 if let sites = result.successValue?.asArray() {
                     strongSelf.pinnedSites = sites


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11333)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24663)

## :bulb: Description
Adding `strongSelf` in closure since the crash seems to happen when the object is deallocated. I also ensured we leave the `DispatchGroup` if there's no `strongSelf`.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

