### PR TITLE
Bugfix FXIOS-11315 [Bookmarks Evolution] Prevent memory leak in BookmarksViewController

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -119,6 +119,9 @@ class BookmarksViewController: SiteTableViewController,
 
     deinit {
         notificationCenter.removeObserver(self)
+
+        // FXIOS-11315: Necessary to prevent BookmarksFolderEmptyStateView from being retained in memory
+        a11yEmptyStateScrollView.removeFromSuperview()
     }
 
     // MARK: - Lifecycle


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11315)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24614)

## :bulb: Description
- Prevent a memory leak in `BookmarksViewController` where `BookmarksFolderEmptyStateView` was not being deallocated as expected

### 📝 Discussion
- Not exactly sure why the `a11yEmptyStateScrollView` and `emptyStateView` are retained after deallocating `BookmarksViewController`, but removing them from the view hierarchy seems to resolve the issue

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

