### PR TITLE
Bugfix MTE-4389 Remove extra swipe from test-sync-disconnect-connect-fxa

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -290,7 +290,7 @@ class IntegrationTests: BaseTestCase {
 
         navigator.nowAt(SettingsScreen)
         mozWaitForElementToExist(app.staticTexts["GENERAL"])
-        app.swipeDown()
+        // app.swipeDown()
         mozWaitForElementToExist(app.staticTexts["ACCOUNT"])
         mozWaitForElementToExist(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -290,7 +290,6 @@ class IntegrationTests: BaseTestCase {
 
         navigator.nowAt(SettingsScreen)
         mozWaitForElementToExist(app.staticTexts["GENERAL"])
-        // app.swipeDown()
         mozWaitForElementToExist(app.staticTexts["ACCOUNT"])
         mozWaitForElementToExist(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4389)


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The sync integration test `test-sync-disconnect-connect-fxa` has been failing consistently since Feb. A part of the cause is that the `swipe()` command on the Settings screen closes the Settings. We need to stay in the settings screen at this point.

Sort of related: The test fails intermittently due to https://github.com/mozilla-mobile/firefox-ios/issues/25271.

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

