### PR TITLE
Add FXIOS-11474 [App Icon 2025] Improve error handling for failing to set the user's alternative app …

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconSelectionView.swift
@@ -16,6 +16,7 @@ struct AppIconSelectionView: View, ThemeApplicable {
     }
 
     @State private var currentAppIcon = AppIcon.initFromSystem()
+    @State private var isShowingErrorAlert = false
 
     // MARK: - Theming
     // FIXME FXIOS-11472 Improve our SwiftUI theming
@@ -40,6 +41,15 @@ struct AppIconSelectionView: View, ThemeApplicable {
                             windowUUID: windowUUID,
                             setAppIcon: setAppIcon
                         )
+                        .alert(isPresented: $isShowingErrorAlert) {
+                            Alert(
+                                title: Text(String.Settings.AppIconSelection.Errors.SelectErrorMessage),
+                                message: nil,
+                                dismissButton: .default(
+                                    Text(String.Settings.AppIconSelection.Errors.SelectErrorConfirmation)
+                                )
+                            )
+                        }
                     }
                 }
                 .background(themeColors.layer2.color)
@@ -78,7 +88,8 @@ struct AppIconSelectionView: View, ThemeApplicable {
         UIApplication.shared.setAlternateIconName(appIcon.appIconAssetName) { error in
             guard error == nil else {
                 logger.log("Failed to set an alternative app icon [\(appIcon)]", level: .fatal, category: .appIcon)
-                // TODO FXIOS-11474 Handle the error with an alert to the user
+                isShowingErrorAlert = true
+
                 return
             }
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2478,6 +2478,20 @@ extension String {
                 value: "App Icon",
                 comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the title displayed at the top of the screen.")
 
+            public struct Errors {
+                public static let SelectErrorMessage = MZLocalizedString(
+                    key: "Settings.AppIconSelection.Errors.SelectErrorMessage.v136",
+                    tableName: "AppIconSelection",
+                    value: "Sorry, there was an error setting your app icon.",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the message displayed when the app fails to set the user's selected app icon.")
+
+                public static let SelectErrorConfirmation = MZLocalizedString(
+                    key: "Settings.AppIconSelection.Errors.SelectErrorConfirmation.v136",
+                    tableName: "AppIconSelection",
+                    value: "OK",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the label for the button to acknowledge that an error setting the app icon has occurred.")
+            }
+
             public struct AppIconNames {
                 public static let Regular = MZLocalizedString(
                     key: "Settings.AppIconSelection.AppIconNames.Regular.Title.v136",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11474)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24976)

## :bulb: Description
Improves error handling for failing to set the user's alternative app icon. 
Adds strings for localization.

<img width="300" alt="Screenshot 2025-02-27 at 5 02 08 PM" src="https://github.com/user-attachments/assets/959c48b8-efd3-4bd1-a636-b04be392c398" />

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

