### PR TITLE
Add FXIOS-11207 [Blueprint Download Manager] Trigger Live Activity

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		0E4AF8612D763EB0002E4238 /* DownloadLiveActivityUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AF8602D763E9D002E4238 /* DownloadLiveActivityUtil.swift */; };
 		0E4AF8652D764046002E4238 /* DownloadProgressManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AF8642D764046002E4238 /* DownloadProgressManager.swift */; };
 		0E65573E2D81CD1A00D7F017 /* DownloadQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E65573D2D81CD1700D7F017 /* DownloadQueue.swift */; };
+		0E6557402D82232B00D7F017 /* DownloadProgressManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E65573F2D82232200D7F017 /* DownloadProgressManagerTests.swift */; };
 		0E6C1E212C909AD7001A43BB /* PasswordGeneratorAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6C1E202C909AD7001A43BB /* PasswordGeneratorAction.swift */; };
 		0E6C1E232C909E04001A43BB /* PasswordGeneratorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6C1E222C909E04001A43BB /* PasswordGeneratorState.swift */; };
 		0E6C1E252C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6C1E242C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift */; };
@@ -2539,6 +2540,7 @@
 		0E4E4A54808AB93E32297350 /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		0E524676A2657BD8147C072A /* gd */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gd; path = gd.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		0E65573D2D81CD1700D7F017 /* DownloadQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadQueue.swift; sourceTree = "<group>"; };
+		0E65573F2D82232200D7F017 /* DownloadProgressManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadProgressManagerTests.swift; sourceTree = "<group>"; };
 		0E6C1E202C909AD7001A43BB /* PasswordGeneratorAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorAction.swift; sourceTree = "<group>"; };
 		0E6C1E222C909E04001A43BB /* PasswordGeneratorState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorState.swift; sourceTree = "<group>"; };
 		0E6C1E242C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorMiddleware.swift; sourceTree = "<group>"; };
@@ -15113,8 +15115,8 @@
 		F84B21D61A090F8100AAB793 /* ClientTests */ = {
 			isa = PBXGroup;
 			children = (
+				0E65573F2D82232200D7F017 /* DownloadProgressManagerTests.swift */,
 				EDADF7822D70D59900C39295 /* AppIconSelection */,
-				94AEF1542D690040003E2623 /* DownloadLiveActivityTest.swift */,
 				0EC57CE12CA31AFC002E3F04 /* PasswordGenerator */,
 				8AFA66012CA2935C0008D0F6 /* RemoteSettings */,
 				8A171A6029F82AD90085770E /* Application */,
@@ -15139,6 +15141,7 @@
 				5A70EF17295E2DF400790249 /* DependencyInjection */,
 				8A11C8122731E54800AC7318 /* DictionaryExtensionsTests.swift */,
 				6ADB651A285C03B100947EA4 /* DownloadHelperTests.swift */,
+				94AEF1542D690040003E2623 /* DownloadLiveActivityTest.swift */,
 				6A3E5D89283831D0001E706E /* DownloadQueueTests.swift */,
 				E1E425312B5A2E9700899550 /* DownloadTests.swift */,
 				1D7B789E2AE088930011E9F2 /* EventQueueTests.swift */,
@@ -18175,6 +18178,7 @@
 				281B2BEA1ADF4D90002917DC /* MockProfile.swift in Sources */,
 				96AF8C1C29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift in Sources */,
 				21FA8FB02AE856590013B815 /* RemoteTabsCoordinatorTests.swift in Sources */,
+				0E6557402D82232B00D7F017 /* DownloadProgressManagerTests.swift in Sources */,
 				C80C11F428B3CD580062922A /* MockUserDefaultsTests.swift in Sources */,
 				E14D6D342CCBA9FF0058B910 /* AddressBarStateTests.swift in Sources */,
 				2F697F7E1A9FD22D009E03AE /* SearchEnginesManagerTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -113,7 +113,11 @@
 		0BF802E62CFF0951005633E5 /* Shared in Frameworks */ = {isa = PBXBuildFile; productRef = 0BF802E52CFF0951005633E5 /* Shared */; };
 		0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */; };
 		0E12A3152CC2D8410037F8EE /* PasswordGeneratorTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E12A3142CC2D8410037F8EE /* PasswordGeneratorTelemetry.swift */; };
+		0E2E01DA2D77810D000BDBCF /* DownloadLiveActivityWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2E01D92D77810D000BDBCF /* DownloadLiveActivityWrapper.swift */; };
 		0E456F152C541CB300EE93BF /* PasswordGeneratorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E456F142C541CB300EE93BF /* PasswordGeneratorViewController.swift */; };
+		0E4AF8612D763EB0002E4238 /* DownloadLiveActivityUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AF8602D763E9D002E4238 /* DownloadLiveActivityUtil.swift */; };
+		0E4AF8652D764046002E4238 /* DownloadProgressManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AF8642D764046002E4238 /* DownloadProgressManager.swift */; };
+		0E65573E2D81CD1A00D7F017 /* DownloadQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E65573D2D81CD1700D7F017 /* DownloadQueue.swift */; };
 		0E6C1E212C909AD7001A43BB /* PasswordGeneratorAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6C1E202C909AD7001A43BB /* PasswordGeneratorAction.swift */; };
 		0E6C1E232C909E04001A43BB /* PasswordGeneratorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6C1E222C909E04001A43BB /* PasswordGeneratorState.swift */; };
 		0E6C1E252C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6C1E242C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift */; };
@@ -1570,7 +1574,6 @@
 		D05434D9225BAA6200FDE4EF /* RustPlaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05434D8225BAA6200FDE4EF /* RustPlaces.swift */; };
 		D05434E3225BBC4100FDE4EF /* RustShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05434E2225BBC4100FDE4EF /* RustShared.swift */; };
 		D057B2AB220103BC000614E0 /* RustLogins.swift in Sources */ = {isa = PBXBuildFile; fileRef = D057B2AA220103BC000614E0 /* RustLogins.swift */; };
-		D0625C98208E87F10081F3B2 /* DownloadQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0625C97208E87F10081F3B2 /* DownloadQueue.swift */; };
 		D0625CA8208FC47A0081F3B2 /* BrowserViewController+DownloadQueueDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0625CA7208FC47A0081F3B2 /* BrowserViewController+DownloadQueueDelegate.swift */; };
 		D07696F820697F9C00FACFD8 /* ReadingListSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07696F720697F9C00FACFD8 /* ReadingListSchema.swift */; };
 		D076971F206AC60900FACFD8 /* ReadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D076971E206AC60900FACFD8 /* ReadingList.swift */; };
@@ -2529,9 +2532,13 @@
 		0E134A0087CE6D183E5DA1D4 /* jv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = jv; path = jv.lproj/Search.strings; sourceTree = "<group>"; };
 		0E2440E3AD220D7C5EB7BB50 /* ia */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ia; path = ia.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		0E2D4E0FA5490EF048AEE106 /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
+		0E2E01D92D77810D000BDBCF /* DownloadLiveActivityWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadLiveActivityWrapper.swift; sourceTree = "<group>"; };
 		0E456F142C541CB300EE93BF /* PasswordGeneratorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorViewController.swift; sourceTree = "<group>"; };
+		0E4AF8602D763E9D002E4238 /* DownloadLiveActivityUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadLiveActivityUtil.swift; sourceTree = "<group>"; };
+		0E4AF8642D764046002E4238 /* DownloadProgressManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadProgressManager.swift; sourceTree = "<group>"; };
 		0E4E4A54808AB93E32297350 /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		0E524676A2657BD8147C072A /* gd */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gd; path = gd.lproj/ErrorPages.strings; sourceTree = "<group>"; };
+		0E65573D2D81CD1700D7F017 /* DownloadQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadQueue.swift; sourceTree = "<group>"; };
 		0E6C1E202C909AD7001A43BB /* PasswordGeneratorAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorAction.swift; sourceTree = "<group>"; };
 		0E6C1E222C909E04001A43BB /* PasswordGeneratorState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorState.swift; sourceTree = "<group>"; };
 		0E6C1E242C90B0E0001A43BB /* PasswordGeneratorMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorMiddleware.swift; sourceTree = "<group>"; };
@@ -9339,7 +9346,6 @@
 		D05434D8225BAA6200FDE4EF /* RustPlaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustPlaces.swift; sourceTree = "<group>"; };
 		D05434E2225BBC4100FDE4EF /* RustShared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustShared.swift; sourceTree = "<group>"; };
 		D057B2AA220103BC000614E0 /* RustLogins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustLogins.swift; sourceTree = "<group>"; };
-		D0625C97208E87F10081F3B2 /* DownloadQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadQueue.swift; sourceTree = "<group>"; };
 		D0625CA7208FC47A0081F3B2 /* BrowserViewController+DownloadQueueDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+DownloadQueueDelegate.swift"; sourceTree = "<group>"; };
 		D07696F720697F9C00FACFD8 /* ReadingListSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListSchema.swift; sourceTree = "<group>"; };
 		D076971E206AC60900FACFD8 /* ReadingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingList.swift; sourceTree = "<group>"; };
@@ -10873,11 +10879,13 @@
 		217641B62D651D8600597B6F /* DownloadHelper */ = {
 			isa = PBXGroup;
 			children = (
+				0E65573D2D81CD1700D7F017 /* DownloadQueue.swift */,
 				7BA8D1C61BA037F500C8AE9E /* DownloadHelper.swift */,
 				217641B72D651DB900597B6F /* MIMEType.swift */,
 				213B7AEF2D779D2400DF0123 /* Download.swift */,
-				D0625C97208E87F10081F3B2 /* DownloadQueue.swift */,
 				D04D1B852097859B0074B35F /* DownloadToast.swift */,
+				0E4AF8642D764046002E4238 /* DownloadProgressManager.swift */,
+				0E2E01D92D77810D000BDBCF /* DownloadLiveActivityWrapper.swift */,
 			);
 			path = DownloadHelper;
 			sourceTree = "<group>";
@@ -14769,6 +14777,7 @@
 		E65075551E37F714006961AC /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				0E4AF8602D763E9D002E4238 /* DownloadLiveActivityUtil.swift */,
 				5AD3B67D2CF665AE00AFA1FE /* UIApplicationInterface.swift */,
 				5AD3B67B2CF65DE300AFA1FE /* LocaleInterface.swift */,
 				8A13FA8C2AD834FA007527AB /* BackgroundTabLoader.swift */,
@@ -17301,6 +17310,7 @@
 				C8610DAA2A0EBF7100B79FF1 /* OnboardingCardDelegate.swift in Sources */,
 				3BB50E111D6274CD004B33DF /* TopSiteItemCell.swift in Sources */,
 				C7CDBEFD2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift in Sources */,
+				0E4AF8652D764046002E4238 /* DownloadProgressManager.swift in Sources */,
 				819656192C80ECFE00E62323 /* MainMenuMiddleware.swift in Sources */,
 				E127313D28B6AD99006F39D2 /* WallpaperSettingsViewModel.swift in Sources */,
 				8A4593C72BF7BECA002758DE /* MicrosurveyTableViewCell.swift in Sources */,
@@ -17561,6 +17571,7 @@
 				C8163851268A0899004C7160 /* AddCredentialViewController.swift in Sources */,
 				8A19ACB22A3290AE001C2147 /* ClearPrivateDataSetting.swift in Sources */,
 				8A9B87AF2C1B39EA0042B894 /* SearchListSection.swift in Sources */,
+				0E2E01DA2D77810D000BDBCF /* DownloadLiveActivityWrapper.swift in Sources */,
 				CA520E7A24913C1B00CCAB48 /* PasswordManagerViewModel.swift in Sources */,
 				8AE1E1CD27B191110024C45E /* SearchBarSettingsViewModel.swift in Sources */,
 				43D16B8529831EA5009F8279 /* Style.swift in Sources */,
@@ -17576,6 +17587,7 @@
 				63F7A9AA2C7529ED005846F5 /* NativeErrorPageModel.swift in Sources */,
 				8A6E63CF2D4A7FB70040D355 /* SectionHeaderState.swift in Sources */,
 				63F7A9AC2C752BB0005846F5 /* NativeErrorPageViewController.swift in Sources */,
+				0E65573E2D81CD1A00D7F017 /* DownloadQueue.swift in Sources */,
 				C88E7A572A0553360072E638 /* OnboardingButtonInfoModel.swift in Sources */,
 				AB9A0C012C6CBC9100BFA22A /* TrackingProtectionDetailsViewController.swift in Sources */,
 				21B548952B1E5F1400DC1DF8 /* InactiveTabsManager.swift in Sources */,
@@ -17924,6 +17936,7 @@
 				8AE9381D2CD920310020E6CF /* TopSiteCell.swift in Sources */,
 				D5D052D92645ABF400759F85 /* ExperimentsSettingsView.swift in Sources */,
 				8A15AB712D5FDA33008BB03C /* AutoplayAccessors.swift in Sources */,
+				0E4AF8612D763EB0002E4238 /* DownloadLiveActivityUtil.swift in Sources */,
 				E134D5802B31FF3100C6B17B /* FakespotAdLinkButton.swift in Sources */,
 				8AE0BF4F2819B10E00F33EC4 /* TopSitesSettingsViewController.swift in Sources */,
 				ED7A08DD2CF6749B0035EC8F /* ShareType.swift in Sources */,
@@ -17985,7 +17998,6 @@
 				7ADC1D192C27D35B003ED924 /* ActionProviderBuilder.swift in Sources */,
 				43162A2F2492DB7800F91658 /* EmptyPrivateTabsView.swift in Sources */,
 				E1380B8D2AEA897C00630AFA /* SidebarEnabledView.swift in Sources */,
-				D0625C98208E87F10081F3B2 /* DownloadQueue.swift in Sources */,
 				9636D92E27F9E5D900771F5E /* GleanPlumbMessage.swift in Sources */,
 				8D8251811F4DE67F00780643 /* AdvancedAccountSettingViewController.swift in Sources */,
 				966E4B2629F2D4AC00299B8D /* AccessoryViewProvider.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -14,14 +14,43 @@ extension BrowserViewController: DownloadQueueDelegate {
         // Do not need toast message for Passbook Passes since we don't save the download
         guard download.mimeType != MIMEType.Passbook else { return }
 
-        // If no other download toast is shown, create a new download toast and show it.
-        guard let downloadToast = self.downloadToast else {
-            presentDownloadProgressToast(download: download, windowUUID: uuid)
+        if let downloadProgressManager = self.downloadProgressManager {
+            // Otherwise, just add this download to the existing download toast.
+            downloadProgressManager.addDownload(download)
             return
         }
+        let downloadProgressManager = DownloadProgressManager(downloads: [download])
+        self.downloadProgressManager = downloadProgressManager
 
-        // Otherwise, just add this download to the existing download toast.
-        downloadToast.addDownload(download)
+        if #available(iOS 16.2, *) {
+            let downloadLiveActivityWrapper = DownloadLiveActivityWrapper(downloadProgressManager: downloadProgressManager)
+            downloadProgressManager.delegates.append(downloadLiveActivityWrapper)
+            self._downloadLiveActivityWrapper = downloadLiveActivityWrapper
+            guard downloadLiveActivityWrapper.start() else {
+                self._downloadLiveActivityWrapper = nil
+                return
+            }
+        }
+        presentDownloadProgressToast(download: download, windowUUID: uuid)
+    }
+
+    func stopDownload(buttonPressed: Bool) {
+        // When this toast is dismissed, be sure to clear this so that any
+        // subsequent downloads cause a new toast to be created.
+        self.downloadToast = nil
+        if #available(iOS 16.2, *), let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
+            downloadLiveActivityWrapper.end(afterSeconds: 0)
+        }
+        self.downloadProgressManager = nil
+
+        // Handle download cancellation
+        if buttonPressed, !downloadQueue.isEmpty {
+            downloadQueue.cancelAll(for: windowUUID)
+
+            SimpleToast().showAlertWithText(.DownloadCancelledToastLabelText,
+                                            bottomContainer: self.contentContainer,
+                                            theme: self.currentTheme())
+        }
     }
 
     func downloadQueue(
@@ -29,7 +58,7 @@ extension BrowserViewController: DownloadQueueDelegate {
         didDownloadCombinedBytes combinedBytesDownloaded: Int64,
         combinedTotalBytesExpected: Int64?
     ) {
-        downloadToast?.combinedBytesDownloaded = combinedBytesDownloaded
+        downloadProgressManager?.combinedBytesDownloaded = combinedBytesDownloaded
     }
 
     func downloadQueue(_ downloadQueue: DownloadQueue, download: Download, didFinishDownloadingTo location: URL) {
@@ -44,25 +73,37 @@ extension BrowserViewController: DownloadQueueDelegate {
 
         // Handle toast notification
         guard let downloadToast = self.downloadToast,
-              let download = downloadToast.downloads.first,
+              let downloadProgressManager = self.downloadProgressManager,
+              let download = downloadProgressManager.downloads.first,
               download.originWindow == windowUUID, downloadQueue.isEmpty
         else { return }
 
         DispatchQueue.main.async { [weak self] in
-                downloadToast.dismiss(false)
-                self?.presentDownloadCompletedToast(filename: download.filename)
+            downloadToast.dismiss(false)
+            if #available(iOS 16.2, *), let downloadLiveActivityWrapper = self?.downloadLiveActivityWrapper {
+                downloadLiveActivityWrapper.end(afterSeconds: 2)
+                self?._downloadLiveActivityWrapper = nil
+            }
+            self?.downloadProgressManager = nil
+            self?.presentDownloadCompletedToast(filename: download.filename)
         }
     }
 
     func downloadQueue(_ downloadQueue: DownloadQueue, didCompleteWithError error: Error?) {
         guard let downloadToast = self.downloadToast,
-              let download = downloadToast.downloads.first,
+              let downloadProgressManager = self.downloadProgressManager,
+              let download = downloadProgressManager.downloads.first,
               download.originWindow == windowUUID
         else { return }
 
         // We only care about download errors specific to our window's downloads
         DispatchQueue.main.async {
             downloadToast.dismiss(false)
+            if #available(iOS 16.2, *), let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
+                downloadLiveActivityWrapper.end(afterSeconds: 2)
+                self._downloadLiveActivityWrapper = nil
+            }
+            self.downloadProgressManager = nil
 
             if error != nil {
                 SimpleToast().showAlertWithText(.DownloadCancelledToastLabelText,
@@ -73,22 +114,15 @@ extension BrowserViewController: DownloadQueueDelegate {
     }
 
     func presentDownloadProgressToast(download: Download, windowUUID: WindowUUID) {
-        let downloadToast = DownloadToast(download: download,
+        guard let downloadProgressManager = self.downloadProgressManager else {return}
+        let downloadToast = DownloadToast(downloadProgressManager: downloadProgressManager,
                                           theme: currentTheme(),
-                                          completion: { buttonPressed in
-            // When this toast is dismissed, be sure to clear this so that any
-            // subsequent downloads cause a new toast to be created.
-            self.downloadToast = nil
-
-            // Handle download cancellation
-            if buttonPressed, !self.downloadQueue.isEmpty {
-                self.downloadQueue.cancelAll(for: windowUUID)
-
-                SimpleToast().showAlertWithText(.DownloadCancelledToastLabelText,
-                                                bottomContainer: self.contentContainer,
-                                                theme: self.currentTheme())
-            }
-        })
+                                          completion: {
+            buttonPressed in self.stopDownload(buttonPressed: buttonPressed)
+                                                      }
+        )
+        
+        downloadProgressManager.delegates.append(downloadToast)
 
         show(toast: downloadToast, duration: nil)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -25,11 +25,12 @@ extension BrowserViewController: DownloadQueueDelegate {
         if #available(iOS 16.2, *), featureFlags.isFeatureEnabled(.downloadLiveActivities, checking: .buildOnly) {
             let downloadLiveActivityWrapper = DownloadLiveActivityWrapper(downloadProgressManager: downloadProgressManager)
             downloadProgressManager.addDelegate(delegate: downloadLiveActivityWrapper)
-            self._downloadLiveActivityWrapper = downloadLiveActivityWrapper
+            self.downloadLiveActivityWrapper = downloadLiveActivityWrapper
             guard downloadLiveActivityWrapper.start() else {
-                self._downloadLiveActivityWrapper = nil
+                self.downloadLiveActivityWrapper = nil
                 return
             }
+            startRandomLiveActivity()
         }
         presentDownloadProgressToast(download: download, windowUUID: uuid)
     }
@@ -84,7 +85,7 @@ extension BrowserViewController: DownloadQueueDelegate {
             downloadToast.dismiss(false)
             if #available(iOS 16.2, *), let downloadLiveActivityWrapper = self?.downloadLiveActivityWrapper {
                 downloadLiveActivityWrapper.end(durationToDismissal: .delayed)
-                self?._downloadLiveActivityWrapper = nil
+                self?.downloadLiveActivityWrapper = nil
             }
             self?.downloadProgressManager = nil
             self?.presentDownloadCompletedToast(filename: download.filename)
@@ -104,7 +105,7 @@ extension BrowserViewController: DownloadQueueDelegate {
             if #available(iOS 16.2, *),
                let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
                 downloadLiveActivityWrapper.end(durationToDismissal: .delayed)
-                self._downloadLiveActivityWrapper = nil
+                self.downloadLiveActivityWrapper = nil
             }
             self.downloadProgressManager = nil
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -24,7 +24,7 @@ extension BrowserViewController: DownloadQueueDelegate {
 
         if #available(iOS 16.2, *), featureFlags.isFeatureEnabled(.downloadLiveActivities, checking: .buildOnly) {
             let downloadLiveActivityWrapper = DownloadLiveActivityWrapper(downloadProgressManager: downloadProgressManager)
-            downloadProgressManager.delegates.append(downloadLiveActivityWrapper)
+            downloadProgressManager.addDelegate(delegate: downloadLiveActivityWrapper)
             self._downloadLiveActivityWrapper = downloadLiveActivityWrapper
             guard downloadLiveActivityWrapper.start() else {
                 self._downloadLiveActivityWrapper = nil
@@ -41,7 +41,7 @@ extension BrowserViewController: DownloadQueueDelegate {
         if #available(iOS 16.2, *),
            featureFlags.isFeatureEnabled(.downloadLiveActivities, checking: .buildOnly),
             let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
-            downloadLiveActivityWrapper.end(afterSeconds: 0)
+            downloadLiveActivityWrapper.end(durationToDismissal: .none)
         }
         self.downloadProgressManager = nil
 
@@ -83,7 +83,7 @@ extension BrowserViewController: DownloadQueueDelegate {
         DispatchQueue.main.async { [weak self] in
             downloadToast.dismiss(false)
             if #available(iOS 16.2, *), let downloadLiveActivityWrapper = self?.downloadLiveActivityWrapper {
-                downloadLiveActivityWrapper.end(afterSeconds: 2)
+                downloadLiveActivityWrapper.end(durationToDismissal: .delayed)
                 self?._downloadLiveActivityWrapper = nil
             }
             self?.downloadProgressManager = nil
@@ -103,7 +103,7 @@ extension BrowserViewController: DownloadQueueDelegate {
             downloadToast.dismiss(false)
             if #available(iOS 16.2, *),
                let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
-                downloadLiveActivityWrapper.end(afterSeconds: 2)
+                downloadLiveActivityWrapper.end(durationToDismissal: .delayed)
                 self._downloadLiveActivityWrapper = nil
             }
             self.downloadProgressManager = nil
@@ -123,7 +123,7 @@ extension BrowserViewController: DownloadQueueDelegate {
                                           completion: { buttonPressed in
             self.stopDownload(buttonPressed: buttonPressed)})
 
-        downloadProgressManager.delegates.append(downloadToast)
+        downloadProgressManager.addDelegate(delegate: downloadToast)
 
         show(toast: downloadToast, duration: nil)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -15,14 +15,14 @@ extension BrowserViewController: DownloadQueueDelegate {
         guard download.mimeType != MIMEType.Passbook else { return }
 
         if let downloadProgressManager = self.downloadProgressManager {
-            // Otherwise, just add this download to the existing download toast.
             downloadProgressManager.addDownload(download)
             return
         }
+
         let downloadProgressManager = DownloadProgressManager(downloads: [download])
         self.downloadProgressManager = downloadProgressManager
 
-        if #available(iOS 16.2, *) {
+        if #available(iOS 16.2, *), featureFlags.isFeatureEnabled(.downloadLiveActivities, checking: .buildOnly) {
             let downloadLiveActivityWrapper = DownloadLiveActivityWrapper(downloadProgressManager: downloadProgressManager)
             downloadProgressManager.delegates.append(downloadLiveActivityWrapper)
             self._downloadLiveActivityWrapper = downloadLiveActivityWrapper
@@ -38,7 +38,9 @@ extension BrowserViewController: DownloadQueueDelegate {
         // When this toast is dismissed, be sure to clear this so that any
         // subsequent downloads cause a new toast to be created.
         self.downloadToast = nil
-        if #available(iOS 16.2, *), let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
+        if #available(iOS 16.2, *),
+           featureFlags.isFeatureEnabled(.downloadLiveActivities, checking: .buildOnly),
+            let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
             downloadLiveActivityWrapper.end(afterSeconds: 0)
         }
         self.downloadProgressManager = nil
@@ -99,7 +101,8 @@ extension BrowserViewController: DownloadQueueDelegate {
         // We only care about download errors specific to our window's downloads
         DispatchQueue.main.async {
             downloadToast.dismiss(false)
-            if #available(iOS 16.2, *), let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
+            if #available(iOS 16.2, *),
+               let downloadLiveActivityWrapper = self.downloadLiveActivityWrapper {
                 downloadLiveActivityWrapper.end(afterSeconds: 2)
                 self._downloadLiveActivityWrapper = nil
             }
@@ -117,11 +120,9 @@ extension BrowserViewController: DownloadQueueDelegate {
         guard let downloadProgressManager = self.downloadProgressManager else {return}
         let downloadToast = DownloadToast(downloadProgressManager: downloadProgressManager,
                                           theme: currentTheme(),
-                                          completion: {
-            buttonPressed in self.stopDownload(buttonPressed: buttonPressed)
-                                                      }
-        )
-        
+                                          completion: { buttonPressed in
+            self.stopDownload(buttonPressed: buttonPressed)})
+
         downloadProgressManager.delegates.append(downloadToast)
 
         show(toast: downloadToast, duration: nil)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+DownloadQueueDelegate.swift
@@ -30,7 +30,6 @@ extension BrowserViewController: DownloadQueueDelegate {
                 self.downloadLiveActivityWrapper = nil
                 return
             }
-            startRandomLiveActivity()
         }
         presentDownloadProgressToast(download: download, windowUUID: uuid)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -115,7 +115,7 @@ class BrowserViewController: UIViewController,
     var downloadProgressManager: DownloadProgressManager?
 
     private var _downloadLiveActivityWrapper: Any?
-    
+
     @available(iOS 16.2, *)
     var downloadLiveActivityWrapper: DownloadLiveActivityWrapper? {
         get {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -114,10 +114,15 @@ class BrowserViewController: UIViewController,
     var downloadToast: DownloadToast? // A toast that is showing the combined download progress
     var downloadProgressManager: DownloadProgressManager?
 
-    var _downloadLiveActivityWrapper: Any?
+    private var _downloadLiveActivityWrapper: Any?
+    
     @available(iOS 16.2, *)
     var downloadLiveActivityWrapper: DownloadLiveActivityWrapper? {
-        return _downloadLiveActivityWrapper as? DownloadLiveActivityWrapper
+        get {
+            return _downloadLiveActivityWrapper as? DownloadLiveActivityWrapper
+        } set(newValue) {
+            _downloadLiveActivityWrapper = newValue
+        }
     }
 
     // popover rotation handling

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -14,6 +14,8 @@ import MobileCoreServices
 import Common
 import Redux
 import WebEngine
+import WidgetKit
+import ActivityKit
 
 import class MozillaAppServices.BookmarkFolderData
 import class MozillaAppServices.BookmarkItemData
@@ -110,6 +112,13 @@ class BrowserViewController: UIViewController,
     var keyboardBackdrop: UIView?
     var pendingToast: Toast? // A toast that might be waiting for BVC to appear before displaying
     var downloadToast: DownloadToast? // A toast that is showing the combined download progress
+    var downloadProgressManager: DownloadProgressManager?
+
+    var _downloadLiveActivityWrapper: Any?
+    @available(iOS 16.2, *)
+    var downloadLiveActivityWrapper: DownloadLiveActivityWrapper? {
+        return _downloadLiveActivityWrapper as? DownloadLiveActivityWrapper
+    }
 
     // popover rotation handling
     var displayedPopoverController: UIViewController?

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/Download.swift
@@ -239,3 +239,27 @@ class BlobDownload: Download {
         }
     }
 }
+
+class MockDownload: Download {
+    var downloadTriggered = false
+    var downloadCanceled = false
+
+    init(filename: String = "filename",
+         totalBytesExpected: Int64? = 20,
+         hasContentEncoding: Bool? = false,
+         originWindow: WindowUUID = WindowUUID.XCTestDefaultUUID
+    ) {
+        super.init(originWindow: originWindow)
+        self.filename = filename
+        self.totalBytesExpected = totalBytesExpected
+        self.hasContentEncoding = hasContentEncoding
+    }
+
+    override func resume() {
+        downloadTriggered = true
+    }
+
+    override func cancel() {
+        downloadCanceled = true
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import WidgetKit
+import ActivityKit
+import Common
+import Shared
+
+@available(iOS 16.2, *)
+class DownloadLiveActivityWrapper: DownloadProgressDelegate {
+    var downloadLiveActivity: Activity<DownloadLiveActivityAttributes>?
+
+    var downloadProgressManager: DownloadProgressManager
+
+    init(downloadProgressManager: DownloadProgressManager) {
+        self.downloadProgressManager = downloadProgressManager
+    }
+
+    func start() -> Bool {
+        let attributes = DownloadLiveActivityAttributes()
+
+        let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
+        let contentState = DownloadLiveActivityAttributes.ContentState(downloads: downloadsStates)
+
+        do {
+            downloadLiveActivity = try Activity<DownloadLiveActivityAttributes>.request(
+                attributes: attributes,
+                content: .init(state: contentState, staleDate: nil),
+                pushType: nil
+            )
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func update() {
+        let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
+        let contentState = DownloadLiveActivityAttributes.ContentState(downloads: downloadsStates)
+        Task { await downloadLiveActivity?.update(using: contentState) }
+    }
+
+    func end(afterSeconds: Double) {
+        let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
+        let contentState = DownloadLiveActivityAttributes.ContentState(downloads: downloadsStates)
+        Task {
+            await downloadLiveActivity?.end(using: contentState,
+                                           dismissalPolicy: .after(.now.addingTimeInterval(afterSeconds)))
+        }
+    }
+
+    func updateCombinedBytesDownloaded(value: Int64) {
+        update()
+    }
+
+    func updateCombinedTotalBytesExpected(value: Int64?) {
+        update()
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -10,16 +10,19 @@ import Shared
 
 @available(iOS 16.2, *)
 class DownloadLiveActivityWrapper: DownloadProgressDelegate {
+    enum DurationToDismissal: Double {
+        case none = 0
+        case delayed = 2
+    }
     var downloadLiveActivity: Activity<DownloadLiveActivityAttributes>?
 
-    weak var downloadProgressManager: DownloadProgressManager?
+    var downloadProgressManager: DownloadProgressManager
 
     init(downloadProgressManager: DownloadProgressManager) {
         self.downloadProgressManager = downloadProgressManager
     }
 
     func start() -> Bool {
-        guard let downloadProgressManager = self.downloadProgressManager else {return false}
         let attributes = DownloadLiveActivityAttributes()
 
         let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
@@ -37,13 +40,12 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
         }
     }
 
-    func end(afterSeconds: Double) {
-        guard let downloadProgressManager = self.downloadProgressManager else {return}
+    func end(durationToDismissal: DurationToDismissal) {
         let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
         let contentState = DownloadLiveActivityAttributes.ContentState(downloads: downloadsStates)
         Task {
             await downloadLiveActivity?.end(using: contentState,
-                                            dismissalPolicy: .after(.now.addingTimeInterval(afterSeconds)))
+                                            dismissalPolicy: .after(.now.addingTimeInterval(durationToDismissal.rawValue)))
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -12,13 +12,14 @@ import Shared
 class DownloadLiveActivityWrapper: DownloadProgressDelegate {
     var downloadLiveActivity: Activity<DownloadLiveActivityAttributes>?
 
-    var downloadProgressManager: DownloadProgressManager
+    weak var downloadProgressManager: DownloadProgressManager?
 
     init(downloadProgressManager: DownloadProgressManager) {
         self.downloadProgressManager = downloadProgressManager
     }
 
     func start() -> Bool {
+        guard let downloadProgressManager = self.downloadProgressManager else {return false}
         let attributes = DownloadLiveActivityAttributes()
 
         let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
@@ -37,12 +38,14 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
     }
 
     func update() {
+        guard let downloadProgressManager = self.downloadProgressManager else {return}
         let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
         let contentState = DownloadLiveActivityAttributes.ContentState(downloads: downloadsStates)
         Task { await downloadLiveActivity?.update(using: contentState) }
     }
 
     func end(afterSeconds: Double) {
+        guard let downloadProgressManager = self.downloadProgressManager else {return}
         let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
         let contentState = DownloadLiveActivityAttributes.ContentState(downloads: downloadsStates)
         Task {

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -47,7 +47,7 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
         let contentState = DownloadLiveActivityAttributes.ContentState(downloads: downloadsStates)
         Task {
             await downloadLiveActivity?.end(using: contentState,
-                                           dismissalPolicy: .after(.now.addingTimeInterval(afterSeconds)))
+                                            dismissalPolicy: .after(.now.addingTimeInterval(afterSeconds)))
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadLiveActivityWrapper.swift
@@ -37,13 +37,6 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
         }
     }
 
-    func update() {
-        guard let downloadProgressManager = self.downloadProgressManager else {return}
-        let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
-        let contentState = DownloadLiveActivityAttributes.ContentState(downloads: downloadsStates)
-        Task { await downloadLiveActivity?.update(using: contentState) }
-    }
-
     func end(afterSeconds: Double) {
         guard let downloadProgressManager = self.downloadProgressManager else {return}
         let downloadsStates = DownloadLiveActivityUtil.buildContentState(downloads: downloadProgressManager.downloads)
@@ -52,13 +45,5 @@ class DownloadLiveActivityWrapper: DownloadProgressDelegate {
             await downloadLiveActivity?.end(using: contentState,
                                             dismissalPolicy: .after(.now.addingTimeInterval(afterSeconds)))
         }
-    }
-
-    func updateCombinedBytesDownloaded(value: Int64) {
-        update()
-    }
-
-    func updateCombinedTotalBytesExpected(value: Int64?) {
-        update()
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadProgressManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadProgressManager.swift
@@ -15,9 +15,17 @@ extension DownloadProgressDelegate {
     func updateCombinedTotalBytesExpected(value: Int64?) {}
 }
 
+class WeakDownloadProgressDelegate {
+    weak var delegate: DownloadProgressDelegate?
+
+    init(_ delegate: DownloadProgressDelegate) {
+        self.delegate = delegate
+    }
+}
+
 class DownloadProgressManager {
     var downloads: [Download] = []
-    var delegates: [DownloadProgressDelegate] = []
+    private var delegates: [WeakDownloadProgressDelegate] = []
 
     init(downloads: [Download]) {
         combinedTotalBytesExpected = 0
@@ -26,14 +34,18 @@ class DownloadProgressManager {
 
     var combinedBytesDownloaded: Int64 = 0 {
         didSet {
-            delegates.forEach({ $0.updateCombinedBytesDownloaded(value: self.combinedBytesDownloaded) })
+            delegates.forEach({ $0.delegate?.updateCombinedBytesDownloaded(value: self.combinedBytesDownloaded) })
         }
     }
 
     var combinedTotalBytesExpected: Int64? {
         didSet {
-            delegates.forEach({ $0.updateCombinedTotalBytesExpected(value: self.combinedTotalBytesExpected) })
+            delegates.forEach({ $0.delegate?.updateCombinedTotalBytesExpected(value: self.combinedTotalBytesExpected) })
         }
+    }
+
+    func addDelegate(delegate: DownloadProgressDelegate) {
+        delegates.append(WeakDownloadProgressDelegate(delegate))
     }
 
     func addDownload(_ download: Download) {

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadProgressManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadProgressManager.swift
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+protocol DownloadProgressDelegate: AnyObject {
+    func updateCombinedBytesDownloaded(value: Int64)
+
+    func updateCombinedTotalBytesExpected(value: Int64?)
+}
+
+extension DownloadProgressDelegate {
+    func updateCombinedBytesDownloaded(value: Int64) {}
+
+    func updateCombinedTotalBytesExpected(value: Int64?) {}
+}
+
+class DownloadProgressManager {
+    var downloads: [Download] = []
+    var delegates: [DownloadProgressDelegate] = []
+
+    init(downloads: [Download]) {
+        combinedTotalBytesExpected = 0
+        downloads.forEach({ addDownload($0) })
+    }
+
+    var combinedBytesDownloaded: Int64 = 0 {
+        didSet {
+            delegates.forEach({ $0.updateCombinedBytesDownloaded(value: self.combinedBytesDownloaded) })
+        }
+    }
+
+    var combinedTotalBytesExpected: Int64? {
+        didSet {
+            delegates.forEach({ $0.updateCombinedTotalBytesExpected(value: self.combinedTotalBytesExpected) })
+        }
+    }
+
+    func addDownload(_ download: Download) {
+        self.downloads.append(download)
+
+        if let combinedTotalBytesExpected = self.combinedTotalBytesExpected {
+            if let totalBytesExpected = download.totalBytesExpected {
+                self.combinedTotalBytesExpected = combinedTotalBytesExpected + totalBytesExpected
+            } else {
+                self.combinedTotalBytesExpected = nil
+            }
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadProgressManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadProgressManager.swift
@@ -57,6 +57,8 @@ class DownloadProgressManager {
             } else {
                 self.combinedTotalBytesExpected = nil
             }
+        } else {
+            delegates.forEach({ $0.delegate?.updateCombinedTotalBytesExpected(value: self.combinedTotalBytesExpected) })
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadToast.swift
@@ -49,14 +49,13 @@ class DownloadToast: Toast, DownloadProgressDelegate {
 
     var progressWidthConstraint: NSLayoutConstraint?
 
-    weak var downloadProgressManager: DownloadProgressManager?
+    var downloadProgressManager: DownloadProgressManager
 
     // Returns true if one or more downloads have encoded data (indicated via response `Content-Encoding` header).
     // If at least one download has encoded data, we cannot get a correct total estimate for all the downloads.
     // In that case, we do not show descriptive text. This will be improved in a later rework of the download manager.
     // FXIOS-9039
     var hasContentEncoding: Bool {
-        guard let downloadProgressManager = self.downloadProgressManager else {return false}
         return downloadProgressManager.downloads.contains(where: { $0.hasContentEncoding ?? false })
     }
 
@@ -78,7 +77,7 @@ class DownloadToast: Toast, DownloadProgressDelegate {
     }
 
     var descriptionText: String {
-        guard !hasContentEncoding, let downloadProgressManager = self.downloadProgressManager else {
+        guard !hasContentEncoding else {
             // We cannot get a correct estimate of encoded downloaded bytes (FXIOS-9039)
             return String()
         }
@@ -147,17 +146,17 @@ class DownloadToast: Toast, DownloadProgressDelegate {
 
     func updatePercent() {
         DispatchQueue.main.async {
-            guard !self.hasContentEncoding, let downloadProgressManager = self.downloadProgressManager else {
+            guard !self.hasContentEncoding else {
                 // We cannot get a correct estimate of encoded downloaded bytes (FXIOS-9039)
                 self.percent = nil
                 return
             }
 
-            guard let combinedTotalBytesExpected = downloadProgressManager.combinedTotalBytesExpected else {
+            guard let combinedTotalBytesExpected = self.downloadProgressManager.combinedTotalBytesExpected else {
                 self.percent = 0.0
                 return
             }
-            let combinedBytesDownloaded = downloadProgressManager.combinedBytesDownloaded
+            let combinedBytesDownloaded = self.downloadProgressManager.combinedBytesDownloaded
 
             self.percent = CGFloat(combinedBytesDownloaded) / CGFloat(combinedTotalBytesExpected)
         }

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadToast.swift
@@ -6,7 +6,7 @@ import Common
 import Shared
 import UIKit
 
-class DownloadToast: Toast {
+class DownloadToast: Toast, DownloadProgressDelegate {
     struct UX {
         static let buttonSize: CGFloat = 40
     }
@@ -49,14 +49,14 @@ class DownloadToast: Toast {
 
     var progressWidthConstraint: NSLayoutConstraint?
 
-    var downloads: [Download] = []
+    var downloadProgressManager: DownloadProgressManager
 
     // Returns true if one or more downloads have encoded data (indicated via response `Content-Encoding` header).
     // If at least one download has encoded data, we cannot get a correct total estimate for all the downloads.
     // In that case, we do not show descriptive text. This will be improved in a later rework of the download manager.
     // FXIOS-9039
     var hasContentEncoding: Bool {
-        return downloads.contains(where: { $0.hasContentEncoding ?? false })
+        return downloadProgressManager.downloads.contains(where: { $0.hasContentEncoding ?? false })
     }
 
     var percent: CGFloat? = 0.0 {
@@ -76,18 +76,6 @@ class DownloadToast: Toast {
         }
     }
 
-    var combinedBytesDownloaded: Int64 = 0 {
-        didSet {
-            updatePercent()
-        }
-    }
-
-    var combinedTotalBytesExpected: Int64? {
-        didSet {
-            updatePercent()
-        }
-    }
-
     var descriptionText: String {
         guard !hasContentEncoding else {
             // We cannot get a correct estimate of encoded downloaded bytes (FXIOS-9039)
@@ -95,11 +83,11 @@ class DownloadToast: Toast {
         }
 
         let downloadedSize = ByteCountFormatter.string(
-            fromByteCount: combinedBytesDownloaded,
+            fromByteCount: downloadProgressManager.combinedBytesDownloaded,
             countStyle: .file
         )
-        let expectedSize = combinedTotalBytesExpected != nil ? ByteCountFormatter.string(
-            fromByteCount: combinedTotalBytesExpected!,
+        let expectedSize = downloadProgressManager.combinedTotalBytesExpected != nil ? ByteCountFormatter.string(
+            fromByteCount: downloadProgressManager.combinedTotalBytesExpected!,
             countStyle: .file
         ) : nil
         let descriptionText = expectedSize != nil ? String(
@@ -108,11 +96,11 @@ class DownloadToast: Toast {
             expectedSize!
         ) : downloadedSize
 
-        guard downloads.count > 1 else {
+        guard downloadProgressManager.downloads.count > 1 else {
             return descriptionText
         }
 
-        let fileCountDescription = String(format: .DownloadMultipleFilesToastDescriptionText, downloads.count)
+        let fileCountDescription = String(format: .DownloadMultipleFilesToastDescriptionText, downloadProgressManager.downloads.count)
 
         return String(
             format: .DownloadMultipleFilesAndProgressToastDescriptionText,
@@ -121,17 +109,19 @@ class DownloadToast: Toast {
         )
     }
 
-    init(download: Download,
+    init(downloadProgressManager: DownloadProgressManager,
          theme: Theme,
-         completion: @escaping (_ buttonPressed: Bool) -> Void) {
+
+         completion: @escaping (Bool) -> Void) {
+        self.downloadProgressManager = downloadProgressManager
         super.init(frame: .zero)
 
         self.completionHandler = completion
         self.clipsToBounds = true
 
-        self.combinedTotalBytesExpected = download.totalBytesExpected
+        let download = self.downloadProgressManager.downloads[0]
 
-        self.downloads.append(download)
+        updatePercent()
 
         self.addSubview(createView(download.filename, descriptionText: self.descriptionText))
 
@@ -153,18 +143,6 @@ class DownloadToast: Toast {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func addDownload(_ download: Download) {
-        downloads.append(download)
-
-        if let combinedTotalBytesExpected = self.combinedTotalBytesExpected {
-            if let totalBytesExpected = download.totalBytesExpected {
-                self.combinedTotalBytesExpected = combinedTotalBytesExpected + totalBytesExpected
-            } else {
-                self.combinedTotalBytesExpected = nil
-            }
-        }
-    }
-
     func updatePercent() {
         DispatchQueue.main.async {
             guard !self.hasContentEncoding else {
@@ -173,12 +151,13 @@ class DownloadToast: Toast {
                 return
             }
 
-            guard let combinedTotalBytesExpected = self.combinedTotalBytesExpected else {
+            guard let combinedTotalBytesExpected = self.downloadProgressManager.combinedTotalBytesExpected else {
                 self.percent = 0.0
                 return
             }
+            let combinedBytesDownloaded = self.downloadProgressManager.combinedBytesDownloaded
 
-            self.percent = CGFloat(self.combinedBytesDownloaded) / CGFloat(combinedTotalBytesExpected)
+            self.percent = CGFloat(combinedBytesDownloaded) / CGFloat(combinedTotalBytesExpected)
         }
     }
 
@@ -276,5 +255,9 @@ class DownloadToast: Toast {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             super.dismiss(buttonPressed)
         }
+    }
+
+    func updateCombinedBytesDownloaded(value: Int64) {
+        updatePercent()
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/DownloadToast.swift
@@ -100,7 +100,8 @@ class DownloadToast: Toast, DownloadProgressDelegate {
             return descriptionText
         }
 
-        let fileCountDescription = String(format: .DownloadMultipleFilesToastDescriptionText, downloadProgressManager.downloads.count)
+        let fileCountDescription = String(format: .DownloadMultipleFilesToastDescriptionText,
+                                          downloadProgressManager.downloads.count)
 
         return String(
             format: .DownloadMultipleFilesAndProgressToastDescriptionText,

--- a/firefox-ios/Client/Utils/DownloadLiveActivityUtil.swift
+++ b/firefox-ios/Client/Utils/DownloadLiveActivityUtil.swift
@@ -5,6 +5,8 @@ import Foundation
 import WidgetKit
 
 typealias DownloadState = DownloadLiveActivityAttributes.ContentState.Download
+
+// TODO: FXIOS-11619 investigate ways to move DownloadLiveActivityUtil code into DownloadLiveActivityAttributes
 struct DownloadLiveActivityUtil {
     static func generateDownloadStateFromDownload(download: Download) -> DownloadState {
         let downloadState = DownloadState(

--- a/firefox-ios/Client/Utils/DownloadLiveActivityUtil.swift
+++ b/firefox-ios/Client/Utils/DownloadLiveActivityUtil.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import Foundation
+import WidgetKit
+
+typealias DownloadState = DownloadLiveActivityAttributes.ContentState.Download
+struct DownloadLiveActivityUtil {
+    static func generateDownloadStateFromDownload(download: Download) -> DownloadState {
+        let downloadState = DownloadState(
+            fileName: download.filename,
+            hasContentEncoding: download.hasContentEncoding,
+            totalBytesExpected: download.totalBytesExpected,
+            bytesDownloaded: download.bytesDownloaded,
+            isComplete: download.isComplete)
+        return downloadState
+    }
+
+    static func buildContentState(downloads: [Download]) -> [DownloadState] {
+        let downloadsStates = downloads.map({ download in generateDownloadStateFromDownload(download: download) })
+        return downloadsStates
+    }
+}

--- a/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
+++ b/firefox-ios/WidgetKit/DownloadManager/DownloadLiveActivity.swift
@@ -12,7 +12,6 @@ import Shared
 struct DownloadLiveActivityAttributes: ActivityAttributes {
     struct ContentState: Codable, Hashable {
         struct Download: Codable, Hashable {
-            var id: UUID
             var fileName: String
             var hasContentEncoding: Bool?
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadLiveActivityTest.swift
@@ -7,7 +7,7 @@ import WidgetKit
 
 @testable import Client
 
-class DownloadLiveActivityTest: XCTestCase {
+class DownloadLiveActivityAttributesTests: XCTestCase {
     func testContentStateComputedProperties() {
         let download1 = makeDownload(type: DownloadType.normal, isComplete: true)
         let download2 = makeDownload(type: DownloadType.contentEncoded, isComplete: true)
@@ -98,7 +98,6 @@ class DownloadLiveActivityTest: XCTestCase {
         isComplete: Bool = false
     ) -> DownloadLiveActivityAttributes.ContentState.Download {
         DownloadLiveActivityAttributes.ContentState.Download(
-            id: UUID(),
             fileName: fileName,
             hasContentEncoding: type == DownloadType.contentEncoded,
             totalBytesExpected: type == DownloadType.nilExpectedBytes ? nil : totalBytesExpected,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadProgressManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadProgressManagerTests.swift
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+import Common
+
+class DownloadProgressManagerTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        DependencyHelperMock().reset()
+        super.tearDown()
+    }
+
+    func testSingleDownloadIntialization() {
+        let download = MockDownload()
+        let downloadProgressManager = createSubject(downloads: [download])
+        XCTAssertEqual(downloadProgressManager.combinedTotalBytesExpected, download.totalBytesExpected)
+        XCTAssertEqual(downloadProgressManager.combinedBytesDownloaded, download.bytesDownloaded)
+    }
+
+    func testAddingContentEncodedDownload() {
+        let download = MockDownload(totalBytesExpected: nil)
+        let download2 = MockDownload()
+        let downloadProgressManager = createSubject(downloads: [download])
+        let mockDelegate = MockDownloadProgressDelegate()
+
+        downloadProgressManager.addDelegate(delegate: mockDelegate)
+
+        downloadProgressManager.addDownload(download2)
+
+        XCTAssertEqual(mockDelegate.didCallUpdateCombinedTotalBytesExpectedCount, 1)
+        XCTAssertNil(downloadProgressManager.combinedTotalBytesExpected)
+    }
+
+    func testAddingMultipleDownloads() {
+        let download = MockDownload()
+        let download2 = MockDownload()
+        let downloadProgressManager = createSubject(downloads: [download])
+        let mockDelegate = MockDownloadProgressDelegate()
+
+        downloadProgressManager.addDelegate(delegate: mockDelegate)
+
+        downloadProgressManager.addDownload(download2)
+
+        XCTAssertEqual(mockDelegate.didCallUpdateCombinedTotalBytesExpectedCount, 1)
+        XCTAssertEqual(mockDelegate.totalBytesExpectedParameter, 40)
+    }
+
+    @available(iOS 16.2, *)
+    func testMemoryLeaks() {
+        let download = MockDownload()
+        let downloadProgressManager = createSubject(downloads: [download])
+        var downloadLiveActivity: DownloadLiveActivityWrapper? = DownloadLiveActivityWrapper(
+            downloadProgressManager: downloadProgressManager)
+        var downloadToast: DownloadToast? = DownloadToast(
+            downloadProgressManager: downloadProgressManager,
+            theme: LightTheme(),
+            completion: { _ in })
+
+        downloadProgressManager.addDelegate(delegate: downloadLiveActivity!)
+        downloadProgressManager.addDelegate(delegate: downloadToast!)
+
+        downloadLiveActivity = nil
+        downloadToast = nil
+
+        let expectation = XCTestExpectation(description: "Wait for 0.5 seconds")
+
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                self.trackForMemoryLeaks(downloadProgressManager)
+                expectation.fulfill()
+            }
+
+            wait(for: [expectation], timeout: 1.0)
+    }
+
+    func createSubject(downloads: [Download]) -> DownloadProgressManager {
+        return DownloadProgressManager(downloads: downloads)
+    }
+}
+
+class MockDownloadProgressDelegate: DownloadProgressDelegate {
+    var didCallUpdateCombinedBytesDownloadedCount = 0
+    var didCallUpdateCombinedTotalBytesExpectedCount = 0
+    var bytesDownloadedParameter: Int64 = 0
+    var totalBytesExpectedParameter: Int64?
+
+    func updateCombinedBytesDownloaded(value: Int64) {
+        didCallUpdateCombinedBytesDownloadedCount += 1
+        bytesDownloadedParameter = value
+    }
+
+    func updateCombinedTotalBytesExpected(value: Int64?) {
+        didCallUpdateCombinedTotalBytesExpectedCount += 1
+        totalBytesExpectedParameter = value
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadQueueTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadQueueTests.swift
@@ -17,7 +17,7 @@ class DownloadQueueTests: XCTestCase {
 
     override func setUp() {
         queue = DownloadQueue()
-        download = MockDownload(originWindow: .XCTestDefaultUUID)
+        download = MockDownload()
 
         super.setUp()
     }
@@ -74,7 +74,7 @@ class DownloadQueueTests: XCTestCase {
     func testDidFinishDownloadingToWithTwoElementsInQueue() {
         let mockQueueDelegate = MockDownloadQueueDelegate()
         queue.addDelegate(mockQueueDelegate)
-        queue.downloads = [download, MockDownload(originWindow: .XCTestDefaultUUID)]
+        queue.downloads = [download, MockDownload(originWindow: WindowUUID.XCTestDefaultUUID)]
         queue.download(download, didFinishDownloadingTo: url)
         XCTAssertEqual(mockQueueDelegate.methodCalled, didFinishDownloadingTo)
     }
@@ -107,19 +107,6 @@ private enum DownloadTestError: Error {
 }
 
 private let url = URL(string: "http://mozilla.org")!
-
-class MockDownload: Download {
-    var downloadTriggered = false
-    var downloadCanceled = false
-
-    override func resume() {
-        downloadTriggered = true
-    }
-
-    override func cancel() {
-        downloadCanceled = true
-    }
-}
 
 class MockDownloadQueueDelegate: DownloadQueueDelegate {
     let windowUUID: WindowUUID = .XCTestDefaultUUID

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
@@ -16,7 +16,7 @@ class DownloadsTests: BaseTestCase {
     override func tearDown() {
         // The downloaded file has to be removed between tests
         app.terminate()
-        app.activate()
+        app.launch()
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(LibraryPanel_Downloads)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11207)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24398)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I've decoupled download storing from the download toast and created a shared class that both the toast and the live activity can reference.
I added delegates to the `DownloadProgressManager` class which are any class that should be updated if total downloaded bytes or expected total bytes change.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

