### PR TITLE
Bugfix FXIOS-11361 Potential fix for SVG related crashes via SwiftDraw SVG preprocessor on Kingfisher

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
             branch: "master"),
         .package(
             url: "https://github.com/onevcat/Kingfisher.git",
-            exact: "8.1.3"),
+            exact: "8.2.0"),
         .package(
             url: "https://github.com/AliSoftware/Dip.git",
             exact: "7.1.1"),

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -66,7 +66,7 @@ let package = Package(
             branch: "master"),
         .package(
             url: "https://github.com/swhitty/SwiftDraw",
-            exact: "0.17.0"),
+            exact: "0.18.3"),
     ],
     targets: [
         .target(name: "Shared",

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -27341,7 +27341,7 @@
 			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
 			requirement = {
 				kind = exactVersion;
-				version = 8.1.3;
+				version = 8.2.0;
 			};
 		};
 		8AB30EC62B6C038600BD9A9B /* XCRemoteSwiftPackageReference "lottie-ios" */ = {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "e6749919f9761d573d37a7d7e78b1b854c191d7f",
-        "version" : "8.1.3"
+        "revision" : "3db26ab625d194c38e68c1a40e43d1bc12743fe0",
+        "version" : "8.2.0"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swhitty/SwiftDraw",
       "state" : {
-        "revision" : "a5c680f07b33f4cc9a451491b417b8119de23c6e",
-        "version" : "0.17.0"
+        "revision" : "2cfd97c753feafe23c767ad3cb4daaf5c5415272",
+        "version" : "0.18.3"
       }
     },
     {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11361)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
@mattreaganmozilla found where the SVG image processing crash was occurring in one of our SPM packages (SwiftDraw) and [logged a bug on their repo](https://github.com/swhitty/SwiftDraw/issues/64#issue-2852333530). After they fixed the bug, I updated the Swift Package.

I also added a couple extra tests written while we were debugging this (they didn't identify the potentially malformed (?) SVG data that caused the crash logged in the ticket, but round out our tests nonetheless).

Note that this is the second time we've fixed this issue... since the issue is not tracked in Sentry we had to go off user reports in slack. Here was the previous attempt: #23921 

This time thanks to @mattreaganmozilla 's debugging we have much greater confidence we are solving the problem in the right place! 🎉 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

