### PR TITLE
Fix [Wallpapers] Clean up wallpaper redux

### DIFF
--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -147,7 +147,8 @@ class SettingsCoordinator: BaseCoordinator,
                 let viewModel = WallpaperSettingsViewModel(
                     wallpaperManager: wallpaperManager,
                     tabManager: tabManager,
-                    theme: themeManager.getCurrentTheme(for: windowUUID)
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    windowUUID: windowUUID
                 )
                 let wallpaperVC = WallpaperSettingsViewController(viewModel: viewModel, windowUUID: windowUUID)
                 wallpaperVC.settingsDelegate = self

--- a/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpaper/Redux/WallpaperState.swift
@@ -43,6 +43,7 @@ struct WallpaperState: ScreenState, Equatable {
 }
 
 struct WallpaperConfiguration: Equatable {
+    var id: String?
     var landscapeImage: UIImage?
     var portraitImage: UIImage?
     var textColor: UIColor?
@@ -51,6 +52,7 @@ struct WallpaperConfiguration: Equatable {
     var hasImage: Bool
 
     init(
+        id: String? = nil,
         landscapeImage: UIImage? = nil,
         portraitImage: UIImage? = nil,
         textColor: UIColor? = nil,
@@ -58,6 +60,7 @@ struct WallpaperConfiguration: Equatable {
         logoTextColor: UIColor? = nil,
         hasImage: Bool = false
     ) {
+        self.id = id
         self.landscapeImage = landscapeImage
         self.portraitImage = portraitImage
         self.textColor = textColor
@@ -68,6 +71,7 @@ struct WallpaperConfiguration: Equatable {
 
     init(wallpaper: Wallpaper) {
         self.init(
+            id: wallpaper.id,
             landscapeImage: wallpaper.landscape,
             portraitImage: wallpaper.portrait,
             textColor: wallpaper.textColor,

--- a/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Wallpapers/v1/Interface/WallpaperManager.swift
@@ -26,7 +26,7 @@ protocol WallpaperManagerInterface {
 }
 
 /// The primary interface for the wallpaper feature.
-class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
+class WallpaperManager: WallpaperManagerInterface {
     enum ThumbnailFilter {
         case none
         case thumbnailsAvailable
@@ -110,15 +110,6 @@ class WallpaperManager: WallpaperManagerInterface, FeatureFlaggable {
         do {
             let storageUtility = WallpaperStorageUtility()
             try storageUtility.store(wallpaper)
-            if featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly) {
-                let wallpaperConfig = WallpaperConfiguration(wallpaper: wallpaper)
-                let action = WallpaperAction(
-                    wallpaperConfiguration: wallpaperConfig,
-                    windowUUID: .unavailable,
-                    actionType: WallpaperMiddlewareActionType.wallpaperDidChange
-                )
-                store.dispatch(action)
-            }
             NotificationCenter.default.post(name: .WallpaperDidChange, object: nil)
             completion(.success(()))
         } catch {

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -350,9 +350,12 @@ extension HomePageSettingViewController {
             guard wallpaperManager.canSettingsBeShown else { return }
 
             let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
-            let viewModel = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
-                                                       tabManager: tabManager,
-                                                       theme: theme)
+            let viewModel = WallpaperSettingsViewModel(
+                wallpaperManager: wallpaperManager,
+                tabManager: tabManager,
+                theme: theme,
+                windowUUID: settings.windowUUID
+            )
             let wallpaperVC = WallpaperSettingsViewController(viewModel: viewModel, windowUUID: tabManager.windowUUID)
             wallpaperVC.settingsDelegate = settingsDelegate
             navigationController?.pushViewController(wallpaperVC, animated: true)

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
@@ -36,9 +36,6 @@ class WallpaperSettingsViewModel: FeatureFlaggable {
         }
     }
 
-    private var theme: Theme
-    private var wallpaperManager: WallpaperManagerInterface
-    private var wallpaperCollections = [WallpaperCollection]()
     var tabManager: TabManager
     var sectionLayout: WallpaperSettingsLayout = .compact // We use the compact layout as default
     var selectedIndexPath: IndexPath?
@@ -47,12 +44,21 @@ class WallpaperSettingsViewModel: FeatureFlaggable {
         return wallpaperCollections.count
     }
 
-    init(wallpaperManager: WallpaperManagerInterface = WallpaperManager(),
-         tabManager: TabManager,
-         theme: Theme) {
+    private var theme: Theme
+    private var wallpaperManager: WallpaperManagerInterface
+    private var wallpaperCollections = [WallpaperCollection]()
+    private let windowUUID: WindowUUID
+
+    init(
+        wallpaperManager: WallpaperManagerInterface = WallpaperManager(),
+        tabManager: TabManager,
+        theme: Theme,
+        windowUUID: WindowUUID
+    ) {
         self.wallpaperManager = wallpaperManager
         self.tabManager = tabManager
         self.theme = theme
+        self.windowUUID = windowUUID
         setupWallpapers()
     }
 
@@ -220,7 +226,7 @@ private extension WallpaperSettingsViewModel {
                 let wallpaperConfig = WallpaperConfiguration(wallpaper: wallpaper)
                 let action = WallpaperAction(
                     wallpaperConfiguration: wallpaperConfig,
-                    windowUUID: .unavailable,
+                    windowUUID: windowUUID,
                     actionType: WallpaperActionType.wallpaperSelected
                 )
                 store.dispatch(action)

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/WallpaperSettings/v1/WallpaperSettingsViewModel.swift
@@ -224,6 +224,9 @@ private extension WallpaperSettingsViewModel {
             // TODO: FXIOS-11486 Move interface for setting wallpaper into Wallpaper middleware
             if featureFlags.isFeatureEnabled(.homepageRebuild, checking: .buildOnly) {
                 let wallpaperConfig = WallpaperConfiguration(wallpaper: wallpaper)
+                // We are passing the wallpaperConfiguration here even though right now it is not being used
+                // by the middleware that is responding to this action. It will be as soon as we move the wallpaper
+                // manager logic to the middlware.
                 let action = WallpaperAction(
                     wallpaperConfiguration: wallpaperConfig,
                     windowUUID: windowUUID,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperSettingsViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperSettingsViewModelTests.swift
@@ -107,9 +107,12 @@ class WallpaperSettingsViewModelTests: XCTestCase {
 //    }
 
     func createSubject() -> WallpaperSettingsViewModel {
-        let subject = WallpaperSettingsViewModel(wallpaperManager: wallpaperManager,
-                                                 tabManager: MockTabManager(),
-                                                 theme: LightTheme())
+        let subject = WallpaperSettingsViewModel(
+            wallpaperManager: wallpaperManager,
+            tabManager: MockTabManager(),
+            theme: LightTheme(),
+            windowUUID: .XCTestDefaultUUID
+        )
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Clean up the redux logic around wallpaper setting from settings. This still needs some more work to really abstract the wallpaper manager from the wallpaper settings but will require more work to redux-ify wallpaper settings. That additional work is tracked [here](https://mozilla-hub.atlassian.net/browse/FXIOS-11486)

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

