### PR TITLE
Bugfix FXIOS-11306 [Address Bar Animation] Loading bar color is incorrect in private mode after force-closing and resuming Firefox.

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3245,9 +3245,11 @@ class BrowserViewController: UIViewController,
 
         tabManager.selectedTab?.applyTheme(theme: currentTheme)
 
+        let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         if !isToolbarRefactorEnabled {
-            let isPrivate = tabManager.selectedTab?.isPrivate ?? false
             legacyUrlBar?.applyUIMode(isPrivate: isPrivate, theme: currentTheme)
+        } else {
+            addressToolbarContainer.applyUIMode(isPrivate: isPrivate, theme: currentTheme)
         }
 
         toolbar.applyTheme(theme: currentTheme)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -27,7 +27,8 @@ final class AddressToolbarContainer: UIView,
                                      StoreSubscriber,
                                      AddressToolbarDelegate,
                                      Autocompletable,
-                                     URLBarViewProtocol {
+                                     URLBarViewProtocol,
+                                     PrivateModeUI {
     private enum UX {
         static let toolbarHorizontalPadding: CGFloat = 16
         static let toolbarIsEditingLeadingPadding: CGFloat = 0

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -430,9 +430,8 @@ final class AddressToolbarContainer: UIView,
             endColor: gradientEndColor
         )
     }
-}
 
-extension AddressToolbarContainer: PrivateModeUI {
+    // MARK: - PrivateModeUI
     func applyUIMode(isPrivate: Bool, theme: Theme) {
         applyProgressBarTheme(isPrivateMode: isPrivate, theme: theme)
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -291,16 +291,8 @@ final class AddressToolbarContainer: UIView,
         compactToolbar.applyTheme(theme: theme)
         regularToolbar.applyTheme(theme: theme)
 
-        let isPrivateMode = model?.isPrivateMode ?? false
-        let gradientStartColor = isPrivateMode ? theme.colors.borderAccentPrivate : theme.colors.borderAccent
-        let gradientMiddleColor = isPrivateMode ? nil : theme.colors.iconAccentPink
-        let gradientEndColor = isPrivateMode ? theme.colors.borderAccentPrivate : theme.colors.iconAccentYellow
-
-        progressBar.setGradientColors(
-            startColor: gradientStartColor,
-            middleColor: gradientMiddleColor,
-            endColor: gradientEndColor
-        )
+        applyProgressBarTheme(isPrivateMode: model?.isPrivateMode ?? false,
+                              theme: theme)
     }
 
     // MARK: - AddressToolbarDelegate
@@ -425,5 +417,23 @@ final class AddressToolbarContainer: UIView,
             let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.cancelEdit)
             store.dispatch(action)
         }
+    }
+
+    private func applyProgressBarTheme(isPrivateMode: Bool, theme: Theme) {
+        let gradientStartColor = isPrivateMode ? theme.colors.borderAccentPrivate : theme.colors.borderAccent
+        let gradientMiddleColor = isPrivateMode ? nil : theme.colors.iconAccentPink
+        let gradientEndColor = isPrivateMode ? theme.colors.borderAccentPrivate : theme.colors.iconAccentYellow
+
+        progressBar.setGradientColors(
+            startColor: gradientStartColor,
+            middleColor: gradientMiddleColor,
+            endColor: gradientEndColor
+        )
+    }
+}
+
+extension AddressToolbarContainer: PrivateModeUI {
+    func applyUIMode(isPrivate: Bool, theme: Theme) {
+        applyProgressBarTheme(isPrivateMode: isPrivate, theme: theme)
     }
 }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -858,7 +858,6 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable, TabEvent
         if featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) {
             isPrivate = tab.isPrivate
         }
-
         let action = PrivateModeAction(isPrivate: isPrivate,
                                        windowUUID: windowUUID,
                                        actionType: PrivateModeActionType.setPrivateModeTo)

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -858,6 +858,7 @@ class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable, TabEvent
         if featureFlags.isFeatureEnabled(.feltPrivacySimplifiedUI, checking: .buildOnly) {
             isPrivate = tab.isPrivate
         }
+
         let action = PrivateModeAction(isPrivate: isPrivate,
                                        windowUUID: windowUUID,
                                        actionType: PrivateModeActionType.setPrivateModeTo)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11306)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24588)

## :bulb: Description
- Use applyUIMode to update theme for progressBar

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

