### PR TITLE
Add FXIOS-11204 [Homepage] [JumpBackIn] handle long press

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuConfiguration.swift
@@ -13,6 +13,10 @@ struct ContextMenuConfiguration: Equatable {
         switch item {
         case .topSite(let state, _):
             return state.site
+        case .jumpBackIn(let config):
+            return Site.createBasicSite(url: config.siteURL, title: config.titleText)
+        case .jumpBackInSyncedTab(let config):
+            return Site.createBasicSite(url: config.url.absoluteString, title: config.titleText)
         case .bookmark(let state):
             return Site.createBasicSite(url: state.site.url, title: state.site.title)
         case .pocket(let state):

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -52,6 +52,8 @@ struct ContextMenuState {
         switch configuration.homepageSection {
         case .topSites:
             actions = [getTopSitesActions(site: site)]
+        case .jumpBackIn:
+            actions = [getJumpBackInActions(site: site)]
         case .bookmarks:
             actions = [getBookmarksActions(site: site)]
         case .pocket:
@@ -164,6 +166,18 @@ struct ContextMenuState {
             dispatchOpenNewTabAction(siteURL: url, isPrivate: false, selectNewTab: true)
             // TODO: FXIOS-10171 - Add telemetry
         }).items
+    }
+
+    // MARK: - JumpBack In section item's context menu actions
+    private func getJumpBackInActions(site: Site) -> [PhotonRowActions] {
+        guard let siteURL = site.url.asURL else { return [] }
+
+        let openInNewTabAction = getOpenInNewTabAction(siteURL: siteURL)
+        let openInNewPrivateTabAction = getOpenInNewPrivateTabAction(siteURL: siteURL)
+        let shareAction = getShareAction(siteURL: site.url)
+        let bookmarkAction = getBookmarkAction(site: site)
+
+        return [openInNewTabAction, openInNewPrivateTabAction, bookmarkAction, shareAction]
     }
 
     // MARK: - Homepage Bookmarks section item's context menu actions


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11204)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24395)

## :bulb: Description
Add showing context menu / photon action sheet when long pressing on jumpback in items.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

# Screenshots

https://github.com/user-attachments/assets/46dff5bb-a685-4d60-a309-6c603ef1a06f


