### PR TITLE
Add FXIOS-10990 [Tab Optimization Phase 1] Add Tests to Tab.swift

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabWebView.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabWebView.swift
@@ -2,19 +2,50 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-@testable import Client
 import WebKit
+import Common
+import Shared
+@testable import Client
 
-class MockTabWebView: TabWebView {
+final class MockTabWebView: TabWebView {
     var loadCalled = 0
     var loadedRequest: URLRequest?
     var goBackCalled = 0
     var goForwardCalled = 0
     var reloadFromOriginCalled = 0
     var stopLoadingCalled = 0
+    var mockTitle: String?
     var loadedURL: URL?
+
+    override var title: String? {
+        return mockTitle
+    }
+
     override var url: URL? {
         return loadedURL
+    }
+
+    override init(frame: CGRect, configuration: WKWebViewConfiguration, windowUUID: WindowUUID) {
+        super.init(frame: frame, configuration: configuration, windowUUID: windowUUID)
+    }
+
+    init(tab: Tab) {
+        super.init(frame: .zero, configuration: WKWebViewConfiguration(), windowUUID: .XCTestDefaultUUID)
+        // Simulating the observer setup is required to use this mock because in production
+        // the observers are set up in Tab.createWebView() which we don't call during test
+        // and the observers are removed every time we call Tab.deinit(), so an error occurs
+        // if we don't first set up the observers manually here.
+        simulateObserverSetup(target: tab)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func simulateObserverSetup(target: NSObject) {
+        addObserver(target, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
+        addObserver(target, forKeyPath: KVOConstants.title.rawValue, options: .new, context: nil)
+        addObserver(target, forKeyPath: KVOConstants.hasOnlySecureContent.rawValue, context: nil)
     }
 
     override func load(_ request: URLRequest) -> WKNavigation? {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -378,30 +378,30 @@ class MockLegacyTabDelegate: LegacyTabDelegate {
     func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {}
 }
 
-// MARK: - MockTabWebView
-class MockTabWebView: TabWebView {
-    var mockTitle: String?
-
-    override var title: String? {
-        return mockTitle
-    }
-
-    init(tab: Tab) {
-        super.init(frame: .zero, configuration: WKWebViewConfiguration(), windowUUID: .XCTestDefaultUUID)
-        // Simulating the observer setup is required to use this mock because in production
-        // the observers are set up in Tab.createWebView() which we don't call during test
-        // and the observers are removed every time we call Tab.deinit(), so an error occurs
-        // if we don't first set up the observers manually here.
-        simulateObserverSetup(target: tab)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func simulateObserverSetup(target: NSObject) {
-        addObserver(target, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
-        addObserver(target, forKeyPath: KVOConstants.title.rawValue, options: .new, context: nil)
-        addObserver(target, forKeyPath: KVOConstants.hasOnlySecureContent.rawValue, context: nil)
-    }
-}
+//// MARK: - MockTabWebView
+//class MockTabWebView: TabWebView {
+//    var mockTitle: String?
+//
+//    override var title: String? {
+//        return mockTitle
+//    }
+//
+//    init(tab: Tab) {
+//        super.init(frame: .zero, configuration: WKWebViewConfiguration(), windowUUID: .XCTestDefaultUUID)
+//        // Simulating the observer setup is required to use this mock because in production
+//        // the observers are set up in Tab.createWebView() which we don't call during test
+//        // and the observers are removed every time we call Tab.deinit(), so an error occurs
+//        // if we don't first set up the observers manually here.
+//        simulateObserverSetup(target: tab)
+//    }
+//
+//    required init?(coder: NSCoder) {
+//        fatalError("init(coder:) has not been implemented")
+//    }
+//
+//    func simulateObserverSetup(target: NSObject) {
+//        addObserver(target, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
+//        addObserver(target, forKeyPath: KVOConstants.title.rawValue, options: .new, context: nil)
+//        addObserver(target, forKeyPath: KVOConstants.hasOnlySecureContent.rawValue, context: nil)
+//    }
+//}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -377,31 +377,3 @@ class MockLegacyTabDelegate: LegacyTabDelegate {
 
     func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {}
 }
-
-//// MARK: - MockTabWebView
-//class MockTabWebView: TabWebView {
-//    var mockTitle: String?
-//
-//    override var title: String? {
-//        return mockTitle
-//    }
-//
-//    init(tab: Tab) {
-//        super.init(frame: .zero, configuration: WKWebViewConfiguration(), windowUUID: .XCTestDefaultUUID)
-//        // Simulating the observer setup is required to use this mock because in production
-//        // the observers are set up in Tab.createWebView() which we don't call during test
-//        // and the observers are removed every time we call Tab.deinit(), so an error occurs
-//        // if we don't first set up the observers manually here.
-//        simulateObserverSetup(target: tab)
-//    }
-//
-//    required init?(coder: NSCoder) {
-//        fatalError("init(coder:) has not been implemented")
-//    }
-//
-//    func simulateObserverSetup(target: NSObject) {
-//        addObserver(target, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
-//        addObserver(target, forKeyPath: KVOConstants.title.rawValue, options: .new, context: nil)
-//        addObserver(target, forKeyPath: KVOConstants.hasOnlySecureContent.rawValue, context: nil)
-//    }
-//}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -53,6 +53,30 @@ class TabTests: XCTestCase {
         XCTAssertEqual(tab.displayTitle, expectedDisplayTitle)
     }
 
+    func testTitle_WhenWebViewTitleIsNil_ThenShouldReturnNil() {
+        let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
+        let mockTabWebView = MockTabWebView(tab: tab)
+        tab.webView = mockTabWebView
+        mockTabWebView.mockTitle = nil
+        XCTAssertNil(tab.title, "Expected title to be nil when webView.title is nil")
+    }
+
+    func testTitle_WhenWebViewTitleIsEmpty_ThenShouldReturnNil() {
+        let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
+        let mockTabWebView = MockTabWebView(tab: tab)
+        tab.webView = mockTabWebView
+        mockTabWebView.mockTitle = ""
+        XCTAssertNil(tab.title, "Expected title to be nil when webView.title is empty")
+    }
+
+    func testTitle_WhenWebViewTitleIsValid_ThenShouldReturnTitle() {
+        let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
+        let mockTabWebView = MockTabWebView(tab: tab)
+        tab.webView = mockTabWebView
+        mockTabWebView.mockTitle = "Test Page Title"
+        XCTAssertEqual(tab.title, "Test Page Title", "Expected title to return the webView's title")
+    }
+
     func testTabDoesntLeak() {
         let tab = Tab(profile: mockProfile, windowUUID: windowUUID)
         tab.tabDelegate = tabDelegate
@@ -118,7 +142,7 @@ class TabTests: XCTestCase {
     func testIsSameTypeAs_trueForTwoPrivateTabs_bothInactive() {
         let lastMonthDate = Date().lastMonth
 
-        let privateInctiveTab1 = Tab(
+        let privateInactiveTab1 = Tab(
             profile: mockProfile,
             isPrivate: true,
             windowUUID: windowUUID,
@@ -131,8 +155,8 @@ class TabTests: XCTestCase {
             tabCreatedTime: lastMonthDate
         )
 
-        XCTAssertTrue(privateInctiveTab1.isSameTypeAs(privateInactiveTab2))
-        XCTAssertTrue(privateInactiveTab2.isSameTypeAs(privateInctiveTab1))
+        XCTAssertTrue(privateInactiveTab1.isSameTypeAs(privateInactiveTab2))
+        XCTAssertTrue(privateInactiveTab2.isSameTypeAs(privateInactiveTab1))
     }
 
     func testIsSameTypeAs_falseForNormalTabAndPrivateTab() {
@@ -195,19 +219,19 @@ class TabTests: XCTestCase {
     func testIsSameTypeAs_trueForTwoNormalTabs_bothInactive() {
         let lastMonthDate = Date().lastMonth
 
-        let normalInctiveTab1 = Tab(
+        let normalInactiveTab1 = Tab(
             profile: mockProfile,
             windowUUID: windowUUID,
             tabCreatedTime: lastMonthDate
         )
-        let normalInctiveTab2 = Tab(
+        let normalInactiveTab2 = Tab(
             profile: mockProfile,
             windowUUID: windowUUID,
             tabCreatedTime: lastMonthDate
         )
 
-        XCTAssertTrue(normalInctiveTab1.isSameTypeAs(normalInctiveTab2))
-        XCTAssertTrue(normalInctiveTab2.isSameTypeAs(normalInctiveTab1))
+        XCTAssertTrue(normalInactiveTab1.isSameTypeAs(normalInactiveTab2))
+        XCTAssertTrue(normalInactiveTab2.isSameTypeAs(normalInactiveTab1))
     }
 
     // MARK: - Document Handling
@@ -352,4 +376,32 @@ class MockLegacyTabDelegate: LegacyTabDelegate {
     func tab(_ tab: Tab, didCreateWebView webView: WKWebView) {}
 
     func tab(_ tab: Tab, willDeleteWebView webView: WKWebView) {}
+}
+
+// MARK: - MockTabWebView
+class MockTabWebView: TabWebView {
+    var mockTitle: String?
+
+    override var title: String? {
+        return mockTitle
+    }
+
+    init(tab: Tab) {
+        super.init(frame: .zero, configuration: WKWebViewConfiguration(), windowUUID: .XCTestDefaultUUID)
+        // Simulating the observer setup is required to use this mock because in production
+        // the observers are set up in Tab.createWebView() which we don't call during test
+        // and the observers are removed every time we call Tab.deinit(), so an error occurs
+        // if we don't first set up the observers manually here.
+        simulateObserverSetup(target: tab)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func simulateObserverSetup(target: NSObject) {
+        addObserver(target, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
+        addObserver(target, forKeyPath: KVOConstants.title.rawValue, options: .new, context: nil)
+        addObserver(target, forKeyPath: KVOConstants.hasOnlySecureContent.rawValue, context: nil)
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10990)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24004)

## :bulb: Description
When making changes to Tab.swift in my previous PR for this ticket a bug was caught by a UI test that I wanted to include a unit test for, so I added three tests for Tab.title

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

