### PR TITLE
Add FXIOS-11580 #25211 support to allow download of png and jpeg extension files

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/DownloadHelper/MIMEType.swift
+++ b/firefox-ios/Client/Frontend/Browser/DownloadHelper/MIMEType.swift
@@ -38,7 +38,9 @@ struct MIMEType {
     private static let downloadableTypes: [String] = [
         MIMEType.PDF,
         MIMEType.OpenDocument,
-        MIMEType.MicrosoftWord
+        MIMEType.MicrosoftWord,
+        MIMEType.PNG,
+        MIMEType.JPEG
     ]
 
     static func canShowInWebView(_ mimeType: String) -> Bool {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11580)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25211)

## :bulb: Description
Support download of jpeg and png extension files

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

