### PR TITLE
Add FXIOS-11298 [Homepage] [JumpBackIn] notifications for fetching tabs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -881,7 +881,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
         switch action.actionType {
         case HeaderActionType.toggleHomepageMode:
             tabManager(for: action.windowUUID).switchPrivacyMode()
-        case HomepageActionType.initialize:
+        case HomepageActionType.initialize, JumpBackInActionType.fetchLocalTabs:
             store.dispatch(
                 TabManagerAction(
                     recentTabs: tabManager(for: action.windowUUID).recentlyAccessedNormalTabs,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -88,7 +88,10 @@ final class HomepageViewController: UIViewController,
             .DefaultSearchEngineUpdated,
             .BookmarksUpdated,
             .RustPlacesOpened,
-            .TabDataUpdated
+            .TabDataUpdated,
+            .TabsTrayDidClose,
+            .TabsTrayDidSelectHomeTab,
+            .TopTabsTabClosed
         ])
 
         subscribeToRedux()
@@ -745,7 +748,10 @@ final class HomepageViewController: UIViewController,
             )
         case .ProfileDidFinishSyncing, .FirefoxAccountChanged:
             dispatchActionToFetchTopSites()
-            dispatchActionToFetchRemoteTabs()
+            dispatchActionToFetchTabs()
+
+        case .TabDataUpdated, .TabsTrayDidClose, .TabsTrayDidSelectHomeTab, .TopTabsTabClosed:
+            dispatchActionToFetchTabs()
         default: break
         }
     }
@@ -759,7 +765,13 @@ final class HomepageViewController: UIViewController,
         )
     }
 
-    private func dispatchActionToFetchRemoteTabs() {
+    private func dispatchActionToFetchTabs() {
+        store.dispatch(
+            JumpBackInAction(
+                windowUUID: self.windowUUID,
+                actionType: JumpBackInActionType.fetchLocalTabs
+            )
+        )
         store.dispatch(
             JumpBackInAction(
                 windowUUID: self.windowUUID,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInAction.swift
@@ -7,5 +7,6 @@ import Redux
 final class JumpBackInAction: Action { }
 
 enum JumpBackInActionType: ActionType {
+    case fetchLocalTabs
     case fetchRemoteTabs
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -45,22 +45,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         let sut = createSubject()
 
         XCTAssertEqual(mockThemeManager?.getCurrentThemeCallCount, 0)
-        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 9)
-        XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
-                                                           .FirefoxAccountChanged,
-                                                           .PrivateDataClearedHistory,
-                                                           .ProfileDidFinishSyncing,
-                                                           .TopSitesUpdated,
-                                                           .DefaultSearchEngineUpdated,
-                                                           .BookmarksUpdated,
-                                                           .RustPlacesOpened,
-                                                           .TabDataUpdated
-        ])
-
-        sut.loadViewIfNeeded()
-
-        XCTAssertEqual(mockThemeManager?.getCurrentThemeCallCount, 1)
-        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 10)
+        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 12)
         XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
                                                            .FirefoxAccountChanged,
                                                            .PrivateDataClearedHistory,
@@ -70,6 +55,27 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
                                                            .BookmarksUpdated,
                                                            .RustPlacesOpened,
                                                            .TabDataUpdated,
+                                                           .TabsTrayDidClose,
+                                                           .TabsTrayDidSelectHomeTab,
+                                                           .TopTabsTabClosed
+        ])
+
+        sut.loadViewIfNeeded()
+
+        XCTAssertEqual(mockThemeManager?.getCurrentThemeCallCount, 1)
+        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 13)
+        XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
+                                                           .FirefoxAccountChanged,
+                                                           .PrivateDataClearedHistory,
+                                                           .ProfileDidFinishSyncing,
+                                                           .TopSitesUpdated,
+                                                           .DefaultSearchEngineUpdated,
+                                                           .BookmarksUpdated,
+                                                           .RustPlacesOpened,
+                                                           .TabDataUpdated,
+                                                           .TabsTrayDidClose,
+                                                           .TabsTrayDidSelectHomeTab,
+                                                           .TopTabsTabClosed,
                                                            .ThemeDidChange
         ])
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11298)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24571)

## :bulb: Description
Add actions to fetch tabs for jumpback in section after observing tab related updates.

Note: A future PR may exist to change the naming of the actions since currently they are named after the consequences of the action taken (this will change all notification related actions, not just jump back in). Will revisit this in a separate PR with the team. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

