### PR TITLE
Refactor FXIOS-11413 [Sponsored tiles] Setup TelemetryContextualIdentifier even when there's no ToS accepted

### DIFF
--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -53,6 +53,10 @@ class AppLaunchUtil {
             if isTermsOfServiceAccepted {
                 TelemetryWrapper.shared.setup(profile: profile)
                 TelemetryWrapper.shared.recordStartUpTelemetry()
+            } else {
+                // If ToS are not accepted, we still need to setup the Contextual Identifier for
+                // the Unified Ads Sponsored tiles
+                TelemetryContextualIdentifier.setupContextId()
             }
         } else {
             logger.setup(sendCrashReports: sendCrashReports)

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -56,7 +56,7 @@ class AppLaunchUtil {
             } else {
                 // If ToS are not accepted, we still need to setup the Contextual Identifier for
                 // the Unified Ads Sponsored tiles
-                TelemetryContextualIdentifier.setupContextId()
+                TelemetryContextualIdentifier.setupContextId(isGleanMetricsAllowed: false)
             }
         } else {
             logger.setup(sendCrashReports: sendCrashReports)

--- a/firefox-ios/Client/Telemetry/TelemetryContextualIdentifier.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryContextualIdentifier.swift
@@ -21,8 +21,8 @@ struct TelemetryContextualIdentifier {
     }
 
     /// Setup the contextual identifier used for some telemetry events
-    /// - Parameter allowed: True when we should setup the GleanMetrics TopSites at the same time as ensuring the `UserDefaults`
-    /// have a proper `contextId` available for this user. False when the ToS are not accepted.
+    /// - Parameter allowed: True when we should setup the GleanMetrics TopSites at the same time as ensuring
+    /// the `UserDefaults` have a proper `contextId` available for this user. False when the ToS are not accepted.
     static func setupContextId(isGleanMetricsAllowed allowed: Bool = true) {
         // Use existing client UUID, if doesn't exists create a new one
         if let stringContextId = contextId, let clientUUID = UUID(uuidString: stringContextId), allowed {

--- a/firefox-ios/Client/Telemetry/TelemetryContextualIdentifier.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryContextualIdentifier.swift
@@ -20,14 +20,19 @@ struct TelemetryContextualIdentifier {
         TelemetryContextualIdentifier.contextId = nil
     }
 
-    static func setupContextId() {
+    /// Setup the contextual identifier used for some telemetry events
+    /// - Parameter allowed: True when we should setup the GleanMetrics TopSites at the same time as ensuring the `UserDefaults`
+    /// have a proper `contextId` available for this user. False when the ToS are not accepted.
+    static func setupContextId(isGleanMetricsAllowed allowed: Bool = true) {
         // Use existing client UUID, if doesn't exists create a new one
-        if let stringContextId = contextId, let clientUUID = UUID(uuidString: stringContextId) {
+        if let stringContextId = contextId, let clientUUID = UUID(uuidString: stringContextId), allowed {
             GleanMetrics.TopSites.contextId.set(clientUUID)
         } else {
             let newUUID = UUID()
-            GleanMetrics.TopSites.contextId.set(newUUID)
             contextId = newUUID.uuidString
+
+            guard allowed else { return }
+            GleanMetrics.TopSites.contextId.set(newUUID)
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryContextualIdentifierTests.swift
@@ -36,6 +36,11 @@ class TelemetryContextualIdentifierTests: XCTestCase {
         XCTAssertEqual(contextId, TelemetryContextualIdentifier.contextId)
     }
 
+    func testContextId_noGleanMetricsSetsContextId() {
+        TelemetryContextualIdentifier.setupContextId(isGleanMetricsAllowed: false)
+        XCTAssertNotNil(TelemetryContextualIdentifier.contextId)
+    }
+
     func testTelemetryWrapper_setsContextId() {
         TelemetryWrapper.shared.setup(profile: MockProfile())
         XCTAssertNotNil(TelemetryContextualIdentifier.contextId)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11413)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Ensure we setup `TelemetryContextualIdentifier` even if ToS are not accepted since the Unified Ads API relies on the contextual identifier whether or not the Glean telemetry is setup or not.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

