### PR TITLE
Bugfix FXIOS-11347 - Memory exhaustion issue w/ `BrowserViewController.updateToolbarStateForTraitCollection`

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -939,7 +939,7 @@ class BrowserViewController: UIViewController,
 
             createLegacyUrlBar()
 
-            legacyUrlBar?.snp.remakeConstraints { make in
+            legacyUrlBar?.snp.makeConstraints { make in
                 legacyUrlBarHeightConstraint = make.height.equalTo(UIConstants.TopToolbarHeightMax).constraint
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -453,12 +453,12 @@ class BrowserViewController: UIViewController,
     }
 
     func updateToolbarStateForTraitCollection(_ newCollection: UITraitCollection) {
-        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: newCollection)
-        let showTopTabs = ToolbarHelper().shouldShowTopTabs(for: newCollection)
-
-        switchToolbarIfNeeded()
-
         DispatchQueue.main.async { [self] in
+            let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: newCollection)
+            let showTopTabs = ToolbarHelper().shouldShowTopTabs(for: newCollection)
+
+            switchToolbarIfNeeded()
+
             if isToolbarRefactorEnabled {
                 if showNavToolbar {
                     navigationToolbarContainer.isHidden = false
@@ -487,35 +487,35 @@ class BrowserViewController: UIViewController,
                     toolbar.isHidden = true
                 }
             }
-        }
-        appMenuBadgeUpdate()
+            appMenuBadgeUpdate()
 
-        if showTopTabs, topTabsViewController == nil {
-            let topTabsViewController = TopTabsViewController(tabManager: tabManager, profile: profile)
-            topTabsViewController.delegate = self
-            addChild(topTabsViewController)
-            header.addArrangedViewToTop(topTabsViewController.view)
-            self.topTabsViewController = topTabsViewController
-            topTabsViewController.applyTheme()
-        } else if showTopTabs, topTabsViewController != nil {
-            topTabsViewController?.applyTheme()
-        } else {
-            if let topTabsView = topTabsViewController?.view {
-                header.removeArrangedView(topTabsView)
+            if showTopTabs, topTabsViewController == nil {
+                let topTabsViewController = TopTabsViewController(tabManager: tabManager, profile: profile)
+                topTabsViewController.delegate = self
+                addChild(topTabsViewController)
+                header.addArrangedViewToTop(topTabsViewController.view)
+                self.topTabsViewController = topTabsViewController
+                topTabsViewController.applyTheme()
+            } else if showTopTabs, topTabsViewController != nil {
+                topTabsViewController?.applyTheme()
+            } else {
+                if let topTabsView = topTabsViewController?.view {
+                    header.removeArrangedView(topTabsView)
+                }
+                topTabsViewController?.removeFromParent()
+                topTabsViewController = nil
             }
-            topTabsViewController?.removeFromParent()
-            topTabsViewController = nil
-        }
 
-        header.setNeedsLayout()
-        view.layoutSubviews()
+            header.setNeedsLayout()
+            view.layoutSubviews()
 
-        if let tab = tabManager.selectedTab,
-           let webView = tab.webView,
-           !isToolbarRefactorEnabled {
-            updateURLBarDisplayURL(tab)
-            navigationToolbar.updateBackStatus(webView.canGoBack)
-            navigationToolbar.updateForwardStatus(webView.canGoForward)
+            if let tab = tabManager.selectedTab,
+               let webView = tab.webView,
+               !isToolbarRefactorEnabled {
+                updateURLBarDisplayURL(tab)
+                navigationToolbar.updateBackStatus(webView.canGoBack)
+                navigationToolbar.updateForwardStatus(webView.canGoForward)
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -456,7 +456,9 @@ class BrowserViewController: UIViewController,
         DispatchQueue.main.async { [self] in
             let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: newCollection)
             let showTopTabs = ToolbarHelper().shouldShowTopTabs(for: newCollection)
+
             switchToolbarIfNeeded()
+
             if isToolbarRefactorEnabled {
                 if showNavToolbar {
                     navigationToolbarContainer.isHidden = false
@@ -469,6 +471,7 @@ class BrowserViewController: UIViewController,
             } else {
                 legacyUrlBar?.topTabsIsShowing = showTopTabs
                 legacyUrlBar?.setShowToolbar(!showNavToolbar)
+
                 if showNavToolbar {
                     toolbar.isHidden = false
                     toolbar.tabToolbarDelegate = self
@@ -502,8 +505,10 @@ class BrowserViewController: UIViewController,
                 topTabsViewController?.removeFromParent()
                 topTabsViewController = nil
             }
+
             header.setNeedsLayout()
             view.layoutSubviews()
+
             if let tab = tabManager.selectedTab,
                let webView = tab.webView,
                !isToolbarRefactorEnabled {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -939,7 +939,7 @@ class BrowserViewController: UIViewController,
 
             createLegacyUrlBar()
 
-            legacyUrlBar?.snp.makeConstraints { make in
+            legacyUrlBar?.snp.remakeConstraints { make in
                 legacyUrlBarHeightConstraint = make.height.equalTo(UIConstants.TopToolbarHeightMax).constraint
             }
         }
@@ -1264,8 +1264,6 @@ class BrowserViewController: UIViewController,
     }
 
     override func updateViewConstraints() {
-        super.updateViewConstraints()
-
         NSLayoutConstraint.activate([
             topTouchArea.topAnchor.constraint(equalTo: view.topAnchor),
             topTouchArea.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -1308,6 +1306,8 @@ class BrowserViewController: UIViewController,
         } else {
             adjustBottomSearchBarForKeyboard()
         }
+
+        super.updateViewConstraints()
     }
 
     private func adjustBottomContentStackView(_ remake: ConstraintMaker) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -453,68 +453,68 @@ class BrowserViewController: UIViewController,
     }
 
     func updateToolbarStateForTraitCollection(_ newCollection: UITraitCollection) {
-            let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: newCollection)
-            let showTopTabs = ToolbarHelper().shouldShowTopTabs(for: newCollection)
+        let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: newCollection)
+        let showTopTabs = ToolbarHelper().shouldShowTopTabs(for: newCollection)
 
-            switchToolbarIfNeeded()
+        switchToolbarIfNeeded()
 
-            if isToolbarRefactorEnabled {
-                if showNavToolbar {
-                    navigationToolbarContainer.isHidden = false
-                    navigationToolbarContainer.applyTheme(theme: currentTheme())
-                    updateTabCountUsingTabManager(self.tabManager)
-                } else {
-                    navigationToolbarContainer.isHidden = true
-                }
-                updateToolbarStateTraitCollectionIfNecessary(newCollection)
+        if isToolbarRefactorEnabled {
+            if showNavToolbar {
+                navigationToolbarContainer.isHidden = false
+                navigationToolbarContainer.applyTheme(theme: currentTheme())
+                updateTabCountUsingTabManager(self.tabManager)
             } else {
-                legacyUrlBar?.topTabsIsShowing = showTopTabs
-                legacyUrlBar?.setShowToolbar(!showNavToolbar)
-
-                if showNavToolbar {
-                    toolbar.isHidden = false
-                    toolbar.tabToolbarDelegate = self
-                    toolbar.applyUIMode(
-                        isPrivate: tabManager.selectedTab?.isPrivate ?? false,
-                        theme: currentTheme()
-                    )
-                    toolbar.applyTheme(theme: currentTheme())
-                    handleMiddleButtonState(currentMiddleButtonState ?? .search)
-                    updateTabCountUsingTabManager(self.tabManager)
-                } else {
-                    toolbar.tabToolbarDelegate = nil
-                    toolbar.isHidden = true
-                }
+                navigationToolbarContainer.isHidden = true
             }
-            appMenuBadgeUpdate()
+            updateToolbarStateTraitCollectionIfNecessary(newCollection)
+        } else {
+            legacyUrlBar?.topTabsIsShowing = showTopTabs
+            legacyUrlBar?.setShowToolbar(!showNavToolbar)
 
-            if showTopTabs, topTabsViewController == nil {
-                let topTabsViewController = TopTabsViewController(tabManager: tabManager, profile: profile)
-                topTabsViewController.delegate = self
-                addChild(topTabsViewController)
-                header.addArrangedViewToTop(topTabsViewController.view)
-                self.topTabsViewController = topTabsViewController
-                topTabsViewController.applyTheme()
-            } else if showTopTabs, topTabsViewController != nil {
-                topTabsViewController?.applyTheme()
+            if showNavToolbar {
+                toolbar.isHidden = false
+                toolbar.tabToolbarDelegate = self
+                toolbar.applyUIMode(
+                    isPrivate: tabManager.selectedTab?.isPrivate ?? false,
+                    theme: currentTheme()
+                )
+                toolbar.applyTheme(theme: currentTheme())
+                handleMiddleButtonState(currentMiddleButtonState ?? .search)
+                updateTabCountUsingTabManager(self.tabManager)
             } else {
-                if let topTabsView = topTabsViewController?.view {
-                    header.removeArrangedView(topTabsView)
-                }
-                topTabsViewController?.removeFromParent()
-                topTabsViewController = nil
+                toolbar.tabToolbarDelegate = nil
+                toolbar.isHidden = true
             }
+        }
+        appMenuBadgeUpdate()
 
-            header.setNeedsLayout()
-            view.layoutSubviews()
-
-            if let tab = tabManager.selectedTab,
-               let webView = tab.webView,
-               !isToolbarRefactorEnabled {
-                updateURLBarDisplayURL(tab)
-                navigationToolbar.updateBackStatus(webView.canGoBack)
-                navigationToolbar.updateForwardStatus(webView.canGoForward)
+        if showTopTabs, topTabsViewController == nil {
+            let topTabsViewController = TopTabsViewController(tabManager: tabManager, profile: profile)
+            topTabsViewController.delegate = self
+            addChild(topTabsViewController)
+            header.addArrangedViewToTop(topTabsViewController.view)
+            self.topTabsViewController = topTabsViewController
+            topTabsViewController.applyTheme()
+        } else if showTopTabs, topTabsViewController != nil {
+            topTabsViewController?.applyTheme()
+        } else {
+            if let topTabsView = topTabsViewController?.view {
+                header.removeArrangedView(topTabsView)
             }
+            topTabsViewController?.removeFromParent()
+            topTabsViewController = nil
+        }
+
+        header.setNeedsLayout()
+        view.layoutSubviews()
+
+        if let tab = tabManager.selectedTab,
+           let webView = tab.webView,
+           !isToolbarRefactorEnabled {
+            updateURLBarDisplayURL(tab)
+            navigationToolbar.updateBackStatus(webView.canGoBack)
+            navigationToolbar.updateForwardStatus(webView.canGoForward)
+        }
     }
 
     func dismissVisibleMenus() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -453,7 +453,6 @@ class BrowserViewController: UIViewController,
     }
 
     func updateToolbarStateForTraitCollection(_ newCollection: UITraitCollection) {
-        DispatchQueue.main.async { [self] in
             let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: newCollection)
             let showTopTabs = ToolbarHelper().shouldShowTopTabs(for: newCollection)
 
@@ -516,7 +515,6 @@ class BrowserViewController: UIViewController,
                 navigationToolbar.updateBackStatus(webView.canGoBack)
                 navigationToolbar.updateForwardStatus(webView.canGoForward)
             }
-        }
     }
 
     func dismissVisibleMenus() {
@@ -1211,7 +1209,9 @@ class BrowserViewController: UIViewController,
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        updateToolbarStateForTraitCollection(traitCollection)
+        DispatchQueue.main.async { [self] in
+            updateToolbarStateForTraitCollection(traitCollection)
+        }
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
             themeManager.applyThemeUpdatesToWindows()
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -456,9 +456,7 @@ class BrowserViewController: UIViewController,
         DispatchQueue.main.async { [self] in
             let showNavToolbar = ToolbarHelper().shouldShowNavigationToolbar(for: newCollection)
             let showTopTabs = ToolbarHelper().shouldShowTopTabs(for: newCollection)
-
             switchToolbarIfNeeded()
-
             if isToolbarRefactorEnabled {
                 if showNavToolbar {
                     navigationToolbarContainer.isHidden = false
@@ -471,7 +469,6 @@ class BrowserViewController: UIViewController,
             } else {
                 legacyUrlBar?.topTabsIsShowing = showTopTabs
                 legacyUrlBar?.setShowToolbar(!showNavToolbar)
-
                 if showNavToolbar {
                     toolbar.isHidden = false
                     toolbar.tabToolbarDelegate = self
@@ -505,10 +502,8 @@ class BrowserViewController: UIViewController,
                 topTabsViewController?.removeFromParent()
                 topTabsViewController = nil
             }
-
             header.setNeedsLayout()
             view.layoutSubviews()
-
             if let tab = tabManager.selectedTab,
                let webView = tab.webView,
                !isToolbarRefactorEnabled {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11347)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24696)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- This crash appeared in v135 and I strongly believe it was because of this commit: https://github.com/mozilla-mobile/firefox-ios/commit/c0acb412581f41c8f20141431af4fc9fd5619dc7. 
- I believe that removing `DispatchQueue.main.async` from inside the method `updateToolbarStateForTraitCollection` and put it where is called would fix the crash and also not cause a regression.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

