### PR TITLE
Add FXIOS-11324 #24642 [WebEngine] Webview configuration on engine creation

### DIFF
--- a/BrowserKit/Sources/WebEngine/Engine.swift
+++ b/BrowserKit/Sources/WebEngine/Engine.swift
@@ -8,8 +8,11 @@ import Foundation
 /// There is only when engine view to be created, but multiple sessions can exists.
 public protocol Engine {
     /// Creates a new view for rendering web content.
+    /// - Returns: The created `EngineView`
     func createView() -> EngineView
 
     /// Creates a new engine session.
-    func createSession(dependencies: EngineSessionDependencies?) throws -> EngineSession
+    /// - Parameter dependencies: Pass in the required session dependencies on creation
+    /// - Returns: The created `EngineSession`
+    func createSession(dependencies: EngineSessionDependencies) throws -> EngineSession
 }

--- a/BrowserKit/Sources/WebEngine/EngineSessionDependencies.swift
+++ b/BrowserKit/Sources/WebEngine/EngineSessionDependencies.swift
@@ -6,9 +6,12 @@ import Foundation
 
 /// Dependencies injected during engine session creation.
 public struct EngineSessionDependencies {
+    var webviewParameters: WKWebviewParameters
     var telemetryProxy: EngineTelemetryProxy?
 
-    public init(telemetryProxy: EngineTelemetryProxy? = nil) {
+    public init(webviewParameters: WKWebviewParameters,
+                telemetryProxy: EngineTelemetryProxy? = nil) {
+        self.webviewParameters = webviewParameters
         self.telemetryProxy = telemetryProxy
     }
 }

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngine.swift
@@ -21,9 +21,11 @@ public class WKEngine: Engine {
         return WKEngineView(frame: .zero)
     }
 
-    public func createSession(dependencies: EngineSessionDependencies?) throws -> EngineSession {
+    public func createSession(dependencies: EngineSessionDependencies) throws -> EngineSession {
+        let configProvider = DefaultWKEngineConfigurationProvider(parameters: dependencies.webviewParameters)
         guard let session = WKEngineSession(userScriptManager: userScriptManager,
-                                            telemetryProxy: dependencies?.telemetryProxy) else {
+                                            telemetryProxy: dependencies.telemetryProxy,
+                                            configurationProvider: configProvider) else {
             throw EngineError.sessionNotCreated
         }
 

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
@@ -5,26 +5,42 @@
 import Foundation
 import WebKit
 
+public struct WKWebviewParameters {
+    /// A boolean value customizable with a user preference indicating whether JavaScript can open windows without user interaction.
+    var blockPopups: Bool
+
+    /// A boolean value indicating if we have a persitent webview data store.
+    var isPrivate: Bool
+
+    public init(blockPopups: Bool, isPrivate: Bool) {
+        self.blockPopups = blockPopups
+        self.isPrivate = isPrivate
+    }
+}
+
 /// Provider to get a configured `WKEngineConfiguration`
 protocol WKEngineConfigurationProvider {
     func createConfiguration() -> WKEngineConfiguration
 }
 
 struct DefaultWKEngineConfigurationProvider: WKEngineConfigurationProvider {
+    private let parameters: WKWebviewParameters
+
+    init(parameters: WKWebviewParameters) {
+        self.parameters = parameters
+    }
+
     func createConfiguration() -> WKEngineConfiguration {
         let configuration = WKWebViewConfiguration()
         configuration.processPool = WKProcessPool()
-        // TODO: FXIOS-11324 Configure KeyBlockPopups
-//        let blockPopups = prefs?.boolForKey(PrefsKeys.KeyBlockPopups) ?? true
-//        configuration.preferences.javaScriptCanOpenWindowsAutomatically = !blockPopups
+        configuration.preferences.javaScriptCanOpenWindowsAutomatically = !parameters.blockPopups
         configuration.userContentController = WKUserContentController()
         configuration.allowsInlineMediaPlayback = true
-        // TODO: FXIOS-11324 Configure isPrivate
-//        if isPrivate {
-//            configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
-//        } else {
-//            configuration.websiteDataStore = WKWebsiteDataStore.default()
-//        }
+        if parameters.isPrivate {
+            configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        } else {
+            configuration.websiteDataStore = WKWebsiteDataStore.default()
+        }
 
         configuration.setURLSchemeHandler(WKInternalSchemeHandler(),
                                           forURLScheme: WKInternalSchemeHandler.scheme)

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineConfigurationProvider.swift
@@ -6,7 +6,8 @@ import Foundation
 import WebKit
 
 public struct WKWebviewParameters {
-    /// A boolean value customizable with a user preference indicating whether JavaScript can open windows without user interaction.
+    /// A boolean value customizable with a user preference indicating whether JavaScript can
+    /// open windows without user interaction.
     var blockPopups: Bool
 
     /// A boolean value indicating if we have a persitent webview data store.

--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineSession.swift
@@ -40,7 +40,7 @@ class WKEngineSession: NSObject,
 
     init?(userScriptManager: WKUserScriptManager,
           telemetryProxy: EngineTelemetryProxy? = nil,
-          configurationProvider: WKEngineConfigurationProvider = DefaultWKEngineConfigurationProvider(),
+          configurationProvider: WKEngineConfigurationProvider,
           webViewProvider: WKWebViewProvider = DefaultWKWebViewProvider(),
           logger: Logger = DefaultLogger.shared,
           sessionData: WKEngineSessionData = WKEngineSessionData(),

--- a/BrowserKit/Tests/WebEngineTests/WKEngineTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineTests.swift
@@ -26,7 +26,9 @@ final class WKEngineTests: XCTestCase {
     func testCreateSessionThenCreatesSession() throws {
         let subject = createSubject()
 
-        let session = try XCTUnwrap(subject.createSession(dependencies: nil))
+        let params = WKWebviewParameters(blockPopups: true, isPrivate: false)
+        let dependencies = EngineSessionDependencies(webviewParameters: params)
+        let session = try XCTUnwrap(subject.createSession(dependencies: dependencies))
         XCTAssertNotNil(session)
     }
 

--- a/SampleBrowser/SampleBrowser/AppDelegate.swift
+++ b/SampleBrowser/SampleBrowser/AppDelegate.swift
@@ -13,7 +13,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     )
 
     lazy var engineProvider: EngineProvider = {
-        let dependencies = EngineSessionDependencies(telemetryProxy: TelemetryHandler())
+        let parameters = WKWebviewParameters(blockPopups: false, isPrivate: false)
+        let dependencies = EngineSessionDependencies(webviewParameters: parameters,
+                                                     telemetryProxy: TelemetryHandler())
         return EngineProvider(sessionDependencies: dependencies)!
     }()
 

--- a/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
+++ b/SampleBrowser/SampleBrowser/Engine/EngineProvider.swift
@@ -11,7 +11,7 @@ struct EngineProvider {
     let view: EngineView
 
     init?(engine: Engine = WKEngine.factory(),
-          sessionDependencies: EngineSessionDependencies? = nil) {
+          sessionDependencies: EngineSessionDependencies) {
         do {
             session = try engine.createSession(dependencies: sessionDependencies)
         } catch {

--- a/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Browser/BrowserViewController.swift
@@ -26,6 +26,7 @@ class BrowserViewController: UIViewController,
     private var engineSession: EngineSession
     private var engineView: EngineView
     private let urlFormatter: URLFormatter
+    private var gradientLayer: CAGradientLayer?
 
     // MARK: - Init
 
@@ -50,12 +51,29 @@ class BrowserViewController: UIViewController,
 
         view.backgroundColor = .clear
         setupProgressBar()
-
-        setupBrowserView(engineView)
         engineSession.delegate = self
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        setGradientBackground()
+    }
+
+    private func setGradientBackground() {
+        self.gradientLayer?.removeFromSuperlayer()
+        let colorTop =  UIColor.orange.cgColor
+        let colorBottom = UIColor.purple.cgColor
+
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.colors = [colorTop, colorBottom]
+        gradientLayer.locations = [0.0, 0.6]
+        gradientLayer.frame = self.view.bounds
+        self.gradientLayer = gradientLayer
+        view.layer.insertSublayer(gradientLayer, at: 0)
+    }
+
     private func setupBrowserView(_ engineView: EngineView) {
+        guard engineView.superview == nil else { return }
         engineView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(engineView)
 
@@ -151,6 +169,8 @@ class BrowserViewController: UIViewController,
     // MARK: - Search
 
     func loadUrlOrSearch(_ searchTerm: SearchTerm) {
+        setupBrowserView(engineView)
+
         if let url = urlFormatter.getURL(entry: searchTerm.term) {
             // Search the entered URL
             let context = BrowsingContext(type: .internalNavigation, url: url)

--- a/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainer.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainer.swift
@@ -30,14 +30,16 @@ class AddressToolbarContainer: UIView, ThemeApplicable {
             toolbarDelegate: toolbarDelegate,
             leadingSpace: 0,
             trailingSpace: 0,
-            isUnifiedSearchEnabled: false
+            isUnifiedSearchEnabled: false,
+            animated: false
         )
         regularToolbar.configure(
             config: model.state,
             toolbarDelegate: toolbarDelegate,
             leadingSpace: 0,
             trailingSpace: 0,
-            isUnifiedSearchEnabled: false
+            isUnifiedSearchEnabled: false,
+            animated: false
         )
     }
 

--- a/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainerModel.swift
+++ b/SampleBrowser/SampleBrowser/UI/Components/AddressToolbarContainerModel.swift
@@ -22,7 +22,8 @@ struct AddressToolbarContainerModel {
             navigationActions: navigationActions,
             pageActions: pageActions,
             browserActions: browserActions,
-            borderPosition: borderPosition)
+            borderPosition: borderPosition,
+            shouldAnimate: false)
     }
 
     private var borderPosition: AddressToolbarBorderPosition? {

--- a/SampleBrowser/SampleBrowser/UI/Suggestion/SuggestionViewController.swift
+++ b/SampleBrowser/SampleBrowser/UI/Suggestion/SuggestionViewController.swift
@@ -13,9 +13,6 @@ class SuggestionViewController: UIViewController, UITableViewDelegate {
     private var dataSource: SuggestionDataSource?
     private weak var delegate: SuggestionViewControllerDelegate?
 
-    private var gradientLayer: CAGradientLayer?
-    private var topIconConstraint: NSLayoutConstraint?
-
     init() {
         self.tableView = UITableView(frame: .zero, style: .grouped)
         super.init(nibName: nil, bundle: nil)
@@ -34,30 +31,6 @@ class SuggestionViewController: UIViewController, UITableViewDelegate {
 
         // Showing app logo when no search is visible
         tableView.isHidden = true
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        setGradientBackground()
-        setTopConstraint()
-    }
-
-    private func setTopConstraint() {
-        let height = view.frame.height / 5
-        topIconConstraint?.constant = height
-    }
-
-    private func setGradientBackground() {
-        self.gradientLayer?.removeFromSuperlayer()
-        let colorTop =  UIColor.orange.cgColor
-        let colorBottom = UIColor.purple.cgColor
-
-        let gradientLayer = CAGradientLayer()
-        gradientLayer.colors = [colorTop, colorBottom]
-        gradientLayer.locations = [0.0, 0.6]
-        gradientLayer.frame = self.view.bounds
-        self.gradientLayer = gradientLayer
-        view.layer.insertSublayer(gradientLayer, at: 0)
     }
 
     private func configureTableView() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11324)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24642)

## :bulb: Description
We should pass down some information from the `Client` when we create an engine session to ensure it's configured at it should, as done in [`makeWebViewConfig`](https://github.com/mozilla-mobile/firefox-ios/blob/7d76fd2410889aa7d1354fe8f1a1e19ec2cc9364/firefox-ios/Client/TabManagement/TabManagerImplementation.swift#L179)

Also fixed the gradient in `SampleBrowser` to make it pretty when we run the app. We were showing the webview right away, instead I'm delaying until we made a search to show the webview so we see this on launch of the `SampleBrowser`:

### 🎥 Sample Browser
<details>
<summary>On launch</summary>

![simulator_screenshot_9CB2F573-2EF5-46E9-8087-B3A2556E7041](https://github.com/user-attachments/assets/8d088fd8-b788-40cb-ae6b-e8b7995b8bc6)

</details>


## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

