### PR TITLE
Bugfix FXIOS-11546 [App Icon 2025] Properly adjust transparent app icon backgrounds for iOS 18

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
@@ -15,8 +15,8 @@ struct AppIconView: View, ThemeApplicable {
     // MARK: - Theming
     // FIXME FXIOS-11472 Improve our SwiftUI theming
     @Environment(\.themeManager)
-    var themeManager
-    @State var currentTheme: Theme = LightTheme()
+    private var themeManager
+    @State private var currentTheme: Theme = LightTheme()
     @State private var themeColors: ThemeColourPalette = LightTheme().colors
 
     struct UX {
@@ -30,13 +30,13 @@ struct AppIconView: View, ThemeApplicable {
         static let appIconDarkBackgroundColor = UIColor(rgb: 33).color
     }
 
-    var selectionImageAccessibilityLabel: String {
+    private var selectionImageAccessibilityLabel: String {
         return isSelected
                ? .Settings.AppIconSelection.Accessibility.AppIconSelectedLabel
                : .Settings.AppIconSelection.Accessibility.AppIconUnselectedLabel
     }
 
-    var selectionAccessibilityHint: String {
+    private var selectionAccessibilityHint: String {
         return .localizedStringWithFormat(
             .Settings.AppIconSelection.Accessibility.AppIconSelectionHint,
             appIcon.displayName
@@ -63,7 +63,7 @@ struct AppIconView: View, ThemeApplicable {
     }
 
     /// Devices prior to iOS 18 cannot change their icon display mode with their system settings
-    var forceLightTheme: Bool {
+    private var forceLightTheme: Bool {
         if #available(iOS 18, *) {
             return false
         } else {
@@ -72,7 +72,7 @@ struct AppIconView: View, ThemeApplicable {
     }
 
     /// The expected default app icon background for iOS 18+ app icons with transparency
-    var appIconBackgroundColor: Color {
+    private var appIconBackgroundColor: Color {
         if forceLightTheme {
             return UX.appIconLightBackgroundColor
         } else {

--- a/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconView.swift
@@ -71,6 +71,20 @@ struct AppIconView: View, ThemeApplicable {
         }
     }
 
+    /// The expected default app icon background for iOS 18+ app icons with transparency
+    var appIconBackgroundColor: Color {
+        if forceLightTheme {
+            return UX.appIconLightBackgroundColor
+        } else {
+            switch currentTheme.type.colorScheme {
+            case .light:
+                return UX.appIconLightBackgroundColor
+            default:
+                return UX.appIconDarkBackgroundColor
+            }
+        }
+    }
+
     private func button(for image: UIImage) -> some View {
         Button(action: {
             setAppIcon(appIcon)
@@ -85,7 +99,7 @@ struct AppIconView: View, ThemeApplicable {
                     .background(
                         forceLightTheme
                         ? UX.appIconLightBackgroundColor
-                        : UX.appIconDarkBackgroundColor
+                        : appIconBackgroundColor
                     )
                     // Pre iOS 18, force Light mode for the icons since users will only ever see Light home screen icons
                     // Note: This fix does not work on iOS15 but it's a small user base


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11546)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25141)

## :bulb: Description
Follow up to the work done in #25219 (see ticket for context). Related to the Settings > App Icons screen.

I accidentally refactored and lost support for iOS 18's default background changing with the theme, but keeping it white on < iOS 18.

@FilippoZazzeroni You called this out yesterday but I missed a test case, I should've done this after all for iOS 18 but with care taken for the `private` theme. 🙂 

<details>
<summary>📷  Device Comparison Screenshots</summary>

<img width="500" alt="Screenshot 2025-03-12 at 3 37 31 PM" src="https://github.com/user-attachments/assets/3fc57bfb-96e6-4257-900f-ec4f06bc8d22" />
<img width="500" alt="Screenshot 2025-03-12 at 3 35 06 PM" src="https://github.com/user-attachments/assets/cf715c7e-c0c0-4440-bd39-0523d8214cf1" />

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

