### PR TITLE
Add FXIOS-11524 [Homepage] [Telemetry] pocket metrics

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuAction.swift
@@ -8,19 +8,23 @@ import Redux
 import Storage
 
 final class ContextMenuAction: Action {
-    var site: Site?
+    let section: HomepageSection?
+    let site: Site?
 
     init(
+        section: HomepageSection? = nil,
         site: Site? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
+        self.section = section
         self.site = site
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
 
 enum ContextMenuActionType: ActionType {
+    case tappedOnOpenNewPrivateTab
     case tappedOnRemoveTopSite
     case tappedOnPinTopSite
     case tappedOnUnpinTopSite

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/ContextMenu/ContextMenuState.swift
@@ -222,7 +222,7 @@ struct ContextMenuState {
             allowIconScaling: true
         ) { _ in
             dispatchOpenNewTabAction(siteURL: siteURL, isPrivate: true)
-            // TODO: FXIOS-10171 - Add telemetry
+            dispatchContextMenuActionForSection(actionType: ContextMenuActionType.tappedOnOpenNewPrivateTab)
         }.items
     }
 
@@ -325,6 +325,16 @@ struct ContextMenuState {
         store.dispatch(
             ContextMenuAction(
                 site: site,
+                windowUUID: windowUUID,
+                actionType: actionType
+            )
+        )
+    }
+
+    private func dispatchContextMenuActionForSection(actionType: ActionType) {
+        store.dispatch(
+            ContextMenuAction(
+                section: configuration.homepageSection,
                 windowUUID: windowUUID,
                 actionType: actionType
             )

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -744,6 +744,17 @@ final class HomepageViewController: UIViewController,
         )
     }
 
+    private func dispatchOpenPocketAction(at index: Int, actionType: ActionType) {
+        let config = OpenPocketTelemetryConfig(isZeroSearch: isZeroSearch, position: index)
+        store.dispatch(
+            PocketAction(
+                telemetryConfig: config,
+                windowUUID: self.windowUUID,
+                actionType: actionType
+            )
+        )
+    }
+
     // MARK: - UICollectionViewDelegate
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let item = dataSource?.itemIdentifier(for: indexPath) else {
@@ -786,6 +797,7 @@ final class HomepageViewController: UIViewController,
                 visitType: .link
             )
             dispatchNavigationBrowserAction(with: destination, actionType: NavigationBrowserActionType.tapOnCell)
+            dispatchOpenPocketAction(at: indexPath.item, actionType: PocketActionType.tapOnHomepagePocketCell)
         case .pocketDiscover(let item):
             let destination = NavigationDestination(
                 .link,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketAction.swift
@@ -6,18 +6,26 @@ import Common
 import Foundation
 import Redux
 
+struct OpenPocketTelemetryConfig {
+    let isZeroSearch: Bool
+    let position: Int
+}
+
 final class PocketAction: Action {
-    var pocketStories: [PocketStoryConfiguration]?
-    var isEnabled: Bool?
+    let pocketStories: [PocketStoryConfiguration]?
+    let isEnabled: Bool?
+    let telemetryConfig: OpenPocketTelemetryConfig?
 
     init(
         pocketStories: [PocketStoryConfiguration]? = nil,
         isEnabled: Bool? = nil,
+        telemetryConfig: OpenPocketTelemetryConfig? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
         self.pocketStories = pocketStories
         self.isEnabled = isEnabled
+        self.telemetryConfig = telemetryConfig
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
@@ -25,6 +33,8 @@ final class PocketAction: Action {
 enum PocketActionType: ActionType {
     case enteredForeground
     case toggleShowSectionSetting
+    case tapOnHomepagePocketCell
+    case viewedSection
 }
 
 enum PocketMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Pocket/PocketMiddleware.swift
@@ -7,8 +7,17 @@ import Redux
 
 final class PocketMiddleware {
     private let pocketManager: PocketManagerProvider
-    init(pocketManager: PocketManagerProvider = AppContainer.shared.resolve()) {
+    private let homepageTelemetry: HomepageTelemetry
+    private let logger: Logger
+
+    init(
+        pocketManager: PocketManagerProvider = AppContainer.shared.resolve(),
+        homepageTelemetry: HomepageTelemetry = HomepageTelemetry(),
+        logger: Logger = DefaultLogger.shared
+    ) {
         self.pocketManager = pocketManager
+        self.homepageTelemetry = homepageTelemetry
+        self.logger = logger
     }
 
     lazy var pocketSectionProvider: Middleware<AppState> = { state, action in
@@ -16,6 +25,13 @@ final class PocketMiddleware {
         case HomepageActionType.initialize,
             PocketActionType.enteredForeground:
             self.getPocketDataAndUpdateState(for: action)
+        case PocketActionType.tapOnHomepagePocketCell:
+            self.sendOpenPocketItemTelemetry(for: action)
+        case PocketActionType.viewedSection:
+            // TODO: FXIOS-11551 - need to add impression call
+            self.homepageTelemetry.sendPocketSectionCounter()
+        case ContextMenuActionType.tappedOnOpenNewPrivateTab:
+            self.sendOpenInPrivateTelemetry(for: action)
         default:
             break
         }
@@ -32,5 +48,29 @@ final class PocketMiddleware {
                 )
             )
         }
+    }
+
+    private func sendOpenPocketItemTelemetry(for action: Action) {
+        guard let config = (action as? PocketAction)?.telemetryConfig else {
+            self.logger.log(
+                "Unable to retrieve config for \(action.actionType)",
+                level: .debug,
+                category: .homepage
+            )
+            return
+        }
+        self.homepageTelemetry.sendTapOnPocketStoryCounter(position: config.position, isZeroSearch: config.isZeroSearch)
+    }
+
+    private func sendOpenInPrivateTelemetry(for action: Action) {
+        guard case .pocket = (action as? ContextMenuAction)?.section else {
+            self.logger.log(
+                "Unable to retrieve section for \(action.actionType)",
+                level: .debug,
+                category: .homepage
+            )
+            return
+        }
+        self.homepageTelemetry.sendOpenInPrivateTabEvent()
     }
 }

--- a/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
@@ -17,6 +17,21 @@ struct HomepageTelemetry {
         gleanWrapper.recordEvent(for: GleanMetrics.Homepage.privateModeToggle, extras: isPrivateModeExtra)
     }
 
+    // MARK: - Pocket
+    func sendTapOnPocketStoryCounter(position: Int, isZeroSearch: Bool = false) {
+        let originExtra: TelemetryWrapper.EventValue = isZeroSearch ? .fxHomepageOriginZeroSearch : .fxHomepageOriginOther
+        gleanWrapper.recordLabel(for: GleanMetrics.Pocket.openStoryOrigin, label: originExtra.rawValue)
+        gleanWrapper.recordLabel(for: GleanMetrics.Pocket.openStoryPosition, label: "position-\(position)")
+    }
+
+    func sendPocketSectionCounter() {
+        gleanWrapper.incrementCounter(for: GleanMetrics.Pocket.sectionImpressions)
+    }
+
+    func sendOpenInPrivateTabEvent() {
+        gleanWrapper.recordEvent(for: GleanMetrics.Pocket.openInPrivateTab)
+    }
+
     // MARK: - Customize Homepage
     func sendTapOnCustomizeHomepageTelemetry() {
         gleanWrapper.incrementCounter(for: GleanMetrics.FirefoxHomePage.customizeHomepageButton)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11524)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25084)

## :bulb: Description
Add pocket metrics for homepage. See more details in telemetry spreadsheet attached to epic. 

- firefox_home_page.pocket_stories_visible - can reuse legacy
- pocket.open_story_position - added 
- pocket.open_story_origin - added
- pocket.section_impressions - need to clarify with PM on more details; added a TODO comment with future ticket
- pocket.open_in_private_tab - added

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)