### PR TITLE
Improve MTE-4365 - testSearchSuggestions test

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -93,7 +93,7 @@ workflows:
             ls /Users/vagrant/git/DerivedData
     - xcode-test-without-building@0.4.0:
         run_if: '{{getenv "RUN_UI_TESTS" | eq "Run_UI_Tests"}}'
-        timeout: 600
+        timeout: 1200
         inputs:
         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.2
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -427,16 +427,20 @@ class SearchTests: BaseTestCase {
     private func typeTextAndValidateSearchSuggestions(text: String, isSwitchOn: Bool) {
         typeOnSearchBar(text: text)
         // Search suggestions are shown
+        let appendArrowBtn = app.tables.cells.buttons.matching(identifier: "appendUpLeftLarge")
         if isSwitchOn {
             mozWaitForElementToExist(app.staticTexts.elementContainingText("google"))
+            mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["Google Search"])
             XCTAssertTrue(app.staticTexts.elementContainingText("google").exists)
             mozWaitForElementToExist(app.tables.cells.staticTexts["g"])
-            XCTAssertTrue(app.tables.cells.count >= 4)
+            XCTAssertTrue(appendArrowBtn.count == 3)
         } else {
             mozWaitForElementToNotExist(app.tables.buttons[StandardImageIdentifiers.Large.appendUpLeft])
             mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["Firefox Suggest"])
             mozWaitForElementToExist(app.tables.cells.firstMatch)
-            XCTAssertTrue(app.tables.cells.count <= 3)
+            // If "Append Arrow buttons" are missing, then google search suggestions are missing
+            mozWaitForElementToNotExist(appendArrowBtn.element)
+            mozWaitForElementToNotExist(app.tables.cells.staticTexts["g"])
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4365

## :bulb: Description
Changing the way we validate suggestions on testSearchSuggestions.
Using append arrow button as a mark. If this is present then we show the search suggestions cells, if not, we only show the history cells.
