### PR TITLE
Bugfix FXIOS-11307 [Homepage] [TopSites] layout logic

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -63,7 +63,6 @@ final class HomepageDiffableDataSource:
 
     func updateSnapshot(
         state: HomepageState,
-        numberOfCellsPerRow: Int,
         jumpBackInDisplayConfig: JumpBackInSectionLayoutConfiguration
     ) {
         var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeItem>()
@@ -78,7 +77,7 @@ final class HomepageDiffableDataSource:
             snapshot.appendItems([.messageCard(configuration)], toSection: .messageCard)
         }
 
-        if let topSites = getTopSites(with: state.topSitesState, and: textColor, numberOfCellsPerRow: numberOfCellsPerRow) {
+        if let (topSites, numberOfCellsPerRow) = getTopSites(with: state.topSitesState, and: textColor) {
             snapshot.appendSections([.topSites(numberOfCellsPerRow)])
             snapshot.appendItems(topSites, toSection: .topSites(numberOfCellsPerRow))
         }
@@ -120,17 +119,16 @@ final class HomepageDiffableDataSource:
     ///   - textColor: text color from wallpaper configuration
     private func getTopSites(
         with topSitesState: TopSitesSectionState,
-        and textColor: TextColor?,
-        numberOfCellsPerRow: Int
-    ) -> [HomepageDiffableDataSource.HomeItem]? {
+        and textColor: TextColor?
+    ) -> ([HomepageDiffableDataSource.HomeItem], Int)? {
         guard topSitesState.shouldShowSection else { return nil }
         let topSites: [HomeItem] = topSitesState.topSitesData.prefix(
-            topSitesState.numberOfRows * numberOfCellsPerRow
+            topSitesState.numberOfRows * topSitesState.numberOfTilesPerRow
         ).compactMap {
             .topSite($0, textColor)
         }
         guard !topSites.isEmpty else { return nil }
-        return topSites
+        return (topSites, topSitesState.numberOfTilesPerRow)
     }
 
     private func getJumpBackInTabs(

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -641,7 +641,11 @@ final class HomepageViewController: UIViewController,
     private func navigateToPocketLearnMore() {
         store.dispatch(
             NavigationBrowserAction(
-                navigationDestination: NavigationDestination(.link, url: homepageState.pocketState.footerURL),
+                navigationDestination: NavigationDestination(
+                    .link,
+                    url: homepageState.pocketState.footerURL,
+                    visitType: .link
+                ),
                 windowUUID: self.windowUUID,
                 actionType: NavigationBrowserActionType.tapOnLink
             )
@@ -722,24 +726,19 @@ final class HomepageViewController: UIViewController,
             )
             dispatchNavigationBrowserAction(with: destination, actionType: NavigationBrowserActionType.tapOnCell)
         case .pocket(let story):
-            store.dispatch(
-                NavigationBrowserAction(
-                    navigationDestination: NavigationDestination(.link, url: story.url),
-                    windowUUID: self.windowUUID,
-                    actionType: NavigationBrowserActionType.tapOnCell
-                )
+            let destination = NavigationDestination(
+                .link,
+                url: story.url,
+                visitType: .link
             )
+            dispatchNavigationBrowserAction(with: destination, actionType: NavigationBrowserActionType.tapOnCell)
         case .pocketDiscover(let item):
-            store.dispatch(
-                NavigationBrowserAction(
-                    navigationDestination: NavigationDestination(
-                        .link,
-                        url: item.url
-                    ),
-                    windowUUID: self.windowUUID,
-                    actionType: NavigationBrowserActionType.tapOnCell
-                )
+            let destination = NavigationDestination(
+                .link,
+                url: item.url,
+                visitType: .link
             )
+            dispatchNavigationBrowserAction(with: destination, actionType: NavigationBrowserActionType.tapOnCell)
         default:
             return
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -116,6 +116,7 @@ final class HomepageViewController: UIViewController,
 
         store.dispatch(
             HomepageAction(
+                numberOfTopSitesPerRow: numberOfTilesPerRow(for: availableWidth),
                 showiPadSetup: shouldUseiPadSetup(),
                 windowUUID: windowUUID,
                 actionType: HomepageActionType.initialize
@@ -232,11 +233,8 @@ final class HomepageViewController: UIViewController,
         self.homepageState = state
         wallpaperView.wallpaperState = state.wallpaperState
 
-        let numberOfCellsPerRow = state.topSitesState.numberOfTilesPerRow ?? numberOfTilesPerRow(for: availableWidth)
-
         dataSource?.updateSnapshot(
             state: state,
-            numberOfCellsPerRow: numberOfCellsPerRow,
             jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
         )
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -132,6 +132,7 @@ final class HomepageViewController: UIViewController,
         wallpaperView.updateImageForOrientationChange()
         store.dispatch(
             HomepageAction(
+                numberOfTopSitesPerRow: numberOfTilesPerRow(for: size.width),
                 windowUUID: windowUUID,
                 actionType: HomepageActionType.viewWillTransition
             )
@@ -230,9 +231,12 @@ final class HomepageViewController: UIViewController,
     func newState(state: HomepageState) {
         self.homepageState = state
         wallpaperView.wallpaperState = state.wallpaperState
+
+        let numberOfCellsPerRow = state.topSitesState.numberOfTilesPerRow ?? numberOfTilesPerRow(for: availableWidth)
+
         dataSource?.updateSnapshot(
             state: state,
-            numberOfCellsPerRow: numberOfTilesPerRow(for: availableWidth),
+            numberOfCellsPerRow: numberOfCellsPerRow,
             jumpBackInDisplayConfig: getJumpBackInDisplayConfig()
         )
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -6,9 +6,16 @@ import Common
 import Redux
 
 final class HomepageAction: Action {
-    var showiPadSetup: Bool?
+    let showiPadSetup: Bool?
+    let numberOfTopSitesPerRow: Int?
 
-    init(showiPadSetup: Bool? = nil, windowUUID: WindowUUID, actionType: any ActionType) {
+    init(
+        numberOfTopSitesPerRow: Int? = nil,
+        showiPadSetup: Bool? = nil,
+        windowUUID: WindowUUID,
+        actionType: any ActionType
+    ) {
+        self.numberOfTopSitesPerRow = numberOfTopSitesPerRow
         self.showiPadSetup = showiPadSetup
         super.init(windowUUID: windowUUID, actionType: actionType)
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -14,6 +14,7 @@ struct TopSitesSectionState: StateType, Equatable {
     var windowUUID: WindowUUID
     let topSitesData: [TopSiteConfiguration]
     let numberOfRows: Int
+    let numberOfTilesPerRow: Int?
     let shouldShowSection: Bool
 
     init(profile: Profile = AppContainer.shared.resolve(), windowUUID: WindowUUID) {
@@ -26,6 +27,7 @@ struct TopSitesSectionState: StateType, Equatable {
             windowUUID: windowUUID,
             topSitesData: [],
             numberOfRows: numberOfRows,
+            numberOfTilesPerRow: nil,
             shouldShowSection: shouldShowSection
         )
     }
@@ -34,11 +36,13 @@ struct TopSitesSectionState: StateType, Equatable {
         windowUUID: WindowUUID,
         topSitesData: [TopSiteConfiguration],
         numberOfRows: Int,
+        numberOfTilesPerRow: Int?,
         shouldShowSection: Bool
     ) {
         self.windowUUID = windowUUID
         self.topSitesData = topSitesData
         self.numberOfRows = numberOfRows
+        self.numberOfTilesPerRow = numberOfTilesPerRow
         self.shouldShowSection = shouldShowSection
     }
 
@@ -55,6 +59,8 @@ struct TopSitesSectionState: StateType, Equatable {
             return handleUpdatedNumberOfRowsAction(action: action, state: state)
         case TopSitesActionType.toggleShowSectionSetting:
             return handleToggleShowSectionSettingAction(action: action, state: state)
+        case HomepageActionType.viewWillTransition:
+            return handleViewChangeAction(action: action, state: state)
         default:
             return defaultState(from: state)
         }
@@ -71,6 +77,7 @@ struct TopSitesSectionState: StateType, Equatable {
             windowUUID: state.windowUUID,
             topSitesData: sites,
             numberOfRows: state.numberOfRows,
+            numberOfTilesPerRow: state.numberOfTilesPerRow,
             shouldShowSection: !sites.isEmpty && state.shouldShowSection
         )
     }
@@ -86,6 +93,23 @@ struct TopSitesSectionState: StateType, Equatable {
             windowUUID: state.windowUUID,
             topSitesData: state.topSitesData,
             numberOfRows: numberOfRows,
+            numberOfTilesPerRow: state.numberOfTilesPerRow,
+            shouldShowSection: state.shouldShowSection
+        )
+    }
+
+    private static func handleViewChangeAction(action: Action, state: Self) -> TopSitesSectionState {
+        guard let homepageAction = action as? HomepageAction,
+              let numberOfTilesPerRow = homepageAction.numberOfTopSitesPerRow
+        else {
+            return defaultState(from: state)
+        }
+
+        return TopSitesSectionState(
+            windowUUID: state.windowUUID,
+            topSitesData: state.topSitesData,
+            numberOfRows: state.numberOfRows,
+            numberOfTilesPerRow: numberOfTilesPerRow,
             shouldShowSection: state.shouldShowSection
         )
     }
@@ -101,6 +125,7 @@ struct TopSitesSectionState: StateType, Equatable {
             windowUUID: state.windowUUID,
             topSitesData: state.topSitesData,
             numberOfRows: state.numberOfRows,
+            numberOfTilesPerRow: state.numberOfTilesPerRow,
             shouldShowSection: isEnabled
         )
     }
@@ -110,6 +135,7 @@ struct TopSitesSectionState: StateType, Equatable {
             windowUUID: state.windowUUID,
             topSitesData: state.topSitesData,
             numberOfRows: state.numberOfRows,
+            numberOfTilesPerRow: state.numberOfTilesPerRow,
             shouldShowSection: state.shouldShowSection
         )
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSitesSectionState.swift
@@ -14,7 +14,7 @@ struct TopSitesSectionState: StateType, Equatable {
     var windowUUID: WindowUUID
     let topSitesData: [TopSiteConfiguration]
     let numberOfRows: Int
-    let numberOfTilesPerRow: Int?
+    let numberOfTilesPerRow: Int
     let shouldShowSection: Bool
 
     init(profile: Profile = AppContainer.shared.resolve(), windowUUID: WindowUUID) {
@@ -27,7 +27,7 @@ struct TopSitesSectionState: StateType, Equatable {
             windowUUID: windowUUID,
             topSitesData: [],
             numberOfRows: numberOfRows,
-            numberOfTilesPerRow: nil,
+            numberOfTilesPerRow: HomepageSectionLayoutProvider.UX.TopSitesConstants.minCards,
             shouldShowSection: shouldShowSection
         )
     }
@@ -36,7 +36,7 @@ struct TopSitesSectionState: StateType, Equatable {
         windowUUID: WindowUUID,
         topSitesData: [TopSiteConfiguration],
         numberOfRows: Int,
-        numberOfTilesPerRow: Int?,
+        numberOfTilesPerRow: Int,
         shouldShowSection: Bool
     ) {
         self.windowUUID = windowUUID
@@ -59,7 +59,7 @@ struct TopSitesSectionState: StateType, Equatable {
             return handleUpdatedNumberOfRowsAction(action: action, state: state)
         case TopSitesActionType.toggleShowSectionSetting:
             return handleToggleShowSectionSettingAction(action: action, state: state)
-        case HomepageActionType.viewWillTransition:
+        case HomepageActionType.initialize, HomepageActionType.viewWillTransition:
             return handleViewChangeAction(action: action, state: state)
         default:
             return defaultState(from: state)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -38,7 +38,6 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         dataSource.updateSnapshot(
             state: HomepageState(windowUUID: .XCTestDefaultUUID),
-            numberOfCellsPerRow: 4,
             jumpBackInDisplayConfig: mockSectionConfig
         )
 
@@ -84,7 +83,6 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         dataSource.updateSnapshot(
             state: updatedState,
-            numberOfCellsPerRow: 4,
             jumpBackInDisplayConfig: mockSectionConfig
         )
 
@@ -113,7 +111,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             )
         )
 
-        dataSource.updateSnapshot(state: updatedState, numberOfCellsPerRow: 4, jumpBackInDisplayConfig: mockSectionConfig)
+        dataSource.updateSnapshot(state: updatedState, jumpBackInDisplayConfig: mockSectionConfig)
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .topSites(4)), 8)
@@ -138,7 +136,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             )
         )
 
-        dataSource.updateSnapshot(state: state, numberOfCellsPerRow: 4, jumpBackInDisplayConfig: mockSectionConfig)
+        dataSource.updateSnapshot(state: state, jumpBackInDisplayConfig: mockSectionConfig)
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil)), 21)
@@ -168,7 +166,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             )
         )
 
-        dataSource.updateSnapshot(state: state, numberOfCellsPerRow: 4, jumpBackInDisplayConfig: mockSectionConfig)
+        dataSource.updateSnapshot(state: state, jumpBackInDisplayConfig: mockSectionConfig)
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .messageCard), 1)
@@ -200,7 +198,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             )
         )
 
-        dataSource.updateSnapshot(state: state, numberOfCellsPerRow: 4, jumpBackInDisplayConfig: mockSectionConfig)
+        dataSource.updateSnapshot(state: state, jumpBackInDisplayConfig: mockSectionConfig)
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfItems(inSection: .bookmarks(nil)), 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/TopSitesSectionStateTests.swift
@@ -106,21 +106,21 @@ final class TopsSitesSectionStateTests: XCTestCase {
         XCTAssertTrue(newState.shouldShowSection)
     }
 
-    func test_toggleShowSectionSetting_withToggleOff_returnsExpectedState() throws {
+    func test_numberOfTilesPerRow_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = topSiteReducer()
 
         let newState = reducer(
             initialState,
-            TopSitesAction(
-                isEnabled: false,
+            HomepageAction(
+                numberOfTopSitesPerRow: 8,
                 windowUUID: .XCTestDefaultUUID,
-                actionType: TopSitesActionType.toggleShowSectionSetting
+                actionType: HomepageActionType.viewWillTransition
             )
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertFalse(newState.shouldShowSection)
+        XCTAssertEqual(newState.numberOfTilesPerRow, 8)
     }
 
     // MARK: - Private


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11307)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24593)

## :bulb: Description
Fix how we determine the number of tiles for top sites. This issue only exists with the `Toolbar Redesign` disabled. This is because we are dispatching more actions with the `Toolbar Redesign` so it causes the `numberOfTilesPerRow` to re-calculate more often. The issue without the toolbar redesign is that we call the calculation less often and the last call was calculated with the wrong size. 

This change guarantees that we are calculating the proper number of tiles before the view changes by dispatching an action that updates the state with the updated number of tiles that causes the datasource to be updated with the proper data.

Also sneaked in a fix from a bug introduced by https://github.com/mozilla-mobile/firefox-ios/pull/24543

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots

https://github.com/user-attachments/assets/3c5a29c4-9f56-4cb0-80c5-a31609b0042c

