### PR TITLE
Refactor FXIOS-11184 [WebEngine] Adjusting Observer functionalities in EngineSession to be on par with production

### DIFF
--- a/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDelegate.swift
@@ -19,6 +19,9 @@ public protocol EngineSessionDelegate: AnyObject {
     /// Event to indicate the loading progress has been updated.
     func onProgress(progress: Double)
 
+    /// Event to indicate we should hide the progress bar since we don't want to animate it for example on localhost
+    func onHideProgressBar()
+
     /// Event to indicate there has been a navigation change.
     func onNavigationStateChange(canGoBack: Bool, canGoForward: Bool)
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalURL.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Internal/WKInternalURL.swift
@@ -97,7 +97,7 @@ final class WKInternalURL: InternalURL {
         return nil
     }
 
-    private var isErrorPage: Bool {
+    var isErrorPage: Bool {
         return WKInternalURL.Path.errorpage.matches(url.path)
     }
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -278,11 +278,11 @@ class WKEngineSession: NSObject,
         // Will be used as needed when we start using the engine session
         switch path {
         case .canGoBack:
-            guard let canGoBack = change?[.newKey] as? Bool else { return }
+            guard let canGoBack = change?[.newKey] as? Bool else { break }
             delegate?.onNavigationStateChange(canGoBack: canGoBack,
                                               canGoForward: webView.canGoForward)
         case .canGoForward:
-            guard let canGoForward = change?[.newKey] as? Bool else { return }
+            guard let canGoForward = change?[.newKey] as? Bool else { break }
             delegate?.onNavigationStateChange(canGoBack: webView.canGoBack,
                                               canGoForward: canGoForward)
         case .contentSize:

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -278,18 +278,25 @@ class WKEngineSession: NSObject,
         // Will be used as needed when we start using the engine session
         switch path {
         case .canGoBack:
-            delegate?.onNavigationStateChange(canGoBack: webView.canGoBack,
+            guard let canGoBack = change?[.newKey] as? Bool else { return }
+            delegate?.onNavigationStateChange(canGoBack: canGoBack,
                                               canGoForward: webView.canGoForward)
         case .canGoForward:
+            guard let canGoForward = change?[.newKey] as? Bool else { return }
             delegate?.onNavigationStateChange(canGoBack: webView.canGoBack,
-                                              canGoForward: webView.canGoForward)
+                                              canGoForward: canGoForward)
         case .contentSize:
             // TODO: FXIOS-8086 - Handle view port in WebEngine
             break
         case .estimatedProgress:
-            delegate?.onProgress(progress: webView.estimatedProgress)
+            if let url = webView.url, !WKInternalURL.isValid(url: url) {
+                delegate?.onProgress(progress: webView.estimatedProgress)
+            } else {
+                delegate?.onHideProgressBar()
+            }
         case .loading:
             guard let loading = change?[.newKey] as? Bool else { break }
+            setupLoadingSpinnerFor(webView, isLoading: loading)
             delegate?.onLoadingStateChange(loading: loading)
         case .title:
             guard let title = webView.title else { break }
@@ -302,24 +309,39 @@ class WKEngineSession: NSObject,
     }
 
     private func handleHasOnlySecureContentChanged(_ value: Bool) {
+        sessionData.hasOnlySecureContent = value
         delegate?.onHasOnlySecureContentChanged(secure: value)
     }
 
     private func handleTitleChange(title: String) {
         // Ensure that the title actually changed to prevent repeated calls to onTitleChange
-        if !title.isEmpty {
+        if !title.isEmpty, title != sessionData.title {
             sessionData.title = title
             delegate?.onTitleChange(title: title)
         }
+    }
 
-        // TODO: FXIOS-8273 - Add telemetry integration in WebEngine and first telemetry call
-        // TelemetryWrapper.recordEvent(category: .action, method: .navigate, object: .tab)
+    private func setupLoadingSpinnerFor(_ webView: WKEngineWebView, isLoading: Bool) {
+        if isLoading {
+            webView.engineScrollView?.refreshControl?.beginRefreshing()
+        } else {
+            webView.engineScrollView?.refreshControl?.endRefreshing()
+        }
     }
 
     private func handleURLChange() {
         // Special case for "about:blank" popups, if the webView.url is nil, keep the sessionData url as "about:blank"
         if sessionData.url?.absoluteString == EngineConstants.aboutBlank
             && webView.url == nil { return }
+
+        // Ensure we do have a URL from that observer
+        guard let url = webView.url else { return }
+
+        // Security safety check (Bugzilla #1933079)
+        if let internalURL = WKInternalURL(url), internalURL.isErrorPage, !internalURL.isAuthorized {
+            webView.load(URLRequest(url: URL(string: EngineConstants.aboutBlank)!))
+            return
+        }
 
         // To prevent spoofing, only change the URL immediately if the new URL is on
         // the same origin as the current URL. Otherwise, do nothing and wait for

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSessionData.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSessionData.swift
@@ -10,4 +10,5 @@ struct WKEngineSessionData {
     var lastRequest: URLRequest?
     var title: String?
     var pageMetadata: EnginePageMetadata?
+    var hasOnlySecureContent: Bool?
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKScrollView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKScrollView.swift
@@ -6,6 +6,7 @@ import UIKit
 
 /// The `WKEngineWebView` scroll view
 protocol WKScrollView {
+    var refreshControl: UIRefreshControl? { get set }
     func setContentOffset(
         _ contentOffset: CGPoint,
         animated: Bool

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockEngineScrollView.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockEngineScrollView.swift
@@ -3,9 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import UIKit
 @testable import WebEngine
 
 class MockEngineScrollView: WKScrollView {
+    var refreshControl: UIRefreshControl?
     var setContentOffsetCalled = 0
     var savedContentOffset: CGPoint?
 

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockEngineSessionDelegate.swift
@@ -9,6 +9,7 @@ import UIKit.UIContextMenuConfiguration
 class MockEngineSessionDelegate: EngineSessionDelegate {
     var onTitleChangeCalled = 0
     var onProgressCalled = 0
+    var onHideProgressCalled = 0
     var onNavigationStateChangeCalled = 0
     var onLoadingStateChangeCalled = 0
     var onLocationChangedCalled = 0
@@ -50,6 +51,10 @@ class MockEngineSessionDelegate: EngineSessionDelegate {
     func onProgress(progress: Double) {
         onProgressCalled += 1
         savedProgressValue = progress
+    }
+
+    func onHideProgressBar() {
+        onHideProgressCalled += 1
     }
 
     func onNavigationStateChange(canGoBack: Bool, canGoForward: Bool) {

--- a/BrowserKit/Tests/WebEngineTests/Mock/MockUIRefreshControl.swift
+++ b/BrowserKit/Tests/WebEngineTests/Mock/MockUIRefreshControl.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+class MockUIRefreshControl: UIRefreshControl {
+    var beginRefreshingCalled = 0
+    var endRefreshingCalled = 0
+
+    override func beginRefreshing() {
+        beginRefreshingCalled += 1
+    }
+
+    override func endRefreshing() {
+        endRefreshingCalled += 1
+    }
+}

--- a/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineSessionTests.swift
@@ -571,7 +571,6 @@ final class WKEngineSessionTests: XCTestCase {
                               change: nil,
                               context: nil)
 
-
         XCTAssertEqual(subject?.sessionData.url, nil)
         XCTAssertEqual(webViewProvider.webView.loadCalled, 1)
         XCTAssertEqual(webViewProvider.webView.url, URL(string: "about:blank")!)

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -21,7 +21,6 @@ protocol NavigationDelegate: AnyObject {
 class BrowserViewController: UIViewController,
                              EngineSessionDelegate,
                              FindInPageHelperDelegate {
-
     weak var navigationDelegate: NavigationDelegate?
     private lazy var progressView: UIProgressView = .build { _ in }
     private var engineSession: EngineSession

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -21,6 +21,7 @@ protocol NavigationDelegate: AnyObject {
 class BrowserViewController: UIViewController,
                              EngineSessionDelegate,
                              FindInPageHelperDelegate {
+
     weak var navigationDelegate: NavigationDelegate?
     private lazy var progressView: UIProgressView = .build { _ in }
     private var engineSession: EngineSession
@@ -198,6 +199,10 @@ class BrowserViewController: UIViewController,
 
     func onProgress(progress: Double) {
         progressView.setProgress(Float(progress), animated: true)
+    }
+
+    func onHideProgressBar() {
+        progressView.isHidden = true
     }
 
     func onNavigationStateChange(canGoBack: Bool, canGoForward: Bool) {

--- a/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainer.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainer.swift
@@ -30,14 +30,16 @@ class AddressToolbarContainer: UIView, ThemeApplicable {
             toolbarDelegate: toolbarDelegate,
             leadingSpace: 0,
             trailingSpace: 0,
-            isUnifiedSearchEnabled: false
+            isUnifiedSearchEnabled: false,
+            animated: false
         )
         regularToolbar.configure(
             config: model.state,
             toolbarDelegate: toolbarDelegate,
             leadingSpace: 0,
             trailingSpace: 0,
-            isUnifiedSearchEnabled: false
+            isUnifiedSearchEnabled: false,
+            animated: false
         )
     }
 

--- a/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainerModel.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainerModel.swift
@@ -22,7 +22,8 @@ struct AddressToolbarContainerModel {
             navigationActions: navigationActions,
             pageActions: pageActions,
             browserActions: browserActions,
-            borderPosition: borderPosition)
+            borderPosition: borderPosition,
+            shouldAnimate: false)
     }
 
     private var borderPosition: AddressToolbarBorderPosition? {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11184)

## :bulb: Description
Adjust some more of the `WKEngineSession` to be on par with production code, mostly with `observeValue` that were updated in the last couple of months. Added tests and made sure `SampleBrowser` project can run.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

