### PR TITLE
Bugfix FXIOS-11365 [Toolbar] Long press actions not working when accessibility text size is enabled

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
@@ -36,7 +36,9 @@ final class TabNumberButton: ToolbarButton {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override public func configure(element: ToolbarElement) {
+    override func configure(
+        element: ToolbarElement,
+        notificationCenter: NotificationProtocol = NotificationCenter.default) {
         super.configure(element: element)
 
         guard let numberOfTabs = element.numberOfTabs else { return }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11365)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24736)

## :bulb: Description
Fixes the long press actions not being shown for toolbar buttons when accessibility text size was used.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

