### PR TITLE
Bugfix FXIOS-10415 ⁃ [Menu redesign] - Incorrect menu icon for zoomed out webpage

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -412,7 +412,17 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
             from: NSNumber(value: tabInfo.zoomLevel),
             number: .percent
         )
-        let title = String(format: .MainMenu.Submenus.Tools.Zoom, zoomLevel)
+
+        let regularZoom: CGFloat = 1.0
+        let zoomSymbol: String = if tabInfo.zoomLevel > regularZoom {
+            .MainMenu.Submenus.Tools.ZoomPositiveSymbol
+        } else if tabInfo.zoomLevel < regularZoom {
+            .MainMenu.Submenus.Tools.ZoomNegativeSymbol
+        } else {
+            ""
+        }
+
+        let title = String(format: .MainMenu.Submenus.Tools.Zoom, "\(zoomSymbol)\(zoomLevel)")
         let icon = tabInfo.zoomLevel == 1.0 ? Icons.zoomOff : Icons.zoomOn
 
         return MenuElement(
@@ -420,7 +430,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
             iconName: icon,
             isEnabled: true,
             isActive: tabInfo.zoomLevel != 1.0,
-            a11yLabel: String(format: .MainMenu.Submenus.Tools.AccessibilityLabels.Zoom, zoomLevel),
+            a11yLabel: String(format: .MainMenu.Submenus.Tools.AccessibilityLabels.Zoom, "\(zoomSymbol)\(zoomLevel)"),
             a11yHint: "",
             a11yId: AccessibilityIdentifiers.MainMenu.zoom,
             action: {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -423,13 +423,13 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         }
 
         let title = String(format: .MainMenu.Submenus.Tools.Zoom, "\(zoomSymbol)\(zoomLevel)")
-        let icon = tabInfo.zoomLevel == 1.0 ? Icons.zoomOff : Icons.zoomOn
+        let icon = tabInfo.zoomLevel == regularZoom ? Icons.zoomOff : Icons.zoomOn
 
         return MenuElement(
             title: title,
             iconName: icon,
             isEnabled: true,
-            isActive: tabInfo.zoomLevel != 1.0,
+            isActive: tabInfo.zoomLevel != regularZoom,
             a11yLabel: String(format: .MainMenu.Submenus.Tools.AccessibilityLabels.Zoom, "\(zoomSymbol)\(zoomLevel)"),
             a11yHint: "",
             a11yId: AccessibilityIdentifiers.MainMenu.zoom,

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4304,6 +4304,16 @@ extension String {
                     tableName: "MainMenu",
                     value: "Zoom",
                     comment: "On the main menu, a string below the Tool submenu title, indicating what kind of tools are available in that menu. This string is for the Zoom tool.")
+                public static let ZoomNegativeSymbol = MZLocalizedString(
+                    key: "MainMenu.Submenus.Tools.Zoom.NegativeSymbol.v137",
+                    tableName: "MainMenu",
+                    value: "-",
+                    comment: "This string is for the Zoom tool, when Zoom value is negative. (-50%)")
+                public static let ZoomPositiveSymbol = MZLocalizedString(
+                    key: "MainMenu.Submenus.Tools.Zoom.PositiveSymbol.v137",
+                    tableName: "MainMenu",
+                    value: "+",
+                    comment: "This string is for the Zoom tool, when Zoom value is positive. (+125%)")
                 public static let ReaderViewOn = MZLocalizedString(
                     key: "MainMenu.Submenus.Tools.ReaderView.On.Title.v131",
                     tableName: "MainMenu",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10415)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22808)

## :bulb: Description
Added + and - for Zoom option label

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

