### PR TITLE
Refactor FXIOS-11415 logins keychain calls

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -22,10 +22,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         .value()
         .creditCardAutofillStatus
 
+    private let rustKeychainEnabled = FxNimbus.shared
+        .features
+        .rustKeychainRefactor
+        .value()
+        .rustKeychainEnabled
+
     lazy var profile: Profile = BrowserProfile(
         localName: "profile",
         fxaCommandsDelegate: UIApplication.shared.fxaCommandsDelegate,
-        creditCardAutofillEnabled: creditCardAutofillStatus
+        creditCardAutofillEnabled: creditCardAutofillStatus,
+        rustKeychainEnabled: rustKeychainEnabled
     )
 
     lazy var themeManager: ThemeManager = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)

--- a/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/NimbusFlaggableFeature.swift
@@ -57,6 +57,7 @@ enum NimbusFeatureFlagID: String, CaseIterable {
     case toolbarNavigationHint
     case tosFeature
     case trackingProtectionRefactor
+    case useRustKeychain
     case zoomFeature
 
     // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`. Add in alphabetical order.
@@ -79,7 +80,8 @@ enum NimbusFeatureFlagID: String, CaseIterable {
                 .pdfRefactor,
                 .downloadLiveActivities,
                 .unifiedAds,
-                .unifiedSearch:
+                .unifiedSearch,
+                .useRustKeychain:
             return rawValue + PrefsKeys.FeatureFlags.DebugSuffixKey
         default:
             return nil
@@ -157,6 +159,7 @@ struct NimbusFlaggableFeature: HasNimbusSearchBar {
                 .toolbarNavigationHint,
                 .tosFeature,
                 .trackingProtectionRefactor,
+                .useRustKeychain,
                 .zoomFeature:
             return nil
         }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -145,7 +145,7 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 },
                 FeatureFlagsBoolSetting(
                     with: .useRustKeychain,
-                    titleText: format(string: "Enable Rust Keychain for Rust Components"),
+                    titleText: format(string: "Enable Rust Keychain"),
                     statusText: format(string: "Toggle to enable Rust Components rust keychain")
                 ) { [weak self] _ in
                     self?.reloadView()

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -144,6 +144,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                     self?.reloadView()
                 },
                 FeatureFlagsBoolSetting(
+                    with: .useRustKeychain,
+                    titleText: format(string: "Enable Rust Keychain for Rust Components"),
+                    statusText: format(string: "Toggle to enable Rust Components rust keychain")
+                ) { [weak self] _ in
+                    self?.reloadView()
+                },
+                FeatureFlagsBoolSetting(
                     with: .sentFromFirefox,
                     titleText: format(string: "Enable Sent from Firefox"),
                     statusText: format(string: "Toggle to enable Sent from Firefox to append text to WhatsApp shares")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -145,6 +145,9 @@ final class NimbusFeatureFlagLayer {
         case .trackingProtectionRefactor:
             return checkTrackingProtectionRefactor(from: nimbus)
 
+        case .useRustKeychain:
+            return checkUseRustKeychainFeature(from: nimbus)
+
         case .zoomFeature:
             return checkZoomFeature(from: nimbus)
         }
@@ -442,5 +445,9 @@ final class NimbusFeatureFlagLayer {
 
     private func checkNICErrorPageFeature(from nimbus: FxNimbus) -> Bool {
         return nimbus.features.nativeErrorPageFeature.value().noInternetConnectionError
+    }
+
+    private func checkUseRustKeychainFeature(from nimbus: FxNimbus) -> Bool {
+        return nimbus.features.rustKeychainRefactor.value().rustKeychainEnabled
     }
 }

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -230,8 +230,10 @@ open class BrowserProfile: Profile {
             fatalError("Could not create directory at root path: \(error)")
         }
     }()
+    private var rustKeychainEnabled = false
     fileprivate let name: String
-    fileprivate let keychain: MZKeychainWrapper
+    fileprivate let keychain: RustKeychain
+    fileprivate let legacyKeychain: MZKeychainWrapper
     var isShutdown = false
 
     internal let files: FileAccessor
@@ -257,6 +259,7 @@ open class BrowserProfile: Profile {
     init(localName: String,
          fxaCommandsDelegate: FxACommandsDelegate? = nil,
          creditCardAutofillEnabled: Bool = false,
+         rustKeychainEnabled: Bool = false,
          clear: Bool = false,
          logger: Logger = DefaultLogger.shared) {
         logger.log("Initing profile \(localName) on thread \(Thread.current).",
@@ -264,7 +267,9 @@ open class BrowserProfile: Profile {
                    category: .setup)
         self.name = localName
         self.files = ProfileFileAccessor(localName: localName)
-        self.keychain = MZKeychainWrapper.sharedClientAppContainerKeychain
+        self.rustKeychainEnabled = rustKeychainEnabled
+        self.keychain = KeychainManager.shared
+        self.legacyKeychain = KeychainManager.legacyShared
         self.logger = logger
         self.fxaCommandsDelegate = fxaCommandsDelegate
 
@@ -301,7 +306,11 @@ open class BrowserProfile: Profile {
             logger.log("New profile. Removing old Keychain/Prefs data.",
                        level: .info,
                        category: .setup)
-            MZKeychainWrapper.wipeKeychain()
+            if rustKeychainEnabled {
+                RustKeychain.wipeKeychain()
+            } else {
+                MZKeychainWrapper.wipeKeychain()
+            }
             prefs.clearAll()
         }
 
@@ -311,7 +320,8 @@ open class BrowserProfile: Profile {
         // Initiating the sync manager has to happen prior to the databases being opened,
         // because opening them can trigger events to which the SyncManager listens.
         self.syncManager = RustSyncManager(profile: self,
-                                           creditCardAutofillEnabled: creditCardAutofillEnabled)
+                                           creditCardAutofillEnabled: creditCardAutofillEnabled,
+                                           rustKeychainEnabled: rustKeychainEnabled)
 
         let notificationCenter = NotificationCenter.default
 
@@ -676,7 +686,7 @@ open class BrowserProfile: Profile {
             fileURLWithPath: directory,
             isDirectory: true
         ).appendingPathComponent("loginsPerField.db").path
-        return RustLogins(databasePath: databasePath)
+        return RustLogins(databasePath: databasePath, rustKeychainEnabled: self.rustKeychainEnabled)
     }()
 
     lazy var remoteSettingsService: RemoteSettingsService? = {
@@ -755,24 +765,39 @@ open class BrowserProfile: Profile {
         prefs.removeObjectForKey(PrefsKeys.KeyLastRemoteTabSyncTime)
 
         // Save the keys that will be restored
-        let rustAutofillKey = RustAutofillEncryptionKeys()
-        let creditCardKey = keychain.string(forKey: rustAutofillKey.ccKeychainKey)
         let rustLoginsKeys = RustLoginEncryptionKeys()
-        let perFieldKey = keychain.string(forKey: rustLoginsKeys.loginPerFieldKeychainKey)
-        // Remove all items, removal is not key-by-key specific (due to the risk of failing to delete something),
-        // simply restore what is needed.
-        keychain.removeAllKeys()
+        let rustAutofillKey = RustAutofillEncryptionKeys()
+        var loginsKey: String?
+        let creditCardKey = legacyKeychain.string(forKey: rustAutofillKey.ccKeychainKey)
 
-        if let perFieldKey = perFieldKey {
-            keychain.set(
-                perFieldKey,
-                forKey: rustLoginsKeys.loginPerFieldKeychainKey,
-                withAccessibility: .afterFirstUnlock
-            )
+        if rustKeychainEnabled {
+            (loginsKey, _) = keychain.getLoginsKeyData()
+
+            // Remove all items, removal is not key-by-key specific (due to the risk of failing to delete something),
+            // simply restore what is needed.
+            keychain.removeAllKeys()
+
+            if let loginsKey = loginsKey {
+                keychain.setLoginsKey(loginsKey)
+            }
+        } else {
+            loginsKey = legacyKeychain.string(forKey: rustLoginsKeys.loginPerFieldKeychainKey)
+
+            // Remove all items, removal is not key-by-key specific (due to the risk of failing to delete something),
+            // simply restore what is needed.
+            legacyKeychain.removeAllKeys()
+
+            if let loginsKey = loginsKey {
+                legacyKeychain.set(loginsKey,
+                                   forKey: rustLoginsKeys.loginPerFieldKeychainKey,
+                                   withAccessibility: .afterFirstUnlock)
+            }
         }
 
         if let creditCardKey = creditCardKey {
-            keychain.set(creditCardKey, forKey: rustAutofillKey.ccKeychainKey, withAccessibility: .afterFirstUnlock)
+            legacyKeychain.set(creditCardKey,
+                               forKey: rustAutofillKey.ccKeychainKey,
+                               withAccessibility: .afterFirstUnlock)
         }
 
         // Tell any observers that our account has changed.

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -36,6 +36,7 @@ public class RustSyncManager: NSObject, SyncManager {
     private let fxaDeclinedEngines = "fxa.cwts.declinedSyncEngines"
     private var notificationCenter: NotificationProtocol
     var creditCardAutofillEnabled = false
+    var rustKeychainEnabled = false
 
     let fifteenMinutesInterval = TimeInterval(60 * 15)
 
@@ -68,6 +69,7 @@ public class RustSyncManager: NSObject, SyncManager {
 
     init(profile: BrowserProfile,
          creditCardAutofillEnabled: Bool = false,
+         rustKeychainEnabled: Bool = false,
          logger: Logger = DefaultLogger.shared,
          notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.profile = profile
@@ -77,6 +79,7 @@ public class RustSyncManager: NSObject, SyncManager {
 
         super.init()
         self.creditCardAutofillEnabled = creditCardAutofillEnabled
+        self.rustKeychainEnabled = rustKeychainEnabled
     }
 
     @objc
@@ -273,9 +276,15 @@ public class RustSyncManager: NSObject, SyncManager {
                     .prefsForSync
                     .branch("scratchpad")
                     .stringForKey("keyLabel") {
-                        MZKeychainWrapper
-                            .sharedClientAppContainerKeychain
-                            .removeObject(forKey: keyLabel)
+                        if self.rustKeychainEnabled {
+                            RustKeychain
+                                .sharedClientAppContainerKeychain
+                                .removeObject(key: keyLabel)
+                        } else {
+                            MZKeychainWrapper
+                                .sharedClientAppContainerKeychain
+                                .removeObject(forKey: keyLabel)
+                        }
                 }
                 self.prefsForSync.clearAll()
             }

--- a/firefox-ios/Storage/MockRustKeychain.swift
+++ b/firefox-ios/Storage/MockRustKeychain.swift
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import func MozillaAppServices.createCanary
+import func MozillaAppServices.createKey
+
 class MockRustKeychain: RustKeychain {
     static let shared = MockRustKeychain()
 
@@ -11,16 +14,45 @@ class MockRustKeychain: RustKeychain {
         super.init(serviceName: "Test")
     }
 
-    override func getBaseKeychainQuery(key: String) -> [String: Any] {
-        return [:]
+    override public func removeObject(key: String) {
+        _ = storage.removeValue(forKey: key)
+    }
+
+    override public func removeAllKeys() {
+        storage.removeAll()
+    }
+
+    override public func setLoginsKey(_ value: String) {
+        storage[loginsKeyIdentifier] = value
+    }
+
+    override public func getLoginsKeyData() -> (String?, String?) {
+        return (storage[loginsKeyIdentifier], storage[loginsCanaryKeyIdentifier])
+    }
+
+    override public class func wipeKeychain() {}
+
+    override func createLoginsKeyData() throws -> String {
+        guard let keyValue = try? createKey(),
+              let canaryValue = try? createCanary(text: loginsCanaryPhrase, encryptionKey: keyValue) else {
+            throw LoginEncryptionKeyError.noKeyCreated
+        }
+
+        storage[loginsCanaryKeyIdentifier] = canaryValue
+        storage[loginsKeyIdentifier] = keyValue
+        return keyValue
     }
 
     override func queryKeychainForKey(key: String) -> Result<String?, Error> {
         return .success(storage[key])
     }
 
-    override func addOrUpdateKeychainKey(_ value: String, key: String) -> OSStatus {
-        storage[key] = value
-        return errSecSuccess
+    override func createAndStoreKey(canaryPhrase: String, canaryIdentifier: String, keyIdentifier: String) throws -> String {
+        let keyValue = try createKey()
+        let canaryValue = try createCanary(text: canaryPhrase, encryptionKey: keyValue)
+
+        storage[canaryIdentifier] = canaryValue
+        storage[keyIdentifier] = keyValue
+        return keyValue
     }
 }

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -202,7 +202,6 @@ public extension LoginEntry {
 public class RustLoginEncryptionKeys {
     public let loginPerFieldKeychainKey = "appservices.key.logins.perfield"
     let legacyKeychain = KeychainManager.legacyShared
-    let keychain = KeychainManager.shared
 
     let canaryPhraseKey = "canaryPhrase"
     let canaryPhrase = "a string for checking validity of the key"

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -199,27 +199,11 @@ public extension LoginEntry {
     }
 }
 
-public enum LoginEncryptionKeyError: Error {
-    case noKeyCreated
-    case illegalState
-    case dbRecordCountVerificationError(String)
-}
-
-/// Running tests on Bitrise code that reads/writes to keychain silently fails.
-/// SecItemAdd status: -34018 - A required entitlement isn't present.
-/// This should be removed if we ever have keychain support on our CI.
-class KeychainManager {
-    static var shared: MZKeychainWrapper = {
-        AppConstants.isRunningTest
-            ? MockMZKeychainWrapper.shared
-            : MZKeychainWrapper.sharedClientAppContainerKeychain
-    }()
-}
-
 public class RustLoginEncryptionKeys {
     public let loginPerFieldKeychainKey = "appservices.key.logins.perfield"
-
+    let legacyKeychain = KeychainManager.legacyShared
     let keychain = KeychainManager.shared
+
     let canaryPhraseKey = "canaryPhrase"
     let canaryPhrase = "a string for checking validity of the key"
 
@@ -235,12 +219,12 @@ public class RustLoginEncryptionKeys {
             let canary = try createCanary(text: canaryPhrase, encryptionKey: secret)
 
             DispatchQueue.global(qos: .background).sync {
-                self.keychain.set(secret,
-                                  forKey: self.loginPerFieldKeychainKey,
-                                  withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
-                self.keychain.set(canary,
-                                  forKey: self.canaryPhraseKey,
-                                  withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
+                legacyKeychain.set(secret,
+                                   forKey: loginPerFieldKeychainKey,
+                                   withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
+                legacyKeychain.set(canary,
+                                   forKey: canaryPhraseKey,
+                                   withAccessibility: MZKeychainItemAccessibility.afterFirstUnlock)
             }
             return secret
         } catch let err as NSError {
@@ -322,6 +306,8 @@ public class RustLogins: LoginsProtocol, KeyManager {
 
     let queue: DispatchQueue
     var storage: LoginsStorage?
+    let rustKeychain = KeychainManager.shared
+    var rustKeychainEnabled = false
 
     private(set) var isOpen = false
 
@@ -330,9 +316,11 @@ public class RustLogins: LoginsProtocol, KeyManager {
     private let logger: Logger
 
     public init(databasePath: String,
-                logger: Logger = DefaultLogger.shared) {
+                logger: Logger = DefaultLogger.shared,
+                rustKeychainEnabled: Bool = false) {
         self.perFieldDatabasePath = databasePath
         self.logger = logger
+        self.rustKeychainEnabled = rustKeychainEnabled
 
         queue = DispatchQueue(label: "RustLogins queue: \(databasePath)", attributes: [])
     }
@@ -849,7 +837,9 @@ public class RustLogins: LoginsProtocol, KeyManager {
             }
 
             do {
-                let key = try rustKeys.createAndStoreKey()
+                let key = self.rustKeychainEnabled ?
+                    try self.rustKeychain.createLoginsKeyData() :
+                    try rustKeys.createAndStoreKey()
                 completion(.success(key))
             } catch let error as NSError {
                 self.logger.log("Error creating logins encryption key",
@@ -865,8 +855,8 @@ public class RustLogins: LoginsProtocol, KeyManager {
         var keychainData: (String?, String?) = (nil, nil)
 
         DispatchQueue.global(qos: .background).sync {
-            let key = rustKeys.keychain.string(forKey: rustKeys.loginPerFieldKeychainKey)
-            let encryptedCanaryPhrase = rustKeys.keychain.string(forKey: rustKeys.canaryPhraseKey)
+            let key = rustKeys.legacyKeychain.string(forKey: rustKeys.loginPerFieldKeychainKey)
+            let encryptedCanaryPhrase = rustKeys.legacyKeychain.string(forKey: rustKeys.canaryPhraseKey)
             keychainData = (key, encryptedCanaryPhrase)
         }
 
@@ -875,7 +865,15 @@ public class RustLogins: LoginsProtocol, KeyManager {
 
     public func getStoredKey(completion: @escaping (Result<String, NSError>) -> Void) {
         let rustKeys = RustLoginEncryptionKeys()
-        let (key, encryptedCanaryPhrase) = getKeychainData(rustKeys: rustKeys)
+        var key: String?
+        var encryptedCanaryPhrase: String?
+
+        if self.rustKeychainEnabled {
+            (key, encryptedCanaryPhrase) = rustKeychain.getLoginsKeyData()
+        } else {
+            (key, encryptedCanaryPhrase) = getKeychainData(rustKeys: rustKeys)
+        }
+
         switch(key, encryptedCanaryPhrase) {
         case (.some(key), .some(encryptedCanaryPhrase)):
                 self.handleExpectedKeyAction(rustKeys: rustKeys,
@@ -968,7 +966,9 @@ public class RustLogins: LoginsProtocol, KeyManager {
                 // There are no records in the database so we don't need to wipe any
                 // existing login records. We just need to create a new key.
                 do {
-                    let key = try rustKeys.createAndStoreKey()
+                    let key = self.rustKeychainEnabled ?
+                        try self.rustKeychain.createLoginsKeyData() :
+                        try rustKeys.createAndStoreKey()
                     completion(.success(key))
                 } catch let error as NSError {
                     completion(.failure(error))
@@ -1008,10 +1008,22 @@ public class RustLogins: LoginsProtocol, KeyManager {
     * ```
     */
     public func getKey() throws -> Data {
-        let rustKeys = RustLoginEncryptionKeys()
-        guard let keyData = rustKeys.keychain.data(forKey: rustKeys.loginPerFieldKeychainKey) else {
-            throw LoginsStoreError.MissingKey
+        if self.rustKeychainEnabled {
+            switch rustKeychain.queryKeychainForKey(key: rustKeychain.loginsKeyIdentifier) {
+            case .success(let result):
+                guard let data = result, let key = data.data(using: String.Encoding.utf8) else {
+                    throw LoginsStoreError.MissingKey
+                }
+                return key
+            case .failure:
+                throw LoginsStoreError.MissingKey
+            }
+        } else {
+            let rustKeys = RustLoginEncryptionKeys()
+            guard let keyData = rustKeys.legacyKeychain.data(forKey: rustKeys.loginPerFieldKeychainKey) else {
+                throw LoginsStoreError.MissingKey
+            }
+            return keyData
         }
-        return keyData
     }
 }

--- a/firefox-ios/Storage/RustKeychain.swift
+++ b/firefox-ios/Storage/RustKeychain.swift
@@ -3,12 +3,49 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Shared
+
+import class MozillaAppServices.MZKeychainWrapper
+import enum MozillaAppServices.AutofillApiError
+import enum MozillaAppServices.MZKeychainItemAccessibility
+import func MozillaAppServices.checkCanary
+import func MozillaAppServices.createCanary
+import func MozillaAppServices.createKey
+
+public enum LoginEncryptionKeyError: Error {
+    case noKeyCreated
+    case illegalState
+    case dbRecordCountVerificationError(String)
+}
+
+/// Running tests on Bitrise code that reads/writes to keychain silently fails.
+/// SecItemAdd status: -34018 - A required entitlement isn't present.
+/// This should be removed if we ever have keychain support on our CI.
+public class KeychainManager {
+    public static var shared = {
+        AppConstants.isRunningTest
+            ? MockRustKeychain.shared
+            : RustKeychain.sharedClientAppContainerKeychain
+    }()
+
+    public static var legacyShared = {
+        AppConstants.isRunningTest
+            ? MockMZKeychainWrapper.shared
+            : MZKeychainWrapper.sharedClientAppContainerKeychain
+    }()
+}
 
 open class RustKeychain {
     public private(set) var serviceName: String
     public private(set) var accessGroup: String?
 
-    static var sharedClientAppContainerKeychain: RustKeychain {
+    private let logger: Logger
+
+    public let loginsKeyIdentifier = "appservices.key.logins.perfield"
+    public let loginsCanaryKeyIdentifier = "canaryPhrase"
+    let loginsCanaryPhrase = "a string for checking validity of the key"
+
+    public static var sharedClientAppContainerKeychain: RustKeychain {
         let baseBundleIdentifier = AppInfo.baseBundleIdentifier
 
         guard let accessGroupPrefix = Bundle.main.object(forInfoDictionaryKey: "MozDevelopmentTeam") as? String else {
@@ -18,27 +55,89 @@ open class RustKeychain {
                             accessGroup: AppInfo.keychainAccessGroupWithPrefix(accessGroupPrefix))
     }
 
-    public init(serviceName: String, accessGroup: String? = nil) {
+    public init(serviceName: String,
+                accessGroup: String? = nil,
+                logger: Logger = DefaultLogger.shared) {
         self.serviceName = serviceName
         self.accessGroup = accessGroup
+        self.logger = logger
     }
 
     struct KeychainError: Error {
         let errorMessage: String
     }
 
-    func getBaseKeychainQuery(key: String) -> [String: Any] {
-        let encodedIdentifier: Data? = key.data(using: String.Encoding.utf8)
+    public func removeObject(key: String) {
+        let keychainQueryDictionary: [String: Any] = getBaseKeychainQuery(key: key)
+        let status = SecItemDelete(keychainQueryDictionary as CFDictionary)
+        logErrorFromStatus(status, errMsg: "Failed to remove key \(key)")
+    }
+
+    public func removeAllKeys() {
         var keychainQueryDictionary: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
-                                                       kSecAttrService as String: self.serviceName,
-                                                       kSecAttrSynchronizable as String: false]
-        keychainQueryDictionary[kSecAttrGeneric as String] = encodedIdentifier
-        keychainQueryDictionary[kSecAttrAccount as String] = encodedIdentifier
+                                                      kSecAttrService as String: serviceName]
 
         if let accessGroup = self.accessGroup {
             keychainQueryDictionary[kSecAttrAccessGroup as String] = accessGroup
         }
-        return keychainQueryDictionary
+
+        let status = SecItemDelete(keychainQueryDictionary as CFDictionary)
+        logErrorFromStatus(status, errMsg: "Failed to remove all keys")
+    }
+
+    public func setLoginsKey(_ value: String) {
+        addOrUpdateKeychainKey(value, key: loginsKeyIdentifier)
+    }
+
+    public func getLoginsKeyData() -> (String?, String?) {
+        return getEncryptionKeyData(keyIdentifier: loginsKeyIdentifier, canaryKeyIdentifier: loginsCanaryKeyIdentifier)
+    }
+
+    public class func wipeKeychain() {
+        deleteKeychainSecClass(kSecClassGenericPassword) // Generic password items
+        deleteKeychainSecClass(kSecClassInternetPassword) // Internet password items
+        deleteKeychainSecClass(kSecClassCertificate) // Certificate items
+        deleteKeychainSecClass(kSecClassKey) // Cryptographic key items
+        deleteKeychainSecClass(kSecClassIdentity) // Identity items
+    }
+
+    func logAutofillStoreError(err: AutofillApiError, errorDomain: String, errorMessage: String) {
+        var message: String {
+            switch err {
+            case .SqlError(let message),
+                    .CryptoError(let message),
+                    .NoSuchRecord(let message),
+                    .UnexpectedAutofillApiError(let message):
+                return message
+            case .InterruptedError:
+                return "Interrupted Error"
+            }
+        }
+
+        logger.log(errorMessage,
+                   level: .warning,
+                   category: .storage,
+                   description: "\(errorDomain) - \(err.descriptionValue): \(message)")
+    }
+
+    func createLoginsKeyData() throws -> String {
+        do {
+            return try createAndStoreKey(canaryPhrase: loginsCanaryPhrase,
+                                         canaryIdentifier: loginsCanaryKeyIdentifier,
+                                         keyIdentifier: loginsKeyIdentifier)
+        } catch let err as NSError {
+            if let loginsStoreError = err as? LoginsStoreError {
+                logLoginsStoreError(err: loginsStoreError,
+                                    errorDomain: err.domain,
+                                    errorMessage: "Error while creating and storing logins key")
+            } else {
+                logger.log("Unknown error while creating and storing logins key",
+                           level: .warning,
+                           category: .storage,
+                           description: err.localizedDescription)
+            }
+        }
+        throw LoginEncryptionKeyError.noKeyCreated
     }
 
     func queryKeychainForKey(key: String) -> Result<String?, Error> {
@@ -61,7 +160,23 @@ open class RustKeychain {
         return .success(String(data: data, encoding: .utf8))
     }
 
-    func addOrUpdateKeychainKey(_ value: String, key: String) -> OSStatus {
+    func createAndStoreKey(canaryPhrase: String, canaryIdentifier: String, keyIdentifier: String) throws -> String {
+         let keyValue = try createKey()
+         let canaryValue = try createCanary(text: canaryPhrase, encryptionKey: keyValue)
+
+         DispatchQueue.global(qos: .background).sync {
+             addOrUpdateKeychainKey(keyValue, key: keyIdentifier)
+             addOrUpdateKeychainKey(canaryValue, key: canaryIdentifier)
+         }
+         return keyValue
+    }
+
+    private class func deleteKeychainSecClass(_ secClass: AnyObject) {
+        let query = [kSecClass as String: secClass]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    private func addOrUpdateKeychainKey(_ value: String, key: String) {
         var addQueryDictionary = getBaseKeychainQuery(key: key)
         addQueryDictionary[kSecValueData as String] = value.data(using: String.Encoding.utf8)
         addQueryDictionary[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
@@ -69,10 +184,101 @@ open class RustKeychain {
         let addStatus = SecItemAdd(addQueryDictionary as CFDictionary, nil)
 
         if addStatus == errSecDuplicateItem {
-            return SecItemUpdate(getBaseKeychainQuery(key: key) as CFDictionary,
-                                 [kSecValueData: value.data(using: String.Encoding.utf8)] as CFDictionary)
+            let updateStatus = SecItemUpdate(getBaseKeychainQuery(key: key) as CFDictionary,
+                                             [kSecValueData: value.data(using: String.Encoding.utf8)] as CFDictionary)
+            if updateStatus != errSecSuccess {
+                logErrorFromStatus(updateStatus, errMsg: "Failed to update \(key) keychain key")
+            }
         } else {
-            return addStatus
+            logErrorFromStatus(addStatus, errMsg: "Failed to add \(key) keychain key")
         }
+    }
+
+    private func getEncryptionKeyData(keyIdentifier: String, canaryKeyIdentifier: String) -> (String?, String?) {
+        var keychainData: (String?, String?) = (nil, nil)
+
+        DispatchQueue.global(qos: .background).sync {
+            let key = getDataFromResult(queryKeychainForKey(key: keyIdentifier))
+            let canary = getDataFromResult(queryKeychainForKey(key: canaryKeyIdentifier))
+
+            keychainData = (key, canary)
+        }
+        return keychainData
+    }
+
+    private func getDataFromResult(_ result: Result<String?, Error>) -> String? {
+        switch result {
+        case .success(let value):
+            guard let data = value else {
+                return nil
+            }
+            return data
+        case .failure(let err):
+            // This failure could be the result of failing to retrieve saved keychain
+            // data or querying for key data that hasn't been created yet in the case
+            // of a first-time sync sign in for instance.
+
+            logger.log("Failed to get keychain data: \(err)",
+                       level: .debug,
+                       category: .storage)
+            return nil
+        }
+    }
+
+    private func getBaseKeychainQuery(key: String) -> [String: Any] {
+        let encodedIdentifier: Data? = key.data(using: String.Encoding.utf8)
+        var keychainQueryDictionary: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+                                                       kSecAttrService as String: self.serviceName,
+                                                       kSecAttrSynchronizable as String: false]
+        keychainQueryDictionary[kSecAttrGeneric as String] = encodedIdentifier
+        keychainQueryDictionary[kSecAttrAccount as String] = encodedIdentifier
+
+        if let accessGroup = self.accessGroup {
+            keychainQueryDictionary[kSecAttrAccessGroup as String] = accessGroup
+        }
+        return keychainQueryDictionary
+    }
+
+    private func logErrorFromStatus(_ status: OSStatus, errMsg: String) {
+        guard status != errSecSuccess else {
+            return
+        }
+        let result = SecCopyErrorMessageString(status, nil)
+        let defaultMsg = "Unknown Error"
+        let detailedMsg = result == nil ? defaultMsg : result as? String ?? defaultMsg
+
+        self.logger.log("\(errMsg): \(detailedMsg)",
+                        level: .warning,
+                        category: .storage)
+    }
+
+    private func logLoginsStoreError(
+        err: LoginsStoreError,
+        errorDomain: String,
+        errorMessage: String
+    ) {
+        var message: String {
+            switch err {
+            case .InvalidRecord(let message),
+                    .NoSuchRecord(let message),
+                    .Interrupted(let message),
+                    .SyncAuthInvalid(let message),
+                    .UnexpectedLoginsApiError(let message):
+                return message
+            case .InvalidKey:
+                return "InvalidKey"
+            case .MissingKey:
+                return "MissingKey"
+            case .EncryptionFailed(reason: let reason):
+                return "EncryptionFailed reason:\(reason)"
+            case .DecryptionFailed(reason: let reason):
+                return "DecryptionFailed reason:\(reason)"
+            }
+        }
+
+        logger.log(errorMessage,
+                   level: .warning,
+                   category: .storage,
+                   description: "\(errorDomain) - \(err.descriptionValue): \(message)")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
@@ -8,7 +8,117 @@ import XCTest
 
 @testable import Storage
 
+// This class uses the logic enabled with the `useRustKeychain` feature flag. It will replace
+// LegacyRustLoginsTests once the feature flag is removed.
 class RustLoginsTests: XCTestCase {
+    var files: FileAccessor!
+    var logins: RustLogins!
+
+    override func setUp() {
+        super.setUp()
+        files = MockFiles()
+
+        if let rootDirectory = try? files.getAndEnsureDirectory() {
+            let databasePath = URL(
+                fileURLWithPath: rootDirectory,
+                isDirectory: true
+            ).appendingPathComponent("testLoginsPerField.db").path
+            try? files.remove("testLoginsPerField.db")
+
+            logins = RustLogins(databasePath: databasePath,
+                                rustKeychainEnabled: true)
+            _ = logins.reopenIfClosed()
+        } else {
+            XCTFail("Could not retrieve root directory")
+        }
+    }
+
+    func addLogin() -> Deferred<Maybe<String>> {
+        let login = LoginEntry(fromJSONDict: [
+            "hostname": "https://example.com",
+            "formSubmitUrl": "https://example.com",
+            "username": "username",
+            "password": "password"
+        ])
+        return logins.addLogin(login: login)
+    }
+
+    func testListLogins() {
+        let listResult1 = logins.listLogins().value
+        XCTAssertTrue(listResult1.isSuccess)
+        XCTAssertNotNil(listResult1.successValue)
+        XCTAssertEqual(listResult1.successValue!.count, 0)
+        let addResult = addLogin().value
+        XCTAssertTrue(addResult.isSuccess)
+        XCTAssertNotNil(addResult.successValue)
+        let listResult2 = logins.listLogins().value
+        XCTAssertTrue(listResult2.isSuccess)
+        XCTAssertNotNil(listResult2.successValue)
+        XCTAssertEqual(listResult2.successValue!.count, 1)
+    }
+
+    func testAddLogin() {
+        let addResult = addLogin().value
+        XCTAssertTrue(addResult.isSuccess)
+        XCTAssertNotNil(addResult.successValue)
+        let getResult = logins.getLogin(id: addResult.successValue!).value
+        XCTAssertTrue(getResult.isSuccess)
+        XCTAssertNotNil(getResult.successValue!)
+        XCTAssertEqual(getResult.successValue!!.id, addResult.successValue!)
+    }
+
+    func testUpdateLogin() {
+        let addResult = addLogin().value
+        XCTAssertTrue(addResult.isSuccess)
+        XCTAssertNotNil(addResult.successValue)
+        let getResult1 = logins.getLogin(id: addResult.successValue!).value
+        XCTAssertTrue(getResult1.isSuccess)
+        XCTAssertNotNil(getResult1.successValue!)
+        let login = getResult1.successValue!
+        XCTAssertEqual(login!.id, addResult.successValue!)
+
+        let updatedLogin = LoginEntry(
+                origin: login!.hostname,
+                httpRealm: login!.httpRealm,
+                formActionOrigin: login!.formSubmitUrl,
+                usernameField: login!.usernameField,
+                passwordField: login!.passwordField,
+                password: "password2",
+                username: ""
+        )
+
+        let updateResult = logins.updateLogin(id: login!.id, login: updatedLogin).value
+        XCTAssertTrue(updateResult.isSuccess)
+        let getResult2 = logins.getLogin(id: login!.id).value
+        XCTAssertTrue(getResult2.isSuccess)
+        XCTAssertNotNil(getResult2.successValue!)
+        let password = getResult2.successValue!!.password
+        XCTAssertEqual(password, "password2")
+    }
+
+    func testDeleteLogin() {
+        let addResult = addLogin().value
+        XCTAssertTrue(addResult.isSuccess)
+        XCTAssertNotNil(addResult.successValue)
+        let getResult1 = logins.getLogin(id: addResult.successValue!).value
+        XCTAssertTrue(getResult1.isSuccess)
+        XCTAssertNotNil(getResult1.successValue!)
+        let login = getResult1.successValue!
+        XCTAssertEqual(login!.id, addResult.successValue!)
+        let deleteResult = logins.deleteLogin(id: login!.id).value
+        XCTAssertTrue(deleteResult.isSuccess)
+        XCTAssertNotNil(deleteResult.successValue!)
+        XCTAssertTrue(deleteResult.successValue!)
+        let getResult2 = logins.getLogin(id: login!.id).value
+        XCTAssertTrue(getResult2.isSuccess)
+        XCTAssertNil(getResult2.successValue!)
+    }
+}
+
+// This class tests the rust components keychain logic that uses MZKeychainWrapper.
+// Once the nimbus logic for the `useRustKeychain` flag is removed, LegacyRustLoginsTests
+// will be obsolete.
+class LegacyRustLoginsTests: XCTestCase {
     var files: FileAccessor!
     var logins: RustLogins!
 

--- a/firefox-ios/nimbus-features/rustKeychainRefactor.yaml
+++ b/firefox-ios/nimbus-features/rustKeychainRefactor.yaml
@@ -1,0 +1,21 @@
+# The configuration for the rustKeychain feature
+features:
+  rust-keychain-refactor:
+    description: >
+      Feature that enables use of the rust keychain logic for storing and retrieving
+      rust component encryption key data.
+    variables:
+      rust-keychain-enabled:
+        description: >
+          Whether the use of the rust keychain logic is enabled for rust components. When
+          enabled, the rust keychain is used to store and retrieve encryption key data for
+          rust components. Otherwise, the pre-existing MZKeychainWrapper logic is used.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          rust-keychain-enabled: false
+      - channel: developer
+        value:
+          rust-keychain-enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -41,6 +41,7 @@ include:
   - nimbus-features/ratingPromptFeature.yaml
   - nimbus-features/reduxSearchSettingsFeature.yaml
   - nimbus-features/searchEngineConsolidationFeature.yaml
+  - nimbus-features/rustKeychainRefactor.yaml
   - nimbus-features/searchFeature.yaml
   - nimbus-features/sentFromFirefoxFeature.yaml
   - nimbus-features/splashScreenFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11415)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24843)

## :bulb: Description
This PR adds `RustKeychain` calls to `RustLogins` to be enabled by a Nimbus flag. It also pulls existing logic from `RustLoginEncryptionKeys` into `RustKeychain` to consolidate the encryption logic in one class. Once the nimbus rollout is complete `RustLoginEncryptionKeys` can be removed with the nimbus logic.

Ultimately the `MZKeychainWrapper` calls will be removed once these changes are rolled out. This is a part of a larger effort to remove the archived `MZKeychainWrapper` logic from iOS.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

