### PR TITLE
Add FXIOS-11361 Add unit test for special SVG case when processing favicons

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -91,6 +91,7 @@ let package = Package(
             dependencies: ["SiteImageView", .product(name: "GCDWebServers", package: "GCDWebServer")],
             resources: [
                 .copy("Resources/mozilla.ico"),
+                .copy("Resources/inf-nan.svg"),
                 .copy("Resources/hackernews.svg")
             ]
         ),

--- a/BrowserKit/Tests/SiteImageViewTests/Resources/inf-nan.svg
+++ b/BrowserKit/Tests/SiteImageViewTests/Resources/inf-nan.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="160" height="160">
+	<g transform="translate(50, -20) rotate(30)">
+  	  <path d="m 80 20 a 50 50 0 1 0 50 50 h -50 z" fill="pink" stroke="black" stroke-width="2"/>
+	  <path d="M 1e-12,50 A1,1e-16 0 0 0 1e-7,50" fill="none"/>
+  	</g>
+</svg>

--- a/BrowserKit/Tests/SiteImageViewTests/SVGImageProcessorTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/SVGImageProcessorTests.swift
@@ -9,8 +9,42 @@ import Kingfisher
 import GCDWebServers
 
 class SVGImageProcessorTests: XCTestCase {
-    func testDownloadingSVGImage_withKingfisherProcessor() async {
-        let assetType: AssetType = .svg
+    func testDownloadingSVGImage_withKingfisherProcessor_forStandardSVGCase() async {
+        let assetType: AssetType = .svgCase1
+        let expectedRasterSize = CGSize(width: 360, height: 360)
+
+        guard let imageData = try? dataFor(type: assetType) else {
+            XCTFail("Could not load test asset")
+            return
+        }
+
+        guard let mockedURL = try? await startMockImageServer(imageData: imageData, forAssetType: assetType) else {
+            XCTFail("Check bundle setup for mock server response data")
+            return
+        }
+
+        let exp = expectation(description: "Image download and parse")
+
+        let siteDownloader = DefaultSiteImageDownloader()
+        siteDownloader.downloadImage(with: mockedURL, options: [.processor(SVGImageProcessor())]) { result in
+            switch result {
+            case .success(let result):
+                XCTAssertEqual(result.originalData, imageData)
+                XCTAssertEqual(result.url, mockedURL)
+                XCTAssertEqual(result.image.size, expectedRasterSize)
+                exp.fulfill()
+            case .failure(let error):
+                XCTFail("Should not have an error: \(error) \(error.errorDescription ?? "")")
+                exp.fulfill()
+            }
+        }
+
+        await fulfillment(of: [exp], timeout: 2.0)
+    }
+
+    /// FXIOS-11361: Tests a special SVG which previously caused crashes in older versions of SwiftDraw.
+    func testDownloadingSVGImage_withKingfisherProcessor_forSpecialSVGCase() async {
+        let assetType: AssetType = .svgCase2
         let expectedRasterSize = CGSize(width: 360, height: 360)
 
         guard let imageData = try? dataFor(type: assetType) else {
@@ -133,14 +167,15 @@ extension SVGImageProcessorTests {
 
     enum AssetType {
         case ico
-        case svg
+        case svgCase1
+        case svgCase2
         case badType
 
         var contentType: String {
             switch self {
             case .ico:
                 return "image/x-icon"
-            case .svg:
+            case .svgCase1, .svgCase2:
                 return "image/svg+xml"
             case .badType:
                 return "garbage asset type $23%12@!!!//asd"
@@ -154,8 +189,10 @@ extension SVGImageProcessorTests {
         switch type {
         case .ico:
             fileURL = Bundle.module.url(forResource: "mozilla", withExtension: "ico")
-        case .svg:
+        case .svgCase1:
             fileURL = Bundle.module.url(forResource: "hackernews", withExtension: "svg")
+        case .svgCase2:
+            fileURL = Bundle.module.url(forResource: "inf-nan", withExtension: "svg")
         case .badType:
             guard let badData = "some non-image data".data(using: .utf8) else {
                 throw MockImageServerError.badData


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11361)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24729)

## :bulb: Description
This is a followup PR to the fix in this #24780. 

@swhitty was able [to reproduce the crash](https://github.com/mozilla-mobile/firefox-ios/pull/24780#issuecomment-2660763851) with a specific SVG, so I have added a special test case for that SVG to our unit tests. I confirmed this SVG does indeed trigger the crash, and that updating SwiftDraw to the latest 0.18.3 fixes the issue! 👍 

Thanks @swhitty for your quick fix and help on this [over on your repo](https://github.com/swhitty/SwiftDraw/issues/64#issuecomment-2660761475)! 🙏 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

