### PR TITLE
Add MTE-4135 Use Github Actions for Focus L10n screenshots

### DIFF
--- a/.github/workflows/focus-ios-l10n-locales.yml
+++ b/.github/workflows/focus-ios-l10n-locales.yml
@@ -1,0 +1,54 @@
+name: L10n Focus iOS screenshots (one set of locales only)
+on:
+  workflow_call:
+    inputs:
+      locales:
+        required: true
+        type: string
+      branch:
+        required: false
+        type: string
+        default: "main"
+      derived-data:
+        required: true
+        type: string
+        default: ""
+
+jobs:
+  get-screenshots:
+    name: Generate screenshots
+    runs-on: macos-15
+    steps:
+      - name: Clone firefox-ios repo
+        uses: actions/checkout@v4
+        with:
+          repository: mozilla-mobile/firefox-ios
+          ref: ${{ inputs.branch }}
+      - name: Setup Xcode
+        run: |
+          sudo rm -rf /Applications/Xcode.app
+          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+          xcodebuild -version
+      - name: Run setup scripts for Focus
+        run: |
+          ./checkout.sh
+      - name: Fetch derived data
+        id: download-derived-data
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.derived-data }}
+      - name: Extract derived data
+        run: |
+          ls -la *.tar.gz
+          gunzip l10n-screenshots-dd.tar.gz
+          tar -xvf l10n-screenshots-dd.tar
+      - name: Generate screenshots
+        continue-on-error: true
+        run: |
+          focus-ios/l10n-screenshots.sh --test-without-building ${{ inputs.locales }}
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          path: ./l10n-screenshots
+          retention-days: 90
+          name: Screenshots

--- a/.github/workflows/focus-ios-l10n-screenshots.yml
+++ b/.github/workflows/focus-ios-l10n-screenshots.yml
@@ -7,7 +7,7 @@ on:
                 required: true
                 type: string
     schedule:
-        - cron: "0 4 * * 0"
+        - cron: "0 4 * * 1,3,5"
 
 jobs:
     get-screenshots:
@@ -35,7 +35,17 @@ jobs:
             - name: Generate screenshots
               continue-on-error: true
               run: |
-                  focus-ios/l10n-screenshots.sh --test-without-building ab, af, an, ar, az, be, bg, bn, bo, br, bs, ca, co, cs, cy, da, de, el, en-CA, en-GB, en-US, eo, es, es-AR, es-CL, es-ES, es-MX, et, eu, fa, zh-TW
+                  # Process selected locales depending on the day of week
+                  day_of_week=`date +%u`
+                  locales=en-US
+                  if [[ "$locales" == "1" ]]; then
+                    locales="ab, af, an, ar, az, be, bg, bn, bo, br, bs, ca, co, cs, cy, da, de, el, en-CA, en-GB, en-US, eo, es, es-AR, es-CL, es-ES, es-MX, et, eu, fa, zh-TW"
+                  elif [[ "$locales" == "3" ]]; then
+                    locales="fi, fr, ga-IE, gd, gl, gu-IN, he, hi-IN, hr, hu, hy-AM, ia, id, is, it, ja, jv, ka, kk, km, kn, ko, lo, lt, lv, ml, mr, ms, my, nb-NO"
+                  elif [[ "$locales" == "5" ]]; then
+                    locales="ne-NP, nl, nn-NO, oc, or, pa-IN, pl, pt-BR, pt-PT, rm, ro, ru, si, sk, sl, sq, su, sv-SE, ta, te, th, tl, tr, tt, ug, uk, ur, uz, vi, zh-CN"
+                  fi
+                  focus-ios/l10n-screenshots.sh --test-without-building $locales
             - name: Upload screenshots
               uses: actions/upload-artifact@v4.3.3
               with:

--- a/.github/workflows/focus-ios-l10n-screenshots.yml
+++ b/.github/workflows/focus-ios-l10n-screenshots.yml
@@ -1,0 +1,44 @@
+name: L10n Focus iOS screenshots
+on:
+    workflow_dispatch:
+        inputs:
+            branch:
+                default: main
+                required: true
+                type: string
+    schedule:
+        - cron: "0 4 * * 0"
+
+jobs:
+    get-screenshots:
+        name: Generate screenshots
+        runs-on: macos-15
+        steps:
+            - name: Clone firefox-ios repo
+              uses: actions/checkout@v4
+              with:
+                ref: ${{ inputs.branch }}
+            - name: Setup Xcode
+              run: |
+                  sudo rm -rf /Applications/Xcode.app
+                  sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+                  xcodebuild -version
+            - name: Run setup scripts for Focus
+              run: |
+                  ./checkout.sh
+            - name: Compile Focus iOS
+              run: |
+                  xcodebuild build-for-testing -scheme FocusSnapshotTests \
+                    -project focus-ios/Blockzilla.xcodeproj \
+                    -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' \
+                    -derivedDataPath l10n-screenshots-dd
+            - name: Generate screenshots
+              continue-on-error: true
+              run: |
+                  focus-ios/l10n-screenshots.sh --test-without-building ab, af, an, ar, az, be, bg, bn, bo, br, bs, ca, co, cs, cy, da, de, el, en-CA, en-GB, en-US, eo, es, es-AR, es-CL, es-ES, es-MX, et, eu, fa, zh-TW
+            - name: Upload screenshots
+              uses: actions/upload-artifact@v4.3.3
+              with:
+                path: ./l10n-screenshots
+                retention-days: 90
+                name: Screenshots

--- a/.github/workflows/focus-ios-l10n-screenshots.yml
+++ b/.github/workflows/focus-ios-l10n-screenshots.yml
@@ -1,54 +1,88 @@
 name: L10n Focus iOS screenshots
 on:
-    workflow_dispatch:
-        inputs:
-            branch:
-                default: main
-                required: true
-                type: string
-    schedule:
-        - cron: "0 4 * * 1,3,5"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch from firefox-ios repo"
+        required: false
+        type: string
+        default: "main"
+  schedule:
+    - cron: "0 4 * * 1"
 
 jobs:
-    get-screenshots:
-        name: Generate screenshots
-        runs-on: macos-15
-        steps:
-            - name: Clone firefox-ios repo
-              uses: actions/checkout@v4
-              with:
-                ref: ${{ inputs.branch }}
-            - name: Setup Xcode
-              run: |
-                  sudo rm -rf /Applications/Xcode.app
-                  sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
-                  xcodebuild -version
-            - name: Run setup scripts for Focus
-              run: |
-                  ./checkout.sh
-            - name: Compile Focus iOS
-              run: |
-                  xcodebuild build-for-testing -scheme FocusSnapshotTests \
-                    -project focus-ios/Blockzilla.xcodeproj \
-                    -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' \
-                    -derivedDataPath l10n-screenshots-dd
-            - name: Generate screenshots
-              continue-on-error: true
-              run: |
-                  # Process selected locales depending on the day of week
-                  day_of_week=`date +%u`
-                  locales=en-US
-                  if [[ "$locales" == "1" ]]; then
-                    locales="ab, af, an, ar, az, be, bg, bn, bo, br, bs, ca, co, cs, cy, da, de, el, en-CA, en-GB, en-US, eo, es, es-AR, es-CL, es-ES, es-MX, et, eu, fa, zh-TW"
-                  elif [[ "$locales" == "3" ]]; then
-                    locales="fi, fr, ga-IE, gd, gl, gu-IN, he, hi-IN, hr, hu, hy-AM, ia, id, is, it, ja, jv, ka, kk, km, kn, ko, lo, lt, lv, ml, mr, ms, my, nb-NO"
-                  elif [[ "$locales" == "5" ]]; then
-                    locales="ne-NP, nl, nn-NO, oc, or, pa-IN, pl, pt-BR, pt-PT, rm, ro, ru, si, sk, sl, sq, su, sv-SE, ta, te, th, tl, tr, tt, ug, uk, ur, uz, vi, zh-CN"
-                  fi
-                  focus-ios/l10n-screenshots.sh --test-without-building $locales
-            - name: Upload screenshots
-              uses: actions/upload-artifact@v4.3.3
-              with:
-                path: ./l10n-screenshots
-                retention-days: 90
-                name: Screenshots
+  determine-locales:
+    name: Determine lists of locales
+    runs-on: macos-15
+    outputs:
+      group1: ${{ steps.my_locales.outputs.group1 }}
+      group2: ${{ steps.my_locales.outputs.group2 }}
+      group3: ${{ steps.my_locales.outputs.group3 }}
+    steps:
+      - name: Clone firefoxios-l01n repo
+        uses: actions/checkout@v4
+        with:
+          repository: mozilla-l10n/firefoxios-l10n
+      - name: Determine locales needed
+        id: my_locales
+        run: |
+          ls | grep -e "^..$" -e "^..-..$" > locales.txt
+          split -n 3 locales.txt locales-
+          group1=`tr '\n' ' ' < locales-aa`
+          group2=`tr '\n' ' ' < locales-ab`
+          group3=`tr '\n' ' ' < locales-ac`
+          echo "group1=$group1" >> $GITHUB_OUTPUT
+          echo "group2=$group2" >> $GITHUB_OUTPUT
+          echo "group3=$group3" >> $GITHUB_OUTPUT
+  
+  compile:
+    name: Compile Focus for L10n
+    runs-on: macos-15
+    steps:
+      - name: Clone firefox-ios repo
+        uses: actions/checkout@v4
+        with:
+          repository: mozilla-mobile/firefox-ios
+          ref: ${{ inputs.branch }}
+      - name: Setup Xcode
+        run: |
+          sudo rm -rf /Applications/Xcode.app
+          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+          xcodebuild -version
+      - name: Run setup scripts for Focus
+        run: |
+          ./checkout.sh
+      - name: Compile Focus iOS
+        run: |
+          xcodebuild build-for-testing -scheme FocusSnapshotTests \
+            -project focus-ios/Blockzilla.xcodeproj \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' \
+            -derivedDataPath l10n-screenshots-dd
+      - name: Targzip Derived Data
+        run: |
+          tar -czvf l10n-screenshots-dd.tar.gz l10n-screenshots-dd/*
+          ls -la *.tar.gz
+      - name: Save Derived Data
+        id: upload-derived-data
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: xcode-l10n-focus-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
+          path: l10n-screenshots-dd.tar.gz
+          retention-days: 2   
+      
+  generate-screenshots:
+    name: Generate Screenshots
+    needs: [determine-locales, compile]
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        locales: [ 
+          "${{ needs.determine-locales.outputs.group1 }}", 
+          "${{ needs.determine-locales.outputs.group2 }}",
+          "${{ needs.determine-locales.outputs.group3 }}"]  
+    uses: ./.github/workflows/focus-ios-l10n-locales.yml
+    with:
+      locales: "${{ matrix.locales }}"
+      branch: "${{ inputs.branch }}"
+      derived-data: "xcode-l10n-focus-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4135)

## :bulb: Description

I (almost) copied and pasted the yml file from my experiment repo to here.
https://github.com/clarmso/firefox-ios-tools-experiment/actions/runs/13279539004

Here I dynamically determine the set of locales to work on (91 at the time of writing), compile once and dispatch 3 different jobs to generate the screenshots. One job cannot handle all locales because of the 6-hour timelimit of Github Actions runner. 

Each job takes 1/3 of the locales. It takes just under 5 hours to finish.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

