### PR TITLE
Fix MTE-4274 - testFilterWebsiteData test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
@@ -82,6 +82,8 @@ class DataManagementTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2802088
     func testFilterWebsiteData() {
+        cleanAllData()
+        navigator.nowAt(NewTabScreen)
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
         navigator.goto(NewTabScreen)
         navigator.openURL(path(forTestPage: "test-example.html"))

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -553,7 +553,11 @@ class NavigationTest: BaseTestCase {
         // Note: Additional matches may also appear if the external website updates.
         XCTAssertEqual(app.links.matching(identifier: "SauceDemo.com").count, 1, "Too many matches")
 
-        scrollToElement(app.links["SauceDemo.com"].firstMatch)
+        if #available(iOS 18, *) {
+            scrollToElement(app.links["SauceDemo.com"].firstMatch)
+        } else {
+            app.swipeUp()
+        }
         app.links["SauceDemo.com"].firstMatch.tap(force: true)
         waitUntilPageLoad()
         // Sometimes first tap is not working on iPad


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4274

## :bulb: Description
Fixed testFilterWebsiteData by cleaning data first from leftovers entries
Included a fix also for testOpenExternalLink on iOS 17 and less
