### PR TITLE
Add FXIOS-11342 [Dark Mode] Detect pages that are in dark mode

### DIFF
--- a/BrowserKit/Sources/Shared/Extensions/UIColorExtensions.swift
+++ b/BrowserKit/Sources/Shared/Extensions/UIColorExtensions.swift
@@ -50,4 +50,35 @@ extension UIColor {
     public var color: Color {
         return Color(self)
     }
+
+    /// Converts a normalized sRGB component to its linear value as defined by the WCAG 2.2 spec for relative luminance.
+    /// See: https://www.w3.org/TR/WCAG22/#dfn-relative-luminance
+    ///
+    /// For values ≤ 0.04045, the component is divided by 12.92;
+    /// otherwise, it is adjusted using an exponent of 2.4.
+    func linearizeChannel(_ channel: CGFloat) -> CGFloat {
+        return channel <= 0.04045
+            ? channel / 12.92
+            : pow((channel + 0.055) / 1.055, 2.4)
+    }
+
+    /// Computes the relative luminance of the color as defined in WCAG 2.2.
+    /// See: https://www.w3.org/TR/WCAG22/#dfn-relative-luminance
+    ///
+    /// The relative luminance is a measure of the perceived brightness of a color,
+    /// normalized to 0 for the darkest black and 1 for the lightest white.
+    ///
+    /// The color's sRGB components are extracted and linearized with the WCAG formula,
+    /// then combined using the coefficients 0.2126 (red), 0.7152 (green), and 0.0722 (blue).
+    private var relativeLuminance: CGFloat {
+        let linearRed = linearizeChannel(self.components.red)
+        let linearGreen = linearizeChannel(self.components.green)
+        let linearBlue = linearizeChannel(self.components.blue)
+
+        return 0.2126 * linearRed + 0.7152 * linearGreen + 0.0722 * linearBlue
+    }
+
+    public var isDark: Bool {
+        return relativeLuminance < 0.5
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3591,7 +3591,7 @@ extension BrowserViewController: LegacyTabDelegate {
         let printHelper = PrintHelper(tab: tab)
         tab.addContentScriptToPage(printHelper, name: PrintHelper.name())
 
-        let nightModeHelper = NightModeHelper()
+        let nightModeHelper = NightModeHelper(tab: tab)
         tab.addContentScriptToCustomWorld(nightModeHelper, name: NightModeHelper.name())
 
         // XXX: Bug 1390200 - Disable NSUserActivity/CoreSpotlight temporarily

--- a/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -6,8 +6,11 @@ import Foundation
 import WebKit
 import Shared
 import Common
+import Glean
 
 class NightModeHelper: TabContentScript, FeatureFlaggable {
+    private weak var tab: Tab?
+
     private enum NightModeKeys {
         static let Status = "profile.NightModeStatus"
         static let DarkThemeEnabled = "NightModeEnabledDarkTheme"
@@ -19,6 +22,10 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
 
     func scriptMessageHandlerNames() -> [String]? {
         return ["NightMode"]
+    }
+
+    required init(tab: Tab) {
+        self.tab = tab
     }
 
     static func jsCallbackBuilder(_ enabled: Bool) -> String {
@@ -85,8 +92,10 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
     }
 
     static func isPageInDarkMode(webView: WKWebView?, completion: @escaping (Bool) -> Void) {
+        let timerId = GleanMetrics.DarkReader.websiteDarkThemeDetection.start()
         takePageSnapshot(for: webView, at: 0.6, width: 300, height: 400) { color in
             let isPageDark = color?.isDark ?? false
+            GleanMetrics.DarkReader.websiteDarkThemeDetection.stopAndAccumulate(timerId)
             completion(isPageDark)
         }
     }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -42,7 +42,7 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         NightModeHelper.isPageInDarkMode(webView: webView) { isInDarkPage in
             let enableComputedDarkMode = !isInDarkPage && NightModeHelper.isActivated()
             webView.evaluateJavascriptInCustomContentWorld(
-                NightModeHelper.jsCallbackBuilder(enableComputedDarkMode, "foo4"),
+                NightModeHelper.jsCallbackBuilder(enableComputedDarkMode),
                 in: .world(name: NightModeHelper.name())
             )
         }
@@ -100,7 +100,13 @@ class NightModeHelper: TabContentScript, FeatureFlaggable {
         }
     }
 
-    private static func takePageSnapshot(for webView: WKWebView?, at verticalOffset: CGFloat, width: CGFloat, height: CGFloat, completion: @escaping (UIColor?) -> Void) {
+    private static func takePageSnapshot(
+        for webView: WKWebView?,
+        at verticalOffset: CGFloat,
+        width: CGFloat,
+        height: CGFloat,
+        completion: @escaping (UIColor?) -> Void
+    ) {
         guard let webView = webView else { return }
 
         // Ensure width does not exceed the webView’s frame width

--- a/firefox-ios/Client/Frontend/TabContentsScripts/UserScriptManager.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/UserScriptManager.swift
@@ -17,11 +17,6 @@ class UserScriptManager: FeatureFlaggable {
         source: "window.__firefox__.NoImageMode.setEnabled(true)",
         injectionTime: .atDocumentStart,
         forMainFrameOnly: true)
-    private let nightModeUserScript = WKUserScript(
-        source: NightModeHelper.jsCallbackBuilder(true),
-        injectionTime: .atDocumentEnd,
-        forMainFrameOnly: true,
-        in: .world(name: NightModeHelper.name()))
     private let printHelperUserScript = WKUserScript.createInPageContentWorld(
         source: "window.print = function () { window.webkit.messageHandlers.printHandler.postMessage({}) }",
         injectionTime: .atDocumentEnd,
@@ -130,11 +125,7 @@ class UserScriptManager: FeatureFlaggable {
         }
         // Inject the Print Helper. This needs to be in the `page` content world in order to hook `window.print()`.
         webView?.configuration.userContentController.addUserScript(printHelperUserScript)
-        // If Night Mode is enabled, inject a small user script to ensure
-        // that it gets enabled immediately when the DOM loads.
-        if nightMode {
-            webView?.configuration.userContentController.addUserScript(nightModeUserScript)
-        }
+
         // If No Image Mode is enabled, inject a small user script to ensure
         // that it gets enabled immediately when the DOM loads.
         if noImageMode {

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/NightModeAtDocumentEnd/NightModeHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/NightModeAtDocumentEnd/NightModeHelper.js
@@ -24,6 +24,18 @@ Object.defineProperty(window.__firefox__.NightMode, "setEnabled", {
   },
 });
 
+function documentReady(callback) {
+  const listener = () => {
+    if (document.readyState !== "complete") return;
+    document.removeEventListener("readystatechange", listener);
+    callback();
+  };
+  document.addEventListener("readystatechange", listener);
+  listener();
+}
+
 window.addEventListener("pageshow", () => {
-  webkit.messageHandlers.NightMode.postMessage({ state: "ready" });
+  documentReady(() =>
+    webkit.messageHandlers.NightMode.postMessage({ state: "ready" })
+  );
 });

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -370,10 +370,15 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     var nightMode: Bool {
         didSet {
             guard nightMode != oldValue else { return }
-            webView?.evaluateJavascriptInCustomContentWorld(
-                NightModeHelper.jsCallbackBuilder(nightMode),
-                in: .world(name: NightModeHelper.name())
-            )
+            NightModeHelper.isPageInDarkMode(webView: webView) { [weak self] isInDarkPage in
+                guard let self = self else { return }
+                let enableComputedDarkMode = !isInDarkPage && NightModeHelper.isActivated()
+                webView?.evaluateJavascriptInCustomContentWorld(
+                    NightModeHelper.jsCallbackBuilder(enableComputedDarkMode, "foo3"),
+                    in: .world(name: NightModeHelper.name())
+                )
+            }
+
             UserScriptManager.shared.injectUserScriptsIntoWebView(
                 webView,
                 nightMode: nightMode,

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -374,7 +374,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
                 guard let self = self else { return }
                 let enableComputedDarkMode = !isInDarkPage && NightModeHelper.isActivated()
                 webView?.evaluateJavascriptInCustomContentWorld(
-                    NightModeHelper.jsCallbackBuilder(enableComputedDarkMode, "foo3"),
+                    NightModeHelper.jsCallbackBuilder(enableComputedDarkMode),
                     in: .world(name: NightModeHelper.name())
                 )
             }

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -6556,3 +6556,17 @@ nimbus_system:
       - chumphreys@mozilla.com
       - project-nimbus@mozilla.com
     expires: never
+
+dark_reader:
+  website_dark_theme_detection:
+    type: timing_distribution
+    time_unit: millisecond
+    description: >
+      Counts how long it takes for our sampling algorithm to detect the theme of a webpage
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/17717
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/18012
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11342)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24688)

## :bulb: Description
The problem with all dark extensions is that it’s not obvious whether the page the extension is trying to darken is already in dark mode. Dark Reader addresses this by applying a unified background color. However, this approach is limited because Dark Reader sometimes messes up, and the page’s native dark theme is usually the best representation of the website. The idea behind this patch is to apply Dark Reader only to pages that are not already in dark mode (something no other browser currently does). 

To do so we take a screenshot ( 300 x 400 ) from the middle of the page ( idea being that middle is a better spot since top could have ads or headers and bottom has footers ), get an average of all the colors, then determine how dark that average color is using [fancy calcs ](https://www.w3.org/TR/WCAG22/#dfn-relative-luminance). If the page is mostly dark, this should be a reliable way to tell that it’s already in dark mode on load.

A few things that I am still thinking about:
- Performance: Locally the op to take a screenshot and determine darkness is ~50ms. Just need to make sure that we only do this operation when needed.  
- Edge cases: I am taking a screenshot in the middle but in theory that could land on say an image or something else that is not representative of the whole page.  Maybe we can make this better later by taking two smaller screenshots in different places.

<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

