### PR TITLE
Refactor FXIOS-11423 #24866 [Sponsored tiles] Ensure proper tile order for unified ads API

### DIFF
--- a/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/DataManagement/UnifiedAds/UnifiedAdsProvider.swift
@@ -37,6 +37,11 @@ class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, FeatureFlagga
         case noDataAvailable
     }
 
+    enum TileOrder: String {
+        case position1 = "newtab_mobile_tile_1"
+        case position2 = "newtab_mobile_tile_2"
+    }
+
     init(
         networking: ContileNetworking = DefaultContileNetwork(with: NetworkUtils.defaultURLSession()),
         urlCache: URLCache = URLCache.shared,
@@ -91,8 +96,8 @@ class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, FeatureFlagga
         let requestBody = RequestBody(
             context_id: contextId,
             placements: [
-                AdPlacement(placement: "newtab_mobile_tile_1", count: 1),
-                AdPlacement(placement: "newtab_mobile_tile_2", count: 1)
+                AdPlacement(placement: TileOrder.position1.rawValue, count: 1),
+                AdPlacement(placement: TileOrder.position2.rawValue, count: 1)
             ]
         )
 
@@ -134,7 +139,8 @@ class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, FeatureFlagga
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             let tilesDictionary = try decoder.decode([String: [UnifiedTile]].self, from: data)
-            let tiles = tilesDictionary.values.flatMap { $0 }
+            let placementOrder = [TileOrder.position1.rawValue, TileOrder.position2.rawValue]
+            let tiles = placementOrder.compactMap { tilesDictionary[$0] }.flatMap { $0 }
 
             guard !tiles.isEmpty else {
                 completion(.failure(Error.noDataAvailable))

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/UnifiedAdsProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Home/TopSites/UnifiedAdsProviderTests.swift
@@ -95,6 +95,22 @@ class UnifiedAdsProviderTests: XCTestCase {
         }
     }
 
+    func testfetchTiles_whenInvertedOrder_thenReturnsProperTileOrder() {
+        networking.data = getData(from: invertedTiles)
+        networking.response = getResponse(from: 200)
+        let subject = createSubject()
+
+        subject.fetchTiles { result in
+            switch result {
+            case let .success(tiles):
+                XCTAssertEqual(tiles[0].name, "Test1")
+                XCTAssertEqual(tiles[1].name, "Test2")
+            default:
+                XCTFail("Expected success, got \(result) instead")
+            }
+        }
+    }
+
     // MARK: - Cache
 
     func testCaching_whenCacheData_thenSucceedsFromCache() {
@@ -231,6 +247,37 @@ class UnifiedAdsProviderTests: XCTestCase {
             "image_url": "https://www.test8.com",
             "name": "Test2",
             "block_key": "6789"
+        }
+    ]
+}
+"""
+
+    let invertedTiles = """
+{
+    "newtab_mobile_tile_2": [
+        {
+            "format": "tile",
+            "url": "https://www.test5.com",
+            "callbacks": {
+                "click": "https://www.test6.com",
+                "impression": "https://www.test7.com"
+            },
+            "image_url": "https://www.test8.com",
+            "name": "Test2",
+            "block_key": "6789"
+        }
+    ],
+    "newtab_mobile_tile_1": [
+        {
+            "format": "tile",
+            "url": "https://www.test1.com",
+            "callbacks": {
+                "click": "https://www.test2.com",
+                "impression": "https://www.test3.com"
+            },
+            "image_url": "https://www.test4.com",
+            "name": "Test1",
+            "block_key": "12345"
         }
     ]
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11423)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24866)

## :bulb: Description
Ensure proper tile order for unified ads API. The `newtab_mobile_tile_1` needs to be in position 1 and `newtab_mobile_tile_2` needs to be in position 2.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

