### PR TITLE
Bugfix [Tab Optimization Phase 1] FXIOS-11339 Make the minimum amount of tabs in a row 2 for small screens

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -29,10 +29,9 @@ class TabsSectionManager {
         let maxNumberOfCellsPerRow = Int(availableWidth / UX.cellEstimatedWidth)
         let minNumberOfCellsPerRow = 2
 
-        var numberOfCellsPerRow = maxNumberOfCellsPerRow
-        if numberOfCellsPerRow < minNumberOfCellsPerRow {
-            numberOfCellsPerRow = minNumberOfCellsPerRow
-        }
+        // maxNumberOfCellsPerRow returns 1 on smaller screen sizes which is inconvenient to scroll through
+        // so here we check we have 2 cells per row at minimum.
+        let numberOfCellsPerRow = maxNumberOfCellsPerRow < minNumberOfCellsPerRow ? minNumberOfCellsPerRow : maxNumberOfCellsPerRow
 
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .estimated(UX.cellEstimatedWidth),

--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -31,7 +31,9 @@ class TabsSectionManager {
 
         // maxNumberOfCellsPerRow returns 1 on smaller screen sizes which is inconvenient to scroll through
         // so here we check we have 2 cells per row at minimum.
-        let numberOfCellsPerRow = maxNumberOfCellsPerRow < minNumberOfCellsPerRow ? minNumberOfCellsPerRow : maxNumberOfCellsPerRow
+        let numberOfCellsPerRow = maxNumberOfCellsPerRow < minNumberOfCellsPerRow
+                                  ? minNumberOfCellsPerRow
+                                  : maxNumberOfCellsPerRow
 
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .estimated(UX.cellEstimatedWidth),

--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -26,7 +26,13 @@ class TabsSectionManager {
 
     func layoutSection(_ layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
         let availableWidth = layoutEnvironment.container.effectiveContentSize.width
-        let maxNumberOfCellPerRow = Int(availableWidth / UX.cellEstimatedWidth)
+        let maxNumberOfCellsPerRow = Int(availableWidth / UX.cellEstimatedWidth)
+        let minNumberOfCellsPerRow = 2
+
+        var numberOfCellsPerRow = maxNumberOfCellsPerRow
+        if numberOfCellsPerRow < minNumberOfCellsPerRow {
+            numberOfCellsPerRow = minNumberOfCellsPerRow
+        }
 
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .estimated(UX.cellEstimatedWidth),
@@ -40,7 +46,7 @@ class TabsSectionManager {
         )
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
                                                        subitem: item,
-                                                       count: maxNumberOfCellPerRow)
+                                                       count: numberOfCellsPerRow)
         group.interItemSpacing = .fixed(UX.cardSpacing)
         let section = NSCollectionLayoutSection(group: group)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11339)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24677)

## :bulb: Description
Set a min and a max amount for number of cells per row so that we are locked to 2 at minimum on small screen sizes (iPhone SE 1st gen, iPod touch).

## Before
![Untitled 2](https://github.com/user-attachments/assets/632cdb0e-48b8-410e-b3c1-768fedd73070)

## After
![Simulator Screenshot - iPhone SE (1st generation) - 2025-02-11 at 10 08 42](https://github.com/user-attachments/assets/7bca50e9-2ff4-4ba6-92f2-bdbec37b7d39)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

