### PR TITLE
Bugfix FXIOS-8283 ⁃ Siri shortcut opens two new tabs instead of one

### DIFF
--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -6,11 +6,17 @@ import CoreSpotlight
 import Foundation
 import Glean
 import Shared
+import Common
 
 final class RouteBuilder: FeatureFlaggable {
     private var isPrivate = false
     private var prefs: Prefs?
-    private var shouldOpenNewTab = true
+    private var mainQueue: DispatchQueueInterface
+    var shouldOpenNewTab = true
+
+    init(mainQueue: DispatchQueueInterface = DispatchQueue.main) {
+        self.mainQueue = mainQueue
+    }
 
     func configure(isPrivate: Bool,
                    prefs: Prefs) {
@@ -159,7 +165,7 @@ final class RouteBuilder: FeatureFlaggable {
         // By using shouldOpenNewTab we avoid duplicated user activities, from Siri, for new tab.
         if userActivity.activityType == SiriShortcuts.activityType.openURL.rawValue && shouldOpenNewTab {
             shouldOpenNewTab = false
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            mainQueue.asyncAfter(deadline: .now() + 1) { [weak self] in
                 self?.shouldOpenNewTab = true
             }
             return .search(url: nil, isPrivate: false)

--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -10,6 +10,7 @@ import Shared
 final class RouteBuilder: FeatureFlaggable {
     private var isPrivate = false
     private var prefs: Prefs?
+    private var shouldOpenNewTab = true
 
     func configure(isPrivate: Bool,
                    prefs: Prefs) {
@@ -155,7 +156,12 @@ final class RouteBuilder: FeatureFlaggable {
 
     func makeRoute(userActivity: NSUserActivity) -> Route? {
         // If the user activity is a Siri shortcut to open the app, show a new search tab.
-        if userActivity.activityType == SiriShortcuts.activityType.openURL.rawValue {
+        // By using shouldOpenNewTab we avoid duplicated user activities, from Siri, for new tab.
+        if userActivity.activityType == SiriShortcuts.activityType.openURL.rawValue && shouldOpenNewTab {
+            shouldOpenNewTab = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                self?.shouldOpenNewTab = true
+            }
             return .search(url: nil, isPrivate: false)
         }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 @testable import Client
 
 class RouteBuilderTests: XCTestCase {
@@ -19,7 +20,7 @@ class RouteBuilderTests: XCTestCase {
         randomActivity.webpageURL = testURL
     }
     func test_makeRoute_HandlesAnyActivityType() {
-        let routeBuilder = createSubject()
+        let routeBuilder = createSubject(mainQueue: MockDispatchQueue())
 
         let route = routeBuilder.makeRoute(
             userActivity: handoffUserActivity
@@ -38,8 +39,18 @@ class RouteBuilderTests: XCTestCase {
         XCTAssertEqual(randomRoute, .search(url: testURL, isPrivate: false))
     }
 
-    private func createSubject() -> RouteBuilder {
-        let subject = RouteBuilder()
+    func test_makeRoute_ResetsShouldOpenNewTabAfterDelay() {
+        let routeBuilder = createSubject(mainQueue: MockDispatchQueue())
+        routeBuilder.shouldOpenNewTab = true
+        let userActivity = NSUserActivity(activityType: SiriShortcuts.activityType.openURL.rawValue)
+
+        _ = routeBuilder.makeRoute(userActivity: userActivity)
+
+        XCTAssertTrue(routeBuilder.shouldOpenNewTab)
+     }
+
+    private func createSubject(mainQueue: MockDispatchQueue) -> RouteBuilder {
+        let subject = RouteBuilder(mainQueue: mainQueue)
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8283)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/18375)

## :bulb: Description
Added a workaround to avoid duplicated Siri new tab shortcut

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

