### PR TITLE
Add FXIOS-8685 A login password or username can be edited without being in Edit mode

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -386,6 +386,11 @@ extension PasswordDetailViewController {
 
     @objc
     func doneEditing() {
+        // Only update if user made changes
+        guard usernameField?.text?.isEmpty == false, passwordField?.text?.isEmpty == false else {
+            return
+        }
+
         isEditingFieldData = false
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .edit,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8685)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19269)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
There's an edge case when the user deletes both fields, nothing is actually saved the but the button state is changed and it does not reflect the not editable state anymore.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

