### PR TITLE
Document [DocC] Updates to CI and Xcode for building docs

### DIFF
--- a/.github/workflows/firefox-ios-publish-docc.yml
+++ b/.github/workflows/firefox-ios-publish-docc.yml
@@ -1,10 +1,12 @@
 name: Deploy Docc
 on:
-  # Runs on pushes where BrowserKit files are modified
+  workflow_dispatch: # Allow manual runs
   push:
-    paths:
+    branches:
+      - main
+    paths: # Only runs on changes to BrowserKit files
       - BrowserKit/Sources/ComponentLibrary/**
-  workflow_dispatch: {} # adding the workflow_dispatch so it can be triggered manually
+      - .github/workflows/firefox-ios-publish-docc.yml
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -14,7 +16,7 @@ permissions:
 
 # Allow one concurrent deployment
 concurrency:
-  group: "pages"
+  group: github-pages
   cancel-in-progress: true
 
 jobs:
@@ -24,12 +26,15 @@ jobs:
       # Must be set to this for deploying to GitHub Pages
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-13
+    runs-on: macos-15
+    env:
+      XCODE: '16.2'
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
+      - name: Switch to Xcode ${{env.XCODE}}
+        uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0'
-      - name: Checkout 🛎️
+          xcode-version: ${{env.XCODE}}
+      - name: Checkout
         uses: actions/checkout@v4
       - name: Build DocC
         run: |
@@ -42,12 +47,11 @@ jobs:
             --hosting-base-path "firefox-ios" \
             --output-path docs;
           echo "<script>window.location.href += \"/documentation/componentlibrary\"</script>" > docs/index.html;
-          echo "Building DocC step done"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload only docs directory
           path: 'docs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/focus-ios-l10n-screenshots.yml
+++ b/.github/workflows/focus-ios-l10n-screenshots.yml
@@ -19,7 +19,7 @@ jobs:
       group2: ${{ steps.my_locales.outputs.group2 }}
       group3: ${{ steps.my_locales.outputs.group3 }}
     steps:
-      - name: Clone firefoxios-l01n repo
+      - name: Clone firefoxios-l10n repo
         uses: actions/checkout@v4
         with:
           repository: mozilla-l10n/firefoxios-l10n

--- a/BrowserKit/Sources/ComponentLibrary/Documentation.docc/General Components/LinkButton.md
+++ b/BrowserKit/Sources/ComponentLibrary/Documentation.docc/General Components/LinkButton.md
@@ -10,7 +10,7 @@ The `LinkButton` is a subclass of the `UIButton`. This means properties of the `
 
 > This image is illustrative only. For precise examples of iOS implementation, please run the SampleApplication.
 
-![The LinkButton on iOS]LinkButton
+![The LinkButton on iOS](LinkButton)
 
 ## Topics
 


### PR DESCRIPTION
## :bulb: Description

Only triggers docs build on pushes to _main_ to get rid of 95% failed deployments due to environments protections (other branches/PRs are not allowed to publish, so the builds only waste resources…)

This also updates key actions to avoid any breakage once deprecated versions stop running. (It also ought to fix any permissions issues currently annotated by the outdated artifact actions versions.)

The runner image is updated from macOS 13 to macOS 15 and a recent Xcode matching the project.

The update from Xcode 15.0 to 16.2 comes with some cosmetic changes:

| Xcode 15 | Xcode 16 |
|--------|--------|
| _(Before:)_ | _(After:)_ | 
| Home: |   | 
| <img width="640" alt="Screenshot 2025-02-16 at 22 01 34 Large" src="https://github.com/user-attachments/assets/60af9722-3b44-4639-82d9-86d4fe8a1a52" /> | <img width="640" alt="Screenshot 2025-02-16 at 22 01 39 Large" src="https://github.com/user-attachments/assets/f809c86f-2ea0-4601-a9c3-bcaaa756aa35" /> |
| Item: |   | 
| ![Screenshot 2025-02-16 at 22 02 55 Large](https://github.com/user-attachments/assets/4657c2f5-ba89-42b4-b68e-9089724b9c77) | ![Screenshot 2025-02-16 at 22 03 05 Large](https://github.com/user-attachments/assets/bcb9868e-16d4-4581-98a5-caa5246634a3) |
| [Demo:] | compare: | 
| https://janbrasna.github.io/firefox-ios/ | http://mozilla-mobile.github.io/firefox-ios/ | 

This also fixes some naming woes and broken links.

Run logs: [`janbrasna/firefox-ios`:/13359708616/job/37307436570](https://github.com/janbrasna/firefox-ios/actions/runs/13359708616/job/37307436570)