### PR TITLE
Refactor FXIOS-11596 [Tab tray UI experiment] Adjust background color, adjust X button

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -443,6 +443,7 @@ struct AccessibilityIdentifiers {
         static let learnMoreButton = "learnMoreButton"
         static let collectionView = "TabDisplayView.collectionView"
         static let tabCell = "TabDisplayView.tabCell"
+        static let closeButton = "badge mask"
 
         struct InactiveTabs {
             static let headerLabel = "InactiveTabs.headerLabel"

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -25,6 +25,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
                                                                   trailing: 10)
         static let closeButtonTop: CGFloat = 6
         static let closeButtonTrailing: CGFloat = 8
+        static let closeButtonOverlaySpacing: CGFloat = 16
         static let tabViewFooterSpacing: CGFloat = 4
         static let shadowRadius: CGFloat = 4
         static let shadowOffset = CGSize(width: 0, height: 2)
@@ -89,6 +90,10 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         button.alpha = 0.5
     }
 
+    private lazy var closeButtonOverlay: UIImageView = .build { imageView in
+        imageView.image = UIImage(named: StandardImageIdentifiers.Medium.cross)?.withRenderingMode(.alwaysTemplate)
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         favicon.layer.cornerRadius = UX.faviconSize.height / 2
@@ -116,7 +121,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         footerView.addArrangedSubview(titleText)
         faviconContainer.addSubview(favicon)
 
-        backgroundHolder.addSubviews(screenshotView, smallFaviconView, closeButton)
+        backgroundHolder.addSubviews(screenshotView, smallFaviconView, closeButton, closeButtonOverlay)
 
         accessibilityCustomActions = [
             UIAccessibilityCustomAction(name: .TabTrayCloseAccessibilityCustomAction,
@@ -179,6 +184,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     func applyTheme(theme: Theme) {
         backgroundHolder.backgroundColor = theme.colors.layer1
         closeButton.tintColor = theme.colors.iconPrimary
+        closeButtonOverlay.tintColor = theme.colors.textInverted
         titleText.textColor = theme.colors.textPrimary
         screenshotView.backgroundColor = theme.colors.layer1
         favicon.tintColor = theme.colors.textPrimary
@@ -300,6 +306,13 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
             smallFaviconView.widthAnchor.constraint(equalToConstant: UX.fallbackFaviconSize.width),
             smallFaviconView.centerYAnchor.constraint(equalTo: backgroundHolder.centerYAnchor),
             smallFaviconView.centerXAnchor.constraint(equalTo: backgroundHolder.centerXAnchor),
+
+            closeButtonOverlay.centerXAnchor.constraint(equalTo: closeButton.centerXAnchor),
+            closeButtonOverlay.centerYAnchor.constraint(equalTo: closeButton.centerYAnchor),
+            closeButtonOverlay.widthAnchor.constraint(equalTo: closeButton.widthAnchor,
+                                                      constant: -UX.closeButtonOverlaySpacing),
+            closeButtonOverlay.heightAnchor.constraint(equalTo: closeButton.heightAnchor,
+                                                       constant: -UX.closeButtonOverlaySpacing)
         ])
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -81,7 +81,7 @@ class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
     }
 
     private lazy var closeButton: UIButton = .build { button in
-        button.setImage(UIImage.templateImageNamed(StandardImageIdentifiers.Large.crossCircleFill), for: [])
+        button.setImage(UIImage.templateImageNamed(ImageIdentifiers.badgeMask), for: [])
         button.imageView?.contentMode = .scaleAspectFit
         button.contentMode = .center
         var configuration = UIButton.Configuration.plain()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -181,10 +181,10 @@ class TabDisplayPanelViewController: UIViewController,
 
         if isTabTrayUIExperimentsEnabled {
             gradientLayer.colors = [
-                currentTheme().colors.layer1.cgColor,
-                currentTheme().colors.layer1.cgColor,
-                currentTheme().colors.layer1.withAlphaComponent(0.95).cgColor,
-                currentTheme().colors.layer1.withAlphaComponent(0.0).cgColor
+                currentTheme().colors.layer3.cgColor,
+                currentTheme().colors.layer3.cgColor,
+                currentTheme().colors.layer3.withAlphaComponent(0.95).cgColor,
+                currentTheme().colors.layer3.withAlphaComponent(0.0).cgColor
             ]
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -278,11 +278,7 @@ class TabDisplayView: UIView,
 
     func applyTheme(theme: Theme) {
         self.theme = theme
-        if isTabTrayUIExperimentsEnabled {
-            collectionView.backgroundColor = theme.colors.layer1
-        } else {
-            collectionView.backgroundColor = theme.colors.layer3
-        }
+        collectionView.backgroundColor = theme.colors.layer3
     }
 
     private func getSection(for sectionIndex: Int) -> TabDisplayViewSection {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -104,7 +104,7 @@ class ActivityStreamTest: BaseTestCase {
         waitUntilPageLoad()
         // navigator.performAction(Action.AcceptRemovingAllTabs)
         navigator.goto(TabTray)
-        app.collectionViews.buttons[StandardImageIdentifiers.Large.crossCircleFill].waitAndTap()
+        app.collectionViews.buttons[AccessibilityIdentifiers.TabTray.closeButton].waitAndTap()
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -381,7 +381,7 @@ class HistoryTests: BaseTestCase {
         waitForTabsButton()
         navigator.goto(TabTray)
         mozWaitForElementToExist(app.cells.staticTexts[webpage["label"]!])
-        app.cells.buttons[StandardImageIdentifiers.Large.crossCircleFill].firstMatch.waitAndTap()
+        app.cells.buttons[AccessibilityIdentifiers.TabTray.closeButton].firstMatch.waitAndTap()
 
         // On private mode, the "Recently Closed Tabs List" is empty
         navigator.performAction(Action.OpenNewTabFromTabTray)
@@ -465,7 +465,7 @@ class HistoryTests: BaseTestCase {
     private func closeFirstTabByX() {
         waitForTabsButton()
         navigator.goto(TabTray)
-        app.cells.buttons[StandardImageIdentifiers.Large.crossCircleFill].firstMatch.waitAndTap()
+        app.cells.buttons[AccessibilityIdentifiers.TabTray.closeButton].firstMatch.waitAndTap()
     }
 
     private func closeKeyboard() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -134,7 +134,7 @@ class JumpBackInTests: BaseTestCase {
         } else {
             mozWaitForElementToExist(app.segmentedControls["navBarTabTray"])
         }
-        app.cells["Example Domain"].buttons[StandardImageIdentifiers.Large.crossCircleFill].waitAndTap()
+        app.cells["Example Domain"].buttons[AccessibilityIdentifiers.TabTray.closeButton].waitAndTap()
 
         // Revisit the "Jump Back In" section
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.TabTray.newTabButton], timeout: TIMEOUT)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TopTabsTest.swift
@@ -104,9 +104,9 @@ class TopTabsTest: BaseTestCase {
         mozWaitForElementToExist(app.cells.staticTexts[urlLabel])
         // Close the tab using 'x' button
         if iPad() {
-            app.cells.buttons[StandardImageIdentifiers.Large.crossCircleFill].waitAndTap()
+            app.cells.buttons[AccessibilityIdentifiers.TabTray.closeButton].waitAndTap()
         } else {
-            app.otherElements.cells.buttons[StandardImageIdentifiers.Large.crossCircleFill].waitAndTap()
+            app.otherElements.cells.buttons[AccessibilityIdentifiers.TabTray.closeButton].waitAndTap()
         }
 
         // After removing only one tab it automatically goes to HomepanelView
@@ -426,9 +426,9 @@ class TopTabsTest: BaseTestCase {
         // Tab tray UI experiment doesn't have toasts notifications anymore
         // https://github.com/mozilla-mobile/firefox-ios/issues/25343
         // Close multiple tabs by pressing X button
-//        let crossCircleFillLarge = StandardImageIdentifiers.Large.crossCircleFill
+//        let closeButton = AccessibilityIdentifiers.TabTray.closeButton
 //        for _ in 0...3 {
-//            app.collectionViews.cells["Homepage. Currently selected tab."].buttons[crossCircleFillLarge].waitAndTap()
+//            app.collectionViews.cells["Homepage. Currently selected tab."].buttons[closeButton].waitAndTap()
 //            // A toast notification is displayed with the message "Tab Closed" and the Undo option
 //            waitForElementsToExist(
 //                [
@@ -437,7 +437,7 @@ class TopTabsTest: BaseTestCase {
 //                ]
 //            )
 //        }
-//        app.collectionViews.buttons[crossCircleFillLarge].waitAndTap()
+//        app.collectionViews.buttons[closeButton].waitAndTap()
 //        waitForElementsToExist(
 //            [
 //                app.buttons["Undo"],


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11596)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25250)

## :bulb: Description
Some slight adjustment to improve usability:
- The X button is sometimes not visible properly on some website. We didn't have that problem in our current tab tray since the tab cell has a banner at the top (so the X is always visible). Since now the X is on the tab thumbnail, we depend on the color of the website. I am ensuring we have a clear opaque X on top of the X button image with the transparency, so the X button is always visible. See screenshots below of what I mean. It's a quick fix solution, I'll note it down so we revisit later.
- I had not noticed the background color of the normal tabs wasn't the same anymore of the sync and private tabs, fixing that as well.

### 🎥 Screenshots
<details>
<summary>The X button not always visible</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-03-13 at 16 18 17](https://github.com/user-attachments/assets/06d0f1a8-9990-401b-9d87-addbc4bb62e5)

</details>

<details>
<summary>The X button is now visible (dark mode)</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-03-13 at 17 37 29](https://github.com/user-attachments/assets/2225e047-7414-4833-9fcf-9020e9109f09)

</details>

<details>
<summary>The X button is now visible (light mode)</summary>

![Simulator Screenshot - iPhone 16 Pro - 2025-03-13 at 17 37 07](https://github.com/user-attachments/assets/cdcaabcb-f57b-441c-bad8-2ebd810a4012)

</details>

## :pencil: Checklist
You have to check all boxes before merging
- [X] Filled in the above information (tickets numbers and description of your work)
- [X] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed, I updated documentation / comments for complex code and public methods
- [X] If needed, added a backport comment (example `@Mergifyio backport release/v120`)

