### PR TITLE
Remove FXIOS-11350 Remove ASGroup from History Panel applySnapshot

### DIFF
--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -499,7 +499,7 @@ class HistoryPanel: UIViewController,
                 if sectionData.count > sectionDataUniqued.count {
                     let numberOfDuplicates = sectionData.count - sectionDataUniqued.count
                     logger.log(
-                        "Duplicates (\(numberOfDuplicates)) found in HistoryPanel applySnapshot method in section \(section).",
+                        "Duplicates found in HistoryPanel applySnapshot method in section \(section): \(numberOfDuplicates)",
                         level: .fatal,
                         category: .library
                     )
@@ -514,44 +514,6 @@ class HistoryPanel: UIViewController,
                     sectionDataUniqued, // FXIOS-10996 Force unique while we investigate history panel crashes
                     toSection: section
                 )
-            }
-        }
-
-        // Insert the ASGroup at the correct spot!
-        viewModel.searchTermGroups.forEach { grouping in
-            if let groupSection = viewModel.shouldAddGroupToSections(group: grouping) {
-                guard let individualItem = grouping.groupedItems.last,
-                      let lastVisit = individualItem.latestVisit
-                else { return }
-
-                let groupTimeInterval = TimeInterval.fromMicrosecondTimestamp(lastVisit.date)
-                let sectionData = viewModel.dateGroupedSites.itemsForSection(groupSection.rawValue - 1)
-
-                let groupPlacedAfterItem = sectionData.first(where: { site in
-                    guard let lastVisit = site.latestVisit else { return false }
-
-                    return groupTimeInterval > TimeInterval.fromMicrosecondTimestamp(lastVisit.date)
-                })
-
-                if let groupPlacedAfterItem {
-                    logger.log(
-                        "Inserted search terms group in HistoryPanel after Site",
-                        level: .fatal,
-                        category: .library
-                    )
-
-                    // In this case, we have Site items AND a group in the section.
-                    snapshot.insertItems([grouping], beforeItem: groupPlacedAfterItem)
-                } else {
-                    logger.log(
-                        "Inserted search terms group in HistoryPanel after ASGroup",
-                        level: .fatal,
-                        category: .library
-                    )
-
-                    // Looks like this group's the only item in the section
-                    snapshot.appendItems([grouping], toSection: groupSection)
-                }
             }
         }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11350)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24702)

## :bulb: Description
First part of work for FXIOS-11350 (simply stops rendering the ASGroups in the history panel). More code will have to be pulled out later to fully remove this feature.

This removes 2 `.fatal` logs that should have been `.info` logs and are cluttering Sentry for v136. Also updates the history panel crash log for easier searching in Sentry.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

