### PR TITLE
Bugfix FXIOS-11386 [Bookmarks Evolution] Prevent cyclic bookmark folder structure

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewModel.swift
@@ -71,10 +71,8 @@ class EditFolderViewModel {
 
     private func getFolderStructure(_ selectedFolder: Folder) {
         Task { @MainActor [weak self] in
-            let folders = await self?.folderFetcher.fetchFolders().filter {
-                // exclude the current editing folder from the folder structure
-                return $0.guid != self?.folder?.guid
-            }
+            guard let currentGuid = self?.folder?.guid else { return }
+            let folders = await self?.folderFetcher.fetchFolders(excludedGuids: [currentGuid])
             guard let folders else { return }
             self?.folderStructures = folders
             self?.onFolderStatusUpdate?()

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
@@ -6,7 +6,14 @@ import Foundation
 import MozillaAppServices
 
 protocol FolderHierarchyFetcher {
+    func fetchFolders(excludedGuids: [String]) async -> [Folder]
     func fetchFolders() async -> [Folder]
+}
+
+extension FolderHierarchyFetcher {
+    func fetchFolders() async -> [Folder] {
+        await fetchFolders(excludedGuids: [])
+    }
 }
 
 struct Folder: Equatable, Hashable {
@@ -31,7 +38,7 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
     let profile: Profile
     let rootFolderGUID: String
 
-    func fetchFolders() async -> [Folder] {
+    func fetchFolders(excludedGuids: [String] = []) async -> [Folder] {
         let numDesktopBookmarks = await countDesktopBookmarks()
         return await withCheckedContinuation { continuation in
             profile.places.getBookmarksTree(rootGUID: rootFolderGUID, recursive: true) { result in
@@ -65,6 +72,7 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
                         recursiveAddSubFolders(folder,
                                                folders: &folders,
                                                hasDesktopBookmarks: hasDesktopBookmarks,
+                                               excludedGuids: excludedGuids,
                                                prefixFolders: desktopFolders)
                     }
                 case .failure: return
@@ -85,8 +93,13 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
                                         folders: inout [Folder],
                                         hasDesktopBookmarks: Bool,
                                         indent: Int = 0,
+                                        excludedGuids: [String],
                                         prefixFolders: [BookmarkFolderData] = []) {
-        if !BookmarkRoots.DesktopRoots.contains(folder.guid) || hasDesktopBookmarks {
+        // Only add the folder if it is:
+        // a) A desktop folder and we have desktop bookmarks
+        // b) Not a desktop or excluded folder
+        if (BookmarkRoots.DesktopRoots.contains(folder.guid) && hasDesktopBookmarks) ||
+            (!BookmarkRoots.DesktopRoots.contains(folder.guid) && !excludedGuids.contains(folder.guid)) {
             folders.append(Folder(title: folder.title, guid: folder.guid, indentation: indent))
 
             // Prepend desktop folders to the top of the mobile bookmarks folder hierarchy
@@ -100,7 +113,8 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
                 subFolder,
                 folders: &folders,
                 hasDesktopBookmarks: hasDesktopBookmarks,
-                indent: indentation
+                indent: indentation,
+                excludedGuids: excludedGuids
             )
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockFolderHierarchyFetcher.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockFolderHierarchyFetcher.swift
@@ -8,7 +8,7 @@ class MockFolderHierarchyFetcher: FolderHierarchyFetcher {
     var fetchFoldersCalled = 0
     var mockFolderStructures = [Folder(title: "Example", guid: "123456", indentation: 0)]
 
-    func fetchFolders() async -> [Folder] {
+    func fetchFolders(excludedGuids: [String] = []) async -> [Folder] {
         fetchFoldersCalled += 1
         return mockFolderStructures
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11386)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24777)

## :bulb: Description
- Prevent subfolders of the folder being edited from appearing in the parent folder selector hierarchy

### 📝 Discussion
- This was problematic because setting a folder's parent to be one of it's children would cause a circular dependency/infinite loop and eventually lead to a crash

### 📸 Screenshots

For this example, the folder structure is as follows:

```
- Bookmarks
  - Folder b
  - Folder a
  - Folder 1 [we are editing this folder]
    - Folder 2
```

| Before | After |
| ------------- | ------------- |
| <img width="559" alt="Screenshot 2025-02-20 at 4 33 39 PM" src="https://github.com/user-attachments/assets/ab2f6534-9c99-4520-88db-0de17b917b70" /> | <img width="559" alt="Screenshot 2025-02-20 at 4 31 43 PM" src="https://github.com/user-attachments/assets/35989470-8cb5-4de5-9f40-03638c744e74" /> |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

