### PR TITLE
Add FXIOS-11526 [Homepage] [Telemetry] event for tapping on items

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
@@ -23,7 +23,7 @@ enum NavigationBrowserActionType: ActionType {
     // Native views
     case tapOnTrackingProtection
     case tapOnShareSheet
-    case tapOnCustomizeHomepage
+    case tapOnCustomizeHomepageButton
     case tapOnSettingsSection
 
     // link related

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -156,7 +156,7 @@ struct BrowserViewControllerState: ScreenState, Equatable {
         state: BrowserViewControllerState
     ) -> BrowserViewControllerState {
         switch action.actionType {
-        case NavigationBrowserActionType.tapOnCustomizeHomepage,
+        case NavigationBrowserActionType.tapOnCustomizeHomepageButton,
             NavigationBrowserActionType.tapOnTrackingProtection,
             NavigationBrowserActionType.tapOnCell,
             NavigationBrowserActionType.tapOnLink,

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/HomepageDiffableDataSource.swift
@@ -59,6 +59,27 @@ final class HomepageDiffableDataSource:
                 CustomizeHomepageSectionCell.self
             ]
         }
+
+        var telemetryTappedItemType: HomepageTelemetry.TappedItemType? {
+            switch self {
+            case .topSite:
+                return .topSite
+            case .jumpBackIn:
+                return .jumpBackInTab
+            case .jumpBackInSyncedTab:
+                return .jumpBackInSyncedTab
+            case .bookmark:
+                return .bookmark
+            case .pocket:
+                return .story
+            case .pocketDiscover:
+                return .storyDiscoverMore
+            case .customizeHomepage:
+                return .customizeHomepage
+            default:
+                return nil
+            }
+        }
     }
 
     func updateSnapshot(

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageAction.swift
@@ -5,18 +5,25 @@
 import Common
 import Redux
 
+struct HomepageTelemetryExtras {
+    let itemType: HomepageTelemetry.TappedItemType?
+}
+
 final class HomepageAction: Action {
     let showiPadSetup: Bool?
     let numberOfTopSitesPerRow: Int?
+    let telemetryExtras: HomepageTelemetryExtras?
 
     init(
         numberOfTopSitesPerRow: Int? = nil,
         showiPadSetup: Bool? = nil,
+        telemetryExtras: HomepageTelemetryExtras? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
     ) {
         self.numberOfTopSitesPerRow = numberOfTopSitesPerRow
         self.showiPadSetup = showiPadSetup
+        self.telemetryExtras = telemetryExtras
         super.init(windowUUID: windowUUID, actionType: actionType)
     }
 }
@@ -26,4 +33,5 @@ enum HomepageActionType: ActionType {
     case traitCollectionDidChange
     case viewWillTransition
     case viewWillAppear
+    case didSelectItem
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage Rebuild/Redux/HomepageMiddleware.swift
@@ -13,8 +13,27 @@ final class HomepageMiddleware {
 
     lazy var homepageProvider: Middleware<AppState> = { state, action in
         switch action.actionType {
-        case NavigationBrowserActionType.tapOnCustomizeHomepage:
-            self.homepageTelemetry.sendTapOnCustomizeHomepageTelemetry()
+        case NavigationBrowserActionType.tapOnCustomizeHomepageButton:
+            self.homepageTelemetry.sendItemTappedTelemetryEvent(for: .customizeHomepage)
+
+        case NavigationBrowserActionType.tapOnBookmarksShowMoreButton:
+            self.homepageTelemetry.sendItemTappedTelemetryEvent(for: .bookmarkShowAll)
+
+        case NavigationBrowserActionType.tapOnJumpBackInShowAllButton:
+            guard case let .tabTray(panelType) = (action as? NavigationBrowserAction)?
+                .navigationDestination.destination
+            else { return }
+
+            self.homepageTelemetry.sendItemTappedTelemetryEvent(
+                for: panelType == .syncedTabs ? .jumpBackInSyncedTabShowAll : .jumpBackInTabShowAll
+            )
+
+        case HomepageActionType.didSelectItem:
+            guard let extras = (action as? HomepageAction)?.telemetryExtras, let type = extras.itemType else {
+                return
+            }
+            self.homepageTelemetry.sendItemTappedTelemetryEvent(for: type)
+
         default:
             break
         }

--- a/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
@@ -16,7 +16,7 @@ struct HomepageTelemetry {
         case bookmarkShowAll = "bookmarks_show_all_button"
         case story = "story"
         case storyDiscoverMore = "stories_discover_more"
-        case customizeHomepage = "customize_homepage"
+        case customizeHomepage = "customize_homepage_button"
 
         var sectionName: String {
             switch self {

--- a/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
@@ -6,10 +6,43 @@ import Foundation
 import Glean
 
 struct HomepageTelemetry {
-    private let gleanWrapper: GleanWrapper
+    enum TappedItemType: String {
+        case topSite = "top_site"
+        case jumpBackInTab = "jump_back_in_tab"
+        case jumpBackInSyncedTab = "jump_back_in_synced_tab"
+        case jumpBackInTabShowAll = "jump_back_in_show_all_button"
+        case jumpBackInSyncedTabShowAll = "synced_show_all_button"
+        case bookmark = "bookmark"
+        case bookmarkShowAll = "bookmarks_show_all_button"
+        case story = "story"
+        case storyDiscoverMore = "stories_discover_more"
+        case customizeHomepage = "customize_homepage"
 
+        var sectionName: String {
+            switch self {
+            case .topSite:
+                return "top_sites"
+            case .jumpBackInTab, .jumpBackInSyncedTab, .jumpBackInTabShowAll, .jumpBackInSyncedTabShowAll:
+                return "jump_back_in"
+            case .bookmark, .bookmarkShowAll:
+                return "bookmarks"
+            case .story, .storyDiscoverMore:
+                return "stories"
+            case .customizeHomepage:
+                return "customize_homepage"
+            }
+        }
+    }
+
+    private let gleanWrapper: GleanWrapper
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.gleanWrapper = gleanWrapper
+    }
+
+    // MARK: - General
+    func sendItemTappedTelemetryEvent(for itemType: TappedItemType) {
+        let itemNameExtra = GleanMetrics.Homepage.ItemTappedExtra(section: itemType.sectionName, type: itemType.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.Homepage.itemTapped, extras: itemNameExtra)
     }
 
     // MARK: - Top Sites
@@ -53,10 +86,5 @@ struct HomepageTelemetry {
 
     func sendOpenInPrivateTabEventForPocket() {
         gleanWrapper.recordEvent(for: GleanMetrics.Pocket.openInPrivateTab)
-    }
-
-    // MARK: - Customize Homepage
-    func sendTapOnCustomizeHomepageTelemetry() {
-        gleanWrapper.incrementCounter(for: GleanMetrics.FirefoxHomePage.customizeHomepageButton)
     }
 }

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -2731,7 +2731,7 @@ homepage:
        description: |
         The type of item that was tapped on the homepage. This name is found in `HomepageTelemetry.TappedItemType`.
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/11526
+      - https://github.com/mozilla-mobile/firefox-ios/issues/25297
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25297
     notification_emails:

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -2731,7 +2731,7 @@ homepage:
        description: |
         The type of item that was tapped on the homepage. This name is found in `HomepageTelemetry.TappedItemType`.
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/25297
+      - https://github.com/mozilla-mobile/firefox-ios/issues/25086
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/25297
     notification_emails:

--- a/firefox-ios/Client/metrics.yaml
+++ b/firefox-ios/Client/metrics.yaml
@@ -2715,6 +2715,32 @@ firefox_home_page:
       - fx-ios-data-stewards@mozilla.com
     expires: "2025-07-01"
 
+# HomePage - General
+homepage:
+  item_tapped:
+    type: event
+    description: |
+      Records when an item has been tapped on the homepage.
+    extra_keys:
+      section:
+       type: string
+       description: |
+        The section that the item belongs to on the homepage. This section name is found in `HomepageTelemetry.TappedItemType` under `sectionName`.
+      type:
+       type: string
+       description: |
+        The type of item that was tapped on the homepage. This name is found in `HomepageTelemetry.TappedItemType`.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/11526
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/25297
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2025-07-01"
+    metadata:
+      tags:
+        - Homepage
+
 # Metrics related to the history panel of the library
 library:
   panel_pressed:

--- a/firefox-ios/Client/tags.yaml
+++ b/firefox-ios/Client/tags.yaml
@@ -11,6 +11,9 @@
 ---
 $schema: moz://mozilla.org/schemas/glean/tags/1-0-0
 
+Homepage:
+  description: Corresponds to the homepage feature and all content that resides on the page.
+  
 AppIconSelection:
   description: Corresponds to the feature where users can change their default app icon in the settings.
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewControllerStateTests.swift
@@ -94,7 +94,7 @@ final class BrowserViewControllerStateTests: XCTestCase {
 
         XCTAssertNil(initialState.navigationDestination)
 
-        let action = getNavigationBrowserAction(for: .tapOnCustomizeHomepage, destination: .settings(.homePage))
+        let action = getNavigationBrowserAction(for: .tapOnCustomizeHomepageButton, destination: .settings(.homePage))
         let newState = reducer(initialState, action)
 
         XCTAssertEqual(newState.navigationDestination?.destination, .settings(.homePage))

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
@@ -48,7 +48,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
-        XCTAssertEqual(savedExtras.type, "customize_homepage")
+        XCTAssertEqual(savedExtras.type, "customize_homepage_button")
         XCTAssertEqual(savedExtras.section, "customize_homepage")
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage Rebuild/Redux/HomepageMiddlewareTests.swift
@@ -31,18 +31,129 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = NavigationBrowserAction(
             navigationDestination: NavigationDestination(.settings(.homePage)),
             windowUUID: .XCTestDefaultUUID,
-            actionType: NavigationBrowserActionType.tapOnCustomizeHomepage
+            actionType: NavigationBrowserActionType.tapOnCustomizeHomepageButton
         )
 
         subject.homepageProvider(AppState(), action)
 
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents?[0] as? CounterMetricType)
-        let expectedMetricType = type(of: GleanMetrics.FirefoxHomePage.customizeHomepageButton)
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
+        )
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras as? GleanMetrics.Homepage.ItemTappedExtra
+        )
+        let expectedMetricType = type(of: GleanMetrics.Homepage.itemTapped)
         let resultMetricType = type(of: savedMetric)
         let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
 
-        XCTAssertEqual(mockGleanWrapper.incrementCounterCalled, 1)
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(savedExtras.type, "customize_homepage")
+        XCTAssertEqual(savedExtras.section, "customize_homepage")
+    }
+
+    func test_tapOnBookmarksShowMoreButtonAction_sendTelemetryData() throws {
+        let subject = createSubject()
+        let action = NavigationBrowserAction(
+            navigationDestination: NavigationDestination(.link),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: NavigationBrowserActionType.tapOnBookmarksShowMoreButton
+        )
+
+        subject.homepageProvider(AppState(), action)
+
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
+        )
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras as? GleanMetrics.Homepage.ItemTappedExtra
+        )
+        let expectedMetricType = type(of: GleanMetrics.Homepage.itemTapped)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(savedExtras.type, "bookmarks_show_all_button")
+        XCTAssertEqual(savedExtras.section, "bookmarks")
+    }
+
+    func test_tapOnJumpBackInShowAllButtonAction_sendTelemetryData() throws {
+        let subject = createSubject()
+        let action = NavigationBrowserAction(
+            navigationDestination: NavigationDestination(.tabTray(.tabs)),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: NavigationBrowserActionType.tapOnJumpBackInShowAllButton
+        )
+
+        subject.homepageProvider(AppState(), action)
+
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
+        )
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras as? GleanMetrics.Homepage.ItemTappedExtra
+        )
+        let expectedMetricType = type(of: GleanMetrics.Homepage.itemTapped)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(savedExtras.type, "jump_back_in_show_all_button")
+        XCTAssertEqual(savedExtras.section, "jump_back_in")
+    }
+
+    func test_tapOnJumpBackInSyncedShowAllButtonAction_sendTelemetryData() throws {
+        let subject = createSubject()
+        let action = NavigationBrowserAction(
+            navigationDestination: NavigationDestination(.tabTray(.syncedTabs)),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: NavigationBrowserActionType.tapOnJumpBackInShowAllButton
+        )
+
+        subject.homepageProvider(AppState(), action)
+
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
+        )
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras as? GleanMetrics.Homepage.ItemTappedExtra
+        )
+        let expectedMetricType = type(of: GleanMetrics.Homepage.itemTapped)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(savedExtras.type, "synced_show_all_button")
+        XCTAssertEqual(savedExtras.section, "jump_back_in")
+    }
+
+    func test_didSelectItemAction_sendTelemetryData() throws {
+        let subject = createSubject()
+        let action = HomepageAction(
+            telemetryExtras: HomepageTelemetryExtras(itemType: .topSite),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.didSelectItem
+        )
+
+        subject.homepageProvider(AppState(), action)
+
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents?[0] as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
+        )
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras as? GleanMetrics.Homepage.ItemTappedExtra
+        )
+        let expectedMetricType = type(of: GleanMetrics.Homepage.itemTapped)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(savedExtras.type, "top_site")
+        XCTAssertEqual(savedExtras.section, "top_sites")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11526)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25086)

## :bulb: Description
Add telemetry event for tapping on an item in the homepage section. This includes the following items:

**Card Items**
- top sites
- jump back in local tab
- jump back in synced tab
- bookmark item
- pocket item
- pocket discover item

**Other**
- bookmarks show all
- jump back in show all (local tabs)
- jump back in synced tabs show all
- customize homepage

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

