### PR TITLE
Add FXIOS-11460 #24929 [Tab Tray UI Experiments] Add fade view

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -31,7 +31,8 @@ class BrowserCoordinator: BaseCoordinator,
                           MainMenuCoordinatorDelegate,
                           ETPCoordinatorSSLStatusDelegate,
                           SearchEngineSelectionCoordinatorDelegate,
-                          BookmarksRefactorFeatureFlagProvider {
+                          BookmarksRefactorFeatureFlagProvider,
+                          FeatureFlaggable {
     private struct UX {
         static let searchEnginePopoverSize = CGSize(width: 250, height: 536)
     }
@@ -980,7 +981,12 @@ class BrowserCoordinator: BaseCoordinator,
         }
         let navigationController = DismissableNavigationViewController()
         let isPad = UIDevice.current.userInterfaceIdiom == .pad
-        let modalPresentationStyle: UIModalPresentationStyle = isPad ? .fullScreen: .formSheet
+        let modalPresentationStyle: UIModalPresentationStyle
+        if featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly) {
+            modalPresentationStyle = .fullScreen
+        } else {
+            modalPresentationStyle = isPad ? .fullScreen: .formSheet
+        }
         navigationController.modalPresentationStyle = modalPresentationStyle
 
         let tabTrayCoordinator = TabTrayCoordinator(

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -37,6 +37,8 @@ class TabTrayViewController: UIViewController,
             static let undoDuration = DispatchTimeInterval.seconds(3)
         }
         static let fixedSpaceWidth: CGFloat = 32
+        static let segmentedControlTopSpacing: CGFloat = 8
+        static let segmentedControlHorizontalSpacing: CGFloat = 16
     }
 
     // MARK: Theme
@@ -270,6 +272,7 @@ class TabTrayViewController: UIViewController,
             navigationItem.leftBarButtonItem = nil
             navigationItem.titleView = nil
             if isTabTrayUIExperimentsEnabled {
+                navigationController?.setNavigationBarHidden(true, animated: false)
                 navigationItem.rightBarButtonItems = nil
             } else {
                 navigationItem.rightBarButtonItems = [doneButton]
@@ -368,24 +371,43 @@ class TabTrayViewController: UIViewController,
     private func setupForiPhone() {
         navigationItem.titleView = nil
         updateTitle()
-        view.addSubview(navigationToolbar)
         view.addSubviews(containerView)
-        navigationToolbar.setItems([UIBarButtonItem(customView: segmentedControl)], animated: false)
+        if isTabTrayUIExperimentsEnabled {
+            containerView.addSubview(segmentedControl)
+            segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                containerView.topAnchor.constraint(equalTo: view.topAnchor),
+                containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                containerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
 
-        NSLayoutConstraint.activate([
-            navigationToolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            navigationToolbar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            navigationToolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            navigationToolbar.bottomAnchor.constraint(equalTo: containerView.topAnchor).priority(.defaultLow),
+                segmentedControl.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
+                                                          constant: UX.segmentedControlHorizontalSpacing),
+                segmentedControl.bottomAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.bottomAnchor),
+                segmentedControl.trailingAnchor.constraint(equalTo: containerView.trailingAnchor,
+                                                           constant: -UX.segmentedControlHorizontalSpacing)
+            ])
+        } else {
+            view.addSubview(navigationToolbar)
+            navigationToolbar.setItems([UIBarButtonItem(customView: segmentedControl)], animated: false)
 
-            containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            containerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
+            NSLayoutConstraint.activate([
+                navigationToolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                navigationToolbar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                navigationToolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                navigationToolbar.bottomAnchor.constraint(equalTo: containerView.topAnchor).priority(.defaultLow),
+
+                containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                containerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            ])
+        }
     }
 
     private func updateTitle() {
-        navigationItem.title = tabTrayState.navigationTitle
+        if !isTabTrayUIExperimentsEnabled {
+            navigationItem.title = tabTrayState.navigationTitle
+        }
     }
 
     private func setupForiPad() {
@@ -519,16 +541,26 @@ class TabTrayViewController: UIViewController,
         addChild(panel)
         panel.beginAppearanceTransition(true, animated: true)
         containerView.addSubview(panel.view)
-        containerView.bringSubviewToFront(navigationToolbar)
+        containerView.bringSubviewToFront(navigationToolbar) // Laurie
         panel.endAppearanceTransition()
         panel.view.translatesAutoresizingMaskIntoConstraints = false
 
-        NSLayoutConstraint.activate([
-            panel.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            panel.view.topAnchor.constraint(equalTo: containerView.topAnchor),
-            panel.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            panel.view.bottomAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.bottomAnchor),
-        ])
+        if isTabTrayUIExperimentsEnabled {
+            NSLayoutConstraint.activate([
+                panel.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+                panel.view.topAnchor.constraint(equalTo: containerView.topAnchor),
+                panel.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+                panel.view.bottomAnchor.constraint(equalTo: segmentedControl.topAnchor,
+                                                   constant: -UX.segmentedControlTopSpacing),
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                panel.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+                panel.view.topAnchor.constraint(equalTo: containerView.topAnchor),
+                panel.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+                panel.view.bottomAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.bottomAnchor),
+            ])
+        }
 
         panel.didMove(toParent: self)
         updateTitle()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -541,7 +541,7 @@ class TabTrayViewController: UIViewController,
         addChild(panel)
         panel.beginAppearanceTransition(true, animated: true)
         containerView.addSubview(panel.view)
-        containerView.bringSubviewToFront(navigationToolbar) // Laurie
+        containerView.bringSubviewToFront(navigationToolbar)
         panel.endAppearanceTransition()
         panel.view.translatesAutoresizingMaskIntoConstraints = false
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -209,14 +209,11 @@ class ActivityStreamTest: BaseTestCase {
         waitForTabsButton()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         waitForExistence(app.cells.staticTexts[defaultTopSite["bookmarkLabel"]!])
-        var numTabsOpen = app.collectionViews.element(boundBy: 1).cells.count
+        let numTabsOpen = app.otherElements["Tabs Tray"].collectionViews.cells.count
         if iPad() {
             navigator.goto(TabTray)
-            numTabsOpen = app.otherElements["Tabs Tray"].collectionViews.cells.count
-            waitForExistence(app.otherElements["Tabs Tray"].collectionViews.cells.firstMatch)
-        } else {
-            waitForExistence(app.collectionViews.element(boundBy: 1).cells.firstMatch)
         }
+        waitForExistence(app.otherElements["Tabs Tray"].collectionViews.cells.firstMatch)
         XCTAssertEqual(numTabsOpen, 1, "New tab not open")
     }
     private func checkNumberOfExpectedTopSites(numberOfExpectedTopSites: Int) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -456,7 +456,7 @@ class BookmarksTests: BaseTestCase {
         }
         navigator.goto(TabTray)
         if !iPad() {
-            mozWaitForElementToExist(app.staticTexts["Private Browsing"])
+            mozWaitForElementToExist(app.segmentedControls.buttons["Private"])
         }
         // Tap to "Remove bookmark"
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleRegularMode)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -873,11 +873,11 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             privateModeSelector = app.navigationBars.segmentedControls.buttons.element(boundBy: 1)
             syncModeSelector = app.navigationBars.segmentedControls.buttons.element(boundBy: 2)
         } else {
-            regularModeSelector = app.toolbars["Toolbar"]
+            regularModeSelector = app
                 .segmentedControls[AccessibilityIdentifiers.TabTray.navBarSegmentedControl].buttons.element(boundBy: 0)
-            privateModeSelector = app.toolbars["Toolbar"]
+            privateModeSelector = app
                 .segmentedControls[AccessibilityIdentifiers.TabTray.navBarSegmentedControl].buttons.element(boundBy: 1)
-            syncModeSelector = app.toolbars["Toolbar"]
+            syncModeSelector = app
                 .segmentedControls[AccessibilityIdentifiers.TabTray.navBarSegmentedControl].buttons.element(boundBy: 2)
         }
         screenState.tap(regularModeSelector, forAction: Action.ToggleRegularMode) { userState in

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -318,7 +318,7 @@ class HistoryTests: BaseTestCase {
         if isTablet {
             mozWaitForElementToExist(app.navigationBars.segmentedControls["navBarTabTray"])
         } else {
-            mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
+            mozWaitForElementToExist(app.segmentedControls["navBarTabTray"])
         }
         mozWaitForElementToExist(app.staticTexts[bookOfMozilla["title"]!])
         // userState.numTabs does not work on iOS 15
@@ -352,14 +352,14 @@ class HistoryTests: BaseTestCase {
         if isTablet {
             mozWaitForElementToExist(app.navigationBars.segmentedControls["navBarTabTray"])
         } else {
-            mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
+            mozWaitForElementToExist(app.segmentedControls["navBarTabTray"])
         }
         XCTAssertFalse(app.staticTexts[bookOfMozilla["title"]!].isHittable)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         if isTablet {
             XCTAssertTrue(app.segmentedControls.buttons["Private"].isSelected)
         } else {
-            mozWaitForElementToExist(app.staticTexts["Private Browsing"])
+            XCTAssertTrue(app.segmentedControls["navBarTabTray"].buttons["privateModeLarge"].isSelected)
         }
         mozWaitForElementToExist(app.staticTexts[bookOfMozilla["title"]!])
         XCTAssertEqual(userState.numTabs, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -132,7 +132,7 @@ class JumpBackInTests: BaseTestCase {
         if isTablet {
             mozWaitForElementToExist(app.navigationBars.segmentedControls["navBarTabTray"])
         } else {
-            mozWaitForElementToExist(app.navigationBars.staticTexts["Open Tabs"])
+            mozWaitForElementToExist(app.segmentedControls["navBarTabTray"])
         }
         app.cells["Example Domain"].buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11460)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24929)

## :bulb: Description
This work adds a fade view in the tab tray. The segment control was moved to the bottom since for now the new one doesn't exist.

### 🎥 Screenshot
<details>
<summary>Tab tray with fade</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-24 at 23 42 27](https://github.com/user-attachments/assets/41caac97-229b-4dd6-be0e-d2a713aace4a)

</details>

### 🎥 Video
<details>
<summary>Tab tray with many tabs</summary>

https://github.com/user-attachments/assets/2ee5fc79-4ec0-43a8-97d3-87a4e21ffe9d

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

