### PR TITLE
Add MTE-4327 Add Home page accessibility testing

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -631,6 +631,7 @@
 		5FACA10C2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 5FACA10B2D099A9E00B289BC /* AccessibilityTestPlan.xctestplan */; };
 		5FACA1102D099DCD00B289BC /* A11ySearchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */; };
 		5FC276552894AEFF00AF2721 /* LibraryPanelHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30B101D1AA7F9C600C01CA3 /* LibraryPanelHelper.swift */; };
+		5FEB88332D6F5E4A00ECE6B1 /* A11yHomePageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FEB88322D6F5E4A00ECE6B1 /* A11yHomePageTests.swift */; };
 		5FF4AF5C2CC69CC900BABC62 /* TodayWidgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF4AF5B2CC69CC900BABC62 /* TodayWidgetTests.swift */; };
 		6025B109267B6BB300F59F6B /* NoSearchResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6025B107267B6BB300F59F6B /* NoSearchResultCell.swift */; };
 		6025B10A267B6BB300F59F6B /* SelectPasswordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6025B108267B6BB300F59F6B /* SelectPasswordCell.swift */; };
@@ -7308,6 +7309,7 @@
 		5FDA464827F20C9C0060E924 /* FxNimbus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxNimbus.swift; sourceTree = "<group>"; };
 		5FDA464927F20C9C0060E924 /* Metrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
 		5FE34931820AAF71C31C383E /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
+		5FEB88322D6F5E4A00ECE6B1 /* A11yHomePageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A11yHomePageTests.swift; sourceTree = "<group>"; };
 		5FF4AF5B2CC69CC900BABC62 /* TodayWidgetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodayWidgetTests.swift; sourceTree = "<group>"; };
 		6025B107267B6BB300F59F6B /* NoSearchResultCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoSearchResultCell.swift; sourceTree = "<group>"; };
 		6025B108267B6BB300F59F6B /* SelectPasswordCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectPasswordCell.swift; sourceTree = "<group>"; };
@@ -11116,6 +11118,7 @@
 				B1F90EC02BB3F6B600A4D431 /* ZoomingTests.swift */,
 				5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */,
 				5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */,
+				5FEB88322D6F5E4A00ECE6B1 /* A11yHomePageTests.swift */,
 			);
 			path = XCUITests;
 			sourceTree = "<group>";
@@ -16508,6 +16511,7 @@
 				2CB1A65A1FDEA8B60084E96D /* NewTabSettings.swift in Sources */,
 				0B3D670E1E09B90B00C1EFC7 /* AuthenticationTest.swift in Sources */,
 				D4C4BDCE2253725E00986F04 /* LibraryTests.swift in Sources */,
+				5FEB88332D6F5E4A00ECE6B1 /* A11yHomePageTests.swift in Sources */,
 				2CCF17532105E4FD00705AE5 /* DisplaySettingsTests.swift in Sources */,
 				B1CA62822C0DB43600D31625 /* MultiWindowTests.swift in Sources */,
 				2C97EC711E72C80E0092EC18 /* TopTabsTest.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -47,6 +47,10 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "A11yHomePageTests",
+        "A11yHomePageTests\/testA11yHomePageAccessibilityLabels()",
+        "A11yHomePageTests\/testA11yHomePageAudit()",
+        "A11yHomePageTests\/testA11yHomePageVoiceOverNavigation()",
         "A11yOnboardingTests",
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",

--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -29,6 +29,10 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "A11yHomePageTests",
+        "A11yHomePageTests\/testA11yHomePageAccessibilityLabels()",
+        "A11yHomePageTests\/testA11yHomePageAudit()",
+        "A11yHomePageTests\/testA11yHomePageVoiceOverNavigation()",
         "A11yOnboardingTests",
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",

--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -14,6 +14,10 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "A11yHomePageTests",
+        "A11yHomePageTests\/testA11yHomePageAccessibilityLabels()",
+        "A11yHomePageTests\/testA11yHomePageAudit()",
+        "A11yHomePageTests\/testA11yHomePageVoiceOverNavigation()",
         "A11yOnboardingTests",
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest1.xctestplan
@@ -15,6 +15,10 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "A11yHomePageTests",
+        "A11yHomePageTests\/testA11yHomePageAccessibilityLabels()",
+        "A11yHomePageTests\/testA11yHomePageAudit()",
+        "A11yHomePageTests\/testA11yHomePageVoiceOverNavigation()",
         "A11yOnboardingTests",
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest2.xctestplan
@@ -15,6 +15,10 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "A11yHomePageTests",
+        "A11yHomePageTests\/testA11yHomePageAccessibilityLabels()",
+        "A11yHomePageTests\/testA11yHomePageAudit()",
+        "A11yHomePageTests\/testA11yHomePageVoiceOverNavigation()",
         "A11yOnboardingTests",
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest3.xctestplan
@@ -15,6 +15,10 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "A11yHomePageTests",
+        "A11yHomePageTests\/testA11yHomePageAccessibilityLabels()",
+        "A11yHomePageTests\/testA11yHomePageAudit()",
+        "A11yHomePageTests\/testA11yHomePageVoiceOverNavigation()",
         "A11yOnboardingTests",
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
@@ -15,6 +15,10 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "A11yHomePageTests",
+        "A11yHomePageTests\/testA11yHomePageAccessibilityLabels()",
+        "A11yHomePageTests\/testA11yHomePageAudit()",
+        "A11yHomePageTests\/testA11yHomePageVoiceOverNavigation()",
         "A11yOnboardingTests",
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
@@ -37,6 +37,10 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "A11yHomePageTests",
+        "A11yHomePageTests\/testA11yHomePageAccessibilityLabels()",
+        "A11yHomePageTests\/testA11yHomePageAudit()",
+        "A11yHomePageTests\/testA11yHomePageVoiceOverNavigation()",
         "A11yOnboardingTests",
         "A11yOnboardingTests\/testA11yFirstRunTour()",
         "A11ySearchTest",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yHomePageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yHomePageTests.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+class A11yHomePageTests: BaseTestCase {
+    func testA11yHomePageAudit() throws {
+        guard #available(iOS 17.0, *), !skipPlatform else { return }
+
+        try app.performAccessibilityAudit()
+    }
+
+    func testA11yHomePageAccessibilityLabels() throws {
+        var missingLabels: [A11yUtils.MissingAccessibilityElement] = []
+        guard #available(iOS 17.0, *), !skipPlatform else { return }
+
+        A11yUtils.checkMissingLabels(
+            in: app.buttons.allElementsBoundByIndex,
+            screenName: "Home Page",
+            missingLabels: &missingLabels,
+            elementType: "Button"
+        )
+
+        A11yUtils.checkMissingLabels(
+            in: app.images.allElementsBoundByIndex,
+            screenName: "Home Page",
+            missingLabels: &missingLabels,
+            elementType: "Image"
+        )
+
+        A11yUtils.checkMissingLabels(
+            in: app.staticTexts.allElementsBoundByIndex,
+            screenName: "Home Page",
+            missingLabels: &missingLabels,
+            elementType: "Static Text"
+        )
+
+        // Generate Report
+        A11yUtils.generateAndAttachReport(missingLabels: missingLabels)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yUtils.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yUtils.swift
@@ -25,7 +25,7 @@ class A11yUtils: XCTestCase {
             let hasA11yLabel = !(element.accessibilityLabel?.isEmpty ?? true)
             let hasLabel = !(element.label.isEmpty) // Checks visible UI label
 
-            if !hasA11yLabel && !hasLabel { // Only fail if both are missing
+            if !hasA11yLabel && !hasLabel && !element.identifier.isEmpty {
                 missingLabels.append(A11yUtils.MissingAccessibilityElement(
                     elementType: elementType,
                     identifier: element.identifier,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4327)

## :bulb: Description
This PR adds the accessibility testing for the home page. There is a test that perform the accessibility audit and other test to get all the elements without the accessibility label value.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

