### PR TITLE
Add FXIOS-11336 widget backgrounds to respond to Light and Dark system modes (iOS 18 home screen)

### DIFF
--- a/firefox-ios/WidgetKit/Assets.xcassets/backgroundColor.colorset/Contents.json
+++ b/firefox-ios/WidgetKit/Assets.xcassets/backgroundColor.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.133",
-          "green" : "0.106",
-          "red" : "0.110"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -72,6 +72,7 @@ struct ImageButtonWithLabel: View {
                                 endPoint: .topTrailing
                             )
                         )
+                        .widgetAccentableCompat()
                 }
 
                 VStack(alignment: .center, spacing: 50.0) {

--- a/firefox-ios/WidgetKit/UIView+extension.swift
+++ b/firefox-ios/WidgetKit/UIView+extension.swift
@@ -15,4 +15,13 @@ extension View {
             return background(backgroundView)
         }
     }
+
+    @ViewBuilder
+    func widgetAccentableCompat() -> some View {
+        if #available(iOSApplicationExtension 16.0, *) {
+            self.widgetAccentable()
+        } else {
+            self
+        }
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11336)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24671)

## :bulb: Description
- Update backgroundColor for LightMode widget
- Add support for Customize > Tinted option for widget

### 🎥 Screenshot
<details>
<summary>Widget background color</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-24 at 14 56 39](https://github.com/user-attachments/assets/49d37467-fb21-4610-8092-070071737bce)


</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

