### PR TITLE
Bugfix FXIOS-11481 ⁃ Fix hangs in AutocompleteTextField setTextWithouthSearching

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/firefox-ios/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -47,13 +47,6 @@ class AutocompleteTextField: UITextField,
     private var notifyTextChanged: (() -> Void)?
     private var lastReplacement: String?
 
-    override var text: String? {
-        didSet {
-            super.text = text
-            self.textDidChange(self)
-        }
-    }
-
     override var accessibilityValue: String? {
         get {
             return (self.text ?? "") + (self.autocompleteTextLabel?.text ?? "")
@@ -210,6 +203,7 @@ class AutocompleteTextField: UITextField,
         let text = (self.text ?? "") + (self.autocompleteTextLabel?.text ?? "")
         let didRemoveCompletion = removeCompletion()
         self.text = text
+        self.textDidChange(self)
         hideCursor = false
         // Move the cursor to the end of the completion.
         if didRemoveCompletion {
@@ -344,7 +338,7 @@ class AutocompleteTextField: UITextField,
     }
 
     func setTextWithoutSearching(_ text: String) {
-        super.text = text
+        self.text = text
         hideCursor = autocompleteTextLabel != nil
         removeCompletion()
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11481)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24969)

## :bulb: Description
Deleted override text var and called textDidChange when is necessary

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

