### PR TITLE
Bugfix MTE-4135 Duplicate folder names in upload

### DIFF
--- a/.github/workflows/focus-ios-l10n-locales.yml
+++ b/.github/workflows/focus-ios-l10n-locales.yml
@@ -44,11 +44,14 @@ jobs:
           tar -xvf l10n-screenshots-dd.tar
       - name: Generate screenshots
         continue-on-error: true
+        id: screenshots
         run: |
           focus-ios/l10n-screenshots.sh --test-without-building ${{ inputs.locales }}
+          hash=`echo "${{ inputs.locales }}" | shasum | awk '{print $1}'`
+          echo "hash=$hash" >> $GITHUB_OUTPUT
       - name: Upload screenshots
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v4.6.0
         with:
           path: ./l10n-screenshots
           retention-days: 90
-          name: Screenshots-${{ job.container.id }}
+          name: Screenshots-${{ steps.screenshots.outputs.hash }}

--- a/.github/workflows/focus-ios-l10n-screenshots.yml
+++ b/.github/workflows/focus-ios-l10n-screenshots.yml
@@ -86,3 +86,16 @@ jobs:
       locales: "${{ matrix.locales }}"
       branch: "${{ inputs.branch }}"
       derived-data: "xcode-l10n-focus-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}"
+
+  merge-screenshots:
+    name: Merge all screenshots
+    needs: generate-screenshots
+    runs-on: macOS-15
+    steps:
+      - name: Merge screenshots
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: FocusL10nScreenshots
+          pattern: Screenshots-*
+          delete-merged: true
+          retention-days: 14


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4135)

## :bulb: Description
Github Actions `actions/upload-artifact` v4 introduced a breaking change that the uploaded filename can't be duplicated within the same job. The job does not have access to `job.container.id`. I suggest that we generate a unique temporary identifier by the list of locales.

When all 3 jobs are finished, we can merge all uploads into one file.

Github Actions run with this change:
https://github.com/mozilla-mobile/firefox-ios/actions/runs/13318717831

A much smaller example on how merging upload-artifact works:
https://github.com/clarmso/firefox-ios-tools-experiment/actions/runs/13318073969

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

