### PR TITLE
Bugfix FXIOS-11039 Handle "Last bookmark" home screen quick action after deleting a bookmark

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -32,7 +32,8 @@ class BrowserViewController: UIViewController,
                              AddressToolbarContainerDelegate,
                              BookmarksRefactorFeatureFlagProvider,
                              BookmarksHandlerDelegate,
-                             FeatureFlaggable {
+                             FeatureFlaggable,
+                             CanRemoveQuickActionBookmark {
     private enum UX {
         static let ShowHeaderTapAreaHeight: CGFloat = 32
     }
@@ -281,6 +282,7 @@ class BrowserViewController: UIViewController,
     let downloadQueue: DownloadQueue
 
     private let bookmarksSaver: BookmarksSaver
+    let bookmarksHandler: BookmarksHandler
 
     var newTabSettings: NewTabPage {
         return NewTabAccessors.getNewTabPage(profile.prefs)
@@ -318,6 +320,7 @@ class BrowserViewController: UIViewController,
         self.logger = logger
         self.appAuthenticator = appAuthenticator
         self.bookmarksSaver = DefaultBookmarksSaver(profile: profile)
+        self.bookmarksHandler = profile.places
 
         super.init(nibName: nil, bundle: nil)
         didInit()
@@ -1744,6 +1747,7 @@ class BrowserViewController: UIViewController,
         profile.places.deleteBookmarksWithURL(url: urlString).uponQueue(.main) { result in
             guard result.isSuccess else { return }
             self.showBookmarkToast(urlString: urlString, title: title, action: .remove)
+            self.removeBookmarkShortcut()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -209,8 +209,7 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol,
                                      iconString: StandardImageIdentifiers.Large.bookmarkSlash,
                                      allowIconScaling: true,
                                      tapHandler: { _ in
-
-            self.viewModel.profile.places.deleteBookmarksWithURL(url: site.url).uponQueue(.main)  { result in
+            self.viewModel.profile.places.deleteBookmarksWithURL(url: site.url).uponQueue(.main) { result in
                 guard result.isSuccess else { return }
                 self.removeBookmarkShortcut()
             }

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -98,7 +98,7 @@ class LegacyHomepageViewController:
         )
         self.syncTabContextualHintViewController =
         ContextualHintViewController(with: syncTabContextualViewProvider, windowUUID: tabManager.windowUUID)
-        self.contextMenuHelper = HomepageContextMenuHelper(viewModel: viewModel, toastContainer: toastContainer)
+        self.contextMenuHelper = HomepageContextMenuHelper(profile: profile, viewModel: viewModel, toastContainer: toastContainer)
 
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter

--- a/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/LegacyHomepageViewController.swift
@@ -98,7 +98,11 @@ class LegacyHomepageViewController:
         )
         self.syncTabContextualHintViewController =
         ContextualHintViewController(with: syncTabContextualViewProvider, windowUUID: tabManager.windowUUID)
-        self.contextMenuHelper = HomepageContextMenuHelper(profile: profile, viewModel: viewModel, toastContainer: toastContainer)
+        self.contextMenuHelper = HomepageContextMenuHelper(
+            profile: profile,
+            viewModel: viewModel,
+            toastContainer: toastContainer
+        )
 
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContextMenuHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContextMenuHelperTests.swift
@@ -35,7 +35,7 @@ class ContextMenuHelperTests: XCTestCase {
                                           isPrivate: false,
                                           tabManager: MockTabManager(),
                                           theme: LightTheme())
-        let helper = HomepageContextMenuHelper(viewModel: viewModel, toastContainer: UIView())
+        let helper = HomepageContextMenuHelper(profile: profile, viewModel: viewModel, toastContainer: UIView())
 
         helper.sendHistoryHighlightContextualTelemetry(type: .remove)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -39,6 +39,7 @@ final class BrowserCoordinatorTests: XCTestCase, FeatureFlaggable {
     }
 
     override func tearDown() {
+        profile.shutdown()
         self.mockRouter = nil
         self.profile = nil
         self.overlayModeManager = nil

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultBookmarksSaverTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/DefaultBookmarksSaverTests.swift
@@ -24,6 +24,7 @@ final class DefaultBookmarksSaverTests: XCTestCase {
     }
 
     override func tearDown() {
+        mockProfile.shutdown()
         mockProfile = nil
         testBookmarkGUID = nil
         testFolderGUID = nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11039)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24090)

## :bulb: Description
- Properly handle updating or removing the "Last bookmark" home screen quick action when the most recent bookmark was deleted from either a homepage or weblink context menu

### 🎥 Videos
<details>
<summary>Before</summary>

Homepage context menu: 

https://github.com/user-attachments/assets/0361bca5-5b9e-4a9c-a8fc-4921e5146224

Weblink context menu:

https://github.com/user-attachments/assets/39443cde-b69e-49e7-9f67-1dd0e75a8bd4

</details>

<details>
<summary>After</summary>

Homepage context menu: 

https://github.com/user-attachments/assets/839e9629-f21c-4948-8515-beb6601e884e

Weblink context menu:

https://github.com/user-attachments/assets/b8dea922-5bbd-4bc9-bc0e-e601a23be2a0

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

