### PR TITLE
Bugfix FXIOS-11561 Reset Glean in test teardown for tests directly hitting Glean

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerTests.swift
@@ -36,7 +36,6 @@ class BrowserViewControllerTests: XCTestCase {
         profile = nil
         tabManager = nil
         browserViewController = nil
-        Glean.shared.registerPings(GleanMetrics.Pings.shared)
         Glean.shared.resetGlean(clearStores: true)
         super.tearDown()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
@@ -13,6 +13,12 @@ class RecordedNimbusContextTests: XCTestCase {
     override func setUp() {
         Glean.shared.enableTestingMode()
         Glean.shared.resetGlean(clearStores: true)
+        super.setUp()
+    }
+
+    override func tearDown() {
+        Glean.shared.resetGlean(clearStores: true)
+        super.tearDown()
     }
 
     /**


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25164)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
I think that we get some weird glean side affects if we are not tearing down tests correctly. Not sure if this fixes the test slowness but here is hoping.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

