### PR TITLE
Bugfix FXIOS-11352 #24709 ⁃ [Focus] - The selected word is not displayed in the URL bar after paste

### DIFF
--- a/focus-ios/Blockzilla/UIComponents/URLBar/URLBar.swift
+++ b/focus-ios/Blockzilla/UIComponents/URLBar/URLBar.swift
@@ -1017,12 +1017,7 @@ class URLBar: UIView {
         let truncatedURL = components?.host
         
         let (locationText, isSearchQuery) = delegate?.urlBarDisplayTextForURL(url) ?? (nil, false)
-        var displayText: String?
-        if isSearchQuery {
-            displayText = locationText
-        } else {
-            displayText = truncatedURL
-        }
+        var displayText = isSearchQuery ? locationText : truncatedURL
         
         urlTextField.text = displayFullUrl ? fullUrl : displayText
         truncatedUrlText.text = truncatedURL

--- a/focus-ios/Blockzilla/UIComponents/URLBar/URLBar.swift
+++ b/focus-ios/Blockzilla/UIComponents/URLBar/URLBar.swift
@@ -1017,7 +1017,7 @@ class URLBar: UIView {
         let truncatedURL = components?.host
         
         let (locationText, isSearchQuery) = delegate?.urlBarDisplayTextForURL(url) ?? (nil, false)
-        var displayText = isSearchQuery ? locationText : truncatedURL
+        let displayText = isSearchQuery ? locationText : truncatedURL
         
         urlTextField.text = displayFullUrl ? fullUrl : displayText
         truncatedUrlText.text = truncatedURL

--- a/focus-ios/Blockzilla/UIComponents/URLBar/URLBar.swift
+++ b/focus-ios/Blockzilla/UIComponents/URLBar/URLBar.swift
@@ -1015,7 +1015,15 @@ class URLBar: UIView {
         components?.password = nil
         let fullUrl = components?.url?.absoluteString
         let truncatedURL = components?.host
-        let displayText = truncatedURL
+        
+        let (locationText, isSearchQuery) = delegate?.urlBarDisplayTextForURL(url) ?? (nil, false)
+        var displayText: String?
+        if isSearchQuery {
+            displayText = locationText
+        } else {
+            displayText = truncatedURL
+        }
+        
         urlTextField.text = displayFullUrl ? fullUrl : displayText
         truncatedUrlText.text = truncatedURL
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11352)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24709)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
<img src = "https://github.com/user-attachments/assets/70d936f0-a65f-4355-bd1a-2e8bc3eb0096" width = 300 />
Searching by keyword now shows it in the url bar.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

