### PR TITLE
Refactor FXIOS-10334 #22650 [Javascript alerts] Turn feature flag on in release

### DIFF
--- a/firefox-ios/nimbus-features/jsAlertRefactor.yaml
+++ b/firefox-ios/nimbus-features/jsAlertRefactor.yaml
@@ -8,7 +8,7 @@ features:
         description: >
           When true this enables the new JS alerts system to be used
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10334)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22650)

## :bulb: Description
Turn the feature flag ON in release builds. This is being experimented on in v135 and all is going well so far, so I want to turn this on by default in v136 so we don't have to do another experiment in there (but still have the possibility to turn it off if something goes wrong).

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

