### PR TITLE
Localize FXIOS-9612 #21206 [FirefoxHomepage][shortcut] Localized Pinned Tiles for voice over accessibility 

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteConfiguration.swift
@@ -15,7 +15,7 @@ struct TopSiteConfiguration: Hashable, Equatable {
     }
 
     var accessibilityLabel: String? {
-        return isSponsored ? "\(title), \(sponsoredText)" : title
+        return isSponsored ? "\(pinnedStatusTitle), \(sponsoredText)" : pinnedStatusTitle
     }
 
     var isPinned: Bool {
@@ -76,5 +76,15 @@ struct TopSiteConfiguration: Hashable, Equatable {
         }
 
         return "history-based"
+    }
+}
+
+private extension TopSiteConfiguration {
+    var pinnedText: String {
+        return .FirefoxHomepage.Shortcuts.Pinned
+    }
+
+    var pinnedStatusTitle: String {
+        isPinned ? "\(pinnedText): \(title)" : title
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteConfiguration.swift
@@ -80,11 +80,14 @@ struct TopSiteConfiguration: Hashable, Equatable {
 }
 
 private extension TopSiteConfiguration {
-    var pinnedText: String {
-        return .FirefoxHomepage.Shortcuts.Pinned
+    var pinnedTitle: String {
+        .localizedStringWithFormat(
+            .FirefoxHomepage.Shortcuts.PinnedAccessibilityLabel,
+            title
+        )
     }
 
     var pinnedStatusTitle: String {
-        isPinned ? "\(pinnedText): \(title)" : title
+        return isPinned ? pinnedTitle : title
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/TopSites/TopSiteConfiguration.swift
@@ -14,6 +14,17 @@ struct TopSiteConfiguration: Hashable, Equatable {
         return .FirefoxHomepage.Shortcuts.Sponsored
     }
 
+    private var pinnedTitle: String {
+        .localizedStringWithFormat(
+            .FirefoxHomepage.Shortcuts.PinnedAccessibilityLabel,
+            title
+        )
+    }
+
+    private var pinnedStatusTitle: String {
+        return isPinned ? pinnedTitle : title
+    }
+
     var accessibilityLabel: String? {
         return isSponsored ? "\(pinnedStatusTitle), \(sponsoredText)" : pinnedStatusTitle
     }
@@ -76,18 +87,5 @@ struct TopSiteConfiguration: Hashable, Equatable {
         }
 
         return "history-based"
-    }
-}
-
-private extension TopSiteConfiguration {
-    var pinnedTitle: String {
-        .localizedStringWithFormat(
-            .FirefoxHomepage.Shortcuts.PinnedAccessibilityLabel,
-            title
-        )
-    }
-
-    var pinnedStatusTitle: String {
-        return isPinned ? pinnedTitle : title
     }
 }

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
@@ -13,6 +13,17 @@ final class TopSite: FeatureFlaggable {
     var sponsoredText: String {
         return .FirefoxHomepage.Shortcuts.Sponsored
     }
+    
+    private var pinnedTitle: String {
+        .localizedStringWithFormat(
+            .FirefoxHomepage.Shortcuts.PinnedAccessibilityLabel,
+            title
+        )
+    }
+
+    private var pinnedStatusTitle: String {
+        isPinned ? pinnedTitle : title
+    }
 
     var accessibilityLabel: String? {
         return isSponsored ? "\(pinnedStatusTitle), \(sponsoredText)" : pinnedStatusTitle
@@ -69,18 +80,5 @@ final class TopSite: FeatureFlaggable {
         }
 
         return "history-based"
-    }
-}
-
-private extension TopSite {
-    var pinnedTitle: String {
-        .localizedStringWithFormat(
-            .FirefoxHomepage.Shortcuts.PinnedAccessibilityLabel,
-            title
-        )
-    }
-
-    var pinnedStatusTitle: String {
-        isPinned ? pinnedTitle : title
     }
 }

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
@@ -73,11 +73,14 @@ final class TopSite: FeatureFlaggable {
 }
 
 private extension TopSite {
-    var pinnedText: String {
-        return .FirefoxHomepage.Shortcuts.Pinned
+    var pinnedTitle: String {
+        .localizedStringWithFormat(
+            .FirefoxHomepage.Shortcuts.PinnedAccessibilityLabel,
+            title
+        )
     }
 
     var pinnedStatusTitle: String {
-        isPinned ? "\(pinnedText): \(title)" : title
+        isPinned ? pinnedTitle : title
     }
 }

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
@@ -15,7 +15,7 @@ final class TopSite: FeatureFlaggable {
     }
 
     var accessibilityLabel: String? {
-        return isSponsored ? "\(title), \(sponsoredText)" : title
+        return isSponsored ? "\(pinnedStatusTitle), \(sponsoredText)" : pinnedStatusTitle
     }
 
     var isPinned: Bool {
@@ -69,5 +69,15 @@ final class TopSite: FeatureFlaggable {
         }
 
         return "history-based"
+    }
+}
+
+private extension TopSite {
+    var pinnedText: String {
+        return .FirefoxHomepage.Shortcuts.Pinned
+    }
+
+    var pinnedStatusTitle: String {
+        isPinned ? "\(pinnedText): \(title)" : title
     }
 }

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSite.swift
@@ -13,7 +13,7 @@ final class TopSite: FeatureFlaggable {
     var sponsoredText: String {
         return .FirefoxHomepage.Shortcuts.Sponsored
     }
-    
+
     private var pinnedTitle: String {
         .localizedStringWithFormat(
             .FirefoxHomepage.Shortcuts.PinnedAccessibilityLabel,

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1177,7 +1177,7 @@ extension String {
                 key: "FirefoxHomepage.Shortcuts.Pinned.AccessibilityLabel.v139",
                 tableName: "FirefoxHomepage",
                 value: "Pinned: %@",
-                comment: "Accessiblity label for shortcuts tile on the Firefox home page, indicating that the tile is a pinned tile."
+                comment: "Accessibility label for shortcuts tile on the Firefox home page, indicating that the tile is a pinned tile. The placeholder will be replaced by the title of the website."
             )
         }
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1173,11 +1173,11 @@ extension String {
                 value: "Sponsored",
                 comment: "This string will show under a shortcuts tile on the firefox home page, indicating that the tile is a sponsored tile. Space is limited, please keep as short as possible.")
 
-            public static let Pinned = MZLocalizedString(
-                key: "FirefoxHomepage.Shortcuts.Pinned.v139",
+            public static let PinnedAccessibilityLabel = MZLocalizedString(
+                key: "FirefoxHomepage.Shortcuts.Pinned.AccessibilityLabel.v139",
                 tableName: "FirefoxHomepage",
-                value: "Pinned",
-                comment: "This string will be played in voice over for shortcuts tile on the Firefox home page, indicating that the tile is a pinned tile. This is voice over only localization"
+                value: "Pinned: %@",
+                comment: "Accessiblity label for shortcuts tile on the Firefox home page, indicating that the tile is a pinned tile."
             )
         }
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1177,7 +1177,7 @@ extension String {
                 key: "FirefoxHomepage.Shortcuts.Pinned.AccessibilityLabel.v139",
                 tableName: "FirefoxHomepage",
                 value: "Pinned: %@",
-                comment: "Accessibility label for shortcuts tile on the Firefox home page, indicating that the tile is a pinned tile. The placeholder will be replaced by the title of the website."
+                comment: "Accessibility label for shortcuts tile on the Firefox home page, indicating that the tile is a pinned tile. %@ is the title of the website."
             )
         }
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1172,6 +1172,13 @@ extension String {
                 tableName: nil,
                 value: "Sponsored",
                 comment: "This string will show under a shortcuts tile on the firefox home page, indicating that the tile is a sponsored tile. Space is limited, please keep as short as possible.")
+
+            public static let Pinned = MZLocalizedString(
+                key: "FirefoxHomepage.Shortcuts.Pinned.v136",
+                tableName: "FirefoxHomepage",
+                value: "Pinned",
+                comment: "This string will be played in voice over for shortcuts tile on the Firefox home page, indicating that the tile is a pinned tile. This is voice over only localization"
+            )
         }
 
         public struct YourLibrary { }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1174,7 +1174,7 @@ extension String {
                 comment: "This string will show under a shortcuts tile on the firefox home page, indicating that the tile is a sponsored tile. Space is limited, please keep as short as possible.")
 
             public static let Pinned = MZLocalizedString(
-                key: "FirefoxHomepage.Shortcuts.Pinned.v136",
+                key: "FirefoxHomepage.Shortcuts.Pinned.v139",
                 tableName: "FirefoxHomepage",
                 value: "Pinned",
                 comment: "This string will be played in voice over for shortcuts tile on the Firefox home page, indicating that the tile is a pinned tile. This is voice over only localization"

--- a/firefox-ios/Shared/en-US.lproj/Localizable.strings
+++ b/firefox-ios/Shared/en-US.lproj/Localizable.strings
@@ -370,9 +370,6 @@
 /* This string will show under a shortcuts tile on the firefox home page, indicating that the tile is a sponsored tile. Space is limited, please keep as short as possible. */
 "FirefoxHomepage.Shortcuts.Sponsored.v100" = "Sponsored";
 
-/* This string will be played in voice over for shortcuts tile on the Firefox home page, indicating that the tile is a pinned tile. This is voice over only localization */
-"FirefoxHomepage.Shortcuts.Pinned.v136" = "Pinned";
-
 /* Accessibility Label for the tab toolbar Forward button */
 "Forward" = "Forward";
 

--- a/firefox-ios/Shared/en-US.lproj/Localizable.strings
+++ b/firefox-ios/Shared/en-US.lproj/Localizable.strings
@@ -370,6 +370,9 @@
 /* This string will show under a shortcuts tile on the firefox home page, indicating that the tile is a sponsored tile. Space is limited, please keep as short as possible. */
 "FirefoxHomepage.Shortcuts.Sponsored.v100" = "Sponsored";
 
+/* This string will be played in voice over for shortcuts tile on the Firefox home page, indicating that the tile is a pinned tile. This is voice over only localization */
+"FirefoxHomepage.Shortcuts.Pinned.v136" = "Pinned";
+
 /* Accessibility Label for the tab toolbar Forward button */
 "Forward" = "Forward";
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -109,7 +109,7 @@ class BrowsingPDFTests: BaseTestCase {
         // Open pdf from pinned site
         let pdfTopSite = app
             .collectionViews[AccessibilityIdentifiers.FirefoxHomepage.collectionView]
-            .links[PDF_website["bookmarkLabel"]!]
+            .links["Pinned: \(PDF_website["bookmarkLabel"]!)"]
             .children(matching: .other)
             .element
             .children(matching: .other)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -23,10 +23,10 @@ class PhotonActionSheetTests: BaseTestCase {
         let cell = itemCell.staticTexts["Example Domain"]
         mozWaitForElementToExist(cell)
         if #available(iOS 17, *) {
-            mozWaitForElementToExist(app.links["Example Domain"].images[StandardImageIdentifiers.Small.pinBadgeFill])
+            mozWaitForElementToExist(app.links["Pinned: Example Domain"].images[StandardImageIdentifiers.Small.pinBadgeFill])
         } else {
             // No identifier is available for iOS 17 amd below
-            mozWaitForElementToExist(app.links["Example Domain"].images.element(boundBy: 1))
+            mozWaitForElementToExist(app.links["Pinned: Example Domain"].images.element(boundBy: 1))
         }
 
         // Remove pin


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9612)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21206)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added localisation to new tab pinned tiles to play when voice over is played.  both the new and legacy homepage are updated.

Before pinned tiles where playing as 
Google , Wikipedia ...

Now
Pinned: Google, Pinned: Wikipedia

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [x] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [x] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

