### PR TITLE
Refactor FXIOS-7301 [Swiftlint] Remove 1 closure_body_length violation from RustAutofill.swift and decrease threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,8 +103,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 51
-  error: 51
+  warning: 50
+  error: 50
 
 file_header:
   required_string: |

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -455,29 +455,7 @@ public class RustAutofill {
             case (.some(key), .none), (.none, .some(encryptedCanaryPhrase)):
                 self.handleUnexpectedKey(rustKeys: rustKeys, completion: completion)
             case (.none, .none):
-                // We didn't expect the key to be present, which either means this is a first-time
-                // call or the key data has been cleared from the keychain.
-                self.hasCreditCards { result in
-                    switch result {
-                    case .success(let hasCreditCards):
-                        if hasCreditCards {
-                            // Since the key data isn't present and we have credit card records in
-                            // the database, we both scrub the records and reset the key.
-                            self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
-                        } else {
-                            // There are no records in the database so we don't need to scrub any
-                            // existing credit card records. We just need to create a new key.
-                            do {
-                                let key = try rustKeys.createAndStoreKey()
-                                completion(.success(key))
-                            } catch let error as NSError {
-                                completion(.failure(error))
-                            }
-                        }
-                    case .failure(let err):
-                        completion(.failure(err as NSError))
-                    }
-                }
+                self.handleFirstTimeCallOrClearKeychainKey(rustKeys: rustKeys, completion: completion)
             default:
                 // If none of the above cases apply, we're in a state that shouldn't be possible
                 // but is disallowed nonetheless

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -512,6 +512,36 @@ public class RustAutofill {
         }
     }
 
+    private func handleExpectedKey(rustKeys: RustAutofillEncryptionKeys,
+                                   encryptedCanaryPhrase: String?,
+                                   key: String?,
+                                   completion: @escaping (Result<String, NSError>) -> Void) {
+        // We expected the key to be present, and it is.
+        var canaryIsValid = false
+        do {
+            canaryIsValid = try rustKeys.checkCanary(
+                canary: encryptedCanaryPhrase!,
+                text: rustKeys.canaryPhrase,
+                key: key!
+            )
+        } catch let error as NSError {
+            self.logger.log("Error validating autofill encryption key",
+                            level: .warning,
+                            category: .storage,
+                            description: error.localizedDescription)
+            completion(.failure(error))
+            return
+        }
+        if canaryIsValid {
+            completion(.success(key!))
+        } else {
+            self.logger.log("Autofill key was corrupted, new one generated",
+                            level: .warning,
+                            category: .storage)
+            self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
+        }
+    }
+
     // MARK: - Private Helper Methods
 
     private func handleDatabaseError(_ error: NSError) {

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -453,7 +453,7 @@ public class RustAutofill {
                                              key: key,
                                              completion: completion)
             case (.some(key), .none), (.none, .some(encryptedCanaryPhrase)):
-                self.handleUnexpectedKey(rustKeys: rustKeys, completion: completion)
+                self.handleUnexpectedKeyAction(rustKeys: rustKeys, completion: completion)
             case (.none, .none):
                 self.handleFirstTimeCallOrClearedKeychain(rustKeys: rustKeys, completion: completion)
             default:
@@ -494,8 +494,8 @@ public class RustAutofill {
         }
     }
 
-    private func handleUnexpectedKey(rustKeys: RustAutofillEncryptionKeys,
-                                     completion: @escaping (Result<String, NSError>) -> Void) {
+    private func handleUnexpectedKeyAction(rustKeys: RustAutofillEncryptionKeys,
+                                           completion: @escaping (Result<String, NSError>) -> Void) {
         // The key is present, but we didn't expect it to be there.
         // or
         // We expected the key to be present, but it's gone missing on us

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -448,7 +448,10 @@ public class RustAutofill {
         getKeychainData(rustKeys: rustKeys) { (key, encryptedCanaryPhrase) in
             switch (key, encryptedCanaryPhrase) {
             case (.some(key), .some(encryptedCanaryPhrase)):
-                self.handleExpectedKey(rustKeys: rustKeys, encryptedCanaryPhrase: encryptedCanaryPhrase, key: key, completion: completion)
+                self.handleExpectedKey(rustKeys: rustKeys,
+                                       encryptedCanaryPhrase: encryptedCanaryPhrase,
+                                       key: key,
+                                       completion: completion)
             case (.some(key), .none), (.none, .some(encryptedCanaryPhrase)):
                 // The key is present, but we didn't expect it to be there.
                 // or

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -455,7 +455,7 @@ public class RustAutofill {
             case (.some(key), .none), (.none, .some(encryptedCanaryPhrase)):
                 self.handleUnexpectedKey(rustKeys: rustKeys, completion: completion)
             case (.none, .none):
-                self.handleFirstTimeCallOrClearKeychainKey(rustKeys: rustKeys, completion: completion)
+                self.handleFirstTimeCallOrClearedKeychain(rustKeys: rustKeys, completion: completion)
             default:
                 // If none of the above cases apply, we're in a state that shouldn't be possible
                 // but is disallowed nonetheless
@@ -505,8 +505,8 @@ public class RustAutofill {
         self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
     }
 
-    private func handleFirstTimeCallOrClearKeychainKey(rustKeys: RustAutofillEncryptionKeys,
-                                                       completion: @escaping (Result<String, NSError>) -> Void) {
+    private func handleFirstTimeCallOrClearedKeychain(rustKeys: RustAutofillEncryptionKeys,
+                                                      completion: @escaping (Result<String, NSError>) -> Void) {
         // We didn't expect the key to be present, which either means this is a first-time
         // call or the key data has been cleared from the keychain.
         self.hasCreditCards { result in

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -487,9 +487,9 @@ public class RustAutofill {
         if canaryIsValid {
             completion(.success(key!))
         } else {
-            self.logger.log("Autofill key was corrupted, new one generated",
-                            level: .warning,
-                            category: .storage)
+            logger.log("Autofill key was corrupted, new one generated",
+                       level: .warning,
+                       category: .storage)
             self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
         }
     }

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -499,9 +499,9 @@ public class RustAutofill {
         // The key is present, but we didn't expect it to be there.
         // or
         // We expected the key to be present, but it's gone missing on us
-        self.logger.log("Autofill key lost, new one generated",
-                        level: .warning,
-                        category: .storage)
+        logger.log("Autofill key lost, new one generated",
+                   level: .warning,
+                   category: .storage)
         self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
     }
 

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -490,7 +490,7 @@ public class RustAutofill {
             logger.log("Autofill key was corrupted, new one generated",
                        level: .warning,
                        category: .storage)
-            self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
+            resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
         }
     }
 

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -448,30 +448,7 @@ public class RustAutofill {
         getKeychainData(rustKeys: rustKeys) { (key, encryptedCanaryPhrase) in
             switch (key, encryptedCanaryPhrase) {
             case (.some(key), .some(encryptedCanaryPhrase)):
-                // We expected the key to be present, and it is.
-                var canaryIsValid = false
-                do {
-                    canaryIsValid = try rustKeys.checkCanary(
-                        canary: encryptedCanaryPhrase!,
-                        text: rustKeys.canaryPhrase,
-                        key: key!
-                    )
-                } catch let error as NSError {
-                    self.logger.log("Error validating autofill encryption key",
-                                    level: .warning,
-                                    category: .storage,
-                                    description: error.localizedDescription)
-                    completion(.failure(error))
-                    return
-                }
-                if canaryIsValid {
-                    completion(.success(key!))
-                } else {
-                    self.logger.log("Autofill key was corrupted, new one generated",
-                                    level: .warning,
-                                    category: .storage)
-                    self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
-                }
+                self.handleExpectedKey(rustKeys: rustKeys, encryptedCanaryPhrase: encryptedCanaryPhrase, key: key, completion: completion)
             case (.some(key), .none), (.none, .some(encryptedCanaryPhrase)):
                 // The key is present, but we didn't expect it to be there.
                 // or

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -522,6 +522,17 @@ public class RustAutofill {
         }
     }
 
+    private func handleUnexpectedKey(rustKeys: RustAutofillEncryptionKeys,
+                                     completion: @escaping (Result<String, NSError>) -> Void) {
+        // The key is present, but we didn't expect it to be there.
+        // or
+        // We expected the key to be present, but it's gone missing on us
+        self.logger.log("Autofill key lost, new one generated",
+                        level: .warning,
+                        category: .storage)
+        self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
+    }
+
     // MARK: - Private Helper Methods
 
     private func handleDatabaseError(_ error: NSError) {

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -509,7 +509,7 @@ public class RustAutofill {
                                                             completion: @escaping (Result<String, NSError>) -> Void) {
         // We didn't expect the key to be present, which either means this is a first-time
         // call or the key data has been cleared from the keychain.
-        self.hasCreditCards { result in
+        hasCreditCards { result in
             switch result {
             case .success(let hasCreditCards):
                 if hasCreditCards {

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -477,10 +477,10 @@ public class RustAutofill {
                 key: key!
             )
         } catch let error as NSError {
-            self.logger.log("Error validating autofill encryption key",
-                            level: .warning,
-                            category: .storage,
-                            description: error.localizedDescription)
+            logger.log("Error validating autofill encryption key",
+                       level: .warning,
+                       category: .storage,
+                       description: error.localizedDescription)
             completion(.failure(error))
             return
         }

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -455,7 +455,7 @@ public class RustAutofill {
             case (.some(key), .none), (.none, .some(encryptedCanaryPhrase)):
                 self.handleUnexpectedKeyAction(rustKeys: rustKeys, completion: completion)
             case (.none, .none):
-                self.handleFirstTimeCallOrClearedKeychain(rustKeys: rustKeys, completion: completion)
+                self.handleFirstTimeCallOrClearedKeychainAction(rustKeys: rustKeys, completion: completion)
             default:
                 // If none of the above cases apply, we're in a state that shouldn't be possible
                 // but is disallowed nonetheless
@@ -505,8 +505,8 @@ public class RustAutofill {
         self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
     }
 
-    private func handleFirstTimeCallOrClearedKeychain(rustKeys: RustAutofillEncryptionKeys,
-                                                      completion: @escaping (Result<String, NSError>) -> Void) {
+    private func handleFirstTimeCallOrClearedKeychainAction(rustKeys: RustAutofillEncryptionKeys,
+                                                            completion: @escaping (Result<String, NSError>) -> Void) {
         // We didn't expect the key to be present, which either means this is a first-time
         // call or the key data has been cleared from the keychain.
         self.hasCreditCards { result in

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -448,10 +448,10 @@ public class RustAutofill {
         getKeychainData(rustKeys: rustKeys) { (key, encryptedCanaryPhrase) in
             switch (key, encryptedCanaryPhrase) {
             case (.some(key), .some(encryptedCanaryPhrase)):
-                self.handleExpectedKey(rustKeys: rustKeys,
-                                       encryptedCanaryPhrase: encryptedCanaryPhrase,
-                                       key: key,
-                                       completion: completion)
+                self.handleExpectedKeyAction(rustKeys: rustKeys,
+                                             encryptedCanaryPhrase: encryptedCanaryPhrase,
+                                             key: key,
+                                             completion: completion)
             case (.some(key), .none), (.none, .some(encryptedCanaryPhrase)):
                 self.handleUnexpectedKey(rustKeys: rustKeys, completion: completion)
             case (.none, .none):
@@ -464,10 +464,10 @@ public class RustAutofill {
         }
     }
 
-    private func handleExpectedKey(rustKeys: RustAutofillEncryptionKeys,
-                                   encryptedCanaryPhrase: String?,
-                                   key: String?,
-                                   completion: @escaping (Result<String, NSError>) -> Void) {
+    private func handleExpectedKeyAction(rustKeys: RustAutofillEncryptionKeys,
+                                         encryptedCanaryPhrase: String?,
+                                         key: String?,
+                                         completion: @escaping (Result<String, NSError>) -> Void) {
         // We expected the key to be present, and it is.
         var canaryIsValid = false
         do {

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -453,13 +453,7 @@ public class RustAutofill {
                                        key: key,
                                        completion: completion)
             case (.some(key), .none), (.none, .some(encryptedCanaryPhrase)):
-                // The key is present, but we didn't expect it to be there.
-                // or
-                // We expected the key to be present, but it's gone missing on us
-                self.logger.log("Autofill key lost, new one generated",
-                                level: .warning,
-                                category: .storage)
-                self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
+                self.handleUnexpectedKey(rustKeys: rustKeys, completion: completion)
             case (.none, .none):
                 // We didn't expect the key to be present, which either means this is a first-time
                 // call or the key data has been cleared from the keychain.

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -527,6 +527,33 @@ public class RustAutofill {
         self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
     }
 
+    private func handleFirstTimeCallOrClearKeychainKey(rustKeys: RustAutofillEncryptionKeys,
+                                                       completion: @escaping (Result<String, NSError>) -> Void) {
+        // We didn't expect the key to be present, which either means this is a first-time
+        // call or the key data has been cleared from the keychain.
+        self.hasCreditCards { result in
+            switch result {
+            case .success(let hasCreditCards):
+                if hasCreditCards {
+                    // Since the key data isn't present and we have credit card records in
+                    // the database, we both scrub the records and reset the key.
+                    self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
+                } else {
+                    // There are no records in the database so we don't need to scrub any
+                    // existing credit card records. We just need to create a new key.
+                    do {
+                        let key = try rustKeys.createAndStoreKey()
+                        completion(.success(key))
+                    } catch let error as NSError {
+                        completion(.failure(error))
+                    }
+                }
+            case .failure(let err):
+                completion(.failure(err as NSError))
+            }
+        }
+    }
+
     // MARK: - Private Helper Methods
 
     private func handleDatabaseError(_ error: NSError) {

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -502,7 +502,7 @@ public class RustAutofill {
         logger.log("Autofill key lost, new one generated",
                    level: .warning,
                    category: .storage)
-        self.resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
+        resetCreditCardsAndKey(rustKeys: rustKeys, completion: completion)
     }
 
     private func handleFirstTimeCallOrClearedKeychainAction(rustKeys: RustAutofillEncryptionKeys,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 1 `closure_body_length` violation from the `RustAutofill.swift` file. Also, this PR decrease the warning and error threshold to 50.

Unlike previous pull requests, this one addresses some switch-case statements that aren't easy to define. I'm proposing in this PR to name the new functions based on the comments contained in each block of code.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

