### PR TITLE
Add FXIOS-11547 Limit iOS 15 - iOS 17 devices to Light mode only App Icons in the App Icon Selection screen

### DIFF
--- a/BrowserKit/Sources/Common/Theming/ThemeType.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeType.swift
@@ -4,12 +4,23 @@
 
 import Foundation
 import UIKit
+import SwiftUI
 
 public enum ThemeType: String {
     case light = "normal" // This needs to match the string used in the legacy system
     case dark
     case privateMode
     case nightMode
+
+    /// Returns the SwiftUI ColorScheme for this theme (e.g. to use for image asset selection).
+    public var colorScheme: ColorScheme {
+        switch self {
+        case .light:
+            return ColorScheme.light
+        case .dark, .nightMode, .privateMode:
+            return ColorScheme.dark
+        }
+    }
 
     public func getInterfaceStyle() -> UIUserInterfaceStyle {
         return switch self {

--- a/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
@@ -16,6 +16,7 @@ struct AppIconView: View, ThemeApplicable {
     // FIXME FXIOS-11472 Improve our SwiftUI theming
     @Environment(\.themeManager)
     var themeManager
+    @State var currentTheme: Theme = LightTheme()
     @State private var themeColors: ThemeColourPalette = LightTheme().colors
 
     struct UX {
@@ -25,6 +26,8 @@ struct AppIconView: View, ThemeApplicable {
         static let itemPaddingVertical: CGFloat = 2
         static let appIconSize: CGFloat = 50
         static let appIconBorderWidth: CGFloat = 1
+        static let appIconLightBackgroundColor = Color.white
+        static let appIconDarkBackgroundColor = UIColor(rgb: 33).color
     }
 
     var selectionImageAccessibilityLabel: String {
@@ -59,6 +62,15 @@ struct AppIconView: View, ThemeApplicable {
         }
     }
 
+    /// Devices prior to iOS 18 cannot change their icon display mode with their system settings
+    var forceLightTheme: Bool {
+        if #available(iOS 18, *) {
+            return false
+        } else {
+            return true
+        }
+    }
+
     private func button(for image: UIImage) -> some View {
         Button(action: {
             setAppIcon(appIcon)
@@ -68,6 +80,18 @@ struct AppIconView: View, ThemeApplicable {
                 Image(uiImage: image)
                     .resizable()
                     .frame(width: UX.appIconSize, height: UX.appIconSize)
+                    .background(
+                        forceLightTheme
+                        ? UX.appIconLightBackgroundColor
+                        : UX.appIconDarkBackgroundColor
+                    )
+                    // Pre iOS 18, force Light mode for the icons since users will only ever see Light home screen icons
+                    // NOTE: This fix does not work on iOS15 but it's a small user base
+                    .colorScheme(
+                        forceLightTheme
+                        ? ColorScheme.light
+                        : currentTheme.type.colorScheme
+                    )
                     .cornerRadius(UX.cornerRadius)
                     .overlay(
                         // Add rounded border
@@ -91,6 +115,7 @@ struct AppIconView: View, ThemeApplicable {
     }
 
     func applyTheme(theme: Theme) {
+        self.currentTheme = theme
         self.themeColors = theme.colors
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
@@ -80,13 +80,15 @@ struct AppIconView: View, ThemeApplicable {
                 Image(uiImage: image)
                     .resizable()
                     .frame(width: UX.appIconSize, height: UX.appIconSize)
+                    // Note: Do not fallback to the current app theme, because the user can view settings in the private mode
+                    // theme, but app icons can only be Light or Dark
                     .background(
                         forceLightTheme
                         ? UX.appIconLightBackgroundColor
                         : UX.appIconDarkBackgroundColor
                     )
                     // Pre iOS 18, force Light mode for the icons since users will only ever see Light home screen icons
-                    // NOTE: This fix does not work on iOS15 but it's a small user base
+                    // Note: This fix does not work on iOS15 but it's a small user base
                     .colorScheme(
                         forceLightTheme
                         ? ColorScheme.light


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11547)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25142)

## :bulb: Description

This PR is for the App Icon Selection screen in Settings > App Icon.

When on a device pre-iOS 18, only show icons in Light mode. This is because there is no system dark mode for app icons on the home screen, so to show dark variants is misleading.

### Demo

Note how the iOS 18 sim on the very right can show a dark "Default" icon and all the dark variants for the other app icons. For iOS 15 - iOS 17, we show Light "Default" and Light variants, even in Private mode theme (achieved by opening a private tab and entering Settings > App Icon).

<img height="400" alt="Screenshot 2025-03-10 at 4 40 58 PM" src="https://github.com/user-attachments/assets/c69fbbe1-d93e-4fb0-8662-730071c0e669" />

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

