### PR TITLE
Bugfix FXIOS-11391 ⁃ [RTL] Submenus arrows in the overlay menu are pointing the wrong way

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuCell.swift
@@ -62,7 +62,9 @@ public class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
         self.contentStackView.spacing = model.description != nil ? UX.contentSpacing : UX.noDescriptionContentSpacing
         self.icon.image = UIImage(named: model.iconName)?.withRenderingMode(.alwaysTemplate)
         self.accessoryArrowView.image =
-        UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate)
+        UIImage(named: StandardImageIdentifiers.Large.chevronRight)?
+            .withRenderingMode(.alwaysTemplate)
+            .imageFlippedForRightToLeftLayoutDirection()
         self.isAccessibilityElement = true
         self.isUserInteractionEnabled = !model.isEnabled ? false : true
         self.accessibilityIdentifier = model.a11yId


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11391)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24793)

## :bulb: Description
Added imageFlippedForRightToLeftLayoutDirection() property to chevronRight image

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

