### PR TITLE
Add EXP-5154 add Nimbus ping and submit it on RecordedNimbusContext.record completion

### DIFF
--- a/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
+++ b/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
@@ -126,7 +126,6 @@ class RecordedNimbusContext: RecordedContext {
             daysOpenedInLast28: eventQueryValues[RecordedNimbusContext.DAYS_OPENED_IN_LAST_28].toInt64()
         )
 
-        GleanMetrics.Pings.shared.nimbus.setEnabled(enabled: true)
         GleanMetrics.NimbusSystem.recordedNimbusContext.set(
             GleanMetrics.NimbusSystem.RecordedNimbusContextObject(
                 isFirstRun: isFirstRun,

--- a/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
+++ b/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
@@ -20,7 +20,7 @@ private extension Double? {
     }
 }
 
-public extension Int32? {
+extension Int32? {
     func toInt64() -> Int64? {
         guard let self = self else { return nil }
         return Int64(self)

--- a/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
+++ b/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
@@ -20,7 +20,7 @@ private extension Double? {
     }
 }
 
-private extension Int32? {
+public extension Int32? {
     func toInt64() -> Int64? {
         guard let self = self else { return nil }
         return Int64(self)
@@ -126,6 +126,7 @@ class RecordedNimbusContext: RecordedContext {
             daysOpenedInLast28: eventQueryValues[RecordedNimbusContext.DAYS_OPENED_IN_LAST_28].toInt64()
         )
 
+        GleanMetrics.Pings.shared.nimbus.setEnabled(enabled: true)
         GleanMetrics.NimbusSystem.recordedNimbusContext.set(
             GleanMetrics.NimbusSystem.RecordedNimbusContextObject(
                 isFirstRun: isFirstRun,
@@ -141,6 +142,7 @@ class RecordedNimbusContext: RecordedContext {
                 isDefaultBrowser: isDefaultBrowser
             )
         )
+        GleanMetrics.Pings.shared.nimbus.submit()
         logger.log("record end", level: .debug, category: .experiments)
     }
 

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -6595,3 +6595,5 @@ nimbus_system:
       - chumphreys@mozilla.com
       - project-nimbus@mozilla.com
     expires: never
+    send_in_pings:
+      - nimbus

--- a/firefox-ios/Client/pings.yaml
+++ b/firefox-ios/Client/pings.yaml
@@ -155,7 +155,7 @@ nimbus:
   bugs:
     - https://mozilla-hub.atlassian.net/browse/EXP-5154
   data_reviews:
-    - 'TODO'
+    - https://github.com/mozilla-mobile/firefox-ios/pull/24950
   notification_emails:
     - chumphreys@mozilla.com
     - project-nimbus@mozilla.com

--- a/firefox-ios/Client/pings.yaml
+++ b/firefox-ios/Client/pings.yaml
@@ -159,6 +159,3 @@ nimbus:
   notification_emails:
     - chumphreys@mozilla.com
     - project-nimbus@mozilla.com
-  metadata:
-    follows_collection_enabled: false
-    include_info_sections: false

--- a/firefox-ios/Client/pings.yaml
+++ b/firefox-ios/Client/pings.yaml
@@ -150,7 +150,7 @@ usage-deletion-request:
 nimbus:
   description: |
     This ping is submitted by Nimbus code after the enrollment workflow has completed.
-  include_client_id: false
+  include_client_id: true
   send_if_empty: true
   bugs:
     - https://mozilla-hub.atlassian.net/browse/EXP-5154

--- a/firefox-ios/Client/pings.yaml
+++ b/firefox-ios/Client/pings.yaml
@@ -146,3 +146,19 @@ usage-deletion-request:
     set_upload_enabled: |
       The ping was submitted due to the usage-reporting data preference changing from
       enabled to disabled.
+      
+nimbus:
+  description: |
+    This ping is submitted by Nimbus code after the enrollment workflow has completed.
+  include_client_id: false
+  send_if_empty: true
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/EXP-5154
+  data_reviews:
+    - 'TODO'
+  notification_emails:
+    - chumphreys@mozilla.com
+    - project-nimbus@mozilla.com
+  metadata:
+    follows_collection_enabled: false
+    include_info_sections: false

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
@@ -53,24 +53,32 @@ class RecordedNimbusContextTests: XCTestCase {
 
     func testObjectRecordedToGleanMatchesExpected() throws {
         let recordedContext = RecordedNimbusContext(isFirstRun: true, isReviewCheckerEnabled: true, isDefaultBrowser: true)
+
+        let expectation = expectation(description: "The Firefox Suggest ping was sent")
+        GleanMetrics.Pings.shared.nimbus.testBeforeNextSubmit { e in
+            let value = GleanMetrics.NimbusSystem.recordedNimbusContext.testGetValue()
+
+            XCTAssertNotNil(value)
+            XCTAssertEqual(value?.appVersion, recordedContext.appVersion)
+            XCTAssertEqual(value?.isFirstRun, recordedContext.isFirstRun)
+            XCTAssertEqual(value?.isPhone, recordedContext.isPhone)
+            XCTAssertEqual(value?.isReviewCheckerEnabled, recordedContext.isReviewCheckerEnabled)
+            XCTAssertEqual(value?.locale, recordedContext.locale)
+            XCTAssertEqual(value?.region, recordedContext.region)
+            XCTAssertEqual(value?.language, recordedContext.language)
+            XCTAssertEqual(value?.daysSinceInstall, recordedContext.daysSinceInstall.toInt64())
+            XCTAssertEqual(value?.daysSinceUpdate, recordedContext.daysSinceUpdate.toInt64())
+            XCTAssertEqual(value?.isDefaultBrowser, recordedContext.isDefaultBrowser)
+
+            XCTAssertNotNil(value?.eventQueryValues)
+            XCTAssertEqual(value?.eventQueryValues?.daysOpenedInLast28, 1)
+            expectation.fulfill()
+        }
+
         recordedContext.setEventQueryValues(eventQueryValues: [RecordedNimbusContext.DAYS_OPENED_IN_LAST_28: 1.5])
         recordedContext.record()
-        let value = GleanMetrics.NimbusSystem.recordedNimbusContext.testGetValue()
 
-        XCTAssertNotNil(value)
-        XCTAssertEqual(value?.appVersion, recordedContext.appVersion)
-        XCTAssertEqual(value?.isFirstRun, recordedContext.isFirstRun)
-        XCTAssertEqual(value?.isPhone, recordedContext.isPhone)
-        XCTAssertEqual(value?.isReviewCheckerEnabled, recordedContext.isReviewCheckerEnabled)
-        XCTAssertEqual(value?.locale, recordedContext.locale)
-        XCTAssertEqual(value?.region, recordedContext.region)
-        XCTAssertEqual(value?.language, recordedContext.language)
-        XCTAssertEqual(Int(value!.daysSinceInstall!), Int(recordedContext.daysSinceInstall!))
-        XCTAssertEqual(Int(value!.daysSinceUpdate!), Int(recordedContext.daysSinceUpdate!))
-        XCTAssertEqual(value?.isDefaultBrowser, recordedContext.isDefaultBrowser)
-
-        XCTAssertNotNil(value?.eventQueryValues)
-        XCTAssertEqual(value?.eventQueryValues?.daysOpenedInLast28, 1)
+        wait(for: [expectation], timeout: 5.0)
     }
 
     func testGetEventQueries() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
@@ -54,24 +54,10 @@ class RecordedNimbusContextTests: XCTestCase {
     func testObjectRecordedToGleanMatchesExpected() throws {
         let recordedContext = RecordedNimbusContext(isFirstRun: true, isReviewCheckerEnabled: true, isDefaultBrowser: true)
 
+        var value: GleanMetrics.NimbusSystem.RecordedNimbusContextObject?
         let expectation = expectation(description: "The Firefox Suggest ping was sent")
         GleanMetrics.Pings.shared.nimbus.testBeforeNextSubmit { e in
-            let value = GleanMetrics.NimbusSystem.recordedNimbusContext.testGetValue()
-
-            XCTAssertNotNil(value)
-            XCTAssertEqual(value?.appVersion, recordedContext.appVersion)
-            XCTAssertEqual(value?.isFirstRun, recordedContext.isFirstRun)
-            XCTAssertEqual(value?.isPhone, recordedContext.isPhone)
-            XCTAssertEqual(value?.isReviewCheckerEnabled, recordedContext.isReviewCheckerEnabled)
-            XCTAssertEqual(value?.locale, recordedContext.locale)
-            XCTAssertEqual(value?.region, recordedContext.region)
-            XCTAssertEqual(value?.language, recordedContext.language)
-            XCTAssertEqual(value?.daysSinceInstall, recordedContext.daysSinceInstall.toInt64())
-            XCTAssertEqual(value?.daysSinceUpdate, recordedContext.daysSinceUpdate.toInt64())
-            XCTAssertEqual(value?.isDefaultBrowser, recordedContext.isDefaultBrowser)
-
-            XCTAssertNotNil(value?.eventQueryValues)
-            XCTAssertEqual(value?.eventQueryValues?.daysOpenedInLast28, 1)
+            value = GleanMetrics.NimbusSystem.recordedNimbusContext.testGetValue()
             expectation.fulfill()
         }
 
@@ -79,6 +65,21 @@ class RecordedNimbusContextTests: XCTestCase {
         recordedContext.record()
 
         wait(for: [expectation], timeout: 5.0)
+
+        XCTAssertNotNil(value)
+        XCTAssertEqual(value?.appVersion, recordedContext.appVersion)
+        XCTAssertEqual(value?.isFirstRun, recordedContext.isFirstRun)
+        XCTAssertEqual(value?.isPhone, recordedContext.isPhone)
+        XCTAssertEqual(value?.isReviewCheckerEnabled, recordedContext.isReviewCheckerEnabled)
+        XCTAssertEqual(value?.locale, recordedContext.locale)
+        XCTAssertEqual(value?.region, recordedContext.region)
+        XCTAssertEqual(value?.language, recordedContext.language)
+        XCTAssertEqual(value?.daysSinceInstall, recordedContext.daysSinceInstall.toInt64())
+        XCTAssertEqual(value?.daysSinceUpdate, recordedContext.daysSinceUpdate.toInt64())
+        XCTAssertEqual(value?.isDefaultBrowser, recordedContext.isDefaultBrowser)
+
+        XCTAssertNotNil(value?.eventQueryValues)
+        XCTAssertEqual(value?.eventQueryValues?.daysOpenedInLast28, 1)
     }
 
     func testGetEventQueries() throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/EXP-5154)

## :bulb: Description
- Added a ping for Nimbus
- Updated `RecordedNimbusContext.record()` to enable+submit the ping

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

