### PR TITLE
Fixes MTE-4340 - for bookmark and navigation tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -60,14 +60,7 @@ class BookmarksTests: BaseTestCase {
         // Go back, check it's still bookmarked, check it's on bookmarks home panel
         waitForTabsButton()
         navigator.goto(TabTray)
-        if iPad() {
-            app.collectionViews
-                .cells["Example Domain"].children(matching: .other)
-                .element.children(matching: .other)
-                .element.waitAndTap()
-        } else {
-            app.cells.staticTexts["Example Domain"].waitAndTap()
-        }
+        app.cells.staticTexts["Example Domain"].waitAndTap()
         navigator.nowAt(BrowserTab)
         waitForTabsButton()
         checkBookmarked()
@@ -455,9 +448,6 @@ class BookmarksTests: BaseTestCase {
             navigator.performAction(Action.CloseURLBarOpen)
         }
         navigator.goto(TabTray)
-        if !iPad() {
-            mozWaitForElementToExist(app.segmentedControls.buttons["Private"])
-        }
         // Tap to "Remove bookmark"
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleRegularMode)
         navigator.performAction(Action.OpenNewTabFromTabTray)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -486,7 +486,11 @@ class NavigationTest: BaseTestCase {
         if iPad() {
             app.buttons["Private"].waitAndTap()
         } else {
-            app.buttons["privateModeLarge"].waitAndTap()
+            // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/25093
+            // Waiting is needed before switching to private tab in order to display the expected domain
+            sleep(3)
+            // workaround end
+            app.buttons[StandardImageIdentifiers.Large.privateMode].waitAndTap()
         }
         numTabs = app.otherElements["Tabs Tray"].cells.count
         XCTAssertEqual(numTabs, 1, "Total number of private opened tabs should be 1")


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4340

## :bulb: Description
Fixes on bookmark tests and an workaround for a navigation test