### PR TITLE
Several MTE-4375 - fixed for tests on iOS 17 and 15

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -12,9 +12,6 @@ let newTopSite = [
     "topSiteLabel": "Mozilla",
     "bookmarkLabel": "Mozilla - Internet for people, not profit (US)"
 ]
-let newTopSiteiOS15 = [
-    "bookmarkLabel": "Mozilla — Internet for people, not profit"
-]
 let allDefaultTopSites = ["Facebook", "YouTube", "Amazon", "Wikipedia", "X"]
 
 class ActivityStreamTest: BaseTestCase {
@@ -43,6 +40,7 @@ class ActivityStreamTest: BaseTestCase {
         XCUIDevice.shared.orientation = .portrait
         super.tearDown()
     }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2273342
     // Smoketest
     func testDefaultSites() throws {
@@ -63,6 +61,7 @@ class ActivityStreamTest: BaseTestCase {
             ]
         )
     }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2272218
     func testTopSites2Add() {
         if iPad() {
@@ -71,6 +70,7 @@ class ActivityStreamTest: BaseTestCase {
             checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 8)
         }
     }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2272219
     func testTopSitesRemoveAllExceptDefaultClearPrivateData() {
         waitForExistence(app.links.staticTexts["Internet for people, not profit — Mozilla (US)"], timeout: TIMEOUT_LONG)
@@ -91,6 +91,7 @@ class ActivityStreamTest: BaseTestCase {
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         mozWaitForElementToNotExist(app.cells.staticTexts[newTopSite["bookmarkLabel"]!])
     }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2272220
     func testTopSitesRemoveAllExceptPinnedClearPrivateData() {
         waitForExistence(TopSiteCellgroup)
@@ -108,23 +109,11 @@ class ActivityStreamTest: BaseTestCase {
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         let topSitesCells = app.collectionViews.links["TopSitesCell"]
-        if #available(iOS 16, *) {
-            waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
-        } else {
-            waitForExistence(topSitesCells.staticTexts[newTopSiteiOS15["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
-        }
+        waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
-        if #available(iOS 16, *) {
-            topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].press(forDuration: 1)
-        } else {
-            topSitesCells.staticTexts[newTopSiteiOS15["bookmarkLabel"]!].press(forDuration: 1)
-        }
+        topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].press(forDuration: 1)
         selectOptionFromContextMenu(option: "Pin")
-        if #available(iOS 16, *) {
-            waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
-        } else {
-            waitForExistence(topSitesCells.staticTexts[newTopSiteiOS15["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
-        }
+        waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!], timeout: TIMEOUT_LONG)
         waitForExistence(app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton])
         navigator.performAction(Action.CloseURLBarOpen)
         navigator.nowAt(NewTabScreen)
@@ -132,13 +121,10 @@ class ActivityStreamTest: BaseTestCase {
         navigator.goto(ClearPrivateDataSettings)
         navigator.performAction(Action.AcceptClearPrivateData)
         navigator.goto(HomePanelsScreen)
-        if #available(iOS 16, *) {
-            waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!])
-        } else {
-            waitForExistence(topSitesCells.staticTexts[newTopSiteiOS15["bookmarkLabel"]!])
-        }
+        waitForExistence(topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!])
         checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
     }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2272514
     func testTopSitesShiftAfterRemovingOne() {
         // Check top site in first and second cell
@@ -169,6 +155,7 @@ class ActivityStreamTest: BaseTestCase {
             "First top site does not match"
         )
     }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2273338
     // Smoketest
     func testTopSitesOpenInNewPrivateTab() throws {
@@ -191,6 +178,7 @@ class ActivityStreamTest: BaseTestCase {
         waitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField],
                              value: "wikipedia.org")
     }
+
     // Smoketest
     func testTopSitesOpenInNewPrivateTabDefaultTopSite() {
         XCTExpectFailure("The app was not launched", strict: false) {
@@ -217,12 +205,14 @@ class ActivityStreamTest: BaseTestCase {
         waitForExistence(app.otherElements["Tabs Tray"].collectionViews.cells.firstMatch)
         XCTAssertEqual(numTabsOpen, 1, "New tab not open")
     }
+
     private func checkNumberOfExpectedTopSites(numberOfExpectedTopSites: Int) {
         mozWaitForElementToExist(app.links[TopSites.itemCell])
         let numberOfTopSites = app.collectionViews.links.matching(identifier: TopSites.itemCell).count
         mozWaitForElementToExist(app.collectionViews.links.matching(identifier: TopSites.itemCell).firstMatch)
         XCTAssertEqual(numberOfTopSites, numberOfExpectedTopSites, "The number of Top Sites is not correct")
     }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2273339
     func testContextMenuInLandscape() {
         // For iPhone test is failing to find top sites in landscape
@@ -244,6 +234,7 @@ class ActivityStreamTest: BaseTestCase {
             XCUIDevice.shared.orientation = .portrait
         }
     }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2436086
     func testLongTapOnTopSiteOptions() {
         waitForExistence(app.links[TopSites.itemCell])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PocketTests.swift
@@ -73,7 +73,11 @@ class PocketTests: BaseTestCase {
         // The url textField is not empty
         let url = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
         XCTAssertNotEqual(url.value as? String, "", "The url textField is empty")
-        app.buttons["TabToolbar.backButton"].waitAndTap()
+        let backButton = app.buttons[AccessibilityIdentifiers.Toolbar.backButton]
+        backButton.waitAndTap()
+        if #unavailable(iOS 17) {
+            backButton.waitAndTap()
+        }
 
         scrollToElement(app.buttons[AccessibilityIdentifiers.FirefoxHomepage.Pocket.footerLearnMoreLabel],
                         direction: SwipeDirection.up,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -126,7 +126,8 @@ class SearchTests: BaseTestCase {
         // Copy, Paste and Go to url
         navigator.goto(URLBarOpen)
         typeOnSearchBar(text: "www.mozilla.org")
-        if iPad() {
+        if #available(iOS 17, *), ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 17
+            || iPad() {
             urlBarAddress.waitAndTap()
             urlBarAddress.waitAndTap()
         } else {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4375

## :bulb: Description
Fixes for testCopyPasteComplete, testPocketEnabledByDefault and testTopSitesRemoveAllExceptPinnedClearPrivateData