### PR TITLE
Bugfix FXIOS-11514 ⁃ Weird behavior when closing all tabs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
@@ -323,7 +323,7 @@ class TopTabDisplayManager: NSObject {
     func performCloseAction(for tab: Tab) {
         guard !isDragging else { return }
 
-        getTabs { [weak self] tabsToDisplay in
+        getTabs { [weak self] _ in
             self?.tabManager.removeTabWithCompletion(tab.tabUUID, completion: nil)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabDisplayManager.swift
@@ -324,17 +324,7 @@ class TopTabDisplayManager: NSObject {
         guard !isDragging else { return }
 
         getTabs { [weak self] tabsToDisplay in
-            guard let self else { return }
-            // If it is the last tab of regular mode we automatically create an new tab
-            if !self.isPrivate,
-               tabsToDisplay.count == 1 {
-                self.tabManager.removeTabWithCompletion(tab.tabUUID) {
-                    self.tabManager.selectTab(self.tabManager.addTab())
-                }
-                return
-            }
-
-            self.tabManager.removeTabWithCompletion(tab.tabUUID, completion: nil)
+            self?.tabManager.removeTabWithCompletion(tab.tabUUID, completion: nil)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11514)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25069)

## :bulb: Description
After closing tabs code refactor, is no more necessary to execute another code for non private and one last tab case

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

