### PR TITLE
Bugfix [Tab Optimization Phase 1] FXIOS-10990 Tab Title Shows Wrong Text

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
@@ -709,6 +709,10 @@ extension TopTabDisplayManager: TabManagerDelegate {
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {
         cancelDragAndGestures()
     }
+
+    func tabManagerTabDidFinishLoading() {
+        refreshStore(evenIfHidden: true)
+    }
 }
 
 extension TopTabDisplayManager: Notifiable {

--- a/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
@@ -711,7 +711,7 @@ extension TopTabDisplayManager: TabManagerDelegate {
     }
 
     func tabManagerTabDidFinishLoading() {
-        refreshStore(evenIfHidden: true)
+        refreshStore()
     }
 }
 

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -381,13 +381,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     var contentBlocker: FirefoxTabContentBlocker?
 
     /// The last title shown by this tab. Used by the tab tray to show titles for zombie tabs.
-    var lastTitle: String? {
-        didSet {
-            guard let title = lastTitle else { return }
-            print(title)
-            print("hi")
-        }
-    }
+    var lastTitle: String?
 
     /// Whether or not the desktop site was requested with the last request, reload or navigation.
     var changedUserAgent = false {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -204,11 +204,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     }
 
     var title: String? {
-        if let title = webView?.title, !title.isEmpty {
-            return webView?.title
-        }
-
-        return nil
+        return webView?.title
     }
 
     /// This property returns, ideally, the web page's title. Otherwise, based on the page being internal

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -247,7 +247,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         } else if let url = url, let about = InternalURL(url)?.aboutComponent {
             backUpName = about
         }
-        
+
         return displayTitle.isEmpty ? backUpName : displayTitle
     }
 

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -226,7 +226,6 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         // Then, if it's not Home, and it's also not a complete and valid URL, display what was "entered" as the title.
         if let url = self.url, !InternalURL.isValid(url: url), let shownUrl = url.displayURL?.absoluteString {
             return shownUrl
-            // this is what happens when we type the url but don't get the title
         }
 
         // Finally, somehow lastTitle is persisted (and webView's title isn't).
@@ -248,13 +247,8 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         } else if let url = url, let about = InternalURL(url)?.aboutComponent {
             backUpName = about
         }
-
-        if displayTitle.isEmpty {
-            return backUpName
-        } else {
-            return displayTitle
-        }
-//        return displayTitle.isEmpty ? backUpName : displayTitle
+        
+        return displayTitle.isEmpty ? backUpName : displayTitle
     }
 
     var canGoBack: Bool {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -204,7 +204,11 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     }
 
     var title: String? {
-        return webView?.title
+        if let title = webView?.title, !title.isEmpty {
+            return webView?.title
+        }
+
+        return nil
     }
 
     /// This property returns, ideally, the web page's title. Otherwise, based on the page being internal

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -230,6 +230,7 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
         // Then, if it's not Home, and it's also not a complete and valid URL, display what was "entered" as the title.
         if let url = self.url, !InternalURL.isValid(url: url), let shownUrl = url.displayURL?.absoluteString {
             return shownUrl
+            // this is what happens when we type the url but don't get the title
         }
 
         // Finally, somehow lastTitle is persisted (and webView's title isn't).
@@ -252,7 +253,12 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
             backUpName = about
         }
 
-        return displayTitle.isEmpty ? backUpName : displayTitle
+        if displayTitle.isEmpty {
+            return backUpName
+        } else {
+            return displayTitle
+        }
+//        return displayTitle.isEmpty ? backUpName : displayTitle
     }
 
     var canGoBack: Bool {
@@ -385,7 +391,13 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     var contentBlocker: FirefoxTabContentBlocker?
 
     /// The last title shown by this tab. Used by the tab tray to show titles for zombie tabs.
-    var lastTitle: String?
+    var lastTitle: String? {
+        didSet {
+            guard let title = lastTitle else { return }
+            print(title)
+            print("hi")
+        }
+    }
 
     /// Whether or not the desktop site was requested with the last request, reload or navigation.
     var changedUserAgent = false {

--- a/firefox-ios/Client/TabManagement/TabManagerDelegate.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerDelegate.swift
@@ -19,6 +19,7 @@ protocol TabManagerDelegate: AnyObject {
     func tabManagerDidAddTabs(_ tabManager: TabManager)
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?)
     func tabManagerUpdateCount()
+    func tabManagerTabDidFinishLoading()
 }
 
 extension TabManagerDelegate {
@@ -30,6 +31,7 @@ extension TabManagerDelegate {
     func tabManagerDidAddTabs(_ tabManager: TabManager) {}
     func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {}
     func tabManagerUpdateCount() {}
+    func tabManagerTabDidFinishLoading() {}
 }
 
 // MARK: - WeakTabManagerDelegate

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1308,6 +1308,7 @@ extension TabManagerImplementation: WKNavigationDelegate {
 
             if let title = webView.title, selectedTab?.webView == webView {
                 selectedTab?.lastTitle = title
+                selectedTab?.displayTitle = title
             }
 
             storeChanges()

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1308,6 +1308,7 @@ extension TabManagerImplementation: WKNavigationDelegate {
 
             if let title = webView.title, selectedTab?.webView == webView {
                 selectedTab?.lastTitle = title
+                delegates.forEach { $0.get()?.tabManagerTabDidFinishLoading() }
             }
 
             storeChanges()

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1308,7 +1308,6 @@ extension TabManagerImplementation: WKNavigationDelegate {
 
             if let title = webView.title, selectedTab?.webView == webView {
                 selectedTab?.lastTitle = title
-                selectedTab?.displayTitle = title
             }
 
             storeChanges()

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -376,7 +376,7 @@ open class BrowserProfile: Profile {
         let visitType = VisitType.fromRawValue(rawValue: v)
         if let url = notification.userInfo!["url"] as? URL, !isIgnoredURL(url),
         let title = notification.userInfo!["title"] as? NSString {
-            // Only record local vists if the change notification originated from a non-private tab
+            // Only record local visits if the change notification originated from a non-private tab
             if !(notification.userInfo!["isPrivate"] as? Bool ?? false) {
                 let result = self.places.applyObservation(
                     visitObservation: VisitObservation(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10990)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24533)

## :bulb: Description
Add delegate method `tabManagerTabDidFinishLoading` to notify the `TopTabDisplayManager` when the webView has finished loading so it can reload its views and get the updated displayTitle.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

