### PR TITLE
Bugfix [PDF Refactor] FXIOS-11331 handle PDF download issue

### DIFF
--- a/BrowserKit/Sources/Shared/Extensions/URLExtensions.swift
+++ b/BrowserKit/Sources/Shared/Extensions/URLExtensions.swift
@@ -137,16 +137,20 @@ extension URL {
             return self
         }
 
-        if self.absoluteString.starts(with: "blob:") {
+        if absoluteString.starts(with: "blob:") {
             return URL(string: "blob:")
         }
 
-        if self.isFileURL {
-            return URL(string: "file://\(self.lastPathComponent)")
+        if isFileURL {
+            if #available(iOS 16.0, *) {
+                return URL(filePath: lastPathComponent)
+            } else {
+                return URL(fileURLWithPath: lastPathComponent)
+            }
         }
 
-        if self.isReaderModeURL {
-            return self.decodeReaderModeURL?.havingRemovedAuthorisationComponents()
+        if isReaderModeURL {
+            return decodeReaderModeURL?.havingRemovedAuthorisationComponents()
         }
 
         if let internalUrl = InternalURL(self), internalUrl.isErrorPage {
@@ -154,7 +158,7 @@ extension URL {
         }
 
         if !InternalURL.isValid(url: self) {
-            return self.havingRemovedAuthorisationComponents()
+            return havingRemovedAuthorisationComponents()
         }
 
         return nil

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -795,10 +795,14 @@ extension BrowserViewController: WKNavigationDelegate {
                                    context: nil)
             }
             tempPDF.onDownloadStarted = {
+                self?.scrollController.showToolbars(animated: true)
                 self?.observeValue(forKeyPath: KVOConstants.loading.rawValue,
                                    of: webView,
                                    change: [.newKey: true],
                                    context: nil)
+            }
+            tempPDF.onDownloadError = {
+                self?.navigationHandler?.removeDocumentLoading()
             }
             tab?.enqueueDocument(tempPDF)
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -780,6 +780,7 @@ extension BrowserViewController: WKNavigationDelegate {
                            response: URLResponse,
                            request: URLRequest) {
         navigationHandler?.showDocumentLoading()
+        scrollController.showToolbars(animated: false)
         let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
         cookieStore.getAllCookies { [weak tab, weak webView, weak self] cookies in
             let tempPDF = DefaultTemporaryDocument(
@@ -795,7 +796,6 @@ extension BrowserViewController: WKNavigationDelegate {
                                    context: nil)
             }
             tempPDF.onDownloadStarted = {
-                self?.scrollController.showToolbars(animated: true)
                 self?.observeValue(forKeyPath: KVOConstants.loading.rawValue,
                                    of: webView,
                                    change: [.newKey: true],

--- a/firefox-ios/Client/Frontend/Browser/TemporaryDocument.swift
+++ b/firefox-ios/Client/Frontend/Browser/TemporaryDocument.swift
@@ -44,6 +44,7 @@ class DefaultTemporaryDocument: NSObject,
     var isDownloading: Bool {
         return currentDownloadTask != nil
     }
+    private var localFileURL: URL?
 
     private let mimeType: String?
     private(set) var filename: String

--- a/firefox-ios/Client/Frontend/Browser/TemporaryDocument.swift
+++ b/firefox-ios/Client/Frontend/Browser/TemporaryDocument.swift
@@ -44,7 +44,6 @@ class DefaultTemporaryDocument: NSObject,
     var isDownloading: Bool {
         return currentDownloadTask != nil
     }
-    private var localFileURL: URL?
 
     private let mimeType: String?
     private(set) var filename: String
@@ -196,7 +195,7 @@ class DefaultTemporaryDocument: NSObject,
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         invalidateSession()
         guard let url = storeTempDownloadFile(at: location) else {
-            onDownload?(nil)
+            onDownloadError?()
             return
         }
         ensureMainThread { [weak self] in
@@ -208,7 +207,7 @@ class DefaultTemporaryDocument: NSObject,
         guard let error else { return }
         logger.log("Error downloading temp document: \(error)", level: .debug, category: .webview)
 
-        currentDownloadTask = nil
+        invalidateSession()
         ensureMainThread {
             self.onDownloadError?()
         }

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -977,10 +977,9 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
     @discardableResult
     private func cancelTemporaryDocumentDownload(forceReload: Bool = true) -> Bool {
         guard let temporaryDocument else { return false }
-
+        self.temporaryDocument = nil
         if temporaryDocument.isDownloading {
             temporaryDocument.invalidateSession()
-            self.temporaryDocument = nil
             if forceReload {
                 reload()
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11331)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24661)

## :bulb: Description
Handle PDF download error by removing the document loading view.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

