### PR TITLE
Bugfix FXIOS-11544 [App Icon 2025] Remove repeated "selected" VoiceOver announcement on the selected app icon row

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
@@ -105,9 +105,9 @@ struct AppIconView: View, ThemeApplicable {
                     .foregroundStyle(themeColors.textPrimary.color)
                 Spacer()
                 if isSelected {
+                    // swiftlint:disable:next accessibility_label_for_image
                     Image(systemName: UX.checkmarkImageIdentifier)
                         .foregroundStyle(themeColors.actionPrimary.color)
-                        .accessibilityLabel(selectionImageAccessibilityLabel)
                 }
             }
             .padding(.horizontal, UX.itemPaddingHorizontal)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11544)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25135)

## :bulb: Description
On the App Icon Selection screen in Settings > App Icon, the VoiceOver currently reads "selected" twice for the currently selected App Icon row.

This extra callout has been removed, also requiring a swiftlint ignore line.

<img width="400" alt="Screenshot 2025-03-12 at 3 08 43 PM" src="https://github.com/user-attachments/assets/e1dbf3ef-d2d3-4fea-9afb-53ce3b1e7d1f" />

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

