### PR TITLE
Refactor FXIOS-8469 Minor cleanup: SearchEngineProvider

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/DefaultSearchEngineProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/DefaultSearchEngineProvider.swift
@@ -10,9 +10,6 @@ protocol SearchEngineProvider {
     func getOrderedEngines(customEngines: [OpenSearchEngine],
                            orderedEngineNames: [String]?,
                            completion: @escaping ([OpenSearchEngine]) -> Void)
-    func getUnorderedBundledEnginesFor(locale: Locale,
-                                       possibleLanguageIdentifier: [String],
-                                       completion: @escaping ([OpenSearchEngine]) -> Void)
 }
 
 class DefaultSearchEngineProvider: SearchEngineProvider {
@@ -68,9 +65,9 @@ class DefaultSearchEngineProvider: SearchEngineProvider {
         })
     }
 
-    func getUnorderedBundledEnginesFor(locale: Locale,
-                                       possibleLanguageIdentifier: [String],
-                                       completion: @escaping ([OpenSearchEngine]) -> Void ) {
+    private func getUnorderedBundledEnginesFor(locale: Locale,
+                                               possibleLanguageIdentifier: [String],
+                                               completion: @escaping ([OpenSearchEngine]) -> Void ) {
         let region = locale.regionCode ?? "US"
         let parser = OpenSearchParser(pluginMode: true)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/MockSearchEngineProvider.swift
@@ -68,10 +68,4 @@ class MockSearchEngineProvider: SearchEngineProvider {
                            completion: @escaping ([OpenSearchEngine]) -> Void) {
         completion(mockEngines)
     }
-
-    func getUnorderedBundledEnginesFor(locale: Locale,
-                                       possibleLanguageIdentifier: [String],
-                                       completion: @escaping ([OpenSearchEngine]) -> Void) {
-        unorderedEngines = completion
-    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-8469)

## :bulb: Description

Minor cleanup: the public protocol for `SearchEngineProvider` shouldn't include an unordered option since it isn't used anywhere (except internally by our default implementation).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

