### PR TITLE
Bugfix FXIOS-9428 [Homepage] viewWillAppear gets called multiple times

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1567,7 +1567,7 @@ class BrowserViewController: UIViewController,
 
         let isErrorURL = url.flatMap { InternalURL($0)?.isErrorPage } ?? false
 
-        guard url != nil else {
+        guard let url else {
             showEmbeddedWebview()
             if !isToolbarRefactorEnabled {
                 legacyUrlBar?.locationView.reloadButton.reloadButtonState = .disabled
@@ -1576,8 +1576,8 @@ class BrowserViewController: UIViewController,
         }
 
         /// Used for checking if current error code is for no internet connection
-        let isNICErrorCode = url?.absoluteString.contains(String(Int(
-            CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue))) ?? false
+        let isNICErrorCode = url.absoluteString.contains(String(Int(
+            CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue)))
         let noInternetConnectionEnabled = isNICErrorCode && isNICErrorPageEnabled
         let genericErrorPageEnabled = isErrorURL && isNativeErrorPageEnabled
 
@@ -4001,12 +4001,18 @@ extension BrowserViewController: TabManagerDelegate {
             webView.accessibilityIdentifier = "contentView"
             webView.accessibilityElementsHidden = false
 
-            browserDelegate?.show(webView: webView)
+            if featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly) {
+                updateEmbeddedContent(isHomeTab: selectedTab.isFxHomeTab, with: webView)
+            } else {
+                browserDelegate?.show(webView: webView)
+            }
+
             if selectedTab.isFxHomeTab {
                 // Added as initial fix for WKWebView memory leak. Needs further investigation.
                 // See: [FXIOS-10612] + [FXIOS-10335]
                 needsReload = true
             }
+
             if webView.url == nil {
                 // The webView can go gray if it was zombified due to memory pressure.
                 // When this happens, the URL is nil, so try restoring the page upon selection.
@@ -4070,6 +4076,15 @@ extension BrowserViewController: TabManagerDelegate {
 
         if needsReload {
             selectedTab.reloadPage()
+        }
+    }
+
+    /// Updates the content in BVC depending on whether its a home page or web page
+    private func updateEmbeddedContent(isHomeTab: Bool, with webView: WKWebView) {
+        if isHomeTab {
+            updateInContentHomePanel(webView.url)
+        } else {
+            browserDelegate?.show(webView: webView)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9428)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/20872)

## :bulb: Description
Multiple calls were originally occurring because the previous embedded view contained a webview even though the user never encounters a web page. This was due to the `browserDelegate?.show(webView: webView)` being triggered, which updated the content container. To address the multiple calls to `viewWillAppear`, added a fix to not call that method if the current tab is the homepage.  

Wrapped the fix under the feature flag for the homepage rebuild project and will keep an eye out to see if any issues arises from it.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots
Goes through different scenarios in showing the homepage, see chart in JIRA ticket for more details. A call to `viewWillAppear` gets triggered only if the homepage is not already embedded as the content.

- App launch
- Open From Tab 
- Toggle Private 
- Open From Button 
- Tap on Search Bar

https://github.com/user-attachments/assets/66a82447-a1ce-46aa-94ae-48bb052d8e34