### PR TITLE
Bugfix FXIOS-10917  Firefox on iPadOS fails to download from Google Docs Website

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		2173326829CCDA8E007F20C7 /* TabScrollControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */; };
 		2173326A29CCF901007F20C7 /* UIPanGestureRecognizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */; };
 		21737FB72878A4BD000A9A92 /* HistoryPanelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21737FB528789EA9000A9A92 /* HistoryPanelViewModelTests.swift */; };
+		217641B82D651DB900597B6F /* MIMEType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217641B72D651DB900597B6F /* MIMEType.swift */; };
 		2178A6A0291454B5002EC290 /* ReaderModeThemeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A69F291454B5002EC290 /* ReaderModeThemeButton.swift */; };
 		2178A6A229145506002EC290 /* ReaderModeFontSizeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A6A129145506002EC290 /* ReaderModeFontSizeLabel.swift */; };
 		2178A6A4291455F7002EC290 /* ReaderModeFontSizeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A6A3291455F7002EC290 /* ReaderModeFontSizeButton.swift */; };
@@ -2704,6 +2705,7 @@
 		2173326629CCD259007F20C7 /* TabScrollControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabScrollControllerTests.swift; sourceTree = "<group>"; };
 		2173326929CCF901007F20C7 /* UIPanGestureRecognizerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPanGestureRecognizerMock.swift; sourceTree = "<group>"; };
 		21737FB528789EA9000A9A92 /* HistoryPanelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryPanelViewModelTests.swift; sourceTree = "<group>"; };
+		217641B72D651DB900597B6F /* MIMEType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIMEType.swift; sourceTree = "<group>"; };
 		2178A69F291454B5002EC290 /* ReaderModeThemeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeThemeButton.swift; sourceTree = "<group>"; };
 		2178A6A129145506002EC290 /* ReaderModeFontSizeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontSizeLabel.swift; sourceTree = "<group>"; };
 		2178A6A3291455F7002EC290 /* ReaderModeFontSizeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontSizeButton.swift; sourceTree = "<group>"; };
@@ -10464,6 +10466,15 @@
 			path = ThemeSettings;
 			sourceTree = "<group>";
 		};
+		217641B62D651D8600597B6F /* DownloadHelper */ = {
+			isa = PBXGroup;
+			children = (
+				7BA8D1C61BA037F500C8AE9E /* DownloadHelper.swift */,
+				217641B72D651DB900597B6F /* MIMEType.swift */,
+			);
+			path = DownloadHelper;
+			sourceTree = "<group>";
+		};
 		2178A69D291453CC002EC290 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -11917,7 +11928,6 @@
 		8A590C5F28C122FF0032F1AA /* OpenInHelper */ = {
 			isa = PBXGroup;
 			children = (
-				7BA8D1C61BA037F500C8AE9E /* DownloadHelper.swift */,
 				8A590C6028C123100032F1AA /* OpenPassBookHelper.swift */,
 				8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */,
 			);
@@ -13745,6 +13755,7 @@
 				C849E45F26B9C36600260F0B /* EnhancedTrackingProtection */,
 				23F2C365244E44FA00FA4496 /* Tabs */,
 				E17798942BD6B30700F6F0EB /* Toolbars */,
+				217641B62D651D8600597B6F /* DownloadHelper */,
 				D38F02D01C05127100175932 /* Authenticator.swift */,
 				C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */,
 				C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */,
@@ -16990,6 +17001,7 @@
 				5A64225129CB506500EEC3E5 /* TabManagerDelegate.swift in Sources */,
 				8A93F86029D36EBD004159D9 /* Router.swift in Sources */,
 				C8417D222657F0600010B877 /* LibraryViewModel.swift in Sources */,
+				217641B82D651DB900597B6F /* MIMEType.swift in Sources */,
 				219935E92B070F9000E5966F /* TabPanelAction.swift in Sources */,
 				8A5D1CB22A30D756005AD35C /* SiriPageSetting.swift in Sources */,
 				39A359E41BFCCE94006B9E87 /* UserActivityHandler.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1067,38 +1067,6 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 }
 
-// MARK: - WKDownloadDelegate
-extension BrowserViewController: WKDownloadDelegate {
-    // Handle file destination for download
-    func download(_ download: WKDownload,
-                  decideDestinationUsing response: URLResponse,
-                  suggestedFilename: String,
-                  completionHandler: @escaping (URL?) -> Void) {
-        let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let destinationURL = documentsPath.appendingPathComponent(suggestedFilename)
-        print("Saving file to: \(destinationURL)")
-
-        completionHandler(destinationURL)
-    }
-
-    // Handle download completion
-    func downloadDidFinish(_ download: WKDownload) {
-        print("YRD ------ Download finished! ------")
-        DispatchQueue.main.async {
-            let alert = UIAlertController(title: "Download Complete",
-                                          message: "Your file has been saved to the Documents folder.",
-                                          preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            self.present(alert, animated: true)
-        }
-    }
-
-    // Handle download errors
-    func download(_ download: WKDownload, didFailWithError error: Error, resumeData: Data?) {
-        print("YRD ------ Download failed: \(error.localizedDescription)")
-    }
-}
-
 // MARK: - Private
 private extension BrowserViewController {
     // Handle Universal link for Firefox wallpaper setting

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -767,13 +767,12 @@ extension BrowserViewController: WKNavigationDelegate {
             tab.mimeType = response.mimeType
         }
 
-        // Allow download not from main frame. update to use donwloadable docs after
-        if !navigationResponse.isForMainFrame, response.mimeType == MIMEType.PDF {
-            if let downloadHelper = DownloadHelper(request: request, response: response, cookieStore: cookieStore) {
+        // Allow download files . update to use downloadable docs after
+        let downloadHelper = DownloadHelper(request: request, response: response, cookieStore: cookieStore)
+        if let downloadHelper, downloadHelper.shouldDownloadAttachment(), !navigationResponse.isForMainFrame {
                 handleDownloadFiles(downloadHelper: downloadHelper)
                 decisionHandler(.cancel)
                 return
-            }
         }
 
         // If none of our helpers are responsible for handling this response,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -735,9 +735,11 @@ extension BrowserViewController: WKNavigationDelegate {
             present(alert, animated: true)
         }
 
-        // Check if this response should be downloaded. Only handles Blob URL Downloads
+        // Check if this response should be downloaded
         if let downloadHelper = DownloadHelper(request: request, response: response, cookieStore: cookieStore),
-            downloadHelper.shouldDownloadBlob(canShowInWebView: canShowInWebView, forceDownload: forceDownload) {
+            downloadHelper.shouldDownloadFile(canShowInWebView: canShowInWebView,
+                                              forceDownload: forceDownload,
+                                              isForMainFrame: navigationResponse.isForMainFrame) {
             handleDownloadFiles(downloadHelper: downloadHelper)
             decisionHandler(.cancel)
             return
@@ -765,14 +767,6 @@ extension BrowserViewController: WKNavigationDelegate {
             }
 
             tab.mimeType = response.mimeType
-        }
-
-        // Allow download files . update to use downloadable docs after
-        let downloadHelper = DownloadHelper(request: request, response: response, cookieStore: cookieStore)
-        if let downloadHelper, downloadHelper.shouldDownloadAttachment(), !navigationResponse.isForMainFrame {
-                handleDownloadFiles(downloadHelper: downloadHelper)
-                decisionHandler(.cancel)
-                return
         }
 
         // If none of our helpers are responsible for handling this response,

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadHelper.swift
@@ -44,7 +44,7 @@ class DownloadHelper: NSObject {
         }
 
         // Handles attachments downloads.
-        // Only supports PDF ATM but can be expanded to support more extension
+        // Only supports PDF and Words docs but can be expanded to support more extensions
         if shouldDownloadAttachment(isForMainFrame: isForMainFrame) {
             return true
         }

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadHelper.swift
@@ -7,56 +7,6 @@ import Foundation
 import MobileCoreServices
 import WebKit
 import Shared
-import UniformTypeIdentifiers
-
-struct MIMEType {
-    static let Bitmap = "image/bmp"
-    static let CSS = "text/css"
-    static let GIF = "image/gif"
-    static let JavaScript = "text/javascript"
-    static let JPEG = "image/jpeg"
-    static let HTML = "text/html"
-    static let OctetStream = "application/octet-stream"
-    static let Passbook = "application/vnd.apple.pkpass"
-    static let PDF = "application/pdf"
-    static let PlainText = "text/plain"
-    static let PNG = "image/png"
-    static let WebP = "image/webp"
-    static let Calendar = "text/calendar"
-    static let USDZ = "model/vnd.usdz+zip"
-    static let Reality = "model/vnd.reality"
-
-    private static let webViewViewableTypes: [String] = [
-        MIMEType.Bitmap,
-        MIMEType.GIF,
-        MIMEType.JPEG,
-        MIMEType.HTML,
-        MIMEType.PDF,
-        MIMEType.PlainText,
-        MIMEType.PNG,
-        MIMEType.WebP]
-
-    static func canShowInWebView(_ mimeType: String) -> Bool {
-        return webViewViewableTypes.contains(mimeType.lowercased())
-    }
-
-    static func mimeTypeFromFileExtension(_ fileExtension: String) -> String {
-        if let uti = UTType(filenameExtension: fileExtension),
-           let mimeType = uti.preferredMIMEType {
-            return mimeType as String
-        }
-
-        return MIMEType.OctetStream
-    }
-
-    static func fileExtensionFromMIMEType(_ mimeType: String) -> String? {
-        if let uti = UTType(mimeType: mimeType),
-           let fileExtension = uti.preferredFilenameExtension {
-            return fileExtension as String
-        }
-        return nil
-    }
-}
 
 class DownloadHelper: NSObject {
     private let request: URLRequest
@@ -85,7 +35,7 @@ class DownloadHelper: NSObject {
 
     func shouldDownloadBlob(canShowInWebView: Bool, forceDownload: Bool) -> Bool {
         let mimeType = preflightResponse.mimeType ?? MIMEType.OctetStream
-        let isAttachment = mimeType == MIMEType.OctetStream
+        let isBinaryData = mimeType == MIMEType.OctetStream
 
         // Bug 1474339 - Don't auto-download files served with 'Content-Disposition: attachment'
         // Leaving this here for now, but commented out. Checking this HTTP header is
@@ -93,9 +43,17 @@ class DownloadHelper: NSObject {
         // let contentDisposition = (response as? HTTPURLResponse)?.allHeaderFields["Content-Disposition"] as? String
         // let isAttachment = contentDisposition?.starts(with: "attachment") ?? (mimeType == MIMEType.OctetStream)
 
-        guard isAttachment || !canShowInWebView || forceDownload else { return false }
+        guard isBinaryData || !canShowInWebView || forceDownload else { return false }
 
         return true
+    }
+
+    func shouldDownloadAttachment() -> Bool {
+        let contentDisposition = (preflightResponse as? HTTPURLResponse)?.allHeaderFields["Content-Disposition"] as? String
+        let isAttachment = contentDisposition?.starts(with: "attachment") ?? false
+        let canBeDownloaded = MIMEType.canBeDownloaded(preflightResponse.mimeType)
+
+        return isAttachment && canBeDownloaded
     }
 
     func downloadViewModel(windowUUID: WindowUUID,

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/MIMEType.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/MIMEType.swift
@@ -21,6 +21,8 @@ struct MIMEType {
     static let Calendar = "text/calendar"
     static let USDZ = "model/vnd.usdz+zip"
     static let Reality = "model/vnd.reality"
+    static let OpenDocument = "application/msword"
+    static let MicrosoftWord = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
     private static let webViewViewableTypes: [String] = [
         MIMEType.Bitmap,
@@ -34,7 +36,9 @@ struct MIMEType {
     ]
 
     private static let downloadableTypes: [String] = [
-        MIMEType.PDF
+        MIMEType.PDF,
+        MIMEType.OpenDocument,
+        MIMEType.MicrosoftWord
     ]
 
     static func canShowInWebView(_ mimeType: String) -> Bool {

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/MIMEType.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/MIMEType.swift
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import UniformTypeIdentifiers
+
+struct MIMEType {
+    static let Bitmap = "image/bmp"
+    static let CSS = "text/css"
+    static let GIF = "image/gif"
+    static let JavaScript = "text/javascript"
+    static let JPEG = "image/jpeg"
+    static let HTML = "text/html"
+    static let OctetStream = "application/octet-stream"
+    static let Passbook = "application/vnd.apple.pkpass"
+    static let PDF = "application/pdf"
+    static let PlainText = "text/plain"
+    static let PNG = "image/png"
+    static let WebP = "image/webp"
+    static let Calendar = "text/calendar"
+    static let USDZ = "model/vnd.usdz+zip"
+    static let Reality = "model/vnd.reality"
+
+    private static let webViewViewableTypes: [String] = [
+        MIMEType.Bitmap,
+        MIMEType.GIF,
+        MIMEType.JPEG,
+        MIMEType.HTML,
+        MIMEType.PDF,
+        MIMEType.PlainText,
+        MIMEType.PNG,
+        MIMEType.WebP
+    ]
+
+    private static let downloadableTypes: [String] = [
+        MIMEType.PDF
+    ]
+
+    static func canShowInWebView(_ mimeType: String) -> Bool {
+        return webViewViewableTypes.contains(mimeType.lowercased())
+    }
+
+    static func canBeDownloaded(_ mimeType: String?) -> Bool {
+        guard let mimeType else { return false }
+        return downloadableTypes.contains(mimeType.lowercased())
+    }
+
+    static func mimeTypeFromFileExtension(_ fileExtension: String) -> String {
+        if let uti = UTType(filenameExtension: fileExtension),
+           let mimeType = uti.preferredMIMEType {
+            return mimeType as String
+        }
+
+        return MIMEType.OctetStream
+    }
+
+    static func fileExtensionFromMIMEType(_ mimeType: String) -> String? {
+        if let uti = UTType(mimeType: mimeType),
+           let fileExtension = uti.preferredFilenameExtension {
+            return fileExtension as String
+        }
+        return nil
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadHelperTests.swift
@@ -11,136 +11,96 @@ class DownloadHelperTests: XCTestCase {
     func test_init_whenMIMETypeIsNil_initializeCorrectly() {
         let response = anyResponse(mimeType: nil)
 
-        var subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: false
-        )
-        XCTAssertNotNil(subject)
-
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: false,
-            forceDownload: true
-        )
-        XCTAssertNotNil(subject)
-
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: false,
-            forceDownload: false
-        )
-        XCTAssertNotNil(subject)
-
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: true
-        )
+        let subject = createSubject(request: anyRequest(),
+                                    response: response,
+                                    cookieStore: cookieStore())
         XCTAssertNotNil(subject)
     }
 
-    func test_init_whenMIMETypeIsNotOctetStream_initializeCorrectly() {
-        for mimeType in allMIMETypes() {
-            if mimeType == MIMEType.OctetStream { continue }
+    func test_shouldDownloadFile_whenMIMETypeOctetStream_isTrue() {
+        let mimeType = MIMEType.OctetStream
 
-            let response = anyResponse(mimeType: mimeType)
+        let response = anyResponse(mimeType: mimeType)
+        let subject = createSubject(request: anyRequest(),
+                                    response: response,
+                                    cookieStore: cookieStore())
+        let shouldDownload = subject?.shouldDownloadFile(canShowInWebView: true,
+                                                         forceDownload: false,
+                                                         isForMainFrame: false)
+        XCTAssertTrue(shouldDownload ?? false)
+    }
 
-            var subject = DownloadHelper(
-                request: anyRequest(),
-                response: response,
-                cookieStore: cookieStore(),
-                canShowInWebView: true,
-                forceDownload: false
-            )
-            XCTAssertNil(subject)
+    func test_shouldDownloadFile_whenMIMETypeIsNotOctetStream_isFalse() {
+        let mimeType = MIMEType.GIF
 
-            subject = DownloadHelper(
-                request: anyRequest(),
-                response: response,
-                cookieStore: cookieStore(),
-                canShowInWebView: false,
-                forceDownload: true
-            )
-            XCTAssertNotNil(subject)
-
-            subject = DownloadHelper(
-                request: anyRequest(),
-                response: response,
-                cookieStore: cookieStore(),
-                canShowInWebView: false,
-                forceDownload: false
-            )
-            XCTAssertNotNil(subject)
-
-            subject = DownloadHelper(
-                request: anyRequest(),
-                response: response,
-                cookieStore: cookieStore(),
-                canShowInWebView: true,
-                forceDownload: true
-            )
-            XCTAssertNotNil(subject)
+        let response = anyResponse(mimeType: mimeType)
+        if let subject = createSubject(request: anyRequest(),
+                                       response: response,
+                                       cookieStore: cookieStore()) {
+            let shouldDownload = subject.shouldDownloadFile(canShowInWebView: true,
+                                                            forceDownload: false,
+                                                            isForMainFrame: false)
+            XCTAssertFalse(shouldDownload)
         }
     }
 
-    func test_init_whenMIMETypeIsOctetStream_initializeCorrectly() {
-        let response = anyResponse(mimeType: MIMEType.OctetStream)
+    func test_shouldDownloadFile_whenCanShowInWebview_isFalse() {
+        let response = anyResponse(mimeType: MIMEType.GIF)
 
-        var subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: false
-        )
-        XCTAssertNotNil(subject)
+        if let subject = createSubject(request: anyRequest(),
+                                       response: response,
+                                       cookieStore: cookieStore()) {
+            let shouldDownload = subject.shouldDownloadFile(canShowInWebView: true,
+                                                            forceDownload: false,
+                                                            isForMainFrame: false)
+            XCTAssertFalse(shouldDownload)
+        }
+    }
 
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: false,
-            forceDownload: true
-        )
-        XCTAssertNotNil(subject)
+    func test_shouldDownloadFile_whenCanNotShowInWebview_isTrue() {
+        let response = anyResponse(mimeType: MIMEType.GIF)
 
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: true
-        )
-        XCTAssertNotNil(subject)
+        if let subject = createSubject(request: anyRequest(),
+                                       response: response,
+                                       cookieStore: cookieStore()) {
+            let shouldDownload = subject.shouldDownloadFile(canShowInWebView: false,
+                                                            forceDownload: false,
+                                                            isForMainFrame: false)
+            XCTAssertTrue(shouldDownload)
+        }
+    }
 
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: false,
-            forceDownload: false
-        )
-        XCTAssertNotNil(subject)
+    func test_shouldDownloadFile_whenNotForceDownload_isFalse() {
+        let response = anyResponse(mimeType: MIMEType.GIF)
+
+        if let subject = createSubject(request: anyRequest(),
+                                       response: response,
+                                       cookieStore: cookieStore()) {
+            let shouldDownload = subject.shouldDownloadFile(canShowInWebView: true,
+                                                            forceDownload: false,
+                                                            isForMainFrame: false)
+            XCTAssertFalse(shouldDownload)
+        }
+    }
+
+    func test_shouldDownloadFile_whenForceDownload_isTrue() {
+        let response = anyResponse(mimeType: MIMEType.GIF)
+
+        if let subject = createSubject(request: anyRequest(),
+                                       response: response,
+                                       cookieStore: cookieStore()) {
+            let shouldDownload = subject.shouldDownloadFile(canShowInWebView: false,
+                                                            forceDownload: true,
+                                                            isForMainFrame: false)
+            XCTAssertTrue(shouldDownload)
+        }
     }
 
     func test_downloadViewModel_whenRequestURLIsWrong_deliversEmptyResult() {
         let request = anyRequest(urlString: "wrong-url.com")
-        let subject = DownloadHelper(
-            request: request,
-            response: anyResponse(mimeType: nil),
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: false
-        )
+        let subject = createSubject(request: request,
+                                    response: anyResponse(mimeType: nil),
+                                    cookieStore: cookieStore())
 
         let downloadViewModel = subject?.downloadViewModel(windowUUID: .XCTestDefaultUUID, okAction: { _ in })
 
@@ -149,13 +109,9 @@ class DownloadHelperTests: XCTestCase {
 
     func test_downloadViewModel_deliversCorrectTitle() {
         let response = anyResponse(urlString: "http://some-domain.com/some-image.jpg")
-        let subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: false
-        )
+        let subject = createSubject(request: anyRequest(),
+                                    response: response,
+                                    cookieStore: cookieStore())
 
         let downloadViewModel = subject?.downloadViewModel(windowUUID: .XCTestDefaultUUID, okAction: { _ in })
 
@@ -163,13 +119,9 @@ class DownloadHelperTests: XCTestCase {
     }
 
     func test_downloadViewModel_deliversCorrectCancelButtonTitle() {
-        let subject = DownloadHelper(
-            request: anyRequest(),
-            response: anyResponse(mimeType: nil),
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: false
-        )
+        let subject = createSubject(request: anyRequest(),
+                                    response: anyResponse(mimeType: nil),
+                                    cookieStore: cookieStore())
 
         let downloadViewModel = subject?.downloadViewModel(windowUUID: .XCTestDefaultUUID, okAction: { _ in })
 
@@ -177,6 +129,14 @@ class DownloadHelperTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    private func createSubject(request: URLRequest,
+                               response: URLResponse,
+                               cookieStore: WKHTTPCookieStore) -> DownloadHelper? {
+        return DownloadHelper(request: request,
+                              response: response,
+                              cookieStore: cookieStore)
+    }
 
     private func anyRequest(urlString: String = "http://any-url.com") -> URLRequest {
         return URLRequest(url: URL(string: urlString)!, cachePolicy: anyCachePolicy(), timeoutInterval: 60.0)
@@ -206,23 +166,5 @@ class DownloadHelperTests: XCTestCase {
 
     private func anyCachePolicy() -> URLRequest.CachePolicy {
         return .useProtocolCachePolicy
-    }
-
-    private func allMIMETypes() -> [String] {
-        return [MIMEType.Bitmap,
-                MIMEType.CSS,
-                MIMEType.GIF,
-                MIMEType.JavaScript,
-                MIMEType.JPEG,
-                MIMEType.HTML,
-                MIMEType.OctetStream,
-                MIMEType.Passbook,
-                MIMEType.PDF,
-                MIMEType.PlainText,
-                MIMEType.PNG,
-                MIMEType.WebP,
-                MIMEType.Calendar,
-                MIMEType.USDZ,
-                MIMEType.Reality]
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10917)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23857)

## :bulb: Description
- Add logic to support download of attachments for PDF files and Word docs (can be expanded to support more extension files)
- Break down logic to allow downloads on automatic Blob URL downloads and attachments file checking MIMEType
- Fix and add Unit test

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

