### PR TITLE
Add FXIOS-11594 Initialize app services before any other rust components

### DIFF
--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -8,6 +8,7 @@ import Shared
 import Storage
 import Account
 import Glean
+import MozillaAppServices
 
 class AppLaunchUtil {
     private var logger: Logger
@@ -80,6 +81,9 @@ class AppLaunchUtil {
         profile.prefs.setBool(LegacyFeatureFlagsManager.shared.isFeatureEnabled(.bookmarksRefactor,
                                                                                 checking: .buildOnly),
                               forKey: PrefsKeys.IsBookmarksRefactorEnabled)
+
+        // Initialize app services ( including NSS ). Must be called before any other calls to rust components.
+        MozillaAppServices.initialize()
 
         // Start initializing the Nimbus SDK. This should be done after Glean
         // has been started.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11594)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25248)

## :bulb: Description
initialize MozillaAppServices before any other rust components

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

