### PR TITLE
Revert "Bugfix FXIOS-10852 ⁃ [iPad] - Weird behavior of tabs after a specific scenario"

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -369,8 +369,9 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
     /// Close tab and trigger refresh
     /// - Parameter tabUUID: UUID of the tab to be closed/removed
     private func closeTabFromTabPanel(with tabUUID: TabUUID, uuid: WindowUUID, isPrivate: Bool) {
-        Task { @MainActor in
+        Task {
             let shouldDismiss = await self.closeTab(with: tabUUID, uuid: uuid, isPrivate: isPrivate)
+            await self.triggerRefresh(uuid: uuid, isPrivate: isPrivate)
 
             if isPrivate && tabManager(for: uuid).privateTabs.isEmpty {
                 let didLoadAction = TabPanelViewAction(panelType: isPrivate ? .privateTabs : .tabs,
@@ -391,10 +392,6 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
                                                        windowUUID: uuid,
                                                        actionType: GeneralBrowserActionType.showToast)
                 store.dispatch(toastAction)
-                let tabManager = tabManager(for: uuid)
-                if let selectedTab = tabManager.selectedTab, selectedTab.isPrivate {
-                    tabManager.addTab(nil, isPrivate: false)
-                }
             } else {
                 let toastAction = TabPanelMiddlewareAction(toastType: .closedSingleTab,
                                                            windowUUID: uuid,
@@ -490,9 +487,6 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
                                                            windowUUID: uuid,
                                                            actionType: GeneralBrowserActionType.showToast)
                     store.dispatch(toastAction)
-                    if let selectedTab = tabManager.selectedTab, selectedTab.isPrivate {
-                        tabManager.addTab(nil, isPrivate: false)
-                    }
                 }
             }
         }


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#24506 This was causing the UI to not update the tab close even though the tab was being removed.

Uploading Simulator Screen Recording - iPhone 16 Pro - 2025-02-25 at 16.09.57.mp4…

