### PR TITLE
Bugfix Focus: string Onboarding.TermsOfUse.Title is exported without the value

### DIFF
--- a/focus-ios/Blockzilla/Onboarding/OnboardingFactory.swift
+++ b/focus-ios/Blockzilla/Onboarding/OnboardingFactory.swift
@@ -145,10 +145,13 @@ fileprivate extension String {
     static let defaultBrowserOnboardingViewSecondSubtitleV2 = String(format: NSLocalizedString("Onboarding.DefaultBrowser.SecondSubtitle.V2", value: "Make %@ your default to protect your data with every link you open.", comment: "Text for a label that indicates the second subtitle for the default browser onboarding screen version 2. %@ is the app name (for example “Firefox Focus” or ”Firefox Klar”)."), AppInfo.shortProductName)
     static let defaultBrowserOnboardingViewTopButtonTitleV2 = NSLocalizedString("Onboarding.DefaultBrowser.TopButtonTitle.V2", value: "Set as Default Browser", comment: "Text for a label that indicates the title of the top button from the default browser onboarding screen version 2.")
     static let defaultBrowserOnboardingViewBottomButtonTitleV2 = NSLocalizedString("Onboarding.DefaultBrowser.BottomButtonTitle.V2", value: "Skip", comment: "Text for a label that indicates the title of the bottom button from the default browser onboarding screen version 2.")
-    static let termsOfUseTitle = NSLocalizedString(
-        "Onboarding.TermsOfUse.Title",
-        value: String(format: "Welcome to %@", AppInfo.productName),
-        comment: "Title for the Terms of Use screen during onboarding. %@ is the app name (for example “Firefox Focus” or ”Firefox Klar”)."
+    static let termsOfUseTitle = String(
+        format: NSLocalizedString(
+            "Onboarding.TermsOfUse.Title",
+            value: "Welcome to %@",
+            comment: "Title for the Terms of Use screen during onboarding. %@ is the app name (for example “Firefox Focus” or ”Firefox Klar”)."
+        ),
+        AppInfo.productName
     )
     static let termsOfUseSubtitle = NSLocalizedString(
         "Onboarding.TermsOfUse.Subtitle",


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25261)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Fix string export

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [ ] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

