### PR TITLE
Remove [Stickers] Remove a11y labels from stickers

### DIFF
--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/1.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/1.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Firefox logo",
+    "accessibility-label" : "",
     "filename" : "1.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/10.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/10.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Hot dog",
+    "accessibility-label" : "",
     "filename" : "10.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/11.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/11.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Pizza with melting cheese",
+    "accessibility-label" : "",
     "filename" : "11.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/12.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/12.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Cookie with bite taken",
+    "accessibility-label" : "",
     "filename" : "12.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/13.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/13.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Lightning bolt",
+    "accessibility-label" : "",
     "filename" : "13.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/14.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/14.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Red heart",
+    "accessibility-label" : "",
     "filename" : "14.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/15.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/15.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Messages with heart",
+    "accessibility-label" : "",
     "filename" : "15.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/16.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/16.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Computer face with crossed-out eyes",
+    "accessibility-label" : "",
     "filename" : "16.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/17.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/17.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Upside-down face and smiling face on slider controls",
+    "accessibility-label" : "",
     "filename" : "17.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/18.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/18.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Upside-down face on trash bin",
+    "accessibility-label" : "",
     "filename" : "18.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/19.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/19.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Conversation bubble with symbols",
+    "accessibility-label" : "",
     "filename" : "19.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/2.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/2.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Winking fox",
+    "accessibility-label" : "",
     "filename" : "2.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/20.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/20.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Lock with heart",
+    "accessibility-label" : "",
     "filename" : "20.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/21.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/21.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Firefox browser windows",
+    "accessibility-label" : "",
     "filename" : "21.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/3.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/3.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Fox on laptop",
+    "accessibility-label" : "",
     "filename" : "3.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/4.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/4.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Nervous face with sweat",
+    "accessibility-label" : "",
     "filename" : "4.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/5.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/5.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Smiling face",
+    "accessibility-label" : "",
     "filename" : "5.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/6.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/6.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Melting face",
+    "accessibility-label" : "",
     "filename" : "6.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/7.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/7.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Cactus with sunglasses",
+    "accessibility-label" : "",
     "filename" : "7.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/8.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/8.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Gorilla with sunglasses",
+    "accessibility-label" : "",
     "filename" : "8.png"
   }
 }

--- a/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/9.sticker/Contents.json
+++ b/firefox-ios/sticker/StickersCatalog.xcstickers/Sticker Pack.stickerpack/9.sticker/Contents.json
@@ -4,7 +4,7 @@
     "version" : 1
   },
   "properties" : {
-    "accessibility-label" : "Eyes",
+    "accessibility-label" : "",
     "filename" : "9.png"
   }
 }


### PR DESCRIPTION
## :scroll: Tickets
~[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)~
~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~

## :bulb: Description
Removes the accessibility labels from stickers as importing the localization fails the build for stickers. We will work on a solution in another ticket.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

