### PR TITLE
Fix MTE-4299 Revert version numbers update for focus_release workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2097,15 +2097,15 @@ workflows:
     - focus-configure-nimbus
     - focus-configure-sentry
     steps:
-    - certificate-and-profile-installer@1.11.4: {}
-    - xcode-archive@5.4.0:
+    - certificate-and-profile-installer@1: {}
+    - xcode-archive@3:
         inputs:
         - project_path: focus-ios/Blockzilla.xcodeproj
         - scheme: Focus
         - team_id: 43AQ936H96
         - export_method: app-store
         title: Build Focus
-    - deploy-to-itunesconnect-application-loader@1.5.0:
+    - deploy-to-itunesconnect-application-loader@1:
         inputs:
         - connection: 'off'
         - app_password: "$APPLE_ACCOUNT_PW"
@@ -2118,13 +2118,13 @@ workflows:
             set -x
             focus-ios/focus-ios-tests/tools/sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif \
               --org mozilla --project focus-ios "$BITRISE_DSYM_DIR_PATH"
-    - xcode-archive@5.4.0:
+    - xcode-archive@3:
         inputs:
         - project_path: focus-ios/Blockzilla.xcodeproj
         - scheme: Klar
         - export_method: app-store
         title: Build Klar
-    - deploy-to-itunesconnect-application-loader@1.5.0:
+    - deploy-to-itunesconnect-application-loader@1:
         inputs:
         - connection: 'off'
         - app_password: "$APPLE_ACCOUNT_PW"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4299)

## :bulb: Description
If we update the version number of the step xcode-archive the focus_release workflow fails. I reverted to the previous version in order to unblock the workflow.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

