### PR TITLE
Bugfix FXIOS-11555  Lifecycle Observer Misses willEnterForeground on First Launch

### DIFF
--- a/focus-ios/Blockzilla/GleanUsageReportingMetricsService.swift
+++ b/focus-ios/Blockzilla/GleanUsageReportingMetricsService.swift
@@ -89,6 +89,9 @@ class GleanLifecycleObserver {
             name: UIApplication.didEnterBackgroundNotification,
             object: nil
         )
+        
+        // Handle the case where the app is already in the foreground when the observer is started
+        handleForegroundEvent()
     }
 
     func stopObserving() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11555)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Call handleForegroundEvent when registering the lifecycle observers to ensure the event is captured even if it has already occurred.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

