### PR TITLE
Add FXIOS-11522 [Homepage] [Telemetry] general homepage impression

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1020,7 +1020,7 @@ class BrowserCoordinator: BaseCoordinator,
             store.dispatch(
                 TabTrayAction(
                     windowUUID: self.windowUUID,
-                    actionType: TabTrayActionType.modalSwipedToClose
+                    actionType: TabTrayActionType.onViewDismissed
                 )
             )
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -94,6 +94,7 @@ enum TabPanelMiddlewareActionType: ActionType {
     case refreshInactiveTabs
     case showToast
     case scrollToTab
+    case didTabTrayClose
 }
 
 final class ScreenshotAction: Action {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabTrayAction.swift
@@ -26,8 +26,7 @@ class TabTrayAction: Action {
 enum  TabTrayActionType: ActionType {
     case tabTrayDidLoad
     case changePanel
-    case doneButtonTapped
-    case modalSwipedToClose
+    case onViewDismissed
 
     // Middleware actions
     case didLoadTabTray

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -679,12 +679,6 @@ class TabTrayViewController: UIViewController,
     @objc
     private func doneButtonTapped() {
         notificationCenter.post(name: .TabsTrayDidClose, withUserInfo: windowUUID.userInfo)
-        store.dispatch(
-            TabTrayAction(
-                windowUUID: windowUUID,
-                actionType: TabTrayActionType.doneButtonTapped
-            )
-        )
         delegate?.didFinish()
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageViewController.swift
@@ -162,6 +162,7 @@ final class HomepageViewController: UIViewController,
         super.viewWillAppear(animated)
         /// Used as a trigger for showing a microsurvey based on viewing the homepage
         Experiments.events.recordEvent(BehavioralTargetingEvent.homepageViewed)
+        guard homepageState.shouldSendImpression else { return }
         store.dispatch(
             HomepageAction(
                 windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
@@ -13,6 +13,8 @@ final class HomepageMiddleware {
 
     lazy var homepageProvider: Middleware<AppState> = { state, action in
         switch action.actionType {
+        case HomepageActionType.viewWillAppear, TabPanelMiddlewareActionType.didTabTrayClose:
+            self.homepageTelemetry.sendHomepageImpressionEvent()
         case NavigationBrowserActionType.tapOnCustomizeHomepage:
             self.homepageTelemetry.sendTapOnCustomizeHomepageTelemetry()
         default:

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageState.swift
@@ -16,6 +16,10 @@ struct HomepageState: ScreenState, Equatable {
     let bookmarkState: BookmarksSectionState
     let pocketState: PocketState
     let wallpaperState: WallpaperState
+    // FXIOS-11522 - Used to send impressions when homepage is added to the hierarchy
+    // and its the top view.
+    // The only case where we experience this issue is on tab tray, because it is a modal so far.
+    let shouldSendImpression: Bool
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let homepageState = store.state.screenState(
@@ -35,7 +39,8 @@ struct HomepageState: ScreenState, Equatable {
             jumpBackInState: homepageState.jumpBackInState,
             bookmarkState: homepageState.bookmarkState,
             pocketState: homepageState.pocketState,
-            wallpaperState: homepageState.wallpaperState
+            wallpaperState: homepageState.wallpaperState,
+            shouldSendImpression: homepageState.shouldSendImpression
         )
     }
 
@@ -48,7 +53,8 @@ struct HomepageState: ScreenState, Equatable {
             jumpBackInState: JumpBackInSectionState(windowUUID: windowUUID),
             bookmarkState: BookmarksSectionState(windowUUID: windowUUID),
             pocketState: PocketState(windowUUID: windowUUID),
-            wallpaperState: WallpaperState(windowUUID: windowUUID)
+            wallpaperState: WallpaperState(windowUUID: windowUUID),
+            shouldSendImpression: true
         )
     }
 
@@ -60,7 +66,8 @@ struct HomepageState: ScreenState, Equatable {
         jumpBackInState: JumpBackInSectionState,
         bookmarkState: BookmarksSectionState,
         pocketState: PocketState,
-        wallpaperState: WallpaperState
+        wallpaperState: WallpaperState,
+        shouldSendImpression: Bool
     ) {
         self.windowUUID = windowUUID
         self.headerState = headerState
@@ -70,6 +77,7 @@ struct HomepageState: ScreenState, Equatable {
         self.bookmarkState = bookmarkState
         self.pocketState = pocketState
         self.wallpaperState = wallpaperState
+        self.shouldSendImpression = shouldSendImpression
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -88,7 +96,34 @@ struct HomepageState: ScreenState, Equatable {
                 jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
                 bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
                 pocketState: PocketState.reducer(state.pocketState, action),
-                wallpaperState: WallpaperState.reducer(state.wallpaperState, action)
+                wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
+                shouldSendImpression: state.shouldSendImpression
+            )
+
+        case TabTrayActionType.didLoadTabTray:
+            return HomepageState(
+                windowUUID: state.windowUUID,
+                headerState: HeaderState.reducer(state.headerState, action),
+                messageState: MessageCardState.reducer(state.messageState, action),
+                topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
+                jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
+                bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
+                pocketState: PocketState.reducer(state.pocketState, action),
+                wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
+                shouldSendImpression: false
+            )
+
+        case TabTrayActionType.dismissTabTray:
+            return HomepageState(
+                windowUUID: state.windowUUID,
+                headerState: HeaderState.reducer(state.headerState, action),
+                messageState: MessageCardState.reducer(state.messageState, action),
+                topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
+                jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
+                bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
+                pocketState: PocketState.reducer(state.pocketState, action),
+                wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
+                shouldSendImpression: true
             )
         default:
             return defaultState(from: state, action: action)
@@ -122,7 +157,8 @@ struct HomepageState: ScreenState, Equatable {
             jumpBackInState: jumpBackInState,
             bookmarkState: bookmarkState,
             pocketState: pocketState,
-            wallpaperState: wallpaperState
+            wallpaperState: wallpaperState,
+            shouldSendImpression: state.shouldSendImpression
         )
     }
 

--- a/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
@@ -12,6 +12,11 @@ struct HomepageTelemetry {
         self.gleanWrapper = gleanWrapper
     }
 
+    // MARK: - General Homepage
+    func sendHomepageImpressionEvent() {
+        gleanWrapper.recordEvent(for: GleanMetrics.Homepage.viewed)
+    }
+
     // MARK: - Top Sites
     enum ContextMenuTelemetryActionType: String {
         case remove, unpin, pin, settings, sponsoredSupport

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -2715,6 +2715,23 @@ firefox_home_page:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-07-01"
 
+# HomePage - General
+homepage:
+  viewed:
+    type: event
+    description: |
+      Records when the homepage is viewed.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/11522
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25284
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-07-01"
+    metadata:
+      tags:
+        - Homepage
+
 # Metrics related to the history panel of the library
 library:
   panel_pressed:

--- a/firefox-ios/Client/tags.yaml
+++ b/firefox-ios/Client/tags.yaml
@@ -11,6 +11,9 @@
 ---
 $schema: moz://mozilla.org/schemas/glean/tags/1-0-0
 
+Homepage:
+  description: Corresponds to the homepage feature and all content that resides on the page.
+
 AppIconSelection:
   description: Corresponds to the feature where users can change their default app icon in the settings.
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
@@ -45,6 +45,42 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 
+    func test_viewWillAppearAction_sendsTelemetryData() throws {
+        let subject = createSubject()
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.viewWillAppear
+        )
+
+        subject.homepageProvider(AppState(), action)
+
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents?[0] as? EventMetricType<NoExtras>)
+        let expectedMetricType = type(of: GleanMetrics.Homepage.viewed)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func test_didTabTrayCloseAction_sendsTelemetryData() throws {
+        let subject = createSubject()
+        let action = TabPanelMiddlewareAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TabPanelMiddlewareActionType.didTabTrayClose
+        )
+
+        subject.homepageProvider(AppState(), action)
+
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents?[0] as? EventMetricType<NoExtras>)
+        let expectedMetricType = type(of: GleanMetrics.Homepage.viewed)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
     // MARK: - Helpers
     private func createSubject() -> HomepageMiddleware {
         return HomepageMiddleware(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageStateTests.swift
@@ -25,6 +25,7 @@ final class HomepageStateTests: XCTestCase {
 
         XCTAssertFalse(initialState.headerState.isPrivate)
         XCTAssertFalse(initialState.headerState.showiPadSetup)
+        XCTAssertTrue(initialState.shouldSendImpression)
     }
 
     func test_initializeAction_returnsExpectedState() {
@@ -43,6 +44,38 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertFalse(newState.headerState.isPrivate)
         XCTAssertTrue(newState.headerState.showiPadSetup)
+    }
+
+    func test_didLoadTabTrayAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = homepageReducer()
+
+        let newState = reducer(
+            initialState,
+            TabTrayAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: TabTrayActionType.didLoadTabTray
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(newState.shouldSendImpression)
+    }
+
+    func test_dismissTabTrayAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = homepageReducer()
+
+        let newState = reducer(
+            initialState,
+            TabTrayAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: TabTrayActionType.dismissTabTray
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertTrue(newState.shouldSendImpression)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -136,36 +136,11 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
     }
 
-    func test_tabTrayModalSwipedToCloseAction_returnsRecentTabs() throws {
+    func test_tabTrayDismissedAction_returnsRecentTabs() throws {
         let subject = createSubject()
         let action = TabTrayAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: TabTrayActionType.modalSwipedToClose
-        )
-
-        let expectation = XCTestExpectation(description: "Recent tabs should be returned")
-
-        mockStore.dispatchCalled = {
-            expectation.fulfill()
-        }
-
-        subject.tabsPanelProvider(appState, action)
-
-        wait(for: [expectation])
-
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabManagerAction)
-        let actionType = try XCTUnwrap(actionCalled.actionType as? TabManagerMiddlewareActionType)
-
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
-        XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
-    }
-
-    func test_tabTrayDoneButtonTappedAction_returnsRecentTabs() throws {
-        let subject = createSubject()
-        let action = TabTrayAction(
-            windowUUID: .XCTestDefaultUUID,
-            actionType: TabTrayActionType.doneButtonTapped
+            actionType: TabTrayActionType.onViewDismissed
         )
 
         let expectation = XCTestExpectation(description: "Recent tabs should be returned")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11522)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25082)

## :bulb: Description
Add new homepage impression event. We add a property called `shouldShowImpression` to the state which is based on the tab tray view controller is appeared or not. We also add a new action `didTabTrayClose` to dispatch an action if the homepage is selected to act as an impression event.
- This should also address the issue here: https://mozilla-hub.atlassian.net/browse/FXIOS-11156. The issue in that ticket would be addressed if we have the tab tray in full screen which we have an experiment for. So this PR includes a fix, but I'm hoping we can remove it if we decide to go full screen. 

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

