### PR TITLE
Remove MTE-4386 - outdated workarounds

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest4.xctestplan
@@ -27,6 +27,7 @@
         "ActivityStreamTest\/testContextMenuInLandscape()",
         "ActivityStreamTest\/testLongTapOnTopSiteOptions()",
         "ActivityStreamTest\/testShortcutsToggle()",
+        "ActivityStreamTest\/testSiteCanBeAddedToShortcuts()",
         "ActivityStreamTest\/testTopSites2Add()",
         "ActivityStreamTest\/testTopSitesRemoveAllExceptDefaultClearPrivateData()",
         "ActivityStreamTest\/testTopSitesRemoveAllExceptPinnedClearPrivateData()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -192,8 +192,6 @@ class ActivityStreamTest: BaseTestCase {
         app.collectionViews["FxCollectionView"].links[defaultTopSite["bookmarkLabel"]!].press(forDuration: 1)
         selectOptionFromContextMenu(option: "Open in a Private Tab")
         // Check that two tabs are open and one of them is the default top site one
-        // Workaround needed after xcode 11.3 update Issue 5937
-        sleep(3)
         navigator.nowAt(HomePanelsScreen)
         waitForTabsButton()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
@@ -253,7 +251,7 @@ class ActivityStreamTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2855325
-    func testsiteCanBeAddedToShortcuts() {
+    func testSiteCanBeAddedToShortcuts() {
         addWebsiteToShortcut(website: url_3)
         let itemCell = app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
         let cell = itemCell.staticTexts["Example Domain"]

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
@@ -139,9 +139,7 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         navigator.nowAt(BrowserTab)
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
-        // Workaround to be sure the snackbar disappears
         waitUntilPageLoad()
-        app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].waitAndTap()
         navigator.goto(BrowserTabMenu)
         navigator.goto(RequestDesktopSite) // toggle off
         waitUntilPageLoad()
@@ -167,8 +165,6 @@ class DesktopModeTestsIphone: IphoneOnlyTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateMode)
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
         waitUntilPageLoad()
-        // Workaround
-        app.buttons[AccessibilityIdentifiers.Toolbar.reloadButton].waitAndTap()
         navigator.goto(BrowserTabMenu)
         navigator.goto(RequestDesktopSite)
         waitUntilPageLoad()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -30,9 +30,7 @@ class FindInPageTests: BaseTestCase {
     func testFindInLargeDoc() {
         navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
         waitUntilPageLoad()
-        // Workaround until FxSGraph is fixed to allow the previous way with goto
         navigator.nowAt(BrowserTab)
-
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])
         navigator.goto(FindInPage)
 
@@ -118,7 +116,6 @@ class FindInPageTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2323714
     func testFindInPageTwoWordsSearchLargeDoc() {
         navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
-        // Workaround until FxSGraph is fixed to allow the previous way with goto
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         navigator.goto(FindInPage)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -439,7 +439,6 @@ class HistoryTests: BaseTestCase {
     private func navigateToPage() {
         navigator.openURL("example.com")
         waitUntilPageLoad()
-        // Workaround as the item does not appear if there is only that tab open
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         let cancelButton = app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton]
@@ -464,19 +463,9 @@ class HistoryTests: BaseTestCase {
     }
 
     private func closeFirstTabByX() {
-        // Workaround for FXIOS-5128. To be replaced by tapping "Close All Tabs"
         waitForTabsButton()
         navigator.goto(TabTray)
-        if isTablet {
-            app.otherElements["Tabs Tray"]
-                .collectionViews
-                .cells
-                .element(boundBy: 0)
-                .buttons[StandardImageIdentifiers.Large.crossCircleFill]
-                .waitAndTap()
-        } else {
-            app.cells.buttons[StandardImageIdentifiers.Large.crossCircleFill].firstMatch.waitAndTap()
-        }
+        app.cells.buttons[StandardImageIdentifiers.Large.crossCircleFill].firstMatch.waitAndTap()
     }
 
     private func closeKeyboard() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -46,14 +46,7 @@ class PhotonActionSheetTests: BaseTestCase {
         navigator.openURL("example.com")
         waitUntilPageLoad()
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from CoreSimulatorBridge"])
-
-        // Temporarily workaround for the url bar redesign work FXIOS-8172:
-        // Launch "Share" from the hamburger menu instead of the share icon from the
-        // awesome bar.
-        // mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.shareButton], timeout: 10)
-        // app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].tap()
-        navigator.goto(ToolsBrowserTabMenu)
-        app.cells[AccessibilityIdentifiers.MainMenu.share].waitAndTap()
+        app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
 
         if #unavailable(iOS 16) {
             waitForElementsToExist(

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -151,10 +151,8 @@ class TrackingProtectionTests: BaseTestCase {
         XCTAssertEqual(switchValueOFF as? String, "0")
 
         // Open TP Settings menu
-        // app.buttons["Privacy settings"].waitAndTap()
-        // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/23706
-        navigator.goto(SettingsScreen)
-        app.staticTexts["Tracking Protection"].waitAndTap()
+        app.buttons[AccessibilityIdentifiers.EnhancedTrackingProtection
+            .MainScreen.trackingProtectionSettingsButton].waitAndTap()
         mozWaitForElementToExist(app.navigationBars["Tracking Protection"], timeout: 5)
         let switchSettingsValue = app.switches["prefkey.trackingprotection.normalbrowsing"].value!
         XCTAssertEqual(switchSettingsValue as? String, "1")


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-4386

## :bulb: Description
Several changes regarding outdated workarounds from auto tests
