### PR TITLE
Refactor FXIOS-11360 [a11y] SimpleToast should adjust height with bigger font sizes

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
@@ -23,13 +23,16 @@ struct SimpleToast: ThemeApplicable {
         label.font = FXFontStyles.Regular.subheadline.scaledFont()
         label.numberOfLines = 0
         label.backgroundColor = .clear
+        label.adjustsFontSizeToFitWidth = true
+        label.setContentHuggingPriority(.required, for: .vertical)
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
     }
 
     private let heightConstraint: NSLayoutConstraint
 
     init() {
         heightConstraint = containerView.heightAnchor
-            .constraint(equalToConstant: Toast.UX.toastHeightWithShadow)
+            .constraint(greaterThanOrEqualToConstant: Toast.UX.toastHeightWithShadow)
     }
 
     func showAlertWithText(_ text: String,
@@ -58,7 +61,7 @@ struct SimpleToast: ThemeApplicable {
                                                  constant: -Toast.UX.shadowVerticalSpacing),
             shadowView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor,
                                                constant: -Toast.UX.shadowHorizontalSpacing / 2),
-            shadowView.heightAnchor.constraint(equalToConstant: Toast.UX.toastHeightWithoutShadow),
+            shadowView.heightAnchor.constraint(greaterThanOrEqualToConstant: Toast.UX.toastHeightWithoutShadow),
 
             toastLabel.topAnchor.constraint(equalTo: shadowView.topAnchor),
             toastLabel.leadingAnchor.constraint(equalTo: shadowView.leadingAnchor,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11360)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24725)

## :bulb: Description
- Replaced fixed height constraint on shadowView to allow dynamic resizing.
- Added content hugging and compression resistance priorities for `toastLabel` to prevent text clipping.
- Enabled Dynamic Type support for `toastLabel` to adjust for larger font sizes.

<details>
  <summary>Before</summary>

  | Dynamic Type On  | Dynamic Type Off  |
  |-------------|-------------|
  | ![Simulator Screenshot - iPhone 16 - 2025-02-13 at 09 25 34](https://github.com/user-attachments/assets/9e1256fb-cefe-4be7-b8d5-b8cf78fef7dc) | ![Simulator Screenshot - iPhone 16 - 2025-02-13 at 09 25 03](https://github.com/user-attachments/assets/911dd0c2-dddd-4b9d-8493-ddc9e56f93be) |

</details>

<details>
  <summary>After</summary>

  | Dynamic Type On  | Dynamic Type Off  |
  |-------------|-------------|
  | ![Simulator Screenshot - iPhone 16 - 2025-02-13 at 09 27 51](https://github.com/user-attachments/assets/d8a933ee-d0d5-4772-a863-d51efc5c4c11) | ![Simulator Screenshot - iPhone 16 - 2025-02-13 at 09 28 11](https://github.com/user-attachments/assets/f80db325-4e5b-46cd-a0e2-53a566bc86bf) |

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

