### PR TITLE
Refactor FXIOS-24073 [GleanWrapper] Glean wrapper usage in Webviewtelemetry

### DIFF
--- a/firefox-ios/Client/Telemetry/WebviewTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/WebviewTelemetry.swift
@@ -8,21 +8,26 @@ import Glean
 /// Measure with a time distribution https://mozilla.github.io/glean/book/reference/metrics/timing_distribution.html
 /// how long it takes to load a webpage
 final class WebViewLoadMeasurementTelemetry {
+    private let gleanWrapper: GleanWrapper
     private var loadTimerId: GleanTimerId?
 
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
     func start() {
-        loadTimerId = GleanMetrics.Webview.pageLoad.start()
+        loadTimerId = gleanWrapper.startTiming(for: GleanMetrics.Webview.pageLoad)
     }
 
     func stop() {
         guard let timerId = loadTimerId else { return }
-        GleanMetrics.Webview.pageLoad.stopAndAccumulate(timerId)
+        gleanWrapper.stopAndAccumulateTiming(for: GleanMetrics.Webview.pageLoad, timerId: timerId)
         loadTimerId = nil
     }
 
     func cancel() {
-        if let loadTimerId {
-            GleanMetrics.Webview.pageLoad.cancel(loadTimerId)
+        if let timerId = loadTimerId {
+            gleanWrapper.cancelTiming(for: GleanMetrics.Webview.pageLoad, timerId: timerId)
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewTelemetryTests.swift
@@ -33,4 +33,3 @@ class WebviewTelemetryTests: XCTestCase {
         XCTAssertEqual(mockGlean.cancelTimingCalled, 1, "Cancel timer should be called once")
     }
 }
-

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebviewTelemetryTests.swift
@@ -8,33 +8,29 @@ import Glean
 import XCTest
 
 class WebviewTelemetryTests: XCTestCase {
+    var mockGlean: MockGleanWrapper!
+    var subject: WebViewLoadMeasurementTelemetry!
+
     override func setUp() {
         super.setUp()
-        // Due to changes allow certain custom pings to implement their own opt-out
-        // independent of Glean, custom pings may need to be registered manually in
-        // tests in order to put them in a state in which they can collect data.
-        Glean.shared.registerPings(GleanMetrics.Pings.shared)
-        Glean.shared.resetGlean(clearStores: true)
+        mockGlean = MockGleanWrapper()
+        subject = WebViewLoadMeasurementTelemetry(gleanWrapper: mockGlean)
     }
 
-    func testLoadMeasurement() throws {
-        let subject = WebViewLoadMeasurementTelemetry()
-
+    func testLoadMeasurement() {
         subject.start()
         subject.stop()
 
-        let resultValue = try XCTUnwrap(GleanMetrics.Webview.pageLoad.testGetValue())
-        XCTAssertEqual(1, resultValue.count, "Should have been measured once")
-        XCTAssertEqual(0, GleanMetrics.Webview.pageLoad.testGetNumRecordedErrors(.invalidValue))
+        XCTAssertEqual(mockGlean.startTimingCalled, 1, "Start timer should be called once")
+        XCTAssertEqual(mockGlean.stopAndAccumulateCalled, 1, "Stop and accumulate timer should be called once")
     }
 
     func testCancelLoadMeasurement() {
-        let subject = WebViewLoadMeasurementTelemetry()
-
         subject.start()
         subject.cancel()
 
-        XCTAssertNil(GleanMetrics.Webview.pageLoad.testGetValue(), "Should not have been measured")
-        XCTAssertEqual(0, GleanMetrics.Webview.pageLoad.testGetNumRecordedErrors(.invalidValue))
+        XCTAssertEqual(mockGlean.startTimingCalled, 1, "Start timer should be called once")
+        XCTAssertEqual(mockGlean.cancelTimingCalled, 1, "Cancel timer should be called once")
     }
 }
+


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11024)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24073)

## :bulb: Description
I refactored theWebViewLoadMeasurementTelemetry class to inject GleanWrapper

Changes I made:
- Injected GleanWrapper into WebViewLoadMeasurementTelemetry via the initializer.
- Replaced direct calls to Glean with the injected gleanWrapper dependency.
- Updated unit tests (WebviewTelemetryTests) to use MockGleanWrapper, ensuring we can verify telemetry interactions without depending on Glean itself.

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

