### PR TITLE
Fixes MTE-4319 - on several failures

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -109,7 +109,6 @@
         "OnboardingTests\/testOnboardingSignIn()",
         "PerformanceTests",
         "PhotonActionSheetTests\/testPinToShortcuts()",
-        "PhotonActionSheetTests\/testShareOptionIsShown()",
         "PhotonActionSheetTests\/testSharePageWithShareSheetOptions()",
         "PrivateBrowsingTest\/testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad()",
         "PrivateBrowsingTest\/testLongPressLinkOptionsPrivateMode()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
@@ -102,7 +102,6 @@
         "OnboardingTests\/testWhatsNewPage()",
         "OpeningScreenTests",
         "PerformanceTests",
-        "PhotonActionSheetTests\/testSendToDeviceFromPageOptionsMenu()",
         "PhotonActionSheetTests\/testShareSheetOpenAndCancel()",
         "PhotonActionSheetTests\/testShareSheetSendToDevice()",
         "PocketTest",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -544,10 +544,11 @@ class CreditCardsTests: BaseTestCase {
     }
 
     private func selectCreditCardOnFormWebsite() {
-        mozWaitForElementToExist(app.scrollViews.otherElements.tables.buttons["Test"])
+        let nameOnCard = app.scrollViews.otherElements.tables.buttons.element(boundBy: 2)
+        mozWaitForElementToExist(nameOnCard)
         var attempts = 4
-        while app.scrollViews.otherElements.tables.buttons["Test"].isHittable && attempts > 0 {
-            app.scrollViews.otherElements.tables.cells.firstMatch.waitAndTap()
+        while nameOnCard.isHittable && attempts > 0 {
+            nameOnCard.waitAndTap()
             attempts -= 1
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -33,9 +33,6 @@ class PhotonActionSheetTests: BaseTestCase {
         cell.press(forDuration: 2)
         app.tables.cells.otherElements[StandardImageIdentifiers.Large.pinSlash].waitAndTap()
         // Check that it has been unpinned
-        /* FIXME: Adding a workaround until https://github.com/mozilla-mobile/firefox-ios/issues/22323 is fixed
-         * We will wait for the pinned icon on the example.com tile to disappear (max 8 seconds polling)
-         */
         if #available(iOS 17, *) {
             mozWaitForElementToNotExist(app.links["Example Domain"].images[StandardImageIdentifiers.Small.pinBadgeFill])
         } else {
@@ -43,36 +40,6 @@ class PhotonActionSheetTests: BaseTestCase {
         }
 
         mozWaitForElementToNotExist(cell)
-    }
-
-    // https://mozilla.testrail.io/index.php?/cases/view/2322067
-    // Smoketest
-    func testShareOptionIsShown() {
-        // Temporarily disabled until url bar redesign work FXIOS-8172
-//        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
-//        waitUntilPageLoad()
-//        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
-//        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
-//
-//        // Wait to see the Share options sheet
-//        mozWaitForElementToExist(app.cells["Copy"], timeout: 15)
-    }
-
-    // https://mozilla.testrail.io/index.php?/cases/view/2322667
-    func testSendToDeviceFromPageOptionsMenu() {
-        // User not logged in
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
-        waitUntilPageLoad()
-        // Temporarily disabled until url bar redesign work FXIOS-8172
-        /*
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
-        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
-        mozWaitForElementToExist(app.cells["Send Link to Device"], timeout: 10)
-        app.cells["Send Link to Device"].tap()
-        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.ShareTo.HelpView.doneButton])
-        XCTAssertTrue(app.staticTexts["You are not signed in to your account."].exists)
-        XCTAssertTrue(app.staticTexts["Please open Firefox, go to Settings and sign in to continue."].exists)
-        */
     }
 
     private func openNewShareSheet() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabCounterTests.swift
@@ -68,7 +68,7 @@ class TabCounterTests: BaseTestCase {
             XCTAssertTrue(tabsOpenTabTray.hasSuffix("2"))
 
             app.otherElements["Tabs Tray"].cells
-                .element(boundBy: 0).buttons[StandardImageIdentifiers.Large.cross].waitAndTap()
+                .element(boundBy: 0).buttons[StandardImageIdentifiers.Large.crossCircleFill].waitAndTap()
         }
 
         app.otherElements["Tabs Tray"].cells.element(boundBy: 0).waitAndTap()
@@ -79,7 +79,6 @@ class TabCounterTests: BaseTestCase {
         XCTAssertEqual("1", tabsOpen as? String)
 
         navigator.goto(TabTray)
-        mozWaitForElementToExist(app.navigationBars["Open Tabs"])
         tabsOpen = app.segmentedControls.buttons.element(boundBy: 0).label
         XCTAssertTrue(app.segmentedControls.buttons.element(boundBy: 0).isSelected)
         if !isTablet {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -393,8 +393,8 @@ class TopTabsTest: BaseTestCase {
         navigator.goto(TabTray)
         let tabsTrayCell = app.otherElements["Tabs Tray"].cells
         if !iPad() {
-            let numTab = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value as? String
-            XCTAssertEqual(Int(numTab!), tabsTrayCell.count)
+            let numTab = app.buttons.element(boundBy: 3).label
+            XCTAssertEqual(Int(numTab), tabsTrayCell.count)
         } else {
             XCTAssertEqual(tabsTrayCell.count, 2)
             XCTAssertTrue(app.buttons.elementContainingText("2").exists)
@@ -407,9 +407,8 @@ class TopTabsTest: BaseTestCase {
         app.buttons["Undo"].waitAndTap()
         // Only the latest tab closed is restored
         if !iPad() {
-            let numTab = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton].value as? String
             let tabsTrayCell = app.otherElements["Tabs Tray"].cells
-            XCTAssertEqual(Int(numTab!), tabsTrayCell.count)
+            XCTAssertEqual(1, tabsTrayCell.count)
         }
         mozWaitForElementToExist(app.otherElements.cells.staticTexts[urlLabelExample])
     }
@@ -429,7 +428,7 @@ class TopTabsTest: BaseTestCase {
         navigator.goto(TabTray)
         // Close multiple tabs by pressing X button
         for _ in 0...3 {
-            app.collectionViews.cells["Homepage. Currently selected tab."].buttons["crossLarge"].waitAndTap()
+            app.collectionViews.cells["Homepage. Currently selected tab."].buttons["crossCircleFillLarge"].waitAndTap()
             // A toast notification is displayed with the message "Tab Closed" and the Undo option
             waitForElementsToExist(
                 [
@@ -438,7 +437,7 @@ class TopTabsTest: BaseTestCase {
                 ]
             )
         }
-        app.collectionViews.buttons["crossLarge"].waitAndTap()
+        app.collectionViews.buttons["crossCircleFillLarge"].waitAndTap()
         waitForElementsToExist(
             [
                 app.buttons["Undo"],


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4319

## :bulb: Description
Added an improvement on the way we are selecting saved cards (hoping to fix 2 flaky tests on iPad with this)
Removed tests that are related to share options. These scenarios are also covered in ShareToolbarTests
There was a merge recently related to tab tray, added fixes for 2 tests that started to fail because of it.
