### PR TITLE
Refactor FXIOS-11244 Replace ActionToast usage in AddressAutofillSettingsViewController with ButtonToast

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillSettingsViewController.swift
@@ -32,6 +32,8 @@ class AddressAutofillSettingsViewController: SensitiveViewController, Themeable 
 
     // MARK: Views
 
+    var buttonToast: ButtonToast?
+
     /// Hosting controller for the empty state view in address autofill settings.
     var addressAutofillSettingsPageView: UIHostingController<AddressAutofillSettingsView>
 
@@ -90,13 +92,16 @@ class AddressAutofillSettingsViewController: SensitiveViewController, Themeable 
             guard let self else { return }
             switch status {
             case let .error(errorType):
-                ActionToast(
-                    text: errorType.message,
-                    bottomContainer: view,
-                    theme: themeManager.getCurrentTheme(for: windowUUID),
-                    buttonTitle: errorType.actionTitle,
-                    buttonAction: errorType.action
-                ).show()
+                let viewModel = ButtonToastViewModel(labelText: errorType.message,
+                                                     buttonText: errorType.actionTitle)
+                let toast = ButtonToast(viewModel: viewModel,
+                                        theme: themeManager.getCurrentTheme(for: windowUUID),
+                                        completion: { buttonTap in
+                    if buttonTap {
+                        errorType.action()
+                    }
+                })
+                show(toast: toast)
             default:
                 SimpleToast().showAlertWithText(
                     status.message,
@@ -104,6 +109,24 @@ class AddressAutofillSettingsViewController: SensitiveViewController, Themeable 
                     theme: themeManager.getCurrentTheme(for: windowUUID)
                 )
             }
+        }
+    }
+
+    private func show(toast: Toast,
+                      afterWaiting delay: DispatchTimeInterval = Toast.UX.toastDelayBefore,
+                      duration: DispatchTimeInterval? = Toast.UX.toastDismissAfter) {
+        if let buttonToast = toast as? ButtonToast {
+            self.buttonToast = buttonToast
+        }
+
+        toast.showToast(viewController: self, delay: delay, duration: duration) { toast in
+            [
+                toast.leadingAnchor.constraint(equalTo: self.view.leadingAnchor,
+                                               constant: Toast.UX.toastSidePadding),
+                toast.trailingAnchor.constraint(equalTo: self.view.trailingAnchor,
+                                                constant: -Toast.UX.toastSidePadding),
+                toast.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
+            ]
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/SimpleToast.swift
@@ -38,7 +38,7 @@ struct SimpleToast: ThemeApplicable {
     func showAlertWithText(_ text: String,
                            bottomContainer: UIView,
                            theme: Theme,
-                           bottomConstraintPadding: CGFloat = 0) {
+                           bottomConstraintPadding: CGFloat = 16) {
         toastLabel.text = text
         bottomContainer.addSubview(containerView)
         containerView.addSubview(shadowView)
@@ -51,7 +51,7 @@ struct SimpleToast: ThemeApplicable {
             containerView.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor,
                                                     constant: -Toast.UX.toastSidePadding),
             containerView.bottomAnchor.constraint(equalTo: bottomContainer.bottomAnchor,
-                                                  constant: bottomConstraintPadding),
+                                                  constant: -bottomConstraintPadding),
 
             shadowView.topAnchor.constraint(equalTo: containerView.topAnchor,
                                             constant: Toast.UX.shadowHorizontalSpacing / 2),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11244)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24458)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11383)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24765)

## :bulb: Description
- Replace `ActionToast` usage in `AddressAutofillSettingsViewController` with `ButtonToast`
- Update bottom padding inside `SimpleToast` because did not respect safe area

<details>
  <summary>Before</summary>

  | Portrait  | Landscape | 
  |-------------|-------------|
  | ![Simulator Screenshot - iPhone 16 - 2025-02-20 at 11 38 15](https://github.com/user-attachments/assets/ba4a5827-17ee-4d41-bf1b-655e24b4d01e) | ![Simulator Screenshot - iPhone 16 - 2025-02-20 at 11 38 17](https://github.com/user-attachments/assets/759e081f-ef31-482f-9d6b-cbeb18fbdba2) |

</details>

<details>
  <summary>After</summary>

  | Portrait  | Landscape | 
  |-------------|-------------|
  | ![Simulator Screenshot - iPhone 16 - 2025-02-20 at 11 39 25](https://github.com/user-attachments/assets/cfc4587f-3c80-4389-be18-53c73a90288b) | ![Simulator Screenshot - iPhone 16 - 2025-02-20 at 11 39 27](https://github.com/user-attachments/assets/4c93cd63-e270-42ac-9115-ddec1a091d1c)


</details>

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

