### PR TITLE
Fix MTE-4360 Fix today widget UI test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -625,7 +625,6 @@ class TodayWidgetTests: BaseTestCase {
         mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: TIMEOUT)
         springboard.alerts.buttons["Allow Paste"].waitAndTap()
         // Verify the copied string is in the URL field
-        
         mozWaitForElementToExist(urlBarAddress, timeout: TIMEOUT)
         mozWaitForValueContains(urlBarAddress, value: copiedString, timeout: TIMEOUT)
         guard let urlField = urlBarAddress.value as? String else {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -423,15 +423,7 @@ class TodayWidgetTests: BaseTestCase {
         // Tap outside the alert to dismiss it
         mozWaitForElementToExist(newPrivateSearch)
         coordinate.tap()
-        // Terminate the app to start a fresh session
-        app.terminate()
-        // Reopen and check the Private Tab widget
         tapOnWidget(widgetType: "Private Tab")
-        // Handle different UI behavior on iPad and iPhone
-        if !iPad() {
-            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
-            app.buttons["CloseButton"].waitAndTap()
-        }
         // Verify the presence of Private Mode message
         mozWaitForElementToExist(app.staticTexts["Leave no traces on this device"])
         // Verify private mode toggle is on
@@ -497,19 +489,13 @@ class TodayWidgetTests: BaseTestCase {
         coordinate.tap()
         // Copy the string to the clipboard
         UIPasteboard.general.string = copiedString
-        app.terminate()
-        // Reopen and interact with the Copied Link widget
         tapOnWidget(widgetType: "Copied Link")
         // Handle paste alert
         if #available(iOS 16, *) {
             mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: TIMEOUT)
             springboard.alerts.buttons["Allow Paste"].waitAndTap()
         }
-        // Handle iPad/iPhone UI differences
-        if !iPad() {
-            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
-            app.buttons["CloseButton"].waitAndTap()
-        }
+
         // Verify the copied string is in the URL field
         mozWaitForElementToExist(urlBarAddress, timeout: TIMEOUT)
         mozWaitForValueContains(urlBarAddress, value: copiedString, timeout: TIMEOUT)
@@ -564,7 +550,6 @@ class TodayWidgetTests: BaseTestCase {
             throw XCTSkip("iOS 16 is required")
         }
         XCUIDevice.shared.press(.home)
-        app.terminate()
         goToTodayWidgetPage()
         // Remove Firefox Widget if it already exists
         if checkPresenceFirefoxWidget() {
@@ -589,10 +574,7 @@ class TodayWidgetTests: BaseTestCase {
         springboard.buttons.matching(NSPredicate(
             format: "label CONTAINS[c] %@", "Private Tab")
         ).element.firstMatch.waitAndTap()
-        if !iPad() {
-            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
-            app.buttons["CloseButton"].waitAndTap()
-        }
+
         // Verify the presence of Private Mode message
         mozWaitForElementToExist(app.staticTexts["Leave no traces on this device"])
         // Verify private mode toggle is on
@@ -615,7 +597,7 @@ class TodayWidgetTests: BaseTestCase {
         let copiedString = "mozilla.org"
         UIPasteboard.general.string = copiedString
         XCUIDevice.shared.press(.home)
-        app.terminate()
+
         goToTodayWidgetPage()
         // Remove Firefox Widget if it already exists
         if checkPresenceFirefoxWidget() {
@@ -643,10 +625,7 @@ class TodayWidgetTests: BaseTestCase {
         mozWaitElementHittable(element: springboard.alerts.buttons["Allow Paste"], timeout: TIMEOUT)
         springboard.alerts.buttons["Allow Paste"].waitAndTap()
         // Verify the copied string is in the URL field
-        if !iPad() {
-            mozWaitElementHittable(element: app.buttons["CloseButton"], timeout: TIMEOUT)
-            app.buttons["CloseButton"].waitAndTap()
-        }
+        
         mozWaitForElementToExist(urlBarAddress, timeout: TIMEOUT)
         mozWaitForValueContains(urlBarAddress, value: copiedString, timeout: TIMEOUT)
         guard let urlField = urlBarAddress.value as? String else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4360)

## :bulb: Description
This PR fixes the Today Widget tests. I removed the `app.terminate()` command in several tests. This command is not needed anymore.

## :pencil: Checklist
You have to check all boxes before merging
- [X ] Filled in the above information (tickets numbers and description of your work)
- [X ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

