### PR TITLE
Bugfix FXIOS-11429 [Bookmarks Evolution] Show subfolders of desktop folders

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
@@ -104,7 +104,7 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
 
             // Prepend desktop folders to the top of the mobile bookmarks folder hierarchy
             if folder.guid == BookmarkRoots.MobileFolderGUID {
-                prependDesktopFolders(folder, folders: &folders, indent: indent, prefixFolders: prefixFolders)
+                prependDesktopFolders(folder, folders: &folders, indent: indent, excludedGuids: excludedGuids, prefixFolders: prefixFolders)
             }
         } else { return }
         for case let subFolder as BookmarkFolderData in folder.children ?? [] {
@@ -135,9 +135,16 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
     private func prependDesktopFolders(_ folder: BookmarkFolderData,
                                        folders: inout [Folder],
                                        indent: Int = 0,
+                                       excludedGuids: [String],
                                        prefixFolders: [BookmarkFolderData] = []) {
         prefixFolders.forEach {
-            folders.append(Folder(title: $0.title, guid: $0.guid, indentation: indent + 2))
+            recursiveAddSubFolders(
+                $0,
+                folders: &folders,
+                hasDesktopBookmarks: true,
+                indent: indent + 2,
+                excludedGuids: excludedGuids
+            )
         }
         // Find the first desktop folder and prepend a dummy folder object to use for the "DESKTOP BOOKMARKS" header
         if let firstDesktopFolderIndex = folders.firstIndex(where: { BookmarkRoots.DesktopRoots.contains($0.guid) }) {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/FolderHierarchyFetcher.swift
@@ -104,7 +104,13 @@ struct DefaultFolderHierarchyFetcher: FolderHierarchyFetcher, BookmarksRefactorF
 
             // Prepend desktop folders to the top of the mobile bookmarks folder hierarchy
             if folder.guid == BookmarkRoots.MobileFolderGUID {
-                prependDesktopFolders(folder, folders: &folders, indent: indent, excludedGuids: excludedGuids, prefixFolders: prefixFolders)
+                prependDesktopFolders(
+                    folder,
+                    folders: &folders,
+                    indent: indent,
+                    excludedGuids: excludedGuids,
+                    prefixFolders: prefixFolders
+                )
             }
         } else { return }
         for case let subFolder as BookmarkFolderData in folder.children ?? [] {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11429)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24882)

## :bulb: Description
- Show subfolders of desktop folders in the parent folder selector when editing a bookmark/folder
- When editing one of these subfolders, we also make sure to exclude it and it's subfolders

### 📸 Screenshots

| Before | After |
| ------------- | ------------- |
| <img width="559" alt="Screenshot 2025-02-21 at 1 57 08 PM" src="https://github.com/user-attachments/assets/20308560-d266-4198-aa2a-4becad226a78" /> | <img width="559" alt="Screenshot 2025-02-21 at 1 55 38 PM" src="https://github.com/user-attachments/assets/77881995-2f38-4d7b-8ac1-71bc188e38a9" /> |

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

