### PR TITLE
Bugfix FXIOS-11223 [Bookmarks Evolution] Restore bookmark toast edit button functionality

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -568,8 +568,9 @@ class BrowserCoordinator: BaseCoordinator,
         }
     }
 
-    func editLatestBookmark() {
-        browserViewController.openBookmarkEditPanel()
+    func editBookmarkForCurrentTab() {
+        guard let urlString = tabManager.selectedTab?.url?.absoluteString else { return }
+        browserViewController.openBookmarkEditPanel(urlString: urlString)
     }
 
     func showFindInPage() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
@@ -52,7 +52,14 @@ class ActionProviderBuilder {
         )
     }
 
-    func addRemoveBookmarkLink(urlString: String, title: String?, removeBookmark: @escaping (String, String?, Site?) -> Void) {
+    func addRemoveBookmarkLink(
+        urlString: String,
+        title: String?,
+        removeBookmark: @escaping (
+            String,
+            String?,
+            Site?
+        ) -> Void) {
         actions.append(
             UIAction(
                 title: .RemoveBookmarkContextMenuTitle,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/ActionProviderBuilder.swift
@@ -52,14 +52,14 @@ class ActionProviderBuilder {
         )
     }
 
-    func addRemoveBookmarkLink(url: URL, title: String?, removeBookmark: @escaping (URL, String?, Site?) -> Void) {
+    func addRemoveBookmarkLink(urlString: String, title: String?, removeBookmark: @escaping (String, String?, Site?) -> Void) {
         actions.append(
             UIAction(
                 title: .RemoveBookmarkContextMenuTitle,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
                 identifier: UIAction.Identifier("linkContextMenu.removeBookmarkLink")
             ) { _ in
-                removeBookmark(url, title, nil)
+                removeBookmark(urlString, title, nil)
                 let bookmarksTelemetry = BookmarksTelemetry()
                 bookmarksTelemetry.deleteBookmark(eventLabel: .pageActionMenu)
             }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+KeyCommands.swift
@@ -45,7 +45,7 @@ extension BrowserViewController {
               let url = tab.canonicalURL?.displayURL else { return }
 
         if !contentContainer.hasAnyHomepage {
-            addBookmark(url: url.absoluteString, title: tab.title)
+            addBookmark(urlString: url.absoluteString, title: tab.title)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -356,7 +356,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate, UIDocumentPickerDele
                                                  buttonText: .BookmarksEdit)
             let toast = ButtonToast(viewModel: viewModel,
                                     theme: currentTheme()) { isButtonTapped in
-                isButtonTapped ? self.openBookmarkEditPanel() : nil
+                isButtonTapped ? self.openBookmarkEditPanel(url: bookmarkURL) : nil
             }
             if isBookmarkRefactorEnabled {
                 self.show(toast: toast, duration: DispatchTimeInterval.milliseconds(8000))

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -349,14 +349,14 @@ extension BrowserViewController: ToolBarActionMenuDelegate, UIDocumentPickerDele
         presentWithModalDismissIfNeeded(viewController, animated: true)
     }
 
-    func showToast(_ bookmarkURL: URL? = nil, _ title: String?, message: String, toastAction: MenuButtonToastAction) {
+    func showToast(_ urlString: String? = nil, _ title: String?, message: String, toastAction: MenuButtonToastAction) {
         switch toastAction {
         case .bookmarkPage:
             let viewModel = ButtonToastViewModel(labelText: message,
                                                  buttonText: .BookmarksEdit)
             let toast = ButtonToast(viewModel: viewModel,
                                     theme: currentTheme()) { isButtonTapped in
-                isButtonTapped ? self.openBookmarkEditPanel(url: bookmarkURL) : nil
+                isButtonTapped ? self.openBookmarkEditPanel(urlString: urlString) : nil
             }
             if isBookmarkRefactorEnabled {
                 self.show(toast: toast, duration: DispatchTimeInterval.milliseconds(8000))
@@ -370,7 +370,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate, UIDocumentPickerDele
                                     theme: currentTheme()) { [weak self] isButtonTapped in
                 guard let self, let currentTab = tabManager.selectedTab else { return }
                 isButtonTapped ? self.addBookmark(
-                    url: bookmarkURL?.absoluteString ?? currentTab.url?.absoluteString ?? "",
+                    urlString: urlString ?? currentTab.url?.absoluteString ?? "",
                     title: title ?? currentTab.title
                 ) : nil
             }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -434,6 +434,7 @@ extension BrowserViewController: ToolBarActionMenuDelegate, UIDocumentPickerDele
     }
 
     func showEditBookmark() {
-        openBookmarkEditPanel()
+        guard let urlString = tabManager.selectedTab?.url?.absoluteString else { return }
+        openBookmarkEditPanel(urlString: urlString)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -370,7 +370,7 @@ extension BrowserViewController: WKUIDelegate {
             .value
             .successValue ?? false
         if isBookmarkedSite {
-            actionBuilder.addRemoveBookmarkLink(url: url,
+            actionBuilder.addRemoveBookmarkLink(urlString: url.absoluteString,
                                                 title: title,
                                                 removeBookmark: self.removeBookmark)
         } else {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1692,13 +1692,13 @@ class BrowserViewController: UIViewController,
         }
     }
 
-    func addBookmark(url: String, title: String? = nil, site: Site? = nil) {
+    func addBookmark(urlString: String, title: String? = nil, site: Site? = nil) {
         var title = (title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         if title.isEmpty {
-            title = url
+            title = urlString
         }
 
-        let shareItem = ShareItem(url: url, title: title)
+        let shareItem = ShareItem(url: urlString, title: title)
 
         Task {
             await self.bookmarksSaver.createBookmark(url: shareItem.url, title: shareItem.title, position: 0)
@@ -1711,17 +1711,17 @@ class BrowserViewController: UIViewController,
         QuickActionsImplementation().addDynamicApplicationShortcutItemOfType(.openLastBookmark,
                                                                              withUserData: userData,
                                                                              toApplication: .shared)
-        showBookmarkToast(bookmarkURL: URL(string: url), action: .add)
+        showBookmarkToast(urlString: urlString, action: .add)
     }
 
-    func removeBookmark(url: URL, title: String?, site: Site? = nil) {
-        profile.places.deleteBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
+    func removeBookmark(urlString: String, title: String?, site: Site? = nil) {
+        profile.places.deleteBookmarksWithURL(url: urlString).uponQueue(.main) { result in
             guard result.isSuccess else { return }
-            self.showBookmarkToast(bookmarkURL: url, title: title, action: .remove)
+            self.showBookmarkToast(urlString: urlString, title: title, action: .remove)
         }
     }
 
-    private func showBookmarkToast(bookmarkURL: URL? = nil, title: String? = nil, action: BookmarkAction) {
+    private func showBookmarkToast(urlString: String? = nil, title: String? = nil, action: BookmarkAction) {
         switch action {
         case .add:
             if !isBookmarkRefactorEnabled {
@@ -1735,12 +1735,12 @@ class BrowserViewController: UIViewController,
                     guard let bookmarkFolder = result.successValue as? BookmarkFolderData else { return }
                     let folderName = bookmarkFolder.title
                     let message = String(format: .Bookmarks.Menu.SavedBookmarkToastLabel, folderName)
-                    self.showToast(bookmarkURL, title, message: message, toastAction: .bookmarkPage)
+                    self.showToast(urlString, title, message: message, toastAction: .bookmarkPage)
                 }
             // If recent bookmarks folder is nil or the mobile (default) folder
             } else {
                 showToast(
-                    bookmarkURL,
+                    urlString,
                     title,
                     message: .Bookmarks.Menu.SavedBookmarkToastDefaultFolderLabel,
                     toastAction: .bookmarkPage
@@ -1748,7 +1748,7 @@ class BrowserViewController: UIViewController,
             }
         case .remove:
             self.showToast(
-                bookmarkURL,
+                urlString,
                 title,
                 message: .LegacyAppMenu.RemoveBookmarkConfirmMessage,
                 toastAction: .removeBookmark
@@ -1757,7 +1757,7 @@ class BrowserViewController: UIViewController,
     }
 
     /// This function opens a standalone bookmark edit view separate from library -> bookmarks panel -> edit bookmark.
-    internal func openBookmarkEditPanel(url: URL? = nil) {
+    internal func openBookmarkEditPanel(urlString: String? = nil) {
         guard !profile.isShutdown else { return }
 
         let bookmarksTelemetry = BookmarksTelemetry()
@@ -1765,8 +1765,8 @@ class BrowserViewController: UIViewController,
 
         // Open refactored bookmark edit view
         if isBookmarkRefactorEnabled {
-            guard let url else { return }
-            profile.places.getBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
+            guard let urlString else { return }
+            profile.places.getBookmarksWithURL(url: urlString).uponQueue(.main) { result in
                 guard let bookmarkItem = result.successValue?.first,
                 let parentGuid = bookmarkItem.parentGUID else { return }
                 self.profile.places.getBookmark(guid: parentGuid).uponQueue(.main) { result in
@@ -3811,8 +3811,8 @@ extension BrowserViewController: HomePanelDelegate {
         navigationHandler?.show(settings: settingsPage)
     }
 
-    func homePanelDidRequestBookmarkToast(url: URL?, action: BookmarkAction) {
-        showBookmarkToast(bookmarkURL: url, action: action)
+    func homePanelDidRequestBookmarkToast(urlString: String?, action: BookmarkAction) {
+        showBookmarkToast(urlString: urlString, action: action)
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1711,7 +1711,7 @@ class BrowserViewController: UIViewController,
         QuickActionsImplementation().addDynamicApplicationShortcutItemOfType(.openLastBookmark,
                                                                              withUserData: userData,
                                                                              toApplication: .shared)
-        showBookmarkToast(action: .add)
+        showBookmarkToast(bookmarkURL: URL(string: url), action: .add)
     }
 
     func removeBookmark(url: URL, title: String?, site: Site? = nil) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -711,9 +711,9 @@ class BrowserViewController: UIViewController,
                 .removeShortcut,
                 .removeFromReadingList:
             showToast()
-        case .addBookmark:
+        case .addBookmark(let urlString):
             if isBookmarkRefactorEnabled {
-                showBookmarkToast(action: .add)
+                showBookmarkToast(urlString: urlString, action: .add)
             } else {
                 showToast()
             }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1735,11 +1735,16 @@ class BrowserViewController: UIViewController,
                     guard let bookmarkFolder = result.successValue as? BookmarkFolderData else { return }
                     let folderName = bookmarkFolder.title
                     let message = String(format: .Bookmarks.Menu.SavedBookmarkToastLabel, folderName)
-                    self.showToast(message: message, toastAction: .bookmarkPage)
+                    self.showToast(bookmarkURL, title, message: message, toastAction: .bookmarkPage)
                 }
             // If recent bookmarks folder is nil or the mobile (default) folder
             } else {
-                showToast(message: .Bookmarks.Menu.SavedBookmarkToastDefaultFolderLabel, toastAction: .bookmarkPage)
+                showToast(
+                    bookmarkURL,
+                    title,
+                    message: .Bookmarks.Menu.SavedBookmarkToastDefaultFolderLabel,
+                    toastAction: .bookmarkPage
+                )
             }
         case .remove:
             self.showToast(
@@ -1752,7 +1757,7 @@ class BrowserViewController: UIViewController,
     }
 
     /// This function opens a standalone bookmark edit view separate from library -> bookmarks panel -> edit bookmark.
-    internal func openBookmarkEditPanel() {
+    internal func openBookmarkEditPanel(url: URL? = nil) {
         guard !profile.isShutdown else { return }
 
         let bookmarksTelemetry = BookmarksTelemetry()
@@ -1760,7 +1765,7 @@ class BrowserViewController: UIViewController,
 
         // Open refactored bookmark edit view
         if isBookmarkRefactorEnabled {
-            guard let url = tabManager.selectedTab?.url else { return }
+            guard let url else { return }
             profile.places.getBookmarksWithURL(url: url.absoluteString).uponQueue(.main) { result in
                 guard let bookmarkItem = result.successValue?.first,
                 let parentGuid = bookmarkItem.parentGUID else { return }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -8,7 +8,7 @@ import MenuKit
 import Shared
 
 protocol MainMenuCoordinatorDelegate: AnyObject {
-    func editLatestBookmark()
+    func editBookmarkForCurrentTab()
     func openURLInNewTab(_ url: URL?)
     func openNewTab(inPrivateMode: Bool)
     func showLibraryPanel(_ panel: Route.HomepanelSection)
@@ -82,7 +82,7 @@ class MainMenuCoordinator: BaseCoordinator, FeatureFlaggable {
                 self.navigationHandler?.showLibraryPanel(.downloads)
 
             case .editBookmark:
-                self.navigationHandler?.editLatestBookmark()
+                self.navigationHandler?.editBookmarkForCurrentTab()
 
             case .findInPage:
                 self.navigationHandler?.showFindInPage()

--- a/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -12,7 +12,7 @@ import Common
 
 protocol ToolBarActionMenuDelegate: AnyObject {
     func updateToolbarState()
-    func addBookmark(url: String, title: String?, site: Site?)
+    func addBookmark(urlString: String, title: String?, site: Site?)
 
     @discardableResult
     func openURLInNewTab(_ url: URL?, isPrivate: Bool) -> Tab
@@ -20,7 +20,7 @@ protocol ToolBarActionMenuDelegate: AnyObject {
 
     func showLibrary(panel: LibraryPanelType)
     func showViewController(viewController: UIViewController)
-    func showToast(_ bookmarkURL: URL?, _ title: String?, message: String, toastAction: MenuButtonToastAction)
+    func showToast(_ bookmarkURL: String?, _ title: String?, message: String, toastAction: MenuButtonToastAction)
     func showFindInPage()
     func showCustomizeHomePage()
     func showZoomPage(tab: Tab)
@@ -31,8 +31,8 @@ protocol ToolBarActionMenuDelegate: AnyObject {
 }
 
 extension ToolBarActionMenuDelegate {
-    func showToast(_ bookmarkURL: URL? = nil, _ title: String? = nil, message: String, toastAction: MenuButtonToastAction) {
-        showToast(bookmarkURL, title, message: message, toastAction: toastAction)
+    func showToast(_ urlString: String? = nil, _ title: String? = nil, message: String, toastAction: MenuButtonToastAction) {
+        showToast(urlString, title, message: message, toastAction: toastAction)
     }
 }
 
@@ -734,7 +734,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
             else { return }
 
             // The method in BVC also handles the toast for this use case
-            self.delegate?.addBookmark(url: url.absoluteString, title: tab.title, site: nil)
+            self.delegate?.addBookmark(urlString: url.absoluteString, title: tab.title, site: nil)
             let bookmarksTelemetry = BookmarksTelemetry()
             bookmarksTelemetry.addBookmark(eventLabel: .pageActionMenu)
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -413,7 +413,8 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
                                                                              withUserData: userData,
                                                                              toApplication: .shared)
 
-        let toastAction = TabPanelMiddlewareAction(toastType: .addBookmark,
+        // The Tab Tray uses a "SimpleToast", so the urlString will go unused
+        let toastAction = TabPanelMiddlewareAction(toastType: .addBookmark(urlString: shareItem.url),
                                                    windowUUID: uuid,
                                                    actionType: TabPanelMiddlewareActionType.showToast)
         store.dispatch(toastAction)
@@ -713,9 +714,10 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
             let shareItem = createShareItem(with: tabID, and: action.windowUUID)
             addToBookmarks(shareItem)
 
+            guard let shareItem else { return }
             store.dispatch(
                 GeneralBrowserAction(
-                    toastType: .addBookmark,
+                    toastType: .addBookmark(urlString: shareItem.url),
                     windowUUID: action.windowUUID,
                     actionType: GeneralBrowserActionType.showToast
                 )

--- a/firefox-ios/Client/Frontend/Browser/ToastType.swift
+++ b/firefox-ios/Client/Frontend/Browser/ToastType.swift
@@ -6,7 +6,7 @@ import Foundation
 import Common
 
 enum ToastType: Equatable {
-    case addBookmark
+    case addBookmark(urlString: String)
     case addToReadingList
     case addShortcut
     case clearCookies

--- a/firefox-ios/Client/Frontend/Home/HomePanelDelegate.swift
+++ b/firefox-ios/Client/Frontend/Home/HomePanelDelegate.swift
@@ -12,7 +12,7 @@ protocol HomePanelDelegate: AnyObject {
     func homePanelDidRequestToOpenLibrary(panel: LibraryPanelType)
     func homePanelDidRequestToOpenTabTray(withFocusedTab tabToFocus: Tab?, focusedSegment: TabTrayPanelType?)
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection)
-    func homePanelDidRequestBookmarkToast(url: URL?, action: BookmarkAction)
+    func homePanelDidRequestBookmarkToast(urlString: String?, action: BookmarkAction)
 }
 
 extension HomePanelDelegate {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -12,8 +12,8 @@ import Redux
 /// Classes conforming to this protocol can manage adding and removing bookmarks.
 /// Since bookmarks are not using Redux, we use this instead of dispatching an action.
 protocol BookmarksHandlerDelegate: AnyObject {
-    func addBookmark(url: String, title: String?, site: Site?)
-    func removeBookmark(url: URL, title: String?, site: Site?)
+    func addBookmark(urlString: String, title: String?, site: Site?)
+    func removeBookmark(urlString: String, title: String?, site: Site?)
 }
 
 /// State to populate actions for the `PhotonActionSheet` view
@@ -242,15 +242,7 @@ struct ContextMenuState {
                                      iconString: StandardImageIdentifiers.Large.bookmarkSlash,
                                      allowIconScaling: true,
                                      tapHandler: { _ in
-            guard let siteURL = site.url.asURL else {
-                self.logger.log(
-                    "Unable to retrieve URL for \(site.url), unable to remove bookmarks",
-                    level: .warning,
-                    category: .homepage
-                )
-                return
-            }
-            bookmarkDelegate.removeBookmark(url: siteURL, title: site.title, site: site)
+            bookmarkDelegate.removeBookmark(urlString: site.url, title: site.title, site: site)
             // TODO: FXIOS-10171 - Add telemetry
         })
     }
@@ -261,7 +253,7 @@ struct ContextMenuState {
                                      allowIconScaling: true,
                                      tapHandler: { _ in
             // The method in BVC also handles the toast for this use case
-            bookmarkDelegate.addBookmark(url: site.url, title: site.title, site: site)
+            bookmarkDelegate.addBookmark(urlString: site.url, title: site.title, site: site)
             // TODO: FXIOS-10171 - Add telemetry
         })
     }

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -231,7 +231,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol,
                                                                                  withUserData: userData,
                                                                                  toApplication: .shared)
 
-            self.delegate?.homePanelDidRequestBookmarkToast(url: nil, action: .add)
+            self.delegate?.homePanelDidRequestBookmarkToast(url: URL(string: site.url), action: .add)
             self.bookmarksTelemetry.addBookmark(eventLabel: .activityStream)
         })
     }

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -13,7 +13,7 @@ import enum MozillaAppServices.BookmarkRoots
 protocol HomepageContextMenuHelperDelegate: UIViewController {
     func homePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool, selectNewTab: Bool)
     func homePanelDidRequestToOpenSettings(at settingsPage: Route.SettingsSection)
-    func homePanelDidRequestBookmarkToast(url: URL?, action: BookmarkAction)
+    func homePanelDidRequestBookmarkToast(urlString: String?, action: BookmarkAction)
 }
 // swiftlint:enable class_delegate_protocol
 
@@ -206,8 +206,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol,
             // We don't need to do anything after this call completes
             _ = self.viewModel.profile.places.deleteBookmarksWithURL(url: site.url)
 
-            let url = URL(string: site.url)
-            self.delegate?.homePanelDidRequestBookmarkToast(url: url, action: .remove)
+            self.delegate?.homePanelDidRequestBookmarkToast(urlString: site.url, action: .remove)
             self.bookmarksTelemetry.deleteBookmark(eventLabel: .activityStream)
         })
     }
@@ -231,7 +230,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol,
                                                                                  withUserData: userData,
                                                                                  toApplication: .shared)
 
-            self.delegate?.homePanelDidRequestBookmarkToast(url: URL(string: site.url), action: .add)
+            self.delegate?.homePanelDidRequestBookmarkToast(urlString: shareItem.url, action: .add)
             self.bookmarksTelemetry.addBookmark(eventLabel: .activityStream)
         })
     }

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -893,8 +893,8 @@ extension LegacyHomepageViewController: HomepageContextMenuHelperDelegate {
         homePanelDelegate?.homePanelDidRequestToOpenSettings(at: settingsPage)
     }
 
-    func homePanelDidRequestBookmarkToast(url: URL?, action: BookmarkAction) {
-        homePanelDelegate?.homePanelDidRequestBookmarkToast(url: url, action: action)
+    func homePanelDidRequestBookmarkToast(urlString: String?, action: BookmarkAction) {
+        homePanelDelegate?.homePanelDidRequestBookmarkToast(urlString: urlString, action: action)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/ContextMenu/ContextMenuCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/ContextMenu/ContextMenuCoordinatorTests.swift
@@ -64,6 +64,6 @@ final class ContextMenuCoordinatorTests: XCTestCase {
 }
 
 class MockBookmarksHandlerDelegate: BookmarksHandlerDelegate {
-    func addBookmark(url: String, title: String?, site: Site?) { }
-    func removeBookmark(url: URL, title: String?, site: Site?) { }
+    func addBookmark(urlString: String, title: String?, site: Site?) { }
+    func removeBookmark(urlString: String, title: String?, site: Site?) { }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11223)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24418)

## :bulb: Description
- The "Edit" button on the "Add bookmark" toast, presented when adding a bookmark from either a homepage cell (JBI or Pocket) or web link context menu's, will now open the "Edit bookmark" view 
- Refactored the toast call hierarchy to take in a string (`urlString`) instead of a URL type

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

