### PR TITLE
Bugfix MTE-4370 "Bitrise Xcode Check and Update" should query the latest available stacks

### DIFF
--- a/test-fixtures/update.py
+++ b/test-fixtures/update.py
@@ -38,6 +38,34 @@ def parse_semver(raw_str):
     else:
         return False
 
+def latest_stack():
+    try:
+        resp = requests.get(BITRISE_STACK_INFO)
+        resp_json = resp.json()['available_stacks']
+        keys = sorted([key for key in resp_json.keys() if 'osx-xcode-edge' not in key], reverse=True)
+        return keys[0]
+    except HTTPError as http_error:
+        print('An HTTP error has occurred: {http_error}')
+    except Exception as err:
+        print('An exception has occurred: {err}')
+        
+def latest_stable_stack():
+    try:
+        resp = requests.get(BITRISE_STACK_INFO)
+        resp_json = resp.json()['available_stacks']
+        keys = sorted([key for key in resp_json.keys() if '-edge' not in key], reverse=True)
+        return keys[0]
+    except HTTPError as http_error:
+        print('An HTTP error has occurred: {http_error}')
+    except Exception as err:
+        print('An exception has occurred: {err}')
+        
+def write_to_bitrise_yml(yaml, version):
+    yaml['workflows'][WORKFLOW]['meta']['bitrise.io']['stack'] = '{0}{1}'.format(pattern, version)
+    with open(tmp_file, 'w+') as tmpfile:
+        obj_yaml.dump(yaml, tmpfile)
+        copyfile(tmp_file, BITRISE_YML)
+        os.remove(tmp_file)
 
 def default_stack():
     try:
@@ -58,7 +86,8 @@ if __name__ == '__main__':
     4. modify bitrise.yml (update stack value)
     '''
 
-    default_semver = default_stack().split(pattern)[1]
+    latest_stable_semver = latest_stable_stack().split(pattern)[1]
+    latest_semver = latest_stack().split(pattern)[1]
     tmp_file = 'tmp.yml'
 
     with open(BITRISE_YML, 'r') as infile:
@@ -75,15 +104,28 @@ if __name__ == '__main__':
         
         # remove pattern prefix from current_semver to compare with largest
         current_semver = current_semver.split(pattern)[1]
-
-        if current_semver >= default_semver:
-            print('Xcode version unchanged or more recent! aborting.')
+        
+        print("current_semver: {0}".format(current_semver))
+        print("latest_stable_semver: {0}".format(latest_stable_semver))
+        print("latest_semver: {0}".format(latest_semver))
+        
+        # if we use an edge stack currently, see if there is a new stable version
+        if '-edge' in current_semver:
+            # if there is a stable stack of the same version or later, use stable stack.
+            # otherwise do nothing
+            if latest_stable_semver >= current_semver.replace('-edge', ''):
+                print("Stable version of Bitrise stack available: {0} ... updating bitrise.yml!".format(latest_stable_semver))
+                write_to_bitrise_yml(y, latest_stable_semver)
+            else:
+                print('No stable version of Bitrise stack available! aborting.')
+        # if we are using a stable stack, see if there is a new stable version
+        elif current_semver < latest_stable_semver:
+            print('New stable Bitrise stack available: {0} ... updating bitrise.yml!'.format(latest_stable_semver))
+            write_to_bitrise_yml(y, latest_stable_semver)
+        # if a new edge version is available, update bitrise.yml
+        elif current_semver < latest_semver:
+            print('New edge version of Bitrise stack available: {0} ... updating bitrise.yml!'.format(latest_semver))
+            write_to_bitrise_yml(y, latest_semver)
+        # we're using the absolutely latest version available
         else:
-            print('New Xcode version available: {0} ... updating bitrise.yml!'.format(default_semver))
-            # add prefix pattern back to be recognizable by bitrise
-            # as a valid stack value
-            y['workflows'][WORKFLOW]['meta']['bitrise.io']['stack'] = '{0}{1}'.format(pattern, default_semver)
-            with open(tmp_file, 'w+') as tmpfile:
-                obj_yaml.dump(y, tmpfile)
-                copyfile(tmp_file, BITRISE_YML)
-                os.remove(tmp_file)
+             print('Xcode version unchanged or more recent! aborting.')


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4370)

## :bulb: Description
The existing "Bitrise Xcode Check and Update" Github Actions checks for the "default stack" available from Bitrise, which is just the latest major release (".0" release). We need at least 16.2 for our work and this github actions fails to notify us for the new Bitrise stacks available.

The change consists of the following:
* If we use an `-edge` stack, query for the latest stable version of the stack. If there's a stable version, update bitrise.yml.
* If there's a newer stable version of the stack, update bitrise.yml.
* If we use a stable version of the stack, query for the latest (including edge) of the stack. If there's a newer stack, update bitrise.yml

I tested using the following cases. Latest available stack version is osx-xcode-16.3.x-edge. Latest stable is osx-xcode-16.2.x.
* Current stack: osx-xcode-16.2.x ➡️ bump to osx-xcode-16.3.x-edge
* Current stack: osx-xcode-16.2.x-edge ➡️ bump to osx-xcode-16.2.x
* Current stack: osx-xcode-16.1.x ➡️ bump to osx-xcode-16.2.x
* Current stack: osx-xcode-16.3.x ➡️  bump to osx-xcode-16.3.x-edge
* Current stack: osx-xcode-16.3.x-edge. No change

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

