### PR TITLE
Add FXIOS-11185 [Blueprint Download Manager] Deep Linking for Live Activities & Dynamic Island

### DIFF
--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -15,7 +15,11 @@ struct DownloadLiveActivityAttributes: ActivityAttributes {
 struct DownloadLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: DownloadLiveActivityAttributes.self) { _ in
-            EmptyView()
+            // Using Rectangle instead of EmptyView because the hitbox
+            // of the empty view is too small (likely non existent),
+            // meaning we'd never be redirected to the downloads panel
+            Rectangle()
+                .widgetURL(URL(string: URL.mozInternalScheme + "://deep-link?url=/homepanel/downloads"))
         } dynamicIsland: { _ in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.center) {
@@ -36,7 +40,7 @@ struct DownloadLiveActivity: Widget {
                 EmptyView()
             } minimal: {
                 EmptyView()
-            }
+            }.widgetURL(URL(string: URL.mozInternalScheme + "://deep-link?url=/homepanel/downloads"))
         }
-   }
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11185)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24362)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Made it so that whenever the dynamic island views as well as the live activity views are pressed, they open the downloads panel using deep links.

https://github.com/user-attachments/assets/521ce017-563a-4dd0-b3e8-2b8b8efab969



## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

