### PR TITLE
Bugfix FXIOS-11608 [Toolbar redesign] Changing tabs on iPad while in edit mode shows new tab in edit mode

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -223,7 +223,7 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     }
 
     private func normalizeString(_ string: String) -> String {
-        return string.lowercased().stringByTrimmingLeadingCharactersInSet(CharacterSet.whitespaces)
+        return string.stringByTrimmingLeadingCharactersInSet(CharacterSet.whitespaces)
     }
 
     // Reset the cursor to the end of the text field.

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -402,10 +402,8 @@ final class LocationView: UIView,
 
         // Start overlay mode & select text when in edit mode with a search term
         if shouldShowKeyboard, config.shouldSelectSearchTerm {
-            DispatchQueue.main.async {
-                self.urlTextField.text = text
-                self.urlTextField.selectAll(nil)
-            }
+            self.urlTextField.text = text
+            self.urlTextField.selectAll(nil)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11608)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25278)

## :bulb: Description
The dispatch caused the address toolbar to go back into edit mode although the state was in the meantime changed to display mode for the address toolbar. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

