### PR TITLE
Remove FXIOS-10865 Remove unused imports

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewModel.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewModel.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import UIKit
-import Common
 
 /// The view model used to configure a `BottomSheetViewController`
 public struct BottomSheetViewModel {

--- a/BrowserKit/Sources/Shared/Functions.swift
+++ b/BrowserKit/Sources/Shared/Functions.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Common
 
 // Pipelining.
 precedencegroup PipelinePrecedence {

--- a/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageHandler.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import Common
 
 public protocol SiteImageHandler {
     func getImage(model: SiteImageModel) async -> UIImage

--- a/BrowserKit/Sources/SiteImageView/SiteImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/SiteImageView.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import Common
 
 /// Used in HeroImageView and FaviconImageView to update their image using the SiteImageHandler
 protocol SiteImageView: UIView {

--- a/BrowserKit/Sources/UnifiedSearchKit/SearchEngineTableView.swift
+++ b/BrowserKit/Sources/UnifiedSearchKit/SearchEngineTableView.swift
@@ -5,7 +5,6 @@
 import Foundation
 import UIKit
 import Common
-import MenuKit
 
 // FXIOS-10189 This class will be refactored into a generic UITableView solution later. For now, it is largely a clone of
 // MenuKit's work. Eventually both this target and the MenuKit target will leverage a common reusable tableView component.

--- a/BrowserKit/Tests/TabDataStoreTests/Mocks/TabFileManagerMock.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/Mocks/TabFileManagerMock.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 @testable import TabDataStore
-import Common
 
 class TabFileManagerMock: TabFileManager {
     var primaryDirectoryURL: URL?

--- a/BrowserKit/Tests/TabDataStoreTests/TabDataStoreTests.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/TabDataStoreTests.swift
@@ -4,7 +4,6 @@
 
 import XCTest
 @testable import TabDataStore
-import Common
 
 final class TabDataStoreTests: XCTestCase {
     private var mockFileManager: TabFileManagerMock!

--- a/BrowserKit/Tests/ToolbarKitTests/ToolbarManagerTests.swift
+++ b/BrowserKit/Tests/ToolbarKitTests/ToolbarManagerTests.swift
@@ -4,7 +4,6 @@
 
 import XCTest
 @testable import ToolbarKit
-import Common
 
 final class ToolbarManagerTests: XCTestCase {
     // Address toolbar border

--- a/firefox-ios/Client/Application/BackgroundFetchAndProcessingUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundFetchAndProcessingUtility.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import BackgroundTasks
-import Common
 
 protocol BackgroundUtilityProtocol {
     func scheduleTaskOnAppBackground()

--- a/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
+++ b/firefox-ios/Client/Application/BackgroundFirefoxSuggestIngestUtility.swift
@@ -5,7 +5,6 @@
 import BackgroundTasks
 import Common
 import Foundation
-import Shared
 import Storage
 
 /// A background utility that downloads and stores new Firefox Suggest

--- a/firefox-ios/Client/Application/DependencyHelper.swift
+++ b/firefox-ios/Client/Application/DependencyHelper.swift
@@ -3,9 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Storage
-import Shared
 import Common
-import TabDataStore
 
 class DependencyHelper {
     func bootstrapDependencies() {

--- a/firefox-ios/Client/Application/QuickActions.swift
+++ b/firefox-ios/Client/Application/QuickActions.swift
@@ -4,8 +4,6 @@
 
 import Foundation
 import Common
-import Storage
-import Shared
 
 // MARK: - ShortcutType
 enum ShortcutType: String {

--- a/firefox-ios/Client/Application/RemoteSettings/RemoteSettingsUtils.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/RemoteSettingsUtils.swift
@@ -5,7 +5,6 @@
 import Foundation
 import MozillaAppServices
 import Common
-import Shared
 
 class RemoteSettingsUtils {
     private let logger: Logger

--- a/firefox-ios/Client/Application/WebServerUtil.swift
+++ b/firefox-ios/Client/Application/WebServerUtil.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Common
 import Foundation
 import GCDWebServers
 import Shared

--- a/firefox-ios/Client/Application/WindowEventCoordinator.swift
+++ b/firefox-ios/Client/Application/WindowEventCoordinator.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Common
-import Shared
 
 /// Events related to multiple window support on iPad. These events are
 /// always associated with one window in particular, but are typically of

--- a/firefox-ios/Client/Application/WindowManager+DebugUtilities.swift
+++ b/firefox-ios/Client/Application/WindowManager+DebugUtilities.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Common
-import Shared
 import TabDataStore
 
 extension WindowManagerImplementation {

--- a/firefox-ios/Client/BookmarkItemsHelper.swift
+++ b/firefox-ios/Client/BookmarkItemsHelper.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Shared
 
 import class MozillaAppServices.BookmarkItemData
 

--- a/firefox-ios/Client/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/firefox-ios/Client/ContentBlocker/TrackingProtectionPageStats.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Shared
 import Common
 
 struct TPPageStats {

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -8,7 +8,6 @@ import WebKit
 import Shared
 import Storage
 import Redux
-import TabDataStore
 import PDFKit
 
 import enum MozillaAppServices.VisitType

--- a/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CredentialAutofillCoordinator.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Common
 import Storage
-import Shared
 import WebKit
 import ComponentLibrary
 

--- a/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/EnhancedTrackingProtectionCoordinator.swift
@@ -5,7 +5,6 @@
 import Common
 import Foundation
 import WebKit
-import Shared
 
 protocol EnhancedTrackingProtectionCoordinatorDelegate: AnyObject {
     func didFinishEnhancedTrackingProtection(from coordinator: EnhancedTrackingProtectionCoordinator)

--- a/firefox-ios/Client/Coordinators/Launch/LaunchType.swift
+++ b/firefox-ios/Client/Coordinators/Launch/LaunchType.swift
@@ -3,8 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Common
-import Shared
 
 enum LaunchCoordinatorType {
     case SceneCoordinator, BrowserCoordinator

--- a/firefox-ios/Client/Coordinators/Library/HistoryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/HistoryCoordinator.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Common
 import Shared
-import Storage
 
 protocol HistoryCoordinatorDelegate: AnyObject, LibraryPanelCoordinatorDelegate {
     func showRecentlyClosedTab()

--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -4,8 +4,6 @@
 
 import Common
 import Foundation
-import Shared
-import Storage
 
 import enum MozillaAppServices.VisitType
 

--- a/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -4,7 +4,6 @@
 
 import Common
 import UIKit
-import Shared
 
 /// Each scene has it's own scene coordinator, which is the root coordinator for a scene.
 class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinishedLoadingDelegate {

--- a/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
@@ -4,7 +4,6 @@
 
 import Common
 import UIKit
-import Shared
 
 class BrowserWindow: UIWindow {
     let uuid: WindowUUID

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -4,7 +4,6 @@
 
 import Common
 import Foundation
-import Shared
 import Redux
 import SwiftUI
 

--- a/firefox-ios/Client/Experiments/Messaging/NimbusMessagingEvaluationUtility.swift
+++ b/firefox-ios/Client/Experiments/Messaging/NimbusMessagingEvaluationUtility.swift
@@ -2,9 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Common
 import Foundation
-import Shared
 
 import protocol MozillaAppServices.NimbusMessagingHelperProtocol
 

--- a/firefox-ios/Client/Experiments/Messaging/NimbusMessagingHelperUtilityProtocol.swift
+++ b/firefox-ios/Client/Experiments/Messaging/NimbusMessagingHelperUtilityProtocol.swift
@@ -3,8 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Common
-import Shared
 
 import protocol MozillaAppServices.NimbusMessagingHelperProtocol
 

--- a/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
+++ b/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
@@ -5,7 +5,6 @@
 import Common
 import Foundation
 import Glean
-import Shared
 
 import func MozillaAppServices.getCalculatedAttributes
 import func MozillaAppServices.getLocaleTag

--- a/firefox-ios/Client/Extensions/EnvironmentValues+Extension.swift
+++ b/firefox-ios/Client/Extensions/EnvironmentValues+Extension.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
-import Shared
 import Common
 
 extension EnvironmentValues {

--- a/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import Shared
 
 typealias UIAlertActionCallback = (UIAlertAction) -> Void
 

--- a/firefox-ios/Client/Extensions/UIView+ThemeUUIDIdentifiable.swift
+++ b/firefox-ios/Client/Extensions/UIView+ThemeUUIDIdentifiable.swift
@@ -4,7 +4,6 @@
 
 import UIKit
 import Common
-import Shared
 
 extension UIView: Common.ThemeUUIDIdentifiable {
     /// Convenience that allows most UIViews to automatically reference their parent window UUID.

--- a/firefox-ios/Client/FeatureFlags/CoreFlaggableFeature.swift
+++ b/firefox-ios/Client/FeatureFlags/CoreFlaggableFeature.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import Shared
 import UIKit
 
 /// Core features are features that are used for developer purposes and are

--- a/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
+++ b/firefox-ios/Client/FeatureFlags/LegacyFeatureFlagsManager.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Shared
 import Common
 
 // MARK: - Protocol

--- a/firefox-ios/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/firefox-ios/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import Shared
 
 class SensitiveViewController: UIViewController {
     private enum VisibilityState {

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutoFillBottomSheetView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutoFillBottomSheetView.swift
@@ -3,9 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
-import Shared
 import Common
-import ComponentLibrary
 
 struct AddressAutoFillBottomSheetView: View {
     let windowUUID: WindowUUID

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -4,7 +4,6 @@
 
 import Common
 import SwiftUI
-import Shared
 
 // MARK: - AddressAutofillToggle
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
@@ -4,7 +4,6 @@
 
 import SwiftUI
 import Common
-import Shared
 
 import struct MozillaAppServices.Address
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 import Common
 import Shared
-import Storage
 
 // MARK: - AddressListView
 

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListViewModel.swift
@@ -4,7 +4,6 @@
 
 import SwiftUI
 import Common
-import Shared
 import Storage
 import struct MozillaAppServices.UpdatableAddressFields
 import struct MozillaAppServices.Address

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressScrollView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressScrollView.swift
@@ -4,7 +4,6 @@
 
 import SwiftUI
 import Common
-import Shared
 
 // MARK: - AddressScrollView
 

--- a/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
@@ -4,7 +4,6 @@
 
 import UIKit
 import Common
-import Shared
 
 /// Custom UIBarButtonItem with an autofill accessory view.
 ///

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetFooterView.swift
@@ -5,7 +5,6 @@
 import Common
 import ComponentLibrary
 import UIKit
-import Shared
 
 class CreditCardBottomSheetFooterView: UITableViewHeaderFooterView, ReusableCell, ThemeApplicable {
     private struct UX {

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -5,7 +5,6 @@
 import Common
 import ComponentLibrary
 import Foundation
-import Shared
 import Storage
 import UIKit
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -4,9 +4,7 @@
 
 import Common
 import Foundation
-import Storage
 import SwiftUI
-import Shared
 
 import struct MozillaAppServices.CreditCard
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardItemRow.swift
@@ -5,7 +5,6 @@
 import Common
 import Foundation
 import SwiftUI
-import Shared
 
 import struct MozillaAppServices.CreditCard
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSectionHeader.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSectionHeader.swift
@@ -4,7 +4,6 @@
 
 import Common
 import SwiftUI
-import Shared
 
 struct CreditCardSectionHeader: View {
     // Theming

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewController.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import Shared
 import SwiftUI
 import UIKit
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardTableViewModel.swift
@@ -5,7 +5,6 @@
 import Foundation
 import UIKit
 import SwiftUI
-import Shared
 
 import struct MozillaAppServices.CreditCard
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
@@ -5,7 +5,6 @@
 import Common
 import Foundation
 import SwiftUI
-import Shared
 
 protocol ToggleModelDelegate: AnyObject {
     func toggleDidChange(_ toggleModel: ToggleModel)

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
@@ -5,7 +5,6 @@
 import Common
 import Foundation
 import SwiftUI
-import Shared
 
 enum CreditCardInputType: String {
     case name, number, expiration

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/RemoveCardButton.swift
@@ -5,7 +5,6 @@
 import Common
 import Foundation
 import SwiftUI
-import Shared
 
 struct RemoveCardButton: View {
     // Theming

--- a/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/LoginAutofillView.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import SwiftUI
-import Shared
 import Common
 
 struct LoginAutofillView: View {

--- a/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserPrompts.swift
@@ -5,7 +5,6 @@
 import Common
 import Foundation
 import WebKit
-import Shared
 
 @objc
 protocol JSPromptAlertControllerDelegate: AnyObject {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -4,7 +4,6 @@
 
 import Common
 import Foundation
-import Shared
 
 extension BrowserViewController: DownloadQueueDelegate {
     func downloadQueue(_ downloadQueue: DownloadQueue, didStartDownload download: Download) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+UIDropInteractionDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+UIDropInteractionDelegate.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Storage
 
 import enum MozillaAppServices.VisitType
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+URLBarDelegate.swift
@@ -5,7 +5,6 @@
 import Shared
 import Glean
 import Common
-import ComponentLibrary
 
 import enum MozillaAppServices.VisitType
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -12,9 +12,7 @@ import SnapKit
 import Account
 import MobileCoreServices
 import Common
-import ComponentLibrary
 import Redux
-import ToolbarKit
 
 import class MozillaAppServices.BookmarkFolderData
 import class MozillaAppServices.BookmarkItemData

--- a/firefox-ios/Client/Frontend/Browser/DefaultSearchPrefs.swift
+++ b/firefox-ios/Client/Frontend/Browser/DefaultSearchPrefs.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Shared
 
 /*
  This only makes sense if you look at the structure of List.json

--- a/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionDetailsVC.swift
+++ b/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionDetailsVC.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Common
-import Shared
 import SiteImageView
 
 class EnhancedTrackingProtectionDetailsVC: UIViewController, Themeable {

--- a/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionDetailsVM.swift
+++ b/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionDetailsVM.swift
@@ -4,7 +4,6 @@
 
 import Common
 import Foundation
-import Shared
 
 struct EnhancedTrackingProtectionDetailsVM {
     let topLevelDomain: String

--- a/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
+++ b/firefox-ios/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import Shared
 
 class EnhancedTrackingProtectionMenuVM {
     // MARK: - Variables

--- a/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
+++ b/firefox-ios/Client/Frontend/Browser/Event Queue/AppEvent.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Shared
 import Common
 
 /// Base event type protocol. Conforming types must be hashable.

--- a/firefox-ios/Client/Frontend/Browser/FindInPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/FindInPageBar.swift
@@ -4,7 +4,6 @@
 
 import Common
 import UIKit
-import Shared
 
 protocol FindInPageBarDelegate: AnyObject {
     func findInPage(_ findInPage: FindInPageBar, didTextChange text: String)

--- a/firefox-ios/Client/Frontend/Browser/MailProviders.swift
+++ b/firefox-ios/Client/Frontend/Browser/MailProviders.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Shared
 
 // mailto headers: subject, body, cc, bcc
 

--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Shared
 import WebKit
 import Common
 

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchHighlightItem.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchHighlightItem.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Storage
 
 struct SearchHighlightItem {
     private let highlightItem: HighlightItem


### PR DESCRIPTION
## :scroll: Tickets
[Jira issue](https://mozilla-hub.atlassian.net/browse/FXIOS-10865)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/23702)

## :bulb: Description
Removing unused imports detected through [Periphery](https://github.com/peripheryapp/periphery) tool

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)
