### PR TITLE
Fix FXIOS-9006 [Tab Improvements] Switch to private mode if neccisary before opening a new tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2712,9 +2712,9 @@ class BrowserViewController: UIViewController,
             logger.log("No request for openURLInNewTab", level: .debug, category: .tabs)
         }
 
+        switchToPrivacyMode(isPrivate: isPrivate)
         let tab = tabManager.addTab(request, isPrivate: isPrivate)
         tabManager.selectTab(tab)
-        switchToPrivacyMode(isPrivate: isPrivate)
         return tab
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -7,6 +7,7 @@ import Storage
 import XCTest
 import Shared
 import Glean
+import Common
 
 @testable import Client
 
@@ -67,5 +68,19 @@ class BrowserViewControllerTests: XCTestCase {
         ))
 
         wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testOpenURLInNewTab_withPrivateModeEnabled() {
+        let topTabsViewController = TopTabsViewController(tabManager: tabManager, profile: profile)
+        browserViewController.topTabsViewController = topTabsViewController
+        browserViewController.openURLInNewTab(nil, isPrivate: true)
+        XCTAssertEqual(topTabsViewController.privateModeButton.tintColor, DarkTheme().colors.iconOnColor)
+        XCTAssertTrue(tabManager.addTabWasCalled)
+        XCTAssertNotNil(tabManager.selectedTab)
+        guard let selectedTab = tabManager.selectedTab else {
+            XCTFail("selected tab was nil")
+            return
+        }
+        XCTAssertTrue(selectedTab.isPrivate)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -34,6 +34,11 @@ class BrowserViewControllerTests: XCTestCase {
     override func tearDown() {
         TelemetryContextualIdentifier.clearUserDefaults()
         DependencyHelperMock().reset()
+        profile = nil
+        tabManager = nil
+        browserViewController = nil
+        Glean.shared.registerPings(GleanMetrics.Pings.shared)
+        Glean.shared.resetGlean(clearStores: true)
         super.tearDown()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -142,7 +142,7 @@ class MockTabManager: TabManager {
                 isPrivate: Bool
     ) -> Tab {
         addTabWasCalled = true
-        return Tab(profile: MockProfile(), windowUUID: windowUUID)
+        return Tab(profile: MockProfile(), isPrivate: isPrivate, windowUUID: windowUUID)
     }
 
     func backgroundRemoveAllTabs(isPrivate: Bool,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -35,6 +35,8 @@ class MockTabManager: TabManager {
 
     var removeTabsByURLCalled = 0
 
+    var addTabWasCalled = false
+
     init(
         windowUUID: WindowUUID = WindowUUID.XCTestDefaultUUID,
         recentlyAccessedNormalTabs: [Tab] = [Tab]()
@@ -139,6 +141,7 @@ class MockTabManager: TabManager {
                 zombie: Bool,
                 isPrivate: Bool
     ) -> Tab {
+        addTabWasCalled = true
         return Tab(profile: MockProfile(), windowUUID: windowUUID)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9006)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/19873)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Switch the logic so that opening a new tab in private mode switches the UI to private mode first before opening the tab


Uploading Simulator Screen Recording - iPhone 16 Pro - 2025-02-24 at 10.44.09.mp4…

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

