### PR TITLE
Add FXIOS-11498 [Homepage] behavioral targeting event for microsurvey

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -162,6 +162,12 @@ final class HomepageViewController: UIViewController,
         addTapGestureRecognizerToDismissKeyboard()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        /// Used as a trigger for showing a microsurvey based on viewing the homepage
+        Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         stopCFRsTimer()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11498)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25025)

## :bulb: Description
Add behavioral targeting event that was used in legacy to trigger whether to show a microsurvey

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

