### PR TITLE
Fix [App Icons] clean up AppIconView swiftui view logic flow

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
@@ -47,11 +47,26 @@ struct AppIconView: View, ThemeApplicable {
     }
 
     var body: some View {
-        guard let image = UIImage(named: appIcon.imageSetAssetName) else {
-            return EmptyView()
+        subView
+        .onAppear {
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
+        .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
+            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
+            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+        }
+    }
 
-        return Group {
+    @ViewBuilder private var subView: some View {
+        if let image = UIImage(named: appIcon.imageSetAssetName) {
+            buttonGroup(for: image)
+        } else {
+            EmptyView()
+        }
+    }
+
+    private func buttonGroup(for image: UIImage) -> some View {
+        Group {
             Button(action: { setAppIcon(appIcon) }) {
                 HStack {
                     Image(systemName: selectionImageIdentifier)
@@ -80,13 +95,6 @@ struct AppIconView: View, ThemeApplicable {
             }
             .background(Color.clear)
             .accessibilityHint(selectionAccessibilityHint)
-        }
-        .onAppear {
-            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .ThemeDidChange)) { notification in
-            guard let uuid = notification.windowUUID, uuid == windowUUID else { return }
-            applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
     }
 


### PR DESCRIPTION
## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The logic flow in this swiftui view was a little messed up (the guard let does not create a clear logic flow that returns a view on every branch). It was causing the compiler to be confused. This should fix this. 

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

