### PR TITLE
Add FXIOS-11473 [App Icon 2025] Add telemetry for the app icon selection screen in settings

### DIFF
--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -1538,6 +1538,51 @@ shopping.settings:
     send_in_pings:
       - metrics
 
+# Metrics related to the App Settings
+settings.app_icon:
+  selected:
+    type: event
+    description: |
+      Records when the user changes their app icon in the app settings.
+    extra_keys:
+      name:
+        type: string
+        description: |
+          The name of the app icon the user has selected.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-11473
+    data_reviews:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-11473
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-06-01"
+    metadata:
+      tags:
+        - AppIconSelection
+        - Settings
+
+# Settings main menu
+settings.main_menu:
+  option_selected:
+    type: event
+    description: |
+      Records when the user taps an option in the app settings main menu.
+    extra_keys:
+      option:
+        type: string
+        description: |
+          The option type selected from the settings main menu.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-11473
+    data_reviews:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-11473
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-06-01"
+    metadata:
+      tags:
+        - Settings
+
 # Key Commands
 key_commands:
   press_key_command_action:

--- a/firefox-ios/Client/tags.yaml
+++ b/firefox-ios/Client/tags.yaml
@@ -11,6 +11,12 @@
 ---
 $schema: moz://mozilla.org/schemas/glean/tags/1-0-0
 
+AppIconSelection:
+  description: Corresponds to the feature where users can change their default app icon in the settings.
+
+Settings:
+  description: Corresponds to all the options encompassed in the app's settings screens.
+
 TopSites:
   description: Corresponds to the [Feature:TopSites](https://mozilla-hub.atlassian.net/browse/FXIOS-3464)
     label on GitHub.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11473)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Add telemetry for the app icon selection screen in settings.

Note: Putting this PR up so I can get the ball rolling on data review. Implementation and unit tests to follow shortly.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

