### PR TITLE
Bugfix FXIOS-11536 usage-deletion-request ping is missing the required usage profile_id metric field in some pings

### DIFF
--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		8A6445902BA3905100759319 /* disconnect-block-content.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A6445892BA3904100759319 /* disconnect-block-content.json */; };
 		8A6445912BA3905100759319 /* disconnect-block-social.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A6445872BA3904100759319 /* disconnect-block-social.json */; };
 		8A6445922BA3905100759319 /* web-fonts.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A6445842BA38B8600759319 /* web-fonts.json */; };
+		8C0AB2292D817EC700E88035 /* ProfileIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C0AB2282D817EC700E88035 /* ProfileIdentifier.swift */; };
 		8C1B5DEE2BC43C5E001B1964 /* SearchWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C1B5DEC2BC43C19001B1964 /* SearchWidgetView.swift */; };
 		8C28008F2D49354400ED6D07 /* Shared in Frameworks */ = {isa = PBXBuildFile; productRef = 8C28008E2D49354400ED6D07 /* Shared */; };
 		8C2800912D49357C00ED6D07 /* Shared in Frameworks */ = {isa = PBXBuildFile; productRef = 8C2800902D49357C00ED6D07 /* Shared */; };
@@ -688,6 +689,7 @@
 		8A6445872BA3904100759319 /* disconnect-block-social.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "disconnect-block-social.json"; path = "../../ContentBlockingLists/disconnect-block-social.json"; sourceTree = "<group>"; };
 		8A6445882BA3904100759319 /* disconnect-block-advertising.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "disconnect-block-advertising.json"; path = "../../ContentBlockingLists/disconnect-block-advertising.json"; sourceTree = "<group>"; };
 		8A6445892BA3904100759319 /* disconnect-block-content.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "disconnect-block-content.json"; path = "../../ContentBlockingLists/disconnect-block-content.json"; sourceTree = "<group>"; };
+		8C0AB2282D817EC700E88035 /* ProfileIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileIdentifier.swift; sourceTree = "<group>"; };
 		8C1B5DEC2BC43C19001B1964 /* SearchWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchWidgetView.swift; sourceTree = "<group>"; };
 		8C75DF652D3E636A00924EAB /* TelemetryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryManager.swift; sourceTree = "<group>"; };
 		8C8906AB2D0B3E9F003734FE /* UsageProfileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageProfileManager.swift; sourceTree = "<group>"; };
@@ -1904,6 +1906,7 @@
 				E4BF2DD61BACE8CA00DA9D68 /* AppDelegate.swift */,
 				8C8906AB2D0B3E9F003734FE /* UsageProfileManager.swift */,
 				8C90C3BD2D48F0DB00DDA361 /* GleanUsageReportingMetricsService.swift */,
+				8C0AB2282D817EC700E88035 /* ProfileIdentifier.swift */,
 				D3E2C8E91D9F0E6200DEBE3D /* BrowserViewController.swift */,
 				D3E3CA7C1DA827AD0079C94B /* HomeViewController.swift */,
 				C8D0305A27E89CC0000664DA /* InternalSettings */,
@@ -2668,6 +2671,7 @@
 				C8CE05072743FA89002057C6 /* UIAction+MenuAction.swift in Sources */,
 				163BFFE62125EE260007CEBC /* SiriShortcuts.swift in Sources */,
 				E5E4505028CF4575005A01F1 /* TipManager.swift in Sources */,
+				8C0AB2292D817EC700E88035 /* ProfileIdentifier.swift in Sources */,
 				16074B6D2114364C003B671F /* PhotonActionSheet.swift in Sources */,
 				E5E4504E28CF4548005A01F1 /* TipsPageViewController.swift in Sources */,
 				C8337DF62710898800093D42 /* TrackingProtectionState.swift in Sources */,

--- a/focus-ios/Blockzilla/AppDelegate.swift
+++ b/focus-ios/Blockzilla/AppDelegate.swift
@@ -364,6 +364,14 @@ extension AppDelegate {
 // MARK: - Telemetry & Tooling setup
 extension AppDelegate {
     func setupTelemetry() {
+        let channel = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" ? "testflight" : "release"
+        let configuration = Configuration(channel: channel)
+
+        Glean.shared.initialize(
+            uploadEnabled: TelemetryManager.shared.isGleanEnabled,
+            configuration: configuration,
+            buildInfo: GleanMetrics.GleanBuild.info
+        )
         let activeSearchEngine = SearchEngineManager(prefs: UserDefaults.standard).activeEngine
         let defaultSearchEngineProvider = activeSearchEngine.isCustom ? "custom" : activeSearchEngine.name
         GleanMetrics.Search.defaultEngine.set(defaultSearchEngineProvider)
@@ -389,15 +397,6 @@ extension AppDelegate {
         }
 
         Glean.shared.registerPings(GleanMetrics.Pings.shared)
-
-        let channel = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" ? "testflight" : "release"
-        let configuration = Configuration(channel: channel)
-
-        Glean.shared.initialize(
-            uploadEnabled: TelemetryManager.shared.isGleanEnabled,
-            configuration: configuration,
-            buildInfo: GleanMetrics.GleanBuild.info
-        )
 
         let url = URL(string: "firefox://", invalidCharacters: false)!
         // Send "at startup" telemetry

--- a/focus-ios/Blockzilla/AppDelegate.swift
+++ b/focus-ios/Blockzilla/AppDelegate.swift
@@ -385,7 +385,7 @@ extension AppDelegate {
         if TelemetryManager.shared.isNewTosEnabled {
             gleanUsageReportingMetricsService.start()
         } else {
-            gleanUsageReportingMetricsService.unsetUsageProfileId()
+            gleanUsageReportingMetricsService.lifecycleObserver.profileIdentifier.unsetUsageProfileId()
         }
 
         Glean.shared.registerPings(GleanMetrics.Pings.shared)

--- a/focus-ios/Blockzilla/ProfileIdentifier.swift
+++ b/focus-ios/Blockzilla/ProfileIdentifier.swift
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+
+import Foundation
+import Glean
+
+// MARK: - ProfileIdentifier Implementation
+
+class ProfileIdentifier {
+    struct Constants {
+        static let profileIdKey = "profileId"
+        static let canaryUUID = UUID(uuidString: "beefbeef-beef-beef-beef-beeefbeefbee")!
+        static let fileName = "profile_identifier.txt"
+    }
+    
+    // File URL for backup storage
+    private var fileURL: URL {
+        let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        return documentsDirectory.appendingPathComponent(Constants.profileIdKey)
+    }
+    
+    // Clear the profile ID from all storage locations
+    func unsetUsageProfileId() {
+        // Clear from UserDefaults
+        UserDefaults.standard.removeObject(forKey: Constants.profileIdKey)
+        
+        // Clear from file backup
+        try? FileManager.default.removeItem(at: fileURL)
+        
+        // Set canary UUID in metrics
+        GleanMetrics.Usage.profileId.set(Constants.canaryUUID)
+    }
+    
+    // Check and set the profile ID from available storage locations
+    func checkAndSetProfileId() {
+        // Try to get from UserDefaults first
+        if let uuidFromDefaults = getProfileIdFromUserDefaults() {
+            // Found in UserDefaults, use it and ensure backup exists
+            useAndBackupProfileId(uuidFromDefaults)
+            return
+        }
+        
+        // Try to get from file backup
+        if let uuidFromFile = getProfileIdFromFile() {
+            // Found in file, use it and ensure it's in UserDefaults
+            useAndBackupProfileId(uuidFromFile)
+            return
+        }
+        
+        // No ID found, generate a new one and store it everywhere
+        let newUUID = GleanMetrics.Usage.profileId.generateAndSet()
+        storeProfileId(newUUID)
+    }
+    
+    // Helper to retrieve UUID from UserDefaults
+    private func getProfileIdFromUserDefaults() -> UUID? {
+        guard let uuidString = UserDefaults.standard.string(forKey: Constants.profileIdKey),
+              let uuid = UUID(uuidString: uuidString) else {
+            return nil
+        }
+        return uuid
+    }
+    
+    // Helper to retrieve UUID from file backup
+    private func getProfileIdFromFile() -> UUID? {
+        do {
+            let data = try Data(contentsOf: fileURL)
+            if let uuidString = String(data: data, encoding: .utf8),
+               let uuid = UUID(uuidString: uuidString) {
+                return uuid
+            }
+        } catch {
+            // File doesn't exist or couldn't be read
+            return nil
+        }
+        return nil
+    }
+    
+    // Store UUID in all locations
+    private func storeProfileId(_ uuid: UUID) {
+        // Store in UserDefaults
+        UserDefaults.standard.set(uuid.uuidString, forKey: Constants.profileIdKey)
+        
+        // Store in file backup
+        do {
+            try uuid.uuidString.write(to: fileURL, atomically: true, encoding: .utf8)
+        } catch {
+            print("Failed to write UUID to file: \(error)")
+        }
+        
+        // Set in metrics
+        GleanMetrics.Usage.profileId.set(uuid)
+    }
+    
+    // Use an existing UUID and ensure it's backed up everywhere
+    private func useAndBackupProfileId(_ uuid: UUID) {
+        storeProfileId(uuid)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11536)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Save profile id on disk as a backup in case it can't be read from user defaults.
## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

