### PR TITLE
Bugfix Use non-edge stack in other workflows

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -784,7 +784,7 @@ workflows:
     description: This Workflow is to build the app using latest xcode available in Bitrise
     meta:
       bitrise.io:
-        stack: osx-xcode-16.2.x-edge
+        stack: osx-xcode-16.2.x
         machine_type_id: g2-m1.8core
   L10nBuild:
     steps:
@@ -879,7 +879,7 @@ workflows:
       the rest of the builds
     meta:
       bitrise.io:
-        stack: osx-xcode-16.2.x-edge
+        stack: osx-xcode-16.2.x
         machine_type_id: g2-m1.8core
   L10nScreenshotsTests:
     steps:
@@ -924,7 +924,7 @@ workflows:
       This Workflow is to run L10n tests for all locales
     meta:
       bitrise.io:
-        stack: osx-xcode-16.2.x-edge
+        stack: osx-xcode-16.2.x
         machine_type_id: g2-m1.8core
   SPM_Deploy_Prod_Beta:
     steps:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Similar to  https://github.com/mozilla-mobile/firefox-ios/commit/01c7138512001bfb54319d5c08f4ddf65fafe660, we should use the non-edge version of the Bitrise stack so that the other workflows keep working.

L10nBuild on this branch: https://app.bitrise.io/build/9f3cd6da-779b-4233-b1c2-b1facd1bbe63

I confirmed that there's an update on Feb 24 that caused the existing build to fail: The simulator devices are defaulted to iOS 18.3 instead of iOS 18.2.
https://stacks.bitrise.io/changelogs/osx-xcode-16.2.x-edge/

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

