### PR TITLE
Bugfix MTE-4135 Upload screenshot filename should be unique

### DIFF
--- a/.github/workflows/focus-ios-l10n-locales.yml
+++ b/.github/workflows/focus-ios-l10n-locales.yml
@@ -51,4 +51,4 @@ jobs:
         with:
           path: ./l10n-screenshots
           retention-days: 90
-          name: Screenshots
+          name: Screenshots-${{ job.container.id }}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4135)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description

The workflow should fail because all jobs attempted to upload a file named `Screenshot`. Note that only one job uploads the file successfully.
https://github.com/clarmso/firefox-ios-tools-experiment/actions/runs/13279539004

Here I added a unique identifier to the filename so that all jobs could upload the screenshots generated.

Test run with the change:
https://github.com/clarmso/firefox-ios-tools-experiment/actions/runs/13301235809

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

