### PR TITLE
Add FXIOS-11506 [ci] allow routes on staging repo

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -111,7 +111,7 @@ tasks:
               || (tasks_for == "github-push" && short_head_branch == "main")
               || (tasks_for == "github-release" && releaseAction == "published")
             then:
-                taskId: 
+                taskId:
                     $if: 'tasks_for != "action"'
                     then: '${ownTaskId}'
                 taskGroupId:
@@ -155,7 +155,7 @@ tasks:
                 routes:
                     $flattenDeep:
                         - checks
-                        - $if: 'level == "3"'
+                        - $if: '!isPullRequest'
                           then:
                             - tc-treeherder.v2.${project}.${head_sha}
                             - $if: 'tasks_for == "github-push"'


### PR DESCRIPTION
## :scroll: Tickets
https://github.com/mozilla-mobile/firefox-ios/issues/25045
Jira: https://mozilla-hub.atlassian.net/browse/FXIOS-11506

## :bulb: Description
Since the staging repo is level 1, this allows for the staging repo main branch to have the necessary routes for staging releases

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

