### PR TITLE
Bugfix FXIOS-11566 - [Toolbar Redesign] - After switching from portrait to landscape or vice versa the search term in address bar is empty

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -229,7 +229,7 @@ final class AddressToolbarContainer: UIView,
 
             if shouldSwitchToolbars {
                 switchToolbars()
-                guard model?.shouldSelectSearchTerm == false else { return }
+                guard model?.shouldSelectSearchTerm == false, model?.isEditing == true else { return }
                 store.dispatch(
                     ToolbarAction(
                         searchTerm: searchTerm,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11566)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25179)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Add additional check before dispatching `didSetSearchTerm` action.

### Video
https://github.com/user-attachments/assets/9e773520-027c-442b-b4e3-b2d571f9ea18

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

