### PR TITLE
Refactor `pipes` usage with `shlex`

### DIFF
--- a/taskcluster/ffios_taskgraph/job.py
+++ b/taskcluster/ffios_taskgraph/job.py
@@ -7,7 +7,7 @@ from taskgraph.transforms.run import run_task_using, configure_taskdesc_for_run
 from taskgraph.util.schema import Schema, taskref_or_string
 from voluptuous import Required, Optional
 
-from pipes import quote as shell_quote
+from shlex import quote as shell_quote
 
 secret_schema = {
     Required("name"): str,


### PR DESCRIPTION
The pipes module has been deprecated since python 3.11 and got removed in python 3.13 [1]
This documentation isn't very helpful because it says to use `subprocess` as a replacement for the pipes module which makes no sense in our case. However, the python2 documentation has some more context about this and it turns out that the `pipes.quote` function has been deprecated and replaced by `shlex.quote` since python 2.7 [2]

[1]: https://docs.python.org/3.13/library/pipes.html
[2]: https://docs.python.org/2.7/library/pipes.html#pipes.quote
