### PR TITLE
Refactor FXIOS-9450 #20911 [Accessibility] Toast message with bigger font sizes

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -32,7 +32,7 @@ public class BrowserAddressToolbar: UIView,
         static let iconsAnimationDelay: CGFloat = 0.075
     }
 
-    public var notificationCenter: any Common.NotificationProtocol = NotificationCenter.default
+    public var notificationCenter: any NotificationProtocol = NotificationCenter.default
     private weak var toolbarDelegate: AddressToolbarDelegate?
     private var theme: Theme?
     private var droppableUrl: URL?

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -352,8 +352,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate, UIDocumentPickerDele
         switch toastAction {
         case .bookmarkPage:
             let viewModel = ButtonToastViewModel(labelText: message,
-                                                 buttonText: .BookmarksEdit,
-                                                 textAlignment: .left)
+                                                 buttonText: .BookmarksEdit)
             let toast = ButtonToast(viewModel: viewModel,
                                     theme: currentTheme()) { isButtonTapped in
                 isButtonTapped ? self.openBookmarkEditPanel() : nil
@@ -365,8 +364,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate, UIDocumentPickerDele
             }
         case .removeBookmark:
             let viewModel = ButtonToastViewModel(labelText: message,
-                                                 buttonText: .UndoString,
-                                                 textAlignment: .left)
+                                                 buttonText: .UndoString)
             let toast = ButtonToast(viewModel: viewModel,
                                     theme: currentTheme()) { [weak self] isButtonTapped in
                 guard let self, let currentTab = tabManager.selectedTab else { return }
@@ -378,8 +376,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate, UIDocumentPickerDele
             show(toast: toast)
         case .closeTab:
             let viewModel = ButtonToastViewModel(labelText: message,
-                                                 buttonText: .UndoString,
-                                                 textAlignment: .left)
+                                                 buttonText: .UndoString)
             let toast = ButtonToast(viewModel: viewModel,
                                     theme: currentTheme()) { [weak self] isButtonTapped in
                 guard let self,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3496,7 +3496,6 @@ extension BrowserViewController: ClipboardBarDisplayHandlerDelegate {
     func shouldDisplay() {
         let viewModel = ButtonToastViewModel(
             labelText: .GoToCopiedLink,
-            descriptionText: "",
             buttonText: .GoButtonTittle
         )
 

--- a/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
@@ -41,13 +41,11 @@ class ButtonToast: Toast {
     private var titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.subheadline.scaledFont()
         label.numberOfLines = 0
-        label.textAlignment = .natural
     }
 
     private var descriptionLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.footnote.scaledFont()
         label.numberOfLines = 0
-        label.textAlignment = .natural
     }
 
     private var roundedButton: UIButton = .build { button in

--- a/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
@@ -11,41 +11,43 @@ struct ButtonToastViewModel {
     var descriptionText: String?
     var imageName: String?
     var buttonText: String?
-    var textAlignment: NSTextAlignment = .left
 }
 
 class ButtonToast: Toast {
     struct UX {
         static let delay = DispatchTimeInterval.milliseconds(900)
-        static let padding: CGFloat = 15
-        static let buttonPadding: CGFloat = 10
+        static let stackViewSpacing: CGFloat = 8
+        static let spacing: CGFloat = 8
+        static let buttonPadding: CGFloat = 8
         static let buttonBorderRadius: CGFloat = 8
         static let buttonBorderWidth: CGFloat = 1
-        static let widthOffset: CGFloat = 20
+        static let topBottomButtonPadding: CGFloat = 8
     }
 
     // MARK: - UI
-    private var horizontalStackView: UIStackView = .build { stackView in
-        stackView.axis = .horizontal
-        stackView.alignment = .center
-        stackView.spacing = UX.padding
+    private var contentStackView: UIStackView = .build { stackView in
+        stackView.spacing = UX.stackViewSpacing
     }
-
     private var imageView: UIImageView = .build { imageView in }
 
     private var labelStackView: UIStackView = .build { stackView in
         stackView.axis = .vertical
         stackView.alignment = .leading
+        stackView.setContentCompressionResistancePriority(.required, for: .vertical)
+        stackView.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
 
     private var titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.subheadline.scaledFont()
         label.numberOfLines = 0
+        label.textAlignment = .natural
     }
 
     private var descriptionLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.footnote.scaledFont()
         label.numberOfLines = 0
+        // LAURIE - test with RTL
+        label.textAlignment = .natural
     }
 
     private var roundedButton: UIButton = .build { button in
@@ -66,9 +68,9 @@ class ButtonToast: Toast {
 
         self.completionHandler = completion
 
-        self.clipsToBounds = true
+        clipsToBounds = true
         let createdToastView = createView(viewModel: viewModel)
-        self.addSubview(createdToastView)
+        addSubview(createdToastView)
 
         NSLayoutConstraint.activate([
             toastView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Toast.UX.shadowVerticalSpacing),
@@ -81,7 +83,7 @@ class ButtonToast: Toast {
         animationConstraint = toastView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor,
                                                              constant: Toast.UX.toastHeightWithShadow)
         animationConstraint?.isActive = true
-        if let theme = theme {
+        if let theme {
             applyTheme(theme: theme)
         }
     }
@@ -92,36 +94,32 @@ class ButtonToast: Toast {
 
     private func createView(viewModel: ButtonToastViewModel) -> UIView {
         if let imageName = viewModel.imageName {
+            // TODO: LAURIE - Test as well
             imageView = UIImageView(image: UIImage.templateImageNamed(imageName))
-            horizontalStackView.addArrangedSubview(imageView)
+            contentStackView.addArrangedSubview(imageView)
         }
 
-        titleLabel.textAlignment = viewModel.textAlignment
         titleLabel.text = viewModel.labelText
-
         labelStackView.addArrangedSubview(titleLabel)
-
         if let descriptionText = viewModel.descriptionText {
+            // TODO: LAURIE - needed?
             titleLabel.lineBreakMode = .byClipping
             titleLabel.numberOfLines = 1 // if showing a description we cant wrap to the second line
             titleLabel.adjustsFontSizeToFitWidth = true
 
-            descriptionLabel.textAlignment = viewModel.textAlignment
             descriptionLabel.text = descriptionText
             labelStackView.addArrangedSubview(descriptionLabel)
         }
 
-        horizontalStackView.addArrangedSubview(labelStackView)
-        setupPaddedButton(stackView: horizontalStackView, buttonText: viewModel.buttonText)
-        toastView.addSubview(horizontalStackView)
+        contentStackView.addArrangedSubview(labelStackView)
+        setupPaddedButton(stackView: contentStackView, buttonText: viewModel.buttonText)
+        toastView.addSubview(contentStackView)
 
         NSLayoutConstraint.activate([
-            labelStackView.centerYAnchor.constraint(equalTo: horizontalStackView.centerYAnchor),
-
-            horizontalStackView.leadingAnchor.constraint(equalTo: toastView.leadingAnchor, constant: UX.padding),
-            horizontalStackView.trailingAnchor.constraint(equalTo: toastView.trailingAnchor),
-            horizontalStackView.bottomAnchor.constraint(equalTo: toastView.safeAreaLayoutGuide.bottomAnchor),
-            horizontalStackView.topAnchor.constraint(equalTo: toastView.topAnchor)
+            contentStackView.leadingAnchor.constraint(equalTo: toastView.leadingAnchor, constant: UX.spacing),
+            contentStackView.trailingAnchor.constraint(equalTo: toastView.trailingAnchor, constant: -UX.spacing),
+            contentStackView.bottomAnchor.constraint(equalTo: toastView.bottomAnchor, constant: -UX.spacing),
+            contentStackView.topAnchor.constraint(equalTo: toastView.topAnchor, constant: UX.spacing)
         ])
         return toastView
     }
@@ -129,29 +127,17 @@ class ButtonToast: Toast {
     func setupPaddedButton(stackView: UIStackView, buttonText: String?) {
         guard let buttonText = buttonText else { return }
 
-        let paddedView = UIView()
-        paddedView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.addArrangedSubview(paddedView)
-
+        stackView.addArrangedSubview(roundedButton)
         roundedButton.setTitle(buttonText, for: [])
-        paddedView.addSubview(roundedButton)
 
         NSLayoutConstraint.activate([
             roundedButton.heightAnchor.constraint(
                 equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.height + 2 * UX.buttonPadding),
             roundedButton.widthAnchor.constraint(
-                equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * UX.buttonPadding),
-            roundedButton.centerYAnchor.constraint(equalTo: paddedView.centerYAnchor),
-            roundedButton.centerXAnchor.constraint(equalTo: paddedView.centerXAnchor),
-
-            paddedView.topAnchor.constraint(equalTo: stackView.topAnchor),
-            paddedView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
-            paddedView.widthAnchor.constraint(equalTo: roundedButton.widthAnchor, constant: UX.widthOffset)
+                equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * UX.buttonPadding)
         ])
 
         roundedButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(buttonPressed)))
-
-        paddedView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(buttonPressed)))
     }
 
     override func applyTheme(theme: Theme) {
@@ -162,6 +148,21 @@ class ButtonToast: Toast {
         imageView.tintColor = theme.colors.textInverted
         roundedButton.setTitleColor(theme.colors.textInverted, for: [])
         roundedButton.layer.borderColor = theme.colors.borderInverted.cgColor
+    }
+
+    override func adjustLayoutForA11ySizeCategory() {
+        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        if contentSizeCategory.isAccessibilityCategory {
+            contentStackView.axis = .vertical
+            contentStackView.alignment = .leading
+            contentStackView.distribution = .fillProportionally
+        } else {
+            contentStackView.axis = .horizontal
+            contentStackView.alignment = .center
+            contentStackView.distribution = .fill
+        }
+
+        setNeedsLayout()
     }
 
     // MARK: - Button action
@@ -188,7 +189,6 @@ class PasteControlToast: ButtonToast {
         pasteControl.translatesAutoresizingMaskIntoConstraints = false
         pasteControl.layer.borderWidth = UX.buttonBorderWidth
         pasteControl.layer.cornerRadius = UX.buttonBorderRadius
-        pasteControl.widthAnchor.constraint(equalToConstant: 90).isActive = true
 
         return pasteControl
     }()
@@ -204,19 +204,8 @@ class PasteControlToast: ButtonToast {
     }
 
     override func setupPaddedButton(stackView: UIStackView, buttonText: String?) {
-        let paddedView = UIView()
-        paddedView.translatesAutoresizingMaskIntoConstraints = false
-        paddedView.addSubview(pasteControl)
-        stackView.addArrangedSubview(paddedView)
-
-        NSLayoutConstraint.activate([
-            pasteControl.centerYAnchor.constraint(equalTo: paddedView.centerYAnchor),
-            pasteControl.centerXAnchor.constraint(equalTo: paddedView.centerXAnchor),
-
-            paddedView.topAnchor.constraint(equalTo: stackView.topAnchor),
-            paddedView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
-            paddedView.widthAnchor.constraint(equalTo: pasteControl.widthAnchor, constant: UX.widthOffset)
-        ])
+        stackView.addArrangedSubview(pasteControl)
+        pasteControl.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
 
     override func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
@@ -47,7 +47,6 @@ class ButtonToast: Toast {
     private var descriptionLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.footnote.scaledFont()
         label.numberOfLines = 0
-        // LAURIE - test with RTL
         label.textAlignment = .natural
     }
 
@@ -95,7 +94,6 @@ class ButtonToast: Toast {
 
     private func createView(viewModel: ButtonToastViewModel) -> UIView {
         if let imageName = viewModel.imageName {
-            // TODO: LAURIE - Test as well
             imageView = UIImageView(image: UIImage.templateImageNamed(imageName))
             contentStackView.addArrangedSubview(imageView)
         }
@@ -103,7 +101,6 @@ class ButtonToast: Toast {
         titleLabel.text = viewModel.labelText
         labelStackView.addArrangedSubview(titleLabel)
         if let descriptionText = viewModel.descriptionText {
-            // TODO: LAURIE - needed?
             titleLabel.lineBreakMode = .byClipping
             titleLabel.numberOfLines = 1 // if showing a description we cant wrap to the second line
             titleLabel.adjustsFontSizeToFitWidth = true

--- a/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/ButtonToast.swift
@@ -28,6 +28,7 @@ class ButtonToast: Toast {
     private var contentStackView: UIStackView = .build { stackView in
         stackView.spacing = UX.stackViewSpacing
     }
+
     private var imageView: UIImageView = .build { imageView in }
 
     private var labelStackView: UIStackView = .build { stackView in

--- a/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
@@ -6,6 +6,7 @@ import Common
 import Shared
 import UIKit
 
+// TODO: Laurie - check bigger font size
 class DownloadToast: Toast {
     struct UX {
         static let buttonSize: CGFloat = 40
@@ -18,7 +19,7 @@ class DownloadToast: Toast {
     private var horizontalStackView: UIStackView = .build { stackView in
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = ButtonToast.UX.padding
+        stackView.spacing = ButtonToast.UX.stackViewSpacing
     }
 
     private var imageView: UIImageView = .build { imageView in
@@ -204,11 +205,11 @@ class DownloadToast: Toast {
 
                 horizontalStackView.leadingAnchor.constraint(
                     equalTo: toastView.leadingAnchor,
-                    constant: ButtonToast.UX.padding
+                    constant: ButtonToast.UX.spacing
                 ),
                 horizontalStackView.trailingAnchor.constraint(
                     equalTo: toastView.trailingAnchor,
-                    constant: -ButtonToast.UX.padding
+                    constant: -ButtonToast.UX.spacing
                 ),
                 horizontalStackView.bottomAnchor.constraint(equalTo: toastView.safeAreaLayoutGuide.bottomAnchor),
                 horizontalStackView.topAnchor.constraint(equalTo: toastView.topAnchor),

--- a/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
@@ -257,10 +257,10 @@ class DownloadToast: Toast {
             // Description label changes with progress and if this isn't clipped the height of the
             // toast changes continually while loading
             descriptionLabel.numberOfLines = 1
-            descriptionLabel.lineBreakMode = .byClipping
+            descriptionLabel.lineBreakMode = .byTruncatingTail
         } else {
             descriptionLabel.numberOfLines = 0
-            descriptionLabel.adjustsFontSizeToFitWidth = false
+            descriptionLabel.lineBreakMode = .byWordWrapping
         }
 
         setNeedsLayout()

--- a/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadToast.swift
@@ -6,7 +6,6 @@ import Common
 import Shared
 import UIKit
 
-// TODO: Laurie - check bigger font size
 class DownloadToast: Toast {
     struct UX {
         static let buttonSize: CGFloat = 40
@@ -16,10 +15,11 @@ class DownloadToast: Toast {
         view.layer.cornerRadius = Toast.UX.toastCornerRadius
     }
 
-    private var horizontalStackView: UIStackView = .build { stackView in
+    private var contentStackView: UIStackView = .build { stackView in
+        stackView.spacing = ButtonToast.UX.stackViewSpacing
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.spacing = ButtonToast.UX.stackViewSpacing
+        stackView.distribution = .fill
     }
 
     private var imageView: UIImageView = .build { imageView in
@@ -140,10 +140,10 @@ class DownloadToast: Toast {
             toastView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Toast.UX.shadowVerticalSpacing),
             toastView.heightAnchor.constraint(equalTo: heightAnchor, constant: -Toast.UX.shadowHorizontalSpacing),
 
-            heightAnchor.constraint(equalToConstant: Toast.UX.toastHeightWithShadow)
+            heightAnchor.constraint(greaterThanOrEqualToConstant: Toast.UX.toastHeightWithShadow)
         ])
 
-        animationConstraint = toastView.topAnchor.constraint(equalTo: topAnchor,
+        animationConstraint = toastView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor,
                                                              constant: Toast.UX.toastHeightWithShadow)
         animationConstraint?.isActive = true
         applyTheme(theme: theme)
@@ -183,7 +183,7 @@ class DownloadToast: Toast {
     }
 
     func createView(_ labelText: String, descriptionText: String) -> UIView {
-        horizontalStackView.addArrangedSubview(imageView)
+        contentStackView.addArrangedSubview(imageView)
 
         titleLabel.text = labelText
         descriptionLabel.text = descriptionText
@@ -191,11 +191,11 @@ class DownloadToast: Toast {
         labelStackView.addArrangedSubview(titleLabel)
         labelStackView.addArrangedSubview(descriptionLabel)
 
-        horizontalStackView.addArrangedSubview(labelStackView)
-        horizontalStackView.addArrangedSubview(closeButton)
+        contentStackView.addArrangedSubview(labelStackView)
+        contentStackView.addArrangedSubview(closeButton)
 
         toastView.addSubview(progressView)
-        toastView.addSubview(horizontalStackView)
+        toastView.addSubview(contentStackView)
 
         NSLayoutConstraint.activate(
             [
@@ -203,16 +203,14 @@ class DownloadToast: Toast {
                 progressView.centerYAnchor.constraint(equalTo: toastView.centerYAnchor),
                 progressView.heightAnchor.constraint(equalTo: toastView.heightAnchor),
 
-                horizontalStackView.leadingAnchor.constraint(
-                    equalTo: toastView.leadingAnchor,
-                    constant: ButtonToast.UX.spacing
-                ),
-                horizontalStackView.trailingAnchor.constraint(
-                    equalTo: toastView.trailingAnchor,
-                    constant: -ButtonToast.UX.spacing
-                ),
-                horizontalStackView.bottomAnchor.constraint(equalTo: toastView.safeAreaLayoutGuide.bottomAnchor),
-                horizontalStackView.topAnchor.constraint(equalTo: toastView.topAnchor),
+                contentStackView.leadingAnchor.constraint(equalTo: toastView.leadingAnchor,
+                                                          constant: ButtonToast.UX.spacing),
+                contentStackView.trailingAnchor.constraint(equalTo: toastView.trailingAnchor,
+                                                           constant: -ButtonToast.UX.spacing),
+                contentStackView.bottomAnchor.constraint(equalTo: toastView.bottomAnchor,
+                                                         constant: -ButtonToast.UX.spacing),
+                contentStackView.topAnchor.constraint(equalTo: toastView.topAnchor,
+                                                      constant: ButtonToast.UX.spacing),
 
                 closeButton.heightAnchor.constraint(equalToConstant: UX.buttonSize),
                 closeButton.widthAnchor.constraint(equalToConstant: UX.buttonSize),
@@ -251,6 +249,21 @@ class DownloadToast: Toast {
         imageView.tintColor = theme.colors.textInverted
         closeButton.tintColor = theme.colors.textInverted
         progressView.backgroundColor = theme.colors.actionPrimaryHover
+    }
+
+    override func adjustLayoutForA11ySizeCategory() {
+        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        if contentSizeCategory.isAccessibilityCategory {
+            // Description label changes with progress and if this isn't clipped the height of the
+            // toast changes continually while loading
+            descriptionLabel.numberOfLines = 1
+            descriptionLabel.lineBreakMode = .byClipping
+        } else {
+            descriptionLabel.numberOfLines = 0
+            descriptionLabel.adjustsFontSizeToFitWidth = false
+        }
+
+        setNeedsLayout()
     }
 
     override func handleTap(_ gestureRecognizer: UIGestureRecognizer) {

--- a/firefox-ios/Client/Frontend/Browser/Toast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toast.swift
@@ -7,7 +7,7 @@ import Foundation
 import UIKit
 import Shared
 
-class Toast: UIView, ThemeApplicable {
+class Toast: UIView, ThemeApplicable, Notifiable {
     struct UX {
         static let toastHeightWithoutShadow: CGFloat = 56
         static let toastHeightWithShadow: CGFloat = 68
@@ -26,6 +26,7 @@ class Toast: UIView, ThemeApplicable {
         static let shadowVerticalSpacing: CGFloat = 8
     }
 
+    public var notificationCenter: NotificationProtocol = NotificationCenter.default
     var animationConstraint: NSLayoutConstraint?
     var completionHandler: ((Bool) -> Void)?
 
@@ -40,6 +41,16 @@ class Toast: UIView, ThemeApplicable {
     }()
 
     lazy var toastView: UIView = .build { _ in }
+
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setupNotifications(forObserver: self, observing: [UIContentSizeCategory.didChangeNotification])
+        adjustLayoutForA11ySizeCategory()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func didMoveToSuperview() {
         super.didMoveToSuperview()
@@ -121,5 +132,18 @@ class Toast: UIView, ThemeApplicable {
         toastView.layer.shadowOffset = UX.shadowOffset
         toastView.layer.shadowColor = theme.colors.shadowDefault.cgColor
         toastView.layer.shadowOpacity = UX.shadowOpacity
+    }
+
+    open func adjustLayoutForA11ySizeCategory() {
+        // To override depending on the subclass
+    }
+
+    // MARK: - Notifiable
+    public func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case UIContentSizeCategory.didChangeNotification:
+            adjustLayoutForA11ySizeCategory()
+        default: break
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -253,8 +253,7 @@ class BookmarksViewController: SiteTableViewController,
 
             let toastVM = ButtonToastViewModel(
                 labelText: String(format: .Bookmarks.Menu.DeletedBookmark, bookmarkNode.title),
-                buttonText: .UndoString,
-                textAlignment: .left)
+                buttonText: .UndoString)
             let toast = ButtonToast(viewModel: toastVM,
                                     theme: self.currentTheme(),
                                     completion: { buttonPressed in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9450)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20911)

## :bulb: Description
- Fixing height constraints for `DownloadToast`, `ButtonToast` and `PasteControlToast`. Stackviews are FUN.
- Download toast isn't perfect since I am clipping the text on bigger font sizes for the description label. If I don't the entire toast seems glitchy due to the height changing (since the progress changes all the time during download and that causes the toast height to change). I am not sure how to improve this and I think it needs UX, but in the meantime this still improves that toast by a lot (since the toast was not even readable beforehand), so I am committing anyway.
- I created another ticket for `SimpleToast` since this toast height relies on animation constraint, and I'm not sure how to fix that one.

### 🎥 Screenshots `DownloadToast`
<details>
<summary>Bigger font size</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-12 at 16 05 48](https://github.com/user-attachments/assets/51e1d444-0a07-4491-9599-2065022fe899)


</details>

<details>
<summary>Smaller font size</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-12 at 15 54 57](https://github.com/user-attachments/assets/2d2755ad-27c8-4458-b3b6-dd383a2e6a9d)


</details>


### 🎥 Screenshots `ButtonToast`
<details>
<summary>Bigger font size</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-12 at 15 05 06](https://github.com/user-attachments/assets/649f86ee-16dc-4438-9a60-3b37e8827245)


</details>

<details>
<summary>Smaller font size</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-12 at 15 14 44](https://github.com/user-attachments/assets/c301e9bf-5d91-488f-9261-9f5f7388008b)


</details>

### 🎥 Screenshots `PasteControlToast`
<details>
<summary>Bigger font size</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-12 at 15 13 17](https://github.com/user-attachments/assets/4c9f51fd-9a16-46cf-8034-43788f333a5a)

</details>

<details>
<summary>Smaller font size</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-12 at 15 14 09](https://github.com/user-attachments/assets/59aa9ca1-b0aa-4008-8b99-a1515469333a)

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

