### PR TITLE
Bugfix FXIOS-11488 - [Tab Tray UI Experiments] - iPad - App crashes when tapping on tabs button

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -545,7 +545,7 @@ class TabTrayViewController: UIViewController,
         panel.endAppearanceTransition()
         panel.view.translatesAutoresizingMaskIntoConstraints = false
 
-        if isTabTrayUIExperimentsEnabled {
+        if isTabTrayUIExperimentsEnabled, !isRegularLayout {
             NSLayoutConstraint.activate([
                 panel.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
                 panel.view.topAnchor.constraint(equalTo: containerView.topAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11488)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24993)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- This PR introduces an additional check for !isRegularLayout to ensure that the layout logic is specific to iPhone. This prevents a crash that occurs when the segmented control does not share the same ancestor with the panel's view.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

