### PR TITLE
Bugfix FXIOS-11409 [Bookmarks Evolution] Edit bookmark menu action opening incorrect bookmark

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1763,7 +1763,6 @@ class BrowserViewController: UIViewController,
         let bookmarksTelemetry = BookmarksTelemetry()
         bookmarksTelemetry.editBookmark(eventLabel: .addBookmarkToast)
 
-
         profile.places.getBookmarksWithURL(url: urlString).uponQueue(.main) { result in
             guard let bookmarkItem = result.successValue?.first,
                   let parentGuid = bookmarkItem.parentGUID else { return }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11409)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

**NOTE:** This branch is based off [fb/FXIOS-11223_fix-bookmarks-toast-edit-button](https://github.com/mozilla-mobile/firefox-ios/tree/fb/FXIOS-11223_fix-bookmarks-toast-edit-button) - so it will duplicate #24838 until that PR is merged and this PR is rebased. Please only refer to commits 8e08e04 and later

## :bulb: Description
- The "Edit Bookmark" menu action (Menu -> Save -> Edit Bookmark) will now open the bookmark of the currently selected tab instead of the most recently saved bookmark (when using legacy bookmarks).
- Refactored `BrowserViewController::openBookmarkEditPanel` a bit to share logic between refactored/legacy bookmark code paths

### 📝 Discussion
- This only became an issue with the new menu because this "Edit Bookmark" action had no equivalent in the legacy menu. Any time we wanted to open the "Edit bookmark" view from outside the bookmarks panel, it was always from a "Bookmark added" toast notification which only cared about the most recently added bookmark.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

