### PR TITLE
Add FXIOS-11463 #24932 [Tab Tray UI Experiments] Empty state

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1056,6 +1056,8 @@
 		8AC1065F28D0CD700013263A /* OpenQLPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */; };
 		8AC225662B6D403200CDA7FD /* HomepageTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC225642B6D3FA400CDA7FD /* HomepageTelemetryTests.swift */; };
 		8AC5D55F28BFE6C8001F6F7F /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */; };
+		8AC6F2242D6E243F00D10A9F /* ExperimentEmptyPrivateTabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC6F2232D6E243F00D10A9F /* ExperimentEmptyPrivateTabsView.swift */; };
+		8AC6F2262D6E263500D10A9F /* ExperimentRemoteTabsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC6F2252D6E263500D10A9F /* ExperimentRemoteTabsEmptyView.swift */; };
 		8AC8841D2D525F7B0033ABF5 /* CrashTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC8841C2D525EFF0033ABF5 /* CrashTracker.swift */; };
 		8AC8841F2D5261170033ABF5 /* MockCrashTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC8841E2D5261170033ABF5 /* MockCrashTracker.swift */; };
 		8AC884212D5262070033ABF5 /* CrashTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC884202D5261FC0033ABF5 /* CrashTrackerTests.swift */; };
@@ -8018,6 +8020,8 @@
 		8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenQLPreviewHelper.swift; sourceTree = "<group>"; };
 		8AC225642B6D3FA400CDA7FD /* HomepageTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageTelemetryTests.swift; sourceTree = "<group>"; };
 		8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
+		8AC6F2232D6E243F00D10A9F /* ExperimentEmptyPrivateTabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentEmptyPrivateTabsView.swift; sourceTree = "<group>"; };
+		8AC6F2252D6E263500D10A9F /* ExperimentRemoteTabsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentRemoteTabsEmptyView.swift; sourceTree = "<group>"; };
 		8AC8841C2D525EFF0033ABF5 /* CrashTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashTracker.swift; sourceTree = "<group>"; };
 		8AC8841E2D5261170033ABF5 /* MockCrashTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCrashTracker.swift; sourceTree = "<group>"; };
 		8AC884202D5261FC0033ABF5 /* CrashTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashTrackerTests.swift; sourceTree = "<group>"; };
@@ -10595,6 +10599,8 @@
 		21C5B3582AF2A7130093F366 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				8AC6F2252D6E263500D10A9F /* ExperimentRemoteTabsEmptyView.swift */,
+				8AC6F2232D6E243F00D10A9F /* ExperimentEmptyPrivateTabsView.swift */,
 				8A2068362D6D52830063A77B /* ExperimentTabCell.swift */,
 				5A679E4A2B239FAE004F2B0D /* TabPeekViewController.swift */,
 				43162A2E2492DB7800F91658 /* EmptyPrivateTabsView.swift */,
@@ -16802,6 +16808,7 @@
 				C45F44691D087DB600CB7EF0 /* TopTabsViewController.swift in Sources */,
 				8A0727462B4890B50071BB9F /* WebviewTelemetry.swift in Sources */,
 				8ADC2A212A3399DC00543DAA /* YourRightsSetting.swift in Sources */,
+				8AC6F2242D6E243F00D10A9F /* ExperimentEmptyPrivateTabsView.swift in Sources */,
 				DF529E9F2AA86FF4003C5373 /* FakespotReviewQualityCardView.swift in Sources */,
 				1D0BA05C24F46A0400D731B5 /* TopSitesProvider.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
@@ -17461,6 +17468,7 @@
 				C8B0F5F5283B7CCE007AE65D /* PocketSponsoredStory.swift in Sources */,
 				8AF6D4E12A856B4500B0474B /* ContileNetworking.swift in Sources */,
 				8AB8571F27D931B40075C173 /* EmptyTopSiteCell.swift in Sources */,
+				8AC6F2262D6E263500D10A9F /* ExperimentRemoteTabsEmptyView.swift in Sources */,
 				CAC458F1249429C20042561A /* PasswordManagerSelectionHelper.swift in Sources */,
 				C8656D75270F834600E199EA /* FlaggableFeatureOptions.swift in Sources */,
 				1BE7A4922C636AEA00460798 /* URLSessionConfiguration+defaultMPTCP.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
@@ -101,9 +101,9 @@ class ExperimentEmptyPrivateTabsView: UIView, EmptyPrivateTabView {
             scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
             scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
 
-            centeredView.topAnchor.constraint(greaterThanOrEqualTo: containerView.topAnchor, constant: UX.verticalPadding),
+            centeredView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: UX.verticalPadding),
             centeredView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            centeredView.bottomAnchor.constraint(lessThanOrEqualTo: containerView.bottomAnchor),
+            centeredView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
             centeredView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
 
             iconImageView.topAnchor.constraint(equalTo: centeredView.topAnchor,
@@ -119,13 +119,16 @@ class ExperimentEmptyPrivateTabsView: UIView, EmptyPrivateTabView {
 
             descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor,
                                                   constant: UX.paddingInBetweenItems),
-            descriptionLabel.leadingAnchor.constraint(equalTo: centeredView.leadingAnchor),
-            descriptionLabel.trailingAnchor.constraint(equalTo: centeredView.trailingAnchor),
+            descriptionLabel.leadingAnchor.constraint(equalTo: centeredView.leadingAnchor,
+                                                      constant: UX.horizontalPadding),
+            descriptionLabel.trailingAnchor.constraint(equalTo: centeredView.trailingAnchor,
+                                                       constant: -UX.horizontalPadding),
 
             learnMoreButton.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor,
                                                  constant: UX.paddingInBetweenItems),
-            learnMoreButton.leadingAnchor.constraint(equalTo: centeredView.leadingAnchor),
-            learnMoreButton.trailingAnchor.constraint(equalTo: centeredView.trailingAnchor),
+            learnMoreButton.leadingAnchor.constraint(greaterThanOrEqualTo: centeredView.leadingAnchor),
+            learnMoreButton.trailingAnchor.constraint(lessThanOrEqualTo: centeredView.trailingAnchor),
+            learnMoreButton.centerXAnchor.constraint(equalTo: centeredView.centerXAnchor),
             learnMoreButton.bottomAnchor.constraint(equalTo: centeredView.bottomAnchor,
                                                     constant: -UX.paddingInBetweenItems),
         ])

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
@@ -108,13 +108,16 @@ class ExperimentRemoteTabsEmptyView: UIView, RemoteTabsEmptyViewProtocol {
 
             descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor,
                                                   constant: UX.paddingInBetweenItems),
-            descriptionLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            descriptionLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            descriptionLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor,
+                                                      constant: UX.horizontalPadding),
+            descriptionLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor,
+                                                       constant: -UX.horizontalPadding),
 
             signInButton.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor,
                                               constant: UX.paddingInBetweenItems),
-            signInButton.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            signInButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            signInButton.leadingAnchor.constraint(greaterThanOrEqualTo: containerView.leadingAnchor),
+            signInButton.trailingAnchor.constraint(lessThanOrEqualTo: containerView.trailingAnchor),
+            signInButton.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
             signInButton.bottomAnchor.constraint(equalTo: containerView.bottomAnchor,
                                                  constant: -UX.paddingInBetweenItems),
         ])

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
@@ -1,0 +1,143 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import UIKit
+import Shared
+
+protocol RemoteTabsEmptyViewProtocol: UIView, ThemeApplicable {
+    func configure(config: RemoteTabsPanelEmptyStateReason,
+                   delegate: RemoteTabsEmptyViewDelegate?)
+}
+
+class ExperimentRemoteTabsEmptyView: UIView, RemoteTabsEmptyViewProtocol {
+    struct UX {
+        static let paddingInBetweenItems: CGFloat = 15
+        static let verticalPadding: CGFloat = 20
+        static let horizontalPadding: CGFloat = 24
+        static let imageSize = CGSize(width: 72, height: 72)
+    }
+
+    weak var delegate: RemoteTabsEmptyViewDelegate?
+
+    // MARK: - UI
+
+    private lazy var containerView: UIView = .build { _ in }
+
+    private let iconImageView: UIImageView = .build { imageView in
+        imageView.contentMode = .scaleAspectFit
+    }
+
+    private let titleLabel: UILabel = .build { label in
+        label.adjustsFontForContentSizeCategory = true
+        label.font = FXFontStyles.Regular.headline.scaledFont()
+        label.textAlignment = .center
+    }
+
+    private let descriptionLabel: UILabel = .build { label in
+        label.adjustsFontForContentSizeCategory = true
+        label.font = FXFontStyles.Regular.footnote.scaledFont()
+        label.numberOfLines = 0
+        label.textAlignment = .center
+    }
+
+    private let signInButton: SecondaryRoundedButton = .build { button in
+        let viewModel = SecondaryRoundedButtonViewModel(
+            title: .Settings.Sync.ButtonTitle,
+            a11yIdentifier: AccessibilityIdentifiers.TabTray.syncDataButton
+        )
+        button.configure(viewModel: viewModel)
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(config: RemoteTabsPanelEmptyStateReason,
+                   delegate: RemoteTabsEmptyViewDelegate?) {
+        self.delegate = delegate
+
+        iconImageView.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.cloud)
+        titleLabel.text =  .EmptySyncedTabsPanelStateTitle
+        descriptionLabel.text = config.localizedString()
+
+        if config == .notLoggedIn || config == .failedToSync {
+            signInButton.addTarget(self, action: #selector(presentSignIn), for: .touchUpInside)
+        } else if config == .syncDisabledByUser {
+            signInButton.addTarget(self, action: #selector(openAccountSettings), for: .touchUpInside)
+        }
+
+        signInButton.isHidden = shouldHideButton(config)
+    }
+
+    private func shouldHideButton(_ state: RemoteTabsPanelEmptyStateReason) -> Bool {
+        return state == .noClients && state == .noTabs
+    }
+
+    private func setupLayout() {
+        containerView.addSubviews(iconImageView, titleLabel, descriptionLabel, signInButton)
+        addSubview(containerView)
+
+        NSLayoutConstraint.activate([
+            containerView.leadingAnchor.constraint(equalTo: leadingAnchor,
+                                                   constant: UX.horizontalPadding),
+            containerView.topAnchor.constraint(equalTo: topAnchor,
+                                               constant: UX.verticalPadding),
+            containerView.trailingAnchor.constraint(equalTo: trailingAnchor,
+                                                    constant: -UX.horizontalPadding),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor,
+                                                  constant: -UX.verticalPadding),
+
+            iconImageView.topAnchor.constraint(equalTo: containerView.topAnchor,
+                                               constant: UX.paddingInBetweenItems),
+            iconImageView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: UX.imageSize.width),
+            iconImageView.heightAnchor.constraint(equalToConstant: UX.imageSize.height),
+
+            titleLabel.topAnchor.constraint(equalTo: iconImageView.bottomAnchor,
+                                            constant: UX.paddingInBetweenItems),
+            titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+
+            descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor,
+                                                  constant: UX.paddingInBetweenItems),
+            descriptionLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            descriptionLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+
+            signInButton.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor,
+                                              constant: UX.paddingInBetweenItems),
+            signInButton.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            signInButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            signInButton.bottomAnchor.constraint(equalTo: containerView.bottomAnchor,
+                                                 constant: -UX.paddingInBetweenItems),
+        ])
+    }
+
+    func applyTheme(theme: Theme) {
+        iconImageView.tintColor = theme.colors.iconDisabled
+        titleLabel.textColor = theme.colors.textPrimary
+        descriptionLabel.textColor = theme.colors.textPrimary
+        signInButton.applyTheme(theme: theme)
+        backgroundColor = theme.colors.layer3
+    }
+
+    @objc
+    private func presentSignIn() {
+        if let delegate = self.delegate {
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .syncSignIn)
+            delegate.remotePanelDidRequestToSignIn()
+        }
+    }
+
+    @objc
+    private func openAccountSettings() {
+        delegate?.presentFxAccountSettings()
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
@@ -13,7 +13,7 @@ protocol RemoteTabsEmptyViewDelegate: AnyObject {
     func remotePanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool)
 }
 
-class RemoteTabsEmptyView: UIView, ThemeApplicable {
+class RemoteTabsEmptyView: UIView, RemoteTabsEmptyViewProtocol {
     struct UX {
         static let verticalPadding: CGFloat = 40
         static let horizontalPadding: CGFloat = 24

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsTableViewController.swift
@@ -37,7 +37,17 @@ class RemoteTabsTableViewController: UITableViewController,
     var currentWindowUUID: UUID? { windowUUID }
 
     private var isShowingEmptyView: Bool { state.showingEmptyState != nil }
-    private let emptyView: RemoteTabsEmptyView = .build()
+    private lazy var emptyView: RemoteTabsEmptyViewProtocol = {
+        if featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly) {
+            let view = ExperimentRemoteTabsEmptyView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            return view
+        } else {
+            let view = RemoteTabsEmptyView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            return view
+        }
+    }()
 
     private var closeTabRemoteDeviceId: String?
     private var closeTab: RemoteTab?
@@ -110,12 +120,12 @@ class RemoteTabsTableViewController: UITableViewController,
 
         tableView.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.syncedTabs
 
-        tableView.addSubview(emptyView)
+        view.addSubview(emptyView)
         NSLayoutConstraint.activate([
-            emptyView.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
-            emptyView.topAnchor.constraint(equalTo: tableView.topAnchor),
-            emptyView.leadingAnchor.constraint(equalTo: tableView.leadingAnchor),
-            emptyView.trailingAnchor.constraint(equalTo: tableView.trailingAnchor),
+            emptyView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            emptyView.topAnchor.constraint(equalTo: view.topAnchor),
+            emptyView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
 
         reloadUI()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -122,7 +122,7 @@ class TabDisplayPanelViewController: UIViewController,
             backgroundPrivacyOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
 
-        if isTabTrayUIExperimentsEnabled, tabsState.isPrivateMode && tabsState.isPrivateTabsEmpty{
+        if isTabTrayUIExperimentsEnabled, !tabsState.isPrivateTabsEmpty {
             gradientLayer.locations = [0.0, 0.1]
             fadeView.layer.addSublayer(gradientLayer)
             view.addSubview(fadeView)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -26,6 +26,14 @@ class TabDisplayPanelViewController: UIViewController,
         return featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly)
     }
 
+    private lazy var layout: TabTrayLayoutType = {
+        return shouldUseiPadSetup() ? .regular : .compact
+    }()
+
+    var isCompactLayout: Bool {
+        return layout == .compact
+    }
+
     // MARK: UI elements
     private lazy var tabDisplayView: TabDisplayView = {
         let view = TabDisplayView(panelType: self.panelType,
@@ -122,7 +130,7 @@ class TabDisplayPanelViewController: UIViewController,
             backgroundPrivacyOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
 
-        if isTabTrayUIExperimentsEnabled, !tabsState.isPrivateTabsEmpty {
+        if isTabTrayUIExperimentsEnabled, !tabsState.isPrivateTabsEmpty, isCompactLayout {
             gradientLayer.locations = [0.0, 0.1]
             fadeView.layer.addSublayer(gradientLayer)
             view.addSubview(fadeView)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -35,7 +35,17 @@ class TabDisplayPanelViewController: UIViewController,
         return view
     }()
     private var backgroundPrivacyOverlay: UIView = .build()
-    private lazy var emptyPrivateTabsView: EmptyPrivateTabsView = .build()
+    private lazy var emptyPrivateTabsView: EmptyPrivateTabView = {
+        if featureFlags.isFeatureEnabled(.tabTrayUIExperiments, checking: .buildOnly) {
+            let view = ExperimentEmptyPrivateTabsView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            return view
+        } else {
+            let view = EmptyPrivateTabsView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            return view
+        }
+    }()
 
     private lazy var fadeView: UIView = .build { view in
         view.isUserInteractionEnabled = false
@@ -112,7 +122,7 @@ class TabDisplayPanelViewController: UIViewController,
             backgroundPrivacyOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
 
-        if isTabTrayUIExperimentsEnabled {
+        if isTabTrayUIExperimentsEnabled, tabsState.isPrivateMode && tabsState.isPrivateTabsEmpty{
             gradientLayer.locations = [0.0, 0.1]
             fadeView.layer.addSublayer(gradientLayer)
             view.addSubview(fadeView)
@@ -158,7 +168,7 @@ class TabDisplayPanelViewController: UIViewController,
     func applyTheme() {
         backgroundPrivacyOverlay.backgroundColor = currentTheme().colors.layerScrim
         tabDisplayView.applyTheme(theme: currentTheme())
-        emptyPrivateTabsView.applyTheme(currentTheme())
+        emptyPrivateTabsView.applyTheme(theme: currentTheme())
 
         if isTabTrayUIExperimentsEnabled {
             gradientLayer.colors = [

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -541,7 +541,7 @@ class TabTrayViewController: UIViewController,
         addChild(panel)
         panel.beginAppearanceTransition(true, animated: true)
         containerView.addSubview(panel.view)
-        containerView.bringSubviewToFront(navigationToolbar)
+        containerView.bringSubviewToFront(navigationToolbar) // Laurie
         panel.endAppearanceTransition()
         panel.view.translatesAutoresizingMaskIntoConstraints = false
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -541,7 +541,7 @@ class TabTrayViewController: UIViewController,
         addChild(panel)
         panel.beginAppearanceTransition(true, animated: true)
         containerView.addSubview(panel.view)
-        containerView.bringSubviewToFront(navigationToolbar) // Laurie
+        containerView.bringSubviewToFront(navigationToolbar)
         panel.endAppearanceTransition()
         panel.view.translatesAutoresizingMaskIntoConstraints = false
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -505,13 +505,24 @@ class TabTrayViewController: UIViewController,
             toast.showToast(viewController: self,
                             delay: UX.Toast.undoDelay,
                             duration: UX.Toast.undoDuration) { toast in
-                [
-                    toast.leadingAnchor.constraint(equalTo: self.view.leadingAnchor,
-                                                   constant: Toast.UX.toastSidePadding),
-                    toast.trailingAnchor.constraint(equalTo: self.view.trailingAnchor,
-                                                    constant: -Toast.UX.toastSidePadding),
-                    toast.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
-                ]
+                if self.isTabTrayUIExperimentsEnabled {
+                    [
+                        toast.leadingAnchor.constraint(equalTo: self.view.leadingAnchor,
+                                                       constant: Toast.UX.toastSidePadding),
+                        toast.trailingAnchor.constraint(equalTo: self.view.trailingAnchor,
+                                                        constant: -Toast.UX.toastSidePadding),
+                        toast.bottomAnchor.constraint(equalTo: self.segmentedControl.topAnchor,
+                                                      constant: -UX.segmentedControlTopSpacing)
+                    ]
+                } else {
+                    [
+                        toast.leadingAnchor.constraint(equalTo: self.view.leadingAnchor,
+                                                       constant: Toast.UX.toastSidePadding),
+                        toast.trailingAnchor.constraint(equalTo: self.view.trailingAnchor,
+                                                        constant: -Toast.UX.toastSidePadding),
+                        toast.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
+                    ]
+                }
             }
             shownToast = toast
         } else {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -405,7 +405,7 @@ class TabTrayViewController: UIViewController,
     }
 
     private func updateTitle() {
-        if !isTabTrayUIExperimentsEnabled {
+        if !isTabTrayUIExperimentsEnabled, !self.isRegularLayout {
             navigationItem.title = tabTrayState.navigationTitle
         }
     }
@@ -505,7 +505,7 @@ class TabTrayViewController: UIViewController,
             toast.showToast(viewController: self,
                             delay: UX.Toast.undoDelay,
                             duration: UX.Toast.undoDuration) { toast in
-                if self.isTabTrayUIExperimentsEnabled {
+                if self.isTabTrayUIExperimentsEnabled, !self.isRegularLayout {
                     [
                         toast.leadingAnchor.constraint(equalTo: self.view.leadingAnchor,
                                                        constant: Toast.UX.toastSidePadding),
@@ -556,7 +556,7 @@ class TabTrayViewController: UIViewController,
         panel.endAppearanceTransition()
         panel.view.translatesAutoresizingMaskIntoConstraints = false
 
-        if isTabTrayUIExperimentsEnabled {
+        if isTabTrayUIExperimentsEnabled, !isRegularLayout {
             NSLayoutConstraint.activate([
                 panel.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
                 panel.view.topAnchor.constraint(equalTo: containerView.topAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11463)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24932)

## :bulb: Description
- This work changes the empty state view when the feature flag is turned ON. The empty state view are swapped entirely so the feature flag is easier to manage. In other words, we have new classes with `ExperimentEmptyPrivateTabsView` and `ExperimentRemoteTabsEmptyView`
- This PR fixes an issue where the fade view was applied on the wrong app state
- This also fixes toast issues in the tab tray

### 🎥 Video
<details>
<summary>Tab tray current state with this PR and flag ON</summary>

https://github.com/user-attachments/assets/ce2ce3b4-f15c-4b37-9fe2-6e3920a3b563

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

