### PR TITLE
Remove FXIOS-11602 [Tab tray UI experiment] No more toasts on tab tray

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -9,7 +9,8 @@ import Storage
 
 import enum MozillaAppServices.BookmarkRoots
 
-class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
+class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider,
+                            FeatureFlaggable {
     private let profile: Profile
     private let logger: Logger
     private let inactiveTabTelemetry = InactiveTabsTelemetry()
@@ -372,27 +373,33 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
             let shouldDismiss = await self.closeTab(with: tabUUID, uuid: uuid, isPrivate: isPrivate)
             triggerRefresh(uuid: uuid, isPrivate: isPrivate)
 
+            let isTabTrayExperimentEnabled = featureFlags.isFeatureEnabled(.tabTrayUIExperiments,
+                                                                           checking: .buildOnly)
             if isPrivate && tabManager(for: uuid).privateTabs.isEmpty {
                 let didLoadAction = TabPanelViewAction(panelType: isPrivate ? .privateTabs : .tabs,
                                                        windowUUID: uuid,
                                                        actionType: TabPanelViewActionType.tabPanelDidLoad)
                 store.dispatch(didLoadAction)
 
-                let toastAction = TabPanelMiddlewareAction(toastType: .closedSingleTab,
-                                                           windowUUID: uuid,
-                                                           actionType: TabPanelMiddlewareActionType.showToast)
-                store.dispatch(toastAction)
+                if !isTabTrayExperimentEnabled {
+                    let toastAction = TabPanelMiddlewareAction(toastType: .closedSingleTab,
+                                                               windowUUID: uuid,
+                                                               actionType: TabPanelMiddlewareActionType.showToast)
+                    store.dispatch(toastAction)
+                }
             } else if shouldDismiss {
                 let dismissAction = TabTrayAction(windowUUID: uuid,
                                                   actionType: TabTrayActionType.dismissTabTray)
                 store.dispatch(dismissAction)
 
-                let toastAction = GeneralBrowserAction(toastType: .closedSingleTab,
-                                                       windowUUID: uuid,
-                                                       actionType: GeneralBrowserActionType.showToast)
-                store.dispatch(toastAction)
+                if !isTabTrayExperimentEnabled {
+                    let toastAction = GeneralBrowserAction(toastType: .closedSingleTab,
+                                                           windowUUID: uuid,
+                                                           actionType: GeneralBrowserActionType.showToast)
+                    store.dispatch(toastAction)
+                }
                 addNewTabIfPrivate(uuid: uuid)
-            } else {
+            } else if !isTabTrayExperimentEnabled {
                 let toastAction = TabPanelMiddlewareAction(toastType: .closedSingleTab,
                                                            windowUUID: uuid,
                                                            actionType: TabPanelMiddlewareActionType.showToast)
@@ -476,16 +483,20 @@ class TabManagerMiddleware: BookmarksRefactorFeatureFlagProvider {
                                                       actionType: TabPanelMiddlewareActionType.refreshTabs)
                 store.dispatch(action)
 
-                if tabsState.isPrivateMode {
+                let isTabTrayExperimentEnabled = featureFlags.isFeatureEnabled(.tabTrayUIExperiments,
+                                                                               checking: .buildOnly)
+                if tabsState.isPrivateMode && !isTabTrayExperimentEnabled {
                     let action = TabPanelMiddlewareAction(toastType: .closedAllTabs(count: privateCount),
                                                           windowUUID: uuid,
                                                           actionType: TabPanelMiddlewareActionType.showToast)
                     store.dispatch(action)
                 } else {
-                    let toastAction = GeneralBrowserAction(toastType: .closedAllTabs(count: normalCount),
-                                                           windowUUID: uuid,
-                                                           actionType: GeneralBrowserActionType.showToast)
-                    store.dispatch(toastAction)
+                    if !isTabTrayExperimentEnabled {
+                        let toastAction = GeneralBrowserAction(toastType: .closedAllTabs(count: normalCount),
+                                                               windowUUID: uuid,
+                                                               actionType: GeneralBrowserActionType.showToast)
+                        store.dispatch(toastAction)
+                    }
                     addNewTabIfPrivate(uuid: uuid)
                 }
             }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -124,7 +124,7 @@ class TopTabsTest: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306865
     // Smoketest
-    func testCloseAllTabsUndo() {
+    func testCloseAllTabsUndo() throws {
         navigator.nowAt(NewTabScreen)
         // A different tab than home is open to do the proper checks
         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
@@ -146,27 +146,28 @@ class TopTabsTest: BaseTestCase {
         }
         checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
 
-        // Close all tabs, undo it and check that the number of tabs is correct
-        navigator.performAction(Action.AcceptRemovingAllTabs)
-
-        app.otherElements.buttons.staticTexts["Undo"].waitAndTap()
-
-        mozWaitForElementToExist(
-            app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
-        )
-        navigator.nowAt(BrowserTab)
-        if !iPad() {
-            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
-        }
-
-        if iPad() {
-            navigator.goto(TabTray)
-        } else {
-            navigator.performAction(Action.CloseURLBarOpen)
-        }
-        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
-
-        mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
+        throw XCTSkip("Skipping since the tab UI experiment doesn't have this toast anymore")
+//        // Close all tabs, undo it and check that the number of tabs is correct
+//        navigator.performAction(Action.AcceptRemovingAllTabs)
+//
+//        app.otherElements.buttons.staticTexts["Undo"].waitAndTap()
+//
+//        mozWaitForElementToExist(
+//            app.collectionViews.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
+//        )
+//        navigator.nowAt(BrowserTab)
+//        if !iPad() {
+//            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
+//        }
+//
+//        if iPad() {
+//            navigator.goto(TabTray)
+//        } else {
+//            navigator.performAction(Action.CloseURLBarOpen)
+//        }
+//        checkNumberOfTabsExpectedToBeOpen(expectedNumberOfTabsOpen: 2)
+//
+//        mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2354473


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11602)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/#25262)

## :bulb: Description
Remove toasts notification on tab tray with this experiment only (so there's still toast notification without the experiment).

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

