### PR TITLE
Refactor FXIOS-11611 [Tab tray UI experiment] Adjust tab thumbnail for dynamic type

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -9,7 +9,7 @@ class TabsSectionManager: FeatureFlaggable {
         // On iPad we can set to have bigger tabs, on iPhone we need smaller ones
         static let cellEstimatedWidth: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 250 : 170
         static let cellAbsoluteHeight: CGFloat = 200
-        static let experimentCellAbsoluteHeight: CGFloat = 220
+        static let experimentCellEstimatedHeight: CGFloat = 240
         static let cardSpacing: CGFloat = 16
         static let experimentCardSpacing: CGFloat = 28
         static let standardInset: CGFloat = 18
@@ -41,13 +41,23 @@ class TabsSectionManager: FeatureFlaggable {
                                   ? minNumberOfCellsPerRow
                                   : maxNumberOfCellsPerRow
 
-        let cellHeight = isTabTrayUIExperimentsEnabled ? UX.experimentCellAbsoluteHeight : UX.cellAbsoluteHeight
-        let itemSize = NSCollectionLayoutSize(
-            widthDimension: .estimated(UX.cellEstimatedWidth),
-            heightDimension: .absolute(cellHeight)
-        )
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let itemSize: NSCollectionLayoutSize
+        let cellHeight: CGFloat
+        if isTabTrayUIExperimentsEnabled {
+            cellHeight = UX.experimentCellEstimatedHeight
+            itemSize = NSCollectionLayoutSize(
+                widthDimension: .estimated(UX.cellEstimatedWidth),
+                heightDimension: .estimated(cellHeight)
+            )
+        } else {
+            cellHeight = UX.cellAbsoluteHeight
+            itemSize = NSCollectionLayoutSize(
+                widthDimension: .estimated(UX.cellEstimatedWidth),
+                heightDimension: .absolute(cellHeight)
+            )
+        }
 
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
             heightDimension: .estimated(cellHeight)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/LayoutManager/TabsSectionManager.swift
@@ -9,7 +9,7 @@ class TabsSectionManager: FeatureFlaggable {
         // On iPad we can set to have bigger tabs, on iPhone we need smaller ones
         static let cellEstimatedWidth: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 250 : 170
         static let cellAbsoluteHeight: CGFloat = 200
-        static let experimentCellEstimatedHeight: CGFloat = 240
+        static let experimentCellEstimatedHeight: CGFloat = 220
         static let cardSpacing: CGFloat = 16
         static let experimentCardSpacing: CGFloat = 28
         static let standardInset: CGFloat = 18

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -29,6 +29,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         static let shadowRadius: CGFloat = 4
         static let shadowOffset = CGSize(width: 0, height: 2)
         static let shadowOpacity: Float = 1
+        static let thumbnailScreenshotHeight: CGFloat = 200
     }
     // MARK: - Properties
 
@@ -43,6 +44,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
     }
 
     private lazy var favicon: FaviconImageView = .build()
+    private lazy var faviconContainer: UIView = .build()
 
     // MARK: - UI
 
@@ -53,6 +55,8 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         stackView.alignment = .fill
         stackView.spacing = UX.tabViewFooterSpacing
         stackView.backgroundColor = .clear
+        stackView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+        stackView.setContentHuggingPriority(.defaultHigh, for: .vertical)
     }
 
     private lazy var backgroundHolder: UIView = .build { view in
@@ -71,6 +75,8 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         label.font = FXFontStyles.Regular.footnote.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.isAccessibilityElement = false
+        label.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+        label.setContentHuggingPriority(.defaultHigh, for: .vertical)
     }
 
     private lazy var closeButton: UIButton = .build { button in
@@ -80,7 +86,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         var configuration = UIButton.Configuration.plain()
         configuration.contentInsets = UX.closeButtonEdgeInset
         button.configuration = configuration
-        button.alpha = 0.5
+        button.alpha = 0.7
     }
 
     private var isTabTrayUIExperimentsEnabled: Bool {
@@ -110,8 +116,9 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         contentView.addSubview(backgroundHolder)
         contentView.addSubview(footerView)
 
-        footerView.addArrangedSubview(favicon)
+        footerView.addArrangedSubview(faviconContainer)
         footerView.addArrangedSubview(titleText)
+        faviconContainer.addSubview(favicon)
 
         backgroundHolder.addSubviews(screenshotView, smallFaviconView, closeButton)
 
@@ -263,16 +270,22 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
             backgroundHolder.topAnchor.constraint(equalTo: contentView.topAnchor),
             backgroundHolder.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             backgroundHolder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            backgroundHolder.bottomAnchor.constraint(equalTo: footerView.topAnchor,
-                                                     constant: -UX.tabViewFooterSpacing),
+            backgroundHolder.heightAnchor.constraint(equalToConstant: UX.thumbnailScreenshotHeight),
 
+            footerView.topAnchor.constraint(equalTo: backgroundHolder.bottomAnchor,
+                                            constant: UX.tabViewFooterSpacing),
             footerView.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor),
             footerView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             footerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             footerView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor),
 
+            faviconContainer.topAnchor.constraint(lessThanOrEqualTo: favicon.topAnchor),
+            faviconContainer.bottomAnchor.constraint(greaterThanOrEqualTo: favicon.bottomAnchor),
+            faviconContainer.leadingAnchor.constraint(equalTo: favicon.leadingAnchor),
+            faviconContainer.trailingAnchor.constraint(equalTo: favicon.trailingAnchor),
             favicon.heightAnchor.constraint(equalToConstant: UX.faviconSize.height),
             favicon.widthAnchor.constraint(equalToConstant: UX.faviconSize.width),
+            favicon.centerYAnchor.constraint(equalTo: titleText.centerYAnchor),
 
             closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize),
             closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -86,7 +86,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell, Fe
         var configuration = UIButton.Configuration.plain()
         configuration.contentInsets = UX.closeButtonEdgeInset
         button.configuration = configuration
-        button.alpha = 0.7
+        button.alpha = 0.5
     }
 
     private var isTabTrayUIExperimentsEnabled: Bool {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11611)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25291)

## :bulb: Description
Adjust tab thumbnail for dynamic type. The previous cell text title was adjusting in height inside the tab cell itself (since the title is at the top of the tab thumbnail, inside of it). Now that the title is at the bottom, outside of the tab thumbnail, the cell height should adapt depending on dynamic type. 

### 🎥 Screenshots
<details>
<summary>Smaller content size</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-03-13 at 13 01 21](https://github.com/user-attachments/assets/84db8d04-0ed9-412f-8d7f-307c08301b02)


</details>

<details>
<summary>Biggest content size</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-03-13 at 13 00 45](https://github.com/user-attachments/assets/a49c3f6c-f7bc-4d9a-86b5-4d7adc577351)

</details>


## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [x] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

