### PR TITLE
Refactor FXIOS-7301 [Swiftlint] Disable closure_body_length rule for a closure on AddressBarState.swift and decrease threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,8 +103,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 53
-  error: 53
+  warning: 51
+  error: 51
 
 file_header:
   required_string: |

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -140,6 +140,7 @@ struct AddressBarState: StateType, Equatable {
         self.alternativeSearchEngine = alternativeSearchEngine
     }
 
+    // swiftlint:disable:next closure_body_length
     static let reducer: Reducer<Self> = { state, action in
         guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
         else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
Following a discussion with @FilippoZazzeroni, we decided to temporarily disable the `closure_body_length` rule for the `reducer` closure of `AddressBarState.swift`. We plan to revisit this issue later, but for now, this adjustment allows us to continue reducing the overall threshold across the project.

For full context on this discussion, please refer to [this comment](https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2605060094). It's a bit lengthy but provides valuable insights.

Also, this PR decrease the warning and error threshold to 51.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

