### PR TITLE
 Add FXIOS-11520 [App Icon 2025] Adjust localized string key for alternative gradient icons (manual backport #25168)

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2545,7 +2545,7 @@ extension String {
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the artsy Firefox for iOS icon of a funny fox lying on top of a globe.")
 
                 public static let OrangeGradient = MZLocalizedString(
-                    key: "Settings.AppIconSelection.AppIconNames.Lazy.OrangeGradient.Title.v136",
+                    key: "Settings.AppIconSelection.AppIconNames.OrangeGradient.Title.v136",
                     tableName: "AppIconSelection",
                     value: "Orange Gradient",
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox icon with an orange gradient background.")
@@ -2569,7 +2569,7 @@ extension String {
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a fox logo.")
 
                 public static let RedGradient = MZLocalizedString(
-                    key: "Settings.AppIconSelection.AppIconNames.Lazy.RedGradient.Title.v136",
+                    key: "Settings.AppIconSelection.AppIconNames.RedGradient.Title.v136",
                     tableName: "AppIconSelection",
                     value: "Red Gradient",
                     comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of the Firefox icon with a red gradient background.")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Manual backport of https://github.com/mozilla-mobile/firefox-ios/pull/25168 due to some wonky merge issues from conflicting backports in [closed backport PR](https://github.com/mozilla-mobile/firefox-ios/pull/25218/files).

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

