### PR TITLE
Bugfix FXIOS-11125 Direct Download Of Blob URLS Not Working

### DIFF
--- a/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/DownloadContentScript.swift
@@ -71,20 +71,12 @@ class DownloadContentScript: TabContentScript {
             DownloadContentScript.blobUrlForDownload = nil
         }
 
-        guard let requestedUrl = DownloadContentScript.blobUrlForDownload else {
-            return
-        }
-
-        guard requestedUrl == url else {
-            return
-        }
-
         // Note: url.lastPathComponent fails on blob: URLs (shrug).
-        var filename = url.absoluteString.components(separatedBy: "/").last ?? "data"
+
+        var filename = dictionary["fileName"] as? String ?? url.absoluteString.components(separatedBy: "/").last ?? "data"
         if filename.isEmpty {
             filename = "data"
         }
-
         if !filename.contains(".") {
             if let fileExtension = MIMEType.fileExtensionFromMIMEType(mimeType) {
                 filename += ".\(fileExtension)"

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
@@ -63,6 +63,8 @@ Object.defineProperty(window.__firefox__, "download", {
 document.addEventListener("click", (event) => {
   if (event.target.localName == "a" && event.target.hasAttribute("download")) {
     event.preventDefault();
+    // The APP_ID_TOKEN is a unique identifier associated with the app used by scripts to verify the *app*
+    // (not JS on the web) is calling into them.
     window.__firefox__.download(event.target.href, APP_ID_TOKEN, event.target.download)
   }
 })

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/DownloadHelper.js
@@ -9,7 +9,7 @@ Object.defineProperty(window.__firefox__, "download", {
   enumerable: false,
   configurable: false,
   writable: false,
-  value: function(url, appIdToken) {
+  value: function(url, appIdToken, fileName = null) {
     if (appIdToken !== APP_ID_TOKEN) {
       return;
     }
@@ -43,7 +43,8 @@ Object.defineProperty(window.__firefox__, "download", {
             url: url,
             mimeType: blob.type,
             size: blob.size,
-            base64String: base64String
+            base64String: base64String,
+            fileName
           });
         });
       };
@@ -59,4 +60,9 @@ Object.defineProperty(window.__firefox__, "download", {
 });
 }
 
-
+document.addEventListener("click", (event) => {
+  if (event.target.localName == "a" && event.target.hasAttribute("download")) {
+    event.preventDefault();
+    window.__firefox__.download(event.target.href, APP_ID_TOKEN, event.target.download)
+  }
+})


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11125)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24260)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added an event listener which checks if an "a" tag that is clicked on is a blob url with the download attribute. If so, it calls the download JS method which properly handles downloading blobs. Also I extended the download method to now potentially take the filename of the file to be downloaded if available.


https://github.com/user-attachments/assets/5416bfb6-5ac1-4d32-be10-b54b1cce69b9


1st Link: Blob URL with download attribute set
2nd Link: Blob URL without download attribute set

The page hosted locally in the video contains the following two files:
[index.html](https://pastebin.com/4ncTXit0)
[index.js](https://pastebin.com/ANtPiivD)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

