### PR TITLE
Add FXIOS-11226 [Homepage] [JumpBackIn] show / hide section

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabManagerAction.swift
@@ -19,5 +19,5 @@ final class TabManagerAction: Action {
 }
 
 enum TabManagerMiddlewareActionType: ActionType {
-    case fetchRecentTabs
+    case fetchedRecentTabs
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -886,7 +886,7 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
                 TabManagerAction(
                     recentTabs: tabManager(for: action.windowUUID).recentlyAccessedNormalTabs,
                     windowUUID: action.windowUUID,
-                    actionType: TabManagerMiddlewareActionType.fetchRecentTabs
+                    actionType: TabManagerMiddlewareActionType.fetchedRecentTabs
                 )
             )
         case JumpBackInActionType.tapOnCell:

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -137,7 +137,7 @@ final class HomepageDiffableDataSource:
         with state: JumpBackInSectionState,
         and config: JumpBackInSectionLayoutConfiguration
     ) -> ([HomepageDiffableDataSource.HomeItem], JumpBackInSectionLayoutConfiguration)? {
-        // TODO: FXIOS-11226 Show items or hide items depending user prefs / feature flag
+        guard state.shouldShowSection else { return nil }
         var updatedConfig = config
         updatedConfig.hasSyncedTab = state.mostRecentSyncedTab != nil
 
@@ -153,7 +153,7 @@ final class HomepageDiffableDataSource:
                 tabs.insert(.jumpBackInSyncedTab(mostRecentSyncedTab), at: 0)
             }
         }
-
+        guard !tabs.isEmpty else { return nil }
         return (tabs, updatedConfig)
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInAction.swift
@@ -6,13 +6,16 @@ import Common
 import Redux
 
 final class JumpBackInAction: Action {
+    let isEnabled: Bool?
     let tab: Tab?
 
     init(
+        isEnabled: Bool? = nil,
         tab: Tab? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.isEnabled = isEnabled
         self.tab = tab
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
@@ -22,4 +25,5 @@ enum JumpBackInActionType: ActionType {
     case fetchLocalTabs
     case fetchRemoteTabs
     case tapOnCell
+    case toggleShowSectionSetting
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/JumpBackIn/JumpBackInSectionState.swift
@@ -55,7 +55,7 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
         }
 
         switch action.actionType {
-        case TabManagerMiddlewareActionType.fetchRecentTabs:
+        case TabManagerMiddlewareActionType.fetchedRecentTabs:
             return handleInitializeAction(for: state, with: action)
         case RemoteTabsMiddlewareActionType.fetchedMostRecentSyncedTab:
             return handleRemoteTabsAction(for: state, with: action)

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -135,7 +135,15 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         let jumpBackInSetting = BoolSetting(
             with: .jumpBackIn,
             titleText: NSAttributedString(string: .Settings.Homepage.CustomizeFirefoxHome.JumpBackIn)
-        )
+        ) { value in
+            store.dispatch(
+                JumpBackInAction(
+                    isEnabled: value,
+                    windowUUID: self.windowUUID,
+                    actionType: JumpBackInActionType.toggleShowSectionSetting
+                )
+            )
+        }
 
         let historyHighlightsSetting = BoolSetting(
             with: .historyHighlights,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageDiffableDataSourceTests.swift
@@ -43,10 +43,9 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         )
 
         let snapshot = dataSource.snapshot()
-        XCTAssertEqual(snapshot.numberOfSections, 3)
+        XCTAssertEqual(snapshot.numberOfSections, 2)
         let expectedSections: [HomepageSection] = [
             .header,
-            .jumpBackIn(nil, mockSectionConfig),
             .customizeHomepage
         ]
         XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
@@ -120,7 +119,6 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         let expectedSections: [HomepageSection] = [
             .header,
             .topSites(4),
-            .jumpBackIn(nil, mockSectionConfig),
             .customizeHomepage
         ]
         XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
@@ -144,7 +142,6 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(nil)), 21)
         let expectedSections: [HomepageSection] = [
             .header,
-            .jumpBackIn(nil, mockSectionConfig),
             .pocket(nil),
             .customizeHomepage
         ]
@@ -176,7 +173,6 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         let expectedSections: [HomepageSection] = [
             .header,
             .messageCard,
-            .jumpBackIn(nil, mockSectionConfig),
             .customizeHomepage
         ]
         XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
@@ -206,8 +202,31 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot.numberOfItems(inSection: .bookmarks(nil)), 1)
         let expectedSections: [HomepageSection] = [
             .header,
-            .jumpBackIn(nil, mockSectionConfig),
             .bookmarks(nil),
+            .customizeHomepage
+        ]
+        XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
+    }
+
+    func test_updateSnapshot_withValidState_returnJumpBackInSection() throws {
+        let dataSource = try XCTUnwrap(diffableDataSource)
+
+        let state = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            TabManagerAction(
+                recentTabs: [createTab(urlString: "www.mozilla.org")],
+                windowUUID: .XCTestDefaultUUID,
+                actionType: TabManagerMiddlewareActionType.fetchedRecentTabs
+            )
+        )
+
+        dataSource.updateSnapshot(state: state, numberOfCellsPerRow: 4, jumpBackInDisplayConfig: mockSectionConfig)
+
+        let snapshot = dataSource.snapshot()
+        XCTAssertEqual(snapshot.numberOfItems(inSection: .jumpBackIn(nil, mockSectionConfig)), 1)
+        let expectedSections: [HomepageSection] = [
+            .header,
+            .jumpBackIn(nil, mockSectionConfig),
             .customizeHomepage
         ]
         XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
@@ -245,5 +264,11 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             layoutType: .compact,
             hasSyncedTab: false
         )
+    }
+
+    private func createTab(urlString: String) -> Tab {
+        let tab = Tab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.url = URL(string: urlString)!
+        return tab
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
@@ -37,7 +37,7 @@ final class JumpBackInSectionStateTests: XCTestCase {
             TabManagerAction(
                 recentTabs: [createTab(urlString: "www.mozilla.org")],
                 windowUUID: .XCTestDefaultUUID,
-                actionType: TabManagerMiddlewareActionType.fetchRecentTabs
+                actionType: TabManagerMiddlewareActionType.fetchedRecentTabs
             )
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/JumpBackInSectionStateTests.swift
@@ -69,6 +69,40 @@ final class JumpBackInSectionStateTests: XCTestCase {
         XCTAssertEqual(newState.mostRecentSyncedTab?.accessibilityLabel, "Tab pickup: Mozilla, Fake client")
     }
 
+    func test_toggleShowSectionSetting_withToggleOn_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = jumpBackInSectionReducer()
+
+        let newState = reducer(
+            initialState,
+            JumpBackInAction(
+                isEnabled: true,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: JumpBackInActionType.toggleShowSectionSetting
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertTrue(newState.shouldShowSection)
+    }
+
+    func test_toggleShowSectionSetting_withToggleOff_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = jumpBackInSectionReducer()
+
+        let newState = reducer(
+            initialState,
+            JumpBackInAction(
+                isEnabled: false,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: JumpBackInActionType.toggleShowSectionSetting
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(newState.shouldShowSection)
+    }
+
     // MARK: - Private
     private func createSubject() -> JumpBackInSectionState {
         return JumpBackInSectionState(windowUUID: .XCTestDefaultUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -58,7 +58,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let actionType = try XCTUnwrap(actionCalled.actionType as? TabManagerMiddlewareActionType)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchRecentTabs)
+        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
         XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11226)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24424)

## :bulb: Description
Implement show / hiding section via user settings. 
- Created new action to dispatch when user toggles setting
- Update state based on the action
- Update diffable datasource check on whether to show section or if tabs are empty

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
https://github.com/user-attachments/assets/79657c04-e1ef-4ae6-a504-3992c1753cd1
