### PR TITLE
FIX FXIOS-11560 Default isBookmarked to false instead of nil and explicitly set it to nil when we need it

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
@@ -37,7 +37,7 @@ class SearchViewModel: FeatureFlaggable, LoaderListener {
 
     var historySites: [Site] {
         delegate?.searchData.compactMap { $0 }
-            .filter { $0.isBookmarked == nil || $0.isBookmarked == false } ?? []
+            .filter { $0.isBookmarked == false } ?? []
     }
 
     private let maxNumOfFirefoxSuggestions: Int32 = 1

--- a/firefox-ios/Storage/SQL/SQLiteHistoryFactories.swift
+++ b/firefox-ios/Storage/SQL/SQLiteHistoryFactories.swift
@@ -17,7 +17,7 @@ extension BrowserDBSQLite {
 
         // FXIOS-10996 improved our `Site` type to have strict unique IDs. But this `historyID` field was previously
         // optional, so we need to migrate users over in v136. Otherwise users will lose all their pinned top sites.
-        var site = Site.createBasicSite(id: id, url: url, title: title)
+        var site = Site.createBasicSite(id: id, url: url, title: title, isBookmarked: nil)
 
         // Extract a boolean from the row if it's present.
         if let isBookmarked = row["is_bookmarked"] as? Int {

--- a/firefox-ios/Storage/Sites/Site.swift
+++ b/firefox-ios/Storage/Sites/Site.swift
@@ -53,7 +53,7 @@ public struct Site: Identifiable, Hashable, Equatable, Codable, CustomStringConv
         id: Int? = nil,
         url: String,
         title: String,
-        isBookmarked: Bool? = nil,
+        isBookmarked: Bool? = false,
         faviconResource: SiteResource? = nil
     ) -> Site {
         var site = Site(id: id ?? UUID().hashValue, url: url, title: title, type: .basic)


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11560)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25161)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Update basic site creation to default `isBookmarked` to false. This is the logic that was currently in place but was not ported over with the refactor of Site code. This change also explicitly sets `isBookmarked` to nil when reading from the database.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

