### PR TITLE
Add FXIOS-10996 Add more History Panel logging to track issue with duplicate Site identifiers

### DIFF
--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -26,9 +26,6 @@ public enum LoggerCategory: String {
     /// Related to old homepage UI and it's data management. To be replaced by the homepage rebuild project.
     case legacyHomepage
 
-    /// Related to the history panel and browsing history.
-    case history
-
     /// Related to new homepage UI and it's data management for the homepage rebuild project.
     case homepage
 

--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -26,6 +26,9 @@ public enum LoggerCategory: String {
     /// Related to old homepage UI and it's data management. To be replaced by the homepage rebuild project.
     case legacyHomepage
 
+    /// Related to the history panel and browsing history.
+    case history
+
     /// Related to new homepage UI and it's data management for the homepage rebuild project.
     case homepage
 

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
@@ -28,11 +28,15 @@ extension HistoryPanel: UISearchBarDelegate {
     }
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        logger.log("User cancelled history search", level: .info, category: .history)
+
         bottomStackView.isHidden = true
         searchBar.resignFirstResponder()
     }
 
     func startSearchState() {
+        logger.log("User initiated history search", level: .info, category: .history)
+
         updatePanelState(newState: .history(state: .search))
         bottomStackView.isHidden = false
         searchbar.becomeFirstResponder()
@@ -53,15 +57,20 @@ extension HistoryPanel: UISearchBarDelegate {
     }
 
     func applySearchSnapshot() {
+        logger.log("Create and apply snapshot from user history search", level: .info, category: .history)
+
         // Create search results snapshot and apply
         var snapshot = NSDiffableDataSourceSnapshot<HistoryPanelSections, AnyHashable>()
         snapshot.appendSections([HistoryPanelSections.searchResults])
         snapshot.appendItems(self.viewModel.searchResultSites)
+
         self.diffableDataSource?.apply(snapshot, animatingDifferences: false)
         self.updateEmptyPanelState()
     }
 
     private func handleEmptySearch() {
+        logger.log("Apply snapshot from user history empty search", level: .info, category: .history)
+
         viewModel.searchResultSites.removeAll()
         applySnapshot()
         updateEmptyPanelState()

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
@@ -28,14 +28,14 @@ extension HistoryPanel: UISearchBarDelegate {
     }
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        logger.log("User cancelled history search", level: .info, category: .history)
+        logger.log("User cancelled history search", level: .info, category: .library)
 
         bottomStackView.isHidden = true
         searchBar.resignFirstResponder()
     }
 
     func startSearchState() {
-        logger.log("User initiated history search", level: .info, category: .history)
+        logger.log("User initiated history search", level: .info, category: .library)
 
         updatePanelState(newState: .history(state: .search))
         bottomStackView.isHidden = false
@@ -67,7 +67,7 @@ extension HistoryPanel: UISearchBarDelegate {
     }
 
     private func handleEmptySearch() {
-        logger.log("Apply snapshot from user history empty search", level: .info, category: .history)
+        logger.log("Apply snapshot from user history empty search", level: .info, category: .library)
 
         viewModel.searchResultSites.removeAll()
         applySnapshot()

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel+Search.swift
@@ -57,8 +57,6 @@ extension HistoryPanel: UISearchBarDelegate {
     }
 
     func applySearchSnapshot() {
-        logger.log("Create and apply snapshot from user history search", level: .info, category: .history)
-
         // Create search results snapshot and apply
         var snapshot = NSDiffableDataSourceSnapshot<HistoryPanelSections, AnyHashable>()
         snapshot.appendSections([HistoryPanelSections.searchResults])

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -504,7 +504,7 @@ class HistoryPanel: UIViewController,
                     logger.log(
                         "Duplicates (\(duplicates.count)) found in HistoryPanel applySnapshot method in section \(section), with \(duplicates.values.sorted(by: { $0 > $1 }).first ?? 0) being the largest number of duplicates for one Site.",
                         level: .fatal,
-                        category: .history
+                        category: .library
                     )
 
                     // If you crash here, please record your steps in ticket FXIOS-10996. Diagnose if possible as you
@@ -540,7 +540,7 @@ class HistoryPanel: UIViewController,
                     logger.log(
                         "Inserted search terms group in HistoryPanel after Site",
                         level: .fatal,
-                        category: .history
+                        category: .library
                     )
 
                     // In this case, we have Site items AND a group in the section.
@@ -549,7 +549,7 @@ class HistoryPanel: UIViewController,
                     logger.log(
                         "Inserted search terms group in HistoryPanel after ASGroup",
                         level: .fatal,
-                        category: .history
+                        category: .library
                     )
 
                     // Looks like this group's the only item in the section

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -493,17 +493,13 @@ class HistoryPanel: UIViewController,
         snapshot.sectionIdentifiers.forEach { section in
             if !viewModel.hiddenSections.contains(where: { $0 == section }) {
                 let sectionData = viewModel.dateGroupedSites.itemsForSection(section.rawValue - 1)
+                let sectionDataUniqued = sectionData.uniqued()
 
                 // FXIOS-10996 Temporary in-place check for duplicates to help diagnose history panel crashes
-                var duplicates: [Site: Int] = [:]
-                for element in sectionData where sectionData.filter({ element == $0 }).count > 1 {
-                    duplicates[element] = (duplicates[element] ?? 0) + 1
-                }
-
-                if !duplicates.isEmpty {
-                    let largestDuplicateCount = duplicates.values.sorted(by: { $0 > $1 }).first ?? 0
+                if sectionData.count > sectionDataUniqued.count {
+                    let numberOfDuplicates = sectionData.count - sectionDataUniqued.count
                     logger.log(
-                        "Duplicates (\(duplicates.count)) found in HistoryPanel applySnapshot method in section \(section), with \(largestDuplicateCount) being the largest number of duplicates for one Site.",
+                        "Duplicates (\(numberOfDuplicates)) found in HistoryPanel applySnapshot method in section \(section).",
                         level: .fatal,
                         category: .library
                     )
@@ -515,7 +511,7 @@ class HistoryPanel: UIViewController,
                 }
 
                 snapshot.appendItems(
-                    sectionData.uniqued(), // FXIOS-10996 Force unique while we investigate history panel crashes
+                    sectionDataUniqued, // FXIOS-10996 Force unique while we investigate history panel crashes
                     toSection: section
                 )
             }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -40,7 +40,7 @@ class HistoryPanel: UIViewController,
     var themeManager: ThemeManager
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol
-    private var logger: Logger
+    var logger: Logger
 
     // We'll be able to prefetch more often the higher this number is. But remember, it's expensive!
     private let historyPanelPrefetchOffset = 8
@@ -523,7 +523,7 @@ class HistoryPanel: UIViewController,
             }
         }
 
-        // Insert your fixed first section and data
+        // Insert your fixed first section and data (e.g. "Recently Closed" cell)
         if let historySection = snapshot.sectionIdentifiers.first, historySection != .additionalHistoryActions {
             snapshot.insertSections([.additionalHistoryActions], beforeSection: historySection)
         } else {

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -507,16 +507,30 @@ class HistoryPanel: UIViewController,
                 else { return }
 
                 let groupTimeInterval = TimeInterval.fromMicrosecondTimestamp(lastVisit.date)
+                let sectionData = viewModel.dateGroupedSites.itemsForSection(groupSection.rawValue - 1)
 
-                if let groupPlacedAfterItem = (
-                    viewModel.dateGroupedSites.itemsForSection(groupSection.rawValue - 1)
-                ).first(where: { site in
+                let groupPlacedAfterItem = sectionData.first(where: { site in
                     guard let lastVisit = site.latestVisit else { return false }
+
                     return groupTimeInterval > TimeInterval.fromMicrosecondTimestamp(lastVisit.date)
-                }) {
+                })
+
+                if let groupPlacedAfterItem {
+                    logger.log(
+                        "Inserted search terms group in HistoryPanel after Site",
+                        level: .fatal,
+                        category: .history
+                    )
+
                     // In this case, we have Site items AND a group in the section.
                     snapshot.insertItems([grouping], beforeItem: groupPlacedAfterItem)
                 } else {
+                    logger.log(
+                        "Inserted search terms group in HistoryPanel after ASGroup",
+                        level: .fatal,
+                        category: .history
+                    )
+
                     // Looks like this group's the only item in the section
                     snapshot.appendItems([grouping], toSection: groupSection)
                 }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -495,7 +495,7 @@ class HistoryPanel: UIViewController,
                 let sectionData = viewModel.dateGroupedSites.itemsForSection(section.rawValue - 1)
                 let sectionDataUniqued = sectionData.uniqued()
 
-                // FXIOS-10996 Temporary in-place check for duplicates to help diagnose history panel crashes
+                // FXIOS-10996 Temporary check for duplicates to help diagnose history panel crashes
                 if sectionData.count > sectionDataUniqued.count {
                     let numberOfDuplicates = sectionData.count - sectionDataUniqued.count
                     logger.log(

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -501,8 +501,9 @@ class HistoryPanel: UIViewController,
                 }
 
                 if !duplicates.isEmpty {
+                    let largestDuplicateCount = duplicates.values.sorted(by: { $0 > $1 }).first ?? 0
                     logger.log(
-                        "Duplicates (\(duplicates.count)) found in HistoryPanel applySnapshot method in section \(section), with \(duplicates.values.sorted(by: { $0 > $1 }).first ?? 0) being the largest number of duplicates for one Site.",
+                        "Duplicates (\(duplicates.count)) found in HistoryPanel applySnapshot method in section \(section), with \(largestDuplicateCount) being the largest number of duplicates for one Site.",
                         level: .fatal,
                         category: .library
                     )

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -826,7 +826,7 @@ extension RustPlaces {
                 self?.logger.log(
                     "RustPlaces sites history returned \(duplicateCount) duplicate Sites",
                     level: .info,
-                    category: .history
+                    category: .library
                 )
             }
 

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -820,7 +820,7 @@ extension RustPlaces {
 
             let sitesUniqued = sites.uniqued()
 
-            // FXIOS-10996 Temporary in-place check for duplicates to help diagnose history panel crashes
+            // FXIOS-10996 Temporary check for duplicates to help diagnose history panel crashes
             if sites.count != sitesUniqued.count {
                 let duplicateCount = sitesUniqued.count - sites.count
                 self?.logger.log(

--- a/firefox-ios/Storage/Rust/RustPlaces.swift
+++ b/firefox-ios/Storage/Rust/RustPlaces.swift
@@ -797,7 +797,7 @@ extension RustPlaces {
     ) -> Deferred<Maybe<Cursor<Site>>> {
         let deferred = getVisitPageWithBound(limit: limit, offset: offset, excludedTypes: excludedTypes)
         let result = Deferred<Maybe<Cursor<Site>>>()
-        deferred.upon { visitInfos in
+        deferred.upon { [weak self] visitInfos in
             guard let visitInfos = visitInfos.successValue else {
                 result.fill(Maybe(failure: visitInfos.failureValue ?? "Unknown Error"))
                 return
@@ -816,7 +816,20 @@ extension RustPlaces {
                 var site = Site.createBasicSite(id: hashValue, url: info.url, title: title)
                 site.latestVisit = Visit(date: UInt64(info.timestamp) * 1000, type: info.visitType)
                 return site
-            }.uniqued()
+            }
+
+            let sitesUniqued = sites.uniqued()
+
+            // FXIOS-10996 Temporary in-place check for duplicates to help diagnose history panel crashes
+            if sites.count != sitesUniqued.count {
+                let duplicateCount = sitesUniqued.count - sites.count
+                self?.logger.log(
+                    "RustPlaces sites history returned \(duplicateCount) duplicate Sites",
+                    level: .info,
+                    category: .history
+                )
+            }
+
             result.fill(Maybe(success: ArrayCursor(data: sites)))
         }
         return result


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10996)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24014)

## :bulb: Description
This PR adds some additional fatal logs and info logs so we have more context in Sentry around our duplicate history identifiers.

As well, in the applySnapshot for the history diffable data source, we are forcing unique elements in prod and crashing with an assertionFailure in dev. That means prod should (hopefully) not crash, and dev should crash in a place where we can investigate the duplication.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

