### PR TITLE
Bugfix FXIOS-11393 ⁃ "Delete tabs" button in Tab Tray doesn't work after action sheet is closed

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -303,6 +303,7 @@ class TabTrayViewController: UIViewController,
 
         if tabTrayState.showCloseConfirmation {
             showCloseAllConfirmation()
+            tabTrayState.showCloseConfirmation = false
         }
 
         if let toastType = tabTrayState.toastType {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11393)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24796)

## :bulb: Description
Fixed the showCloseAllConfirmation alert controller presentation

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x]Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

