### PR TITLE
Add FXIOS-11202 [Homepage] [JumpbackIn] CFR for section

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -148,6 +148,7 @@ class BrowserCoordinator: BaseCoordinator,
     ) {
         let homepageController = self.homepageViewController ?? HomepageViewController(
             windowUUID: windowUUID,
+            isZeroSearch: isZeroSearch,
             overlayManager: overlayManager,
             statusBarScrollDelegate: statusBarScrollDelegate,
             toastContainer: toastContainer

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -9,6 +9,8 @@ import Shared
 
 final class HomepageViewController: UIViewController,
                                     UICollectionViewDelegate,
+                                    UIPopoverPresentationControllerDelegate,
+                                    UIAdaptivePresentationControllerDelegate,
                                     FeatureFlaggable,
                                     ContentContainable,
                                     Themeable,
@@ -44,6 +46,9 @@ final class HomepageViewController: UIViewController,
     // TODO: FXIOS-10541 will handle scrolling for wallpaper and other scroll issues
     private lazy var wallpaperView: WallpaperBackgroundView = .build { _ in }
 
+    private let jumpBackInContextualHintViewController: ContextualHintViewController
+    private let syncTabContextualHintViewController: ContextualHintViewController
+    private let isZeroSearch: Bool
     private var homepageState: HomepageState
     private var lastContentOffsetY: CGFloat = 0
 
@@ -62,7 +67,9 @@ final class HomepageViewController: UIViewController,
 
     // MARK: - Initializers
     init(windowUUID: WindowUUID,
+         profile: Profile = AppContainer.shared.resolve(),
          themeManager: ThemeManager = AppContainer.shared.resolve(),
+         isZeroSearch: Bool,
          overlayManager: OverlayModeManager,
          statusBarScrollDelegate: StatusBarScrollDelegate? = nil,
          toastContainer: UIView,
@@ -72,10 +79,31 @@ final class HomepageViewController: UIViewController,
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
+        self.isZeroSearch = isZeroSearch
         self.overlayManager = overlayManager
         self.statusBarScrollDelegate = statusBarScrollDelegate
         self.toastContainer = toastContainer
         self.logger = logger
+
+        // FXIOS-11490: This should be refactored when we refactor CFR to adhere to Redux
+        let jumpBackInContextualViewProvider = ContextualHintViewProvider(
+            forHintType: .jumpBackIn,
+            with: profile
+        )
+        self.jumpBackInContextualHintViewController = ContextualHintViewController(
+            with: jumpBackInContextualViewProvider,
+            windowUUID: windowUUID
+        )
+
+        let syncTabContextualViewProvider = ContextualHintViewProvider(
+            forHintType: .jumpBackInSyncedTab,
+            with: profile
+        )
+        self.syncTabContextualHintViewController = ContextualHintViewController(
+            with: syncTabContextualViewProvider,
+            windowUUID: windowUUID
+        )
+
         homepageState = HomepageState(windowUUID: windowUUID)
         super.init(nibName: nil, bundle: nil)
 
@@ -106,6 +134,11 @@ final class HomepageViewController: UIViewController,
         notificationCenter.removeObserver(self)
     }
 
+    func stopCFRsTimer() {
+        jumpBackInContextualHintViewController.stopTimer()
+        syncTabContextualHintViewController.stopTimer()
+    }
+
     // MARK: - View lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -126,6 +159,11 @@ final class HomepageViewController: UIViewController,
         listenForThemeChange(view)
         applyTheme()
         addTapGestureRecognizerToDismissKeyboard()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        stopCFRsTimer()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -441,6 +479,7 @@ final class HomepageViewController: UIViewController,
                     self?.navigateToNewTab(with: url)
                 }
             )
+            prepareSyncedTabContextualHint(onCell: syncedTabCell)
             return syncedTabCell
 
         case .bookmark(let item):
@@ -542,6 +581,7 @@ final class HomepageViewController: UIViewController,
                 textColor: textColor,
                 theme: currentTheme
             )
+            prepareJumpBackInContextualHint(onView: sectionLabelCell)
             return sectionLabelCell
         case .bookmarks(let textColor):
             sectionLabelCell.configure(
@@ -755,6 +795,76 @@ final class HomepageViewController: UIViewController,
         default:
             return
         }
+    }
+
+    // MARK: - UIPopoverPresentationControllerDelegate - Context Hints (CFR)
+    func popoverPresentationController(
+        _ popoverPresentationController: UIPopoverPresentationController,
+        willRepositionPopoverTo rect: UnsafeMutablePointer<CGRect>,
+        in view: AutoreleasingUnsafeMutablePointer<UIView>
+    ) {
+        // Do not dismiss if the popover is a CFR when device is rotated
+        guard !jumpBackInContextualHintViewController.isPresenting &&
+                !syncTabContextualHintViewController.isPresenting else { return }
+        popoverPresentationController.presentedViewController.dismiss(animated: false, completion: nil)
+    }
+
+    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+        return true
+    }
+
+    private func prepareJumpBackInContextualHint(onView headerView: LabelButtonHeaderView) {
+        guard jumpBackInContextualHintViewController.shouldPresentHint(),
+              dataSource?.snapshot().sectionIdentifiers.contains(.messageCard) == nil
+        else { return }
+
+        jumpBackInContextualHintViewController.configure(
+            anchor: headerView.titleLabel,
+            withArrowDirection: .down,
+            andDelegate: self,
+            presentedUsing: { [weak self] in
+                guard let self else { return }
+                self.presentContextualHint(with: self.jumpBackInContextualHintViewController)
+            },
+            overlayState: overlayManager)
+    }
+
+    private func prepareSyncedTabContextualHint(onCell cell: SyncedTabCell) {
+        guard syncTabContextualHintViewController.shouldPresentHint() else {
+            syncTabContextualHintViewController.unconfigure()
+            return
+        }
+
+        syncTabContextualHintViewController.configure(
+            anchor: cell.getContextualHintAnchor(),
+            withArrowDirection: .down,
+            andDelegate: self,
+            presentedUsing: { [weak self] in
+                guard let self else { return }
+                self.presentContextualHint(with: self.syncTabContextualHintViewController)
+            },
+            overlayState: overlayManager)
+    }
+
+    private var canModalBePresented: Bool {
+        return presentedViewController == nil && isZeroSearch
+    }
+
+    @objc
+    private func presentContextualHint(with contextualHintViewController: ContextualHintViewController) {
+        guard canModalBePresented else { return }
+        contextualHintViewController.isPresenting = true
+        present(contextualHintViewController, animated: true, completion: nil)
+        UIAccessibility.post(notification: .layoutChanged, argument: contextualHintViewController)
+    }
+
+    // MARK: UIAdaptivePresentationControllerDelegate
+    /// Prevents popovers from becoming modals on iPhone
+    func adaptivePresentationStyle(
+        for controller: UIPresentationController,
+        traitCollection: UITraitCollection
+    ) -> UIModalPresentationStyle {
+        .none
     }
 
     // MARK: - Notifiable

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -48,6 +48,7 @@ final class HomepageViewController: UIViewController,
 
     private let jumpBackInContextualHintViewController: ContextualHintViewController
     private let syncTabContextualHintViewController: ContextualHintViewController
+    // TODO: FXIOS-11504: Move this to state + add comments on what this is + why we use it
     private let isZeroSearch: Bool
     private var homepageState: HomepageState
     private var lastContentOffsetY: CGFloat = 0

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContentContainerTests.swift
@@ -49,6 +49,7 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
+            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )
@@ -60,6 +61,7 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
+            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )
@@ -137,6 +139,7 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
+            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )
@@ -198,6 +201,7 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
+            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )
@@ -240,6 +244,7 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
+            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )
@@ -273,6 +278,7 @@ final class ContentContainerTests: XCTestCase {
         let subject = ContentContainer(frame: .zero)
         let homepage = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
+            isZeroSearch: true,
             overlayManager: overlayModeManager,
             toastContainer: UIView()
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/HomepageViewControllerTests.swift
@@ -198,6 +198,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         let homepageViewController = HomepageViewController(
             windowUUID: .XCTestDefaultUUID,
             themeManager: themeManager,
+            isZeroSearch: true,
             overlayManager: mockOverlayManager,
             statusBarScrollDelegate: statusBarScrollDelegate,
             toastContainer: UIView(),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11202)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24393)

## :bulb: Description
Add CFRs to jump back in section. Followed similar to what we are doing legacy, but cleaned up + modify some areas which code seems redundant or resolved.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

## Screenshots 
| Section CFR | Synced Tabs CFR |
| --- | --- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-02-26 at 09 29 31](https://github.com/user-attachments/assets/c76ee5eb-a79c-4b33-ac80-4f4b4afba3e3) | ![Simulator Screenshot - iPhone 16 Pro - 2025-02-26 at 09 54 59](https://github.com/user-attachments/assets/55bfd6de-52b2-4ab4-a56a-9c1d7839b1e1) |