### PR TITLE
Add FXIOS-11598 [Tab tray UI experiment] Shadow on Experiment tab cell

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -12,7 +12,7 @@ import SiteImageView
 class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, FeatureFlaggable {
     struct UX {
         static let selectedBorderWidth: CGFloat = 3.0
-        static let unselectedBorderWidth: CGFloat = 0.8
+        static let unselectedBorderWidth: CGFloat = 1
         static let cornerRadius: CGFloat = 16
         static let subviewDefaultPadding: CGFloat = 6.0
         static let faviconSize = CGSize(width: 16, height: 16)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -92,14 +92,11 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         favicon.layer.cornerRadius = UX.faviconSize.height / 2
         smallFaviconView.layer.cornerRadius = UX.fallbackFaviconSize.height / 2
 
-        // Ensure background holder has bounds set
-        DispatchQueue.main.async {
-            self.backgroundHolder.layoutIfNeeded()
-            self.contentView.layer.shadowPath = UIBezierPath(
-                roundedRect: self.backgroundHolder.bounds,
-                cornerRadius: self.backgroundHolder.layer.cornerRadius
-            ).cgPath
-        }
+        backgroundHolder.layoutIfNeeded()
+        contentView.layer.shadowPath = UIBezierPath(
+            roundedRect: self.backgroundHolder.bounds,
+            cornerRadius: self.backgroundHolder.layer.cornerRadius
+        ).cgPath
     }
 
     // MARK: - Initializer

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -26,6 +26,9 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         static let closeButtonTop: CGFloat = 6
         static let closeButtonTrailing: CGFloat = 8
         static let tabViewFooterSpacing: CGFloat = 4
+        static let shadowRadius: CGFloat = 4
+        static let shadowOffset = CGSize(width: 0, height: 2)
+        static let shadowOpacity: Float = 1
     }
     // MARK: - Properties
 
@@ -88,6 +91,15 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         super.layoutSubviews()
         favicon.layer.cornerRadius = UX.faviconSize.height / 2
         smallFaviconView.layer.cornerRadius = UX.fallbackFaviconSize.height / 2
+
+        // Ensure background holder has bounds set
+        DispatchQueue.main.async {
+            self.backgroundHolder.layoutIfNeeded()
+            self.contentView.layer.shadowPath = UIBezierPath(
+                roundedRect: self.backgroundHolder.bounds,
+                cornerRadius: self.backgroundHolder.layer.cornerRadius
+            ).cgPath
+        }
     }
 
     // MARK: - Initializer
@@ -171,6 +183,14 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         screenshotView.backgroundColor = theme.colors.layer1
         favicon.tintColor = theme.colors.textPrimary
         smallFaviconView.tintColor = theme.colors.textPrimary
+        setupShadow(theme: theme)
+    }
+
+    func setupShadow(theme: Theme) {
+        contentView.layer.shadowRadius = UX.shadowRadius
+        contentView.layer.shadowOffset = UX.shadowOffset
+        contentView.layer.shadowColor = theme.colors.shadowDefault.cgColor
+        contentView.layer.shadowOpacity = UX.shadowOpacity
     }
 
     // MARK: - Configuration
@@ -232,8 +252,6 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         // Reset any close animations.
         super.prepareForReuse()
         screenshotView.image = nil
-        backgroundHolder.transform = .identity
-        backgroundHolder.alpha = 1
         smallFaviconView.isHidden = true
         layer.shadowOffset = .zero
         layer.shadowPath = nil


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11598)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25253)

## :bulb: Description
Add the shadow on the experiment tab cell

### 🎥 Screenshot
<details>
<summary>Shadow light mode</summary>

![Screenshot 2025-03-11 at 6 43 10 PM](https://github.com/user-attachments/assets/06441def-272c-460d-af49-c5934cf656e6)

</details>

<details>
<summary>Shadow dark mode</summary>

![Screenshot 2025-03-11 at 6 45 04 PM](https://github.com/user-attachments/assets/ed16ff1e-d50d-4f37-8c6b-83293deba64f)

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

