### PR TITLE
Refactor FXIOS-7301 - Remove 2 closure_body_length violations from ImageButtonWithLabel.swift and DefaultBrowserOnboardingView.swift, and decrease threshold

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -103,8 +103,8 @@ line_length:
   ignores_interpolated_strings: true
 
 closure_body_length:
-  warning: 50
-  error: 50
+  warning: 49
+  error: 49
 
 file_header:
   required_string: |

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -91,6 +91,18 @@ struct ImageButtonWithLabel: View {
         }
     }
 
+    var background: some View {
+        return ContainerRelativeShape()
+            .fill(
+                LinearGradient(
+                    gradient: Gradient(colors: link.backgroundColors),
+                    startPoint: .bottomLeading,
+                    endPoint: .topTrailing
+                )
+            )
+            .widgetAccentableCompat()
+    }
+
     var label: some View {
         return VStack(alignment: .leading) {
             if isSmall {

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -77,19 +77,7 @@ struct ImageButtonWithLabel: View {
 
                 VStack(alignment: .center, spacing: 50.0) {
                     HStack(alignment: .top) {
-                        VStack(alignment: .leading) {
-                            if isSmall {
-                                Text(link.label)
-                                    .font(.headline)
-                                    .minimumScaleFactor(0.75)
-                                    .layoutPriority(1000)
-                            } else {
-                                Text(link.label)
-                                    .font(.footnote)
-                                    .minimumScaleFactor(0.75)
-                                    .layoutPriority(1000)
-                            }
-                        }
+                        label
                         Spacer()
                         if link == .search && isSmall {
                             Image(decorative: StandardImageIdentifiers.Large.search)

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -83,7 +83,7 @@ struct ImageButtonWithLabel: View {
         }
     }
 
-    var background: some View {
+    private var background: some View {
         return ContainerRelativeShape()
             .fill(
                 LinearGradient(

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -82,12 +82,7 @@ struct ImageButtonWithLabel: View {
                         logo
                     }
                     if isSmall {
-                        HStack(alignment: .bottom) {
-                            Spacer()
-                            Image(decorative: "faviconFox")
-                                .scaledToFit()
-                                .frame(height: 24.0)
-                        }
+                        icon
                     }
                 }
                 .foregroundColor(Color("widgetLabelColors"))

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -64,15 +64,7 @@ struct ImageButtonWithLabel: View {
         Link(destination: isSmall ? link.smallWidgetUrl : link.mediumWidgetUrl) {
             ZStack(alignment: .leading) {
                 if !isSmall {
-                    ContainerRelativeShape()
-                        .fill(
-                            LinearGradient(
-                                gradient: Gradient(colors: link.backgroundColors),
-                                startPoint: .bottomLeading,
-                                endPoint: .topTrailing
-                            )
-                        )
-                        .widgetAccentableCompat()
+                    background
                 }
 
                 VStack(alignment: .center, spacing: 50.0) {

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -119,5 +119,17 @@ struct ImageButtonWithLabel: View {
             }
         }
     }
+
+    var logo: some View {
+        if link == .search && isSmall {
+            return Image(decorative: StandardImageIdentifiers.Large.search)
+                .scaledToFit()
+                .frame(height: 24.0)
+        } else {
+            return Image(decorative: link.imageName)
+                .scaledToFit()
+                .frame(height: 24.0)
+        }
+    }
 }
 #endif

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -111,7 +111,7 @@ struct ImageButtonWithLabel: View {
         }
     }
 
-    var logo: some View {
+    private var logo: some View {
         if link == .search && isSmall {
             return Image(decorative: StandardImageIdentifiers.Large.search)
                 .scaledToFit()

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -123,5 +123,14 @@ struct ImageButtonWithLabel: View {
                 .frame(height: 24.0)
         }
     }
+
+    var icon: some View {
+        return HStack(alignment: .bottom) {
+            Spacer()
+            Image(decorative: "faviconFox")
+                .scaledToFit()
+                .frame(height: 24.0)
+        }
+    }
 }
 #endif

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -79,15 +79,7 @@ struct ImageButtonWithLabel: View {
                     HStack(alignment: .top) {
                         label
                         Spacer()
-                        if link == .search && isSmall {
-                            Image(decorative: StandardImageIdentifiers.Large.search)
-                                .scaledToFit()
-                                .frame(height: 24.0)
-                        } else {
-                            Image(decorative: link.imageName)
-                                .scaledToFit()
-                                .frame(height: 24.0)
-                        }
+                        logo
                     }
                     if isSmall {
                         HStack(alignment: .bottom) {

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -115,5 +115,21 @@ struct ImageButtonWithLabel: View {
             }
         }
     }
+
+    var label: some View {
+        return VStack(alignment: .leading) {
+            if isSmall {
+                Text(link.label)
+                    .font(.headline)
+                    .minimumScaleFactor(0.75)
+                    .layoutPriority(1000)
+            } else {
+                Text(link.label)
+                    .font(.footnote)
+                    .minimumScaleFactor(0.75)
+                    .layoutPriority(1000)
+            }
+        }
+    }
 }
 #endif

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -95,7 +95,7 @@ struct ImageButtonWithLabel: View {
             .widgetAccentableCompat()
     }
 
-    var label: some View {
+    private var label: some View {
         return VStack(alignment: .leading) {
             if isSmall {
                 Text(link.label)

--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -123,7 +123,7 @@ struct ImageButtonWithLabel: View {
         }
     }
 
-    var icon: some View {
+    private var icon: some View {
         return HStack(alignment: .bottom) {
             Spacer()
             Image(decorative: "faviconFox")

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -28,7 +28,7 @@ struct DefaultBrowserOnboardingView: View {
             .foregroundColor(.secondOnboardingScreenText)
             Spacer()
             defaultBrowserSettingsButton
-            bottomButton
+            defaultBrowserSkipButton
         }
         .padding([.leading, .trailing], .viewPadding)
         .navigationBarHidden(true)
@@ -78,7 +78,7 @@ struct DefaultBrowserOnboardingView: View {
         })
     }
 
-    private var bottomButton: some View {
+    private var defaultBrowserSkipButton: some View {
         return Button(action: {
             viewModel.send(.defaultBrowserSkip)
         }, label: {

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -15,7 +15,7 @@ struct DefaultBrowserOnboardingView: View {
         VStack {
             HStack {
                 Spacer()
-                defaultBrowserCloseButton
+                closeOnboardingButton
             }
             Image.huggingFocus
                 .resizable()
@@ -39,7 +39,7 @@ struct DefaultBrowserOnboardingView: View {
         }
     }
 
-    private var defaultBrowserCloseButton: some View {
+    private var closeOnboardingButton: some View {
         return Button(action: {
             viewModel.send(.defaultBrowserCloseTapped)
         }, label: {

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -26,11 +26,7 @@ struct DefaultBrowserOnboardingView: View {
                 .scaledToFit()
                 .frame(maxHeight: .imageMaxHeight)
             VStack {
-                Text(viewModel.defaultBrowserConfig.title)
-                    .bold()
-                    .font(.system(size: .titleSize))
-                    .multilineTextAlignment(.center)
-                    .padding(.bottom, .titleBottomPadding)
+                title
                 VStack(alignment: .leading) {
                     Text(viewModel.defaultBrowserConfig.firstSubtitle)
                         .padding(.bottom, .firstSubtitleBottomPadding)

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -32,18 +32,7 @@ struct DefaultBrowserOnboardingView: View {
             .foregroundColor(.secondOnboardingScreenText)
             Spacer()
             topButton
-            Button(action: {
-                viewModel.send(.defaultBrowserSkip)
-            }, label: {
-                Text(viewModel.defaultBrowserConfig.bottomButtonTitle)
-                    .foregroundColor(.black)
-                    .font(.body16Bold)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: .buttonHeight)
-                    .background(Color.secondOnboardingScreenBottomButton)
-                    .cornerRadius(.radius)
-            })
-            .padding(.bottom, .skipButtonPadding)
+            bottomButton
         }
         .padding([.leading, .trailing], .viewPadding)
         .navigationBarHidden(true)

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -80,6 +80,20 @@ struct DefaultBrowserOnboardingView: View {
         }
         .font(.body16)
     }
+
+    private var topButton: some View {
+        return Button(action: {
+            viewModel.send(.defaultBrowserSettingsTapped)
+        }, label: {
+            Text(viewModel.defaultBrowserConfig.topButtonTitle)
+                .foregroundColor(.systemBackground)
+                .font(.body16Bold)
+                .frame(maxWidth: .infinity)
+                .frame(height: .buttonHeight)
+                .background(Color.actionButton)
+                .cornerRadius(.radius)
+        })
+    }
 }
 
 fileprivate extension CGFloat {

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -76,6 +76,15 @@ struct DefaultBrowserOnboardingView: View {
             .multilineTextAlignment(.center)
             .padding(.bottom, .titleBottomPadding)
     }
+
+    private var subtitle: some View {
+        return VStack(alignment: .leading) {
+            Text(viewModel.defaultBrowserConfig.firstSubtitle)
+                .padding(.bottom, .firstSubtitleBottomPadding)
+            Text(viewModel.defaultBrowserConfig.secondSubtitle)
+        }
+        .font(.body16)
+    }
 }
 
 fileprivate extension CGFloat {

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -72,6 +72,14 @@ struct DefaultBrowserOnboardingView: View {
             viewModel.send(.defaultBrowserAppeared)
         }
     }
+
+    private var title: some View {
+        return Text(viewModel.defaultBrowserConfig.title)
+            .bold()
+            .font(.system(size: .titleSize))
+            .multilineTextAlignment(.center)
+            .padding(.bottom, .titleBottomPadding)
+    }
 }
 
 fileprivate extension CGFloat {

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -28,7 +28,7 @@ struct DefaultBrowserOnboardingView: View {
             .foregroundColor(.secondOnboardingScreenText)
             Spacer()
             defaultBrowserSettingsButton
-            defaultBrowserSkipButton
+            skipOnboardingButton
         }
         .padding([.leading, .trailing], .viewPadding)
         .navigationBarHidden(true)
@@ -78,7 +78,7 @@ struct DefaultBrowserOnboardingView: View {
         })
     }
 
-    private var defaultBrowserSkipButton: some View {
+    private var skipOnboardingButton: some View {
         return Button(action: {
             viewModel.send(.defaultBrowserSkip)
         }, label: {

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -27,7 +27,7 @@ struct DefaultBrowserOnboardingView: View {
             }
             .foregroundColor(.secondOnboardingScreenText)
             Spacer()
-            defaultBrowserSettingsButton
+            openSettingsButton
             skipOnboardingButton
         }
         .padding([.leading, .trailing], .viewPadding)
@@ -64,7 +64,7 @@ struct DefaultBrowserOnboardingView: View {
         .font(.body16)
     }
 
-    private var defaultBrowserSettingsButton: some View {
+    private var openSettingsButton: some View {
         return Button(action: {
             viewModel.send(.defaultBrowserSettingsTapped)
         }, label: {

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -43,6 +43,14 @@ struct DefaultBrowserOnboardingView: View {
         }
     }
 
+    private var closeButton: some View {
+        return Button(action: {
+            viewModel.send(.defaultBrowserCloseTapped)
+        }, label: {
+            Image.close
+        })
+    }
+
     private var title: some View {
         return Text(viewModel.defaultBrowserConfig.title)
             .bold()

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -15,11 +15,7 @@ struct DefaultBrowserOnboardingView: View {
         VStack {
             HStack {
                 Spacer()
-                Button(action: {
-                    viewModel.send(.defaultBrowserCloseTapped)
-                }, label: {
-                    Image.close
-                })
+                closeButton
             }
             Image.huggingFocus
                 .resizable()

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -27,12 +27,7 @@ struct DefaultBrowserOnboardingView: View {
                 .frame(maxHeight: .imageMaxHeight)
             VStack {
                 title
-                VStack(alignment: .leading) {
-                    Text(viewModel.defaultBrowserConfig.firstSubtitle)
-                        .padding(.bottom, .firstSubtitleBottomPadding)
-                    Text(viewModel.defaultBrowserConfig.secondSubtitle)
-                }
-                .font(.body16)
+                subtitle
             }
             .foregroundColor(.secondOnboardingScreenText)
             Spacer()

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -23,7 +23,7 @@ struct DefaultBrowserOnboardingView: View {
                 .frame(maxHeight: .imageMaxHeight)
             VStack {
                 title
-                subtitle
+                subtitles
             }
             .foregroundColor(.secondOnboardingScreenText)
             Spacer()
@@ -55,7 +55,7 @@ struct DefaultBrowserOnboardingView: View {
             .padding(.bottom, .titleBottomPadding)
     }
 
-    private var subtitle: some View {
+    private var subtitles: some View {
         return VStack(alignment: .leading) {
             Text(viewModel.defaultBrowserConfig.firstSubtitle)
                 .padding(.bottom, .firstSubtitleBottomPadding)

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -15,7 +15,7 @@ struct DefaultBrowserOnboardingView: View {
         VStack {
             HStack {
                 Spacer()
-                closeButton
+                defaultBrowserCloseButton
             }
             Image.huggingFocus
                 .resizable()
@@ -39,7 +39,7 @@ struct DefaultBrowserOnboardingView: View {
         }
     }
 
-    private var closeButton: some View {
+    private var defaultBrowserCloseButton: some View {
         return Button(action: {
             viewModel.send(.defaultBrowserCloseTapped)
         }, label: {

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -84,6 +84,21 @@ struct DefaultBrowserOnboardingView: View {
                 .cornerRadius(.radius)
         })
     }
+
+    private var bottomButton: some View {
+        return Button(action: {
+            viewModel.send(.defaultBrowserSkip)
+        }, label: {
+            Text(viewModel.defaultBrowserConfig.bottomButtonTitle)
+                .foregroundColor(.black)
+                .font(.body16Bold)
+                .frame(maxWidth: .infinity)
+                .frame(height: .buttonHeight)
+                .background(Color.secondOnboardingScreenBottomButton)
+                .cornerRadius(.radius)
+        })
+        .padding(.bottom, .skipButtonPadding)
+    }
 }
 
 fileprivate extension CGFloat {

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -27,7 +27,7 @@ struct DefaultBrowserOnboardingView: View {
             }
             .foregroundColor(.secondOnboardingScreenText)
             Spacer()
-            topButton
+            defaultBrowserSettingsButton
             bottomButton
         }
         .padding([.leading, .trailing], .viewPadding)
@@ -64,7 +64,7 @@ struct DefaultBrowserOnboardingView: View {
         .font(.body16)
     }
 
-    private var topButton: some View {
+    private var defaultBrowserSettingsButton: some View {
         return Button(action: {
             viewModel.send(.defaultBrowserSettingsTapped)
         }, label: {

--- a/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
+++ b/focus-ios/BlockzillaPackage/Sources/Onboarding/SwiftUI Onboarding/DefaultBrowserOnboardingView.swift
@@ -31,17 +31,7 @@ struct DefaultBrowserOnboardingView: View {
             }
             .foregroundColor(.secondOnboardingScreenText)
             Spacer()
-            Button(action: {
-                viewModel.send(.defaultBrowserSettingsTapped)
-            }, label: {
-                Text(viewModel.defaultBrowserConfig.topButtonTitle)
-                    .foregroundColor(.systemBackground)
-                    .font(.body16Bold)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: .buttonHeight)
-                    .background(Color.actionButton)
-                    .cornerRadius(.radius)
-            })
+            topButton
             Button(action: {
                 viewModel.send(.defaultBrowserSkip)
             }, label: {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7301)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16442)

## :bulb: Description
This PR removes 2 `closure_body_length` violations from the `ImageButtonWithLabel.swift` file and `DefaultBrowserOnboardingView.swift` file. The second one is from Focus project, but the SwiftLint showed it as a warning when I decreased the threshold. 

This PR extract some views into new properties to decrease the length of the closure. The threshold was defined to 49.

This PR is part of a series of PRs described here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2197676804 and here https://github.com/mozilla-mobile/firefox-ios/issues/16442#issuecomment-2549957143.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

