### PR TITLE
Add FXIOS-11401 #24879 [Tab Tray UI Experiments] Move doneButton and newTabButton

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
@@ -75,6 +75,35 @@ final class TabTrayViewControllerTests: XCTestCase {
         XCTAssertEqual(viewController.toolbarItems?.count, 0)
     }
 
+    func testBottomToolbarItemsWithExperiment_ForTabsInCompact() {
+        setupNimbusTabTrayUIExperimentTesting(isEnabled: true)
+        let viewController = createSubject()
+
+        viewController.layout = .compact
+        viewController.viewWillAppear(false)
+
+        XCTAssertEqual(viewController.toolbarItems?.count, 5)
+    }
+
+    func testBottomToolbarItemsWithExperiment_ForPrivateTabsInCompact() {
+        setupNimbusTabTrayUIExperimentTesting(isEnabled: true)
+        let viewController = createSubject(selectedSegment: .privateTabs)
+
+        viewController.layout = .compact
+        viewController.viewWillAppear(false)
+
+        XCTAssertEqual(viewController.toolbarItems?.count, 5)
+    }
+
+    func testBottomToolbarItemsWithExperiment_ForSyncTabsEnabledInCompact() {
+        setupNimbusTabTrayUIExperimentTesting(isEnabled: true)
+        let viewController = createSubject(selectedSegment: .syncedTabs)
+        viewController.layout = .compact
+        viewController.viewWillAppear(false)
+
+        XCTAssertEqual(viewController.toolbarItems?.count, 2)
+    }
+
     // MARK: Regular layout
     func testToolbarItems_ForRegular() {
         let viewController = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
@@ -47,6 +47,7 @@ final class TabTrayViewControllerTests: XCTestCase {
     }
 
     func testBottomToolbarItems_ForTabsInCompact() {
+        setupNimbusTabTrayUIExperimentTesting(isEnabled: false)
         let viewController = createSubject()
 
         viewController.layout = .compact
@@ -56,6 +57,7 @@ final class TabTrayViewControllerTests: XCTestCase {
     }
 
     func testBottomToolbarItems_ForPrivateTabsInCompact() {
+        setupNimbusTabTrayUIExperimentTesting(isEnabled: false)
         let viewController = createSubject(selectedSegment: .privateTabs)
 
         viewController.layout = .compact
@@ -65,6 +67,7 @@ final class TabTrayViewControllerTests: XCTestCase {
     }
 
     func testBottomToolbarItems_ForSyncTabsEnabledInCompact() {
+        setupNimbusTabTrayUIExperimentTesting(isEnabled: false)
         let viewController = createSubject(selectedSegment: .syncedTabs)
         viewController.layout = .compact
         viewController.viewWillAppear(false)
@@ -121,6 +124,14 @@ final class TabTrayViewControllerTests: XCTestCase {
             ThemedNavigationController(rootViewController: privateTabsPanel, windowUUID: windowUUID),
             ThemedNavigationController(rootViewController: syncTabs, windowUUID: windowUUID)
         ]
+    }
+
+    private func setupNimbusTabTrayUIExperimentTesting(isEnabled: Bool) {
+        FxNimbus.shared.features.tabTrayUiExperiments.with { _, _ in
+            return TabTrayUiExperiments(
+                enabled: isEnabled
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11401)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24879)

## :bulb: Description
On compact size: Move the Done button to the bottom right in the tab tray. The new tab button (+) is now in the center.
On regular size: No changes

### 🎥 Screenshots
<details>
<summary>Normal mode</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-24 at 20 13 31](https://github.com/user-attachments/assets/c87396e8-759a-4678-9035-faddfde5f1df)


</details>

<details>
<summary>Sync tabs without sync account</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-24 at 20 13 38](https://github.com/user-attachments/assets/bcf37ed8-531b-4cad-8df4-4201cbd58636)


</details>

<details>
<summary>Sync tabs with sync account</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-24 at 20 14 45](https://github.com/user-attachments/assets/14ab417d-7213-4589-a6b3-2b7b55d1ad7f)


</details>


## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

