### PR TITLE
Bugfix FXIOS-11356 [Bookmarks Evolution] Fix bookmarks panel crash

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/BookmarksPanelViewModel.swift
@@ -124,8 +124,9 @@ class BookmarksPanelViewModel: BookmarksRefactorFeatureFlagProvider {
                 // Create a local "Desktop bookmarks" folder only if there exists a bookmark in one of it's nested
                 // subfolders
                 self.bookmarksHandler.countBookmarksInTrees(folderGuids: BookmarkRoots.DesktopRoots.map { $0 }) { result in
-                    switch result {
-                    case .success(let bookmarkCount):
+                    DispatchQueue.main.async {
+                        switch result {
+                        case .success(let bookmarkCount):
                             if bookmarkCount > 0 || !self.isBookmarkRefactorEnabled {
                                 self.hasDesktopFolders = true
                                 let desktopFolder = LocalDesktopFolder()
@@ -133,10 +134,11 @@ class BookmarksPanelViewModel: BookmarksRefactorFeatureFlagProvider {
                             } else {
                                 self.hasDesktopFolders = false
                             }
-                    case .failure(let error):
+                        case .failure(let error):
                             self.logger.log("Error counting bookmarks: \(error)", level: .debug, category: .library)
+                        }
+                        completion()
                     }
-                    completion()
                 }
             }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Bookmarks/BookmarksHandlerMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/Bookmarks/BookmarksHandlerMock.swift
@@ -23,6 +23,7 @@ final class BookmarksHandlerMock: BookmarksHandler {
 
     var getRecentBookmarksCallCount = 0
     var getRecentBookmarksCompletion: (([BookmarkItemData]) -> Void)?
+    var bookmarksInTreeValue = 0
 
     func getRecentBookmarks(limit: UInt, completion: @escaping ([BookmarkItemData]) -> Void) {
         getRecentBookmarksCallCount += 1
@@ -67,6 +68,6 @@ final class BookmarksHandlerMock: BookmarksHandler {
     }
 
     func countBookmarksInTrees(folderGuids: [GUID], completion: @escaping (Result<Int, Error>) -> Void) {
-        completion(.success(0))
+        completion(.success(bookmarksInTreeValue))
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
@@ -121,6 +121,30 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
         waitForExpectations(timeout: 1)
     }
 
+    func testReloadData_createsDesktopBookmarksFolder_whenBookmarksRefactor() {
+        let bookmarksHandler = BookmarksHandlerMock()
+        bookmarksHandler.bookmarksInTreeValue = 1
+        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID, bookmarksHandler: bookmarksHandler)
+        let expectation = expectation(description: "Subject reloaded")
+        subject.reloadData {
+            XCTAssertNotNil(subject.bookmarkFolder)
+            XCTAssertEqual(subject.bookmarkNodes.count, 1, "Mobile folder contains the local desktop folder")
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testReloadData_doesntCreateDesktopBookmarksFolder_whenBookmarksRefactor() {
+        let subject = createSubject(guid: BookmarkRoots.MobileFolderGUID)
+        let expectation = expectation(description: "Subject reloaded")
+        subject.reloadData {
+            XCTAssertNotNil(subject.bookmarkFolder)
+            XCTAssertEqual(subject.bookmarkNodes.count, 0, "Mobile folder does not contain the local desktop folder")
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
     // MARK: - Move row at index
 
     func testMoveRowAtGetNewIndex_NotMobileGuid_atZero() {
@@ -201,9 +225,9 @@ class BookmarksPanelViewModelTests: XCTestCase, FeatureFlaggable {
 }
 
 extension BookmarksPanelViewModelTests {
-    func createSubject(guid: GUID) -> BookmarksPanelViewModel {
+    func createSubject(guid: GUID, bookmarksHandler: BookmarksHandler = BookmarksHandlerMock()) -> BookmarksPanelViewModel {
         let viewModel = BookmarksPanelViewModel(profile: profile,
-                                                bookmarksHandler: BookmarksHandlerMock(),
+                                                bookmarksHandler: bookmarksHandler,
                                                 bookmarkFolderGUID: guid,
                                                 mainQueue: MockDispatchQueue())
         trackForMemoryLeaks(viewModel)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/BookmarkPanelViewModelTests.swift
@@ -204,7 +204,8 @@ extension BookmarksPanelViewModelTests {
     func createSubject(guid: GUID) -> BookmarksPanelViewModel {
         let viewModel = BookmarksPanelViewModel(profile: profile,
                                                 bookmarksHandler: BookmarksHandlerMock(),
-                                                bookmarkFolderGUID: guid)
+                                                bookmarkFolderGUID: guid,
+                                                mainQueue: MockDispatchQueue())
         trackForMemoryLeaks(viewModel)
         return viewModel
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11356)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24720)

## :bulb: Description
- Attempt to fix bookmarks panel crash by updating the tables data source on the main thread

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

