### PR TITLE
Refactor FXIOS-11405 [Toolbar] Show number of open tabs in large content viewer

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -6845,7 +6845,7 @@ extension String {
             comment: "Large content title for the tabs button in the toolbar, specifying the number of tabs open. The placeholder is getting replaced with the number of open tabs.")
 
         public static let TabsButtonOverflowLargeContentTitle = MZLocalizedString(
-            key: "Toolbar.Tabs.Button.A11y.LargeContentTitle.v137",
+            key: "Toolbar.Tabs.Button.A11y.OverflowLargeContentTitle.v137",
             tableName: "Toolbar",
             value: "Tabs open: 99+",
             comment: "Large content title for the tabs button in the toolbar, specifying that more than 99 tabs are open.")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11405)
~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~

## :bulb: Description
Fixes key for overflow large content title.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

