### PR TITLE
Bugfix FXIOS-11625 #25315 ⁃ Open Tabs Appear Last in Search Results When Typing Origin in Firefox iOS

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Search/SearchListSection.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchListSection.swift
@@ -7,9 +7,9 @@ import Foundation
 enum SearchListSection: Int, CaseIterable {
     case searchSuggestions
     case firefoxSuggestions
+    case openedTabs
     case bookmarks
     case remoteTabs
     case history
-    case openedTabs
     case searchHighlights
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11625)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25315)

## :bulb: Description
Moved openedTabs on top of the list of firefox suggest

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

