### PR TITLE
Bugfix v137 String Freeze spacing and ellipses issues

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2713,7 +2713,7 @@ extension String {
         public static let DocumentLoadingLabel = MZLocalizedString(
             key: "WebView.DocumentLoadingLabel.v137",
             tableName: "WebView",
-            value: "Loading ...",
+            value: "Loading…",
             comment: "The label shown while loading a document in the web view's custom document loading UI"
         )
         public static let DocumentLoadingAccessibilityLabel = MZLocalizedString(


### PR DESCRIPTION
## :scroll: Tickets
N/A

## :bulb: Description
As per @Delphine's request on https://github.com/mozilla-l10n/firefoxios-l10n/pull/263#discussion_r1962461463, fix space and replace `...` with ASCII ellipses.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

