### PR TITLE
Bugfix FXIOS-11370 ⁃ Selecting Tracking Protection Level "Strict" removes "Learn More" link

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/ContentBlockerSettingViewController.swift
@@ -47,7 +47,6 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
         super.viewDidLoad()
         applyTheme()
         setupNotifications(forObserver: self, observing: [UIContentSizeCategory.didChangeNotification])
-        linkButton.isHidden = currentBlockingStrength == .strict
     }
 
     override func didRotate(from fromInterfaceOrientation: UIInterfaceOrientation) {
@@ -71,8 +70,6 @@ class ContentBlockerSettingViewController: SettingsTableViewController,
                                          forKey: ContentBlockingConfig.Prefs.StrengthKey)
                     TabContentBlocker.prefsChanged()
                     self.tableView.reloadData()
-
-                    self.linkButton.isHidden = option == .strict
 
                     self.recordEventOnChecked(option: option)
                 })


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11370)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24748)

## :bulb: Description
Display Learn More Link button also for Strict mode

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

