### PR TITLE
Add FXIOS-11299 [Homepage] [JumpBackIn] tapping on cells

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
@@ -11,7 +11,7 @@ enum BrowserNavigationDestination: Equatable {
     case contextMenu
     case settings(Route.SettingsSection)
     case trackingProtectionSettings
-    case tabTray
+    case tabTray(TabTrayPanelType)
     case bookmarksPanel
 
     // Webpage views

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2183,10 +2183,10 @@ class BrowserViewController: UIViewController,
         case .contextMenu:
             guard let configuration = type.contextMenuConfiguration else {
                 logger.log(
-                        "configuration should not be nil when navigating for a context menu type",
-                        level: .warning,
-                        category: .coordinator
-                    )
+                    "configuration should not be nil when navigating for a context menu type",
+                    level: .warning,
+                    category: .coordinator
+                )
                 return
             }
             navigationHandler?.showContextMenu(for: configuration)
@@ -2223,8 +2223,8 @@ class BrowserViewController: UIViewController,
                 toastContainer: config.toastContainer,
                 popoverArrowDirection: config.popoverArrowDirection
             )
-        case .tabTray:
-            navigationHandler?.showTabTray(selectedPanel: .tabs)
+        case .tabTray(let panelType):
+            navigationHandler?.showTabTray(selectedPanel: panelType)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -889,6 +889,10 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
                     actionType: TabManagerMiddlewareActionType.fetchRecentTabs
                 )
             )
+        case JumpBackInActionType.tapOnCell:
+            guard let jumpBackInAction = action as? JumpBackInAction,
+                  let tab = jumpBackInAction.tab else { return }
+            tabManager(for: action.windowUUID).selectTab(tab)
         default:
             break
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInAction.swift
@@ -2,11 +2,24 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Redux
 
-final class JumpBackInAction: Action { }
+final class JumpBackInAction: Action {
+    var tab: Tab?
+
+    init(
+        tab: Tab? = nil,
+        windowUUID: WindowUUID,
+        actionType: any ActionType
+    ) {
+        self.tab = tab
+        super.init(windowUUID: windowUUID, actionType: actionType)
+    }
+}
 
 enum JumpBackInActionType: ActionType {
     case fetchLocalTabs
     case fetchRemoteTabs
+    case tapOnCell
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
@@ -70,7 +70,7 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
                 let itemURL = tab.lastKnownUrl?.absoluteString ?? ""
                 let site = Site.createBasicSite(url: itemURL, title: tab.displayTitle)
                 return JumpBackInTabConfiguration(
-                    tabUUID: tab.tabUUID,
+                    tab: tab,
                     titleText: site.title,
                     descriptionText: site.tileURL.shortDisplayString.capitalized,
                     siteURL: itemURL

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInTabState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInTabState.swift
@@ -6,7 +6,7 @@ import Foundation
 import Common
 
 struct JumpBackInTabConfiguration: Equatable, Hashable {
-    let tabUUID: String
+    let tab: Tab
     let titleText: String
     let descriptionText: String
     let siteURL: String


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11299)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24574)

## :bulb: Description
Add logic for tapping on jumpback in cells (local and remote tabs)
* Tapping on local tab
* Tapping on synced tab
* Tapping on see all synced tabs

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
https://github.com/user-attachments/assets/e3d60e16-1906-4760-ba64-347015a46354