### PR TITLE
Refactor FXIOS-11596 [Tab tray UI experiment] Button is transparent and color is changed on experiment only

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -86,6 +86,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         var configuration = UIButton.Configuration.plain()
         configuration.contentInsets = UX.closeButtonEdgeInset
         button.configuration = configuration
+        button.alpha = 0.5
     }
 
     private var isTabTrayUIExperimentsEnabled: Bool {
@@ -174,7 +175,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
 
     func applyTheme(theme: Theme) {
         backgroundHolder.backgroundColor = theme.colors.layer1
-        closeButton.tintColor = theme.colors.indicatorActive
+        closeButton.tintColor = theme.colors.iconPrimary
         titleText.textColor = theme.colors.textPrimary
         screenshotView.backgroundColor = theme.colors.layer1
         favicon.tintColor = theme.colors.textPrimary


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11596)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25250)

## :bulb: Description
The tab cell close button color is adjusted and it has some transparency on it

### 🎥 Screenshot
<details>
<summary>Tab cell close button</summary>

![Screenshot 2025-03-11 at 5 44 52 PM](https://github.com/user-attachments/assets/a774971e-aa12-4124-ad5b-885e30f5a4e8)


</details>


## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

