### PR TITLE
Remove FXIOS-11484 #24980 Toolbar Autocomplete URL from the list of top sites

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchLoader.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchLoader.swift
@@ -30,13 +30,6 @@ final class SearchLoader: Loader<Cursor<Site>, SearchViewModel>, FeatureFlaggabl
         super.init()
     }
 
-    fileprivate lazy var topDomains: [String]? = {
-        guard let filePath = Bundle.main.path(forResource: "topdomains", ofType: "txt")
-        else { return nil }
-
-        return try? String(contentsOfFile: filePath).components(separatedBy: "\n")
-    }()
-
     fileprivate func getBookmarksAsSites(
         matchingSearchQuery query: String,
         limit: UInt,
@@ -159,16 +152,6 @@ final class SearchLoader: Loader<Cursor<Site>, SearchViewModel>, FeatureFlaggabl
             if let completion = completionForURL(site.url) {
                 autocompleteView.setAutocompleteSuggestion(completion)
                 return
-            }
-        }
-
-        // If there are no search history matches, try matching one of the Alexa top domains.
-        if let topDomains = topDomains {
-            for domain in topDomains {
-                if let completion = completionForDomain(domain) {
-                    autocompleteView.setAutocompleteSuggestion(completion)
-                    return
-                }
             }
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11484)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24980)

## :bulb: Description
- Removes autocomplete address bar with results from top domains list

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

