### PR TITLE
Refactor FXIOS-11426 #24868 [Settings] Create Autofills & passwords

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		21420EF72ABA338D00B28550 /* TabTrayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21420EF62ABA338D00B28550 /* TabTrayCoordinator.swift */; };
 		21420EF92ABC75A400B28550 /* TabTrayCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21420EF82ABC75A400B28550 /* TabTrayCoordinatorTests.swift */; };
 		214EF4152AC5D5D0005BCCDA /* TabDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214EF4142AC5D5D0005BCCDA /* TabDisplayView.swift */; };
+		2152473E2D6E4A4A0078D78A /* AutoFillPasswordSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152473D2D6E4A4A0078D78A /* AutoFillPasswordSettingsViewController.swift */; };
 		21534904288201E300FADB4D /* GleanPlumbMessageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215349022881FA3C00FADB4D /* GleanPlumbMessageManagerTests.swift */; };
 		215349062886007900FADB4D /* GleanPlumbMessageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215349052886007900FADB4D /* GleanPlumbMessageStoreTests.swift */; };
 		215B457F27D7FD4B00E5E800 /* LegacyTabGroupData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215B457E27D7FD4B00E5E800 /* LegacyTabGroupData.swift */; };
@@ -247,6 +248,7 @@
 		2178A6A229145506002EC290 /* ReaderModeFontSizeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A6A129145506002EC290 /* ReaderModeFontSizeLabel.swift */; };
 		2178A6A4291455F7002EC290 /* ReaderModeFontSizeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178A6A3291455F7002EC290 /* ReaderModeFontSizeButton.swift */; };
 		217AEF76284666D4004EED37 /* IntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AEF75284666D4004EED37 /* IntroViewModelTests.swift */; };
+		219588942D6E519F00B8715E /* AutofillPasswordSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219588932D6E519F00B8715E /* AutofillPasswordSetting.swift */; };
 		2197DF8A287624BF00215624 /* LibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2197DF89287624BF00215624 /* LibraryViewModelTests.swift */; };
 		219914052AF963F900153598 /* TabTrayAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219914042AF963F900153598 /* TabTrayAction.swift */; };
 		219935E72B05447C00E5966F /* TabDisplayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219935E62B05447C00E5966F /* TabDisplayModel.swift */; };
@@ -2714,6 +2716,7 @@
 		21420EF62ABA338D00B28550 /* TabTrayCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayCoordinator.swift; sourceTree = "<group>"; };
 		21420EF82ABC75A400B28550 /* TabTrayCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayCoordinatorTests.swift; sourceTree = "<group>"; };
 		214EF4142AC5D5D0005BCCDA /* TabDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayView.swift; sourceTree = "<group>"; };
+		2152473D2D6E4A4A0078D78A /* AutoFillPasswordSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFillPasswordSettingsViewController.swift; sourceTree = "<group>"; };
 		215349022881FA3C00FADB4D /* GleanPlumbMessageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageManagerTests.swift; sourceTree = "<group>"; };
 		215349052886007900FADB4D /* GleanPlumbMessageStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbMessageStoreTests.swift; sourceTree = "<group>"; };
 		215B457E27D7FD4B00E5E800 /* LegacyTabGroupData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyTabGroupData.swift; sourceTree = "<group>"; };
@@ -2739,6 +2742,7 @@
 		2178A6A3291455F7002EC290 /* ReaderModeFontSizeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderModeFontSizeButton.swift; sourceTree = "<group>"; };
 		217AEF75284666D4004EED37 /* IntroViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModelTests.swift; sourceTree = "<group>"; };
 		2194437EA9B44A00EDC037FA /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/FindInPage.strings"; sourceTree = "<group>"; };
+		219588932D6E519F00B8715E /* AutofillPasswordSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillPasswordSetting.swift; sourceTree = "<group>"; };
 		2197DF89287624BF00215624 /* LibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModelTests.swift; sourceTree = "<group>"; };
 		219914042AF963F900153598 /* TabTrayAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayAction.swift; sourceTree = "<group>"; };
 		219935E62B05447C00E5966F /* TabDisplayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayModel.swift; sourceTree = "<group>"; };
@@ -10800,6 +10804,7 @@
 		2F44FC551A9E83E200FD20CC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				2152473D2D6E4A4A0078D78A /* AutoFillPasswordSettingsViewController.swift */,
 				8ADED55B2D6679B200345293 /* BrowsingSettingsViewController.swift */,
 				8A15AB742D5FDB80008BB03C /* AutoplaySettingsViewController.swift */,
 				ED8B49B72D6CF2AE00743444 /* AppIconSelection */,
@@ -11719,6 +11724,7 @@
 			isa = PBXGroup;
 			children = (
 				8A19ACAF2A329078001C2147 /* AutofillCreditCardSettings.swift */,
+				219588932D6E519F00B8715E /* AutofillPasswordSetting.swift */,
 				8A19ACB12A3290AE001C2147 /* ClearPrivateDataSetting.swift */,
 				8A19ACB32A3290D9001C2147 /* ContentBlockerSetting.swift */,
 				8A19ACAD2A329058001C2147 /* PasswordManagerSetting.swift */,
@@ -16781,6 +16787,7 @@
 				8A395552299AF83400B2AFBB /* UIControl+Extension.swift in Sources */,
 				C2A72A692A769460002ACCE2 /* ReadingListCoordinator.swift in Sources */,
 				EDC3C2562CCAC9CB005A047F /* SearchEnginesManager.swift in Sources */,
+				2152473E2D6E4A4A0078D78A /* AutoFillPasswordSettingsViewController.swift in Sources */,
 				F85C7F122721048E004BDBA4 /* Layout.swift in Sources */,
 				DF036E43274FD434002E834E /* HistoryHighlightsCell.swift in Sources */,
 				B2FEA68D2B460D390058E616 /* AddressAutofillSettingsViewController.swift in Sources */,
@@ -17118,6 +17125,7 @@
 				43D16B8529831EA5009F8279 /* Style.swift in Sources */,
 				E16258EF2A83BE0800522742 /* FakespotLoadingView.swift in Sources */,
 				8A5564022D23317100028CA7 /* ContextMenuAction.swift in Sources */,
+				219588942D6E519F00B8715E /* AutofillPasswordSetting.swift in Sources */,
 				8A19ACAB2A32895E001C2147 /* BrowserNavigationHandler.swift in Sources */,
 				8AE80BB82891BE0700BC12EA /* JumpBackInDataAdaptor.swift in Sources */,
 				8A01891C275E9C2A00923EFE /* ClearHistorySheetProvider.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -790,7 +790,7 @@ struct AccessibilityIdentifiers {
         struct BlockImages {
             static let title = "Block Images"
         }
-        
+
         struct AutofillsPasswords {
             static let title = "AutofillsPasswordsSettings"
         }

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -790,6 +790,10 @@ struct AccessibilityIdentifiers {
         struct BlockImages {
             static let title = "Block Images"
         }
+        
+        struct AutofillsPasswords {
+            static let title = "autofillsPasswordsSettings"
+        }
 
         struct Passwords {
             static let usernameField = "usernameField"

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -792,7 +792,7 @@ struct AccessibilityIdentifiers {
         }
         
         struct AutofillsPasswords {
-            static let title = "autofillsPasswordsSettings"
+            static let title = "AutofillsPasswordsSettings"
         }
 
         struct Passwords {

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -90,7 +90,6 @@ class SettingsCoordinator: BaseCoordinator,
         }
     }
 
-    // TODO: Check this
     private func getSettingsViewController(settingsSection section: Route.SettingsSection) -> UIViewController? {
         switch section {
         case .addresses:

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -267,6 +267,7 @@ class SettingsCoordinator: BaseCoordinator,
 
     func pressedAutoFillsPasswords() {
         let viewController = AutoFillPasswordSettingsViewController(profile: profile, windowUUID: windowUUID)
+        viewController.parentCoordinator = self
         router.push(viewController)
     }
 

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -90,6 +90,7 @@ class SettingsCoordinator: BaseCoordinator,
         }
     }
 
+    // TODO: Check this
     private func getSettingsViewController(settingsSection section: Route.SettingsSection) -> UIViewController? {
         switch section {
         case .addresses:
@@ -263,6 +264,11 @@ class SettingsCoordinator: BaseCoordinator,
     }
 
     // MARK: PrivacySettingsDelegate
+
+    func pressedAutoFillsPasswords() {
+        let viewController = AutoFillPasswordSettingsViewController(profile: profile, windowUUID: windowUUID)
+        router.push(viewController)
+    }
 
     func pressedAddressAutofill() {
         let viewModel = AddressAutofillSettingsViewModel(

--- a/firefox-ios/Client/Frontend/Settings/AutoFillPasswordSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/AutoFillPasswordSettingsViewController.swift
@@ -13,7 +13,7 @@ class AutoFillPasswordSettingsViewController: SettingsTableViewController, Featu
          windowUUID: WindowUUID) {
         super.init(style: .grouped, windowUUID: windowUUID)
         self.profile = profile
-        self.title = .Settings.Browsing.Title
+        self.title = .Settings.AutofillAndPassword.Title
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/firefox-ios/Client/Frontend/Settings/AutoFillPasswordSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/AutoFillPasswordSettingsViewController.swift
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Shared
+import Glean
+
+protocol AutofillPasswordDelegate: AnyObject {
+}
+
+class AutoFillPasswordSettingsViewController: SettingsTableViewController, FeatureFlaggable {
+    weak var parentCoordinator: PrivacySettingsDelegate?
+
+    init(profile: Profile,
+         windowUUID: WindowUUID) {
+        super.init(style: .grouped, windowUUID: windowUUID)
+        self.profile = profile
+        self.title = .Settings.Browsing.Title
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func generateSettings() -> [SettingSection] {
+        var sectionItems = [Setting]()
+
+        sectionItems.append(PasswordManagerSetting(settings: self, settingsDelegate: parentCoordinator))
+
+        if featureFlags.isFeatureEnabled(.creditCardAutofillStatus, checking: .buildOnly) {
+            sectionItems.append(AutofillCreditCardSettings(settings: self, settingsDelegate: parentCoordinator))
+        }
+
+        let autofillAddressStatus = AddressLocaleFeatureValidator.isValidRegion()
+        if autofillAddressStatus, let profile {
+            sectionItems.append(AddressAutofillSetting(theme: themeManager.getCurrentTheme(for: windowUUID),
+                                                       profile: profile,
+                                                       settingsDelegate: parentCoordinator))
+        }
+
+        return [SettingSection(children: sectionItems)]
+    }
+}
+
+extension AutoFillPasswordSettingsViewController: PrivacySettingsDelegate {
+    func pressedAddressAutofill() {}
+
+    func pressedCreditCard() {}
+
+    func pressedClearPrivateData() {}
+
+    func pressedContentBlocker() {}
+
+    func pressedPasswords() {}
+
+    func pressedNotifications() {}
+
+    func askedToOpen(url: URL?, withTitle title: NSAttributedString?) {}
+}

--- a/firefox-ios/Client/Frontend/Settings/AutoFillPasswordSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/AutoFillPasswordSettingsViewController.swift
@@ -6,9 +6,6 @@ import Common
 import Shared
 import Glean
 
-protocol AutofillPasswordDelegate: AnyObject {
-}
-
 class AutoFillPasswordSettingsViewController: SettingsTableViewController, FeatureFlaggable {
     weak var parentCoordinator: PrivacySettingsDelegate?
 
@@ -41,20 +38,4 @@ class AutoFillPasswordSettingsViewController: SettingsTableViewController, Featu
 
         return [SettingSection(children: sectionItems)]
     }
-}
-
-extension AutoFillPasswordSettingsViewController: PrivacySettingsDelegate {
-    func pressedAddressAutofill() {}
-
-    func pressedCreditCard() {}
-
-    func pressedClearPrivateData() {}
-
-    func pressedContentBlocker() {}
-
-    func pressedPasswords() {}
-
-    func pressedNotifications() {}
-
-    func askedToOpen(url: URL?, withTitle title: NSAttributedString?) {}
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -343,19 +343,8 @@ class AppSettingsTableViewController: SettingsTableViewController,
 
     private func getPrivacySettings() -> [SettingSection] {
         var privacySettings = [Setting]()
-        privacySettings.append(PasswordManagerSetting(settings: self, settingsDelegate: parentCoordinator))
 
-        let autofillCreditCardStatus = featureFlags.isFeatureEnabled(.creditCardAutofillStatus, checking: .buildOnly)
-        if autofillCreditCardStatus {
-            privacySettings.append(AutofillCreditCardSettings(settings: self, settingsDelegate: parentCoordinator))
-        }
-
-        let autofillAddressStatus = AddressLocaleFeatureValidator.isValidRegion()
-        if autofillAddressStatus, let profile {
-            privacySettings.append(AddressAutofillSetting(theme: themeManager.getCurrentTheme(for: windowUUID),
-                                                          profile: profile,
-                                                          settingsDelegate: parentCoordinator))
-        }
+        privacySettings.append(AutofillPasswordSetting(settings: self, settingsDelegate: parentCoordinator))
 
         privacySettings.append(ClearPrivateDataSetting(settings: self, settingsDelegate: parentCoordinator))
 

--- a/firefox-ios/Client/Frontend/Settings/Main/General/GeneralSettingsDelegate.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/GeneralSettingsDelegate.swift
@@ -14,4 +14,5 @@ protocol GeneralSettingsDelegate: AnyObject {
     func pressedToolbar()
     func pressedTheme()
     func pressedBrowsing()
+    func pressedAutoFillsPasswords()
 }

--- a/firefox-ios/Client/Frontend/Settings/Main/Privacy/AutofillPasswordSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Privacy/AutofillPasswordSetting.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+class AutofillPasswordSetting: Setting {
+    private weak var settingsDelegate: GeneralSettingsDelegate?
+
+    override var accessoryView: UIImageView? {
+        guard let theme else { return nil }
+        return SettingDisclosureUtility.buildDisclosureIndicator(theme: theme)
+    }
+
+    override var accessibilityIdentifier: String? {
+        return AccessibilityIdentifiers.Settings.AutofillsPasswords.title
+    }
+
+    init(settings: SettingsTableViewController,
+         settingsDelegate: GeneralSettingsDelegate?) {
+        self.settingsDelegate = settingsDelegate
+        let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
+        super.init(
+            title: NSAttributedString(
+                string: .Settings.AutofillAndPassword.Title,
+                attributes: [
+                    NSAttributedString.Key.foregroundColor: theme.colors.textPrimary
+                ]
+            )
+        )
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        settingsDelegate?.pressedAutoFillsPasswords()
+    }
+}

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2395,7 +2395,7 @@ extension String {
                 comment: "This is the title for Media customization under the Browsing settings section."
             )
         }
-        
+
         public struct AutofillAndPassword {
             public static let Title = MZLocalizedString(
                 key: "Settings.AutofillAndPassword.Title.v137",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2395,6 +2395,15 @@ extension String {
                 comment: "This is the title for Media customization under the Browsing settings section."
             )
         }
+        
+        public struct AutofillAndPassword {
+            public static let Title = MZLocalizedString(
+                key: "Settings.AutofillAndPassword.Title.v137",
+                tableName: "Settings",
+                value: "Autofills & Passwords",
+                comment: "In the settings menu, in the General section, this is the title for Autofills & Passwords customization section."
+            )
+        }
 
         public struct Notifications {
             public static let Title = MZLocalizedString(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -385,6 +385,15 @@ final class SettingsCoordinatorTests: XCTestCase {
 
     // MARK: - PrivacySettingsDelegate
 
+    func testAutofillPasswordSettingsRoute_pushAutofillPassword() throws {
+        let subject = createSubject()
+
+        subject.pressedAutoFillsPasswords()
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+        XCTAssertTrue(mockRouter.pushedViewController is AutoFillPasswordSettingsViewController)
+    }
+
     func testPrivacySettingsDelegate_handleCreditCardRoute() {
         let subject = createSubject()
         subject.settingsViewController = mockSettingsVC

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -70,6 +70,8 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
 
     func pressedBrowsing() {}
 
+    func pressedAutoFillsPasswords() {}
+
     // MARK: BrowsingSettingsDelegate
 
     func pressedMailApp() {}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AddressesTests.swift
@@ -427,14 +427,24 @@ class AddressesTests: BaseTestCase {
         let settingsQuery = AccessibilityIdentifiers.Settings.self
         waitForElementsToExist(
             [
-                table.cells[settingsQuery.Logins.title],
-                table.cells[settingsQuery.CreditCards.title],
-                table.cells[settingsQuery.Address.title],
+                table.cells[settingsQuery.AutofillsPasswords.title],
                 table.cells[settingsQuery.ClearData.title],
                 app.switches[settingsQuery.ClosePrivateTabs.title],
                 table.cells[settingsQuery.ContentBlocker.title],
                 table.cells[settingsQuery.Notifications.title],
                 table.cells[settingsQuery.PrivacyPolicy.title]
+            ]
+        )
+    }
+
+    private func validateAutofillPasswordOptions() {
+        let table = app.tables.element(boundBy: 0)
+        let settingsQuery = AccessibilityIdentifiers.Settings.self
+        waitForElementsToExist(
+            [
+                table.cells[settingsQuery.Logins.title],
+                table.cells[settingsQuery.CreditCards.title],
+                table.cells[settingsQuery.Address.title]
             ]
         )
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -193,9 +193,7 @@ class CreditCardsTests: BaseTestCase {
         // Enable the "Save and Fill Payment Methods" toggle
         app.switches.element(boundBy: 1).waitAndTap()
         XCTAssertEqual(saveAndFillPaymentMethodsSwitch.value! as? String, "1")
-        app.buttons["Back"].waitAndTap()
-        navigator.nowAt(SettingsScreen)
-        app.buttons["Done"].waitAndTap()
+        navigator.goto(NewTabScreen)
         cardNumber.waitAndTap()
         // The autofill option (Use saved card prompt) is displayed
         if !app.buttons[useSavedCard].waitForExistence(timeout: 3) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -193,7 +193,7 @@ class CreditCardsTests: BaseTestCase {
         // Enable the "Save and Fill Payment Methods" toggle
         app.switches.element(boundBy: 1).waitAndTap()
         XCTAssertEqual(saveAndFillPaymentMethodsSwitch.value! as? String, "1")
-        app.buttons["Settings"].waitAndTap()
+        app.buttons["Back"].waitAndTap()
         navigator.nowAt(SettingsScreen)
         app.buttons["Done"].waitAndTap()
         cardNumber.waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -64,6 +64,7 @@ let AddressesSettings = "AutofillAddress"
 let ToolsBrowserTabMenu = "ToolsBrowserTabMenu"
 let SaveBrowserTabMenu = "SaveBrowserTabMenu"
 let BrowsingSettings = "BrowsingSettings"
+let AutofillPasswordSettings = "AutofillsPasswordsSettings"
 
 // These are in the exact order they appear in the settings
 // screen. XCUIApplication loses them on small screens.
@@ -599,8 +600,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Browsing.title], to: BrowsingSettings)
         screenState.tap(table.cells["SiriSettings"], to: SiriSettings)
         screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Logins.title], to: LoginsSettings)
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.CreditCards.title], to: CreditCardsSettings)
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Address.title], to: AddressesSettings)
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.AutofillsPasswords.title], to: AutofillPasswordSettings)
         screenState.tap(table.cells[AccessibilityIdentifiers.Settings.ClearData.title], to: ClearPrivateDataSettings)
         screenState.tap(
             table.cells[AccessibilityIdentifiers.Settings.ContentBlocker.title],
@@ -1071,6 +1071,15 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             app.segmentedControls["librarySegmentControl"].buttons.element(boundBy: 3),
             to: LibraryPanel_ReadingList
         )
+    }
+    
+    map.addScreenState(AutofillPasswordSettings) { screenState in
+        let table = app.tables.element(boundBy: 0)
+        
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.CreditCards.title], to: CreditCardsSettings)
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Address.title], to: AddressesSettings)
+        
+        screenState.backAction = navigationControllerBackAction
     }
 
     map.addScreenState(LoginsSettings) { screenState in

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -599,7 +599,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.tap(table.cells[AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting], to: ToolbarSettings)
         screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Browsing.title], to: BrowsingSettings)
         screenState.tap(table.cells["SiriSettings"], to: SiriSettings)
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Logins.title], to: LoginsSettings)
         screenState.tap(table.cells[AccessibilityIdentifiers.Settings.AutofillsPasswords.title], to: AutofillPasswordSettings)
         screenState.tap(table.cells[AccessibilityIdentifiers.Settings.ClearData.title], to: ClearPrivateDataSettings)
         screenState.tap(
@@ -1076,6 +1075,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     map.addScreenState(AutofillPasswordSettings) { screenState in
         let table = app.tables.element(boundBy: 0)
         
+        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Logins.title], to: LoginsSettings)
         screenState.tap(table.cells[AccessibilityIdentifiers.Settings.CreditCards.title], to: CreditCardsSettings)
         screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Address.title], to: AddressesSettings)
         

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -94,10 +94,7 @@ class LoginTest: BaseTestCase {
         openLoginsSettingsFromBrowserTab()
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList)
         // Save a login and check that it appears on the list from BrowserTabMenu
-        app.buttons["Back"].waitAndTap()
-        navigator.nowAt(SettingsScreen)
-        waitForExistence(app.buttons["Done"])
-        app.buttons["Done"].waitAndTap()
+        navigator.goto(HomePanelsScreen)
         navigator.nowAt(HomePanelsScreen)
 
         saveLogin(givenUrl: testLoginPage)
@@ -111,11 +108,7 @@ class LoginTest: BaseTestCase {
         // I can't reproduce the issue manually. The issue occurs only during test automation.
         if #available(iOS 16, *) {
             // Check to see how it works with multiple entries in the list- in this case, two for now
-            app.buttons["Settings"].waitAndTap()
-            navigator.nowAt(SettingsScreen)
-            waitForExistence(app.buttons["Done"])
-            app.buttons["Done"].waitAndTap()
-
+            navigator.goto(HomePanelsScreen)
             navigator.nowAt(HomePanelsScreen)
             saveLogin(givenUrl: testSecondLoginPage)
             openLoginsSettings()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -94,7 +94,7 @@ class LoginTest: BaseTestCase {
         openLoginsSettingsFromBrowserTab()
         XCTAssertEqual(app.tables["Login List"].cells.count, defaultNumRowsLoginsList)
         // Save a login and check that it appears on the list from BrowserTabMenu
-        app.buttons["Settings"].waitAndTap()
+        app.buttons["Back"].waitAndTap()
         navigator.nowAt(SettingsScreen)
         waitForExistence(app.buttons["Done"])
         app.buttons["Done"].waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -154,9 +154,7 @@ class SettingsTests: BaseTestCase {
             table.cells[settingsQuery.Browsing.title],
             table.cells[settingsQuery.Theme.title],
             table.cells[settingsQuery.Siri.title],
-            table.cells[settingsQuery.Logins.title],
-            table.cells[settingsQuery.CreditCards.title],
-            table.cells[settingsQuery.Address.title],
+            table.cells[settingsQuery.AutofillsPasswords.title],
             table.cells[settingsQuery.ClearData.title],
             app.switches[settingsQuery.ClosePrivateTabs.title],
             table.cells[settingsQuery.ContentBlocker.title],
@@ -206,6 +204,30 @@ class SettingsTests: BaseTestCase {
             table.cells[settingsQuery.NoImageMode.title],
             app.switches[settingsQuery.ShowLink.title],
             app.switches[settingsQuery.BlockExternal.title]
+        ]
+
+        for i in settingsElements {
+            scrollToElement(i)
+            mozWaitForElementToExist(i)
+            XCTAssertTrue(i.isVisible())
+        }
+    }
+
+    func testAutofillPasswordSettingsOptionSubtitles() {
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(SettingsScreen)
+        let table = app.tables.element(boundBy: 0)
+        mozWaitForElementToExist(table)
+
+        // Navigate to the Browsing settings screen
+        navigator.goto(AutofillPasswordSettings)
+
+        let settingsQuery = AccessibilityIdentifiers.Settings.self
+        let settingsElements = [
+            table.cells[settingsQuery.Logins.title],
+            table.cells[settingsQuery.CreditCards.title],
+            table.cells[settingsQuery.Address.title]
         ]
 
         for i in settingsElements {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11426)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24868)

## :bulb: Description
- Create Autofills & Passwords settings option and view controller
- Move Passwords, Payment methods and Addresses under new option
- Add string and A11yIds
- Fix and add Unit and UI tests

### 🎥 Screenshot
<details>
<summary>Autofills & Passwords Setting</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-02-26 at 13 35 59](https://github.com/user-attachments/assets/cb6d552a-55bf-4081-ac0d-443d84300a5b)


</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

