### PR TITLE
Bugfix MTE-4272 All cells now contains bookmarks

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PerformanceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PerformanceTests.swift
@@ -301,8 +301,7 @@ class PerformanceTests: BaseTestCase {
                 do {
                     // Activity measurement here
                     let bookmarksListSnapshot = try bookmarksList.snapshot()
-                    let bookmarksListCells = bookmarksListSnapshot.children.filter { $0.elementType == .cell }
-                    let bookmarks = bookmarksListCells.dropFirst()
+                    let bookmarks = bookmarksListSnapshot.children.filter { $0.elementType == .cell }
 
                     XCTAssertEqual(bookmarks.count, 1, "Number of cells in 'Bookmarks List' is not equal to 1")
                 } catch {
@@ -357,8 +356,7 @@ class PerformanceTests: BaseTestCase {
                 // Filter out 'Other' elements and drop 'Desktop Bookmarks' cell for a true bookmark count.
                 do {
                     let bookmarksListSnapshot = try bookmarksList.snapshot()
-                    let bookmarksListCells = bookmarksListSnapshot.children.filter { $0.elementType == .cell }
-                    let bookmarks = bookmarksListCells.dropFirst()
+                    let bookmarks = bookmarksListSnapshot.children.filter { $0.elementType == .cell }
 
                     // Activity measurement here
                     XCTAssertEqual(bookmarks.count, 100, "Number of cells in 'Bookmarks List' is not equal to 100")
@@ -415,8 +413,7 @@ class PerformanceTests: BaseTestCase {
                 do {
                     // Activity measurement here
                     let bookmarksListSnapshot = try bookmarksList.snapshot()
-                    let bookmarksListCells = bookmarksListSnapshot.children.filter { $0.elementType == .cell }
-                    let bookmarks = bookmarksListCells.dropFirst()
+                    let bookmarks = bookmarksListSnapshot.children.filter { $0.elementType == .cell }
 
                     XCTAssertEqual(bookmarks.count, 1000, "Number of cells in 'Bookmarks List' is not equal to 1000")
                 } catch {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-4272)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

All cells under the bookmarks table now contains individual entries of bookmarks. (No more off-by-one.)

Bitrise pipeline: https://app.bitrise.io/build/f7e6e324-55a2-44f3-831a-1ebda75ba3fa

## :pencil: Checklist
You have to check all boxes before merging
- [ ] Filled in the above information (tickets numbers and description of your work)
- [ ] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

