### PR TITLE
Bugfix FXIOS-11482 [Autofill] Autofill should ignore password manager fields 

### DIFF
--- a/firefox-ios/Client/Assets/CC_Script/FormAutofillChild.ios.sys.mjs
+++ b/firefox-ios/Client/Assets/CC_Script/FormAutofillChild.ios.sys.mjs
@@ -111,6 +111,10 @@ export class FormAutofillChild {
   onFocusIn(evt) {
     const element = evt.target;
 
+    if(element.shouldIgnoreAutofill) {
+      return;
+    }
+
     this.identifyFieldsWhenFocused(element);
 
     // Only ping swift if current field is either a cc or address field

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LoginsHelper.swift
@@ -136,6 +136,10 @@ class LoginsHelper: TabContentScript, FeatureFlaggable {
               let type = res["type"] as? String
         else { return }
 
+        if type == "clearAccessoryView" {
+            tab?.webView?.accessoryView.reloadViewFor(.standard)
+        }
+
         if self.featureFlags.isFeatureEnabled(.passwordGenerator, checking: .buildOnly) {
             if type == "generatePassword",
                 let tab = self.tab,

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/LoginsHelper.js
@@ -499,6 +499,17 @@ window.__firefox__.includeOnce("LoginsHelper", function() {
     const formHasNewPassword =
       password && Logic.isProbablyANewPasswordField(password);
     const isPasswordField = field === password;
+    const isLoginField = field === username || isPasswordField;
+
+    if(!isLoginField) {
+      return ;
+    }
+
+    // Always clear accessory view when a field is focused to start from a clean state
+    webkit.messageHandlers.loginsManagerMessageHandler.postMessage({
+      type: "clearAccessoryView",
+    });
+    field.shouldIgnoreAutofill = true;
     const isYieldingFocus = LoginManagerContent.activeField === field;
     LoginManagerContent.activeField = field;
     if (formHasNewPassword && isPasswordField && !LoginManagerContent.fromFill) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11482)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24971)

## :bulb: Description
This PR:
- Adds check for formautofill to ignore password manager fields.
- Adds `clearAccessoryView` event to cleanup previous accessroy views from either password manager or autofill
- Fixes https://github.com/mozilla-mobile/firefox-ios/issues/23949 and https://github.com/mozilla-mobile/firefox-ios/issues/23776

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

