### PR TITLE
 Add FXIOS-11520 [App Icon 2025] Add localized strings for several new alternative app icon variants

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2514,11 +2514,71 @@ extension String {
                     value: "Dark Purple",
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox for iOS icon with a dark purple background.")
 
+                public static let Blue = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Blue.Title.v136",
+                    tableName: "AppIconSelection",
+                    value: "Blue",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox icon with a blue background.")
+
+                public static let BlueGradient = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.BlueGradient.Title.v136",
+                    tableName: "AppIconSelection",
+                    value: "Blue Gradient",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox icon with a blue gradient background.")
+
+                public static let Green = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Green.Title.v136",
+                    tableName: "AppIconSelection",
+                    value: "Green",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox icon with a green background.")
+
                 public static let Hug = MZLocalizedString(
                     key: "Settings.AppIconSelection.AppIconNames.Hug.Title.v136",
                     tableName: "AppIconSelection",
                     value: "Hug",
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the artsy Firefox for iOS icon of a character hugging the Firefox logo.")
+
+                public static let Lazy = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Lazy.Title.v136",
+                    tableName: "AppIconSelection",
+                    value: "Lazy",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the artsy Firefox for iOS icon of a funny fox lying on top of a globe.")
+
+                public static let OrangeGradient = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Lazy.OrangeGradient.Title.v136",
+                    tableName: "AppIconSelection",
+                    value: "Orange Gradient",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox icon with an orange gradient background.")
+
+                public static let Pink = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Pink.Title.v136",
+                    tableName: "AppIconSelection",
+                    value: "Pink",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox icon with a pink background.")
+
+                public static let Pixelated = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Pixelated.Title.v136",
+                    tableName: "AppIconSelection",
+                    value: "Pixelated",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a pixelated version of the regular Firefox for iOS app icon.")
+
+                public static let Pride = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Pride.Title.v136",
+                    tableName: "AppIconSelection",
+                    value: "Pride",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a fox logo.")
+
+                public static let RedGradient = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Lazy.RedGradient.Title.v136",
+                    tableName: "AppIconSelection",
+                    value: "Red Gradient",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox icon with a red gradient background.")
+
+                public static let Retro = MZLocalizedString(
+                    key: "Settings.AppIconSelection.AppIconNames.Pixelated.Retro.Title.v136",
+                    tableName: "AppIconSelection",
+                    value: "Retro",
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a retro version of the regular Firefox for iOS app icon.")
             }
 
             public struct Accessibility {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
The strings for PR #25088. Adds labels for the new app icon variants to the localization.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

