### PR TITLE
Add FXIOS-11520 Improve string description for localizers as requested.

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2566,7 +2566,7 @@ extension String {
                     key: "Settings.AppIconSelection.AppIconNames.Pride.Title.v136",
                     tableName: "AppIconSelection",
                     value: "Pride",
-                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a fox logo.")
+                    comment: "On the app icon customization screen where you can select an alternate icon for the app, this is the name of a LGBT+ pride fox logo.")
 
                 public static let RedGradient = MZLocalizedString(
                     key: "Settings.AppIconSelection.AppIconNames.RedGradient.Title.v136",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11520)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25078)

## :bulb: Description
Improve the Pride app icon localization description as requested here https://github.com/mozilla-l10n/firefoxios-l10n/pull/270#discussion_r1989843611

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

