### PR TITLE
Document FXIOS-11533 [Readmes] Simplify referencing Xcode versions and update links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contribution guidelines
-We encourage you to participate in this open source project. We love Pull Requests, Issue Reports, Feature Requests or any kind of positive contribution. Please read the following guidelines and our [Firefox for iOS contributing guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/CONTRIBUTING.md) first.
+We encourage you to participate in this open source project. We love Pull Requests, Issue Reports, Feature Requests or any kind of positive contribution. Please read the following guidelines first.
 
 ## Submitting an Issue
 If you find a bug in the source code or a mistake in the documentation, you can help us by submitting an issue to our repository. Before you submit your issue, search open and closed issues, as it's possible that your question was already answered, or a ticket for the issue already exists.
@@ -36,7 +36,7 @@ If you’d like to work on an issue that isn’t labeled Contributor OK, please 
 ### Reference Person
 Each `Contributor OK` issue typically has a reference person assigned. If you need help or clarification:
 
-- Reach out on [Element Chat](https://chat.mozilla.org/#/home).
+- Reach out on [Mozilla Matrix chat](https://wiki.mozilla.org/Matrix).
 - Alternatively, comment directly on the issue for assistance.
 
 ### Missing Reference Person
@@ -53,10 +53,10 @@ We’ve categorized Contributor OK issues by difficulty to help you get started:
 - `Advanced`: These tasks demand a deeper understanding of the project. They often include complex implementations, significant refactoring, or intricate bug fixes.
 
 ## Pull Requests
-* All pull requests must be associated with a specific Issue. If an issue doesn't exist, please first create it.
-* Before you submit your pull request, search the repository for an open or closed Pull Request that relates to your submission. We don't want to duplicate effort. 
-* PR's should be made from a branch on your personal fork to the `mozilla-mobile:main` branch. Please see the [PR Naming Guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide) for how to name PRs.
-* For committing in your Pull Request, You can checkout [Commits](#commits) for more info.
+* All pull requests must be associated with a specific issue. If an issue doesn't exist, please create it first.
+* Before you submit your pull request, search the repository for open or closed PRs that relate to your submission. We don't want to duplicate effort. 
+* PRs should be made from a branch on your personal fork to the `mozilla-mobile:main` branch. Please see the [Pull Request Naming Guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide) for how to name PRs.
+* For hints how to split and describe your commits, see the ["Commits" section](#commits) below for detailed info.
 
 ### Commits
 * All of a PR's commits will be squashed to keep a clean git history in `main`. This means that technically, individual commit names are not particularly relevant. However, for an easier review process, we should keep the following rules of thumb in mind:
@@ -68,10 +68,12 @@ We’ve categorized Contributor OK issues by difficulty to help you get started:
 * If a comment does not apply to the code review on the PR, please post it on the related issue.
 
 # Building the code
-- Fork and clone the project from the [repository](https://github.com/mozilla-mobile/firefox-ios.git).
-- Use the provided build instructions in the [Readme](https://github.com/mozilla-mobile/firefox-ios/blob/master/README.md) of the repository to build the project. 
+- Fork and clone the project from the [repository](https://github.com/mozilla-mobile/firefox-ios).
+- Use the provided build instructions in the [Readme](https://github.com/mozilla-mobile/firefox-ios/blob/main/README.md) of the repository to build the project. 
 
 ## Run on a Device with a Free Developer Account
+
+> [!IMPORTANT]  
 > Only follow these instructions if you are using the free personal developer accounts. Simply add your Apple ID as an account in Xcode.
 
 Since the bundle identifier we use for Firefox is tied to our developer account, you'll need to generate your own identifier and update the existing configuration.
@@ -84,10 +86,10 @@ Since the bundle identifier we use for Firefox is tied to our developer account,
 
 If you submit a patch, be sure to exclude these files because they are only relevant for your personal build.
 
-## Contributor fix
+## Contributor Fix
 We add the "Contributor Fix" label on tasks that have a PR opened for it, or if a PR has been merged to fix this task. This means if you see this label on a task it's probably fixed and cannot be picked up. Note that tasks still stay opened before we close them as it's the Quality Assurance people that will close those tasks with their final approval of the work.
 
 # Reaching out for help and questions
 If more information is required or contributors have any questions then we suggestion reaching out to us via:
-- Chat: See Element channel [#fx-ios](https://chat.mozilla.org/#/room/#fx-ios:mozilla.org) for general discussion. You can also write DMs to specific teammates on it.
-- Open a [Github discussion](https://github.com/mozilla-mobile/firefox-ios/discussions).
+- Chat: See Matrix channel [#fx-ios](https://chat.mozilla.org/#/room/#fx-ios:mozilla.org) for general discussion. You can also write DMs to specific teammates on it.
+- Open a [GitHub discussion](https://github.com/mozilla-mobile/firefox-ios/discussions).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ If you’d like to work on an issue that isn’t labeled Contributor OK, please 
 ### Reference Person
 Each `Contributor OK` issue typically has a reference person assigned. If you need help or clarification:
 
-- Reach out on [Mozilla Matrix chat](https://wiki.mozilla.org/Matrix).
+- Reach out on [Mozilla Matrix chat](#reaching-out-for-help-and-questions).
 - Alternatively, comment directly on the issue for assistance.
 
 ### Missing Reference Person
@@ -56,7 +56,6 @@ We’ve categorized Contributor OK issues by difficulty to help you get started:
 * All pull requests must be associated with a specific issue. If an issue doesn't exist, please create it first.
 * Before you submit your pull request, search the repository for open or closed PRs that relate to your submission. We don't want to duplicate effort. 
 * PRs should be made from a branch on your personal fork to the `mozilla-mobile:main` branch. Please see the [Pull Request Naming Guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide) for how to name PRs.
-* For hints how to split and describe your commits, see the ["Commits" section](#commits) below for detailed info.
 
 ### Commits
 * All of a PR's commits will be squashed to keep a clean git history in `main`. This means that technically, individual commit names are not particularly relevant. However, for an easier review process, we should keep the following rules of thumb in mind:
@@ -91,5 +90,5 @@ We add the "Contributor Fix" label on tasks that have a PR opened for it, or if 
 
 # Reaching out for help and questions
 If more information is required or contributors have any questions then we suggestion reaching out to us via:
-- Chat: See Matrix channel [#fx-ios](https://chat.mozilla.org/#/room/#fx-ios:mozilla.org) for general discussion. You can also write DMs to specific teammates on it.
+- Chat: See Matrix channel [#fx-ios](https://chat.mozilla.org/#/room/#fx-ios:mozilla.org) for general discussion. You can also write DMs to specific teammates on it. (For more information on how to get started with Matrix, see [Mozilla Matrix wiki page](https://wiki.mozilla.org/Matrix).)
 - Open a [GitHub discussion](https://github.com/mozilla-mobile/firefox-ios/discussions).

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Download [Firefox iOS](https://apps.apple.com/app/firefox-web-browser/id98980492
 </table>
 
 ## Building the code
-This is a mono repository containing both Firefox and Focus iOS projects. For their related build instructions, please follow the project readme.
-- [Firefox for iOS](https://github.com/mozilla-mobile/firefox-ios/blob/main/firefox-ios/README.md)
-- [Focus iOS](https://github.com/mozilla-mobile/firefox-ios/blob/main/focus-ios/README.md)
+This is a mono repository containing both Firefox and Focus iOS projects. For their related build instructions, please follow the project readme:
+- [Firefox for iOS](./firefox-ios/README.md)
+- [Focus iOS](./focus-ios/README.md)
 
 ## Getting involved
 

--- a/firefox-ios/README.md
+++ b/firefox-ios/README.md
@@ -2,15 +2,15 @@
 
 This is the subdirectory that contains the Firefox for iOS application.
 
-For versions of Xcode and Swift this branch of Firefox for iOS works with, and the minimum iOS supported version, see [readme](../README.md) at the root of the project.
+For details on compatible Xcode and Swift versions used to build this project, as well as the minimum iOS version, refer to the root [README](../README.md).
 
 ## Getting Involved
 
-For information about participation, communications channels, instructions how to run on devices using free personal developer accounts, coding standards or PR rules, see the [guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/CONTRIBUTING.md) on how to contribute to this project.
+For information on how to contribute to this project, including communication channels, coding style, PR naming guidelines and more, visit the [Contribution guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/CONTRIBUTING.md).
 
 ## Building the code
 
-1. Install the version of [Xcode](https://developer.apple.com/download/applications/) from Apple that matches what this project uses, as listed in the [table](../README.md) at repository root.
+1. Install the version of [Xcode](https://developer.apple.com/download/applications/) from Apple that matches what this project uses, as listed in the root [README](../README.md).
 1. Install, [Brew](https://brew.sh), Node, and a Python3 virtualenv for localization scripts:
     ```shell
     brew update

--- a/firefox-ios/README.md
+++ b/firefox-ios/README.md
@@ -2,21 +2,15 @@
 
 This is the subdirectory that contains the Firefox for iOS application.
 
-## Main branch
-
-Firefox for iOS works with [Xcode 16.1](https://developer.apple.com/download/all/?q=xcode), Swift 5.6 and supports iOS 15.0 and above.
-
-Please make sure you aim your pull requests in the right direction.
-
-For bug fixes and features for a specific release, use the version branch.
+For versions of Xcode and Swift this branch of Firefox for iOS works with, and the minimum iOS supported version, see [readme](../README.md) at the root of the project.
 
 ## Getting Involved
 
-See readme at the root of the project for [the guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/README.md) on how to contribute to this project.
+For information about participation, communications channels, instructions how to run on devices using free personal developer accounts, coding standards or PR rules, see the [guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/CONTRIBUTING.md) on how to contribute to this project.
 
 ## Building the code
 
-1. Install the latest [Xcode developer tools](https://developer.apple.com/download/all/) from Apple.
+1. Install the version of [Xcode](https://developer.apple.com/download/applications/) from Apple that matches what this project uses, as listed in the [table](../README.md) at repository root.
 1. Install, [Brew](https://brew.sh), Node, and a Python3 virtualenv for localization scripts:
     ```shell
     brew update
@@ -60,7 +54,7 @@ User Scripts (JavaScript injected into the `WKWebView`) are compiled, concatenat
                 |-- /AtDocumentStart
 ```
 
-This reduces the total possible number of User Scripts down to four. The compiled output from concatenating and minifying the User Scripts placed in these folders resides in `/Client/Assets` and are named accordingly:
+This reduces the total possible number of User Scripts down to four. The compiled output from concatenating and minifying the User Scripts placed in these folders resides in `/Client/Assets` and is named accordingly:
 
 * `AllFramesAtDocumentEnd.js`
 * `AllFramesAtDocumentStart.js`
@@ -77,7 +71,7 @@ npm run dev
 
 ⚠️ Note: `npm run dev` will build the JS bundles in development mode with source maps, which allows tracking down lines in the source code for debugging.
 
-To create a production build of the User Scripts run the following `npm` command in the root directory of the project:
+To create a production build of the User Scripts, run the following `npm` command in the root directory of the project:
 
 ```shell
 npm run build

--- a/focus-ios/README.md
+++ b/focus-ios/README.md
@@ -2,14 +2,11 @@
 
 This is the subdirectory that contains the Focus iOS application.
 
-> Browse like no one’s watching. The new Firefox Focus automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it. Easily erase your history, passwords and cookies, so you won’t get followed by things like unwanted ads.
-> [Download on the App Store](https://itunes.apple.com/app/id1055677337).
-
-For versions of Xcode and Swift this branch of Focus iOS works with, and the minimum iOS supported version, see [readme](../README.md) at the root of the project.
+For details on compatible Xcode and Swift versions used to build this project, as well as the minimum iOS version, refer to the root [README](../README.md).
 
 ## Getting Involved
 
-For information about participation, communication channels, instructions how to run on devices using free personal developer accounts, coding standards or PR rules, see the [guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/CONTRIBUTING.md) on how to contribute to this project.
+For information on how to contribute to this project, including communication channels, coding style, PR naming guidelines and more, visit the [Contribution guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/CONTRIBUTING.md).
 
 ## Build Instructions
 

--- a/focus-ios/README.md
+++ b/focus-ios/README.md
@@ -10,7 +10,7 @@ For information on how to contribute to this project, including communication ch
 
 ## Build Instructions
 
-1. Install the version of [Xcode](https://developer.apple.com/download/applications/) from Apple that matches what this project uses, as listed in the [table](../README.md) at repository root.
+1. Install the version of [Xcode](https://developer.apple.com/download/applications/) from Apple that matches what this project uses, as listed in the root [README](../README.md).
 1. Clone the repository:
    ```shell
    git clone https://github.com/mozilla-mobile/firefox-ios.git

--- a/focus-ios/README.md
+++ b/focus-ios/README.md
@@ -2,35 +2,29 @@
 
 This is the subdirectory that contains the Focus iOS application.
 
-_Browse like no one’s watching. The new Firefox Focus automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it. Easily erase your history, passwords and cookies, so you won’t get followed by things like unwanted ads._
+> Browse like no one’s watching. The new Firefox Focus automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it. Easily erase your history, passwords and cookies, so you won’t get followed by things like unwanted ads.
+> [Download on the App Store](https://itunes.apple.com/app/id1055677337).
 
-Download on the [App Store](https://itunes.apple.com/app/id1055677337).
-
-## Main Branch
-
-This branch works with Xcode 16.1 and supports iOS 15.0 and newer.
-
-Pull requests should be submitted with `main` as the base branch.
+For versions of Xcode and Swift this branch of Focus iOS works with, and the minimum iOS supported version, see [readme](../README.md) at the root of the project.
 
 ## Getting Involved
 
-See readme at the root of the project for [the guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/README.md) on how to contribute to this project.
+For information about participation, communication channels, instructions how to run on devices using free personal developer accounts, coding standards or PR rules, see the [guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/CONTRIBUTING.md) on how to contribute to this project.
 
 ## Build Instructions
 
-1. Install the latest [Xcode developer tools](https://developer.apple.com/download/all/) from Apple.
-2. Clone the repository:
-
-  ```shell
-  git clone https://github.com/mozilla-mobile/firefox-ios.git
-  ```
-
-3. Pull in the project dependencies:
-
-  ```shell
-  cd firefox-ios
-  ./checkout.sh
-  ```
-
-4. Open `Blockzilla.xcodeproj` in Xcode.
-5. Build the `Focus` scheme in Xcode.
+1. Install the version of [Xcode](https://developer.apple.com/download/applications/) from Apple that matches what this project uses, as listed in the [table](../README.md) at repository root.
+1. Clone the repository:
+   ```shell
+   git clone https://github.com/mozilla-mobile/firefox-ios.git
+   ```
+1. Change directories to the project root:
+    ```shell
+    cd firefox-ios
+    ```
+1. Pull in the project dependencies:
+   ```shell
+   ./checkout.sh
+   ```
+1. Open `Blockzilla.xcodeproj` under the `focus-ios` folder in Xcode.
+1. Build the `Focus` scheme in Xcode.


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-11533
Github issue #25101

## :bulb: Description

Xcode, Swift & iOS compatibility is being kept uptodate by automation in repo root readme; the individual project directories have the same info managed manually (that gets out of sync). This makes the content more universal, referencing the table in main readme instead.

Drops duplicate or outdated info in favor of one canonical location. Removes circular link from contributing.

Improves some wording, formatting and markup, adds a bit more context here and there.

_Preview:_
- [janbrasna/`firefox-ios/README.md`](https://github.com/janbrasna/firefox-ios/blob/upd/readme-refs/firefox-ios/README.md)
- [janbrasna/`focus-ios/README.md`](https://github.com/janbrasna/firefox-ios/blob/upd/readme-refs/focus-ios/README.md)
- [janbrasna/`CONTRIBUTING.md`](https://github.com/janbrasna/firefox-ios/blob/upd/readme-refs/CONTRIBUTING.md)

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)