### PR TITLE
Add FXIOS-11462 #24931 [Tab Tray UI Experiments] Update tab cell UI with ExperimentTabCell

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -779,6 +779,7 @@
 		8A1F6C312BC5A6BE00DA6F86 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 8ACD3B972BA8EA8300E73E9A /* PrivacyInfo.xcprivacy */; };
 		8A1F6C322BC5A6C400DA6F86 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 8ACD3B972BA8EA8300E73E9A /* PrivacyInfo.xcprivacy */; };
 		8A1F6C332BC5A6D100DA6F86 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 8ACD3B972BA8EA8300E73E9A /* PrivacyInfo.xcprivacy */; };
+		8A2068372D6D52830063A77B /* ExperimentTabCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2068362D6D52830063A77B /* ExperimentTabCell.swift */; };
 		8A25556D2CF0E0E6009C0989 /* InactiveTabsTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A25556C2CF0E0E6009C0989 /* InactiveTabsTelemetryTests.swift */; };
 		8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */; };
 		8A2825352760399B00395E66 /* KeyboardPressesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */; };
@@ -7728,6 +7729,7 @@
 		8A1E3BE128CBACD7003388C4 /* SponsoredContentFilterUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SponsoredContentFilterUtilityTests.swift; sourceTree = "<group>"; };
 		8A1E3BE528CBBF44003388C4 /* OpenSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSearchEngine.swift; sourceTree = "<group>"; };
 		8A1E93E92A3CDC6100DD540A /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
+		8A2068362D6D52830063A77B /* ExperimentTabCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentTabCell.swift; sourceTree = "<group>"; };
 		8A25556C2CF0E0E6009C0989 /* InactiveTabsTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveTabsTelemetryTests.swift; sourceTree = "<group>"; };
 		8A2783F0275FFDC50080D29D /* KeyboardPressesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandler.swift; sourceTree = "<group>"; };
 		8A2825342760399B00395E66 /* KeyboardPressesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPressesHandlerTests.swift; sourceTree = "<group>"; };
@@ -10581,6 +10583,7 @@
 		21C5B3582AF2A7130093F366 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				8A2068362D6D52830063A77B /* ExperimentTabCell.swift */,
 				5A679E4A2B239FAE004F2B0D /* TabPeekViewController.swift */,
 				43162A2E2492DB7800F91658 /* EmptyPrivateTabsView.swift */,
 				1DEBC55D2AC4ED70006E4801 /* RemoteTabsPanel.swift */,
@@ -16829,6 +16832,7 @@
 				7482205C1DBAB56300EEEA72 /* MailProviders.swift in Sources */,
 				8A93F87029D3A597004159D9 /* SceneCoordinator.swift in Sources */,
 				631A36A32CC0B2470044DFEB /* NativeErrorPageHelper.swift in Sources */,
+				8A2068372D6D52830063A77B /* ExperimentTabCell.swift in Sources */,
 				C88E7A602A05551B0072E638 /* NimbusOnboardingFeatureLayerProtocol.swift in Sources */,
 				8CFD56882AAF057D003157A6 /* SwitchFakespotProduction.swift in Sources */,
 				C40046FA1CF8E0B200B08303 /* BackForwardListAnimator.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -11,6 +11,7 @@ class TabsSectionManager: FeatureFlaggable {
         static let cellAbsoluteHeight: CGFloat = 200
         static let experimentCellAbsoluteHeight: CGFloat = 220
         static let cardSpacing: CGFloat = 16
+        static let experimentCardSpacing: CGFloat = 32
         static let standardInset: CGFloat = 18
         static let iPadInset: CGFloat = 50
         static let iPadTopSiteInset: CGFloat = 25
@@ -62,7 +63,7 @@ class TabsSectionManager: FeatureFlaggable {
                                                         leading: horizontalInset,
                                                         bottom: UX.verticalInset,
                                                         trailing: horizontalInset)
-        section.interGroupSpacing = UX.cardSpacing
+        section.interGroupSpacing = isTabTrayUIExperimentsEnabled ? UX.experimentCardSpacing : UX.cardSpacing
 
         return section
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -4,16 +4,21 @@
 
 import Foundation
 
-class TabsSectionManager {
+class TabsSectionManager: FeatureFlaggable {
     struct UX {
         // On iPad we can set to have bigger tabs, on iPhone we need smaller ones
         static let cellEstimatedWidth: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 250 : 170
         static let cellAbsoluteHeight: CGFloat = 200
+        static let experimentCellAbsoluteHeight: CGFloat = 220
         static let cardSpacing: CGFloat = 16
         static let standardInset: CGFloat = 18
         static let iPadInset: CGFloat = 50
         static let iPadTopSiteInset: CGFloat = 25
         static let verticalInset: CGFloat = 20
+    }
+
+    private var isTabTrayUIExperimentsEnabled: Bool {
+        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
     }
 
     static func leadingInset(traitCollection: UITraitCollection,
@@ -35,15 +40,16 @@ class TabsSectionManager {
                                   ? minNumberOfCellsPerRow
                                   : maxNumberOfCellsPerRow
 
+        let cellHeight = isTabTrayUIExperimentsEnabled ? UX.experimentCellAbsoluteHeight : UX.cellAbsoluteHeight
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .estimated(UX.cellEstimatedWidth),
-            heightDimension: .absolute(UX.cellAbsoluteHeight)
+            heightDimension: .absolute(cellHeight)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
-            heightDimension: .estimated(UX.cellAbsoluteHeight)
+            heightDimension: .estimated(cellHeight)
         )
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
                                                        subitem: item,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -12,7 +12,7 @@ import SiteImageView
 class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFlaggable {
     struct UX {
         static let selectedBorderWidth: CGFloat = 3.0
-        static let unselectedBorderWidth: CGFloat = 1.0
+        static let unselectedBorderWidth: CGFloat = 0.8
         static let cornerRadius: CGFloat = 16
         static let subviewDefaultPadding: CGFloat = 6.0
         static let faviconYOffset: CGFloat = 10.0
@@ -23,6 +23,9 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
                                                                   leading: 10,
                                                                   bottom: 10,
                                                                   trailing: 10)
+        static let closeButtonTop: CGFloat = 6
+        static let closeButtonTrailing: CGFloat = 8
+        static let tabViewFooterSpacing: CGFloat = 4
 
         // Using the same sizes for fallback favicon as the top sites on the homepage
         static let imageBackgroundSize = TopSiteItemCell.UX.imageBackgroundSize
@@ -46,7 +49,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         stackView.axis = .horizontal
         stackView.distribution = .fill
         stackView.alignment = .fill
-        stackView.spacing = 4
+        stackView.spacing = UX.tabViewFooterSpacing
         stackView.backgroundColor = .clear
     }
 
@@ -101,6 +104,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         animator = SwipeAnimator(animatingView: self)
         closeButton.addTarget(self, action: #selector(close), for: .touchUpInside)
 
+        layer.cornerRadius = UX.cornerRadius
         contentView.addSubview(backgroundHolder)
         contentView.addSubview(footerView)
 
@@ -221,20 +225,12 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
                                           theme: Theme?) {
         guard let theme = theme else { return }
         if selected {
-            // Laurie
-//            layoutMargins = UIEdgeInsets(top: UX.selectedBorderWidth,
-//                                         left: UX.selectedBorderWidth,
-//                                         bottom: UX.selectedBorderWidth,
-//                                         right: UX.selectedBorderWidth)
             let borderColor = isPrivate ? theme.colors.borderAccentPrivate : theme.colors.borderAccent
             backgroundHolder.layer.borderColor = borderColor.cgColor
             backgroundHolder.layer.borderWidth = UX.selectedBorderWidth
-            backgroundHolder.layer.cornerRadius = UX.cornerRadius
         } else {
-//            layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
             backgroundHolder.layer.borderColor = theme.colors.borderPrimary.cgColor
             backgroundHolder.layer.borderWidth = UX.unselectedBorderWidth
-            backgroundHolder.layer.cornerRadius = UX.cornerRadius
         }
     }
 
@@ -260,7 +256,8 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
             backgroundHolder.topAnchor.constraint(equalTo: contentView.topAnchor),
             backgroundHolder.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             backgroundHolder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            backgroundHolder.bottomAnchor.constraint(equalTo: footerView.topAnchor, constant: -4),
+            backgroundHolder.bottomAnchor.constraint(equalTo: footerView.topAnchor,
+                                                     constant: -UX.tabViewFooterSpacing),
 
             footerView.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor),
             footerView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
@@ -272,8 +269,10 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
 
             closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
             closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
-            closeButton.topAnchor.constraint(equalTo: backgroundHolder.topAnchor, constant: 8),
-            closeButton.trailingAnchor.constraint(equalTo: backgroundHolder.trailingAnchor, constant: -12),
+            closeButton.topAnchor.constraint(equalTo: backgroundHolder.topAnchor,
+                                             constant: UX.closeButtonTop),
+            closeButton.trailingAnchor.constraint(equalTo: backgroundHolder.trailingAnchor,
+                                                  constant: -UX.closeButtonTrailing),
 
             // Screenshot either shown or favicon takes its place as fallback
             screenshotView.topAnchor.constraint(equalTo: backgroundHolder.topAnchor),

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -12,7 +12,7 @@ protocol TabCellDelegate: AnyObject {
     func tabCellDidClose(for tabUUID: TabUUID)
 }
 
-class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFlaggable {
+class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     struct UX {
         static let borderWidth: CGFloat = 3.0
         static let cornerRadius: CGFloat = 16
@@ -76,10 +76,6 @@ class TabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFlagg
         var configuration = UIButton.Configuration.plain()
         configuration.contentInsets = UX.closeButtonEdgeInset
         button.configuration = configuration
-    }
-
-    private var isTabTrayUIExperimentsEnabled: Bool {
-        return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
     }
 
     // MARK: - Initializer

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -353,7 +353,6 @@ class TabDisplayView: UIView,
 
     // MARK: - SwipeAnimatorDelegate
     func swipeAnimator(_ animator: SwipeAnimator) {
-        // Laurie - to test
         guard let tabCell = animator.animatingView as? UICollectionViewCell,
               let indexPath = collectionView.indexPath(for: tabCell) else { return }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -13,7 +13,7 @@ class TabDisplayView: UIView,
                       TabCellDelegate,
                       SwipeAnimatorDelegate,
                       InactiveTabsSectionManagerDelegate,
-                        FeatureFlaggable {
+                      FeatureFlaggable {
     struct UX {
         static let cornerRadius: CGFloat = 6.0
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -134,7 +134,7 @@ class JumpBackInTests: BaseTestCase {
         } else {
             mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
         }
-        app.cells["Example Domain"].buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
+        app.cells["Example Domain"].buttons[StandardImageIdentifiers.Large.crossCircleFill].waitAndTap()
 
         // Revisit the "Jump Back In" section
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11462)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24931)

## :bulb: Description
Add a new `ExperimentTabCell` which is used whenever the Tab tray UI experiments is turned ON. Note that no shadow was added, I wasn't sure this was needed or not. Shadows are a battle in itself, so I think this is fine to merge for now and improve with shadows if needed.

### 🎥 Screenshot light mode
<details>
<summary>Tab tray</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-24 at 21 56 52](https://github.com/user-attachments/assets/79ae7bd3-4fde-4d17-ad3d-9a7d960e6a66)


</details>

### 🎥 Screenshot dark mode
<details>
<summary>Tab tray</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-24 at 21 57 34](https://github.com/user-attachments/assets/09c2c857-b968-456c-b6c6-fb95db56c438)


</details>


## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

