### PR TITLE
Bugfix FXIOS-10534 [Nimbus] Studies should be toggled back on after re-enabling Telemetry

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -217,6 +217,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
             guard let self, let profile = self.profile else { return }
             TermsOfServiceManager(prefs: profile.prefs).shouldSendTechnicalData(value: value)
             studiesSetting.updateSetting(for: value)
+            tableView.reloadData()
         }
         sendTechnicalDataSetting = sendTechnicalDataSettings
 

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/StudiesToggleSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/StudiesToggleSetting.swift
@@ -48,8 +48,9 @@ class StudiesToggleSetting: BoolSetting {
 
         let sendUsageDataPref = prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
 
-        // Special Case (EXP-4780) disable studies if usage data is disabled
-        updateSetting(for: sendUsageDataPref)
+        // Special Case (EXP-4780, FXIOS-10534) disable studies if usage data is disabled
+        // and studies should be toggled back on after re-enabling Telemetry
+        self.enabled = sendUsageDataPref
     }
 
     private func setupSettingDidChange() {
@@ -59,20 +60,23 @@ class StudiesToggleSetting: BoolSetting {
     }
 
     func updateSetting(for isUsageEnabled: Bool) {
-        guard !isUsageEnabled else {
-            // Note: switch should be enabled only when telemetry usage is enabled
-            control.setSwitchTappable(to: true)
-            // We make sure to set this on initialization, in case the setting is turned off
-            // in which case, we would to make sure that users are opted out of experiments
-            Experiments.setStudiesSetting(prefs?.boolForKey(AppConstants.prefStudiesToggle) ?? true)
-            return
-        }
+        self.enabled = isUsageEnabled
+        // We make sure to set this on initialization, in case the setting is turned off
+        // in which case, we would to make sure that users are opted out of experiments
+        // Note: Switch should be enabled only when telemetry usage is enabled
+        updateControlState(isEnabled: isUsageEnabled)
 
-        // Special Case (EXP-4780) disable Studies if usage data is disabled
-        control.setSwitchTappable(to: false)
-        control.toggleSwitch(to: false)
+        // Set experiments study setting based on usage enabled state
+        // Special Case (EXP-4780, FXIOS-10534) disable Studies if usage data is disabled
+        // and studies should be toggled back on after re-enabling Telemetry
+        let studiesEnabled = isUsageEnabled && (prefs?.boolForKey(AppConstants.prefStudiesToggle) ?? true)
+        Experiments.setStudiesSetting(studiesEnabled)
+    }
+
+    private func updateControlState(isEnabled: Bool) {
+        control.setSwitchTappable(to: isEnabled)
+        control.toggleSwitch(to: isEnabled)
         writeBool(control.switchView)
-        Experiments.setStudiesSetting(false)
     }
 
     override var accessibilityIdentifier: String? {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10534)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23080)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Studies toggle is now enabled with telemetry.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

